### PR TITLE
[Security] Upgrade Jackson to 2.12.6

### DIFF
--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -312,14 +312,14 @@ The Apache Software License, Version 2.0
  * JCommander -- com.beust-jcommander-1.78.jar
  * High Performance Primitive Collections for Java -- com.carrotsearch-hppc-0.7.3.jar
  * Jackson
-     - com.fasterxml.jackson.core-jackson-annotations-2.12.3.jar
-     - com.fasterxml.jackson.core-jackson-core-2.12.3.jar
-     - com.fasterxml.jackson.core-jackson-databind-2.12.3.jar
-     - com.fasterxml.jackson.dataformat-jackson-dataformat-yaml-2.12.3.jar
-     - com.fasterxml.jackson.jaxrs-jackson-jaxrs-base-2.12.3.jar
-     - com.fasterxml.jackson.jaxrs-jackson-jaxrs-json-provider-2.12.3.jar
-     - com.fasterxml.jackson.module-jackson-module-jaxb-annotations-2.12.3.jar
-     - com.fasterxml.jackson.module-jackson-module-jsonSchema-2.12.3.jar
+     - com.fasterxml.jackson.core-jackson-annotations-2.12.6.jar
+     - com.fasterxml.jackson.core-jackson-core-2.12.6.jar
+     - com.fasterxml.jackson.core-jackson-databind-2.12.6.jar
+     - com.fasterxml.jackson.dataformat-jackson-dataformat-yaml-2.12.6.jar
+     - com.fasterxml.jackson.jaxrs-jackson-jaxrs-base-2.12.6.jar
+     - com.fasterxml.jackson.jaxrs-jackson-jaxrs-json-provider-2.12.6.jar
+     - com.fasterxml.jackson.module-jackson-module-jaxb-annotations-2.12.6.jar
+     - com.fasterxml.jackson.module-jackson-module-jsonSchema-2.12.6.jar
  * Caffeine -- com.github.ben-manes.caffeine-caffeine-2.9.1.jar
  * Conscrypt -- org.conscrypt-conscrypt-openjdk-uber-2.5.2.jar
  * Proto Google Common Protos -- com.google.api.grpc-proto-google-common-protos-1.17.0.jar

--- a/pom.xml
+++ b/pom.xml
@@ -122,8 +122,8 @@ flexible messaging model and an intuitive client API.</description>
     <log4j2.version>2.17.1</log4j2.version>
     <bouncycastle.version>1.69</bouncycastle.version>
     <bouncycastlefips.version>1.0.2</bouncycastlefips.version>
-    <jackson.version>2.12.3</jackson.version>
-    <jackson.databind.version>2.12.3</jackson.databind.version>
+    <jackson.version>2.12.6</jackson.version>
+    <jackson.databind.version>2.12.6</jackson.databind.version>
     <reflections.version>0.9.11</reflections.version>
     <swagger.version>1.6.2</swagger.version>
     <puppycrawl.checkstyle.version>8.37</puppycrawl.checkstyle.version>

--- a/pulsar-sql/presto-distribution/LICENSE
+++ b/pulsar-sql/presto-distribution/LICENSE
@@ -207,19 +207,19 @@ This projects includes binary packages with the following licenses:
 The Apache Software License, Version 2.0
 
   * Jackson
-    - jackson-annotations-2.12.3.jar
-    - jackson-core-2.12.3.jar
-    - jackson-databind-2.12.3.jar
-    - jackson-dataformat-smile-2.12.3.jar
-    - jackson-datatype-guava-2.12.3.jar
-    - jackson-datatype-jdk8-2.12.3.jar
-    - jackson-datatype-joda-2.12.3.jar
-    - jackson-datatype-jsr310-2.12.3.jar
-    - jackson-dataformat-yaml-2.12.3.jar
-    - jackson-jaxrs-base-2.12.3.jar
-    - jackson-jaxrs-json-provider-2.12.3.jar
-    - jackson-module-jaxb-annotations-2.12.3.jar
-    - jackson-module-jsonSchema-2.12.3.jar
+    - jackson-annotations-2.12.6.jar
+    - jackson-core-2.12.6.jar
+    - jackson-databind-2.12.6.jar
+    - jackson-dataformat-smile-2.12.6.jar
+    - jackson-datatype-guava-2.12.6.jar
+    - jackson-datatype-jdk8-2.12.6.jar
+    - jackson-datatype-joda-2.12.6.jar
+    - jackson-datatype-jsr310-2.12.6.jar
+    - jackson-dataformat-yaml-2.12.6.jar
+    - jackson-jaxrs-base-2.12.6.jar
+    - jackson-jaxrs-json-provider-2.12.6.jar
+    - jackson-module-jaxb-annotations-2.12.6.jar
+    - jackson-module-jsonSchema-2.12.6.jar
  * Guava
     - guava-30.1-jre.jar
     - listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.jar
@@ -440,7 +440,7 @@ The Apache Software License, Version 2.0
   * Snappy
     - snappy-java-1.1.7.jar
   * Jackson
-    - jackson-module-parameter-names-2.12.3.jar
+    - jackson-module-parameter-names-2.12.6.jar
   * Java Assist
     - javassist-3.25.0-GA.jar
   * Java Native Access

--- a/pulsar-sql/presto-distribution/pom.xml
+++ b/pulsar-sql/presto-distribution/pom.xml
@@ -39,10 +39,10 @@
     <objenesis.version>2.6</objenesis.version>
     <objectsize.version>0.0.12</objectsize.version>
     <guice.version>4.2.0</guice.version>
-    <jackson.version>2.12.3</jackson.version>
+    <jackson.version>2.12.6</jackson.version>
     <!--fix Security Vulnerabilities-->
     <!--https://www.cvedetails.com/vulnerability-list/vendor_id-15866/product_id-42991/Fasterxml-Jackson-databind.html-->
-    <jackson.databind.version>2.12.3</jackson.databind.version>
+    <jackson.databind.version>2.12.6</jackson.databind.version>
     <maven.version>3.0.5</maven.version>
     <guava.version>30.1-jre</guava.version>
     <asynchttpclient.version>2.12.1</asynchttpclient.version>


### PR DESCRIPTION
### Motivation

Sonatype Nexus IQ server flags Jackson 2.12.3 vulnerable with id SONATYPE-2021-4682. The issue is a DoS vulnerability https://github.com/FasterXML/jackson-databind/issues/3328 .

### Modifications

- upgrade Jackson from 2.12.3 to 2.12.6