### PR TITLE
Enable CheckStyle Plugin in pulsar-config-validation

### DIFF
--- a/pulsar-config-validation/pom.xml
+++ b/pulsar-config-validation/pom.xml
@@ -47,6 +47,19 @@
                 <artifactId>spotbugs-maven-plugin</artifactId>
                 <version>${spotbugs-maven-plugin.version}</version>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-checkstyle-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>checkstyle</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/pulsar-config-validation/src/main/java/org/apache/pulsar/config/validation/ConfigValidation.java
+++ b/pulsar-config-validation/src/main/java/org/apache/pulsar/config/validation/ConfigValidation.java
@@ -34,7 +34,7 @@ public class ConfigValidation {
     private static final Class DEFAULT_ANNOTATION_CLASS = ConfigValidationAnnotations.class;
 
     /**
-     * Validate the config object with annotations from annotationClass
+     * Validate the config object with annotations from annotationClass.
      * @param config config object
      * @param annotationClass class with annotations to use
      */
@@ -53,7 +53,7 @@ public class ConfigValidation {
     }
 
     /**
-     * Validate the config object with default annotation class
+     * Validate the config object with default annotation class.
      * @param config config object
      */
     public static void validateConfig(Object config) {
@@ -68,7 +68,8 @@ public class ConfigValidation {
         processAnnotations(field.getAnnotations(), field.getName(), value, annotationClass);
     }
 
-    private static void processAnnotations(Annotation[] annotations, String fieldName, Object value, Class annotationClass) {
+    private static void processAnnotations(Annotation[] annotations, String fieldName, Object value,
+                                           Class annotationClass) {
         try {
             for (Annotation annotation : annotations) {
                 String type = annotation.annotationType().getName();

--- a/pulsar-config-validation/src/main/java/org/apache/pulsar/config/validation/ConfigValidationUtils.java
+++ b/pulsar-config-validation/src/main/java/org/apache/pulsar/config/validation/ConfigValidationUtils.java
@@ -160,7 +160,7 @@ public class ConfigValidationUtils {
     /**
      * Declares a method for validating configuration values that is nestable.
      */
-    public static abstract class NestableFieldValidator implements FieldValidator {
+    public abstract static class NestableFieldValidator implements FieldValidator {
         @Override
         public void validateField(String name, Object field) throws IllegalArgumentException {
             validateField(null, name, field);

--- a/pulsar-config-validation/src/main/java/org/apache/pulsar/config/validation/ValidatorImpls.java
+++ b/pulsar-config-validation/src/main/java/org/apache/pulsar/config/validation/ValidatorImpls.java
@@ -18,13 +18,12 @@
  */
 package org.apache.pulsar.config.validation;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.lang.reflect.InvocationTargetException;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * System defined Validator Annotations.


### PR DESCRIPTION
### Motivation

currently, the `pulsar-config-validation` module is not protected by the `checkstyle-plugin`.

### Modifications

- Enable CheckStyle Plugin
- Fix checkstyle violations

### Documentation

Check the box below and label this PR (if you have committer privilege).
Need to update docs?

-  `no-need-doc`
	java checkstyle changes, no need doc.