### PR TITLE
[Client] Fix send chunking message failed when ordering key is set.

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
@@ -490,13 +490,20 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
                 ChunkedMessageCtx chunkedMessageCtx = totalChunks > 1 ? ChunkedMessageCtx.get(totalChunks) : null;
                 byte[] schemaVersion = totalChunks > 1 && msg.getMessageBuilder().hasSchemaVersion() ?
                         msg.getMessageBuilder().getSchemaVersion() : null;
+                byte[] orderingKey = totalChunks > 1 && msg.getMessageBuilder().hasOrderingKey() ?
+                        msg.getMessageBuilder().getOrderingKey() : null;
                 for (int chunkId = 0; chunkId < totalChunks; chunkId++) {
                     // Need to reset the schemaVersion, because the schemaVersion is based on a ByteBuf object in
                     // `MessageMetadata`, if we want to re-serialize the `SEND` command using a same `MessageMetadata`,
                     // we need to reset the ByteBuf of the schemaVersion in `MessageMetadata`, I think we need to
                     // reset `ByteBuf` objects in `MessageMetadata` after call the method `MessageMetadata#writeTo()`.
-                    if (chunkId > 0 && schemaVersion != null) {
-                        msg.getMessageBuilder().setSchemaVersion(schemaVersion);
+                    if (chunkId > 0) {
+                        if (schemaVersion != null) {
+                            msg.getMessageBuilder().setSchemaVersion(schemaVersion);
+                        }
+                        if (orderingKey != null) {
+                            msg.getMessageBuilder().setOrderingKey(orderingKey);
+                        }
                     }
                     serializeAndSendMessage(msg, payload, sequenceId, uuid, chunkId, totalChunks,
                             readStartIndex, ClientCnx.getMaxMessageSize(), compressedPayload, compressed,


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - Name the pull request in the form "[Issue XYZ][component] Title of the pull request", where *XYZ* should be replaced by the actual issue number.
    Skip *Issue XYZ* if there is no associated github issue for this pull request.
    Skip *component* if you are unsure about which is the best component. E.g. `[docs] Fix typo in produce method`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.

**(The sections below can be removed for hotfixes of typos)**
-->

Master Issue: #13688

### Motivation

The root cause is the same as #13688. Chunking messages share the same metadata. And the type of ordering key is bytebuf, which can not be serialized twice.

### Modifications

Reset the field before sending.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.



This change added tests and can be verified as follows:
- See testChunkingWithOrderingKey
### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

Check the box below and label this PR (if you have committer privilege).

Need to update docs? 
  
- [x] `no-need-doc` 
bug fix