### PR TITLE
OF: t2.small ec2 instances are not available in us-west-2d

### DIFF
--- a/deployment/terraform-ansible/aws/terraform.tfvars
+++ b/deployment/terraform-ansible/aws/terraform.tfvars
@@ -28,7 +28,7 @@ num_proxy_nodes     = 1
 base_cidr_block     = "10.0.0.0/16"
 
 instance_types      = {
-  "zookeeper"   = "t2.small"
+  "zookeeper"   = "t3.small"
   "bookie"      = "i3.xlarge"
   "broker"      = "c5.2xlarge"
   "proxy"       = "c5.2xlarge"

--- a/site2/docs/deploy-aws.md
+++ b/site2/docs/deploy-aws.md
@@ -121,7 +121,7 @@ Variable name | Description | Default
 When you run the Ansible playbook, the following AWS resources are used:
 
 * 9 total [Elastic Compute Cloud](https://aws.amazon.com/ec2) (EC2) instances running the [ami-9fa343e7](https://access.redhat.com/articles/3135091) Amazon Machine Image (AMI), which runs [Red Hat Enterprise Linux (RHEL) 7.4](https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html-single/7.4_release_notes/index). By default, that includes:
-  * 3 small VMs for ZooKeeper ([t2.small](https://www.ec2instances.info/?selected=t2.small) instances)
+  * 3 small VMs for ZooKeeper ([t3.small](https://www.ec2instances.info/?selected=t3.small) instances)
   * 3 larger VMs for BookKeeper [bookies](reference-terminology.md#bookie) ([i3.xlarge](https://www.ec2instances.info/?selected=i3.xlarge) instances)
   * 2 larger VMs for Pulsar [brokers](reference-terminology.md#broker) ([c5.2xlarge](https://www.ec2instances.info/?selected=c5.2xlarge) instances)
   * 1 larger VMs for Pulsar [proxy](reference-terminology.md#proxy) ([c5.2xlarge](https://www.ec2instances.info/?selected=c5.2xlarge) instances)


### PR DESCRIPTION
### Motivation

During benchmark testing of Pulsar with openmessaging/benchmark I noticed that t2.small ec2 instances are not available in us-west-2d.

### Modifications

Changed `t2.small` to `t3.small` in three places in two files.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Anything that affects deployment: (yes)

### Documentation
  
- [X] `doc` 
  
 
