### PR TITLE
[Transaction] Duplicate TYPE of Prometheus metrics

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/TransactionAggregator.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/TransactionAggregator.java
@@ -41,7 +41,12 @@ public class TransactionAggregator {
     /**
      * Used for tracking duplicate TYPE definitions.
      */
-    static ThreadLocal<Map<String, String>> threadLocal = ThreadLocal.withInitial(HashMap::new);
+    static FastThreadLocal<Map<String, String>> threadLocal = new FastThreadLocal() {
+        @Override
+        protected Map<String, String> initialValue() {
+            return new HashMap<>();
+        }
+    };
 
     private static final FastThreadLocal<AggregatedTransactionCoordinatorStats> localTransactionCoordinatorStats =
             new FastThreadLocal<AggregatedTransactionCoordinatorStats>() {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/TransactionAggregator.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/TransactionAggregator.java
@@ -41,12 +41,13 @@ public class TransactionAggregator {
     /**
      * Used for tracking duplicate TYPE definitions.
      */
-    static FastThreadLocal<Map<String, String>> threadLocal = new FastThreadLocal() {
-        @Override
-        protected Map<String, String> initialValue() {
-            return new HashMap<>();
-        }
-    };
+    private static final FastThreadLocal<Map<String, String>> threadLocalMetricWithTypeDefinition =
+            new FastThreadLocal() {
+                @Override
+                protected Map<String, String> initialValue() {
+                    return new HashMap<>();
+                }
+             };
 
     private static final FastThreadLocal<AggregatedTransactionCoordinatorStats> localTransactionCoordinatorStats =
             new FastThreadLocal<AggregatedTransactionCoordinatorStats>() {
@@ -66,7 +67,7 @@ public class TransactionAggregator {
 
     public static void generate(PulsarService pulsar, SimpleTextOutputStream stream, boolean includeTopicMetrics) {
         String cluster = pulsar.getConfiguration().getClusterName();
-        Map<String, String> metricWithTypeDefinition = threadLocal.get();
+        Map<String, String> metricWithTypeDefinition = threadLocalMetricWithTypeDefinition.get();
         metricWithTypeDefinition.clear();
 
         if (includeTopicMetrics) {
@@ -161,7 +162,7 @@ public class TransactionAggregator {
     }
 
     static void metricType(SimpleTextOutputStream stream, String name) {
-        Map<String, String> metricWithTypeDefinition = threadLocal.get();
+        Map<String, String> metricWithTypeDefinition = threadLocalMetricWithTypeDefinition.get();
         if (!metricWithTypeDefinition.containsKey(name)) {
             metricWithTypeDefinition.put(name, "gauge");
             stream.write("# TYPE ").write(name).write(" gauge\n");

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/TransactionAggregator.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/TransactionAggregator.java
@@ -20,6 +20,8 @@ package org.apache.pulsar.broker.stats.prometheus;
 
 import static org.apache.pulsar.common.events.EventsTopicNames.checkTopicIsEventsNames;
 import io.netty.util.concurrent.FastThreadLocal;
+import java.util.HashMap;
+import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.bookkeeper.mledger.ManagedLedger;
 import org.apache.bookkeeper.mledger.impl.ManagedLedgerMBeanImpl;
@@ -35,6 +37,11 @@ import org.apache.pulsar.transaction.coordinator.impl.TransactionMetadataStoreSt
 
 @Slf4j
 public class TransactionAggregator {
+
+    /**
+     * Used for tracking duplicate TYPE definitions
+     */
+    static Map<String, String> metricWithTypeDefinition = new HashMap<>();
 
     private static final FastThreadLocal<AggregatedTransactionCoordinatorStats> localTransactionCoordinatorStats =
             new FastThreadLocal<AggregatedTransactionCoordinatorStats>() {
@@ -54,6 +61,7 @@ public class TransactionAggregator {
 
     public static void generate(PulsarService pulsar, SimpleTextOutputStream stream, boolean includeTopicMetrics) {
         String cluster = pulsar.getConfiguration().getClusterName();
+        metricWithTypeDefinition.clear();
 
         if (includeTopicMetrics) {
             pulsar.getBrokerService().getMultiLayerTopicMap().forEach((namespace, bundlesMap) -> {
@@ -146,10 +154,19 @@ public class TransactionAggregator {
                 subscription, managedLedgerStats);
     }
 
+    static void metricType(SimpleTextOutputStream stream, String name) {
+
+        if (!metricWithTypeDefinition.containsKey(name)) {
+            metricWithTypeDefinition.put(name, "gauge");
+            stream.write("# TYPE ").write(name).write(" gauge\n");
+        }
+
+    }
+
     private static void metric(SimpleTextOutputStream stream, String cluster, String name,
                                double value, long coordinatorId) {
-        stream.write("# TYPE ").write(name).write(" gauge\n")
-                .write(name)
+        metricType(stream, name);
+        stream.write(name)
                 .write("{cluster=\"").write(cluster)
                 .write("\",coordinator_id=\"").write(coordinatorId).write("\"} ")
                 .write(value).write(' ').write(System.currentTimeMillis())

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/TransactionAggregator.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/TransactionAggregator.java
@@ -39,7 +39,7 @@ import org.apache.pulsar.transaction.coordinator.impl.TransactionMetadataStoreSt
 public class TransactionAggregator {
 
     /**
-     * Used for tracking duplicate TYPE definitions
+     * Used for tracking duplicate TYPE definitions.
      */
     static Map<String, String> metricWithTypeDefinition = new HashMap<>();
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/TransactionAggregator.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/TransactionAggregator.java
@@ -161,7 +161,7 @@ public class TransactionAggregator {
                 subscription, managedLedgerStats);
     }
 
-    static void metricType(SimpleTextOutputStream stream, String name) {
+    private static void metricType(SimpleTextOutputStream stream, String name) {
         Map<String, String> metricWithTypeDefinition = threadLocalMetricWithTypeDefinition.get();
         if (!metricWithTypeDefinition.containsKey(name)) {
             metricWithTypeDefinition.put(name, "gauge");

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/TransactionAggregator.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/TransactionAggregator.java
@@ -41,7 +41,7 @@ public class TransactionAggregator {
     /**
      * Used for tracking duplicate TYPE definitions.
      */
-    static Map<String, String> metricWithTypeDefinition = new HashMap<>();
+    static ThreadLocal<Map<String, String>> threadLocal = ThreadLocal.withInitial(HashMap::new);
 
     private static final FastThreadLocal<AggregatedTransactionCoordinatorStats> localTransactionCoordinatorStats =
             new FastThreadLocal<AggregatedTransactionCoordinatorStats>() {
@@ -61,6 +61,7 @@ public class TransactionAggregator {
 
     public static void generate(PulsarService pulsar, SimpleTextOutputStream stream, boolean includeTopicMetrics) {
         String cluster = pulsar.getConfiguration().getClusterName();
+        Map<String, String> metricWithTypeDefinition = threadLocal.get();
         metricWithTypeDefinition.clear();
 
         if (includeTopicMetrics) {
@@ -155,7 +156,7 @@ public class TransactionAggregator {
     }
 
     static void metricType(SimpleTextOutputStream stream, String name) {
-
+        Map<String, String> metricWithTypeDefinition = threadLocal.get();
         if (!metricWithTypeDefinition.containsKey(name)) {
             metricWithTypeDefinition.put(name, "gauge");
             stream.write("# TYPE ").write(name).write(" gauge\n");

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/TransactionMetricsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/TransactionMetricsTest.java
@@ -18,8 +18,13 @@
  */
 package org.apache.pulsar.broker.stats;
 
+import com.google.common.base.Splitter;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Sets;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import org.apache.pulsar.broker.ServiceConfiguration;
 import org.apache.pulsar.broker.service.BrokerTestBase;
 import org.apache.pulsar.broker.stats.prometheus.PrometheusMetricsGenerator;
@@ -51,9 +56,11 @@ import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static org.apache.pulsar.broker.stats.PrometheusMetricsTest.parseMetrics;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
 
 public class TransactionMetricsTest extends BrokerTestBase {
 
@@ -337,6 +344,64 @@ public class TransactionMetricsTest extends BrokerTestBase {
         metrics = parseMetrics(metricsStr);
         metric = metrics.get("pulsar_storage_size");
         checkManagedLedgerMetrics(subName2, 32, metric);
+    }
+
+    @Test
+    public void testDuplicateMetricTypeDefinitions() throws Exception{
+        pulsarClient = PulsarClient.builder().serviceUrl(lookupUrl.toString()).enableTransaction(true).build();
+        Producer<byte[]> p1 = pulsarClient
+                .newProducer()
+                .topic("persistent://my-property/use/my-ns/my-topic1")
+                .sendTimeout(0, TimeUnit.SECONDS)
+                .create();
+        Transaction transaction = pulsarClient
+                .newTransaction()
+                .withTransactionTimeout(5, TimeUnit.SECONDS)
+                .build()
+                .get();
+        for (int i = 0; i < 10; i++) {
+            String message = "my-message-" + i;
+            p1.newMessage(transaction)
+                    .value(message.getBytes())
+                    .send();
+        }
+        ByteArrayOutputStream statsOut = new ByteArrayOutputStream();
+        PrometheusMetricsGenerator.generate(pulsar, false, false, false, statsOut);
+        String metricsStr = statsOut.toString();
+
+        Map<String, String> typeDefs = new HashMap<>();
+        Map<String, String> metricNames = new HashMap<>();
+        Pattern typePattern = Pattern.compile("^#\\s+TYPE\\s+(\\w+)\\s+(\\w+)");
+
+        Splitter.on("\n").split(metricsStr).forEach(line -> {
+            if (line.isEmpty()) {
+                return;
+            }
+            if (line.startsWith("#")) {
+                // Check for duplicate type definitions
+                Matcher typeMatcher = typePattern.matcher(line);
+                checkArgument(typeMatcher.matches());
+                String metricName = typeMatcher.group(1);
+                String type = typeMatcher.group(2);
+                // From https://github.com/prometheus/docs/blob/master/content/docs/instrumenting/exposition_formats.md
+                // "Only one TYPE line may exist for a given metric name."
+                if (!typeDefs.containsKey(metricName)) {
+                    typeDefs.put(metricName, type);
+                } else {
+                    fail("Duplicate type definition found for TYPE definition " + metricName);
+                    System.out.println(metricsStr);
+
+                }
+                // From https://github.com/prometheus/docs/blob/master/content/docs/instrumenting/exposition_formats.md
+                // "The TYPE line for a metric name must appear before the first sample is reported for that metric name."
+                if (metricNames.containsKey(metricName)) {
+                    System.out.println(metricsStr);
+                    fail("TYPE definition for " + metricName + " appears after first sample");
+
+                }
+            }
+        });
+
     }
 
     private void checkManagedLedgerMetrics(String tag, double value, Collection<PrometheusMetricsTest.Metric> metrics) {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/TransactionMetricsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/TransactionMetricsTest.java
@@ -349,6 +349,8 @@ public class TransactionMetricsTest extends BrokerTestBase {
     @Test
     public void testDuplicateMetricTypeDefinitions() throws Exception{
         pulsarClient = PulsarClient.builder().serviceUrl(lookupUrl.toString()).enableTransaction(true).build();
+        admin.topics().deletePartitionedTopic(TopicName.TRANSACTION_COORDINATOR_ASSIGN.toString());
+        admin.topics().createPartitionedTopic(TopicName.TRANSACTION_COORDINATOR_ASSIGN.toString(), 3);
         Producer<byte[]> p1 = pulsarClient
                 .newProducer()
                 .topic("persistent://my-property/use/my-ns/my-topic1")


### PR DESCRIPTION
### Motivation
Fix duplicate TYPE statements in the metrics output which leads to parsing of Prometheus metrics.
### Modification
Add a map in TransactionAggregator.java, which used for tracking duplicate TYPE definitions.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API: (yes / no)
  - The schema: (yes / no / don't know)
  - The default values of configurations: (yes / no)
  - The wire protocol: (yes / no)
  - The rest endpoints: (yes / no)
  - The admin cli options: (yes / no)
  - Anything that affects deployment: (yes / no / don't know)

### Documentation

Check the box below or label this PR directly (if you have committer privilege).

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)


