### PR TITLE
Cleanup reference to removed grafana docker image

### DIFF
--- a/docker/publish.sh
+++ b/docker/publish.sh
@@ -64,18 +64,14 @@ set -e
 
 docker tag pulsar:latest ${docker_registry_org}/pulsar:latest
 docker tag pulsar-all:latest ${docker_registry_org}/pulsar-all:latest
-docker tag pulsar-grafana:latest ${docker_registry_org}/pulsar-grafana:latest
 
 docker tag pulsar:latest ${docker_registry_org}/pulsar:$MVN_VERSION
 docker tag pulsar-all:latest ${docker_registry_org}/pulsar-all:$MVN_VERSION
-docker tag pulsar-grafana:latest ${docker_registry_org}/pulsar-grafana:$MVN_VERSION
 
 # Push all images and tags
 docker push ${docker_registry_org}/pulsar:latest
 docker push ${docker_registry_org}/pulsar-all:latest
-docker push ${docker_registry_org}/pulsar-grafana:latest
 docker push ${docker_registry_org}/pulsar:$MVN_VERSION
 docker push ${docker_registry_org}/pulsar-all:$MVN_VERSION
-docker push ${docker_registry_org}/pulsar-grafana:$MVN_VERSION
 
 echo "Finished pushing images to ${docker_registry_org}"


### PR DESCRIPTION
### Motivation

In #13389, I removed the `apachepulsar/pulsar-grafana` docker image. I missed a reference in our publish scripts. Cleaning that up in this PR.

### Verifying this change

Trivial change.

### Does this pull request potentially affect one of the following parts:

No.

### Documentation
  
- [x] `no-need-doc` 
 
This is an internal change to a script.


