### PR TITLE
Enable checkstyle in pulsar-client-tools module

### DIFF
--- a/pulsar-client-tools/pom.xml
+++ b/pulsar-client-tools/pom.xml
@@ -137,6 +137,20 @@
           </execution>
         </executions>
       </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-checkstyle-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>checkstyle</id>
+            <phase>verify</phase>
+            <goals>
+              <goal>check</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CliCommand.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CliCommand.java
@@ -18,26 +18,23 @@
  */
 package org.apache.pulsar.admin.cli;
 
+import com.beust.jcommander.ParameterException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectWriter;
+import com.google.common.collect.Sets;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
-
-import com.google.common.collect.Sets;
 import org.apache.pulsar.client.admin.PulsarAdminException;
 import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.client.impl.MessageIdImpl;
+import org.apache.pulsar.common.naming.NamespaceName;
 import org.apache.pulsar.common.naming.TopicDomain;
 import org.apache.pulsar.common.naming.TopicName;
-import org.apache.pulsar.common.naming.NamespaceName;
 import org.apache.pulsar.common.policies.data.AuthAction;
 import org.apache.pulsar.common.util.ObjectMapperFactory;
-
-import com.beust.jcommander.ParameterException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.ObjectWriter;
-import com.google.common.base.Preconditions;
 
 abstract class CliCommand {
 
@@ -121,7 +118,7 @@ abstract class CliCommand {
     static MessageId validateMessageIdString(String resetMessageIdStr, int partitionIndex) throws PulsarAdminException {
         String[] messageId = resetMessageIdStr.split(":");
         try {
-            Preconditions.checkArgument(messageId.length == 2);
+            com.google.common.base.Preconditions.checkArgument(messageId.length == 2);
             return new MessageIdImpl(Long.parseLong(messageId[0]), Long.parseLong(messageId[1]), partitionIndex);
         } catch (Exception e) {
             throw new PulsarAdminException(
@@ -198,8 +195,8 @@ abstract class CliCommand {
         }
     }
 
-    <K,V> void print(Map<K,V> items) {
-        for(Map.Entry<K,V> entry : items.entrySet()) {
+    <K, V> void print(Map<K, V> items) {
+        for (Map.Entry<K, V> entry : items.entrySet()) {
             print(entry.getKey() + "    " + entry.getValue());
         }
     }

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdBase.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdBase.java
@@ -23,12 +23,10 @@ import com.beust.jcommander.IUsageFormatter;
 import com.beust.jcommander.JCommander;
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.ParameterException;
-
+import java.util.function.Supplier;
 import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.admin.PulsarAdminException;
 import org.apache.pulsar.client.admin.PulsarAdminException.ConnectException;
-
-import java.util.function.Supplier;
 
 public abstract class CmdBase {
     protected final JCommander jcommander;

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdBookies.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdBookies.java
@@ -18,13 +18,11 @@
  */
 package org.apache.pulsar.admin.cli;
 
-import org.apache.pulsar.client.admin.PulsarAdmin;
-import org.apache.pulsar.common.policies.data.BookieInfo;
-
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.Parameters;
-
 import java.util.function.Supplier;
+import org.apache.pulsar.client.admin.PulsarAdmin;
+import org.apache.pulsar.common.policies.data.BookieInfo;
 
 @Parameters(commandDescription = "Operations about bookies rack placement")
 public class CmdBookies extends CmdBase {
@@ -41,7 +39,8 @@ public class CmdBookies extends CmdBase {
     @Parameters(commandDescription = "Gets the rack placement information for a specific bookie in the cluster")
     private class GetBookie extends CliCommand {
 
-        @Parameter(names = { "-b", "--bookie" }, description = "Bookie address (format: `address:port`)", required = true)
+        @Parameter(names = { "-b", "--bookie" },
+                description = "Bookie address (format: `address:port`)", required = true)
         private String bookieAddress;
 
         @Override
@@ -62,7 +61,8 @@ public class CmdBookies extends CmdBase {
     @Parameters(commandDescription = "Remove rack placement information for a specific bookie in the cluster")
     private class RemoveBookie extends CliCommand {
 
-        @Parameter(names = { "-b", "--bookie" }, description = "Bookie address (format: `address:port`)", required = true)
+        @Parameter(names = { "-b", "--bookie" },
+                description = "Bookie address (format: `address:port`)", required = true)
         private String bookieAddress;
 
         @Override
@@ -71,12 +71,14 @@ public class CmdBookies extends CmdBase {
         }
     }
 
-    @Parameters(commandDescription = "Updates the rack placement information for a specific bookie in the cluster (note. bookie address format:`address:port`)")
+    @Parameters(commandDescription = "Updates the rack placement information for a specific bookie in the cluster "
+            + "(note. bookie address format:`address:port`)")
     private class UpdateBookie extends CliCommand {
         @Parameter(names = { "-g", "--group" }, description = "Bookie group name", required = false)
         private String group = "default";
 
-        @Parameter(names = { "-b", "--bookie" }, description = "Bookie address (format: `address:port`)", required = true)
+        @Parameter(names = { "-b", "--bookie" },
+                description = "Bookie address (format: `address:port`)", required = true)
         private String bookieAddress;
 
         @Parameter(names = { "-r", "--rack" }, description = "Bookie rack name", required = true)

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdBrokerStats.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdBrokerStats.java
@@ -18,25 +18,22 @@
  */
 package org.apache.pulsar.admin.cli;
 
+import com.beust.jcommander.Parameter;
+import com.beust.jcommander.Parameters;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectWriter;
+import com.google.gson.Gson;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import com.google.gson.stream.JsonWriter;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.function.Supplier;
-
 import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.common.stats.AllocatorStats;
 import org.apache.pulsar.common.util.ObjectMapperFactory;
-
-import com.google.gson.Gson;
-import com.google.gson.JsonArray;
-import com.google.gson.JsonObject;
-import com.google.gson.stream.JsonWriter;
-
-import com.beust.jcommander.Parameter;
-import com.beust.jcommander.Parameters;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.ObjectWriter;
 
 @Parameters(commandDescription = "Operations to collect broker statistics")
 public class CmdBrokerStats extends CmdBase {

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdBrokers.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdBrokers.java
@@ -18,13 +18,11 @@
  */
 package org.apache.pulsar.admin.cli;
 
-import org.apache.pulsar.client.admin.PulsarAdmin;
-
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.Parameters;
-import org.apache.pulsar.common.naming.TopicVersion;
-
 import java.util.function.Supplier;
+import org.apache.pulsar.client.admin.PulsarAdmin;
+import org.apache.pulsar.common.naming.TopicVersion;
 
 @Parameters(commandDescription = "Operations about brokers")
 public class CmdBrokers extends CmdBase {

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdClusters.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdClusters.java
@@ -70,7 +70,8 @@ public class CmdClusters extends CmdBase {
     protected void validateClusterData(ClusterData clusterData) {
         if (clusterData.isBrokerClientTlsEnabled()) {
             if (clusterData.isBrokerClientTlsEnabledWithKeyStore()) {
-                if (StringUtils.isAnyBlank(clusterData.getBrokerClientTlsTrustStoreType(), clusterData.getBrokerClientTlsTrustStore(),
+                if (StringUtils.isAnyBlank(clusterData.getBrokerClientTlsTrustStoreType(),
+                        clusterData.getBrokerClientTlsTrustStore(),
                         clusterData.getBrokerClientTlsTrustStorePassword())) {
                     throw new RuntimeException(
                             "You must specify tls-trust-store-type, tls-trust-store and tls-trust-store-pwd"
@@ -101,7 +102,8 @@ public class CmdClusters extends CmdBase {
         @Parameter(description = "cluster-name", required = true)
         private java.util.List<String> params;
 
-        @Parameter(names = { "-a", "--all" }, description = "Delete all data (tenants) of the cluster", required = false)
+        @Parameter(names = { "-a", "--all" },
+                description = "Delete all data (tenants) of the cluster", required = false)
         private boolean deleteAll = false;
 
         void run() throws PulsarAdminException {
@@ -110,7 +112,8 @@ public class CmdClusters extends CmdBase {
             if (deleteAll) {
                 for (String tenant : getAdmin().tenants().getTenants()) {
                     for (String namespace : getAdmin().namespaces().getNamespaces(tenant)) {
-                        // Partitioned topic's schema must be deleted by deletePartitionedTopic() but not delete() for each partition
+                        // Partitioned topic's schema must be deleted by deletePartitionedTopic()
+                        // but not delete() for each partition
                         for (String topic : getAdmin().topics().getPartitionedTopicList(namespace)) {
                             getAdmin().topics().deletePartitionedTopic(topic, true, true);
                         }
@@ -132,7 +135,8 @@ public class CmdClusters extends CmdBase {
         @Parameter(description = "cluster-name", required = true)
         private java.util.List<String> params;
 
-        @Parameter(names = "--peer-clusters", description = "Comma separated peer-cluster names [Pass empty string \"\" to delete list]", required = true)
+        @Parameter(names = "--peer-clusters", description = "Comma separated peer-cluster names "
+                + "[Pass empty string \"\" to delete list]", required = true)
         private String peerClusterNames;
 
         void run() throws PulsarAdminException {
@@ -237,7 +241,7 @@ public class CmdClusters extends CmdBase {
     }
 
     /**
-     * Base command
+     * Base command.
      */
     @Getter
     abstract class BaseCommand extends CliCommand {
@@ -274,10 +278,12 @@ public class CmdClusters extends CmdBase {
         @Parameter(names = "--broker-url", description = "broker-service-url", required = false)
         protected String brokerServiceUrl;
 
-        @Parameter(names = "--broker-url-secure", description = "broker-service-url for secure connection", required = false)
+        @Parameter(names = "--broker-url-secure",
+                description = "broker-service-url for secure connection", required = false)
         protected String brokerServiceUrlTls;
 
-        @Parameter(names = "--proxy-url", description = "Proxy-service url when client would like to connect to broker via proxy.", required = false)
+        @Parameter(names = "--proxy-url",
+                description = "Proxy-service url when client would like to connect to broker via proxy.")
         protected String proxyServiceUrl;
 
         @Parameter(names = "--auth-plugin", description = "authentication plugin", required = false)
@@ -286,7 +292,8 @@ public class CmdClusters extends CmdBase {
         @Parameter(names = "--auth-parameters", description = "authentication parameters", required = false)
         protected String authenticationParameters;
 
-        @Parameter(names = "--proxy-protocol", description = "protocol to decide type of proxy routing eg: SNI", required = false)
+        @Parameter(names = "--proxy-protocol",
+                description = "protocol to decide type of proxy routing eg: SNI", required = false)
         protected ProxyProtocol proxyProtocol;
 
         @Parameter(names = "--tls-enable", description = "Enable tls connection", required = false)
@@ -295,22 +302,28 @@ public class CmdClusters extends CmdBase {
         @Parameter(names = "--tls-allow-insecure", description = "Allow insecure tls connection", required = false)
         protected Boolean tlsAllowInsecureConnection;
 
-        @Parameter(names = "--tls-enable-keystore", description = "Whether use KeyStore type to authenticate", required = false)
+        @Parameter(names = "--tls-enable-keystore",
+                description = "Whether use KeyStore type to authenticate", required = false)
         protected Boolean brokerClientTlsEnabledWithKeyStore;
 
-        @Parameter(names = "--tls-trust-store-type", description = "TLS TrustStore type configuration for internal client eg: JKS", required = false)
+        @Parameter(names = "--tls-trust-store-type",
+                description = "TLS TrustStore type configuration for internal client eg: JKS", required = false)
         protected String brokerClientTlsTrustStoreType;
 
-        @Parameter(names = "--tls-trust-store", description = "TLS TrustStore path for internal client", required = false)
+        @Parameter(names = "--tls-trust-store",
+                description = "TLS TrustStore path for internal client", required = false)
         protected String brokerClientTlsTrustStore;
 
-        @Parameter(names = "--tls-trust-store-pwd", description = "TLS TrustStore password for internal client", required = false)
+        @Parameter(names = "--tls-trust-store-pwd",
+                description = "TLS TrustStore password for internal client", required = false)
         protected String brokerClientTlsTrustStorePassword;
 
-        @Parameter(names = "--tls-trust-certs-filepath", description = "path for the trusted TLS certificate file", required = false)
+        @Parameter(names = "--tls-trust-certs-filepath",
+                description = "path for the trusted TLS certificate file", required = false)
         protected String brokerClientTrustCertsFilePath;
 
-        @Parameter(names = "--listener-name", description = "listenerName when client would like to connect to cluster", required = false)
+        @Parameter(names = "--listener-name",
+                description = "listenerName when client would like to connect to cluster", required = false)
         protected String listenerName;
 
         @Parameter(names = "--cluster-config-file", description = "The path to a YAML config file specifying the "

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdFunctionWorker.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdFunctionWorker.java
@@ -19,19 +19,18 @@
 package org.apache.pulsar.admin.cli;
 
 import com.beust.jcommander.Parameters;
+import java.util.function.Supplier;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.api.PulsarClientException;
-
-import java.util.function.Supplier;
 
 @Slf4j
 @Parameters(commandDescription = "Operations to collect function-worker statistics")
 public class CmdFunctionWorker extends CmdBase {
 
     /**
-     * Base command
+     * Base command.
      */
     @Getter
     abstract class BaseCommand extends CliCommand {

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdFunctions.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdFunctions.java
@@ -22,7 +22,6 @@ import static org.apache.commons.lang.StringUtils.isBlank;
 import static org.apache.commons.lang.StringUtils.isNotBlank;
 import static org.apache.pulsar.common.naming.TopicName.DEFAULT_NAMESPACE;
 import static org.apache.pulsar.common.naming.TopicName.PUBLIC_TENANT;
-
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.ParameterException;
 import com.beust.jcommander.Parameters;
@@ -32,7 +31,6 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.reflect.TypeToken;
-
 import java.io.File;
 import java.lang.reflect.Field;
 import java.lang.reflect.Type;
@@ -43,7 +41,6 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Supplier;
-
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang.StringUtils;
@@ -54,16 +51,17 @@ import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.api.SubscriptionInitialPosition;
 import org.apache.pulsar.common.functions.ConsumerConfig;
 import org.apache.pulsar.common.functions.FunctionConfig;
+import org.apache.pulsar.common.functions.FunctionState;
 import org.apache.pulsar.common.functions.ProducerConfig;
 import org.apache.pulsar.common.functions.Resources;
 import org.apache.pulsar.common.functions.UpdateOptionsImpl;
 import org.apache.pulsar.common.functions.Utils;
 import org.apache.pulsar.common.functions.WindowConfig;
-import org.apache.pulsar.common.functions.FunctionState;
 import org.apache.pulsar.common.util.ObjectMapperFactory;
 
 @Slf4j
-@Parameters(commandDescription = "Interface for managing Pulsar Functions (lightweight, Lambda-style compute processes that work with Pulsar)")
+@Parameters(commandDescription = "Interface for managing Pulsar Functions "
+        + "(lightweight, Lambda-style compute processes that work with Pulsar)")
 public class CmdFunctions extends CmdBase {
     private final LocalRunner localRunner;
     private final CreateFunction creater;
@@ -84,7 +82,7 @@ public class CmdFunctions extends CmdBase {
     private final DownloadFunction downloader;
 
     /**
-     * Base command
+     * Base command.
      */
     @Getter
     abstract class BaseCommand extends CliCommand {
@@ -108,7 +106,7 @@ public class CmdFunctions extends CmdBase {
     }
 
     /**
-     * Namespace level command
+     * Namespace level command.
      */
     @Getter
     abstract class NamespaceCommand extends BaseCommand {
@@ -130,7 +128,7 @@ public class CmdFunctions extends CmdBase {
     }
 
     /**
-     * Function level command
+     * Function level command.
      */
     @Getter
     abstract class FunctionCommand extends BaseCommand {
@@ -155,8 +153,8 @@ public class CmdFunctions extends CmdBase {
 
             // Throw an exception if --fqfn is set alongside any combination of --tenant, --namespace, and --name
             if (usesFqfn && usesSetters) {
-                throw new RuntimeException(
-                        "You must specify either a Fully Qualified Function Name (FQFN) or tenant, namespace, and function name");
+                throw new RuntimeException("You must specify either a Fully Qualified Function Name (FQFN) "
+                        + "or tenant, namespace, and function name");
             } else if (usesFqfn) {
                 // If the --fqfn flag is used, parse tenant, namespace, and name using that flag
                 String[] fqfnParts = fqfn.split("/");
@@ -183,7 +181,7 @@ public class CmdFunctions extends CmdBase {
     }
 
     /**
-     * Commands that require a function config
+     * Commands that require a function config.
      */
     @Getter
     abstract class FunctionDetailsCommand extends BaseCommand {
@@ -197,182 +195,229 @@ public class CmdFunctions extends CmdBase {
         protected String functionName;
         // for backwards compatibility purposes
         @Parameter(names = "--className", description = "The class name of a Pulsar Function", hidden = true)
-        protected String DEPRECATED_className;
+        protected String deprecatedClassName;
         @Parameter(names = "--classname", description = "The class name of a Pulsar Function")
         protected String className;
-        @Parameter(names = "--jar", description = "Path to the JAR file for the function (if the function is written in Java). It also supports URL path [http/https/file (file protocol assumes that file already exists on worker host)/function (package URL from packages management service)] from which worker can download the package.", listConverter = StringConverter.class)
+        @Parameter(names = "--jar", description = "Path to the JAR file for the function "
+                + "(if the function is written in Java). It also supports URL path [http/https/file "
+                + "(file protocol assumes that file already exists on worker host)/function "
+                + "(package URL from packages management service)] from which worker can download the package.",
+                listConverter = StringConverter.class)
         protected String jarFile;
-        @Parameter(
-                names = "--py",
-                description = "Path to the main Python file/Python Wheel file for the function (if the function is written in Python). It also supports URL path [http/https/file (file protocol assumes that file already exists on worker host)/function (package URL from packages management service)] from which worker can download the package.",
+        @Parameter(names = "--py", description = "Path to the main Python file/Python Wheel file for the function "
+                + "(if the function is written in Python). It also supports URL path [http/https/file "
+                + "(file protocol assumes that file already exists on worker host)/function "
+                + "(package URL from packages management service)] from which worker can download the package.",
                 listConverter = StringConverter.class)
         protected String pyFile;
-        @Parameter(
-                names = "--go",
-                description = "Path to the main Go executable binary for the function (if the function is written in Go). It also supports URL path [http/https/file (file protocol assumes that file already exists on worker host)/function (package URL from packages management service)] from which worker can download the package.")
+        @Parameter(names = "--go", description = "Path to the main Go executable binary for the function "
+                + "(if the function is written in Go). It also supports URL path [http/https/file "
+                + "(file protocol assumes that file already exists on worker host)/function "
+                + "(package URL from packages management service)] from which worker can download the package.")
         protected String goFile;
-        @Parameter(names = {"-i",
-                "--inputs"}, description = "The input topic or topics (multiple topics can be specified as a comma-separated list) of a Pulsar Function")
+        @Parameter(names = {"-i", "--inputs"}, description = "The input topic or "
+                + "topics (multiple topics can be specified as a comma-separated list) of a Pulsar Function")
         protected String inputs;
         // for backwards compatibility purposes
-        @Parameter(names = "--topicsPattern", description = "TopicsPattern to consume from list of topics under a namespace that match the pattern. [--input] and [--topic-pattern] are mutually exclusive. Add SerDe class name for a pattern in --custom-serde-inputs (supported for java fun only)", hidden = true)
-        protected String DEPRECATED_topicsPattern;
-        @Parameter(names = "--topics-pattern", description = "The topic pattern to consume from list of topics under a namespace that match the pattern. [--input] and [--topic-pattern] are mutually exclusive. Add SerDe class name for a pattern in --custom-serde-inputs (supported for java fun only)")
+        @Parameter(names = "--topicsPattern", description = "TopicsPattern to consume from list of topics "
+                + "under a namespace that match the pattern. [--input] and [--topic-pattern] are mutually exclusive. "
+                + "Add SerDe class name for a pattern in --custom-serde-inputs (supported for java fun only)",
+                hidden = true)
+        protected String deprecatedTopicsPattern;
+        @Parameter(names = "--topics-pattern", description = "The topic pattern to consume from list of topics "
+                + "under a namespace that match the pattern. [--input] and [--topic-pattern] are mutually exclusive. "
+                + "Add SerDe class name for a pattern in --custom-serde-inputs (supported for java fun only)")
         protected String topicsPattern;
 
-        @Parameter(names = {"-o", "--output"}, description = "The output topic of a Pulsar Function (If none is specified, no output is written)")
+        @Parameter(names = {"-o", "--output"},
+                description = "The output topic of a Pulsar Function (If none is specified, no output is written)")
         protected String output;
-        @Parameter(names = "--producer-config", description = "The custom producer configuration (as a JSON string)" )
+        @Parameter(names = "--producer-config", description = "The custom producer configuration (as a JSON string)")
         protected String producerConfig;
         // for backwards compatibility purposes
-        @Parameter(names = "--logTopic", description = "The topic to which the logs of a Pulsar Function are produced", hidden = true)
-        protected String DEPRECATED_logTopic;
+        @Parameter(names = "--logTopic",
+                description = "The topic to which the logs of a Pulsar Function are produced", hidden = true)
+        protected String deprecatedLogTopic;
         @Parameter(names = "--log-topic", description = "The topic to which the logs of a Pulsar Function are produced")
         protected String logTopic;
 
-        @Parameter(names = {"-st", "--schema-type"}, description = "The builtin schema type or custom schema class name to be used for messages output by the function")
+        @Parameter(names = {"-st", "--schema-type"}, description = "The builtin schema type or "
+                + "custom schema class name to be used for messages output by the function")
         protected String schemaType = "";
 
         // for backwards compatibility purposes
-        @Parameter(names = "--customSerdeInputs", description = "The map of input topics to SerDe class names (as a JSON string)", hidden = true)
-        protected String DEPRECATED_customSerdeInputString;
-        @Parameter(names = "--custom-serde-inputs", description = "The map of input topics to SerDe class names (as a JSON string)")
+        @Parameter(names = "--customSerdeInputs",
+                description = "The map of input topics to SerDe class names (as a JSON string)", hidden = true)
+        protected String deprecatedCustomSerdeInputString;
+        @Parameter(names = "--custom-serde-inputs",
+                description = "The map of input topics to SerDe class names (as a JSON string)")
         protected String customSerdeInputString;
-        @Parameter(names = "--custom-schema-inputs", description = "The map of input topics to Schema properties (as a JSON string)")
+        @Parameter(names = "--custom-schema-inputs",
+                description = "The map of input topics to Schema properties (as a JSON string)")
         protected String customSchemaInputString;
-        @Parameter(names = "--custom-schema-outputs", description = "The map of input topics to Schema properties (as a JSON string)")
+        @Parameter(names = "--custom-schema-outputs",
+                description = "The map of input topics to Schema properties (as a JSON string)")
         protected String customSchemaOutputString;
-        @Parameter(names = "--input-specs", description = "The map of inputs to custom configuration (as a JSON string)")
+        @Parameter(names = "--input-specs",
+                description = "The map of inputs to custom configuration (as a JSON string)")
         protected String inputSpecs;
         // for backwards compatibility purposes
-        @Parameter(names = "--outputSerdeClassName", description = "The SerDe class to be used for messages output by the function", hidden = true)
-        protected String DEPRECATED_outputSerdeClassName;
-        @Parameter(names = "--output-serde-classname", description = "The SerDe class to be used for messages output by the function")
+        @Parameter(names = "--outputSerdeClassName",
+                description = "The SerDe class to be used for messages output by the function", hidden = true)
+        protected String deprecatedOutputSerdeClassName;
+        @Parameter(names = "--output-serde-classname",
+                description = "The SerDe class to be used for messages output by the function")
         protected String outputSerdeClassName;
         // for backwards compatibility purposes
-        @Parameter(names = "--functionConfigFile", description = "The path to a YAML config file that specifies the configuration of a Pulsar Function", hidden = true)
-        protected String DEPRECATED_fnConfigFile;
-        @Parameter(names = "--function-config-file", description = "The path to a YAML config file that specifies the configuration of a Pulsar Function")
+        @Parameter(names = "--functionConfigFile", description = "The path to a YAML config file that specifies "
+                + "the configuration of a Pulsar Function", hidden = true)
+        protected String deprecatedFnConfigFile;
+        @Parameter(names = "--function-config-file",
+                description = "The path to a YAML config file that specifies the configuration of a Pulsar Function")
         protected String fnConfigFile;
         // for backwards compatibility purposes
-        @Parameter(names = "--processingGuarantees", description = "The processing guarantees (aka delivery semantics) applied to the function", hidden = true)
-        protected FunctionConfig.ProcessingGuarantees DEPRECATED_processingGuarantees;
-        @Parameter(names = "--processing-guarantees", description = "The processing guarantees (aka delivery semantics) applied to the function")
+        @Parameter(names = "--processingGuarantees", description = "The processing guarantees (aka delivery semantics) "
+                + "applied to the function", hidden = true)
+        protected FunctionConfig.ProcessingGuarantees deprecatedProcessingGuarantees;
+        @Parameter(names = "--processing-guarantees",
+                description = "The processing guarantees (aka delivery semantics) applied to the function")
         protected FunctionConfig.ProcessingGuarantees processingGuarantees;
         // for backwards compatibility purposes
         @Parameter(names = "--userConfig", description = "User-defined config key/values", hidden = true)
-        protected String DEPRECATED_userConfigString;
+        protected String deprecatedUserConfigString;
         @Parameter(names = "--user-config", description = "User-defined config key/values")
         protected String userConfigString;
-        @Parameter(names = "--retainOrdering", description = "Function consumes and processes messages in order", hidden = true)
-        protected Boolean DEPRECATED_retainOrdering;
+        @Parameter(names = "--retainOrdering",
+                description = "Function consumes and processes messages in order", hidden = true)
+        protected Boolean deprecatedRetainOrdering;
         @Parameter(names = "--retain-ordering", description = "Function consumes and processes messages in order")
         protected Boolean retainOrdering;
-        @Parameter(names = "--retain-key-ordering", description = "Function consumes and processes messages in key order")
+        @Parameter(names = "--retain-key-ordering",
+                description = "Function consumes and processes messages in key order")
         protected Boolean retainKeyOrdering;
-        @Parameter(names = "--batch-builder", description = "BatcherBuilder provides two types of batch construction methods, DEFAULT and KEY_BASED. The default value is: DEFAULT")
+        @Parameter(names = "--batch-builder", description = "BatcherBuilder provides two types of "
+                + "batch construction methods, DEFAULT and KEY_BASED. The default value is: DEFAULT")
         protected String batchBuilder;
-        @Parameter(names = "--forward-source-message-property", description = "Forwarding input message's properties to output topic when processing (use false to disable it)", arity = 1)
+        @Parameter(names = "--forward-source-message-property", description = "Forwarding input message's properties "
+                + "to output topic when processing (use false to disable it)", arity = 1)
         protected Boolean forwardSourceMessageProperty = true;
-        @Parameter(names = "--subs-name", description = "Pulsar source subscription name if user wants a specific subscription-name for input-topic consumer")
+        @Parameter(names = "--subs-name", description = "Pulsar source subscription name if user wants a specific "
+                + "subscription-name for input-topic consumer")
         protected String subsName;
-        @Parameter(names = "--subs-position", description = "Pulsar source subscription position if user wants to consume messages from the specified location")
+        @Parameter(names = "--subs-position", description = "Pulsar source subscription position if user wants to "
+                + "consume messages from the specified location")
         protected SubscriptionInitialPosition subsPosition;
-        @Parameter(names = "--parallelism", description = "The parallelism factor of a Pulsar Function (i.e. the number of function instances to run)")
+        @Parameter(names = "--parallelism", description = "The parallelism factor of a Pulsar Function "
+                + "(i.e. the number of function instances to run)")
         protected Integer parallelism;
-        @Parameter(names = "--cpu", description = "The cpu in cores that need to be allocated per function instance(applicable only to docker runtime)")
+        @Parameter(names = "--cpu", description = "The cpu in cores that need to be allocated "
+                + "per function instance(applicable only to docker runtime)")
         protected Double cpu;
-        @Parameter(names = "--ram", description = "The ram in bytes that need to be allocated per function instance(applicable only to process/docker runtime)")
+        @Parameter(names = "--ram", description = "The ram in bytes that need to be allocated "
+                + "per function instance(applicable only to process/docker runtime)")
         protected Long ram;
-        @Parameter(names = "--disk", description = "The disk in bytes that need to be allocated per function instance(applicable only to docker runtime)")
+        @Parameter(names = "--disk", description = "The disk in bytes that need to be allocated "
+                + "per function instance(applicable only to docker runtime)")
         protected Long disk;
         // for backwards compatibility purposes
         @Parameter(names = "--windowLengthCount", description = "The number of messages per window", hidden = true)
-        protected Integer DEPRECATED_windowLengthCount;
+        protected Integer deprecatedWindowLengthCount;
         @Parameter(names = "--window-length-count", description = "The number of messages per window")
         protected Integer windowLengthCount;
         // for backwards compatibility purposes
-        @Parameter(names = "--windowLengthDurationMs", description = "The time duration of the window in milliseconds", hidden = true)
-        protected Long DEPRECATED_windowLengthDurationMs;
-        @Parameter(names = "--window-length-duration-ms", description = "The time duration of the window in milliseconds")
+        @Parameter(names = "--windowLengthDurationMs",
+                description = "The time duration of the window in milliseconds", hidden = true)
+        protected Long deprecatedWindowLengthDurationMs;
+        @Parameter(names = "--window-length-duration-ms",
+                description = "The time duration of the window in milliseconds")
         protected Long windowLengthDurationMs;
         // for backwards compatibility purposes
-        @Parameter(names = "--slidingIntervalCount", description = "The number of messages after which the window slides", hidden = true)
-        protected Integer DEPRECATED_slidingIntervalCount;
-        @Parameter(names = "--sliding-interval-count", description = "The number of messages after which the window slides")
+        @Parameter(names = "--slidingIntervalCount",
+                description = "The number of messages after which the window slides", hidden = true)
+        protected Integer deprecatedSlidingIntervalCount;
+        @Parameter(names = "--sliding-interval-count",
+                description = "The number of messages after which the window slides")
         protected Integer slidingIntervalCount;
         // for backwards compatibility purposes
-        @Parameter(names = "--slidingIntervalDurationMs", description = "The time duration after which the window slides", hidden = true)
-        protected Long DEPRECATED_slidingIntervalDurationMs;
-        @Parameter(names = "--sliding-interval-duration-ms", description = "The time duration after which the window slides")
+        @Parameter(names = "--slidingIntervalDurationMs",
+                description = "The time duration after which the window slides", hidden = true)
+        protected Long deprecatedSlidingIntervalDurationMs;
+        @Parameter(names = "--sliding-interval-duration-ms",
+                description = "The time duration after which the window slides")
         protected Long slidingIntervalDurationMs;
         // for backwards compatibility purposes
-        @Parameter(names = "--autoAck", description = "Whether or not the framework acknowledges messages automatically", hidden = true)
-        protected Boolean DEPRECATED_autoAck = null;
-        @Parameter(names = "--auto-ack", description = "Whether or not the framework acknowledges messages automatically", arity = 1)
+        @Parameter(names = "--autoAck",
+                description = "Whether or not the framework acknowledges messages automatically", hidden = true)
+        protected Boolean deprecatedAutoAck = null;
+        @Parameter(names = "--auto-ack",
+                description = "Whether or not the framework acknowledges messages automatically", arity = 1)
         protected Boolean autoAck;
         // for backwards compatibility purposes
         @Parameter(names = "--timeoutMs", description = "The message timeout in milliseconds", hidden = true)
-        protected Long DEPRECATED_timeoutMs;
+        protected Long deprecatedTimeoutMs;
         @Parameter(names = "--timeout-ms", description = "The message timeout in milliseconds")
         protected Long timeoutMs;
-        @Parameter(names = "--max-message-retries", description = "How many times should we try to process a message before giving up")
+        @Parameter(names = "--max-message-retries",
+                description = "How many times should we try to process a message before giving up")
         protected Integer maxMessageRetries;
-        @Parameter(names = "--custom-runtime-options", description = "A string that encodes options to customize the runtime, see docs for configured runtime for details")
+        @Parameter(names = "--custom-runtime-options", description = "A string that encodes options to "
+                + "customize the runtime, see docs for configured runtime for details")
         protected String customRuntimeOptions;
-        @Parameter(names = "--secrets", description = "The map of secretName to an object that encapsulates how the secret is fetched by the underlying secrets provider")
+        @Parameter(names = "--secrets", description = "The map of secretName to an object that encapsulates "
+                + "how the secret is fetched by the underlying secrets provider")
         protected String secretsString;
-        @Parameter(names = "--dead-letter-topic", description = "The topic where messages that are not processed successfully are sent to")
+        @Parameter(names = "--dead-letter-topic",
+                description = "The topic where messages that are not processed successfully are sent to")
         protected String deadLetterTopic;
         protected FunctionConfig functionConfig;
         protected String userCodeFile;
 
         private void mergeArgs() {
-            if (isBlank(className) && !isBlank(DEPRECATED_className)) {
-                className = DEPRECATED_className;
+            if (isBlank(className) && !isBlank(deprecatedClassName)) {
+                className = deprecatedClassName;
             }
-            if (isBlank(topicsPattern) && !isBlank(DEPRECATED_topicsPattern)) {
-                topicsPattern = DEPRECATED_topicsPattern;
+            if (isBlank(topicsPattern) && !isBlank(deprecatedTopicsPattern)) {
+                topicsPattern = deprecatedTopicsPattern;
             }
-            if (isBlank(logTopic) && !isBlank(DEPRECATED_logTopic)) {
-                logTopic = DEPRECATED_logTopic;
+            if (isBlank(logTopic) && !isBlank(deprecatedLogTopic)) {
+                logTopic = deprecatedLogTopic;
             }
-            if (isBlank(outputSerdeClassName) && !isBlank(DEPRECATED_outputSerdeClassName)) {
-                outputSerdeClassName = DEPRECATED_outputSerdeClassName;
+            if (isBlank(outputSerdeClassName) && !isBlank(deprecatedOutputSerdeClassName)) {
+                outputSerdeClassName = deprecatedOutputSerdeClassName;
             }
-            if (isBlank(customSerdeInputString) && !isBlank(DEPRECATED_customSerdeInputString)) {
-                customSerdeInputString = DEPRECATED_customSerdeInputString;
+            if (isBlank(customSerdeInputString) && !isBlank(deprecatedCustomSerdeInputString)) {
+                customSerdeInputString = deprecatedCustomSerdeInputString;
             }
 
-            if (isBlank(fnConfigFile) && !isBlank(DEPRECATED_fnConfigFile)) {
-                fnConfigFile = DEPRECATED_fnConfigFile;
+            if (isBlank(fnConfigFile) && !isBlank(deprecatedFnConfigFile)) {
+                fnConfigFile = deprecatedFnConfigFile;
             }
-            if (processingGuarantees == null && DEPRECATED_processingGuarantees != null) {
-                processingGuarantees = DEPRECATED_processingGuarantees;
+            if (processingGuarantees == null && deprecatedProcessingGuarantees != null) {
+                processingGuarantees = deprecatedProcessingGuarantees;
             }
-            if (isBlank(userConfigString) && !isBlank(DEPRECATED_userConfigString)) {
-                userConfigString = DEPRECATED_userConfigString;
+            if (isBlank(userConfigString) && !isBlank(deprecatedUserConfigString)) {
+                userConfigString = deprecatedUserConfigString;
             }
-            if (retainOrdering == null && DEPRECATED_retainOrdering != null) {
-                retainOrdering = DEPRECATED_retainOrdering;
+            if (retainOrdering == null && deprecatedRetainOrdering != null) {
+                retainOrdering = deprecatedRetainOrdering;
             }
-            if (windowLengthCount == null && DEPRECATED_windowLengthCount != null) {
-                windowLengthCount = DEPRECATED_windowLengthCount;
+            if (windowLengthCount == null && deprecatedWindowLengthCount != null) {
+                windowLengthCount = deprecatedWindowLengthCount;
             }
-            if (windowLengthDurationMs == null && DEPRECATED_windowLengthDurationMs != null) {
-                windowLengthDurationMs = DEPRECATED_windowLengthDurationMs;
+            if (windowLengthDurationMs == null && deprecatedWindowLengthDurationMs != null) {
+                windowLengthDurationMs = deprecatedWindowLengthDurationMs;
             }
-            if (slidingIntervalCount == null && DEPRECATED_slidingIntervalCount != null) {
-                slidingIntervalCount = DEPRECATED_slidingIntervalCount;
+            if (slidingIntervalCount == null && deprecatedSlidingIntervalCount != null) {
+                slidingIntervalCount = deprecatedSlidingIntervalCount;
             }
-            if (slidingIntervalDurationMs == null && DEPRECATED_slidingIntervalDurationMs != null) {
-                slidingIntervalDurationMs = DEPRECATED_slidingIntervalDurationMs;
+            if (slidingIntervalDurationMs == null && deprecatedSlidingIntervalDurationMs != null) {
+                slidingIntervalDurationMs = deprecatedSlidingIntervalDurationMs;
             }
-            if (autoAck == null && DEPRECATED_autoAck != null) {
-                autoAck = DEPRECATED_autoAck;
+            if (autoAck == null && deprecatedAutoAck != null) {
+                autoAck = deprecatedAutoAck;
             }
-            if (timeoutMs == null && DEPRECATED_timeoutMs != null) {
-                timeoutMs = DEPRECATED_timeoutMs;
+            if (timeoutMs == null && deprecatedTimeoutMs != null) {
+                timeoutMs = deprecatedTimeoutMs;
             }
         }
 
@@ -598,7 +643,8 @@ public class CmdFunctions extends CmdBase {
 
         protected void validateFunctionConfigs(FunctionConfig functionConfig) {
             // go doesn't need className
-            if (functionConfig.getRuntime() == FunctionConfig.Runtime.PYTHON || functionConfig.getRuntime() == FunctionConfig.Runtime.JAVA){
+            if (functionConfig.getRuntime() == FunctionConfig.Runtime.PYTHON
+                    || functionConfig.getRuntime() == FunctionConfig.Runtime.JAVA){
                 if (StringUtils.isEmpty(functionConfig.getClassName())) {
                     throw new IllegalArgumentException("No Function Classname specified");
                 }
@@ -613,26 +659,28 @@ public class CmdFunctions extends CmdBase {
                 org.apache.pulsar.common.functions.Utils.inferMissingNamespace(functionConfig);
             }
 
-            if (isNotBlank(functionConfig.getJar()) && isNotBlank(functionConfig.getPy()) && isNotBlank(functionConfig.getGo())) {
+            if (isNotBlank(functionConfig.getJar()) && isNotBlank(functionConfig.getPy())
+                    && isNotBlank(functionConfig.getGo())) {
                 throw new ParameterException("Either a Java jar or a Python file or a Go executable binary needs to"
                         + " be specified for the function. Cannot specify both.");
             }
 
-            if (isBlank(functionConfig.getJar()) && isBlank(functionConfig.getPy()) && isBlank(functionConfig.getGo())) {
+            if (isBlank(functionConfig.getJar()) && isBlank(functionConfig.getPy())
+                    && isBlank(functionConfig.getGo())) {
                 throw new ParameterException("Either a Java jar or a Python file or a Go executable binary needs to"
                         + " be specified for the function. Please specify one.");
             }
 
-            if (!isBlank(functionConfig.getJar()) && !Utils.isFunctionPackageUrlSupported(functionConfig.getJar()) &&
-                    !new File(functionConfig.getJar()).exists()) {
+            if (!isBlank(functionConfig.getJar()) && !Utils.isFunctionPackageUrlSupported(functionConfig.getJar())
+                    && !new File(functionConfig.getJar()).exists()) {
                 throw new ParameterException("The specified jar file does not exist");
             }
-            if (!isBlank(functionConfig.getPy()) && !Utils.isFunctionPackageUrlSupported(functionConfig.getPy()) &&
-                    !new File(functionConfig.getPy()).exists()) {
+            if (!isBlank(functionConfig.getPy()) && !Utils.isFunctionPackageUrlSupported(functionConfig.getPy())
+                    && !new File(functionConfig.getPy()).exists()) {
                 throw new ParameterException("The specified python file does not exist");
             }
-            if (!isBlank(functionConfig.getGo()) && !Utils.isFunctionPackageUrlSupported(functionConfig.getGo()) &&
-                    !new File(functionConfig.getGo()).exists()) {
+            if (!isBlank(functionConfig.getGo()) && !Utils.isFunctionPackageUrlSupported(functionConfig.getGo())
+                    && !new File(functionConfig.getGo()).exists()) {
                 throw new ParameterException("The specified go executable binary does not exist");
             }
         }
@@ -643,88 +691,94 @@ public class CmdFunctions extends CmdBase {
 
         // TODO: this should become BookKeeper URL and it should be fetched from Pulsar client.
         // for backwards compatibility purposes
-        @Parameter(names = "--stateStorageServiceUrl", description = "The URL for the state storage service (the default is Apache BookKeeper)", hidden = true)
-        protected String DEPRECATED_stateStorageServiceUrl;
-        @Parameter(names = "--state-storage-service-url", description = "The URL for the state storage service (the default is Apache BookKeeper)")
+        @Parameter(names = "--stateStorageServiceUrl", description = "The URL for the state storage service "
+                + "(the default is Apache BookKeeper)", hidden = true)
+        protected String deprecatedStateStorageServiceUrl;
+        @Parameter(names = "--state-storage-service-url", description = "The URL for the state storage service "
+                + "(the default is Apache BookKeeper)")
         protected String stateStorageServiceUrl;
         // for backwards compatibility purposes
         @Parameter(names = "--brokerServiceUrl", description = "The URL for Pulsar broker", hidden = true)
-        protected String DEPRECATED_brokerServiceUrl;
+        protected String deprecatedBrokerServiceUrl;
         @Parameter(names = "--broker-service-url", description = "The URL for Pulsar broker")
         protected String brokerServiceUrl;
         @Parameter(names = "--web-service-url", description = "The URL for Pulsar web service")
         protected String webServiceUrl = null;
         // for backwards compatibility purposes
-        @Parameter(names = "--clientAuthPlugin", description = "Client authentication plugin using which function-process can connect to broker", hidden = true)
-        protected String DEPRECATED_clientAuthPlugin;
-        @Parameter(names = "--client-auth-plugin", description = "Client authentication plugin using which function-process can connect to broker")
+        @Parameter(names = "--clientAuthPlugin", description = "Client authentication plugin using "
+                + "which function-process can connect to broker", hidden = true)
+        protected String deprecatedClientAuthPlugin;
+        @Parameter(names = "--client-auth-plugin",
+                description = "Client authentication plugin using which function-process can connect to broker")
         protected String clientAuthPlugin;
         // for backwards compatibility purposes
         @Parameter(names = "--clientAuthParams", description = "Client authentication param", hidden = true)
-        protected String DEPRECATED_clientAuthParams;
+        protected String deprecatedClientAuthParams;
         @Parameter(names = "--client-auth-params", description = "Client authentication param")
         protected String clientAuthParams;
         // for backwards compatibility purposes
         @Parameter(names = "--use_tls", description = "Use tls connection", hidden = true)
-        protected Boolean DEPRECATED_useTls = null;
+        protected Boolean deprecatedUseTls = null;
         @Parameter(names = "--use-tls", description = "Use tls connection")
         protected boolean useTls;
         // for backwards compatibility purposes
         @Parameter(names = "--tls_allow_insecure", description = "Allow insecure tls connection", hidden = true)
-        protected Boolean DEPRECATED_tlsAllowInsecureConnection = null;
+        protected Boolean deprecatedTlsAllowInsecureConnection = null;
         @Parameter(names = "--tls-allow-insecure", description = "Allow insecure tls connection")
         protected boolean tlsAllowInsecureConnection;
         // for backwards compatibility purposes
-        @Parameter(names = "--hostname_verification_enabled", description = "Enable hostname verification", hidden = true)
-        protected Boolean DEPRECATED_tlsHostNameVerificationEnabled = null;
+        @Parameter(names = "--hostname_verification_enabled",
+                description = "Enable hostname verification", hidden = true)
+        protected Boolean deprecatedTlsHostNameVerificationEnabled = null;
         @Parameter(names = "--hostname-verification-enabled", description = "Enable hostname verification")
         protected boolean tlsHostNameVerificationEnabled;
         // for backwards compatibility purposes
         @Parameter(names = "--tls_trust_cert_path", description = "tls trust cert file path", hidden = true)
-        protected String DEPRECATED_tlsTrustCertFilePath;
+        protected String deprecatedTlsTrustCertFilePath;
         @Parameter(names = "--tls-trust-cert-path", description = "tls trust cert file path")
         protected String tlsTrustCertFilePath;
         // for backwards compatibility purposes
         @Parameter(names = "--instanceIdOffset", description = "Start the instanceIds from this offset", hidden = true)
-        protected Integer DEPRECATED_instanceIdOffset = null;
+        protected Integer deprecatedInstanceIdOffset = null;
         @Parameter(names = "--instance-id-offset", description = "Start the instanceIds from this offset")
         protected Integer instanceIdOffset = 0;
         @Parameter(names = "--runtime", description = "either THREAD or PROCESS. Only applies for Java functions")
         protected String runtime;
         @Parameter(names = "--secrets-provider-classname", description = "Whats the classname for secrets provider")
         protected String secretsProviderClassName;
-        @Parameter(names = "--secrets-provider-config", description = "Config that needs to be passed to secrets provider")
+        @Parameter(names = "--secrets-provider-config",
+                description = "Config that needs to be passed to secrets provider")
         protected String secretsProviderConfig;
         @Parameter(names = "--metrics-port-start", description = "The starting port range for metrics server")
         protected String metricsPortStart;
 
         private void mergeArgs() {
-            if (isBlank(stateStorageServiceUrl) && !isBlank(DEPRECATED_stateStorageServiceUrl)) {
-                stateStorageServiceUrl = DEPRECATED_stateStorageServiceUrl;
+            if (isBlank(stateStorageServiceUrl) && !isBlank(deprecatedStateStorageServiceUrl)) {
+                stateStorageServiceUrl = deprecatedStateStorageServiceUrl;
             }
-            if (isBlank(brokerServiceUrl) && !isBlank(DEPRECATED_brokerServiceUrl)) {
-                brokerServiceUrl = DEPRECATED_brokerServiceUrl;
+            if (isBlank(brokerServiceUrl) && !isBlank(deprecatedBrokerServiceUrl)) {
+                brokerServiceUrl = deprecatedBrokerServiceUrl;
             }
-            if (isBlank(clientAuthPlugin) && !isBlank(DEPRECATED_clientAuthPlugin)) {
-                clientAuthPlugin = DEPRECATED_clientAuthPlugin;
+            if (isBlank(clientAuthPlugin) && !isBlank(deprecatedClientAuthPlugin)) {
+                clientAuthPlugin = deprecatedClientAuthPlugin;
             }
-            if (isBlank(clientAuthParams) && !isBlank(DEPRECATED_clientAuthParams)) {
-                clientAuthParams = DEPRECATED_clientAuthParams;
+            if (isBlank(clientAuthParams) && !isBlank(deprecatedClientAuthParams)) {
+                clientAuthParams = deprecatedClientAuthParams;
             }
-            if (!useTls && DEPRECATED_useTls != null) {
-                useTls = DEPRECATED_useTls;
+            if (!useTls && deprecatedUseTls != null) {
+                useTls = deprecatedUseTls;
             }
-            if (!tlsAllowInsecureConnection && DEPRECATED_tlsAllowInsecureConnection != null) {
-                tlsAllowInsecureConnection = DEPRECATED_tlsAllowInsecureConnection;
+            if (!tlsAllowInsecureConnection && deprecatedTlsAllowInsecureConnection != null) {
+                tlsAllowInsecureConnection = deprecatedTlsAllowInsecureConnection;
             }
-            if (!tlsHostNameVerificationEnabled && DEPRECATED_tlsHostNameVerificationEnabled != null) {
-                tlsHostNameVerificationEnabled = DEPRECATED_tlsHostNameVerificationEnabled;
+            if (!tlsHostNameVerificationEnabled && deprecatedTlsHostNameVerificationEnabled != null) {
+                tlsHostNameVerificationEnabled = deprecatedTlsHostNameVerificationEnabled;
             }
-            if (isBlank(tlsTrustCertFilePath) && !isBlank(DEPRECATED_tlsTrustCertFilePath)) {
-                tlsTrustCertFilePath = DEPRECATED_tlsTrustCertFilePath;
+            if (isBlank(tlsTrustCertFilePath) && !isBlank(deprecatedTlsTrustCertFilePath)) {
+                tlsTrustCertFilePath = deprecatedTlsTrustCertFilePath;
             }
-            if (instanceIdOffset == null && DEPRECATED_instanceIdOffset != null) {
-                instanceIdOffset = DEPRECATED_instanceIdOffset;
+            if (instanceIdOffset == null && deprecatedInstanceIdOffset != null) {
+                instanceIdOffset = deprecatedInstanceIdOffset;
             }
         }
 
@@ -737,8 +791,12 @@ public class CmdFunctions extends CmdBase {
             localRunArgs.add("--functionConfig");
             localRunArgs.add(new Gson().toJson(functionConfig));
             for (Field field : this.getClass().getDeclaredFields()) {
-                if (field.getName().startsWith("DEPRECATED")) continue;
-                if(field.getName().contains("$")) continue;
+                if (field.getName().startsWith("DEPRECATED")) {
+                    continue;
+                }
+                if (field.getName().contains("$")) {
+                    continue;
+                }
                 Object value = field.get(this);
                 if (value != null) {
                     localRunArgs.add("--" + field.getName());
@@ -782,7 +840,8 @@ public class CmdFunctions extends CmdBase {
     @Parameters(commandDescription = "Check the current status of a Pulsar Function")
     class GetFunctionStatus extends FunctionCommand {
 
-        @Parameter(names = "--instance-id", description = "The function instanceId (Get-status of all instances if instance-id is not provided)")
+        @Parameter(names = "--instance-id", description = "The function instanceId "
+                + "(Get-status of all instances if instance-id is not provided)")
         protected String instanceId;
 
         @Override
@@ -790,7 +849,8 @@ public class CmdFunctions extends CmdBase {
             if (isBlank(instanceId)) {
                 print(getAdmin().functions().getFunctionStatus(tenant, namespace, functionName));
             } else {
-                print(getAdmin().functions().getFunctionStatus(tenant, namespace, functionName, Integer.parseInt(instanceId)));
+                print(getAdmin().functions()
+                        .getFunctionStatus(tenant, namespace, functionName, Integer.parseInt(instanceId)));
             }
         }
     }
@@ -798,7 +858,8 @@ public class CmdFunctions extends CmdBase {
     @Parameters(commandDescription = "Get the current stats of a Pulsar Function")
     class GetFunctionStats extends FunctionCommand {
 
-        @Parameter(names = "--instance-id", description = "The function instanceId (Get-stats of all instances if instance-id is not provided)")
+        @Parameter(names = "--instance-id", description = "The function instanceId "
+                + "(Get-stats of all instances if instance-id is not provided)")
         protected String instanceId;
 
         @Override
@@ -807,7 +868,8 @@ public class CmdFunctions extends CmdBase {
             if (isBlank(instanceId)) {
                 print(getAdmin().functions().getFunctionStats(tenant, namespace, functionName));
             } else {
-               print(getAdmin().functions().getFunctionStats(tenant, namespace, functionName, Integer.parseInt(instanceId)));
+               print(getAdmin().functions()
+                       .getFunctionStats(tenant, namespace, functionName, Integer.parseInt(instanceId)));
             }
         }
     }
@@ -815,14 +877,16 @@ public class CmdFunctions extends CmdBase {
     @Parameters(commandDescription = "Restart function instance")
     class RestartFunction extends FunctionCommand {
 
-        @Parameter(names = "--instance-id", description = "The function instanceId (restart all instances if instance-id is not provided)")
+        @Parameter(names = "--instance-id", description = "The function instanceId "
+                + "(restart all instances if instance-id is not provided)")
         protected String instanceId;
 
         @Override
         void runCmd() throws Exception {
             if (isNotBlank(instanceId)) {
                 try {
-                    getAdmin().functions().restartFunction(tenant, namespace, functionName, Integer.parseInt(instanceId));
+                    getAdmin().functions()
+                            .restartFunction(tenant, namespace, functionName, Integer.parseInt(instanceId));
                 } catch (NumberFormatException e) {
                     System.err.println("instance-id must be a number");
                 }
@@ -836,7 +900,8 @@ public class CmdFunctions extends CmdBase {
     @Parameters(commandDescription = "Stops function instance")
     class StopFunction extends FunctionCommand {
 
-        @Parameter(names = "--instance-id", description = "The function instanceId (stop all instances if instance-id is not provided)")
+        @Parameter(names = "--instance-id", description = "The function instanceId "
+                + "(stop all instances if instance-id is not provided)")
         protected String instanceId;
 
         @Override
@@ -857,7 +922,8 @@ public class CmdFunctions extends CmdBase {
     @Parameters(commandDescription = "Starts a stopped function instance")
     class StartFunction extends FunctionCommand {
 
-        @Parameter(names = "--instance-id", description = "The function instanceId (start all instances if instance-id is not provided)")
+        @Parameter(names = "--instance-id", description = "The function instanceId "
+                + "(start all instances if instance-id is not provided)")
         protected String instanceId;
 
         @Override
@@ -935,7 +1001,8 @@ public class CmdFunctions extends CmdBase {
         @Parameter(names = { "-k", "--key" }, description = "Key name of State")
         private String key = null;
 
-        @Parameter(names = { "-w", "--watch" }, description = "Watch for changes in the value associated with a key for a Pulsar Function")
+        @Parameter(names = { "-w", "--watch" }, description = "Watch for changes in the value associated with a key "
+                + "for a Pulsar Function")
         private boolean watch = false;
 
         @Override
@@ -971,8 +1038,7 @@ public class CmdFunctions extends CmdBase {
 
         @Override
         void runCmd() throws Exception {
-            TypeReference<FunctionState> typeRef
-                    = new TypeReference<FunctionState>() {};
+            TypeReference<FunctionState> typeRef = new TypeReference<FunctionState>() {};
             FunctionState stateRepr = ObjectMapperFactory.getThreadLocal().readValue(state, typeRef);
             getAdmin().functions()
                     .putFunctionState(tenant, namespace, functionName, stateRepr);
@@ -982,24 +1048,28 @@ public class CmdFunctions extends CmdBase {
     @Parameters(commandDescription = "Trigger the specified Pulsar Function with a supplied value")
     class TriggerFunction extends FunctionCommand {
         // for backward compatibility purposes
-        @Parameter(names = "--triggerValue", description = "The value with which you want to trigger the function", hidden = true)
-        protected String DEPRECATED_triggerValue;
+        @Parameter(names = "--triggerValue",
+                description = "The value with which you want to trigger the function", hidden = true)
+        protected String deprecatedTriggerValue;
         @Parameter(names = "--trigger-value", description = "The value with which you want to trigger the function")
         protected String triggerValue;
         // for backward compatibility purposes
-        @Parameter(names = "--triggerFile", description = "The path to the file that contains the data with which you want to trigger the function", hidden = true)
-        protected String DEPRECATED_triggerFile;
-        @Parameter(names = "--trigger-file", description = "The path to the file that contains the data with which you want to trigger the function")
+        @Parameter(names = "--triggerFile", description = "The path to the file that contains the data with which "
+                + "you want to trigger the function", hidden = true)
+        protected String deprecatedTriggerFile;
+        @Parameter(names = "--trigger-file", description = "The path to the file that contains the data with which "
+                + "you want to trigger the function")
         protected String triggerFile;
-        @Parameter(names = "--topic", description = "The specific topic name that the function consumes from that you want to inject the data to")
+        @Parameter(names = "--topic", description = "The specific topic name that the function consumes from that"
+                + " you want to inject the data to")
         protected String topic;
 
         public void mergeArgs() {
-            if (isBlank(triggerValue) && !isBlank(DEPRECATED_triggerValue)) {
-                triggerValue = DEPRECATED_triggerValue;
+            if (isBlank(triggerValue) && !isBlank(deprecatedTriggerValue)) {
+                triggerValue = deprecatedTriggerValue;
             }
-            if (isBlank(triggerFile) && !isBlank(DEPRECATED_triggerFile)) {
-                triggerFile = DEPRECATED_triggerFile;
+            if (isBlank(triggerFile) && !isBlank(deprecatedTriggerFile)) {
+                triggerFile = deprecatedTriggerFile;
             }
         }
 
@@ -1010,7 +1080,8 @@ public class CmdFunctions extends CmdBase {
             if (triggerFile == null && triggerValue == null) {
                 throw new ParameterException("Either a trigger value or a trigger filepath needs to be specified");
             }
-            String retval = getAdmin().functions().triggerFunction(tenant, namespace, functionName, topic, triggerValue, triggerFile);
+            String retval = getAdmin().functions()
+                    .triggerFunction(tenant, namespace, functionName, topic, triggerValue, triggerFile);
             System.out.println(retval);
         }
     }
@@ -1022,7 +1093,7 @@ public class CmdFunctions extends CmdBase {
                 names = "--sourceFile",
                 description = "The file whose contents need to be uploaded",
                 listConverter = StringConverter.class, hidden = true)
-        protected String DEPRECATED_sourceFile;
+        protected String deprecatedSourceFile;
         @Parameter(
                 names = "--source-file",
                 description = "The file whose contents need to be uploaded",
@@ -1035,8 +1106,8 @@ public class CmdFunctions extends CmdBase {
         protected String path;
 
         private void mergeArgs() {
-            if (isBlank(sourceFile) && !isBlank(DEPRECATED_sourceFile)) {
-                sourceFile = DEPRECATED_sourceFile;
+            if (isBlank(sourceFile) && !isBlank(deprecatedSourceFile)) {
+                sourceFile = deprecatedSourceFile;
             }
         }
 
@@ -1059,7 +1130,7 @@ public class CmdFunctions extends CmdBase {
                 names = "--destinationFile",
                 description = "The file to store downloaded content",
                 listConverter = StringConverter.class, hidden = true)
-        protected String DEPRECATED_destinationFile;
+        protected String deprecatedDestinationFile;
         @Parameter(
                 names = "--destination-file",
                 description = "The file to store downloaded content",
@@ -1072,8 +1143,8 @@ public class CmdFunctions extends CmdBase {
         protected String path;
 
         private void mergeArgs() {
-            if (isBlank(destinationFile) && !isBlank(DEPRECATED_destinationFile)) {
-                destinationFile = DEPRECATED_destinationFile;
+            if (isBlank(destinationFile) && !isBlank(deprecatedDestinationFile)) {
+                destinationFile = deprecatedDestinationFile;
             }
         }
 
@@ -1163,7 +1234,9 @@ public class CmdFunctions extends CmdBase {
     }
 
     @VisibleForTesting
-    GetFunctionStatus getStatuser() { return functionStatus; }
+    GetFunctionStatus getStatuser() {
+        return functionStatus;
+    }
 
     @VisibleForTesting
     ListFunctions getLister() {
@@ -1213,7 +1286,8 @@ public class CmdFunctions extends CmdBase {
     private void parseFullyQualifiedFunctionName(String fqfn, FunctionConfig functionConfig) {
         String[] args = fqfn.split("/");
         if (args.length != 3) {
-            throw new ParameterException("Fully qualified function names (FQFNs) must be of the form tenant/namespace/name");
+            throw new ParameterException("Fully qualified function names (FQFNs) must "
+                    + "be of the form tenant/namespace/name");
         } else {
             functionConfig.setTenant(args[0]);
             functionConfig.setNamespace(args[1]);

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdGenerateDocument.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdGenerateDocument.java
@@ -24,15 +24,14 @@ import com.beust.jcommander.JCommander;
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.ParameterDescription;
 import com.beust.jcommander.Parameters;
-import lombok.Getter;
-import lombok.extern.slf4j.Slf4j;
-import org.apache.pulsar.client.admin.PulsarAdmin;
-import org.apache.pulsar.client.admin.PulsarAdminException;
-
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.function.Supplier;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.pulsar.client.admin.PulsarAdmin;
+import org.apache.pulsar.client.admin.PulsarAdminException;
 
 @Getter
 @Parameters(commandDescription = "Generate documents automatically.")
@@ -75,9 +74,9 @@ public class CmdGenerateDocument extends CmdBase {
     @Parameters(commandDescription = "Generate document for modules")
     private class GenerateDocument extends CliCommand {
 
-        @Parameter(description = "Please specify the module name, if not, documents will be generated for all modules." +
-                "Optional modules(clusters, tenants, brokers, broker-stats, namespaces, topics, schemas, bookies," +
-                "functions, ns-isolation-policy, resource-quotas, functions, sources, sinks)")
+        @Parameter(description = "Please specify the module name, if not, documents will be generated for all modules."
+                + "Optional modules(clusters, tenants, brokers, broker-stats, namespaces, topics, schemas, bookies,"
+                + "functions, ns-isolation-policy, resource-quotas, functions, sources, sinks)")
         private java.util.List<String> modules;
 
         @Override

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdNamespaceIsolationPolicy.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdNamespaceIsolationPolicy.java
@@ -18,48 +18,59 @@
  */
 package org.apache.pulsar.admin.cli;
 
+import com.beust.jcommander.Parameter;
+import com.beust.jcommander.ParameterException;
+import com.beust.jcommander.Parameters;
+import com.beust.jcommander.converters.CommaParameterSplitter;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
-
 import org.apache.commons.lang3.StringUtils;
 import org.apache.pulsar.admin.cli.utils.NameValueParameterSplitter;
 import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.admin.PulsarAdminException;
 import org.apache.pulsar.common.policies.data.AutoFailoverPolicyData;
 import org.apache.pulsar.common.policies.data.AutoFailoverPolicyType;
-import org.apache.pulsar.common.policies.data.BrokerNamespaceIsolationDataImpl;
 import org.apache.pulsar.common.policies.data.BrokerNamespaceIsolationData;
-import org.apache.pulsar.common.policies.data.NamespaceIsolationDataImpl;
-
-import com.beust.jcommander.Parameter;
-import com.beust.jcommander.ParameterException;
-import com.beust.jcommander.Parameters;
-import com.beust.jcommander.converters.CommaParameterSplitter;
+import org.apache.pulsar.common.policies.data.BrokerNamespaceIsolationDataImpl;
 import org.apache.pulsar.common.policies.data.NamespaceIsolationData;
+import org.apache.pulsar.common.policies.data.NamespaceIsolationDataImpl;
 
 @Parameters(commandDescription = "Operations about namespace isolation policy")
 public class CmdNamespaceIsolationPolicy extends CmdBase {
-    @Parameters(commandDescription = "Create/Update a namespace isolation policy for a cluster. This operation requires Pulsar super-user privileges")
+    @Parameters(commandDescription = "Create/Update a namespace isolation policy for a cluster. "
+            + "This operation requires Pulsar super-user privileges")
     private class SetPolicy extends CliCommand {
         @Parameter(description = "cluster-name policy-name", required = true)
         private List<String> params;
 
-        @Parameter(names = "--namespaces", description = "comma separated namespaces-regex list", required = true, splitter = CommaParameterSplitter.class)
+        @Parameter(names = "--namespaces", description = "comma separated namespaces-regex list",
+                required = true, splitter = CommaParameterSplitter.class)
         private List<String> namespaces;
 
-        @Parameter(names = "--primary", description = "comma separated  primary-broker-regex list. In Pulsar, when namespaces (more specifically, namespace bundles) are assigned dynamically to brokers, the namespace isolation policy limits the set of brokers that can be used for assignment. Before topics are assigned to brokers, you can set the namespace isolation policy with a primary or a secondary regex to select desired brokers. If no broker matches the specified regex, you cannot create a topic. If there are not enough primary brokers, topics are assigned to secondary brokers. If there are not enough secondary brokers, topics are assigned to other brokers which do not have any isolation policies.", required = true, splitter = CommaParameterSplitter.class)
+        @Parameter(names = "--primary", description = "comma separated  primary-broker-regex list. "
+                + "In Pulsar, when namespaces (more specifically, namespace bundles) are assigned dynamically to "
+                + "brokers, the namespace isolation policy limits the set of brokers that can be used for assignment. "
+                + "Before topics are assigned to brokers, you can set the namespace isolation policy with a primary or "
+                + "a secondary regex to select desired brokers. If no broker matches the specified regex, you cannot "
+                + "create a topic. If there are not enough primary brokers, topics are assigned to secondary brokers. "
+                + "If there are not enough secondary brokers, topics are assigned to other brokers which do not have "
+                + "any isolation policies.", required = true, splitter = CommaParameterSplitter.class)
         private List<String> primary;
 
-        @Parameter(names = "--secondary", description = "comma separated secondary-broker-regex list", required = false, splitter = CommaParameterSplitter.class)
+        @Parameter(names = "--secondary", description = "comma separated secondary-broker-regex list",
+                required = false, splitter = CommaParameterSplitter.class)
         private List<String> secondary = new ArrayList<String>(); // optional
 
-        @Parameter(names = "--auto-failover-policy-type", description = "auto failover policy type name ['min_available']", required = true)
+        @Parameter(names = "--auto-failover-policy-type",
+                description = "auto failover policy type name ['min_available']", required = true)
         private String autoFailoverPolicyTypeName;
 
-        @Parameter(names = "--auto-failover-policy-params", description = "comma separated name=value auto failover policy parameters", required = true, converter = NameValueParameterSplitter.class)
+        @Parameter(names = "--auto-failover-policy-params",
+                description = "comma separated name=value auto failover policy parameters",
+                required = true, converter = NameValueParameterSplitter.class)
         private Map<String, String> autoFailoverPolicyParams;
 
         void run() throws PulsarAdminException {
@@ -74,7 +85,8 @@ public class CmdNamespaceIsolationPolicy extends CmdBase {
         }
     }
 
-    @Parameters(commandDescription = "List all namespace isolation policies of a cluster. This operation requires Pulsar super-user privileges")
+    @Parameters(commandDescription = "List all namespace isolation policies of a cluster. "
+            + "This operation requires Pulsar super-user privileges")
     private class GetAllPolicies extends CliCommand {
         @Parameter(description = "cluster-name", required = true)
         private List<String> params;
@@ -89,7 +101,8 @@ public class CmdNamespaceIsolationPolicy extends CmdBase {
         }
     }
 
-    @Parameters(commandDescription = "List all brokers with namespace-isolation policies attached to it. This operation requires Pulsar super-user privileges")
+    @Parameters(commandDescription = "List all brokers with namespace-isolation policies attached to it. "
+            + "This operation requires Pulsar super-user privileges")
     private class GetAllBrokersWithPolicies extends CliCommand {
         @Parameter(description = "cluster-name", required = true)
         private List<String> params;
@@ -105,12 +118,14 @@ public class CmdNamespaceIsolationPolicy extends CmdBase {
         }
     }
 
-    @Parameters(commandDescription = "Get broker with namespace-isolation policies attached to it. This operation requires Pulsar super-user privileges")
+    @Parameters(commandDescription = "Get broker with namespace-isolation policies attached to it. "
+            + "This operation requires Pulsar super-user privileges")
     private class GetBrokerWithPolicies extends CliCommand {
         @Parameter(description = "cluster-name", required = true)
         private List<String> params;
 
-        @Parameter(names = "--broker", description = "Broker-name to get namespace-isolation policies attached to it", required = true)
+        @Parameter(names = "--broker",
+                description = "Broker-name to get namespace-isolation policies attached to it", required = true)
         private String broker;
 
         void run() throws PulsarAdminException {
@@ -123,7 +138,8 @@ public class CmdNamespaceIsolationPolicy extends CmdBase {
         }
     }
 
-    @Parameters(commandDescription = "Get namespace isolation policy of a cluster. This operation requires Pulsar super-user privileges")
+    @Parameters(commandDescription = "Get namespace isolation policy of a cluster. "
+            + "This operation requires Pulsar super-user privileges")
     private class GetPolicy extends CliCommand {
         @Parameter(description = "cluster-name policy-name", required = true)
         private List<String> params;
@@ -132,14 +148,15 @@ public class CmdNamespaceIsolationPolicy extends CmdBase {
             String clusterName = getOneArgument(params, 0, 2);
             String policyName = getOneArgument(params, 1, 2);
 
-            NamespaceIsolationDataImpl nsIsolationData = (NamespaceIsolationDataImpl) getAdmin().clusters().getNamespaceIsolationPolicy(clusterName,
-                    policyName);
+            NamespaceIsolationDataImpl nsIsolationData = (NamespaceIsolationDataImpl) getAdmin().clusters()
+                    .getNamespaceIsolationPolicy(clusterName, policyName);
 
             print(nsIsolationData);
         }
     }
 
-    @Parameters(commandDescription = "Delete namespace isolation policy of a cluster. This operation requires Pulsar super-user privileges")
+    @Parameters(commandDescription = "Delete namespace isolation policy of a cluster. "
+            + "This operation requires Pulsar super-user privileges")
     private class DeletePolicy extends CliCommand {
         @Parameter(description = "cluster-name policy-name", required = true)
         private List<String> params;
@@ -158,8 +175,11 @@ public class CmdNamespaceIsolationPolicy extends CmdBase {
                 .collect(Collectors.toList());
     }
 
-    private NamespaceIsolationData createNamespaceIsolationData(List<String> namespaces, List<String> primary,
-                                                                    List<String> secondary, String autoFailoverPolicyTypeName, Map<String, String> autoFailoverPolicyParams) {
+    private NamespaceIsolationData createNamespaceIsolationData(List<String> namespaces,
+                                                                List<String> primary,
+                                                                List<String> secondary,
+                                                                String autoFailoverPolicyTypeName,
+                                                                Map<String, String> autoFailoverPolicyParams) {
 
         // validate
         namespaces = validateList(namespaces);

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdNamespaces.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdNamespaces.java
@@ -25,6 +25,7 @@ import com.beust.jcommander.converters.CommaParameterSplitter;
 import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
+import io.swagger.util.Json;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -35,8 +36,6 @@ import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
-
-import io.swagger.util.Json;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.pulsar.admin.cli.utils.IOUtils;
 import org.apache.pulsar.client.admin.PulsarAdmin;
@@ -146,7 +145,8 @@ public class CmdNamespaces extends CmdBase {
         @Parameter(description = "tenant/namespace", required = true)
         private java.util.List<String> params;
 
-        @Parameter(names = { "--clusters", "-c" }, description = "List of clusters this namespace will be assigned", required = false)
+        @Parameter(names = { "--clusters", "-c" },
+                description = "List of clusters this namespace will be assigned", required = false)
         private java.util.List<String> clusters;
 
         @Parameter(names = { "--bundles", "-b" }, description = "number of bundles to activate", required = false)
@@ -211,8 +211,8 @@ public class CmdNamespaces extends CmdBase {
         @Parameter(names = "--role", description = "Client role to which grant permissions", required = true)
         private String role;
 
-        @Parameter(names = "--actions", description = "Actions to be granted (produce,consume,sources,sinks," +
-                "functions,packages)", required = true)
+        @Parameter(names = "--actions", description = "Actions to be granted (produce,consume,sources,sinks,"
+                + "functions,packages)", required = true)
         private List<String> actions;
 
         @Override
@@ -254,10 +254,12 @@ public class CmdNamespaces extends CmdBase {
         @Parameter(description = "tenant/namespace", required = true)
         private java.util.List<String> params;
 
-        @Parameter(names = "--subscription", description = "Subscription name for which permission will be granted to roles", required = true)
+        @Parameter(names = "--subscription",
+                description = "Subscription name for which permission will be granted to roles", required = true)
         private String subscription;
 
-        @Parameter(names = "--roles", description = "Client roles to which grant permissions (comma separated roles)", required = true, splitter = CommaParameterSplitter.class)
+        @Parameter(names = "--roles", description = "Client roles to which grant permissions (comma separated roles)",
+                required = true, splitter = CommaParameterSplitter.class)
         private List<String> roles;
 
         @Override
@@ -272,7 +274,8 @@ public class CmdNamespaces extends CmdBase {
         @Parameter(description = "tenant/namespace", required = true)
         private java.util.List<String> params;
 
-        @Parameter(names = "--subscription", description = "Subscription name for which permission will be revoked to roles", required = true)
+        @Parameter(names = "--subscription", description = "Subscription name for which permission "
+                + "will be revoked to roles", required = true)
         private String subscription;
 
         @Parameter(names = "--role", description = "Client role to which revoke permissions", required = true)
@@ -382,7 +385,8 @@ public class CmdNamespaces extends CmdBase {
         @Parameter(description = "tenant/namespace", required = true)
         private java.util.List<String> params;
 
-        @Parameter(names = { "--messageTTL", "-ttl" }, description = "Message TTL in seconds. When the value is set to `0`, TTL is disabled.", required = true)
+        @Parameter(names = { "--messageTTL", "-ttl" }, description = "Message TTL in seconds. "
+                + "When the value is set to `0`, TTL is disabled.", required = true)
         private int messageTTL;
 
         @Override
@@ -502,7 +506,8 @@ public class CmdNamespaces extends CmdBase {
     private class GetAntiAffinityNamespaces extends CliCommand {
 
         @Parameter(names = { "--tenant",
-                "-p" }, description = "tenant is only used for authorization. Client has to be admin of any of the tenant to access this api", required = false)
+                "-p" }, description = "tenant is only used for authorization. "
+                + "Client has to be admin of any of the tenant to access this api", required = false)
         private String tenant;
 
         @Parameter(names = { "--cluster", "-c" }, description = "Cluster name", required = true)
@@ -586,12 +591,12 @@ public class CmdNamespaces extends CmdBase {
         @Parameter(names = { "--disable", "-d" }, description = "Disable allowAutoTopicCreation on namespace")
         private boolean disable = false;
 
-        @Parameter(names = { "--type", "-t" }, description = "Type of topic to be auto-created. " +
-                "Possible values: (partitioned, non-partitioned). Default value: non-partitioned")
+        @Parameter(names = { "--type", "-t" }, description = "Type of topic to be auto-created. "
+                + "Possible values: (partitioned, non-partitioned). Default value: non-partitioned")
         private String type = "non-partitioned";
 
-        @Parameter(names = { "--num-partitions", "-n" }, description = "Default number of partitions of topic to be auto-created," +
-                " applicable to partitioned topics only", required = false)
+        @Parameter(names = { "--num-partitions", "-n" }, description = "Default number of partitions of topic to "
+                + "be auto-created, applicable to partitioned topics only", required = false)
         private Integer defaultNumPartitions = null;
 
         @Override
@@ -604,14 +609,14 @@ public class CmdNamespaces extends CmdBase {
             }
             if (enable) {
                 if (!TopicType.isValidTopicType(type)) {
-                    throw new ParameterException("Must specify type of topic to be created. " +
-                            "Possible values: (partitioned, non-partitioned)");
+                    throw new ParameterException("Must specify type of topic to be created. "
+                            + "Possible values: (partitioned, non-partitioned)");
                 }
 
                 if (TopicType.PARTITIONED.toString().equals(type)
                         && (defaultNumPartitions == null || defaultNumPartitions <= 0)) {
-                    throw new ParameterException("Must specify num-partitions or num-partitions > 0 " +
-                            "for partitioned topic type.");
+                    throw new ParameterException("Must specify num-partitions or num-partitions > 0 "
+                            + "for partitioned topic type.");
                 }
             }
             getAdmin().namespaces().setAutoTopicCreation(namespace,
@@ -740,7 +745,8 @@ public class CmdNamespaces extends CmdBase {
             } else {
                 retentionSizeInMB = -1;
             }
-            getAdmin().namespaces().setRetention(namespace, new RetentionPolicies(retentionTimeInMin, retentionSizeInMB));
+            getAdmin().namespaces()
+                    .setRetention(namespace, new RetentionPolicies(retentionTimeInMin, retentionSizeInMB));
         }
     }
 
@@ -762,10 +768,14 @@ public class CmdNamespaces extends CmdBase {
         private java.util.List<String> params;
 
         @Parameter(names = { "--primary-group",
-                "-pg" }, description = "Bookie-affinity primary-groups (comma separated) name where namespace messages should be written", required = true)
+                "-pg" }, description = "Bookie-affinity primary-groups (comma separated) name "
+                + "where namespace messages should be written", required = true)
         private String bookieAffinityGroupNamePrimary;
         @Parameter(names = { "--secondary-group",
-                "-sg" }, description = "Bookie-affinity secondary-group (comma separated) name where namespace messages should be written. If you want to verify whether there are enough bookies in groups, use `--secondary-group` flag. Messages in this namespace are stored in secondary groups. If a group does not contain enough bookies, a topic cannot be created.", required = false)
+                "-sg" }, description = "Bookie-affinity secondary-group (comma separated) name where namespace "
+                + "messages should be written. If you want to verify whether there are enough bookies in groups, "
+                + "use `--secondary-group` flag. Messages in this namespace are stored in secondary groups. "
+                + "If a group does not contain enough bookies, a topic cannot be created.", required = false)
         private String bookieAffinityGroupNameSecondary;
 
 
@@ -865,9 +875,9 @@ public class CmdNamespaces extends CmdBase {
                 "-u" }, description = "Unload newly split bundles after splitting old bundle", required = false)
         private boolean unload;
 
-        @Parameter(names = { "--split-algorithm-name", "-san" }, description = "Algorithm name for split namespace bundle." +
-            " Valid options are: [range_equally_divide, topic_count_equally_divide]." +
-            " Use broker side config if absent", required = false)
+        @Parameter(names = { "--split-algorithm-name", "-san" }, description = "Algorithm name for split "
+                + "namespace bundle. Valid options are: [range_equally_divide, topic_count_equally_divide]."
+                + " Use broker side config if absent", required = false)
         private String splitAlgorithmName;
 
         @Override
@@ -890,19 +900,23 @@ public class CmdNamespaces extends CmdBase {
         private java.util.List<String> params;
 
         @Parameter(names = { "--msg-dispatch-rate",
-                "-md" }, description = "message-dispatch-rate (default -1 will be overwrite if not passed)", required = false)
+                "-md" }, description = "message-dispatch-rate "
+                + "(default -1 will be overwrite if not passed)", required = false)
         private int msgDispatchRate = -1;
 
         @Parameter(names = { "--byte-dispatch-rate",
-                "-bd" }, description = "byte-dispatch-rate (default -1 will be overwrite if not passed)", required = false)
+                "-bd" }, description = "byte-dispatch-rate "
+                + "(default -1 will be overwrite if not passed)", required = false)
         private long byteDispatchRate = -1;
 
         @Parameter(names = { "--dispatch-rate-period",
-                "-dt" }, description = "dispatch-rate-period in second type (default 1 second will be overwrite if not passed)", required = false)
+                "-dt" }, description = "dispatch-rate-period in second type "
+                + "(default 1 second will be overwrite if not passed)", required = false)
         private int dispatchRatePeriodSec = 1;
 
         @Parameter(names = { "--relative-to-publish-rate",
-                "-rp" }, description = "dispatch rate relative to publish-rate (if publish-relative flag is enabled then broker will apply throttling value to (publish-rate + dispatch rate))", required = false)
+                "-rp" }, description = "dispatch rate relative to publish-rate (if publish-relative flag is enabled "
+                + "then broker will apply throttling value to (publish-rate + dispatch rate))", required = false)
         private boolean relativeToPublishRate = false;
 
         @Override
@@ -930,7 +944,8 @@ public class CmdNamespaces extends CmdBase {
         }
     }
 
-    @Parameters(commandDescription = "Get configured message-dispatch-rate for all topics of the namespace (Disabled if value < 0)")
+    @Parameters(commandDescription = "Get configured message-dispatch-rate for all topics of the namespace "
+            + "(Disabled if value < 0)")
     private class GetDispatchRate extends CliCommand {
         @Parameter(description = "tenant/namespace", required = true)
         private java.util.List<String> params;
@@ -953,7 +968,8 @@ public class CmdNamespaces extends CmdBase {
         private int subscribeRate = -1;
 
         @Parameter(names = { "--subscribe-rate-period",
-                "-st" }, description = "subscribe-rate-period in second type (default 30 second will be overwrite if not passed)", required = false)
+                "-st" }, description = "subscribe-rate-period in second type "
+                + "(default 30 second will be overwrite if not passed)", required = false)
         private int subscribeRatePeriodSec = 30;
 
         @Override
@@ -995,7 +1011,8 @@ public class CmdNamespaces extends CmdBase {
         private java.util.List<String> params;
 
         @Parameter(names = { "--msg-dispatch-rate",
-            "-md" }, description = "message-dispatch-rate (default -1 will be overwrite if not passed)", required = false)
+            "-md" }, description = "message-dispatch-rate "
+                + "(default -1 will be overwrite if not passed)", required = false)
         private int msgDispatchRate = -1;
 
         @Parameter(names = { "--byte-dispatch-rate",
@@ -1003,11 +1020,13 @@ public class CmdNamespaces extends CmdBase {
         private long byteDispatchRate = -1;
 
         @Parameter(names = { "--dispatch-rate-period",
-            "-dt" }, description = "dispatch-rate-period in second type (default 1 second will be overwrite if not passed)", required = false)
+            "-dt" }, description = "dispatch-rate-period in second type "
+                + "(default 1 second will be overwrite if not passed)", required = false)
         private int dispatchRatePeriodSec = 1;
 
         @Parameter(names = { "--relative-to-publish-rate",
-                "-rp" }, description = "dispatch rate relative to publish-rate (if publish-relative flag is enabled then broker will apply throttling value to (publish-rate + dispatch rate))", required = false)
+                "-rp" }, description = "dispatch rate relative to publish-rate (if publish-relative flag is enabled "
+                + "then broker will apply throttling value to (publish-rate + dispatch rate))", required = false)
         private boolean relativeToPublishRate = false;
 
         @Override
@@ -1023,8 +1042,8 @@ public class CmdNamespaces extends CmdBase {
         }
     }
 
-    @Parameters(commandDescription = "Remove subscription configured message-dispatch-rate " +
-            "for all topics of the namespace")
+    @Parameters(commandDescription = "Remove subscription configured message-dispatch-rate "
+            + "for all topics of the namespace")
     private class RemoveSubscriptionDispatchRate extends CliCommand {
         @Parameter(description = "tenant/namespace", required = true)
         private java.util.List<String> params;
@@ -1036,7 +1055,8 @@ public class CmdNamespaces extends CmdBase {
         }
     }
 
-    @Parameters(commandDescription = "Get subscription configured message-dispatch-rate for all topics of the namespace (Disabled if value < 0)")
+    @Parameters(commandDescription = "Get subscription configured message-dispatch-rate for all topics of "
+            + "the namespace (Disabled if value < 0)")
     private class GetSubscriptionDispatchRate extends CliCommand {
         @Parameter(description = "tenant/namespace", required = true)
         private java.util.List<String> params;
@@ -1081,7 +1101,8 @@ public class CmdNamespaces extends CmdBase {
         }
     }
 
-     @Parameters(commandDescription = "Get configured message-publish-rate for all topics of the namespace (Disabled if value < 0)")
+     @Parameters(commandDescription = "Get configured message-publish-rate for all topics of the namespace "
+             + "(Disabled if value < 0)")
     private class GetPublishRate extends CliCommand {
         @Parameter(description = "tenant/namespace", required = true)
         private java.util.List<String> params;
@@ -1099,7 +1120,8 @@ public class CmdNamespaces extends CmdBase {
         private java.util.List<String> params;
 
         @Parameter(names = { "--msg-dispatch-rate",
-            "-md" }, description = "message-dispatch-rate (default -1 will be overwrite if not passed)", required = false)
+            "-md" }, description = "message-dispatch-rate "
+                + "(default -1 will be overwrite if not passed)", required = false)
         private int msgDispatchRate = -1;
 
         @Parameter(names = { "--byte-dispatch-rate",
@@ -1107,7 +1129,8 @@ public class CmdNamespaces extends CmdBase {
         private long byteDispatchRate = -1;
 
         @Parameter(names = { "--dispatch-rate-period",
-            "-dt" }, description = "dispatch-rate-period in second type (default 1 second will be overwrite if not passed)", required = false)
+            "-dt" }, description = "dispatch-rate-period in second type "
+                + "(default 1 second will be overwrite if not passed)", required = false)
         private int dispatchRatePeriodSec = 1;
 
         @Override
@@ -1122,7 +1145,8 @@ public class CmdNamespaces extends CmdBase {
         }
     }
 
-    @Parameters(commandDescription = "Get replicator configured message-dispatch-rate for all topics of the namespace (Disabled if value < 0)")
+    @Parameters(commandDescription = "Get replicator configured message-dispatch-rate for all topics of the namespace "
+            + "(Disabled if value < 0)")
     private class GetReplicatorDispatchRate extends CliCommand {
         @Parameter(description = "tenant/namespace", required = true)
         private java.util.List<String> params;
@@ -1134,8 +1158,8 @@ public class CmdNamespaces extends CmdBase {
         }
     }
 
-    @Parameters(commandDescription = "Remove replicator configured message-dispatch-rate " +
-            "for all topics of the namespace")
+    @Parameters(commandDescription = "Remove replicator configured message-dispatch-rate "
+            + "for all topics of the namespace")
     private class RemoveReplicatorDispatchRate extends CliCommand {
         @Parameter(description = "tenant/namespace", required = true)
         private java.util.List<String> params;
@@ -1167,18 +1191,20 @@ public class CmdNamespaces extends CmdBase {
         @Parameter(names = { "-l", "--limit" }, description = "Size limit (eg: 10M, 16G)", required = true)
         private String limitStr;
 
-        @Parameter(names = { "-lt", "--limitTime" }, description = "Time limit in second, non-positive number for disabling time limit.")
+        @Parameter(names = { "-lt", "--limitTime" },
+                description = "Time limit in second, non-positive number for disabling time limit.")
         private int limitTime = -1;
 
         @Parameter(names = { "-p", "--policy" }, description = "Retention policy to enforce when the limit is reached. "
-                + "Valid options are: [producer_request_hold, producer_exception, consumer_backlog_eviction]", required = true)
+                + "Valid options are: [producer_request_hold, producer_exception, consumer_backlog_eviction]",
+                required = true)
         private String policyStr;
 
-        @Parameter(names = {"-t", "--type"}, description = "Backlog quota type to set. Valid options are: " +
-                "destination_storage and message_age. " + 
-                "destination_storage limits backlog by size (in bytes). " +
-                "message_age limits backlog by time, that is, message timestamp (broker or publish timestamp). " +
-                "You can set size or time to control the backlog, or combine them together to control the backlog. ")
+        @Parameter(names = {"-t", "--type"}, description = "Backlog quota type to set. Valid options are: "
+                + "destination_storage and message_age. "
+                + "destination_storage limits backlog by size (in bytes). "
+                + "message_age limits backlog by time, that is, message timestamp (broker or publish timestamp). "
+                + "You can set size or time to control the backlog, or combine them together to control the backlog. ")
         private String backlogQuotaTypeStr = BacklogQuota.BacklogQuotaType.destination_storage.name();
 
         @Override
@@ -1216,8 +1242,8 @@ public class CmdNamespaces extends CmdBase {
         @Parameter(description = "tenant/namespace", required = true)
         private java.util.List<String> params;
 
-        @Parameter(names = {"-t", "--type"}, description = "Backlog quota type to remove. Valid options are: " +
-                "destination_storage, message_age")
+        @Parameter(names = {"-t", "--type"}, description = "Backlog quota type to remove. Valid options are: "
+                + "destination_storage, message_age")
         private String backlogQuotaTypeStr = BacklogQuota.BacklogQuotaType.destination_storage.name();
 
         @Override
@@ -1272,11 +1298,13 @@ public class CmdNamespaces extends CmdBase {
         private int bookkeeperWriteQuorum;
 
         @Parameter(names = { "-a",
-                "--bookkeeper-ack-quorum" }, description = "Number of acks (guaranteed copies) to wait for each entry", required = true)
+                "--bookkeeper-ack-quorum" },
+                description = "Number of acks (guaranteed copies) to wait for each entry", required = true)
         private int bookkeeperAckQuorum;
 
         @Parameter(names = { "-r",
-                "--ml-mark-delete-max-rate" }, description = "Throttling rate of mark-delete operation (0 means no throttle)", required = true)
+                "--ml-mark-delete-max-rate" },
+                description = "Throttling rate of mark-delete operation (0 means no throttle)", required = true)
         private double managedLedgerMaxMarkDeleteRate;
 
         @Override
@@ -1439,12 +1467,13 @@ public class CmdNamespaces extends CmdBase {
         @Parameter(names = { "--disable-delete-while-inactive", "-d" }, description = "Disable delete while inactive")
         private boolean disableDeleteWhileInactive = false;
 
-        @Parameter(names = {"--max-inactive-duration", "-t"}, description = "Max duration of topic inactivity in seconds" +
-                ",topics that are inactive for longer than this value will be deleted (eg: 1s, 10s, 1m, 5h, 3d)", required = true)
+        @Parameter(names = {"--max-inactive-duration", "-t"}, description = "Max duration of topic inactivity in "
+                + "seconds, topics that are inactive for longer than this value will be deleted "
+                + "(eg: 1s, 10s, 1m, 5h, 3d)", required = true)
         private String deleteInactiveTopicsMaxInactiveDuration;
 
-        @Parameter(names = { "--delete-mode", "-m" }, description = "Mode of delete inactive topic" +
-                ",Valid options are: [delete_when_no_subscriptions, delete_when_subscriptions_caught_up]", required = true)
+        @Parameter(names = { "--delete-mode", "-m" }, description = "Mode of delete inactive topic, Valid options are: "
+                + "[delete_when_no_subscriptions, delete_when_subscriptions_caught_up]", required = true)
         private String inactiveTopicDeleteMode;
 
         @Override
@@ -1459,15 +1488,18 @@ public class CmdNamespaces extends CmdBase {
             }
 
             if (enableDeleteWhileInactive == disableDeleteWhileInactive) {
-                throw new ParameterException("Need to specify either enable-delete-while-inactive or disable-delete-while-inactive");
+                throw new ParameterException("Need to specify either enable-delete-while-inactive or "
+                        + "disable-delete-while-inactive");
             }
             InactiveTopicDeleteMode deleteMode = null;
             try {
                 deleteMode = InactiveTopicDeleteMode.valueOf(inactiveTopicDeleteMode);
             } catch (IllegalArgumentException e) {
-                throw new ParameterException("delete mode can only be set to delete_when_no_subscriptions or delete_when_subscriptions_caught_up");
+                throw new ParameterException("delete mode can only be set to delete_when_no_subscriptions or "
+                        + "delete_when_subscriptions_caught_up");
             }
-            getAdmin().namespaces().setInactiveTopicPolicies(namespace, new InactiveTopicPolicies(deleteMode, (int) maxInactiveDurationInSeconds, enableDeleteWhileInactive));
+            getAdmin().namespaces().setInactiveTopicPolicies(namespace, new InactiveTopicPolicies(deleteMode,
+                    (int) maxInactiveDurationInSeconds, enableDeleteWhileInactive));
         }
     }
 
@@ -1482,8 +1514,9 @@ public class CmdNamespaces extends CmdBase {
         @Parameter(names = { "--disable", "-d" }, description = "Disable delayed delivery messages")
         private boolean disable = false;
 
-        @Parameter(names = { "--time", "-t" }, description = "The tick time for when retrying on delayed delivery messages, " +
-                "affecting the accuracy of the delivery time compared to the scheduled time. (eg: 1s, 10s, 1m, 5h, 3d)")
+        @Parameter(names = { "--time", "-t" }, description = "The tick time for when retrying on "
+                + "delayed delivery messages, affecting the accuracy of the delivery time compared to "
+                + "the scheduled time. (eg: 1s, 10s, 1m, 5h, 3d)")
         private String delayedDeliveryTimeStr = "1s";
 
         @Override
@@ -1605,7 +1638,8 @@ public class CmdNamespaces extends CmdBase {
         @Parameter(description = "tenant/namespace", required = true)
         private java.util.List<String> params;
 
-        @Parameter(names = { "--max-producers-per-topic", "-p" }, description = "maxProducersPerTopic for a namespace", required = true)
+        @Parameter(names = { "--max-producers-per-topic", "-p" },
+                description = "maxProducersPerTopic for a namespace", required = true)
         private int maxProducersPerTopic;
 
         @Override
@@ -1632,7 +1666,8 @@ public class CmdNamespaces extends CmdBase {
         @Parameter(description = "tenant/namespace", required = true)
         private java.util.List<String> params;
 
-        @Parameter(names = { "--max-consumers-per-topic", "-c" }, description = "maxConsumersPerTopic for a namespace", required = true)
+        @Parameter(names = { "--max-consumers-per-topic", "-c" },
+                description = "maxConsumersPerTopic for a namespace", required = true)
         private int maxConsumersPerTopic;
 
         @Override
@@ -1683,7 +1718,8 @@ public class CmdNamespaces extends CmdBase {
         @Parameter(description = "tenant/namespace", required = true)
         private java.util.List<String> params;
 
-        @Parameter(names = { "--max-consumers-per-subscription", "-c" }, description = "maxConsumersPerSubscription for a namespace", required = true)
+        @Parameter(names = { "--max-consumers-per-subscription", "-c" },
+                description = "maxConsumersPerSubscription for a namespace", required = true)
         private int maxConsumersPerSubscription;
 
         @Override
@@ -1710,7 +1746,8 @@ public class CmdNamespaces extends CmdBase {
         @Parameter(description = "tenant/namespace", required = true)
         private java.util.List<String> params;
 
-        @Parameter(names = { "--max-unacked-messages-per-topic", "-c" }, description = "maxUnackedMessagesPerConsumer for a namespace", required = true)
+        @Parameter(names = { "--max-unacked-messages-per-topic", "-c" },
+                description = "maxUnackedMessagesPerConsumer for a namespace", required = true)
         private int maxUnackedMessagesPerConsumer;
 
         @Override
@@ -1749,7 +1786,8 @@ public class CmdNamespaces extends CmdBase {
         @Parameter(description = "tenant/namespace", required = true)
         private java.util.List<String> params;
 
-        @Parameter(names = { "--max-unacked-messages-per-subscription", "-c" }, description = "maxUnackedMessagesPerSubscription for a namespace", required = true)
+        @Parameter(names = { "--max-unacked-messages-per-subscription", "-c" },
+                description = "maxUnackedMessagesPerSubscription for a namespace", required = true)
         private int maxUnackedMessagesPerSubscription;
 
         @Override
@@ -1971,11 +2009,11 @@ public class CmdNamespaces extends CmdBase {
 
         @Parameter(names = { "--compatibility", "-c" },
                 description = "Compatibility level required for new schemas created via a Producer. "
-                        + "Possible values (FULL, BACKWARD, FORWARD, " +
-                        "UNDEFINED, BACKWARD_TRANSITIVE, " +
-                        "FORWARD_TRANSITIVE, FULL_TRANSITIVE, " +
-                        "ALWAYS_INCOMPATIBLE," +
-                        "ALWAYS_COMPATIBLE).")
+                        + "Possible values (FULL, BACKWARD, FORWARD, "
+                        + "UNDEFINED, BACKWARD_TRANSITIVE, "
+                        + "FORWARD_TRANSITIVE, FULL_TRANSITIVE, "
+                        + "ALWAYS_INCOMPATIBLE,"
+                        + "ALWAYS_COMPATIBLE).")
         private String strategyParam = null;
 
         @Override
@@ -1987,8 +2025,8 @@ public class CmdNamespaces extends CmdBase {
             try {
                 strategy = SchemaCompatibilityStrategy.valueOf(strategyStr);
             } catch (IllegalArgumentException exception) {
-                throw new ParameterException(String.format("Illegal schema compatibility strategy %s. " +
-                        "Possible values: %s", strategyStr, Arrays.toString(SchemaCompatibilityStrategy.values())));
+                throw new ParameterException(String.format("Illegal schema compatibility strategy %s. "
+                        + "Possible values: %s", strategyStr, Arrays.toString(SchemaCompatibilityStrategy.values())));
             }
             getAdmin().namespaces().setSchemaCompatibilityStrategy(namespace, strategy);
         }
@@ -2074,8 +2112,8 @@ public class CmdNamespaces extends CmdBase {
 
         @Parameter(
                 names = {"--driver", "-d"},
-                description = "Driver to use to offload old data to long term storage, " +
-                        "(Possible values: S3, aws-s3, google-cloud-storage, filesystem, azureblob)",
+                description = "Driver to use to offload old data to long term storage, "
+                        + "(Possible values: S3, aws-s3, google-cloud-storage, filesystem, azureblob)",
                 required = true)
         private String driver;
 
@@ -2149,22 +2187,26 @@ public class CmdNamespaces extends CmdBase {
 
         @Parameter(
                 names = {"--offloadedReadPriority", "-orp"},
-                description = "Read priority for offloaded messages. By default, once messages are offloaded to long-term storage, brokers read messages from long-term storage, but messages can still exist in BookKeeper for a period depends on your configuration. For messages that exist in both long-term storage and BookKeeper, you can set where to read messages from with the option `tiered-storage-first` or `bookkeeper-first`.",
+                description = "Read priority for offloaded messages. By default, once messages are offloaded to "
+                        + "long-term storage, brokers read messages from long-term storage, but messages can "
+                        + "still exist in BookKeeper for a period depends on your configuration. "
+                        + "For messages that exist in both long-term storage and BookKeeper, you can set where to "
+                        + "read messages from with the option `tiered-storage-first` or `bookkeeper-first`.",
                 required = false
         )
         private String offloadReadPriorityStr;
 
-        public final List<String> DRIVER_NAMES = OffloadPoliciesImpl.DRIVER_NAMES;
+        public final List<String> driverNames = OffloadPoliciesImpl.DRIVER_NAMES;
 
         public boolean driverSupported(String driver) {
-            return DRIVER_NAMES.stream().anyMatch(d -> d.equalsIgnoreCase(driver));
+            return driverNames.stream().anyMatch(d -> d.equalsIgnoreCase(driver));
         }
 
         public boolean isS3Driver(String driver) {
             if (StringUtils.isEmpty(driver)) {
                 return false;
             }
-            return driver.equalsIgnoreCase(DRIVER_NAMES.get(0)) || driver.equalsIgnoreCase(DRIVER_NAMES.get(1));
+            return driver.equalsIgnoreCase(driverNames.get(0)) || driver.equalsIgnoreCase(driverNames.get(1));
         }
 
         public boolean positiveCheck(String paramName, long value) {
@@ -2186,9 +2228,8 @@ public class CmdNamespaces extends CmdBase {
             String namespace = validateNamespace(params);
 
             if (!driverSupported(driver)) {
-                throw new ParameterException(
-                        "The driver " + driver + " is not supported, " +
-                                "(Possible values: " + String.join(",", DRIVER_NAMES) + ").");
+                throw new ParameterException("The driver " + driver + " is not supported, "
+                        + "(Possible values: " + String.join(",", driverNames) + ").");
             }
 
             if (isS3Driver(driver) && Strings.isNullOrEmpty(region) && Strings.isNullOrEmpty(endpoint)) {
@@ -2207,7 +2248,7 @@ public class CmdNamespaces extends CmdBase {
             }
 
             int readBufferSizeInBytes = OffloadPoliciesImpl.DEFAULT_READ_BUFFER_SIZE_IN_BYTES;
-            if (StringUtils.isNotEmpty(readBufferSizeStr) ) {
+            if (StringUtils.isNotEmpty(readBufferSizeStr)) {
                 long readBufferSize = validateSizeString(readBufferSizeStr);
                 if (positiveCheck("ReadBufferSize", readBufferSize)
                         && maxValueCheck("ReadBufferSize", readBufferSize, Integer.MAX_VALUE)) {
@@ -2244,8 +2285,8 @@ public class CmdNamespaces extends CmdBase {
                 try {
                     offloadedReadPriority = OffloadedReadPriority.fromString(this.offloadReadPriorityStr);
                 } catch (Exception e) {
-                    throw new ParameterException("--offloadedReadPriority parameter must be one of " +
-                            Arrays.stream(OffloadedReadPriority.values())
+                    throw new ParameterException("--offloadedReadPriority parameter must be one of "
+                            + Arrays.stream(OffloadedReadPriority.values())
                                     .map(OffloadedReadPriority::toString)
                                     .collect(Collectors.joining(","))
                             + " but got: " + this.offloadReadPriorityStr, e);
@@ -2293,7 +2334,8 @@ public class CmdNamespaces extends CmdBase {
         @Parameter(description = "tenant/namespace", required = true)
         private java.util.List<String> params;
 
-        @Parameter(names = {"--max-topics-per-namespace", "-t"}, description = "max topics per namespace", required = true)
+        @Parameter(names = {"--max-topics-per-namespace", "-t"},
+                description = "max topics per namespace", required = true)
         private int maxTopicsPerNamespace;
 
         @Override
@@ -2361,18 +2403,18 @@ public class CmdNamespaces extends CmdBase {
             String namespace = validateNamespace(params);
             Map<String, String> map = new HashMap<>();
             if (properties.size() == 0) {
-                throw new ParameterException(String.format("Required at least one property for the namespace, " +
-                        "but found %d.", properties.size()));
+                throw new ParameterException(String.format("Required at least one property for the namespace, "
+                        + "but found %d.", properties.size()));
             }
             for (String property : properties) {
                 if (!property.contains("=")) {
-                    throw new ParameterException(String.format("Invalid key value pair '%s', " +
-                            "valid format like 'a=a,b=b,c=c'.", property));
+                    throw new ParameterException(String.format("Invalid key value pair '%s', "
+                            + "valid format like 'a=a,b=b,c=c'.", property));
                 } else {
                     String[] keyValue = property.split("=");
                     if (keyValue.length != 2) {
-                        throw new ParameterException(String.format("Invalid key value pair '%s', " +
-                                "valid format like 'a=a,b=b,c=c'.", property));
+                        throw new ParameterException(String.format("Invalid key value pair '%s', "
+                                + "valid format like 'a=a,b=b,c=c'.", property));
                     }
                     map.put(keyValue[0], keyValue[1]);
                 }

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdNonPersistentTopics.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdNonPersistentTopics.java
@@ -20,12 +20,10 @@ package org.apache.pulsar.admin.cli;
 
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.Parameters;
-
+import java.util.function.Supplier;
 import org.apache.pulsar.client.admin.NonPersistentTopics;
 import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.admin.PulsarAdminException;
-
-import java.util.function.Supplier;
 
 @SuppressWarnings("deprecation")
 @Parameters(commandDescription = "Operations on non-persistent topics", hidden = true)

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdPackages.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdPackages.java
@@ -21,13 +21,12 @@ package org.apache.pulsar.admin.cli;
 import com.beust.jcommander.DynamicParameter;
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.Parameters;
-import org.apache.pulsar.client.admin.Packages;
-import org.apache.pulsar.client.admin.PulsarAdmin;
-import org.apache.pulsar.packages.management.core.common.PackageMetadata;
-
 import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Supplier;
+import org.apache.pulsar.client.admin.Packages;
+import org.apache.pulsar.client.admin.PulsarAdmin;
+import org.apache.pulsar.packages.management.core.common.PackageMetadata;
 
 /**
  * Commands for administering packages.
@@ -73,13 +72,13 @@ class CmdPackages extends CmdBase {
         @Parameter(description = "type://tenant/namespace/packageName@version", required = true)
         private String packageName;
 
-        @Parameter(names = "--description", description=  "descriptions of a package", required = true)
+        @Parameter(names = "--description", description = "descriptions of a package", required = true)
         private String description;
 
         @Parameter(names = "--contact", description = "contact info of a package")
         private String contact;
 
-        @DynamicParameter(names = {"--properties", "-P"},  description ="external information of a package")
+        @DynamicParameter(names = {"--properties", "-P"},  description = "external information of a package")
         private Map<String, String> properties = new HashMap<>();
 
         @Override
@@ -95,13 +94,13 @@ class CmdPackages extends CmdBase {
         @Parameter(description = "type://tenant/namespace/packageName@version", required = true)
         private String packageName;
 
-        @Parameter(names = "--description", description=  "descriptions of a package", required = true)
+        @Parameter(names = "--description", description = "descriptions of a package", required = true)
         private String description;
 
         @Parameter(names = "--contact", description = "contact information of a package")
         private String contact;
 
-        @DynamicParameter(names = {"--properties", "-P"},  description ="external infromations of a package")
+        @DynamicParameter(names = {"--properties", "-P"}, description = "external infromations of a package")
         private Map<String, String> properties = new HashMap<>();
 
         @Parameter(names = "--path", description = "file path of the package", required = true)
@@ -135,8 +134,8 @@ class CmdPackages extends CmdBase {
 
     @Parameters(commandDescription = "List all versions of the given package")
     private class ListPackageVersionsCmd extends CliCommand {
-        @Parameter(description = "the package name you want to query, don't need to specify the package version. " +
-            "type://tenant/namespace/packageName", required = true)
+        @Parameter(description = "the package name you want to query, don't need to specify the package version. "
+                + "type://tenant/namespace/packageName", required = true)
         private String packageName;
 
         @Override

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdPersistentTopics.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdPersistentTopics.java
@@ -31,7 +31,6 @@ import java.util.List;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
-
 import org.apache.pulsar.client.admin.LongRunningProcessStatus;
 import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.admin.PulsarAdminException;
@@ -42,8 +41,8 @@ import org.apache.pulsar.client.impl.BatchMessageIdImpl;
 import org.apache.pulsar.client.impl.MessageIdImpl;
 import org.apache.pulsar.common.util.RelativeTimeUtil;
 
-@Parameters(commandDescription = "Operations on persistent topics. The persistent-topics " +
-        "has been deprecated in favor of topics", hidden = true)
+@Parameters(commandDescription = "Operations on persistent topics. The persistent-topics "
+        + "has been deprecated in favor of topics", hidden = true)
 public class CmdPersistentTopics extends CmdBase {
     private Topics persistentTopics;
 
@@ -124,8 +123,8 @@ public class CmdPersistentTopics extends CmdBase {
         @Parameter(names = "--role", description = "Client role to which grant permissions", required = true)
         private String role;
 
-        @Parameter(names = "--actions", description = "Actions to be granted (produce,consume,sources,sinks," +
-                "functions,packages)", required = true)
+        @Parameter(names = "--actions", description = "Actions to be granted (produce,consume,sources,sinks,"
+                + "functions,packages)", required = true)
         private List<String> actions;
 
         @Override
@@ -249,7 +248,8 @@ public class CmdPersistentTopics extends CmdBase {
         @Parameter(description = "persistent://tenant/namespace/topic", required = true)
         private java.util.List<String> params;
 
-        @Parameter(names = "--force", description = "Close all producer/consumer/replicator and delete topic forcefully")
+        @Parameter(names = "--force",
+                description = "Close all producer/consumer/replicator and delete topic forcefully")
         private boolean force = false;
 
         @Override
@@ -265,7 +265,8 @@ public class CmdPersistentTopics extends CmdBase {
         @Parameter(description = "persistent://tenant/namespace/topic", required = true)
         private java.util.List<String> params;
 
-        @Parameter(names = "--force", description = "Close all producer/consumer/replicator and delete topic forcefully")
+        @Parameter(names = "--force",
+                description = "Close all producer/consumer/replicator and delete topic forcefully")
         private boolean force = false;
 
         @Override
@@ -287,8 +288,8 @@ public class CmdPersistentTopics extends CmdBase {
         }
     }
 
-    @Parameters(commandDescription = "Truncate a topic. \n"
-            + "\t\tThe truncate operation will move all cursors to the end of the topic and delete all inactive ledgers. ")
+    @Parameters(commandDescription = "Truncate a topic. \n\t\tThe truncate operation will move all cursors to the end "
+            + "of the topic and delete all inactive ledgers. ")
     private class TruncateCmd extends CliCommand {
         @Parameter(description = "persistent://tenant/namespace/topic\n", required = true)
         private java.util.List<String> params;
@@ -378,8 +379,9 @@ public class CmdPersistentTopics extends CmdBase {
         }
     }
 
-    @Parameters(commandDescription = "Get the stats for the partitioned topic and its connected producers and consumers. "
-            + "All the rates are computed over a 1 minute window and are relative the last completed 1 minute period.")
+    @Parameters(commandDescription = "Get the stats for the partitioned topic and "
+            + "its connected producers and consumers. All the rates are computed over a 1 minute window and "
+            + "are relative the last completed 1 minute period.")
     private class GetPartitionedStats extends CliCommand {
         @Parameter(description = "persistent://tenant/namespace/topic", required = true)
         private java.util.List<String> params;
@@ -394,8 +396,9 @@ public class CmdPersistentTopics extends CmdBase {
         }
     }
 
-    @Parameters(commandDescription = "Get the stats-internal for the partitioned topic and its connected producers and consumers. "
-            + "All the rates are computed over a 1 minute window and are relative the last completed 1 minute period.")
+    @Parameters(commandDescription = "Get the stats-internal for the partitioned topic and "
+            + "its connected producers and consumers. All the rates are computed over a 1 minute window and "
+            + "are relative the last completed 1 minute period.")
     private class GetPartitionedStatsInternal extends CliCommand {
         @Parameter(description = "persistent://tenant/namespace/topic", required = true)
         private java.util.List<String> params;
@@ -441,7 +444,8 @@ public class CmdPersistentTopics extends CmdBase {
         }
     }
 
-    @Parameters(commandDescription = "Expire messages that older than given expiry time (in seconds) for the subscription")
+    @Parameters(commandDescription = "Expire messages that older than given expiry time (in seconds) "
+            + "for the subscription")
     private class ExpireMessages extends CliCommand {
         @Parameter(description = "persistent://tenant/namespace/topic", required = true)
         private java.util.List<String> params;
@@ -450,7 +454,8 @@ public class CmdPersistentTopics extends CmdBase {
                 "--subscription" }, description = "Subscription to be skip messages on", required = true)
         private String subName;
 
-        @Parameter(names = { "-t", "--expireTime" }, description = "Expire messages older than time in seconds", required = true)
+        @Parameter(names = { "-t", "--expireTime" },
+                description = "Expire messages older than time in seconds", required = true)
         private long expireTimeInSeconds;
 
         @Override
@@ -460,12 +465,14 @@ public class CmdPersistentTopics extends CmdBase {
         }
     }
 
-    @Parameters(commandDescription = "Expire messages that older than given expiry time (in seconds) for all subscriptions")
+    @Parameters(commandDescription = "Expire messages that older than given expiry time (in seconds) "
+            + "for all subscriptions")
     private class ExpireMessagesForAllSubscriptions extends CliCommand {
         @Parameter(description = "persistent://tenant/namespace/topic", required = true)
         private java.util.List<String> params;
 
-        @Parameter(names = { "-t", "--expireTime" }, description = "Expire messages older than time in seconds", required = true)
+        @Parameter(names = { "-t", "--expireTime" },
+                description = "Expire messages older than time in seconds", required = true)
         private long expireTimeInSeconds;
 
         @Override
@@ -485,7 +492,8 @@ public class CmdPersistentTopics extends CmdBase {
         private String subscriptionName;
 
         @Parameter(names = { "--messageId",
-                "-m" }, description = "messageId where to create the subscription. It can be either 'latest', 'earliest' or (ledgerId:entryId)", required = false)
+                "-m" }, description = "messageId where to create the subscription. "
+                + "It can be either 'latest', 'earliest' or (ledgerId:entryId)", required = false)
         private String messageIdStr = "latest";
 
         @Override
@@ -514,7 +522,8 @@ public class CmdPersistentTopics extends CmdBase {
         private String subName;
 
         @Parameter(names = { "--time",
-                "-t" }, description = "time in minutes to reset back to (or minutes, hours,days,weeks eg: 100m, 3h, 2d, 5w)", required = false)
+                "-t" }, description = "time in minutes to reset back to "
+                + "(or minutes, hours,days,weeks eg: 100m, 3h, 2d, 5w)", required = false)
         private String resetTimeStr;
 
         @Parameter(names = { "--messageId",
@@ -586,7 +595,8 @@ public class CmdPersistentTopics extends CmdBase {
                 }
                 if (msg.getMessageId() instanceof BatchMessageIdImpl) {
                     BatchMessageIdImpl msgId = (BatchMessageIdImpl) msg.getMessageId();
-                    System.out.println("Batch Message ID: " + msgId.getLedgerId() + ":" + msgId.getEntryId() + ":" + msgId.getBatchIndex());
+                    System.out.println("Batch Message ID: " + msgId.getLedgerId() + ":" + msgId.getEntryId() + ":"
+                            + msgId.getBatchIndex());
                 } else {
                     MessageIdImpl msgId = (MessageIdImpl) msg.getMessageId();
                     System.out.println("Message ID: " + msgId.getLedgerId() + ":" + msgId.getEntryId());

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdProxyStats.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdProxyStats.java
@@ -18,11 +18,6 @@
  */
 package org.apache.pulsar.admin.cli;
 
-import java.io.IOException;
-import java.util.function.Supplier;
-
-import org.apache.pulsar.client.admin.PulsarAdmin;
-
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.Parameters;
 import com.google.gson.Gson;
@@ -30,6 +25,9 @@ import com.google.gson.GsonBuilder;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
+import java.io.IOException;
+import java.util.function.Supplier;
+import org.apache.pulsar.client.admin.PulsarAdmin;
 
 @Parameters(commandDescription = "Operations to collect Proxy statistics")
 public class CmdProxyStats extends CmdBase {

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdResourceGroups.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdResourceGroups.java
@@ -21,11 +21,10 @@ package org.apache.pulsar.admin.cli;
 
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.Parameters;
+import java.util.function.Supplier;
 import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.admin.PulsarAdminException;
 import org.apache.pulsar.common.policies.data.ResourceGroup;
-
-import java.util.function.Supplier;
 
 @Parameters(commandDescription = "Operations about ResourceGroups")
 public class CmdResourceGroups extends CmdBase {
@@ -54,20 +53,24 @@ public class CmdResourceGroups extends CmdBase {
         private java.util.List<String> params;
 
         @Parameter(names = { "--msg-publish-rate",
-                "-mp" }, description = "message-publish-rate (default -1 will be overwrite if not passed)", required = false)
+                "-mp" }, description = "message-publish-rate "
+                + "(default -1 will be overwrite if not passed)", required = false)
         private int publishRateInMsgs = -1;
 
         @Parameter(names = { "--byte-publish-rate",
-                "-bp" }, description = "byte-publish-rate (default -1 will be overwrite if not passed)", required = false)
+                "-bp" }, description = "byte-publish-rate "
+                + "(default -1 will be overwrite if not passed)", required = false)
         private long publishRateInBytes = -1;
 
 
         @Parameter(names = { "--msg-dispatch-rate",
-                "-md" }, description = "message-dispatch-rate (default -1 will be overwrite if not passed)", required = false)
+                "-md" }, description = "message-dispatch-rate "
+                + "(default -1 will be overwrite if not passed)", required = false)
         private int dispatchRateInMsgs = -1;
 
         @Parameter(names = { "--byte-dispatch-rate",
-                "-bd" }, description = "byte-dispatch-rate (default -1 will be overwrite if not passed)", required = false)
+                "-bd" }, description = "byte-dispatch-rate "
+                + "(default -1 will be overwrite if not passed)", required = false)
         private long dispatchRateInBytes = -1;
 
         @Override
@@ -89,20 +92,24 @@ public class CmdResourceGroups extends CmdBase {
         private java.util.List<String> params;
 
         @Parameter(names = { "--msg-publish-rate",
-                "-mp" }, description = "message-publish-rate (default -1 will be overwrite if not passed)", required = false)
+                "-mp" }, description = "message-publish-rate "
+                + "(default -1 will be overwrite if not passed)", required = false)
         private int publishRateInMsgs = -1;
 
         @Parameter(names = { "--byte-publish-rate",
-                "-bp" }, description = "byte-publish-rate (default -1 will be overwrite if not passed)", required = false)
+                "-bp" }, description = "byte-publish-rate "
+                + "(default -1 will be overwrite if not passed)", required = false)
         private long publishRateInBytes = -1;
 
 
         @Parameter(names = { "--msg-dispatch-rate",
-                "-md" }, description = "message-dispatch-rate (default -1 will be overwrite if not passed)", required = false)
+                "-md" }, description = "message-dispatch-rate "
+                + "(default -1 will be overwrite if not passed)", required = false)
         private int dispatchRateInMsgs = -1;
 
         @Parameter(names = { "--byte-dispatch-rate",
-                "-bd" }, description = "byte-dispatch-rate (default -1 will be overwrite if not passed)", required = false)
+                "-bd" }, description = "byte-dispatch-rate "
+                + "(default -1 will be overwrite if not passed)", required = false)
         private long dispatchRateInBytes = -1;
 
         @Override

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdResourceQuotas.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdResourceQuotas.java
@@ -18,20 +18,19 @@
  */
 package org.apache.pulsar.admin.cli;
 
+import com.beust.jcommander.Parameter;
+import com.beust.jcommander.ParameterException;
+import com.beust.jcommander.Parameters;
+import java.util.function.Supplier;
 import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.admin.PulsarAdminException;
 import org.apache.pulsar.common.policies.data.ResourceQuota;
 
-import com.beust.jcommander.Parameter;
-import com.beust.jcommander.ParameterException;
-import com.beust.jcommander.Parameters;
-
-import java.util.function.Supplier;
-
 @Parameters(commandDescription = "Operations about resource quotas")
 public class CmdResourceQuotas extends CmdBase {
 
-    @Parameters(commandDescription = "Get the resource quota for specified namespace bundle, or default quota if no namespace/bundle specified.")
+    @Parameters(commandDescription = "Get the resource quota for specified namespace bundle, "
+            + "or default quota if no namespace/bundle specified.")
     private class GetResourceQuota extends CliCommand {
 
         @Parameter(names = { "--namespace",
@@ -55,7 +54,8 @@ public class CmdResourceQuotas extends CmdBase {
         }
     }
 
-    @Parameters(commandDescription = "Set the resource quota for specified namespace bundle, or default quota if no namespace/bundle specified.")
+    @Parameters(commandDescription = "Set the resource quota for specified namespace bundle, "
+            + "or default quota if no namespace/bundle specified.")
     private class SetResourceQuota extends CliCommand {
 
         @Parameter(names = { "--namespace",

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdSchemas.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdSchemas.java
@@ -26,7 +26,6 @@ import java.io.File;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.util.function.Supplier;
-
 import org.apache.pulsar.admin.cli.utils.SchemaExtractor;
 import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.api.schema.SchemaDefinition;
@@ -121,8 +120,7 @@ public class CmdSchemas extends CmdBase {
         private boolean alwaysAllowNull = true;
 
         @Parameter(names = { "-n", "--dry-run"},
-                   description = "dost not apply to schema registry, " +
-                                 "just prints the post schema payload")
+                   description = "dost not apply to schema registry, just prints the post schema payload")
         private boolean dryRun = false;
 
         @Override
@@ -145,8 +143,7 @@ public class CmdSchemas extends CmdBase {
             } else if (type.equalsIgnoreCase("json")){
                 input.setType("JSON");
                 input.setSchema(SchemaExtractor.getJsonSchemaInfo(schemaDefinition));
-            }
-            else {
+            } else {
                 throw new Exception("Unknown schema type specified as type");
             }
             input.setProperties(schemaDefinition.getProperties());

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdSinks.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdSinks.java
@@ -22,7 +22,6 @@ import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import static org.apache.pulsar.common.naming.TopicName.DEFAULT_NAMESPACE;
 import static org.apache.pulsar.common.naming.TopicName.PUBLIC_TENANT;
-
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.ParameterException;
 import com.beust.jcommander.Parameters;
@@ -33,7 +32,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.reflect.TypeToken;
-
 import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.Field;
@@ -47,10 +45,8 @@ import java.util.Map;
 import java.util.Set;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
-
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
-
 import org.apache.commons.lang3.text.WordUtils;
 import org.apache.pulsar.admin.cli.utils.CmdUtils;
 import org.apache.pulsar.client.admin.PulsarAdmin;
@@ -60,9 +56,9 @@ import org.apache.pulsar.common.functions.ConsumerConfig;
 import org.apache.pulsar.common.functions.FunctionConfig;
 import org.apache.pulsar.common.functions.Resources;
 import org.apache.pulsar.common.functions.UpdateOptionsImpl;
+import org.apache.pulsar.common.functions.Utils;
 import org.apache.pulsar.common.io.ConnectorDefinition;
 import org.apache.pulsar.common.io.SinkConfig;
-import org.apache.pulsar.common.functions.Utils;
 import org.apache.pulsar.common.util.ObjectMapperFactory;
 
 @Getter
@@ -110,7 +106,7 @@ public class CmdSinks extends CmdBase {
     }
 
     /**
-     * Base command
+     * Base command.
      */
     @Getter
     abstract class BaseCommand extends CliCommand {
@@ -134,74 +130,80 @@ public class CmdSinks extends CmdBase {
         abstract void runCmd() throws Exception;
     }
 
-    @Parameters(commandDescription = "Run a Pulsar IO sink connector locally (rather than deploying it to the Pulsar cluster)")
+    @Parameters(commandDescription = "Run a Pulsar IO sink connector locally "
+            + "(rather than deploying it to the Pulsar cluster)")
     protected class LocalSinkRunner extends CreateSink {
 
-        @Parameter(names = "--state-storage-service-url", description = "The URL for the state storage service (the default is Apache BookKeeper)")
+        @Parameter(names = "--state-storage-service-url",
+                description = "The URL for the state storage service (the default is Apache BookKeeper)")
         protected String stateStorageServiceUrl;
         @Parameter(names = "--brokerServiceUrl", description = "The URL for the Pulsar broker", hidden = true)
-        protected String DEPRECATED_brokerServiceUrl;
+        protected String deprecatedBrokerServiceUrl;
         @Parameter(names = "--broker-service-url", description = "The URL for the Pulsar broker")
         protected String brokerServiceUrl;
 
-        @Parameter(names = "--clientAuthPlugin", description = "Client authentication plugin using which function-process can connect to broker", hidden = true)
-        protected String DEPRECATED_clientAuthPlugin;
-        @Parameter(names = "--client-auth-plugin", description = "Client authentication plugin using which function-process can connect to broker")
+        @Parameter(names = "--clientAuthPlugin", description = "Client authentication plugin using "
+                + "which function-process can connect to broker", hidden = true)
+        protected String deprecatedClientAuthPlugin;
+        @Parameter(names = "--client-auth-plugin",
+                description = "Client authentication plugin using which function-process can connect to broker")
         protected String clientAuthPlugin;
 
         @Parameter(names = "--clientAuthParams", description = "Client authentication param", hidden = true)
-        protected String DEPRECATED_clientAuthParams;
+        protected String deprecatedClientAuthParams;
         @Parameter(names = "--client-auth-params", description = "Client authentication param")
         protected String clientAuthParams;
 
         @Parameter(names = "--use_tls", description = "Use tls connection", hidden = true)
-        protected Boolean DEPRECATED_useTls;
+        protected Boolean deprecatedUseTls;
         @Parameter(names = "--use-tls", description = "Use tls connection")
         protected boolean useTls;
 
         @Parameter(names = "--tls_allow_insecure", description = "Allow insecure tls connection", hidden = true)
-        protected Boolean DEPRECATED_tlsAllowInsecureConnection;
+        protected Boolean deprecatedTlsAllowInsecureConnection;
         @Parameter(names = "--tls-allow-insecure", description = "Allow insecure tls connection")
         protected boolean tlsAllowInsecureConnection;
 
-        @Parameter(names = "--hostname_verification_enabled", description = "Enable hostname verification", hidden = true)
-        protected Boolean DEPRECATED_tlsHostNameVerificationEnabled;
+        @Parameter(names = "--hostname_verification_enabled",
+                description = "Enable hostname verification", hidden = true)
+        protected Boolean deprecatedTlsHostNameVerificationEnabled;
         @Parameter(names = "--hostname-verification-enabled", description = "Enable hostname verification")
         protected boolean tlsHostNameVerificationEnabled;
 
         @Parameter(names = "--tls_trust_cert_path", description = "tls trust cert file path", hidden = true)
-        protected String DEPRECATED_tlsTrustCertFilePath;
+        protected String deprecatedTlsTrustCertFilePath;
         @Parameter(names = "--tls-trust-cert-path", description = "tls trust cert file path")
         protected String tlsTrustCertFilePath;
 
         @Parameter(names = "--secrets-provider-classname", description = "Whats the classname for secrets provider")
         protected String secretsProviderClassName;
-        @Parameter(names = "--secrets-provider-config", description = "Config that needs to be passed to secrets provider")
+        @Parameter(names = "--secrets-provider-config",
+                description = "Config that needs to be passed to secrets provider")
         protected String secretsProviderConfig;
         @Parameter(names = "--metrics-port-start", description = "The starting port range for metrics server")
         protected String metricsPortStart;
 
         private void mergeArgs() {
-            if (isBlank(brokerServiceUrl) && !isBlank(DEPRECATED_brokerServiceUrl)) {
-                brokerServiceUrl = DEPRECATED_brokerServiceUrl;
+            if (isBlank(brokerServiceUrl) && !isBlank(deprecatedBrokerServiceUrl)) {
+                brokerServiceUrl = deprecatedBrokerServiceUrl;
             }
-            if (isBlank(clientAuthPlugin) && !isBlank(DEPRECATED_clientAuthPlugin)) {
-                clientAuthPlugin = DEPRECATED_clientAuthPlugin;
+            if (isBlank(clientAuthPlugin) && !isBlank(deprecatedClientAuthPlugin)) {
+                clientAuthPlugin = deprecatedClientAuthPlugin;
             }
-            if (isBlank(clientAuthParams) && !isBlank(DEPRECATED_clientAuthParams)) {
-                clientAuthParams = DEPRECATED_clientAuthParams;
+            if (isBlank(clientAuthParams) && !isBlank(deprecatedClientAuthParams)) {
+                clientAuthParams = deprecatedClientAuthParams;
             }
-            if (!useTls && DEPRECATED_useTls != null) {
-                useTls = DEPRECATED_useTls;
+            if (!useTls && deprecatedUseTls != null) {
+                useTls = deprecatedUseTls;
             }
-            if (!tlsAllowInsecureConnection && DEPRECATED_tlsAllowInsecureConnection != null) {
-                tlsAllowInsecureConnection = DEPRECATED_tlsAllowInsecureConnection;
+            if (!tlsAllowInsecureConnection && deprecatedTlsAllowInsecureConnection != null) {
+                tlsAllowInsecureConnection = deprecatedTlsAllowInsecureConnection;
             }
-            if (!tlsHostNameVerificationEnabled && DEPRECATED_tlsHostNameVerificationEnabled != null) {
-                tlsHostNameVerificationEnabled = DEPRECATED_tlsHostNameVerificationEnabled;
+            if (!tlsHostNameVerificationEnabled && deprecatedTlsHostNameVerificationEnabled != null) {
+                tlsHostNameVerificationEnabled = deprecatedTlsHostNameVerificationEnabled;
             }
-            if (isBlank(tlsTrustCertFilePath) && !isBlank(DEPRECATED_tlsTrustCertFilePath)) {
-                tlsTrustCertFilePath = DEPRECATED_tlsTrustCertFilePath;
+            if (isBlank(tlsTrustCertFilePath) && !isBlank(deprecatedTlsTrustCertFilePath)) {
+                tlsTrustCertFilePath = deprecatedTlsTrustCertFilePath;
             }
         }
 
@@ -214,8 +216,12 @@ public class CmdSinks extends CmdBase {
             localRunArgs.add("--sinkConfig");
             localRunArgs.add(new Gson().toJson(sinkConfig));
             for (Field field : this.getClass().getDeclaredFields()) {
-                if (field.getName().startsWith("DEPRECATED")) continue;
-                if(field.getName().contains("$")) continue;
+                if (field.getName().startsWith("DEPRECATED")) {
+                    continue;
+                }
+                if (field.getName().contains("$")) {
+                    continue;
+                }
                 Object value = field.get(this);
                 if (value != null) {
                     localRunArgs.add("--" + field.getName());
@@ -286,108 +292,136 @@ public class CmdSinks extends CmdBase {
         protected String sinkType;
 
         @Parameter(names = { "-i",
-                "--inputs" }, description = "The sink's input topic or topics (multiple topics can be specified as a comma-separated list)")
+                "--inputs" }, description = "The sink's input topic or topics "
+                + "(multiple topics can be specified as a comma-separated list)")
         protected String inputs;
 
-        @Parameter(names = "--topicsPattern", description = "TopicsPattern to consume from list of topics under a namespace that match the pattern. [--input] and [--topicsPattern] are mutually exclusive. Add SerDe class name for a pattern in --customSerdeInputs  (supported for java fun only)", hidden = true)
-        protected String DEPRECATED_topicsPattern;
-        @Parameter(names = "--topics-pattern", description = "TopicsPattern to consume from list of topics under a namespace that match the pattern. [--input] and [--topicsPattern] are mutually exclusive. Add SerDe class name for a pattern in --customSerdeInputs  (supported for java fun only)")
+        @Parameter(names = "--topicsPattern", description = "TopicsPattern to consume from list of topics "
+                + "under a namespace that match the pattern. [--input] and [--topicsPattern] are mutually exclusive. "
+                + "Add SerDe class name for a pattern in --customSerdeInputs  (supported for java fun only)",
+                hidden = true)
+        protected String deprecatedTopicsPattern;
+        @Parameter(names = "--topics-pattern", description = "TopicsPattern to consume from list of topics "
+                + "under a namespace that match the pattern. [--input] and [--topicsPattern] are mutually exclusive. "
+                + "Add SerDe class name for a pattern in --customSerdeInputs  (supported for java fun only)")
         protected String topicsPattern;
 
-        @Parameter(names = "--subsName", description = "Pulsar source subscription name if user wants a specific subscription-name for input-topic consumer", hidden = true)
-        protected String DEPRECATED_subsName;
-        @Parameter(names = "--subs-name", description = "Pulsar source subscription name if user wants a specific subscription-name for input-topic consumer")
+        @Parameter(names = "--subsName", description = "Pulsar source subscription name "
+                + "if user wants a specific subscription-name for input-topic consumer", hidden = true)
+        protected String deprecatedSubsName;
+        @Parameter(names = "--subs-name", description = "Pulsar source subscription name "
+                + "if user wants a specific subscription-name for input-topic consumer")
         protected String subsName;
 
-        @Parameter(names = "--subs-position", description = "Pulsar source subscription position if user wants to consume messages from the specified location")
+        @Parameter(names = "--subs-position", description = "Pulsar source subscription position "
+                + "if user wants to consume messages from the specified location")
         protected SubscriptionInitialPosition subsPosition;
 
-        @Parameter(names = "--customSerdeInputs", description = "The map of input topics to SerDe class names (as a JSON string)", hidden = true)
-        protected String DEPRECATED_customSerdeInputString;
-        @Parameter(names = "--custom-serde-inputs", description = "The map of input topics to SerDe class names (as a JSON string)")
+        @Parameter(names = "--customSerdeInputs",
+                description = "The map of input topics to SerDe class names (as a JSON string)", hidden = true)
+        protected String deprecatedCustomSerdeInputString;
+        @Parameter(names = "--custom-serde-inputs",
+                description = "The map of input topics to SerDe class names (as a JSON string)")
         protected String customSerdeInputString;
 
-        @Parameter(names = "--custom-schema-inputs", description = "The map of input topics to Schema types or class names (as a JSON string)")
+        @Parameter(names = "--custom-schema-inputs",
+                description = "The map of input topics to Schema types or class names (as a JSON string)")
         protected String customSchemaInputString;
 
-        @Parameter(names = "--input-specs", description = "The map of inputs to custom configuration (as a JSON string)")
+        @Parameter(names = "--input-specs",
+                description = "The map of inputs to custom configuration (as a JSON string)")
         protected String inputSpecs;
 
-        @Parameter(names = "--max-redeliver-count", description = "Maximum number of times that a message will be redelivered before being sent to the dead letter queue")
+        @Parameter(names = "--max-redeliver-count", description = "Maximum number of times that a message "
+                + "will be redelivered before being sent to the dead letter queue")
         protected Integer maxMessageRetries;
-        @Parameter(names = "--dead-letter-topic", description = "Name of the dead topic where the failing messages will be sent.")
+        @Parameter(names = "--dead-letter-topic",
+                description = "Name of the dead topic where the failing messages will be sent.")
         protected String deadLetterTopic;
 
-        @Parameter(names = "--processingGuarantees", description = "The processing guarantees (aka delivery semantics) applied to the sink", hidden = true)
-        protected FunctionConfig.ProcessingGuarantees DEPRECATED_processingGuarantees;
-        @Parameter(names = "--processing-guarantees", description = "The processing guarantees (aka delivery semantics) applied to the sink")
+        @Parameter(names = "--processingGuarantees",
+                description = "The processing guarantees (aka delivery semantics) applied to the sink", hidden = true)
+        protected FunctionConfig.ProcessingGuarantees deprecatedProcessingGuarantees;
+        @Parameter(names = "--processing-guarantees",
+                description = "The processing guarantees (aka delivery semantics) applied to the sink")
         protected FunctionConfig.ProcessingGuarantees processingGuarantees;
         @Parameter(names = "--retainOrdering", description = "Sink consumes and sinks messages in order", hidden = true)
-        protected Boolean DEPRECATED_retainOrdering;
+        protected Boolean deprecatedRetainOrdering;
         @Parameter(names = "--retain-ordering", description = "Sink consumes and sinks messages in order")
         protected Boolean retainOrdering;
-        @Parameter(names = "--parallelism", description = "The sink's parallelism factor (i.e. the number of sink instances to run)")
+        @Parameter(names = "--parallelism",
+                description = "The sink's parallelism factor (i.e. the number of sink instances to run)")
         protected Integer parallelism;
-        @Parameter(names = {"-a", "--archive"}, description = "Path to the archive file for the sink. It also supports url-path [http/https/file (file protocol assumes that file already exists on worker host)] from which worker can download the package.", listConverter = StringConverter.class)
+        @Parameter(names = {"-a", "--archive"}, description = "Path to the archive file for the sink. It also supports "
+                + "url-path [http/https/file (file protocol assumes that file already exists on worker host)] from "
+                + "which worker can download the package.", listConverter = StringConverter.class)
         protected String archive;
-        @Parameter(names = "--className", description = "The sink's class name if archive is file-url-path (file://)", hidden = true)
-        protected String DEPRECATED_className;
+        @Parameter(names = "--className",
+                description = "The sink's class name if archive is file-url-path (file://)", hidden = true)
+        protected String deprecatedClassName;
         @Parameter(names = "--classname", description = "The sink's class name if archive is file-url-path (file://)")
         protected String className;
 
         @Parameter(names = "--sinkConfigFile", description = "The path to a YAML config file specifying the "
                 + "sink's configuration", hidden = true)
-        protected String DEPRECATED_sinkConfigFile;
+        protected String deprecatedSinkConfigFile;
         @Parameter(names = "--sink-config-file", description = "The path to a YAML config file specifying the "
                 + "sink's configuration")
         protected String sinkConfigFile;
-        @Parameter(names = "--cpu", description = "The CPU (in cores) that needs to be allocated per sink instance (applicable only to Docker runtime)")
+        @Parameter(names = "--cpu", description = "The CPU (in cores) that needs to be allocated "
+                + "per sink instance (applicable only to Docker runtime)")
         protected Double cpu;
-        @Parameter(names = "--ram", description = "The RAM (in bytes) that need to be allocated per sink instance (applicable only to the process and Docker runtimes)")
+        @Parameter(names = "--ram", description = "The RAM (in bytes) that need to be allocated "
+                + "per sink instance (applicable only to the process and Docker runtimes)")
         protected Long ram;
-        @Parameter(names = "--disk", description = "The disk (in bytes) that need to be allocated per sink instance (applicable only to Docker runtime)")
+        @Parameter(names = "--disk", description = "The disk (in bytes) that need to be allocated "
+                + "per sink instance (applicable only to Docker runtime)")
         protected Long disk;
         @Parameter(names = "--sinkConfig", description = "User defined configs key/values", hidden = true)
-        protected String DEPRECATED_sinkConfigString;
+        protected String deprecatedSinkConfigString;
         @Parameter(names = "--sink-config", description = "User defined configs key/values")
         protected String sinkConfigString;
-        @Parameter(names = "--auto-ack", description = "Whether or not the framework will automatically acknowledge messages", arity = 1)
+        @Parameter(names = "--auto-ack",
+                description = "Whether or not the framework will automatically acknowledge messages", arity = 1)
         protected Boolean autoAck;
         @Parameter(names = "--timeout-ms", description = "The message timeout in milliseconds")
         protected Long timeoutMs;
-        @Parameter(names = "--negative-ack-redelivery-delay-ms", description = "The negative ack message redelivery delay in milliseconds")
+        @Parameter(names = "--negative-ack-redelivery-delay-ms",
+                description = "The negative ack message redelivery delay in milliseconds")
         protected Long negativeAckRedeliveryDelayMs;
-        @Parameter(names = "--custom-runtime-options", description = "A string that encodes options to customize the runtime, see docs for configured runtime for details")
+        @Parameter(names = "--custom-runtime-options", description = "A string that encodes options to "
+                + "customize the runtime, see docs for configured runtime for details")
         protected String customRuntimeOptions;
-        @Parameter(names = "--secrets", description = "The map of secretName to an object that encapsulates how the secret is fetched by the underlying secrets provider")
+        @Parameter(names = "--secrets", description = "The map of secretName to an object that encapsulates "
+                + "how the secret is fetched by the underlying secrets provider")
         protected String secretsString;
 
         protected SinkConfig sinkConfig;
 
         private void mergeArgs() {
-            if (isBlank(subsName) && !isBlank(DEPRECATED_subsName)) {
-                subsName = DEPRECATED_subsName;
+            if (isBlank(subsName) && !isBlank(deprecatedSubsName)) {
+                subsName = deprecatedSubsName;
             }
-            if (isBlank(topicsPattern) && !isBlank(DEPRECATED_topicsPattern)) {
-                topicsPattern = DEPRECATED_topicsPattern;
+            if (isBlank(topicsPattern) && !isBlank(deprecatedTopicsPattern)) {
+                topicsPattern = deprecatedTopicsPattern;
             }
-            if (isBlank(customSerdeInputString) && !isBlank(DEPRECATED_customSerdeInputString)) {
-                customSerdeInputString = DEPRECATED_customSerdeInputString;
+            if (isBlank(customSerdeInputString) && !isBlank(deprecatedCustomSerdeInputString)) {
+                customSerdeInputString = deprecatedCustomSerdeInputString;
             }
-            if (processingGuarantees == null && DEPRECATED_processingGuarantees != null) {
-                processingGuarantees = DEPRECATED_processingGuarantees;
+            if (processingGuarantees == null && deprecatedProcessingGuarantees != null) {
+                processingGuarantees = deprecatedProcessingGuarantees;
             }
-            if (retainOrdering == null && DEPRECATED_retainOrdering != null) {
-                retainOrdering = DEPRECATED_retainOrdering;
+            if (retainOrdering == null && deprecatedRetainOrdering != null) {
+                retainOrdering = deprecatedRetainOrdering;
             }
-            if (isBlank(className) && !isBlank(DEPRECATED_className)) {
-                className = DEPRECATED_className;
+            if (isBlank(className) && !isBlank(deprecatedClassName)) {
+                className = deprecatedClassName;
             }
-            if (isBlank(sinkConfigFile) && !isBlank(DEPRECATED_sinkConfigFile)) {
-                sinkConfigFile = DEPRECATED_sinkConfigFile;
+            if (isBlank(sinkConfigFile) && !isBlank(deprecatedSinkConfigFile)) {
+                sinkConfigFile = deprecatedSinkConfigFile;
             }
-            if (isBlank(sinkConfigString) && !isBlank(DEPRECATED_sinkConfigString)) {
-                sinkConfigString = DEPRECATED_sinkConfigString;
+            if (isBlank(sinkConfigString) && !isBlank(deprecatedSinkConfigString)) {
+                sinkConfigString = deprecatedSinkConfigString;
             }
         }
 
@@ -441,7 +475,7 @@ public class CmdSinks extends CmdBase {
                 sinkConfig.setTopicToSchemaType(customSchemaInputMap);
             }
 
-            if(null != inputSpecs){
+            if (null != inputSpecs) {
                 Type type = new TypeToken<Map<String, ConsumerConfig>>(){}.getType();
                 sinkConfig.setInputSpecs(new Gson().fromJson(inputSpecs, type));
             }
@@ -541,8 +575,7 @@ public class CmdSinks extends CmdBase {
 
         protected Map<String, Object> parseConfigs(String str) throws JsonProcessingException {
             ObjectMapper mapper = ObjectMapperFactory.getThreadLocal();
-            TypeReference<HashMap<String,Object>> typeRef
-                = new TypeReference<HashMap<String,Object>>() {};
+            TypeReference<HashMap<String, Object>> typeRef = new TypeReference<HashMap<String, Object>>() {};
 
             return mapper.readValue(str, typeRef);
         }
@@ -555,10 +588,11 @@ public class CmdSinks extends CmdBase {
 
             org.apache.pulsar.common.functions.Utils.inferMissingArguments(sinkConfig);
 
-            if (!Utils.isFunctionPackageUrlSupported(sinkConfig.getArchive()) &&
-                    !sinkConfig.getArchive().startsWith(Utils.BUILTIN)) {
+            if (!Utils.isFunctionPackageUrlSupported(sinkConfig.getArchive())
+                    && !sinkConfig.getArchive().startsWith(Utils.BUILTIN)) {
                 if (!new File(sinkConfig.getArchive()).exists()) {
-                    throw new IllegalArgumentException(String.format("Sink Archive file %s does not exist", sinkConfig.getArchive()));
+                    throw new IllegalArgumentException(String.format("Sink Archive file %s does not exist",
+                            sinkConfig.getArchive()));
                 }
             }
         }
@@ -566,7 +600,8 @@ public class CmdSinks extends CmdBase {
         protected String validateSinkType(String sinkType) throws IOException {
             Set<String> availableSinks;
             try {
-                availableSinks = getAdmin().sinks().getBuiltInSinks().stream().map(ConnectorDefinition::getName).collect(Collectors.toSet());
+                availableSinks = getAdmin().sinks().getBuiltInSinks().stream()
+                        .map(ConnectorDefinition::getName).collect(Collectors.toSet());
             } catch (PulsarAdminException e) {
                 throw new IOException(e);
             }
@@ -582,7 +617,7 @@ public class CmdSinks extends CmdBase {
     }
 
     /**
-     * Sink level command
+     * Sink level command.
      */
     @Getter
     abstract class SinkCommand extends BaseCommand {
@@ -633,7 +668,7 @@ public class CmdSinks extends CmdBase {
     }
 
     /**
-     * List Sources command
+     * List Sources command.
      */
     @Parameters(commandDescription = "List all running Pulsar IO sink connectors")
     protected class ListSinks extends BaseCommand {
@@ -664,7 +699,8 @@ public class CmdSinks extends CmdBase {
     @Parameters(commandDescription = "Check the current status of a Pulsar Sink")
     class GetSinkStatus extends SinkCommand {
 
-        @Parameter(names = "--instance-id", description = "The sink instanceId (Get-status of all instances if instance-id is not provided")
+        @Parameter(names = "--instance-id",
+                description = "The sink instanceId (Get-status of all instances if instance-id is not provided")
         protected String instanceId;
 
         @Override
@@ -680,7 +716,8 @@ public class CmdSinks extends CmdBase {
     @Parameters(commandDescription = "Restart sink instance")
     class RestartSink extends SinkCommand {
 
-        @Parameter(names = "--instance-id", description = "The sink instanceId (restart all instances if instance-id is not provided")
+        @Parameter(names = "--instance-id",
+                description = "The sink instanceId (restart all instances if instance-id is not provided")
         protected String instanceId;
 
         @Override
@@ -701,7 +738,8 @@ public class CmdSinks extends CmdBase {
     @Parameters(commandDescription = "Stops sink instance")
     class StopSink extends SinkCommand {
 
-        @Parameter(names = "--instance-id", description = "The sink instanceId (stop all instances if instance-id is not provided")
+        @Parameter(names = "--instance-id",
+                description = "The sink instanceId (stop all instances if instance-id is not provided")
         protected String instanceId;
 
         @Override
@@ -722,7 +760,8 @@ public class CmdSinks extends CmdBase {
     @Parameters(commandDescription = "Starts sink instance")
     class StartSink extends SinkCommand {
 
-        @Parameter(names = "--instance-id", description = "The sink instanceId (start all instances if instance-id is not provided")
+        @Parameter(names = "--instance-id",
+                description = "The sink instanceId (start all instances if instance-id is not provided")
         protected String instanceId;
 
         @Override

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdSources.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdSources.java
@@ -22,7 +22,6 @@ import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import static org.apache.pulsar.common.naming.TopicName.DEFAULT_NAMESPACE;
 import static org.apache.pulsar.common.naming.TopicName.PUBLIC_TENANT;
-
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.ParameterException;
 import com.beust.jcommander.Parameters;
@@ -33,7 +32,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.reflect.TypeToken;
-
 import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.Field;
@@ -46,23 +44,21 @@ import java.util.Map;
 import java.util.Set;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
-
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
-
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.text.WordUtils;
 import org.apache.pulsar.admin.cli.utils.CmdUtils;
 import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.admin.PulsarAdminException;
+import org.apache.pulsar.common.functions.FunctionConfig;
 import org.apache.pulsar.common.functions.ProducerConfig;
 import org.apache.pulsar.common.functions.Resources;
 import org.apache.pulsar.common.functions.UpdateOptionsImpl;
+import org.apache.pulsar.common.functions.Utils;
 import org.apache.pulsar.common.io.BatchSourceConfig;
 import org.apache.pulsar.common.io.ConnectorDefinition;
-import org.apache.pulsar.common.functions.FunctionConfig;
 import org.apache.pulsar.common.io.SourceConfig;
-import org.apache.pulsar.common.functions.Utils;
 import org.apache.pulsar.common.util.ObjectMapperFactory;
 
 @Getter
@@ -110,7 +106,7 @@ public class CmdSources extends CmdBase {
     }
 
     /**
-     * Base command
+     * Base command.
      */
     @Getter
     abstract class BaseCommand extends CliCommand {
@@ -134,74 +130,81 @@ public class CmdSources extends CmdBase {
         abstract void runCmd() throws Exception;
     }
 
-    @Parameters(commandDescription = "Run a Pulsar IO source connector locally (rather than deploying it to the Pulsar cluster)")
+    @Parameters(commandDescription = "Run a Pulsar IO source connector locally "
+            + "(rather than deploying it to the Pulsar cluster)")
     protected class LocalSourceRunner extends CreateSource {
 
-        @Parameter(names = "--state-storage-service-url", description = "The URL for the state storage service (the default is Apache BookKeeper)")
+        @Parameter(names = "--state-storage-service-url",
+                description = "The URL for the state storage service (the default is Apache BookKeeper)")
         protected String stateStorageServiceUrl;
         @Parameter(names = "--brokerServiceUrl", description = "The URL for the Pulsar broker", hidden = true)
-        protected String DEPRECATED_brokerServiceUrl;
+        protected String deprecatedBrokerServiceUrl;
         @Parameter(names = "--broker-service-url", description = "The URL for the Pulsar broker")
         protected String brokerServiceUrl;
 
-        @Parameter(names = "--clientAuthPlugin", description = "Client authentication plugin using which function-process can connect to broker", hidden = true)
-        protected String DEPRECATED_clientAuthPlugin;
-        @Parameter(names = "--client-auth-plugin", description = "Client authentication plugin using which function-process can connect to broker")
+        @Parameter(names = "--clientAuthPlugin",
+                description = "Client authentication plugin using which function-process can connect to broker",
+                hidden = true)
+        protected String deprecatedClientAuthPlugin;
+        @Parameter(names = "--client-auth-plugin",
+                description = "Client authentication plugin using which function-process can connect to broker")
         protected String clientAuthPlugin;
 
         @Parameter(names = "--clientAuthParams", description = "Client authentication param", hidden = true)
-        protected String DEPRECATED_clientAuthParams;
+        protected String deprecatedClientAuthParams;
         @Parameter(names = "--client-auth-params", description = "Client authentication param")
         protected String clientAuthParams;
 
         @Parameter(names = "--use_tls", description = "Use tls connection", hidden = true)
-        protected Boolean DEPRECATED_useTls;
+        protected Boolean deprecatedUseTls;
         @Parameter(names = "--use-tls", description = "Use tls connection")
         protected boolean useTls;
 
         @Parameter(names = "--tls_allow_insecure", description = "Allow insecure tls connection", hidden = true)
-        protected Boolean DEPRECATED_tlsAllowInsecureConnection;
+        protected Boolean deprecatedTlsAllowInsecureConnection;
         @Parameter(names = "--tls-allow-insecure", description = "Allow insecure tls connection")
         protected boolean tlsAllowInsecureConnection;
 
-        @Parameter(names = "--hostname_verification_enabled", description = "Enable hostname verification", hidden = true)
-        protected Boolean DEPRECATED_tlsHostNameVerificationEnabled;
+        @Parameter(names = "--hostname_verification_enabled",
+                description = "Enable hostname verification", hidden = true)
+        protected Boolean deprecatedTlsHostNameVerificationEnabled;
         @Parameter(names = "--hostname-verification-enabled", description = "Enable hostname verification")
         protected boolean tlsHostNameVerificationEnabled;
 
         @Parameter(names = "--tls_trust_cert_path", description = "tls trust cert file path", hidden = true)
-        protected String DEPRECATED_tlsTrustCertFilePath;
+        protected String deprecatedTlsTrustCertFilePath;
         @Parameter(names = "--tls-trust-cert-path", description = "tls trust cert file path")
         protected String tlsTrustCertFilePath;
 
         @Parameter(names = "--secrets-provider-classname", description = "Whats the classname for secrets provider")
         protected String secretsProviderClassName;
-        @Parameter(names = "--secrets-provider-config", description = "Config that needs to be passed to secrets provider")
+        @Parameter(names = "--secrets-provider-config",
+                description = "Config that needs to be passed to secrets provider")
         protected String secretsProviderConfig;
         @Parameter(names = "--metrics-port-start", description = "The starting port range for metrics server")
         protected String metricsPortStart;
 
         private void mergeArgs() {
-            if (isBlank(brokerServiceUrl) && !isBlank(DEPRECATED_brokerServiceUrl)) {
-                brokerServiceUrl = DEPRECATED_brokerServiceUrl;
+            if (isBlank(brokerServiceUrl) && !isBlank(deprecatedBrokerServiceUrl)) {
+                brokerServiceUrl = deprecatedBrokerServiceUrl;
             }
-            if (isBlank(clientAuthPlugin) && !isBlank(DEPRECATED_clientAuthPlugin)) {
-                clientAuthPlugin = DEPRECATED_clientAuthPlugin;
+            if (isBlank(clientAuthPlugin) && !isBlank(deprecatedClientAuthPlugin)) {
+                clientAuthPlugin = deprecatedClientAuthPlugin;
             }
-            if (isBlank(clientAuthParams) && !isBlank(DEPRECATED_clientAuthParams)) {
-                clientAuthParams = DEPRECATED_clientAuthParams;
+            if (isBlank(clientAuthParams) && !isBlank(deprecatedClientAuthParams)) {
+                clientAuthParams = deprecatedClientAuthParams;
             }
-            if (!useTls && DEPRECATED_useTls != null) {
-                useTls = DEPRECATED_useTls;
+            if (!useTls && deprecatedUseTls != null) {
+                useTls = deprecatedUseTls;
             }
-            if (!tlsAllowInsecureConnection && DEPRECATED_tlsAllowInsecureConnection != null) {
-                tlsAllowInsecureConnection = DEPRECATED_tlsAllowInsecureConnection;
+            if (!tlsAllowInsecureConnection && deprecatedTlsAllowInsecureConnection != null) {
+                tlsAllowInsecureConnection = deprecatedTlsAllowInsecureConnection;
             }
-            if (!tlsHostNameVerificationEnabled && DEPRECATED_tlsHostNameVerificationEnabled != null) {
-                tlsHostNameVerificationEnabled = DEPRECATED_tlsHostNameVerificationEnabled;
+            if (!tlsHostNameVerificationEnabled && deprecatedTlsHostNameVerificationEnabled != null) {
+                tlsHostNameVerificationEnabled = deprecatedTlsHostNameVerificationEnabled;
             }
-            if (isBlank(tlsTrustCertFilePath) && !isBlank(DEPRECATED_tlsTrustCertFilePath)) {
-                tlsTrustCertFilePath = DEPRECATED_tlsTrustCertFilePath;
+            if (isBlank(tlsTrustCertFilePath) && !isBlank(deprecatedTlsTrustCertFilePath)) {
+                tlsTrustCertFilePath = deprecatedTlsTrustCertFilePath;
             }
         }
 
@@ -215,8 +218,12 @@ public class CmdSources extends CmdBase {
             localRunArgs.add("--sourceConfig");
             localRunArgs.add(new Gson().toJson(sourceConfig));
             for (Field field : this.getClass().getDeclaredFields()) {
-                if (field.getName().startsWith("DEPRECATED")) continue;
-                if(field.getName().contains("$")) continue;
+                if (field.getName().startsWith("DEPRECATED")) {
+                    continue;
+                }
+                if (field.getName().contains("$")) {
+                    continue;
+                }
                 Object value = field.get(this);
                 if (value != null) {
                     localRunArgs.add("--" + field.getName());
@@ -286,23 +293,28 @@ public class CmdSources extends CmdBase {
         @Parameter(names = { "-t", "--source-type" }, description = "The source's connector provider")
         protected String sourceType;
 
-        @Parameter(names = "--processingGuarantees", description = "The processing guarantees (aka delivery semantics) applied to the Source", hidden = true)
-        protected FunctionConfig.ProcessingGuarantees DEPRECATED_processingGuarantees;
-        @Parameter(names = "--processing-guarantees", description = "The processing guarantees (aka delivery semantics) applied to the source")
+        @Parameter(names = "--processingGuarantees",
+                description = "The processing guarantees (aka delivery semantics) applied to the Source", hidden = true)
+        protected FunctionConfig.ProcessingGuarantees deprecatedProcessingGuarantees;
+        @Parameter(names = "--processing-guarantees",
+                description = "The processing guarantees (aka delivery semantics) applied to the source")
         protected FunctionConfig.ProcessingGuarantees processingGuarantees;
 
-        @Parameter(names = { "-o", "--destinationTopicName" }, description = "The Pulsar topic to which data is sent", hidden = true)
-        protected String DEPRECATED_destinationTopicName;
+        @Parameter(names = { "-o", "--destinationTopicName" },
+                description = "The Pulsar topic to which data is sent", hidden = true)
+        protected String deprecatedDestinationTopicName;
         @Parameter(names = "--destination-topic-name", description = "The Pulsar topic to which data is sent")
         protected String destinationTopicName;
         @Parameter(names = "--producer-config", description = "The custom producer configuration (as a JSON string)")
         protected String producerConfig;
 
-        @Parameter(names = "--batch-builder", description = "BatchBuilder provides two types of batch construction methods, DEFAULT and KEY_BASED. The default value is: DEFAULT")
+        @Parameter(names = "--batch-builder", description = "BatchBuilder provides two types of "
+                + "batch construction methods, DEFAULT and KEY_BASED. The default value is: DEFAULT")
         protected String batchBuilder;
 
-        @Parameter(names = "--deserializationClassName", description = "The SerDe classname for the source", hidden = true)
-        protected String DEPRECATED_deserializationClassName;
+        @Parameter(names = "--deserializationClassName",
+                description = "The SerDe classname for the source", hidden = true)
+        protected String deprecatedDeserializationClassName;
         @Parameter(names = "--deserialization-classname", description = "The SerDe classname for the source")
         protected String deserializationClassName;
 
@@ -311,58 +323,67 @@ public class CmdSources extends CmdBase {
                         + " or custom Schema class name to be used to encode messages emitted from the source")
         protected String schemaType;
 
-        @Parameter(names = "--parallelism", description = "The source's parallelism factor (i.e. the number of source instances to run)")
+        @Parameter(names = "--parallelism",
+                description = "The source's parallelism factor (i.e. the number of source instances to run)")
         protected Integer parallelism;
         @Parameter(names = { "-a", "--archive" },
-                description = "The path to the NAR archive for the Source. It also supports url-path [http/https/file (file protocol assumes that file already exists on worker host)] from which worker can download the package.", listConverter = StringConverter.class)
+                description = "The path to the NAR archive for the Source. It also supports url-path "
+                        + "[http/https/file (file protocol assumes that file already exists on worker host)] "
+                        + "from which worker can download the package.", listConverter = StringConverter.class)
         protected String archive;
-        @Parameter(names = "--className", description = "The source's class name if archive is file-url-path (file://)", hidden = true)
-        protected String DEPRECATED_className;
+        @Parameter(names = "--className",
+                description = "The source's class name if archive is file-url-path (file://)", hidden = true)
+        protected String deprecatedClassName;
         @Parameter(names = "--classname", description = "The source's class name if archive is file-url-path (file://)")
         protected String className;
         @Parameter(names = "--sourceConfigFile", description = "The path to a YAML config file specifying the "
                 + "source's configuration", hidden = true)
-        protected String DEPRECATED_sourceConfigFile;
+        protected String deprecatedSourceConfigFile;
         @Parameter(names = "--source-config-file", description = "The path to a YAML config file specifying the "
                 + "source's configuration")
         protected String sourceConfigFile;
-        @Parameter(names = "--cpu", description = "The CPU (in cores) that needs to be allocated per source instance (applicable only to Docker runtime)")
+        @Parameter(names = "--cpu", description = "The CPU (in cores) that needs to be allocated "
+                + "per source instance (applicable only to Docker runtime)")
         protected Double cpu;
-        @Parameter(names = "--ram", description = "The RAM (in bytes) that need to be allocated per source instance (applicable only to the process and Docker runtimes)")
+        @Parameter(names = "--ram", description = "The RAM (in bytes) that need to be allocated "
+                + "per source instance (applicable only to the process and Docker runtimes)")
         protected Long ram;
-        @Parameter(names = "--disk", description = "The disk (in bytes) that need to be allocated per source instance (applicable only to Docker runtime)")
+        @Parameter(names = "--disk", description = "The disk (in bytes) that need to be allocated "
+                + "per source instance (applicable only to Docker runtime)")
         protected Long disk;
         @Parameter(names = "--sourceConfig", description = "Source config key/values", hidden = true)
-        protected String DEPRECATED_sourceConfigString;
+        protected String deprecatedSourceConfigString;
         @Parameter(names = "--source-config", description = "Source config key/values")
         protected String sourceConfigString;
         @Parameter(names = "--batch-source-config", description = "Batch source config key/values")
         protected String batchSourceConfigString;
-        @Parameter(names = "--custom-runtime-options", description = "A string that encodes options to customize the runtime, see docs for configured runtime for details")
+        @Parameter(names = "--custom-runtime-options", description = "A string that encodes options to "
+                + "customize the runtime, see docs for configured runtime for details")
         protected String customRuntimeOptions;
-        @Parameter(names = "--secrets", description = "The map of secretName to an object that encapsulates how the secret is fetched by the underlying secrets provider")
+        @Parameter(names = "--secrets", description = "The map of secretName to an object that encapsulates "
+                + "how the secret is fetched by the underlying secrets provider")
         protected String secretsString;
 
         protected SourceConfig sourceConfig;
 
         private void mergeArgs() {
-            if (processingGuarantees == null && DEPRECATED_processingGuarantees != null) {
-                processingGuarantees = DEPRECATED_processingGuarantees;
+            if (processingGuarantees == null && deprecatedProcessingGuarantees != null) {
+                processingGuarantees = deprecatedProcessingGuarantees;
             }
-            if (isBlank(destinationTopicName) && !isBlank(DEPRECATED_destinationTopicName)) {
-                destinationTopicName = DEPRECATED_destinationTopicName;
+            if (isBlank(destinationTopicName) && !isBlank(deprecatedDestinationTopicName)) {
+                destinationTopicName = deprecatedDestinationTopicName;
             }
-            if (isBlank(deserializationClassName) && !isBlank(DEPRECATED_deserializationClassName)) {
-                deserializationClassName = DEPRECATED_deserializationClassName;
+            if (isBlank(deserializationClassName) && !isBlank(deprecatedDeserializationClassName)) {
+                deserializationClassName = deprecatedDeserializationClassName;
             }
-            if (isBlank(className) && !isBlank(DEPRECATED_className)) {
-                className = DEPRECATED_className;
+            if (isBlank(className) && !isBlank(deprecatedClassName)) {
+                className = deprecatedClassName;
             }
-            if (isBlank(sourceConfigFile) && !isBlank(DEPRECATED_sourceConfigFile)) {
-                sourceConfigFile = DEPRECATED_sourceConfigFile;
+            if (isBlank(sourceConfigFile) && !isBlank(deprecatedSourceConfigFile)) {
+                sourceConfigFile = deprecatedSourceConfigFile;
             }
-            if (isBlank(sourceConfigString) && !isBlank(DEPRECATED_sourceConfigString)) {
-                sourceConfigString = DEPRECATED_sourceConfigString;
+            if (isBlank(sourceConfigString) && !isBlank(deprecatedSourceConfigString)) {
+                sourceConfigString = deprecatedSourceConfigString;
             }
         }
 
@@ -458,9 +479,9 @@ public class CmdSources extends CmdBase {
             } catch (Exception ex) {
                 throw new ParameterException("Cannot parse source-config", ex);
             }
-            
+
             if (null != batchSourceConfigString) {
-            	sourceConfig.setBatchSourceConfig(parseBatchSourceConfigs(batchSourceConfigString));
+                sourceConfig.setBatchSourceConfig(parseBatchSourceConfigs(batchSourceConfigString));
             }
 
             if (customRuntimeOptions != null) {
@@ -475,21 +496,20 @@ public class CmdSources extends CmdBase {
                 }
                 sourceConfig.setSecrets(secretsMap);
             }
-            
+
             // check if source configs are valid
             validateSourceConfigs(sourceConfig);
         }
 
         protected Map<String, Object> parseConfigs(String str) throws JsonProcessingException {
             ObjectMapper mapper = ObjectMapperFactory.getThreadLocal();
-            TypeReference<HashMap<String,Object>> typeRef
-                    = new TypeReference<HashMap<String,Object>>() {};
+            TypeReference<HashMap<String, Object>> typeRef = new TypeReference<HashMap<String, Object>>() {};
 
             return mapper.readValue(str, typeRef);
         }
 
-            protected BatchSourceConfig parseBatchSourceConfigs(String str) {
-        	return new Gson().fromJson(str, BatchSourceConfig.class);
+        protected BatchSourceConfig parseBatchSourceConfigs(String str) {
+            return new Gson().fromJson(str, BatchSourceConfig.class);
         }
 
         protected void validateSourceConfigs(SourceConfig sourceConfig) {
@@ -497,31 +517,33 @@ public class CmdSources extends CmdBase {
                 throw new ParameterException("Source archive not specified");
             }
             org.apache.pulsar.common.functions.Utils.inferMissingArguments(sourceConfig);
-            if (!Utils.isFunctionPackageUrlSupported(sourceConfig.getArchive()) &&
-                !sourceConfig.getArchive().startsWith(Utils.BUILTIN)) {
+            if (!Utils.isFunctionPackageUrlSupported(sourceConfig.getArchive())
+                    && !sourceConfig.getArchive().startsWith(Utils.BUILTIN)) {
                 if (!new File(sourceConfig.getArchive()).exists()) {
-                    throw new IllegalArgumentException(String.format("Source Archive %s does not exist", sourceConfig.getArchive()));
+                    throw new IllegalArgumentException(String.format("Source Archive %s does not exist",
+                            sourceConfig.getArchive()));
                 }
             }
             if (isBlank(sourceConfig.getName())) {
                 throw new IllegalArgumentException("Source name not specified");
             }
-            
+
             if (sourceConfig.getBatchSourceConfig() != null) {
-            	validateBatchSourceConfigs(sourceConfig.getBatchSourceConfig());
+                validateBatchSourceConfigs(sourceConfig.getBatchSourceConfig());
             }
         }
-        
+
         protected void validateBatchSourceConfigs(BatchSourceConfig batchSourceConfig) {
-           if (isBlank(batchSourceConfig.getDiscoveryTriggererClassName())) {
-             throw new IllegalArgumentException("Discovery Triggerer not specified");
-           } 
+            if (isBlank(batchSourceConfig.getDiscoveryTriggererClassName())) {
+                throw new IllegalArgumentException("Discovery Triggerer not specified");
+            }
         }
 
         protected String validateSourceType(String sourceType) throws IOException {
             Set<String> availableSources;
             try {
-                availableSources = getAdmin().sources().getBuiltInSources().stream().map(ConnectorDefinition::getName).collect(Collectors.toSet());
+                availableSources = getAdmin().sources().getBuiltInSources().stream()
+                        .map(ConnectorDefinition::getName).collect(Collectors.toSet());
             } catch (PulsarAdminException e) {
                 throw new IOException(e);
             }
@@ -537,7 +559,7 @@ public class CmdSources extends CmdBase {
     }
 
     /**
-     * Function level command
+     * Function level command.
      */
     @Getter
     abstract class SourceCommand extends BaseCommand {
@@ -588,7 +610,7 @@ public class CmdSources extends CmdBase {
     }
 
     /**
-     * List Sources command
+     * List Sources command.
      */
     @Parameters(commandDescription = "List all running Pulsar IO source connectors")
     protected class ListSources extends BaseCommand {
@@ -619,7 +641,8 @@ public class CmdSources extends CmdBase {
     @Parameters(commandDescription = "Check the current status of a Pulsar Source")
     class GetSourceStatus extends SourceCommand {
 
-        @Parameter(names = "--instance-id", description = "The source instanceId (Get-status of all instances if instance-id is not provided")
+        @Parameter(names = "--instance-id",
+                description = "The source instanceId (Get-status of all instances if instance-id is not provided")
         protected String instanceId;
 
         @Override
@@ -627,7 +650,8 @@ public class CmdSources extends CmdBase {
             if (isBlank(instanceId)) {
                 print(getAdmin().sources().getSourceStatus(tenant, namespace, sourceName));
             } else {
-                print(getAdmin().sources().getSourceStatus(tenant, namespace, sourceName, Integer.parseInt(instanceId)));
+                print(getAdmin().sources()
+                        .getSourceStatus(tenant, namespace, sourceName, Integer.parseInt(instanceId)));
             }
         }
     }
@@ -635,7 +659,8 @@ public class CmdSources extends CmdBase {
     @Parameters(commandDescription = "Restart source instance")
     class RestartSource extends SourceCommand {
 
-        @Parameter(names = "--instance-id", description = "The source instanceId (restart all instances if instance-id is not provided")
+        @Parameter(names = "--instance-id",
+                description = "The source instanceId (restart all instances if instance-id is not provided")
         protected String instanceId;
 
         @Override
@@ -656,7 +681,8 @@ public class CmdSources extends CmdBase {
     @Parameters(commandDescription = "Stop source instance")
     class StopSource extends SourceCommand {
 
-        @Parameter(names = "--instance-id", description = "The source instanceId (stop all instances if instance-id is not provided")
+        @Parameter(names = "--instance-id",
+                description = "The source instanceId (stop all instances if instance-id is not provided")
         protected String instanceId;
 
         @Override
@@ -677,7 +703,8 @@ public class CmdSources extends CmdBase {
     @Parameters(commandDescription = "Start source instance")
     class StartSource extends SourceCommand {
 
-        @Parameter(names = "--instance-id", description = "The source instanceId (start all instances if instance-id is not provided")
+        @Parameter(names = "--instance-id",
+                description = "The source instanceId (start all instances if instance-id is not provided")
         protected String instanceId;
 
         @Override

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdTenants.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdTenants.java
@@ -21,12 +21,10 @@ package org.apache.pulsar.admin.cli;
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.Parameters;
 import com.beust.jcommander.converters.CommaParameterSplitter;
-
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.function.Supplier;
-
 import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.admin.PulsarAdminException;
 import org.apache.pulsar.common.policies.data.TenantInfoImpl;
@@ -59,11 +57,14 @@ public class CmdTenants extends CmdBase {
         private java.util.List<String> params;
 
         @Parameter(names = { "--admin-roles",
-                "-r" }, description = "Comma separated list of auth principal allowed to administrate the tenant", required = false, splitter = CommaParameterSplitter.class)
+                "-r" }, description = "Comma separated list of auth principal allowed to administrate the tenant",
+                required = false, splitter = CommaParameterSplitter.class)
         private java.util.List<String> adminRoles;
 
         @Parameter(names = { "--allowed-clusters",
-                "-c" }, description = "Comma separated allowed clusters. If empty, the tenant will have access to all clusters", required = false, splitter = CommaParameterSplitter.class)
+                "-c" }, description = "Comma separated allowed clusters. "
+                + "If empty, the tenant will have access to all clusters",
+                required = false, splitter = CommaParameterSplitter.class)
         private java.util.List<String> allowedClusters;
 
         @Override
@@ -90,11 +91,15 @@ public class CmdTenants extends CmdBase {
         private java.util.List<String> params;
 
         @Parameter(names = { "--admin-roles",
-                "-r" }, description = "Comma separated list of auth principal allowed to administrate the tenant. If empty the current set of roles won't be modified", required = false, splitter = CommaParameterSplitter.class)
+                "-r" }, description = "Comma separated list of auth principal allowed to administrate the tenant. "
+                + "If empty the current set of roles won't be modified",
+                required = false, splitter = CommaParameterSplitter.class)
         private java.util.List<String> adminRoles;
 
         @Parameter(names = { "--allowed-clusters",
-                "-c" }, description = "Comma separated allowed clusters. If omitted, the current set of clusters will be preserved", required = false, splitter = CommaParameterSplitter.class)
+                "-c" }, description = "Comma separated allowed clusters. "
+                + "If omitted, the current set of clusters will be preserved",
+                required = false, splitter = CommaParameterSplitter.class)
         private java.util.List<String> allowedClusters;
 
         @Override

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdTopicPolicies.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdTopicPolicies.java
@@ -88,7 +88,7 @@ public class CmdTopicPolicies extends CmdBase {
         jcommander.addCommand("get-subscription-dispatch-rate", new GetSubscriptionDispatchRate());
         jcommander.addCommand("set-subscription-dispatch-rate", new SetSubscriptionDispatchRate());
         jcommander.addCommand("remove-subscription-dispatch-rate", new RemoveSubscriptionDispatchRate());
-      
+
         jcommander.addCommand("get-publish-rate", new GetPublishRate());
         jcommander.addCommand("set-publish-rate", new SetPublishRate());
         jcommander.addCommand("remove-publish-rate", new RemovePublishRate());
@@ -115,11 +115,12 @@ public class CmdTopicPolicies extends CmdBase {
 
         jcommander.addCommand("get-max-unacked-messages-per-subscription", new GetMaxUnackedMessagesPerSubscription());
         jcommander.addCommand("set-max-unacked-messages-per-subscription", new SetMaxUnackedMessagesPerSubscription());
-        jcommander.addCommand("remove-max-unacked-messages-per-subscription", new RemoveMaxUnackedMessagesPerSubscription());
+        jcommander.addCommand("remove-max-unacked-messages-per-subscription",
+                new RemoveMaxUnackedMessagesPerSubscription());
 
-        jcommander.addCommand("get-inactive-topic-policies",new GetInactiveTopicPolicies());
-        jcommander.addCommand("set-inactive-topic-policies",new SetInactiveTopicPolicies());
-        jcommander.addCommand("remove-inactive-topic-policies",new RemoveInactiveTopicPolicies());
+        jcommander.addCommand("get-inactive-topic-policies", new GetInactiveTopicPolicies());
+        jcommander.addCommand("set-inactive-topic-policies", new SetInactiveTopicPolicies());
+        jcommander.addCommand("remove-inactive-topic-policies", new RemoveInactiveTopicPolicies());
 
     }
 
@@ -144,7 +145,8 @@ public class CmdTopicPolicies extends CmdBase {
         @Parameter(description = "persistent://tenant/namespace/topic", required = true)
         private java.util.List<String> params;
 
-        @Parameter(names = { "--max-consumers-per-subscription", "-c" }, description = "maxConsumersPerSubscription for a namespace", required = true)
+        @Parameter(names = { "--max-consumers-per-subscription", "-c" },
+                description = "maxConsumersPerSubscription for a namespace", required = true)
         private int maxConsumersPerSubscription;
 
         @Parameter(names = { "--global", "-g" }, description = "Whether to set this policy globally. "
@@ -252,7 +254,8 @@ public class CmdTopicPolicies extends CmdBase {
         @Parameter(description = "persistent://tenant/namespace/topic", required = true)
         private java.util.List<String> params;
 
-        @Parameter(names = { "-t", "--ttl" }, description = "Message TTL for topic in second, allowed range from 1 to Integer.MAX_VALUE", required = true)
+        @Parameter(names = { "-t", "--ttl" }, description = "Message TTL for topic in second, "
+                + "allowed range from 1 to Integer.MAX_VALUE", required = true)
         private int messageTTLInSecond;
 
         @Parameter(names = { "--global", "-g" }, description = "Whether to set this policy globally. "
@@ -521,7 +524,8 @@ public class CmdTopicPolicies extends CmdBase {
         @Parameter(description = "persistent://tenant/namespace/topic", required = true)
         private java.util.List<String> params;
 
-        @Parameter(names = {"-m", "--maxNum"}, description = "max unacked messages num on subscription", required = true)
+        @Parameter(names = {"-m", "--maxNum"},
+                description = "max unacked messages num on subscription", required = true)
         private int maxNum;
 
         @Parameter(names = { "--global", "-g" }, description = "Whether to set this policy globally. "
@@ -603,8 +607,9 @@ public class CmdTopicPolicies extends CmdBase {
         @Parameter(names = { "--disable", "-d" }, description = "Disable delayed delivery messages")
         private boolean disable = false;
 
-        @Parameter(names = { "--time", "-t" }, description = "The tick time for when retrying on delayed delivery messages, " +
-                "affecting the accuracy of the delivery time compared to the scheduled time. (eg: 1s, 10s, 1m, 5h, 3d)")
+        @Parameter(names = { "--time", "-t" }, description = "The tick time for when retrying on "
+                + "delayed delivery messages, affecting the accuracy of the delivery time compared to "
+                + "the scheduled time. (eg: 1s, 10s, 1m, 5h, 3d)")
         private String delayedDeliveryTimeStr = "1s";
 
         @Parameter(names = { "--global", "-g" }, description = "Whether to set this policy globally. "
@@ -798,18 +803,20 @@ public class CmdTopicPolicies extends CmdBase {
         @Parameter(names = { "-l", "--limit" }, description = "Size limit (eg: 10M, 16G)")
         private String limitStr = "-1";
 
-        @Parameter(names = { "-lt", "--limitTime" }, description = "Time limit in second, non-positive number for disabling time limit.")
+        @Parameter(names = { "-lt", "--limitTime" },
+                description = "Time limit in second, non-positive number for disabling time limit.")
         private int limitTime = -1;
 
         @Parameter(names = { "-p", "--policy" }, description = "Retention policy to enforce when the limit is reached. "
-                + "Valid options are: [producer_request_hold, producer_exception, consumer_backlog_eviction]", required = true)
+                + "Valid options are: [producer_request_hold, producer_exception, consumer_backlog_eviction]",
+                required = true)
         private String policyStr;
 
-        @Parameter(names = {"-t", "--type"}, description = "Backlog quota type to set. Valid options are: " +
-                "destination_storage and message_age. " +
-                "destination_storage limits backlog by size (in bytes). " +
-                "message_age limits backlog by time, that is, message timestamp (broker or publish timestamp). " +
-                "You can set size or time to control the backlog, or combine them together to control the backlog. ")
+        @Parameter(names = {"-t", "--type"}, description = "Backlog quota type to set. Valid options are: "
+                + "destination_storage and message_age. "
+                + "destination_storage limits backlog by size (in bytes). "
+                + "message_age limits backlog by time, that is, message timestamp (broker or publish timestamp). "
+                + "You can set size or time to control the backlog, or combine them together to control the backlog. ")
         private String backlogQuotaTypeStr = BacklogQuota.BacklogQuotaType.destination_storage.name();
 
         @Parameter(names = { "--global", "-g" }, description = "Whether to set this policy globally. "
@@ -864,7 +871,8 @@ public class CmdTopicPolicies extends CmdBase {
         @Override
         void run() throws PulsarAdminException {
             String persistentTopic = validatePersistentTopic(params);
-            getTopicPolicies(isGlobal).removeBacklogQuota(persistentTopic, BacklogQuota.BacklogQuotaType.valueOf(backlogQuotaType));
+            getTopicPolicies(isGlobal)
+                    .removeBacklogQuota(persistentTopic, BacklogQuota.BacklogQuotaType.valueOf(backlogQuotaType));
         }
     }
 
@@ -952,7 +960,8 @@ public class CmdTopicPolicies extends CmdBase {
         private int subscribeRate = -1;
 
         @Parameter(names = { "--subscribe-rate-period",
-                "-st" }, description = "subscribe-rate-period in second type (default 30 second will be overwrite if not passed)", required = false)
+                "-st" }, description = "subscribe-rate-period in second type "
+                + "(default 30 second will be overwrite if not passed)", required = false)
         private int subscribeRatePeriodSec = 30;
 
         @Parameter(names = {"--global", "-g"}, description = "Whether to set this policy globally.")
@@ -1010,12 +1019,12 @@ public class CmdTopicPolicies extends CmdBase {
                 "--bookkeeper-write-quorum" }, description = "How many writes to make of each entry", required = true)
         private int bookkeeperWriteQuorum;
 
-        @Parameter(names = { "-a",
-                "--bookkeeper-ack-quorum" }, description = "Number of acks (guaranteed copies) to wait for each entry", required = true)
+        @Parameter(names = { "-a", "--bookkeeper-ack-quorum" },
+                description = "Number of acks (guaranteed copies) to wait for each entry", required = true)
         private int bookkeeperAckQuorum;
 
-        @Parameter(names = { "-r",
-                "--ml-mark-delete-max-rate" }, description = "Throttling rate of mark-delete operation (0 means no throttle)", required = true)
+        @Parameter(names = { "-r", "--ml-mark-delete-max-rate" },
+                description = "Throttling rate of mark-delete operation (0 means no throttle)", required = true)
         private double managedLedgerMaxMarkDeleteRate;
 
         @Parameter(names = { "--global", "-g" }, description = "Whether to set this policy globally. "
@@ -1126,19 +1135,23 @@ public class CmdTopicPolicies extends CmdBase {
         private java.util.List<String> params;
 
         @Parameter(names = { "--msg-dispatch-rate",
-                "-md" }, description = "message-dispatch-rate (default -1 will be overwrite if not passed)", required = false)
+                "-md" }, description = "message-dispatch-rate "
+                + "(default -1 will be overwrite if not passed)", required = false)
         private int msgDispatchRate = -1;
 
         @Parameter(names = { "--byte-dispatch-rate",
-                "-bd" }, description = "byte-dispatch-rate (default -1 will be overwrite if not passed)", required = false)
+                "-bd" }, description = "byte-dispatch-rate "
+                + "(default -1 will be overwrite if not passed)", required = false)
         private long byteDispatchRate = -1;
 
         @Parameter(names = { "--dispatch-rate-period",
-                "-dt" }, description = "dispatch-rate-period in second type (default 1 second will be overwrite if not passed)", required = false)
+                "-dt" }, description = "dispatch-rate-period in second type "
+                + "(default 1 second will be overwrite if not passed)", required = false)
         private int dispatchRatePeriodSec = 1;
 
         @Parameter(names = { "--relative-to-publish-rate",
-                "-rp" }, description = "dispatch rate relative to publish-rate (if publish-relative flag is enabled then broker will apply throttling value to (publish-rate + dispatch rate))", required = false)
+                "-rp" }, description = "dispatch rate relative to publish-rate (if publish-relative flag is enabled "
+                + "then broker will apply throttling value to (publish-rate + dispatch rate))", required = false)
         private boolean relativeToPublishRate = false;
 
         @Parameter(names = { "--global", "-g" }, description = "Whether to set this policy globally. "
@@ -1204,12 +1217,13 @@ public class CmdTopicPolicies extends CmdBase {
         @Parameter(names = { "--disable-delete-while-inactive", "-d" }, description = "Disable delete while inactive")
         private boolean disableDeleteWhileInactive = false;
 
-        @Parameter(names = {"--max-inactive-duration", "-t"}, description = "Max duration of topic inactivity in seconds" +
-                ",topics that are inactive for longer than this value will be deleted (eg: 1s, 10s, 1m, 5h, 3d)", required = true)
+        @Parameter(names = {"--max-inactive-duration", "-t"},
+                description = "Max duration of topic inactivity in seconds, topics that are inactive for longer than "
+                        + "this value will be deleted (eg: 1s, 10s, 1m, 5h, 3d)", required = true)
         private String deleteInactiveTopicsMaxInactiveDuration;
 
-        @Parameter(names = { "--delete-mode", "-m" }, description = "Mode of delete inactive topic" +
-                ",Valid options are: [delete_when_no_subscriptions, delete_when_subscriptions_caught_up]", required = true)
+        @Parameter(names = { "--delete-mode", "-m" }, description = "Mode of delete inactive topic, Valid options are: "
+                + "[delete_when_no_subscriptions, delete_when_subscriptions_caught_up]", required = true)
         private String inactiveTopicDeleteMode;
 
         @Parameter(names = { "--global", "-g" }, description = "Whether to set this policy globally. "
@@ -1228,16 +1242,18 @@ public class CmdTopicPolicies extends CmdBase {
             }
 
             if (enableDeleteWhileInactive == disableDeleteWhileInactive) {
-                throw new ParameterException("Need to specify either enable-delete-while-inactive or disable-delete-while-inactive");
+                throw new ParameterException("Need to specify either enable-delete-while-inactive or "
+                        + "disable-delete-while-inactive");
             }
             InactiveTopicDeleteMode deleteMode;
             try {
                 deleteMode = InactiveTopicDeleteMode.valueOf(inactiveTopicDeleteMode);
             } catch (IllegalArgumentException e) {
-                throw new ParameterException("delete mode can only be set to delete_when_no_subscriptions or delete_when_subscriptions_caught_up");
+                throw new ParameterException("delete mode can only be set to delete_when_no_subscriptions or "
+                        + "delete_when_subscriptions_caught_up");
             }
-            getTopicPolicies(isGlobal).setInactiveTopicPolicies(persistentTopic,
-                    new InactiveTopicPolicies(deleteMode, (int) maxInactiveDurationInSeconds, enableDeleteWhileInactive));
+            getTopicPolicies(isGlobal).setInactiveTopicPolicies(persistentTopic, new InactiveTopicPolicies(deleteMode,
+                    (int) maxInactiveDurationInSeconds, enableDeleteWhileInactive));
         }
     }
 
@@ -1288,11 +1304,13 @@ public class CmdTopicPolicies extends CmdBase {
         private long byteDispatchRate = -1;
 
         @Parameter(names = { "--dispatch-rate-period",
-                "-dt" }, description = "dispatch-rate-period in second type (default 1 second will be overwrite if not passed)")
+                "-dt" }, description = "dispatch-rate-period in second type "
+                + "(default 1 second will be overwrite if not passed)")
         private int dispatchRatePeriodSec = 1;
 
         @Parameter(names = { "--relative-to-publish-rate",
-                "-rp" }, description = "dispatch rate relative to publish-rate (if publish-relative flag is enabled then broker will apply throttling value to (publish-rate + dispatch rate))")
+                "-rp" }, description = "dispatch rate relative to publish-rate (if publish-relative flag is enabled "
+                + "then broker will apply throttling value to (publish-rate + dispatch rate))")
         private boolean relativeToPublishRate = false;
 
         @Parameter(names = { "--global", "-g" }, description = "Whether to set this policy globally. "

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdTopics.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdTopics.java
@@ -19,7 +19,6 @@
 package org.apache.pulsar.admin.cli;
 
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
-
 import com.beust.jcommander.IUsageFormatter;
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.ParameterException;
@@ -32,9 +31,8 @@ import com.google.gson.JsonParser;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufUtil;
 import io.netty.buffer.Unpooled;
-
-import java.util.Arrays;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedList;
@@ -46,9 +44,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
-
 import lombok.Getter;
-
 import org.apache.pulsar.client.admin.LongRunningProcessStatus;
 import org.apache.pulsar.client.admin.OffloadProcessStatus;
 import org.apache.pulsar.client.admin.PulsarAdmin;
@@ -186,14 +182,16 @@ public class CmdTopics extends CmdBase {
         jcommander.addCommand("remove-max-unacked-messages-on-consumer", new RemoveMaxUnackedMessagesOnConsumer());
         jcommander.addCommand("get-max-unacked-messages-on-subscription", new GetMaxUnackedMessagesOnSubscription());
         jcommander.addCommand("set-max-unacked-messages-on-subscription", new SetMaxUnackedMessagesOnSubscription());
-        jcommander.addCommand("remove-max-unacked-messages-on-subscription", new RemoveMaxUnackedMessagesOnSubscription());
+        jcommander.addCommand("remove-max-unacked-messages-on-subscription",
+                new RemoveMaxUnackedMessagesOnSubscription());
 
         jcommander.addCommand("get-max-unacked-messages-per-consumer", new GetMaxUnackedMessagesOnConsumer());
         jcommander.addCommand("set-max-unacked-messages-per-consumer", new SetMaxUnackedMessagesOnConsumer());
         jcommander.addCommand("remove-max-unacked-messages-per-consumer", new RemoveMaxUnackedMessagesOnConsumer());
         jcommander.addCommand("get-max-unacked-messages-per-subscription", new GetMaxUnackedMessagesOnSubscription());
         jcommander.addCommand("set-max-unacked-messages-per-subscription", new SetMaxUnackedMessagesOnSubscription());
-        jcommander.addCommand("remove-max-unacked-messages-per-subscription", new RemoveMaxUnackedMessagesOnSubscription());
+        jcommander.addCommand("remove-max-unacked-messages-per-subscription",
+                new RemoveMaxUnackedMessagesOnSubscription());
         jcommander.addCommand("get-publish-rate", new GetPublishRate());
         jcommander.addCommand("set-publish-rate", new SetPublishRate());
         jcommander.addCommand("remove-publish-rate", new RemovePublishRate());
@@ -349,7 +347,8 @@ public class CmdTopics extends CmdBase {
         @Parameter(description = "tenant/namespace", required = true)
         private java.util.List<String> params;
 
-        @Parameter(names = {"-td", "--topic-domain"}, description = "Allowed topic domain (persistent, non_persistent).")
+        @Parameter(names = {"-td", "--topic-domain"},
+                description = "Allowed topic domain (persistent, non_persistent).")
         private TopicDomain topicDomain;
 
         @Override
@@ -379,8 +378,8 @@ public class CmdTopics extends CmdBase {
         @Parameter(names = "--role", description = "Client role to which grant permissions", required = true)
         private String role;
 
-        @Parameter(names = "--actions", description = "Actions to be granted (produce,consume,sources,sinks," +
-                "functions,packages)", required = true)
+        @Parameter(names = "--actions", description = "Actions to be granted (produce,consume,sources,sinks,"
+                + "functions,packages)", required = true)
         private List<String> actions;
 
         @Override
@@ -513,14 +512,14 @@ public class CmdTopics extends CmdBase {
     @Parameters(commandDescription = "Create a non-partitioned topic.")
     private class CreateNonPartitionedCmd extends CliCommand {
 
-    	@Parameter(description = "persistent://tenant/namespace/topic", required = true)
-    	private java.util.List<String> params;
+        @Parameter(description = "persistent://tenant/namespace/topic", required = true)
+        private java.util.List<String> params;
 
-    	@Override
-    	void run() throws Exception {
-    		String topic = validateTopicName(params);
-    		getTopics().createNonPartitionedTopic(topic);
-    	}
+        @Override
+        void run() throws Exception {
+            String topic = validateTopicName(params);
+            getTopics().createNonPartitionedTopic(topic);
+        }
     }
 
     @Parameters(commandDescription = "Update existing non-global partitioned topic. "
@@ -535,7 +534,7 @@ public class CmdTopics extends CmdBase {
         private int numPartitions;
 
         @Parameter(names = { "-f",
-                "--force" }, description = "Update forcefully without validating existing partitioned topic ", required = false)
+                "--force" }, description = "Update forcefully without validating existing partitioned topic")
         private boolean force;
 
         @Override
@@ -603,7 +602,8 @@ public class CmdTopics extends CmdBase {
     }
 
     @Parameters(commandDescription = "Truncate a topic. \n"
-            + "\t\tThe truncate operation will move all cursors to the end of the topic and delete all inactive ledgers. ")
+            + "\t\tThe truncate operation will move all cursors to the end of the topic "
+            + "and delete all inactive ledgers. ")
     private class TruncateCmd extends CliCommand {
         @Parameter(description = "persistent://tenant/namespace/topic\n", required = true)
         private java.util.List<String> params;
@@ -720,8 +720,9 @@ public class CmdTopics extends CmdBase {
         }
     }
 
-    @Parameters(commandDescription = "Get the stats for the partitioned topic and its connected producers and consumers. "
-            + "All the rates are computed over a 1 minute window and are relative the last completed 1 minute period.")
+    @Parameters(commandDescription = "Get the stats for the partitioned topic "
+            + "and its connected producers and consumers. All the rates are computed over a 1 minute window "
+            + "and are relative the last completed 1 minute period.")
     private class GetPartitionedStats extends CliCommand {
         @Parameter(description = "persistent://tenant/namespace/topic", required = true)
         private java.util.List<String> params;
@@ -745,8 +746,9 @@ public class CmdTopics extends CmdBase {
         }
     }
 
-    @Parameters(commandDescription = "Get the internal stats for the partitioned topic and its connected producers and consumers. "
-            + "All the rates are computed over a 1 minute window and are relative the last completed 1 minute period.")
+    @Parameters(commandDescription = "Get the internal stats for the partitioned topic "
+            + "and its connected producers and consumers. All the rates are computed over a 1 minute window "
+            + "and are relative the last completed 1 minute period.")
     private class GetPartitionedStatsInternal extends CliCommand {
         @Parameter(description = "persistent://tenant/namespace/topic", required = true)
         private java.util.List<String> params;
@@ -792,7 +794,8 @@ public class CmdTopics extends CmdBase {
         }
     }
 
-    @Parameters(commandDescription = "Expire messages that older than given expiry time (in seconds) for the subscription")
+    @Parameters(commandDescription = "Expire messages that older than given expiry time (in seconds) "
+            + "for the subscription")
     private class ExpireMessages extends CliCommand {
         @Parameter(description = "persistent://tenant/namespace/topic", required = true)
         private java.util.List<String> params;
@@ -809,14 +812,14 @@ public class CmdTopics extends CmdBase {
         private String messagePosition;
 
         @Parameter(names = { "-e", "--exclude-reset-position" },
-                description = "Exclude the reset position, start consume messages from the next position.", required = false)
+                description = "Exclude the reset position, start consume messages from the next position.")
         private boolean excludeResetPosition = false;
 
         @Override
         void run() throws PulsarAdminException {
             if (expireTimeInSeconds >= 0 && isNotBlank(messagePosition)) {
-                throw new ParameterException(String.format("Can't expire message by time and " +
-                        "by message position at the same time."));
+                throw new ParameterException(String.format("Can't expire message by time and "
+                        + "by message position at the same time."));
             }
             String topic = validateTopicName(params);
             if (expireTimeInSeconds >= 0) {
@@ -827,18 +830,20 @@ public class CmdTopics extends CmdBase {
                 getTopics().expireMessages(topic, subName, messageId, excludeResetPosition);
             } else {
                 throw new ParameterException(
-                        "Either time (--expireTime) or message position (--position) has to be provided" +
-                                " to expire messages");
+                        "Either time (--expireTime) or message position (--position) has to be provided"
+                                + " to expire messages");
             }
         }
     }
 
-    @Parameters(commandDescription = "Expire messages that older than given expiry time (in seconds) for all subscriptions")
+    @Parameters(commandDescription = "Expire messages that older than given expiry time (in seconds) "
+            + "for all subscriptions")
     private class ExpireMessagesForAllSubscriptions extends CliCommand {
         @Parameter(description = "persistent://tenant/namespace/topic", required = true)
         private java.util.List<String> params;
 
-        @Parameter(names = { "-t", "--expireTime" }, description = "Expire messages older than time in seconds", required = true)
+        @Parameter(names = { "-t",
+                "--expireTime" }, description = "Expire messages older than time in seconds", required = true)
         private long expireTimeInSeconds;
 
         @Override
@@ -858,7 +863,8 @@ public class CmdTopics extends CmdBase {
         private String subscriptionName;
 
         @Parameter(names = { "--messageId",
-                "-m" }, description = "messageId where to create the subscription. It can be either 'latest', 'earliest' or (ledgerId:entryId)", required = false)
+                "-m" }, description = "messageId where to create the subscription. "
+                + "It can be either 'latest', 'earliest' or (ledgerId:entryId)", required = false)
         private String messageIdStr = "latest";
 
         @Override
@@ -877,7 +883,8 @@ public class CmdTopics extends CmdBase {
         }
     }
 
-    @Parameters(commandDescription = "Reset position for subscription to a position that is closest to timestamp or messageId.")
+    @Parameters(commandDescription = "Reset position for subscription to a position that is closest to "
+            + "timestamp or messageId.")
     private class ResetCursor extends CliCommand {
         @Parameter(description = "persistent://tenant/namespace/topic", required = true)
         private java.util.List<String> params;
@@ -887,16 +894,16 @@ public class CmdTopics extends CmdBase {
         private String subName;
 
         @Parameter(names = { "--time",
-                "-t" }, description = "time in minutes to reset back to (or minutes, hours,days,weeks eg: 100m, 3h, 2d, 5w)", required = false)
+                "-t" }, description = "time in minutes to reset back to "
+                + "(or minutes, hours, days, weeks eg: 100m, 3h, 2d, 5w)", required = false)
         private String resetTimeStr;
 
         @Parameter(names = { "--messageId",
-                "-m" }, description = "messageId to reset back to ('latest', 'earliest', or 'ledgerId:entryId')", required =
-                false)
+                "-m" }, description = "messageId to reset back to ('latest', 'earliest', or 'ledgerId:entryId')")
         private String resetMessageIdStr;
 
         @Parameter(names = { "-e", "--exclude-reset-position" },
-                description = "Exclude the reset position, start consume messages from the next position.", required = false)
+                description = "Exclude the reset position, start consume messages from the next position.")
         private boolean excludeResetPosition = false;
 
         @Override
@@ -992,7 +999,8 @@ public class CmdTopics extends CmdBase {
                 }
                 if (message.getMessageId() instanceof BatchMessageIdImpl) {
                     BatchMessageIdImpl msgId = (BatchMessageIdImpl) message.getMessageId();
-                    System.out.println("Batch Message ID: " + msgId.getLedgerId() + ":" + msgId.getEntryId() + ":" + msgId.getBatchIndex());
+                    System.out.println("Batch Message ID: " + msgId.getLedgerId() + ":" + msgId.getEntryId() + ":"
+                            + msgId.getBatchIndex());
                 } else {
                     MessageIdImpl msgId = (MessageIdImpl) msg.getMessageId();
                     System.out.println("Message ID: " + msgId.getLedgerId() + ":" + msgId.getEntryId());
@@ -1007,10 +1015,12 @@ public class CmdTopics extends CmdBase {
 
                 if (message.getBrokerEntryMetadata() != null) {
                     if (message.getBrokerEntryMetadata().hasBrokerTimestamp()) {
-                        System.out.println("Broker entry metadata timestamp: " + message.getBrokerEntryMetadata().getBrokerTimestamp());
+                        System.out.println("Broker entry metadata timestamp: "
+                                + message.getBrokerEntryMetadata().getBrokerTimestamp());
                     }
                     if (message.getBrokerEntryMetadata().hasIndex()) {
-                        System.out.println("Broker entry metadata index: " + message.getBrokerEntryMetadata().getIndex());
+                        System.out.println("Broker entry metadata index: "
+                                + message.getBrokerEntryMetadata().getIndex());
                     }
                 }
 
@@ -1025,15 +1035,15 @@ public class CmdTopics extends CmdBase {
     }
 
 
-    @Parameters(commandDescription = "Examine a specific message on a topic by position relative to the" +
-            " earliest or the latest message.")
+    @Parameters(commandDescription = "Examine a specific message on a topic by position relative to the"
+            + " earliest or the latest message.")
     private class ExamineMessages extends CliCommand {
         @Parameter(description = "persistent://tenant/namespace/topic", required = true)
         private java.util.List<String> params;
 
         @Parameter(names = { "-i", "--initialPosition" },
-                description = "Relative start position to examine message." +
-                        "It can be 'latest' or 'earliest', default is latest")
+                description = "Relative start position to examine message."
+                        + "It can be 'latest' or 'earliest', default is latest")
         private String initialPosition = "latest";
 
         @Parameter(names = { "-m", "--messagePosition" },
@@ -1048,7 +1058,8 @@ public class CmdTopics extends CmdBase {
 
             if (message.getMessageId() instanceof BatchMessageIdImpl) {
                 BatchMessageIdImpl msgId = (BatchMessageIdImpl) message.getMessageId();
-                System.out.println("Batch Message ID: " + msgId.getLedgerId() + ":" + msgId.getEntryId() + ":" + msgId.getBatchIndex());
+                System.out.println("Batch Message ID: " + msgId.getLedgerId() + ":" + msgId.getEntryId() + ":"
+                        + msgId.getBatchIndex());
             } else {
                 MessageIdImpl msgId = (MessageIdImpl) message.getMessageId();
                 System.out.println("Message ID: " + msgId.getLedgerId() + ":" + msgId.getEntryId());
@@ -1063,7 +1074,8 @@ public class CmdTopics extends CmdBase {
 
             if (message.getBrokerEntryMetadata() != null) {
                 if (message.getBrokerEntryMetadata().hasBrokerTimestamp()) {
-                    System.out.println("Broker entry metadata timestamp: " + message.getBrokerEntryMetadata().getBrokerTimestamp());
+                    System.out.println("Broker entry metadata timestamp: "
+                            + message.getBrokerEntryMetadata().getBrokerTimestamp());
                 }
                 if (message.getBrokerEntryMetadata().hasIndex()) {
                     System.out.println("Broker entry metadata index: " + message.getBrokerEntryMetadata().getIndex());
@@ -1105,7 +1117,8 @@ public class CmdTopics extends CmdBase {
             } else {
                 if (message.getMessageId() instanceof BatchMessageIdImpl) {
                     BatchMessageIdImpl msgId = (BatchMessageIdImpl) message.getMessageId();
-                    System.out.println("Batch Message ID: " + msgId.getLedgerId() + ":" + msgId.getEntryId() + ":" + msgId.getBatchIndex());
+                    System.out.println("Batch Message ID: " + msgId.getLedgerId() + ":" + msgId.getEntryId() + ":"
+                            + msgId.getBatchIndex());
                 } else {
                     MessageIdImpl msgId = (MessageIdImpl) message.getMessageId();
                     System.out.println("Message ID: " + msgId.getLedgerId() + ":" + msgId.getEntryId());
@@ -1120,10 +1133,12 @@ public class CmdTopics extends CmdBase {
 
                 if (message.getBrokerEntryMetadata() != null) {
                     if (message.getBrokerEntryMetadata().hasBrokerTimestamp()) {
-                        System.out.println("Broker entry metadata timestamp: " + message.getBrokerEntryMetadata().getBrokerTimestamp());
+                        System.out.println("Broker entry metadata timestamp: "
+                                + message.getBrokerEntryMetadata().getBrokerTimestamp());
                     }
                     if (message.getBrokerEntryMetadata().hasIndex()) {
-                        System.out.println("Broker entry metadata index: " + message.getBrokerEntryMetadata().getIndex());
+                        System.out.println("Broker entry metadata index: "
+                                + message.getBrokerEntryMetadata().getIndex());
                     }
                 }
 
@@ -1143,8 +1158,8 @@ public class CmdTopics extends CmdBase {
         private java.util.List<String> params;
 
         @Parameter(names = { "-d", "--datetime" },
-                description = "datetime at or before this messageId. This datetime is in format of ISO_OFFSET_DATE_TIME,"
-                        + " e.g. 2021-06-28T16:53:08Z or 2021-06-28T16:53:08.123456789+08:00",
+                description = "datetime at or before this messageId. This datetime is in format of "
+                        + "ISO_OFFSET_DATE_TIME, e.g. 2021-06-28T16:53:08Z or 2021-06-28T16:53:08.123456789+08:00",
                 required = true)
         private String datetime;
 
@@ -1254,7 +1269,7 @@ public class CmdTopics extends CmdBase {
             }
 
             LinkedList<PersistentTopicInternalStats.LedgerInfo> ledgers = new LinkedList(stats.ledgers);
-            ledgers.get(ledgers.size()-1).size = stats.currentLedgerSize; // doesn't get filled in now it seems
+            ledgers.get(ledgers.size() - 1).size = stats.currentLedgerSize; // doesn't get filled in now it seems
             MessageId messageId = findFirstLedgerWithinThreshold(ledgers, sizeThreshold);
 
             if (messageId == null) {
@@ -1343,18 +1358,20 @@ public class CmdTopics extends CmdBase {
         @Parameter(names = { "-l", "--limit" }, description = "Size limit (eg: 10M, 16G)")
         private String limitStr = "-1";
 
-        @Parameter(names = { "-lt", "--limitTime" }, description = "Time limit in second, non-positive number for disabling time limit.")
+        @Parameter(names = { "-lt", "--limitTime" },
+                description = "Time limit in second, non-positive number for disabling time limit.")
         private int limitTime = -1;
 
-        @Parameter(names = { "-p", "--policy" }, description = "Retention policy to enforce when the limit is reached. "
-                + "Valid options are: [producer_request_hold, producer_exception, consumer_backlog_eviction]", required = true)
+        @Parameter(names = { "-p", "--policy" },
+                description = "Retention policy to enforce when the limit is reached. Valid options are: "
+                        + "[producer_request_hold, producer_exception, consumer_backlog_eviction]", required = true)
         private String policyStr;
 
-        @Parameter(names = {"-t", "--type"}, description = "Backlog quota type to set. Valid options are: " +
-                "destination_storage and message_age. " + 
-                "destination_storage limits backlog by size (in bytes). " +
-                "message_age limits backlog by time, that is, message timestamp (broker or publish timestamp). " +
-                "You can set size or time to control the backlog, or combine them together to control the backlog. ")
+        @Parameter(names = {"-t", "--type"}, description = "Backlog quota type to set. Valid options are: "
+                + "destination_storage and message_age. "
+                + "destination_storage limits backlog by size (in bytes). "
+                + "message_age limits backlog by time, that is, message timestamp (broker or publish timestamp). "
+                + "You can set size or time to control the backlog, or combine them together to control the backlog. ")
         private String backlogQuotaTypeStr = BacklogQuota.BacklogQuotaType.destination_storage.name();
 
         @Override
@@ -1475,8 +1492,9 @@ public class CmdTopics extends CmdBase {
         @Parameter(names = { "--disable", "-d" }, description = "Disable delayed delivery messages")
         private boolean disable = false;
 
-        @Parameter(names = { "--time", "-t" }, description = "The tick time for when retrying on delayed delivery messages, " +
-                "affecting the accuracy of the delivery time compared to the scheduled time. (eg: 1s, 10s, 1m, 5h, 3d)")
+        @Parameter(names = { "--time", "-t" },
+                description = "The tick time for when retrying on delayed delivery messages, affecting the accuracy of "
+                        + "the delivery time compared to the scheduled time. (eg: 1s, 10s, 1m, 5h, 3d)")
         private String delayedDeliveryTimeStr = "1s";
 
         @Override
@@ -1533,7 +1551,8 @@ public class CmdTopics extends CmdBase {
         @Parameter(description = "persistent://tenant/namespace/topic", required = true)
         private java.util.List<String> params;
 
-        @Parameter(names = { "-t", "--ttl" }, description = "Message TTL for topic in second, allowed range from 1 to Integer.MAX_VALUE", required = true)
+        @Parameter(names = { "-t", "--ttl" }, description = "Message TTL for topic in second, "
+                + "allowed range from 1 to Integer.MAX_VALUE", required = true)
         private int messageTTLInSecond;
 
         @Override
@@ -1577,8 +1596,8 @@ public class CmdTopics extends CmdBase {
         @Parameter(description = "persistent://tenant/namespace/topic", required = true)
         private java.util.List<String> params;
 
-        @Parameter(names = { "-i", "--interval" }, description =
-                "Deduplication snapshot interval for topic in second, allowed range from 0 to Integer.MAX_VALUE", required = true)
+        @Parameter(names = { "-i", "--interval" }, description = "Deduplication snapshot interval for topic in second, "
+                + "allowed range from 0 to Integer.MAX_VALUE", required = true)
         private int interval;
 
         @Override
@@ -1839,10 +1858,13 @@ public class CmdTopics extends CmdBase {
                 , description = "ManagedLedger offload deletion lag in bytes")
         private Long offloadDeletionLagInMillis;
 
-        @Parameter(
-                names = {"--offloadedReadPriority", "-orp"},
-                description = "Read priority for offloaded messages. By default, once messages are offloaded to long-term storage, brokers read messages from long-term storage, but messages can still exist in BookKeeper for a period depends on your configuration. For messages that exist in both long-term storage and BookKeeper, you can set where to read messages from with the option `tiered-storage-first` or `bookkeeper-first`.",
-                required = false
+        @Parameter(names = {"--offloadedReadPriority", "-orp"},
+                description = "Read priority for offloaded messages. "
+                        + "By default, once messages are offloaded to long-term storage, "
+                        + "brokers read messages from long-term storage, but messages can still exist in BookKeeper "
+                        + "for a period depends on your configuration. For messages that exist in both "
+                        + "long-term storage and BookKeeper, you can set where to read messages from with the option "
+                        + "`tiered-storage-first` or `bookkeeper-first`."
         )
         private String offloadReadPriorityStr;
 
@@ -1888,11 +1910,13 @@ public class CmdTopics extends CmdBase {
         private int bookkeeperWriteQuorum;
 
         @Parameter(names = { "-a",
-                "--bookkeeper-ack-quorum" }, description = "Number of acks (guaranteed copies) to wait for each entry", required = true)
+                "--bookkeeper-ack-quorum" }, description = "Number of acks (guaranteed copies) to wait for each entry",
+                required = true)
         private int bookkeeperAckQuorum;
 
         @Parameter(names = { "-r",
-                "--ml-mark-delete-max-rate" }, description = "Throttling rate of mark-delete operation (0 means no throttle)", required = true)
+                "--ml-mark-delete-max-rate" }, description = "Throttling rate of mark-delete operation "
+                + "(0 means no throttle)", required = true)
         private double managedLedgerMaxMarkDeleteRate;
 
         @Override
@@ -1936,19 +1960,21 @@ public class CmdTopics extends CmdBase {
         private java.util.List<String> params;
 
         @Parameter(names = { "--msg-dispatch-rate",
-                "-md" }, description = "message-dispatch-rate (default -1 will be overwrite if not passed)", required = false)
+                "-md" }, description = "message-dispatch-rate (default -1 will be overwrite if not passed)")
         private int msgDispatchRate = -1;
 
         @Parameter(names = { "--byte-dispatch-rate",
-                "-bd" }, description = "byte-dispatch-rate (default -1 will be overwrite if not passed)", required = false)
+                "-bd" }, description = "byte-dispatch-rate (default -1 will be overwrite if not passed)")
         private long byteDispatchRate = -1;
 
         @Parameter(names = { "--dispatch-rate-period",
-                "-dt" }, description = "dispatch-rate-period in second type (default 1 second will be overwrite if not passed)", required = false)
+                "-dt" }, description = "dispatch-rate-period in second type "
+                + "(default 1 second will be overwrite if not passed)", required = false)
         private int dispatchRatePeriodSec = 1;
 
         @Parameter(names = { "--relative-to-publish-rate",
-                "-rp" }, description = "dispatch rate relative to publish-rate (if publish-relative flag is enabled then broker will apply throttling value to (publish-rate + dispatch rate))", required = false)
+                "-rp" }, description = "dispatch rate relative to publish-rate (if publish-relative flag is enabled "
+                + "then broker will apply throttling value to (publish-rate + dispatch rate))", required = false)
         private boolean relativeToPublishRate = false;
 
         @Override
@@ -2050,7 +2076,8 @@ public class CmdTopics extends CmdBase {
         @Parameter(description = "persistent://tenant/namespace/topic", required = true)
         private java.util.List<String> params;
 
-        @Parameter(names = {"-m", "--maxNum"}, description = "max unacked messages num on subscription", required = true)
+        @Parameter(names = {"-m", "--maxNum"},
+                description = "max unacked messages num on subscription", required = true)
         private int maxNum;
 
         @Override
@@ -2223,7 +2250,7 @@ public class CmdTopics extends CmdBase {
         private java.util.List<String> params;
 
         @Parameter(names = { "--msg-dispatch-rate",
-            "-md" }, description = "message-dispatch-rate (default -1 will be overwrite if not passed)", required = false)
+            "-md" }, description = "message-dispatch-rate (default -1 will be overwrite if not passed)")
         private int msgDispatchRate = -1;
 
         @Parameter(names = { "--byte-dispatch-rate",
@@ -2231,11 +2258,13 @@ public class CmdTopics extends CmdBase {
         private long byteDispatchRate = -1;
 
         @Parameter(names = { "--dispatch-rate-period",
-            "-dt" }, description = "dispatch-rate-period in second type (default 1 second will be overwrite if not passed)", required = false)
+            "-dt" }, description = "dispatch-rate-period in second type"
+                + " (default 1 second will be overwrite if not passed)")
         private int dispatchRatePeriodSec = 1;
 
         @Parameter(names = { "--relative-to-publish-rate",
-                "-rp" }, description = "dispatch rate relative to publish-rate (if publish-relative flag is enabled then broker will apply throttling value to (publish-rate + dispatch rate))", required = false)
+                "-rp" }, description = "dispatch rate relative to publish-rate (if publish-relative flag is enabled "
+                + "then broker will apply throttling value to (publish-rate + dispatch rate))")
         private boolean relativeToPublishRate = false;
 
         @Override
@@ -2284,7 +2313,7 @@ public class CmdTopics extends CmdBase {
         private java.util.List<String> params;
 
         @Parameter(names = { "--msg-dispatch-rate",
-            "-md" }, description = "message-dispatch-rate (default -1 will be overwrite if not passed)", required = false)
+            "-md" }, description = "message-dispatch-rate (default -1 will be overwrite if not passed)")
         private int msgDispatchRate = -1;
 
         @Parameter(names = { "--byte-dispatch-rate",
@@ -2292,11 +2321,13 @@ public class CmdTopics extends CmdBase {
         private long byteDispatchRate = -1;
 
         @Parameter(names = { "--dispatch-rate-period",
-            "-dt" }, description = "dispatch-rate-period in second type (default 1 second will be overwrite if not passed)", required = false)
+            "-dt" }, description = "dispatch-rate-period in second type "
+            + "(default 1 second will be overwrite if not passed)")
         private int dispatchRatePeriodSec = 1;
 
         @Parameter(names = { "--relative-to-publish-rate",
-                "-rp" }, description = "dispatch rate relative to publish-rate (if publish-relative flag is enabled then broker will apply throttling value to (publish-rate + dispatch rate))", required = false)
+                "-rp" }, description = "dispatch rate relative to publish-rate (if publish-relative flag is enabled "
+                + "then broker will apply throttling value to (publish-rate + dispatch rate))")
         private boolean relativeToPublishRate = false;
 
         @Override
@@ -2462,7 +2493,8 @@ public class CmdTopics extends CmdBase {
         @Parameter(description = "persistent://tenant/namespace/topic", required = true)
         private java.util.List<String> params;
 
-        @Parameter(names = { "--max-consumers-per-subscription", "-c" }, description = "maxConsumersPerSubscription for a namespace", required = true)
+        @Parameter(names = { "--max-consumers-per-subscription", "-c" },
+                description = "maxConsumersPerSubscription for a namespace", required = true)
         private int maxConsumersPerSubscription;
 
         @Override
@@ -2510,12 +2542,13 @@ public class CmdTopics extends CmdBase {
         @Parameter(names = { "--disable-delete-while-inactive", "-d" }, description = "Disable delete while inactive")
         private boolean disableDeleteWhileInactive = false;
 
-        @Parameter(names = {"--max-inactive-duration", "-t"}, description = "Max duration of topic inactivity in seconds" +
-                ",topics that are inactive for longer than this value will be deleted (eg: 1s, 10s, 1m, 5h, 3d)", required = true)
+        @Parameter(names = {"--max-inactive-duration", "-t"}, description = "Max duration of topic inactivity "
+                + "in seconds, topics that are inactive for longer than this value will be deleted "
+                + "(eg: 1s, 10s, 1m, 5h, 3d)", required = true)
         private String deleteInactiveTopicsMaxInactiveDuration;
 
-        @Parameter(names = { "--delete-mode", "-m" }, description = "Mode of delete inactive topic" +
-                ",Valid options are: [delete_when_no_subscriptions, delete_when_subscriptions_caught_up]", required = true)
+        @Parameter(names = { "--delete-mode", "-m" }, description = "Mode of delete inactive topic, Valid options are: "
+                + "[delete_when_no_subscriptions, delete_when_subscriptions_caught_up]", required = true)
         private String inactiveTopicDeleteMode;
 
         @Override
@@ -2530,16 +2563,18 @@ public class CmdTopics extends CmdBase {
             }
 
             if (enableDeleteWhileInactive == disableDeleteWhileInactive) {
-                throw new ParameterException("Need to specify either enable-delete-while-inactive or disable-delete-while-inactive");
+                throw new ParameterException("Need to specify either enable-delete-while-inactive "
+                        + "or disable-delete-while-inactive");
             }
             InactiveTopicDeleteMode deleteMode = null;
             try {
                 deleteMode = InactiveTopicDeleteMode.valueOf(inactiveTopicDeleteMode);
             } catch (IllegalArgumentException e) {
-                throw new ParameterException("delete mode can only be set to delete_when_no_subscriptions or delete_when_subscriptions_caught_up");
+                throw new ParameterException("delete mode can only be set to delete_when_no_subscriptions "
+                        + "or delete_when_subscriptions_caught_up");
             }
-            getTopics().setInactiveTopicPolicies(persistentTopic,
-                    new InactiveTopicPolicies(deleteMode, (int) maxInactiveDurationInSeconds, enableDeleteWhileInactive));
+            getTopics().setInactiveTopicPolicies(persistentTopic, new InactiveTopicPolicies(deleteMode,
+                    (int) maxInactiveDurationInSeconds, enableDeleteWhileInactive));
         }
     }
 
@@ -2622,7 +2657,8 @@ public class CmdTopics extends CmdBase {
         private int subscribeRate = -1;
 
         @Parameter(names = { "--subscribe-rate-period",
-                "-st" }, description = "subscribe-rate-period in second type (default 30 second will be overwrite if not passed)", required = false)
+                "-st" }, description = "subscribe-rate-period in second type "
+                + "(default 30 second will be overwrite if not passed)")
         private int subscribeRatePeriodSec = 30;
 
         @Override
@@ -2696,14 +2732,14 @@ public class CmdTopics extends CmdBase {
         private java.util.List<String> params;
 
         @Parameter(names = { "--messageId",
-                "-m" }, description = "messageId used to calculate backlog size. It can be (ledgerId:entryId).", required = false)
+                "-m" }, description = "messageId used to calculate backlog size. It can be (ledgerId:entryId).")
         private String messagePosition = "-1:-1";
 
         @Override
         void run() throws PulsarAdminException {
             String persistentTopic = validatePersistentTopic(params);
             MessageId messageId;
-            if("-1:-1".equals(messagePosition)) {
+            if ("-1:-1".equals(messagePosition)) {
                 messageId = MessageId.earliest;
             } else {
                 messageId = validateMessageIdString(messagePosition);

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdUsageFormatter.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdUsageFormatter.java
@@ -18,18 +18,17 @@
  */
 package org.apache.pulsar.admin.cli;
 
+import com.beust.jcommander.DefaultUsageFormatter;
+import com.beust.jcommander.JCommander;
+import com.beust.jcommander.Parameters;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
-import com.beust.jcommander.DefaultUsageFormatter;
-import com.beust.jcommander.JCommander;
-import com.beust.jcommander.Parameters;
-
 public class CmdUsageFormatter extends DefaultUsageFormatter {
 
     /**
-     * The commands in this set are hidden and not shown to users
+     * The commands in this set are hidden and not shown to users.
      */
     private Set<String> deprecatedCommands = new HashSet<>();
 
@@ -60,7 +59,7 @@ public class CmdUsageFormatter extends DefaultUsageFormatter {
                 JCommander.ProgramName progName = commands.getKey();
                 String dispName = progName.getDisplayName();
                 //skip the deprecated command
-                if(deprecatedCommands.contains(dispName)){
+                if (deprecatedCommands.contains(dispName)) {
                     continue;
                 }
                 String description = indent + s(4) + dispName + s(6) + getCommandDescription(progName.getName());

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/PulsarAdminTool.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/PulsarAdminTool.java
@@ -18,10 +18,11 @@
  */
 package org.apache.pulsar.admin.cli;
 
+import static org.apache.commons.lang3.StringUtils.isBlank;
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import com.beust.jcommander.JCommander;
 import com.beust.jcommander.Parameter;
 import com.google.common.annotations.VisibleForTesting;
-
 import java.io.FileInputStream;
 import java.lang.reflect.InvocationTargetException;
 import java.util.Arrays;
@@ -31,14 +32,10 @@ import java.util.Properties;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import java.util.function.Supplier;
-
 import org.apache.pulsar.PulsarVersion;
 import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.admin.PulsarAdminBuilder;
 import org.apache.pulsar.client.admin.internal.PulsarAdminImpl;
-
-import static org.apache.commons.lang3.StringUtils.isBlank;
-import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
 public class PulsarAdminTool {
 
@@ -62,9 +59,9 @@ public class PulsarAdminTool {
 
     @Parameter(
         names = { "--auth-params" },
-        description = "Authentication parameters, whose format is determined by the implementation " +
-            "of method `configure` in authentication plugin class, for example \"key1:val1,key2:val2\" " +
-            "or \"{\"key1\":\"val1\",\"key2\":\"val2\"}.")
+            description = "Authentication parameters, whose format is determined by the implementation "
+                    + "of method `configure` in authentication plugin class, for example \"key1:val1,key2:val2\" "
+                    + "or \"{\"key1\":\"val1\",\"key2\":\"val2\"}.")
     String authParams = null;
 
     @Parameter(names = { "--tls-allow-insecure" }, description = "Allow TLS insecure connection")
@@ -168,7 +165,8 @@ public class PulsarAdminTool {
         private final PulsarAdminBuilder pulsarAdminBuilder;
         private final Function<PulsarAdminBuilder, ? extends PulsarAdmin> adminFactory;
         private PulsarAdmin admin;
-        private PulsarAdminSupplier(PulsarAdminBuilder pulsarAdminBuilder, Function<PulsarAdminBuilder, ? extends PulsarAdmin> adminFactory) {
+        private PulsarAdminSupplier(PulsarAdminBuilder pulsarAdminBuilder,
+                                    Function<PulsarAdminBuilder, ? extends PulsarAdmin> adminFactory) {
             this.pulsarAdminBuilder = pulsarAdminBuilder;
             this.adminFactory = adminFactory;
         }
@@ -352,7 +350,7 @@ public class PulsarAdminTool {
             // they are only slowing down the tool
             Runtime.getRuntime().halt(code);
         } else {
-            System.out.println("Exit code is " + code+" (System.exit not called, as we are in test mode)");
+            System.out.println("Exit code is " + code + " (System.exit not called, as we are in test mode)");
         }
     }
 

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/package-info.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/package-info.java
@@ -16,23 +16,4 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.pulsar.client.cli;
-
-import com.beust.jcommander.converters.IParameterSplitter;
-import java.util.LinkedList;
-import java.util.List;
-
-public class NoSplitter implements IParameterSplitter {
-
-    /*
-     * (non-Javadoc)
-     *
-     * @see com.beust.jcommander.converters.IParameterSplitter#split(java.lang.String)
-     */
-    @Override
-    public List<String> split(final String value) {
-        final List<String> result = new LinkedList<>();
-        result.add(value);
-        return result;
-    }
-}
+package org.apache.pulsar.admin.cli;

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/utils/CmdUtils.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/utils/CmdUtils.java
@@ -21,7 +21,6 @@ package org.apache.pulsar.admin.cli.utils;
 import com.beust.jcommander.ParameterException;
 import com.fasterxml.jackson.databind.exc.InvalidFormatException;
 import com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException;
-
 import java.io.File;
 import java.io.IOException;
 import org.apache.pulsar.common.util.ObjectMapperFactory;
@@ -32,8 +31,7 @@ public class CmdUtils {
             return ObjectMapperFactory.getThreadLocalYaml().readValue(new File(file), clazz);
         } catch (Exception ex) {
             if (ex instanceof UnrecognizedPropertyException) {
-                UnrecognizedPropertyException unrecognizedPropertyException
-                        = (UnrecognizedPropertyException) ex;
+                UnrecognizedPropertyException unrecognizedPropertyException = (UnrecognizedPropertyException) ex;
 
                 String exceptionMessage = String.format("Failed to parse config file %s. "
                                 + "Invalid field '%s' on line: %d column: %d. Valid fields are %s",
@@ -43,7 +41,7 @@ public class CmdUtils {
                         unrecognizedPropertyException.getLocation().getColumnNr(),
                         unrecognizedPropertyException.getKnownPropertyIds());
                 throw new ParameterException(exceptionMessage);
-            } else if(ex instanceof InvalidFormatException) {
+            } else if (ex instanceof InvalidFormatException) {
 
                 InvalidFormatException invalidFormatException = (InvalidFormatException) ex;
                 String exceptionMessage = String.format("Failed to parse config file %s. %s on line: %d column: %d",

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/utils/NameValueParameterSplitter.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/utils/NameValueParameterSplitter.java
@@ -18,11 +18,10 @@
  */
 package org.apache.pulsar.admin.cli.utils;
 
-import java.util.HashMap;
-import java.util.Map;
-
 import com.beust.jcommander.IStringConverter;
 import com.beust.jcommander.ParameterException;
+import java.util.HashMap;
+import java.util.Map;
 
 public class NameValueParameterSplitter implements IStringConverter<Map<String, String>> {
 

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/utils/SchemaExtractor.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/utils/SchemaExtractor.java
@@ -18,10 +18,9 @@
  */
 package org.apache.pulsar.admin.cli.utils;
 
+import java.nio.charset.StandardCharsets;
 import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.client.api.schema.SchemaDefinition;
-
-import java.nio.charset.StandardCharsets;
 
 public class SchemaExtractor {
 

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/utils/package-info.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/utils/package-info.java
@@ -16,23 +16,4 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.pulsar.client.cli;
-
-import com.beust.jcommander.converters.IParameterSplitter;
-import java.util.LinkedList;
-import java.util.List;
-
-public class NoSplitter implements IParameterSplitter {
-
-    /*
-     * (non-Javadoc)
-     *
-     * @see com.beust.jcommander.converters.IParameterSplitter#split(java.lang.String)
-     */
-    @Override
-    public List<String> split(final String value) {
-        final List<String> result = new LinkedList<>();
-        result.add(value);
-        return result;
-    }
-}
+package org.apache.pulsar.admin.cli.utils;

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/client/cli/CmdConsume.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/client/cli/CmdConsume.java
@@ -20,7 +20,6 @@ package org.apache.pulsar.client.cli;
 
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import static org.apache.pulsar.client.internal.PulsarClientImplementationBinding.getBytes;
-
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.ParameterException;
 import com.beust.jcommander.Parameters;
@@ -30,7 +29,6 @@ import com.google.common.util.concurrent.RateLimiter;
 import com.google.gson.Gson;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonPrimitive;
-
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.net.URI;
@@ -46,7 +44,6 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
-
 import org.apache.commons.io.HexDump;
 import org.apache.pulsar.client.api.Authentication;
 import org.apache.pulsar.client.api.AuthenticationDataProvider;
@@ -119,8 +116,8 @@ public class CmdConsume {
 
     @Parameter(names = { "--regex" }, description = "Indicate the topic name is a regex pattern")
     private boolean isRegex = false;
-    
-    @Parameter(names = { "-q", "--queue-size" }, description = "Consumer receiver queue size.")
+
+    @Parameter(names = {"-q", "--queue-size"}, description = "Consumer receiver queue size.")
     private int receiverQueueSize = 0;
 
     @Parameter(names = { "-mc", "--max_chunked_msg" }, description = "Max pending chunk messages")
@@ -135,7 +132,8 @@ public class CmdConsume {
                     + "file:///path/to/private.key or data:application/x-pem-file;base64,*****")
     private String encKeyValue;
 
-    @Parameter(names = { "-st", "--schema-type"}, description = "Set a schema type on the consumer, it can be 'bytes' or 'auto_consume'")
+    @Parameter(names = { "-st", "--schema-type"},
+            description = "Set a schema type on the consumer, it can be 'bytes' or 'auto_consume'")
     private String schematype = "bytes";
 
     @Parameter(names = { "-pm", "--pool-messages" }, description = "Use the pooled message", arity = 1)
@@ -160,7 +158,7 @@ public class CmdConsume {
     }
 
     /**
-     * Interprets the message to create a string representation
+     * Interprets the message to create a string representation.
      *
      * @param message
      *            The message to interpret
@@ -270,18 +268,21 @@ public class CmdConsume {
      * @return 0 for success, < 0 otherwise
      */
     public int run() throws PulsarClientException, IOException {
-        if (mainOptions.size() != 1)
+        if (mainOptions.size() != 1) {
             throw (new ParameterException("Please provide one and only one topic name."));
-        if (this.subscriptionName == null || this.subscriptionName.isEmpty())
+        }
+        if (this.subscriptionName == null || this.subscriptionName.isEmpty()) {
             throw (new ParameterException("Subscription name is not provided."));
-        if (this.numMessagesToConsume < 0)
+        }
+        if (this.numMessagesToConsume < 0) {
             throw (new ParameterException("Number of messages should be zero or positive."));
+        }
 
         String topic = this.mainOptions.get(0);
 
-        if(this.serviceURL.startsWith("ws")) {
+        if (this.serviceURL.startsWith("ws")) {
             return consumeFromWebSocket(topic);
-        }else {
+        } else {
             return consume(topic);
         }
     }
@@ -344,7 +345,7 @@ public class CmdConsume {
                             System.out.println(output);
                         } else if (numMessagesConsumed % 1000 == 0) {
                             System.out.println("Received " + numMessagesConsumed + " messages");
-                        }  
+                        }
                         consumer.acknowledge(msg);
                     } finally {
                         msg.release();
@@ -419,7 +420,7 @@ public class CmdConsume {
         }
 
         try {
-            LOG.info("Trying to create websocket session..{}",consumerUri);
+            LOG.info("Trying to create websocket session..{}", consumerUri);
             consumeClient.connect(consumerSocket, consumerUri, consumeRequest);
             connected.get();
         } catch (Exception e) {

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/client/cli/CmdGenerateDocumentation.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/client/cli/CmdGenerateDocumentation.java
@@ -22,14 +22,13 @@ import com.beust.jcommander.JCommander;
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.ParameterDescription;
 import com.beust.jcommander.Parameters;
-import lombok.Getter;
-import lombok.extern.slf4j.Slf4j;
-import org.apache.pulsar.client.api.PulsarClientException;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.pulsar.client.api.PulsarClientException;
 
 @Getter
 @Parameters(commandDescription = "Generate documentation automatically.")

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/client/cli/CmdProduce.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/client/cli/CmdProduce.java
@@ -19,7 +19,6 @@
 package org.apache.pulsar.client.cli;
 
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
-
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.ParameterException;
 import com.beust.jcommander.Parameters;
@@ -27,7 +26,6 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.util.concurrent.RateLimiter;
 import com.google.gson.JsonParseException;
-
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -42,7 +40,6 @@ import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
-
 import org.apache.pulsar.client.api.Authentication;
 import org.apache.pulsar.client.api.AuthenticationDataProvider;
 import org.apache.pulsar.client.api.ClientBuilder;
@@ -97,20 +94,21 @@ public class CmdProduce {
     private List<String> messageFileNames = new ArrayList<>();
 
     @Parameter(names = { "-n", "--num-produce" },
-               description = "Number of times to send message(s), the count of messages/files * num-produce " +
-                       "should below than " + MAX_MESSAGES + ".")
+               description = "Number of times to send message(s), the count of messages/files * num-produce "
+                       + "should below than " + MAX_MESSAGES + ".")
     private int numTimesProduce = 1;
 
     @Parameter(names = { "-r", "--rate" },
-               description = "Rate (in msg/sec) at which to produce," +
-                       " value 0 means to produce messages as fast as possible.")
+               description = "Rate (in msg/sec) at which to produce,"
+                       + " value 0 means to produce messages as fast as possible.")
     private double publishRate = 0;
 
     @Parameter(names = { "-db", "--disable-batching" }, description = "Disable batch sending of messages")
     private boolean disableBatching = false;
-    
+
     @Parameter(names = { "-c",
-            "--chunking" }, description = "Should split the message and publish in chunks if message size is larger than allowed max size")
+            "--chunking" }, description = "Should split the message and publish in chunks if message size is "
+            + "larger than allowed max size")
     private boolean chunkingAllowed = false;
 
     @Parameter(names = { "-s", "--separator" },
@@ -130,7 +128,8 @@ public class CmdProduce {
     @Parameter(names = { "-ks", "--key-schema"}, description = "Schema type (can be bytes,avro,json,string...)")
     private String keySchema = "string";
 
-    @Parameter(names = { "-kvet", "--key-value-encoding-type"}, description = "Key Value Encoding Type (it can be separated or inline)")
+    @Parameter(names = { "-kvet", "--key-value-encoding-type"},
+            description = "Key Value Encoding Type (it can be separated or inline)")
     private String keyValueEncodingType = null;
 
     @Parameter(names = { "-ekn", "--encryption-key-name" }, description = "The public key name to encrypt payload")
@@ -217,7 +216,8 @@ public class CmdProduce {
                 case KEY_VALUE_ENCODING_TYPE_INLINE:
                     break;
                 default:
-                    throw (new ParameterException("--key-value-encoding-type "+keyValueEncodingType+" is not valid, only 'separated' or 'inline'"));
+                    throw (new ParameterException("--key-value-encoding-type "
+                            + keyValueEncodingType + " is not valid, only 'separated' or 'inline'"));
             }
         }
 
@@ -320,11 +320,14 @@ public class CmdProduce {
             case KEY_VALUE_ENCODING_TYPE_NOT_SET:
                 return buildComponentSchema(schema);
             case KEY_VALUE_ENCODING_TYPE_SEPARATED:
-                return Schema.KeyValue(buildComponentSchema(keySchema), buildComponentSchema(schema), KeyValueEncodingType.SEPARATED);
+                return Schema.KeyValue(buildComponentSchema(keySchema), buildComponentSchema(schema),
+                        KeyValueEncodingType.SEPARATED);
             case KEY_VALUE_ENCODING_TYPE_INLINE:
-                return Schema.KeyValue(buildComponentSchema(keySchema), buildComponentSchema(schema), KeyValueEncodingType.INLINE);
+                return Schema.KeyValue(buildComponentSchema(keySchema), buildComponentSchema(schema),
+                        KeyValueEncodingType.INLINE);
             default:
-                throw new IllegalArgumentException("Invalid KeyValueEncodingType "+keyValueEncodingType+", only: 'none','separated' and 'inline");
+                throw new IllegalArgumentException("Invalid KeyValueEncodingType "
+                        + keyValueEncodingType + ", only: 'none','separated' and 'inline");
         }
     }
 
@@ -343,7 +346,7 @@ public class CmdProduce {
                 } else if (schema.startsWith("json:")) {
                     base = buildGenericSchema(SchemaType.JSON, schema.substring(5));
                 } else {
-                    throw new IllegalArgumentException("Invalid schema type: "+schema);
+                    throw new IllegalArgumentException("Invalid schema type: " + schema);
                 }
         }
         return Schema.AUTO_PRODUCE_BYTES(base);
@@ -431,7 +434,7 @@ public class CmdProduce {
                     if (limiter != null) {
                         limiter.acquire();
                     }
-                    produceSocket.send(index++, content).get(30,TimeUnit.SECONDS);
+                    produceSocket.send(index++, content).get(30, TimeUnit.SECONDS);
                     numMessagesSent++;
                 }
             }
@@ -493,8 +496,8 @@ public class CmdProduce {
 
         @OnWebSocketMessage
         public synchronized void onMessage(String msg) throws JsonParseException {
-            LOG.info("ack= {}",msg);
-            if(this.result!=null) {
+            LOG.info("ack= {}", msg);
+            if (this.result != null) {
                 this.result.complete(null);
             }
         }

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/client/cli/PulsarClientTool.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/client/cli/PulsarClientTool.java
@@ -20,11 +20,15 @@ package org.apache.pulsar.client.cli;
 
 import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
-
+import com.beust.jcommander.DefaultUsageFormatter;
+import com.beust.jcommander.IUsageFormatter;
+import com.beust.jcommander.JCommander;
+import com.beust.jcommander.Parameter;
+import com.beust.jcommander.ParameterException;
+import com.beust.jcommander.Parameters;
 import java.io.FileInputStream;
 import java.util.Arrays;
 import java.util.Properties;
-
 import org.apache.pulsar.PulsarVersion;
 import org.apache.pulsar.client.api.Authentication;
 import org.apache.pulsar.client.api.AuthenticationFactory;
@@ -32,13 +36,6 @@ import org.apache.pulsar.client.api.ClientBuilder;
 import org.apache.pulsar.client.api.ProxyProtocol;
 import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.client.api.PulsarClientException.UnsupportedAuthenticationException;
-
-import com.beust.jcommander.DefaultUsageFormatter;
-import com.beust.jcommander.IUsageFormatter;
-import com.beust.jcommander.JCommander;
-import com.beust.jcommander.Parameter;
-import com.beust.jcommander.ParameterException;
-import com.beust.jcommander.Parameters;
 
 @Parameters(commandDescription = "Produce or consume messages on a specified topic")
 public class PulsarClientTool {
@@ -60,9 +57,9 @@ public class PulsarClientTool {
 
     @Parameter(
         names = { "--auth-params" },
-        description = "Authentication parameters, whose format is determined by the implementation " +
-            "of method `configure` in authentication plugin class, for example \"key1:val1,key2:val2\" " +
-            "or \"{\"key1\":\"val1\",\"key2\":\"val2\"}.")
+        description = "Authentication parameters, whose format is determined by the implementation "
+                + "of method `configure` in authentication plugin class, for example \"key1:val1,key2:val2\" "
+                + "or \"{\"key1\":\"val1\",\"key2\":\"val2\"}.")
     String authParams = null;
 
     @Parameter(names = { "-v", "--version" }, description = "Get version of pulsar client")
@@ -218,9 +215,9 @@ public class PulsarClientTool {
         }
 
         PulsarClientTool clientTool = new PulsarClientTool(properties);
-        int exit_code = clientTool.run(Arrays.copyOfRange(args, 1, args.length));
+        int exitCode = clientTool.run(Arrays.copyOfRange(args, 1, args.length));
 
-        System.exit(exit_code);
+        System.exit(exitCode);
 
     }
 }

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/client/cli/package-info.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/client/cli/package-info.java
@@ -17,22 +17,3 @@
  * under the License.
  */
 package org.apache.pulsar.client.cli;
-
-import com.beust.jcommander.converters.IParameterSplitter;
-import java.util.LinkedList;
-import java.util.List;
-
-public class NoSplitter implements IParameterSplitter {
-
-    /*
-     * (non-Javadoc)
-     *
-     * @see com.beust.jcommander.converters.IParameterSplitter#split(java.lang.String)
-     */
-    @Override
-    public List<String> split(final String value) {
-        final List<String> result = new LinkedList<>();
-        result.add(value);
-        return result;
-    }
-}


### PR DESCRIPTION
### Motivation
I found that the code style in the `pulsar-client-tools` module is not standardized but can run through all `CI` When I review [PR#13624](https://github.com/apache/pulsar/pull/13624#discussion_r778916227), which easily leads to lack of standardization of the code.
The purpose of this PR is to introduce `checkstyle-plugin` to avoid the above problems.

### Modifications
- Enable CheckStyle Plugin
- Fix checkstyle violations

### Documentation
- [x] `no-need-doc` 


