### PR TITLE
Fix getInternalStats occasional lack of LeaderInfo

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -2016,7 +2016,7 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
         stats.state = ml.getState().toString();
 
         stats.ledgers = Lists.newArrayList();
-        List<CompletableFuture<String>> futures = includeLedgerMetadata ? Lists.newArrayList() : null;
+        List<CompletableFuture<String>> futures = Lists.newArrayList();
         CompletableFuture<Set<String>> availableBookiesFuture =
                 brokerService.pulsar().getPulsarResources().getBookieResources().listAvailableBookiesAsync();
         availableBookiesFuture.whenComplete((bookies, e) -> {
@@ -2031,7 +2031,7 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
                     info.size = li.getSize();
                     info.offloaded = li.hasOffloadContext() && li.getOffloadContext().getComplete();
                     stats.ledgers.add(info);
-                    if (futures != null) {
+                    if (includeLedgerMetadata) {
                         futures.add(ml.getLedgerMetadata(li.getLedgerId()).handle((lMetadata, ex) -> {
                             if (ex == null) {
                                 info.metadata = lMetadata;
@@ -2049,6 +2049,7 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
                 });
             }
         });
+        futures.add(availableBookiesFuture.handle((strings, throwable) -> null));
 
         // Add ledger info for compacted topic ledger if exist.
         LedgerInfo info = new LedgerInfo();

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -2019,6 +2019,7 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
         List<CompletableFuture<String>> futures = Lists.newArrayList();
         CompletableFuture<Set<String>> availableBookiesFuture =
                 brokerService.pulsar().getPulsarResources().getBookieResources().listAvailableBookiesAsync();
+        futures.add(availableBookiesFuture.handle((strings, throwable) -> null));
         availableBookiesFuture.whenComplete((bookies, e) -> {
             if (e != null) {
                 log.error("[{}] Failed to fetch available bookies.", topic, e);
@@ -2049,7 +2050,6 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
                 });
             }
         });
-        futures.add(availableBookiesFuture.handle((strings, throwable) -> null));
 
         // Add ledger info for compacted topic ledger if exist.
         LedgerInfo info = new LedgerInfo();


### PR DESCRIPTION
### Motivation

#11704 

AdminApiTest is flaky. The testGetPartitionedStatsInternal test method fails sporadically.

The root cause it that `stateFuture` is returned, but `availableBookiesFuture` is not accomplished, so we need ensure that `futures` is all completed before `stateFuture.complete`.

https://github.com/apache/pulsar/blob/5faae1c4e683f4796ad34c1c612de0bcfe754d2a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java#L2176-L2178

### Modifications

* Fix getInternalStats occasional lack of LeaderInfo 

### Documentation

Need to update docs? 

- [x] `no-need-doc` 
  


