### PR TITLE
[Issue 13651][elastic-search] Fix Elasticsearch Sink Invalid type for uuid encoded as logical types

### DIFF
--- a/pulsar-io/elastic-search/src/main/java/org/apache/pulsar/io/elasticsearch/JsonConverter.java
+++ b/pulsar-io/elastic-search/src/main/java/org/apache/pulsar/io/elasticsearch/JsonConverter.java
@@ -197,7 +197,7 @@ public class JsonConverter {
                 new Conversions.UUIDConversion()) {
             @Override
             JsonNode toJson(Schema schema, Object value) {
-                return jsonNodeFactory.textNode(value.toString());
+                return jsonNodeFactory.textNode(value == null ? null : value.toString());
             }
         });
     }

--- a/pulsar-io/elastic-search/src/main/java/org/apache/pulsar/io/elasticsearch/JsonConverter.java
+++ b/pulsar-io/elastic-search/src/main/java/org/apache/pulsar/io/elasticsearch/JsonConverter.java
@@ -197,12 +197,7 @@ public class JsonConverter {
                 new Conversions.UUIDConversion()) {
             @Override
             JsonNode toJson(Schema schema, Object value) {
-                if (!(value instanceof String)) {
-                    throw new IllegalArgumentException("Invalid type for uuid, expected String but was "
-                            + value.getClass());
-                }
-                String uuidString = (String) value;
-                return jsonNodeFactory.textNode(uuidString);
+                return jsonNodeFactory.textNode(value.toString());
             }
         });
     }

--- a/pulsar-io/elastic-search/src/test/java/org/apache/pulsar/io/elasticsearch/JsonConverterTests.java
+++ b/pulsar-io/elastic-search/src/test/java/org/apache/pulsar/io/elasticsearch/JsonConverterTests.java
@@ -26,12 +26,20 @@ import org.apache.avro.Schema;
 import org.apache.avro.SchemaBuilder;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.io.*;
+import org.apache.avro.specific.SpecificDatumReader;
+import org.apache.avro.specific.SpecificDatumWriter;
 import org.testng.annotations.Test;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.nio.charset.StandardCharsets;
-import java.util.*;
+import java.util.Calendar;
+import java.util.GregorianCalendar;
+import java.util.TimeZone;
+import java.util.UUID;
 
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
@@ -80,8 +88,7 @@ public class JsonConverterTests {
     }
 
     @Test
-    public void testLogicalTypesToJson() {
-        Schema decimalType = LogicalTypes.decimal(3,3).addToSchema(Schema.create(Schema.Type.BYTES));
+    public void testLogicalTypesToJson() throws IOException {
         Schema dateType = LogicalTypes.date().addToSchema(Schema.create(Schema.Type.INT));
         Schema timestampMillisType = LogicalTypes.timestampMillis().addToSchema(Schema.create(Schema.Type.LONG));
         Schema timestampMicrosType = LogicalTypes.timestampMicros().addToSchema(Schema.create(Schema.Type.LONG));
@@ -90,7 +97,6 @@ public class JsonConverterTests {
         Schema uuidType = LogicalTypes.uuid().addToSchema(Schema.create(Schema.Type.STRING));
         Schema schema = SchemaBuilder.record("record")
                 .fields()
-                .name("amount").type(decimalType).noDefault()
                 .name("mydate").type(dateType).noDefault()
                 .name("tsmillis").type(timestampMillisType).noDefault()
                 .name("tsmicros").type(timestampMicrosType).noDefault()
@@ -100,24 +106,40 @@ public class JsonConverterTests {
                 .endRecord();
 
         final long MILLIS_PER_DAY = 24 * 60 * 60 * 1000;
-        BigDecimal myDecimal = new BigDecimal("10.34");
+        BigDecimal myDecimal = new BigDecimal("100.003");
         UUID myUuid = UUID.randomUUID();
         Calendar calendar = new GregorianCalendar(TimeZone.getTimeZone("Europe/Copenhagen"));
         GenericRecord genericRecord = new GenericData.Record(schema);
-        genericRecord.put("amount", myDecimal);
         genericRecord.put("mydate", (int)calendar.toInstant().getEpochSecond());
         genericRecord.put("tsmillis", calendar.getTimeInMillis());
         genericRecord.put("tsmicros", calendar.getTimeInMillis() * 1000);
         genericRecord.put("timemillis", (int)(calendar.getTimeInMillis() % MILLIS_PER_DAY));
         genericRecord.put("timemicros", (calendar.getTimeInMillis() %MILLIS_PER_DAY) * 1000);
         genericRecord.put("myuuid", myUuid.toString());
-        JsonNode jsonNode = JsonConverter.toJson(genericRecord);
-        assertEquals(new BigDecimal(jsonNode.get("amount").asText()), myDecimal);
+
+        GenericRecord genericRecord2 = deserialize(serialize(genericRecord, schema), schema);
+        JsonNode jsonNode = JsonConverter.toJson(genericRecord2);
         assertEquals(jsonNode.get("mydate").asInt(), calendar.toInstant().getEpochSecond());
         assertEquals(jsonNode.get("tsmillis").asInt(), (int)calendar.getTimeInMillis());
         assertEquals(jsonNode.get("tsmicros").asLong(), calendar.getTimeInMillis() * 1000);
         assertEquals(jsonNode.get("timemillis").asInt(), (int)(calendar.getTimeInMillis() % MILLIS_PER_DAY));
         assertEquals(jsonNode.get("timemicros").asLong(), (calendar.getTimeInMillis() %MILLIS_PER_DAY) * 1000);
         assertEquals(UUID.fromString(jsonNode.get("myuuid").asText()), myUuid);
+    }
+
+    public static byte[] serialize(GenericRecord record, Schema schema) throws IOException {
+        SpecificDatumWriter<GenericRecord> datumWriter = new SpecificDatumWriter<>(schema);
+        ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+        BinaryEncoder binaryEncoder = new EncoderFactory().binaryEncoder(byteArrayOutputStream, null);
+        datumWriter.write(record, binaryEncoder);
+        binaryEncoder.flush();
+        return byteArrayOutputStream.toByteArray();
+    }
+
+    public static GenericRecord  deserialize(byte[] recordBytes, Schema schema) throws IOException {
+        DatumReader<GenericRecord> datumReader = new SpecificDatumReader<>(schema);
+        ByteArrayInputStream stream = new ByteArrayInputStream(recordBytes);
+        BinaryDecoder binaryDecoder = new DecoderFactory().binaryDecoder(stream, null);
+        return datumReader.read(null, binaryDecoder);
     }
 }


### PR DESCRIPTION
Fixes #13651

### Motivation

Fix the Elasticsearch sink to support AVRO uuid encoded as logical types.

### Modifications

Don't check the decoded field `value` class but just call the `value.toString()` to be able to manage UUID if encoded as a String or encoded as a uuid logical type (so as a java UUID). 

In fact, the AVRO logical types serialisation/deserialisation is managed by an AVRO static variable (`SpecificData.get().addLogicalTypeConversion(new Conversions.UUIDConversion()`) and we don't have a lot of control to configure it before the AVRO serialization/deserialisation actually occurs, it depends on the class loading order, so the toString() trick is a workaround that works in both cases, when `Conversions.UUIDConversion()` is loaded or not as a logical type conversion.

Also remove the BigDecimal testing (in testLogicalTypesToJson) because it is not supported by elasticsearch at the end.

### Documentation

Check the box below or label this PR directly (if you have committer privilege).

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [X] `no-need-doc` 
  
  Fix a bug, does not change the feature or the behaviour.
  
- [ ] `doc` 
  
  (If this PR contains doc changes)