### PR TITLE
[Test] enhance RackAwareTest by adding test for EnforceMinNumRacksPerWriteQu…

### DIFF
--- a/pulsar-broker-common/src/test/java/org/apache/pulsar/bookie/rackawareness/BookieRackAffinityMappingTest.java
+++ b/pulsar-broker-common/src/test/java/org/apache/pulsar/bookie/rackawareness/BookieRackAffinityMappingTest.java
@@ -68,17 +68,18 @@ public class BookieRackAffinityMappingTest {
         store.put(BookieRackAffinityMapping.BOOKIE_INFO_ROOT_PATH, data.getBytes(), Optional.empty()).join();
 
         // Case1: ZKCache is given
-        BookieRackAffinityMapping mapping1 = new BookieRackAffinityMapping();
-        ClientConfiguration bkClientConf1 = new ClientConfiguration();
-        bkClientConf1.setProperty(BookieRackAffinityMapping.METADATA_STORE_INSTANCE, store);
+        BookieRackAffinityMapping mapping = new BookieRackAffinityMapping();
+        ClientConfiguration bkClientConf = new ClientConfiguration();
+        bkClientConf.setProperty(BookieRackAffinityMapping.METADATA_STORE_INSTANCE, store);
 
-        mapping1.setBookieAddressResolver(BookieSocketAddress.LEGACY_BOOKIEID_RESOLVER);
-        mapping1.setConf(bkClientConf1);
-        List<String> racks1 = mapping1
+        mapping.setBookieAddressResolver(BookieSocketAddress.LEGACY_BOOKIEID_RESOLVER);
+        mapping.setConf(bkClientConf);
+        List<String> racks = mapping
                 .resolve(Lists.newArrayList(BOOKIE1.getHostName(), BOOKIE2.getHostName(), BOOKIE3.getHostName()));
-        assertEquals(racks1.get(0), "/rack0");
-        assertEquals(racks1.get(1), "/rack1");
-        assertNull(racks1.get(2));
+
+        assertEquals(racks.get(0), "/rack0");
+        assertEquals(racks.get(1), "/rack1");
+        assertNull(racks.get(2));
     }
 
     @Test
@@ -96,12 +97,12 @@ public class BookieRackAffinityMappingTest {
 
         mapping1.setBookieAddressResolver(BookieSocketAddress.LEGACY_BOOKIEID_RESOLVER);
         mapping1.setConf(bkClientConf1);
-        List<String> racks1 = mapping1
+        List<String> racks = mapping1
                 .resolve(Lists.newArrayList(BOOKIE1.getHostName(), BOOKIE2.getHostName(), BOOKIE3.getHostName()));
 
-        assertNull(racks1.get(0));
-        assertNull(racks1.get(1));
-        assertNull(racks1.get(2));
+        assertNull(racks.get(0));
+        assertNull(racks.get(1));
+        assertNull(racks.get(2));
     }
 
     @Test
@@ -113,9 +114,9 @@ public class BookieRackAffinityMappingTest {
         mapping.setBookieAddressResolver(BookieSocketAddress.LEGACY_BOOKIEID_RESOLVER);
         mapping.setConf(bkClientConf);
         List<String> racks = mapping.resolve(Lists.newArrayList("127.0.0.1", "127.0.0.2", "127.0.0.3"));
-        assertEquals(racks.get(0), null);
-        assertEquals(racks.get(1), null);
-        assertEquals(racks.get(2), null);
+        assertNull(racks.get(0));
+        assertNull(racks.get(1));
+        assertNull(racks.get(2));
 
         Map<String, Map<BookieSocketAddress, BookieInfo>> bookieMapping = new HashMap<>();
         Map<BookieSocketAddress, BookieInfo> mainBookieGroup = new HashMap<>();
@@ -132,7 +133,7 @@ public class BookieRackAffinityMappingTest {
             List<String> r = mapping.resolve(Lists.newArrayList("127.0.0.1", "127.0.0.2", "127.0.0.3"));
             assertEquals(r.get(0), "/rack0");
             assertEquals(r.get(1), "/rack1");
-            assertEquals(r.get(2), null);
+            assertNull(r.get(2));
         });
 
     }
@@ -160,7 +161,7 @@ public class BookieRackAffinityMappingTest {
                 .resolve(Lists.newArrayList(BOOKIE1.getHostName(), BOOKIE2.getHostName(), BOOKIE3.getHostName()));
         assertEquals(racks.get(0), "/rack0");
         assertEquals(racks.get(1), "/rack1");
-        assertEquals(racks.get(2), null);
+        assertNull(racks.get(2));
 
         // add info for BOOKIE3 and check if the mapping picks up the change
         Map<BookieSocketAddress, BookieInfo> secondaryBookieGroup = new HashMap<>();
@@ -180,9 +181,9 @@ public class BookieRackAffinityMappingTest {
 
         Awaitility.await().untilAsserted(() -> {
             List<String> r = mapping.resolve(Lists.newArrayList("127.0.0.1", "127.0.0.2", "127.0.0.3"));
-            assertEquals(r.get(0), null);
-            assertEquals(r.get(1), null);
-            assertEquals(r.get(2), null);
+            assertNull(r.get(0));
+            assertNull(r.get(1));
+            assertNull(r.get(2));
         });
     }
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BkEnsemblesTestBase.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BkEnsemblesTestBase.java
@@ -73,7 +73,9 @@ public abstract class BkEnsemblesTestBase extends TestRetrySupport {
             bkEnsemble.start();
 
             // start pulsar service
-            config = new ServiceConfiguration();
+            if (config == null) {
+                config = new ServiceConfiguration();
+            }
             config.setZookeeperServers("127.0.0.1" + ":" + bkEnsemble.getZookeeperPort());
             config.setAdvertisedAddress("localhost");
             config.setWebServicePort(Optional.of(0));
@@ -110,6 +112,7 @@ public abstract class BkEnsemblesTestBase extends TestRetrySupport {
     @Override
     @AfterMethod(alwaysRun = true)
     protected void cleanup() throws Exception {
+        config = null;
         markCurrentSetupNumberCleaned();
         admin.close();
         pulsar.close();


### PR DESCRIPTION
### Motivation
By now, RackAwareTest only tests the simple behavior of ensemble placement without checking `bookkeeperClientEnforceMinNumRacksPerWriteQuorum`.


### Modifications

1. Adding test for `bookkeeperClientEnforceMinNumRacksPerWriteQuorum`
2. optimize some assert API  `BookieRackAffinityMappingTest`



### Documentation

Check the box below or label this PR directly (if you have committer privilege).

Need to update docs? 

  
- [x] `no-need-doc` 
  
  (Please explain why)
  



