### PR TITLE
[Python] Support is_connected in Python Client

### DIFF
--- a/pulsar-client-cpp/python/pulsar/__init__.py
+++ b/pulsar-client-cpp/python/pulsar/__init__.py
@@ -1077,6 +1077,12 @@ class Producer:
 
         return mb.build()
 
+    def is_connected(self):
+        """
+        Check if the producer is connected or not.
+        """
+        return self._producer.is_connected()
+
 
 class Consumer:
     """
@@ -1233,6 +1239,13 @@ class Consumer:
         self._consumer.close()
         self._client._consumers.remove(self)
 
+    def is_connected(self):
+        """
+        Check if the consumer is connected or not.
+        """
+        return self._consumer.is_connected()
+
+
 
 class Reader:
     """
@@ -1295,6 +1308,13 @@ class Reader:
         """
         self._reader.close()
         self._client._consumers.remove(self)
+
+    def is_connected(self):
+        """
+        Check if the reader is connected or not.
+        """
+        return self._reader.is_connected()
+
 
 class CryptoKeyReader:
     """

--- a/pulsar-client-cpp/python/pulsar_test.py
+++ b/pulsar-client-cpp/python/pulsar_test.py
@@ -167,6 +167,15 @@ class PulsarTest(TestCase):
         self.assertEqual(msg_id, msg.message_id())
         client.close()
 
+    def test_producer_is_connected(self):
+        client = Client(self.serviceUrl)
+        topic = "test_producer_is_connected"
+        producer = client.create_producer(topic)
+        self.assertTrue(producer.is_connected())
+        producer.close()
+        self.assertFalse(producer.is_connected())
+        client.close()
+
     def test_producer_consumer(self):
         client = Client(self.serviceUrl)
         consumer = client.subscribe("my-python-topic-producer-consumer", "my-sub", consumer_type=ConsumerType.Shared)
@@ -467,6 +476,16 @@ class PulsarTest(TestCase):
         self.assertEqual(received_messages[2].data(), b"hello-3")
         client.close()
 
+    def test_consumer_is_connected(self):
+        client = Client(self.serviceUrl)
+        topic = "test_consumer_is_connected"
+        sub = "sub"
+        consumer = client.subscribe(topic, sub)
+        self.assertTrue(consumer.is_connected())
+        consumer.close()
+        self.assertFalse(consumer.is_connected())
+        client.close()
+
     def test_reader_simple(self):
         client = Client(self.serviceUrl)
         reader = client.create_reader("my-python-topic-reader-simple", MessageId.earliest)
@@ -564,6 +583,15 @@ class PulsarTest(TestCase):
 
         reader1.close()
         reader2.close()
+        client.close()
+
+    def test_reader_is_connected(self):
+        client = Client(self.serviceUrl)
+        topic = "test_reader_is_connected"
+        reader = client.create_reader(topic, MessageId.earliest)
+        self.assertTrue(reader.is_connected())
+        reader.close()
+        self.assertFalse(reader.is_connected())
         client.close()
 
     def test_producer_sequence_after_reconnection(self):

--- a/pulsar-client-cpp/python/src/consumer.cc
+++ b/pulsar-client-cpp/python/src/consumer.cc
@@ -111,9 +111,7 @@ void Consumer_seek_timestamp(Consumer& consumer, uint64_t timestamp) {
         CHECK_RESULT(res);
 }
 
-bool Consumer_is_connected(Consumer& consumer) {
-    return consumer.isConnected();
-}
+bool Consumer_is_connected(Consumer& consumer) { return consumer.isConnected(); }
 
 void export_consumer() {
     using namespace boost::python;

--- a/pulsar-client-cpp/python/src/consumer.cc
+++ b/pulsar-client-cpp/python/src/consumer.cc
@@ -111,6 +111,10 @@ void Consumer_seek_timestamp(Consumer& consumer, uint64_t timestamp) {
         CHECK_RESULT(res);
 }
 
+bool Consumer_is_connected(Consumer& consumer) {
+    return consumer.isConnected();
+}
+
 void export_consumer() {
     using namespace boost::python;
 
@@ -132,5 +136,6 @@ void export_consumer() {
         .def("resume_message_listener", &Consumer_resumeMessageListener)
         .def("redeliver_unacknowledged_messages", &Consumer::redeliverUnacknowledgedMessages)
         .def("seek", &Consumer_seek)
-        .def("seek", &Consumer_seek_timestamp);
+        .def("seek", &Consumer_seek_timestamp)
+        .def("is_connected", &Consumer_is_connected);
 }

--- a/pulsar-client-cpp/python/src/producer.cc
+++ b/pulsar-client-cpp/python/src/producer.cc
@@ -75,9 +75,7 @@ void Producer_close(Producer& producer) {
         CHECK_RESULT(res);
 }
 
-bool Producer_is_connected(Producer& producer) {
-    return producer.isConnected();
-}
+bool Producer_is_connected(Producer& producer) { return producer.isConnected(); }
 
 void export_producer() {
     using namespace boost::python;

--- a/pulsar-client-cpp/python/src/producer.cc
+++ b/pulsar-client-cpp/python/src/producer.cc
@@ -75,6 +75,10 @@ void Producer_close(Producer& producer) {
         CHECK_RESULT(res);
 }
 
+bool Producer_is_connected(Producer& producer) {
+    return producer.isConnected();
+}
+
 void export_producer() {
     using namespace boost::python;
 
@@ -103,5 +107,6 @@ void export_producer() {
         .def("flush", &Producer_flush,
              "Flush all the messages buffered in the client and wait until all messages have been\n"
              "successfully persisted\n")
-        .def("close", &Producer_close);
+        .def("close", &Producer_close)
+        .def("is_connected", &Producer_is_connected);
 }

--- a/pulsar-client-cpp/python/src/reader.cc
+++ b/pulsar-client-cpp/python/src/reader.cc
@@ -90,6 +90,10 @@ void Reader_seek_timestamp(Reader& reader, uint64_t timestamp) {
         CHECK_RESULT(res);
 }
 
+bool Reader_is_connected(Reader& reader) {
+    return reader.isConnected();
+}
+
 void export_reader() {
     using namespace boost::python;
 
@@ -100,5 +104,6 @@ void export_reader() {
         .def("has_message_available", &Reader_hasMessageAvailable)
         .def("close", &Reader_close)
         .def("seek", &Reader_seek)
-        .def("seek", &Reader_seek_timestamp);
+        .def("seek", &Reader_seek_timestamp)
+        .def("is_connected", &Reader_is_connected);
 }

--- a/pulsar-client-cpp/python/src/reader.cc
+++ b/pulsar-client-cpp/python/src/reader.cc
@@ -90,9 +90,7 @@ void Reader_seek_timestamp(Reader& reader, uint64_t timestamp) {
         CHECK_RESULT(res);
 }
 
-bool Reader_is_connected(Reader& reader) {
-    return reader.isConnected();
-}
+bool Reader_is_connected(Reader& reader) { return reader.isConnected(); }
 
 void export_reader() {
     using namespace boost::python;


### PR DESCRIPTION
### Motivation
We would like to use `is_connected()` in Python Client.

### Modifications
- Add `is_connected()` to producer/consumer/reader
- Add tests
### Verifying this change
- [ ] Make sure that the change passes the CI checks.

### Documentation
- [x] `no-need-doc` 