### PR TITLE
Avoid call sync method in async rest API for force delete subscription 

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
@@ -1615,21 +1615,22 @@ public class PersistentTopicsBase extends AdminResource {
                     log.info("[{}][{}] Deleted subscription forcefully {}", clientAppId(), topicName, subName);
                     asyncResponse.resume(Response.noContent().build());
                 }).exceptionally(e -> {
-                    if (e instanceof WebApplicationException) {
+                    Throwable cause = e.getCause();
+                    if (cause instanceof WebApplicationException) {
                         if (log.isDebugEnabled()) {
                             log.debug("[{}] Failed to delete subscription forcefully from topic {},"
                                             + " redirecting to other brokers.",
-                                    clientAppId(), topicName, e);
+                                    clientAppId(), topicName, cause);
                         }
                         asyncResponse.resume(e);
-                    } else if (e.getCause() instanceof RestException) {
+                    } else if (cause instanceof RestException) {
                         log.error("[{}] Failed to delete subscription forcefully {} {}",
-                                clientAppId(), topicName, subName, e);
-                        asyncResponse.resume(e.getCause());
+                                clientAppId(), topicName, subName, cause);
+                        asyncResponse.resume(cause);
                     } else {
                         log.error("[{}] Failed to delete subscription forcefully {} {}",
-                                clientAppId(), topicName, subName, e);
-                        asyncResponse.resume(new RestException(e));
+                                clientAppId(), topicName, subName, cause);
+                        asyncResponse.resume(new RestException(cause));
                     }
                     return null;
                 });

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
@@ -1620,7 +1620,7 @@ public class PersistentTopicsBase extends AdminResource {
                         if (log.isDebugEnabled() && ((WebApplicationException) cause).getResponse().getStatus()
                                 == Status.TEMPORARY_REDIRECT.getStatusCode()) {
                             log.debug("[{}] Failed to delete subscription from topic {}, redirecting to other brokers.",
-                                    clientAppId(), topicName, e);
+                                    clientAppId(), topicName, cause);
                         }
                         asyncResponse.resume(cause);
                     } else {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
@@ -1617,10 +1617,10 @@ public class PersistentTopicsBase extends AdminResource {
                 }).exceptionally(e -> {
                     Throwable cause = e.getCause();
                     if (cause instanceof WebApplicationException) {
-                        if (log.isDebugEnabled()) {
-                            log.debug("[{}] Failed to delete subscription forcefully from topic {},"
-                                            + " redirecting to other brokers.",
-                                    clientAppId(), topicName, cause);
+                        if (log.isDebugEnabled() && ((WebApplicationException) e).getResponse().getStatus()
+                                == Status.TEMPORARY_REDIRECT.getStatusCode()) {
+                            log.debug("[{}] Failed to delete subscription from topic {}, redirecting to other brokers.",
+                                    clientAppId(), topicName, e);
                         }
                         asyncResponse.resume(cause);
                     } else {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
@@ -1602,33 +1602,37 @@ public class PersistentTopicsBase extends AdminResource {
 
     private void internalDeleteSubscriptionForNonPartitionedTopicForcefully(AsyncResponse asyncResponse,
                                                                             String subName, boolean authoritative) {
-        try {
-            validateTopicOwnership(topicName, authoritative);
-            validateTopicOperation(topicName, TopicOperation.UNSUBSCRIBE);
-
-            Topic topic = getTopicReference(topicName);
-            Subscription sub = topic.getSubscription(subName);
-            if (sub == null) {
-                asyncResponse.resume(new RestException(Status.NOT_FOUND, "Subscription not found"));
-                return;
-            }
-            sub.deleteForcefully().get();
-            log.info("[{}][{}] Deleted subscription forcefully {}", clientAppId(), topicName, subName);
-            asyncResponse.resume(Response.noContent().build());
-        } catch (Exception e) {
-            if (e instanceof WebApplicationException) {
-                if (log.isDebugEnabled()) {
-                    log.debug("[{}] Failed to delete subscription forcefully from topic {},"
-                                    + " redirecting to other brokers.",
-                            clientAppId(), topicName, e);
-                }
-                asyncResponse.resume(e);
-            } else {
-                log.error("[{}] Failed to delete subscription forcefully {} {}",
-                        clientAppId(), topicName, subName, e);
-                asyncResponse.resume(new RestException(e));
-            }
-        }
+        validateTopicOwnershipAsync(topicName, authoritative)
+                .thenRun(() -> validateTopicOperation(topicName, TopicOperation.UNSUBSCRIBE))
+                .thenCompose(__ -> {
+                    Topic topic = getTopicReference(topicName);
+                    Subscription sub = topic.getSubscription(subName);
+                    if (sub == null) {
+                        throw new RestException(Status.NOT_FOUND, "Subscription not found");
+                    }
+                    return sub.deleteForcefully();
+                }).thenRun(() -> {
+                    log.info("[{}][{}] Deleted subscription forcefully {}", clientAppId(), topicName, subName);
+                    asyncResponse.resume(Response.noContent().build());
+                }).exceptionally(e -> {
+                    if (e instanceof WebApplicationException) {
+                        if (log.isDebugEnabled()) {
+                            log.debug("[{}] Failed to delete subscription forcefully from topic {},"
+                                            + " redirecting to other brokers.",
+                                    clientAppId(), topicName, e);
+                        }
+                        asyncResponse.resume(e);
+                    } else if (e.getCause() instanceof RestException) {
+                        log.error("[{}] Failed to delete subscription forcefully {} {}",
+                                clientAppId(), topicName, subName, e);
+                        asyncResponse.resume(e.getCause());
+                    } else {
+                        log.error("[{}] Failed to delete subscription forcefully {} {}",
+                                clientAppId(), topicName, subName, e);
+                        asyncResponse.resume(new RestException(e));
+                    }
+                    return null;
+                });
     }
 
     protected void internalSkipAllMessages(AsyncResponse asyncResponse, String subName, boolean authoritative) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
@@ -1622,10 +1622,6 @@ public class PersistentTopicsBase extends AdminResource {
                                             + " redirecting to other brokers.",
                                     clientAppId(), topicName, cause);
                         }
-                        asyncResponse.resume(e);
-                    } else if (cause instanceof RestException) {
-                        log.error("[{}] Failed to delete subscription forcefully {} {}",
-                                clientAppId(), topicName, subName, cause);
                         asyncResponse.resume(cause);
                     } else {
                         log.error("[{}] Failed to delete subscription forcefully {} {}",

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
@@ -1617,7 +1617,7 @@ public class PersistentTopicsBase extends AdminResource {
                 }).exceptionally(e -> {
                     Throwable cause = e.getCause();
                     if (cause instanceof WebApplicationException) {
-                        if (log.isDebugEnabled() && ((WebApplicationException) e).getResponse().getStatus()
+                        if (log.isDebugEnabled() && ((WebApplicationException) cause).getResponse().getStatus()
                                 == Status.TEMPORARY_REDIRECT.getStatusCode()) {
                             log.debug("[{}] Failed to delete subscription from topic {}, redirecting to other brokers.",
                                     clientAppId(), topicName, e);


### PR DESCRIPTION
### Motivation

Same to  #13666

### Modifications

- Change sync method to async.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: ( no )
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

- [x] `no-need-doc` 
  

