### PR TITLE
Updating dependencies (guava and what brought in older guava) to get rid of the guava-related CVE-2018-10237 and CVE-2020-8908

### DIFF
--- a/buildtools/pom.xml
+++ b/buildtools/pom.xml
@@ -41,7 +41,7 @@
     <surefire.version>3.0.0-M3</surefire.version>
     <log4j2.version>2.17.1</log4j2.version>
     <slf4j.version>1.7.32</slf4j.version>
-    <testng.version>7.5</testng.version>
+    <testng.version>7.4.0</testng.version>
     <commons-lang3.version>3.11</commons-lang3.version>
     <maven-shade-plugin.version>3.2.4</maven-shade-plugin.version>
     <puppycrawl.checkstyle.version>8.37</puppycrawl.checkstyle.version>

--- a/buildtools/pom.xml
+++ b/buildtools/pom.xml
@@ -41,7 +41,7 @@
     <surefire.version>3.0.0-M3</surefire.version>
     <log4j2.version>2.17.1</log4j2.version>
     <slf4j.version>1.7.32</slf4j.version>
-    <testng.version>7.3.0</testng.version>
+    <testng.version>7.5</testng.version>
     <commons-lang3.version>3.11</commons-lang3.version>
     <maven-shade-plugin.version>3.2.4</maven-shade-plugin.version>
     <puppycrawl.checkstyle.version>8.37</puppycrawl.checkstyle.version>

--- a/buildtools/pom.xml
+++ b/buildtools/pom.xml
@@ -41,7 +41,7 @@
     <surefire.version>3.0.0-M3</surefire.version>
     <log4j2.version>2.17.1</log4j2.version>
     <slf4j.version>1.7.32</slf4j.version>
-    <testng.version>7.4.0</testng.version>
+    <testng.version>7.3.0</testng.version>
     <commons-lang3.version>3.11</commons-lang3.version>
     <maven-shade-plugin.version>3.2.4</maven-shade-plugin.version>
     <puppycrawl.checkstyle.version>8.37</puppycrawl.checkstyle.version>

--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -328,7 +328,7 @@ The Apache Software License, Version 2.0
     - com.google.code.gson-gson-2.8.9.jar
     - io.gsonfire-gson-fire-1.8.5.jar
  * Guava
-    - com.google.guava-guava-30.1-jre.jar
+    - com.google.guava-guava-31.0.1-jre.jar
     - com.google.guava-failureaccess-1.0.1.jar
     - com.google.guava-listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.jar
  * J2ObjC Annotations -- com.google.j2objc-j2objc-annotations-1.3.jar
@@ -426,25 +426,25 @@ The Apache Software License, Version 2.0
     - org.asynchttpclient-async-http-client-2.12.1.jar
     - org.asynchttpclient-async-http-client-netty-utils-2.12.1.jar
  * Jetty
-    - org.eclipse.jetty-jetty-client-9.4.43.v20210629.jar
-    - org.eclipse.jetty-jetty-continuation-9.4.43.v20210629.jar
-    - org.eclipse.jetty-jetty-http-9.4.43.v20210629.jar
-    - org.eclipse.jetty-jetty-io-9.4.43.v20210629.jar
-    - org.eclipse.jetty-jetty-proxy-9.4.43.v20210629.jar
-    - org.eclipse.jetty-jetty-security-9.4.43.v20210629.jar
-    - org.eclipse.jetty-jetty-server-9.4.43.v20210629.jar
-    - org.eclipse.jetty-jetty-servlet-9.4.43.v20210629.jar
-    - org.eclipse.jetty-jetty-servlets-9.4.43.v20210629.jar
-    - org.eclipse.jetty-jetty-util-9.4.43.v20210629.jar
-    - org.eclipse.jetty-jetty-util-ajax-9.4.43.v20210629.jar
-    - org.eclipse.jetty.websocket-javax-websocket-client-impl-9.4.43.v20210629.jar
-    - org.eclipse.jetty.websocket-websocket-api-9.4.43.v20210629.jar
-    - org.eclipse.jetty.websocket-websocket-client-9.4.43.v20210629.jar
-    - org.eclipse.jetty.websocket-websocket-common-9.4.43.v20210629.jar
-    - org.eclipse.jetty.websocket-websocket-server-9.4.43.v20210629.jar
-    - org.eclipse.jetty.websocket-websocket-servlet-9.4.43.v20210629.jar
-    - org.eclipse.jetty-jetty-alpn-conscrypt-server-9.4.43.v20210629.jar
-    - org.eclipse.jetty-jetty-alpn-server-9.4.43.v20210629.jar
+    - org.eclipse.jetty-jetty-client-9.4.44.v20210927.jar
+    - org.eclipse.jetty-jetty-continuation-9.4.44.v20210927.jar
+    - org.eclipse.jetty-jetty-http-9.4.44.v20210927.jar
+    - org.eclipse.jetty-jetty-io-9.4.44.v20210927.jar
+    - org.eclipse.jetty-jetty-proxy-9.4.44.v20210927.jar
+    - org.eclipse.jetty-jetty-security-9.4.44.v20210927.jar
+    - org.eclipse.jetty-jetty-server-9.4.44.v20210927.jar
+    - org.eclipse.jetty-jetty-servlet-9.4.44.v20210927.jar
+    - org.eclipse.jetty-jetty-servlets-9.4.44.v20210927.jar
+    - org.eclipse.jetty-jetty-util-9.4.44.v20210927.jar
+    - org.eclipse.jetty-jetty-util-ajax-9.4.44.v20210927.jar
+    - org.eclipse.jetty.websocket-javax-websocket-client-impl-9.4.44.v20210927.jar
+    - org.eclipse.jetty.websocket-websocket-api-9.4.44.v20210927.jar
+    - org.eclipse.jetty.websocket-websocket-client-9.4.44.v20210927.jar
+    - org.eclipse.jetty.websocket-websocket-common-9.4.44.v20210927.jar
+    - org.eclipse.jetty.websocket-websocket-server-9.4.44.v20210927.jar
+    - org.eclipse.jetty.websocket-websocket-servlet-9.4.44.v20210927.jar
+    - org.eclipse.jetty-jetty-alpn-conscrypt-server-9.4.44.v20210927.jar
+    - org.eclipse.jetty-jetty-alpn-server-9.4.44.v20210927.jar
  * SnakeYaml -- org.yaml-snakeyaml-1.30.jar
  * RocksDB - org.rocksdb-rocksdbjni-6.10.2.jar
  * Google Error Prone Annotations - com.google.errorprone-error_prone_annotations-2.5.1.jar
@@ -545,7 +545,7 @@ MIT License
     - org.slf4j-slf4j-api-1.7.32.jar
     - org.slf4j-jcl-over-slf4j-1.7.32.jar
  * The Checker Framework
-    - org.checkerframework-checker-qual-3.5.0.jar
+    - org.checkerframework-checker-qual-3.12.0.jar
 
 Protocol Buffers License
  * Protocol Buffers

--- a/pom.xml
+++ b/pom.xml
@@ -213,7 +213,7 @@ flexible messaging model and an intuitive client API.</description>
     <!-- Set docker-java.version to the version of docker-java used in Testcontainers -->
     <docker-java.version>3.2.8</docker-java.version>
     <kerby.version>1.1.1</kerby.version>
-    <testng.version>7.5</testng.version>
+    <testng.version>7.4.0</testng.version>
     <junit4.version>4.13.1</junit4.version>
     <mockito.version>3.12.4</mockito.version>
     <powermock.version>2.0.9</powermock.version>

--- a/pom.xml
+++ b/pom.xml
@@ -213,7 +213,7 @@ flexible messaging model and an intuitive client API.</description>
     <!-- Set docker-java.version to the version of docker-java used in Testcontainers -->
     <docker-java.version>3.2.8</docker-java.version>
     <kerby.version>1.1.1</kerby.version>
-    <testng.version>7.4.0</testng.version>
+    <testng.version>7.3.0</testng.version>
     <junit4.version>4.13.1</junit4.version>
     <mockito.version>3.12.4</mockito.version>
     <powermock.version>2.0.9</powermock.version>

--- a/pom.xml
+++ b/pom.xml
@@ -110,7 +110,7 @@ flexible messaging model and an intuitive client API.</description>
     <curator.version>5.1.0</curator.version>
     <netty.version>4.1.72.Final</netty.version>
     <netty-tc-native.version>2.0.46.Final</netty-tc-native.version>
-    <jetty.version>9.4.43.v20210629</jetty.version>
+    <jetty.version>9.4.44.v20210927</jetty.version>
     <conscrypt.version>2.5.2</conscrypt.version>
     <jersey.version>2.34</jersey.version>
     <athenz.version>1.10.9</athenz.version>
@@ -159,11 +159,11 @@ flexible messaging model and an intuitive client API.</description>
     <debezium.version>1.7.1.Final</debezium.version>
     <jsonwebtoken.version>0.11.1</jsonwebtoken.version>
     <opencensus.version>0.18.0</opencensus.version>
-    <hbase.version>2.3.0</hbase.version>
-    <guava.version>30.1-jre</guava.version>
+    <hbase.version>2.4.9</hbase.version>
+    <guava.version>31.0.1-jre</guava.version>
     <jcip.version>1.0</jcip.version>
     <prometheus-jmx.version>0.14.0</prometheus-jmx.version>
-    <confluent.version>5.3.2</confluent.version>
+    <confluent.version>7.0.1</confluent.version>
     <kafka.confluent.schemaregistryclient.version>5.3.0</kafka.confluent.schemaregistryclient.version>
     <kafka.confluent.avroserializer.version>5.3.0</kafka.confluent.avroserializer.version>
     <kafka-avro-convert-jackson.version>1.9.13</kafka-avro-convert-jackson.version>
@@ -213,7 +213,7 @@ flexible messaging model and an intuitive client API.</description>
     <!-- Set docker-java.version to the version of docker-java used in Testcontainers -->
     <docker-java.version>3.2.8</docker-java.version>
     <kerby.version>1.1.1</kerby.version>
-    <testng.version>7.3.0</testng.version>
+    <testng.version>7.5</testng.version>
     <junit4.version>4.13.1</junit4.version>
     <mockito.version>3.12.4</mockito.version>
     <powermock.version>2.0.9</powermock.version>
@@ -576,26 +576,10 @@ flexible messaging model and an intuitive client API.</description>
 
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
-        <artifactId>jetty-servlet</artifactId>
+        <artifactId>jetty-bom</artifactId>
         <version>${jetty.version}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>org.eclipse.jetty</groupId>
-        <artifactId>jetty-servlets</artifactId>
-        <version>${jetty.version}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>org.eclipse.jetty</groupId>
-        <artifactId>jetty-proxy</artifactId>
-        <version>${jetty.version}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>org.eclipse.jetty</groupId>
-        <artifactId>jetty-util</artifactId>
-        <version>${jetty.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
       </dependency>
 
       <dependency>

--- a/pulsar-io/canal/pom.xml
+++ b/pulsar-io/canal/pom.xml
@@ -32,6 +32,11 @@
     <artifactId>pulsar-io-canal</artifactId>
     <name>Pulsar IO :: Canal</name>
 
+    <properties>
+        <spring.version>5.0.20.RELEASE</spring.version>
+        <canal.version>1.1.5</canal.version>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>${project.groupId}</groupId>
@@ -52,11 +57,54 @@
             <artifactId>fastjson</artifactId>
             <version>1.2.73</version>
         </dependency>
+
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-core</artifactId>
+            <version>${spring.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-aop</artifactId>
+            <version>${spring.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-context</artifactId>
+            <version>${spring.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-jdbc</artifactId>
+            <version>${spring.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-orm</artifactId>
+            <version>${spring.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.alibaba.otter</groupId>
+            <artifactId>canal.protocol</artifactId>
+            <version>${canal.version}</version>
+        </dependency>
         <dependency>
             <groupId>com.alibaba.otter</groupId>
             <artifactId>canal.client</artifactId>
-            <version>1.1.4</version>
+            <version>${canal.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>ch.qos.logback</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.springframework</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
+
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>

--- a/pulsar-io/flume/pom.xml
+++ b/pulsar-io/flume/pom.xml
@@ -66,12 +66,12 @@
         <dependency>
             <groupId>org.apache.avro</groupId>
             <artifactId>avro</artifactId>
-            <version>1.8.1</version>
+            <version>1.10.2</version>
         </dependency>
         <dependency>
             <groupId>org.apache.avro</groupId>
             <artifactId>avro-ipc</artifactId>
-            <version>1.8.1</version>
+            <version>1.10.2</version>
         </dependency>
         <dependency>
             <groupId>org.apache.curator</groupId>
@@ -106,7 +106,7 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>18.0</version>
+            <version>${guava.version}</version>
         </dependency>
     </dependencies>
 

--- a/pulsar-io/flume/pom.xml
+++ b/pulsar-io/flume/pom.xml
@@ -31,6 +31,10 @@
     <artifactId>pulsar-io-flume</artifactId>
     <name>Pulsar IO :: Flume</name>
 
+    <properties>
+        <avro.version>1.8.2</avro.version>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>${project.groupId}</groupId>
@@ -54,8 +58,8 @@
             <type>pom</type>
             <exclusions>
                 <exclusion>
-                    <artifactId>avro-ipc</artifactId>
                     <groupId>org.apache.avro</groupId>
+                    <artifactId>avro-ipc</artifactId>
                 </exclusion>
                 <exclusion>
                     <artifactId>avro</artifactId>
@@ -66,12 +70,27 @@
         <dependency>
             <groupId>org.apache.avro</groupId>
             <artifactId>avro</artifactId>
-            <version>1.10.2</version>
+            <version>${avro.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>commons-lang</groupId>
+            <artifactId>commons-lang</artifactId>
+            <version>2.6</version>
         </dependency>
         <dependency>
             <groupId>org.apache.avro</groupId>
             <artifactId>avro-ipc</artifactId>
-            <version>1.10.2</version>
+            <version>${avro.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.mortbay.jetty</groupId>
+                    <artifactId>servlet-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>io.netty</groupId>
+                    <artifactId>netty</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.curator</groupId>

--- a/pulsar-sql/presto-distribution/LICENSE
+++ b/pulsar-sql/presto-distribution/LICENSE
@@ -374,7 +374,7 @@ The Apache Software License, Version 2.0
   * JCommander
     - jcommander-1.78.jar
   * FindBugs JSR305
-    - jsr305-3.0.1.jar
+    - jsr305-3.0.2.jar
   * Objenesis
     - objenesis-2.6.jar
   * Okio

--- a/pulsar-sql/presto-distribution/LICENSE
+++ b/pulsar-sql/presto-distribution/LICENSE
@@ -255,22 +255,22 @@ The Apache Software License, Version 2.0
  * Joda Time
     - joda-time-2.10.5.jar
   * Jetty
-    - http2-client-9.4.43.v20210629.jar
-    - http2-common-9.4.43.v20210629.jar
-    - http2-hpack-9.4.43.v20210629.jar
-    - http2-http-client-transport-9.4.43.v20210629.jar
-    - jetty-alpn-client-9.4.43.v20210629.jar
-    - http2-server-9.4.43.v20210629.jar
-    - jetty-alpn-java-client-9.4.43.v20210629.jar
-    - jetty-client-9.4.43.v20210629.jar
-    - jetty-http-9.4.43.v20210629.jar
-    - jetty-io-9.4.43.v20210629.jar
-    - jetty-jmx-9.4.43.v20210629.jar
-    - jetty-security-9.4.43.v20210629.jar
-    - jetty-server-9.4.43.v20210629.jar
-    - jetty-servlet-9.4.43.v20210629.jar
-    - jetty-util-9.4.43.v20210629.jar
-    - jetty-util-ajax-9.4.43.v20210629.jar
+    - http2-client-9.4.44.v20210927.jar
+    - http2-common-9.4.44.v20210927.jar
+    - http2-hpack-9.4.44.v20210927.jar
+    - http2-http-client-transport-9.4.44.v20210927.jar
+    - jetty-alpn-client-9.4.44.v20210927.jar
+    - http2-server-9.4.44.v20210927.jar
+    - jetty-alpn-java-client-9.4.44.v20210927.jar
+    - jetty-client-9.4.44.v20210927.jar
+    - jetty-http-9.4.44.v20210927.jar
+    - jetty-io-9.4.44.v20210927.jar
+    - jetty-jmx-9.4.44.v20210927.jar
+    - jetty-security-9.4.44.v20210927.jar
+    - jetty-server-9.4.44.v20210927.jar
+    - jetty-servlet-9.4.44.v20210927.jar
+    - jetty-util-9.4.44.v20210927.jar
+    - jetty-util-ajax-9.4.44.v20210927.jar
   * Apache BVal
     - bval-jsr-2.0.0.jar
   * Bytecode
@@ -374,7 +374,7 @@ The Apache Software License, Version 2.0
   * JCommander
     - jcommander-1.78.jar
   * FindBugs JSR305
-    - jsr305-3.0.2.jar
+    - jsr305-3.0.1.jar
   * Objenesis
     - objenesis-2.6.jar
   * Okio
@@ -490,7 +490,7 @@ MIT License
  * JUL to SLF4J Bridge
    - jul-to-slf4j-1.7.32.jar
  * Checker Qual
-   - checker-qual-3.5.0.jar
+   - checker-qual-3.12.0.jar 
 
 CDDL - 1.0
  * OSGi Resource Locator

--- a/pulsar-sql/presto-distribution/LICENSE
+++ b/pulsar-sql/presto-distribution/LICENSE
@@ -221,7 +221,7 @@ The Apache Software License, Version 2.0
     - jackson-module-jaxb-annotations-2.12.6.jar
     - jackson-module-jsonSchema-2.12.6.jar
  * Guava
-    - guava-30.1-jre.jar
+    - guava-31.0.1-jre.jar
     - listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.jar
     - failureaccess-1.0.1.jar
  * Google Guice

--- a/pulsar-sql/presto-distribution/pom.xml
+++ b/pulsar-sql/presto-distribution/pom.xml
@@ -44,7 +44,7 @@
     <!--https://www.cvedetails.com/vulnerability-list/vendor_id-15866/product_id-42991/Fasterxml-Jackson-databind.html-->
     <jackson.databind.version>2.12.6</jackson.databind.version>
     <maven.version>3.0.5</maven.version>
-    <guava.version>30.1-jre</guava.version>
+    <guava.version>31.0.1-jre</guava.version>
     <asynchttpclient.version>2.12.1</asynchttpclient.version>
     <errorprone.version>2.5.1</errorprone.version>
     <javax.servlet-api>4.0.1</javax.servlet-api>
@@ -99,10 +99,6 @@
         <exclusion>
           <groupId>javax.activation</groupId>
           <artifactId>activation</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>com.google.guava</groupId>
-          <artifactId>guava</artifactId>
         </exclusion>
       </exclusions>
     </dependency>

--- a/pulsar-sql/presto-distribution/pom.xml
+++ b/pulsar-sql/presto-distribution/pom.xml
@@ -100,6 +100,10 @@
           <groupId>javax.activation</groupId>
           <artifactId>activation</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>com.google.guava</groupId>
+          <artifactId>guava</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
 

--- a/src/owasp-dependency-check-suppressions.xml
+++ b/src/owasp-dependency-check-suppressions.xml
@@ -20,183 +20,183 @@
 
 -->
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
-  <!-- add supressions for known vulnerabilities detected by OWASP Dependency Check -->
-  <suppress>
-    <notes>Ignore netty CVEs in GRPC shaded Netty.</notes>
-    <filePath regex="true">.*grpc-netty-shaded.*</filePath>
-    <cpe>cpe:/a:netty:netty</cpe>
-  </suppress>
-  <suppress>
-    <notes>Suppress all pulsar-presto-distribution vulnerabilities</notes>
-    <filePath regex="true">.*pulsar-presto-distribution-.*</filePath>
-    <vulnerabilityName regex="true">.*</vulnerabilityName>
-  </suppress>
-  <suppress>
-    <notes>Suppress libthrift-0.12.0.jar vulnerabilities</notes>
-    <gav>org.apache.thrift:libthrift:0.12.0</gav>
-    <vulnerabilityName regex="true">.*</vulnerabilityName>
-  </suppress>
-  <suppress>
-    <notes>Suppress Zookeeper 3.6.2 vulnerabilities</notes>
-    <gav regex="true">org\.apache\.zookeeper:.*:3\.6\.2</gav>
-    <vulnerabilityName regex="true">.*</vulnerabilityName>
-  </suppress>
+    <!-- add supressions for known vulnerabilities detected by OWASP Dependency Check -->
+    <suppress>
+        <notes>Ignore netty CVEs in GRPC shaded Netty.</notes>
+        <filePath regex="true">.*grpc-netty-shaded.*</filePath>
+        <cpe>cpe:/a:netty:netty</cpe>
+    </suppress>
+    <suppress>
+        <notes>Suppress all pulsar-presto-distribution vulnerabilities</notes>
+        <filePath regex="true">.*pulsar-presto-distribution-.*</filePath>
+        <vulnerabilityName regex="true">.*</vulnerabilityName>
+    </suppress>
+    <suppress>
+        <notes>Suppress libthrift-0.12.0.jar vulnerabilities</notes>
+        <gav>org.apache.thrift:libthrift:0.12.0</gav>
+        <vulnerabilityName regex="true">.*</vulnerabilityName>
+    </suppress>
+    <suppress>
+        <notes>Suppress Zookeeper 3.6.2 vulnerabilities</notes>
+        <gav regex="true">org\.apache\.zookeeper:.*:3\.6\.2</gav>
+        <vulnerabilityName regex="true">.*</vulnerabilityName>
+    </suppress>
 
-  <!-- see https://github.com/alibaba/canal/issues/4010 -->
+    <!-- see https://github.com/alibaba/canal/issues/4010 -->
     <suppress>
         <notes><![CDATA[
        file name: canal.client-1.1.5.jar (shaded: com.google.guava:guava:22.0)
        ]]></notes>
-        <packageUrl regex="true">^pkg:maven/com\.google\.guava/guava@22.0$</packageUrl>
+        <sha1>b87878db57d5cfc2ca7d3972cc8f7486bf02fbca</sha1>
         <cve>CVE-2018-10237</cve>
     </suppress>
     <suppress>
         <notes><![CDATA[
        file name: canal.client-1.1.5.jar (shaded: com.google.guava:guava:22.0)
        ]]></notes>
-        <packageUrl regex="true">^pkg:maven/com\.google\.guava/guava@22.0$</packageUrl>
+        <sha1>b87878db57d5cfc2ca7d3972cc8f7486bf02fbca</sha1>
         <cve>CVE-2020-8908</cve>
     </suppress>
 
-  <!-- clickhouse: security scan matches client lib to the server CVEs -->
-  <suppress>
-    <notes><![CDATA[
+    <!-- clickhouse: security scan matches client lib to the server CVEs -->
+    <suppress>
+        <notes><![CDATA[
     file name: avro-1.10.2.jar
     ]]></notes>
-    <packageUrl regex="true">^pkg:maven/org\.apache\.avro/avro@.*$</packageUrl>
-    <cve>CVE-2021-43045</cve>
-  </suppress>
-  <suppress>
-    <notes><![CDATA[
+        <sha1>a65aaa91c1aeceb3dd4859dbb9765d1c2063f5a2</sha1>
+        <cve>CVE-2021-43045</cve>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[
     file name: clickhouse-jdbc-0.3.2.jar
     ]]></notes>
-    <packageUrl regex="true">^pkg:maven/ru\.yandex\.clickhouse/clickhouse\-jdbc@.*$</packageUrl>
-    <cve>CVE-2018-14668</cve>
-  </suppress>
-  <suppress>
-    <notes><![CDATA[
+        <sha1>fa9a1ccda7d78edb51a3a33d3493566092786a30</sha1>
+        <cve>CVE-2018-14668</cve>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[
     file name: clickhouse-jdbc-0.3.2.jar
     ]]></notes>
-    <packageUrl regex="true">^pkg:maven/ru\.yandex\.clickhouse/clickhouse\-jdbc@.*$</packageUrl>
-    <cve>CVE-2018-14669</cve>
-  </suppress>
-  <suppress>
-    <notes><![CDATA[
+        <sha1>fa9a1ccda7d78edb51a3a33d3493566092786a30</sha1>
+        <cve>CVE-2018-14669</cve>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[
     file name: clickhouse-jdbc-0.3.2.jar
     ]]></notes>
-    <packageUrl regex="true">^pkg:maven/ru\.yandex\.clickhouse/clickhouse\-jdbc@.*$</packageUrl>
-    <cve>CVE-2018-14670</cve>
-  </suppress>
-  <suppress>
-    <notes><![CDATA[
+        <sha1>fa9a1ccda7d78edb51a3a33d3493566092786a30</sha1>
+        <cve>CVE-2018-14670</cve>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[
     file name: clickhouse-jdbc-0.3.2.jar
     ]]></notes>
-    <packageUrl regex="true">^pkg:maven/ru\.yandex\.clickhouse/clickhouse\-jdbc@.*$</packageUrl>
-    <cve>CVE-2018-14671</cve>
-  </suppress>
-  <suppress>
-    <notes><![CDATA[
+        <sha1>fa9a1ccda7d78edb51a3a33d3493566092786a30</sha1>
+        <cve>CVE-2018-14671</cve>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[
     file name: clickhouse-jdbc-0.3.2.jar
     ]]></notes>
-    <packageUrl regex="true">^pkg:maven/ru\.yandex\.clickhouse/clickhouse\-jdbc@.*$</packageUrl>
-    <cve>CVE-2018-14672</cve>
-  </suppress>
-  <suppress>
-    <notes><![CDATA[
+        <sha1>fa9a1ccda7d78edb51a3a33d3493566092786a30</sha1>
+        <cve>CVE-2018-14672</cve>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[
     file name: clickhouse-jdbc-0.3.2.jar
     ]]></notes>
-    <packageUrl regex="true">^pkg:maven/ru\.yandex\.clickhouse/clickhouse\-jdbc@.*$</packageUrl>
-    <cve>CVE-2019-15024</cve>
-  </suppress>
-  <suppress>
-    <notes><![CDATA[
+        <sha1>fa9a1ccda7d78edb51a3a33d3493566092786a30</sha1>
+        <cve>CVE-2019-15024</cve>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[
     file name: clickhouse-jdbc-0.3.2.jar
     ]]></notes>
-    <packageUrl regex="true">^pkg:maven/ru\.yandex\.clickhouse/clickhouse\-jdbc@.*$</packageUrl>
-    <cve>CVE-2019-16535</cve>
-  </suppress>
-  <suppress>
-    <notes><![CDATA[
+        <sha1>fa9a1ccda7d78edb51a3a33d3493566092786a30</sha1>
+        <cve>CVE-2019-16535</cve>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[
     file name: clickhouse-jdbc-0.3.2.jar
     ]]></notes>
-    <packageUrl regex="true">^pkg:maven/ru\.yandex\.clickhouse/clickhouse\-jdbc@.*$</packageUrl>
-    <cve>CVE-2019-18657</cve>
-  </suppress> 
-  <suppress>
-    <notes><![CDATA[
+        <sha1>fa9a1ccda7d78edb51a3a33d3493566092786a30</sha1>
+        <cve>CVE-2019-18657</cve>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[
     file name: clickhouse-jdbc-0.3.2.jar
     ]]></notes>
-    <packageUrl regex="true">^pkg:maven/ru\.yandex\.clickhouse/clickhouse\-jdbc@.*$</packageUrl>
-    <cve>CVE-2021-25263</cve>
-  </suppress>
-  <suppress>
-     <notes><![CDATA[
+        <sha1>fa9a1ccda7d78edb51a3a33d3493566092786a30</sha1>
+        <cve>CVE-2021-25263</cve>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[
      file name: logback-core-1.1.3.jar
      ]]></notes>
-     <packageUrl regex="true">^pkg:maven/ch\.qos\.logback/logback\-core@.*$</packageUrl>
-     <cpe>cpe:/a:qos:logback</cpe>
-  </suppress>
-  <suppress>
-     <notes><![CDATA[
+        <sha1>e3c02049f2dbbc764681b40094ecf0dcbc99b157</sha1>
+        <cpe>cpe:/a:qos:logback</cpe>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[
      file name: rocketmq-acl-4.5.2.jar
      ]]></notes>
-     <packageUrl regex="true">^pkg:maven/org\.apache\.rocketmq/rocketmq\-acl@.*$</packageUrl>
-     <cpe>cpe:/a:apache:rocketmq</cpe>
-  </suppress>
-  <suppress>
-     <notes><![CDATA[
+        <sha1>0e2bd9c162280cd79c2ea0f67f174ee5d7b84ddd</sha1>
+        <cpe>cpe:/a:apache:rocketmq</cpe>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[
      file name: spring-core-3.2.18.RELEASE.jar
      ]]></notes>
-     <packageUrl regex="true">^pkg:maven/org\.springframework/spring\-core@.*$</packageUrl>
-     <cpe>cpe:/a:pivotal_software:spring_framework</cpe>
-   </suppress>
-  <suppress>
-     <notes><![CDATA[
+        <sha1>0e2bd9c162280cd79c2ea0f67f174ee5d7b84ddd</sha1>
+        <cpe>cpe:/a:pivotal_software:spring_framework</cpe>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[
      file name: spring-core-3.2.18.RELEASE.jar
      ]]></notes>
-     <packageUrl regex="true">^pkg:maven/org\.springframework/spring\-core@.*$</packageUrl>
-     <cpe>cpe:/a:springsource:spring_framework</cpe>
-  </suppress>
-  <suppress>
-     <notes><![CDATA[
+        <sha1>0e2bd9c162280cd79c2ea0f67f174ee5d7b84ddd</sha1>
+        <cpe>cpe:/a:springsource:spring_framework</cpe>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[
      file name: spring-core-3.2.18.RELEASE.jar
      ]]></notes>
-     <packageUrl regex="true">^pkg:maven/org\.springframework/spring\-core@.*$</packageUrl>
-     <cpe>cpe:/a:vmware:spring_framework</cpe>
-  </suppress>
-  <suppress>
-     <notes><![CDATA[
+        <sha1>0e2bd9c162280cd79c2ea0f67f174ee5d7b84ddd</sha1>
+        <cpe>cpe:/a:vmware:spring_framework</cpe>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[
      file name: spring-core-3.2.18.RELEASE.jar
      ]]></notes>
-     <packageUrl regex="true">^pkg:maven/org\.springframework/spring\-core@.*$</packageUrl>
-     <cpe>cpe:/a:vmware:springsource_spring_framework</cpe>
-  </suppress>
-  <suppress>
-     <notes><![CDATA[
+        <sha1>0e2bd9c162280cd79c2ea0f67f174ee5d7b84ddd</sha1>
+        <cpe>cpe:/a:vmware:springsource_spring_framework</cpe>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[
      file name: logback-classic-1.1.3.jar
      ]]></notes>
-     <packageUrl regex="true">^pkg:maven/ch\.qos\.logback/logback\-classic@.*$</packageUrl>
-     <cpe>cpe:/a:qos:logback</cpe>
-  </suppress>
-  <suppress>
-     <notes><![CDATA[
+        <sha1>d90276fff414f06cb375f2057f6778cd63c6082f</sha1>
+        <cpe>cpe:/a:qos:logback</cpe>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[
      file name: logback-core-1.1.3.jar
      ]]></notes>
-     <packageUrl regex="true">^pkg:maven/ch\.qos\.logback/logback\-core@.*$</packageUrl>
-     <vulnerabilityName>CVE-2017-5929</vulnerabilityName>
-   </suppress>
-  <suppress>
-     <notes><![CDATA[
+        <sha1>e3c02049f2dbbc764681b40094ecf0dcbc99b157</sha1>
+        <vulnerabilityName>CVE-2017-5929</vulnerabilityName>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[
      file name: logback-classic-1.1.3.jar
      ]]></notes>
-     <packageUrl regex="true">^pkg:maven/ch\.qos\.logback/logback\-classic@.*$</packageUrl>
-     <cve>CVE-2017-5929</cve>
-  </suppress>
-  <suppress>
-     <notes><![CDATA[
+        <sha1>d90276fff414f06cb375f2057f6778cd63c6082f</sha1>
+        <cve>CVE-2017-5929</cve>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[
      file name: logback-classic-1.1.3.jar
      ]]></notes>
-     <packageUrl regex="true">^pkg:maven/ch\.qos\.logback/logback\-classic@.*$</packageUrl>
-     <cve>CVE-2021-42550</cve>
-  </suppress>   
+        <sha1>d90276fff414f06cb375f2057f6778cd63c6082f</sha1>
+        <cve>CVE-2021-42550</cve>
+    </suppress>
 </suppressions>

--- a/src/owasp-dependency-check-suppressions.xml
+++ b/src/owasp-dependency-check-suppressions.xml
@@ -43,28 +43,20 @@
   </suppress>
 
   <!-- see https://github.com/alibaba/canal/issues/4010 -->
-  <suppress>
-    <notes><![CDATA[
-   file name: canal.client-1.1.4.jar (shaded: com.google.guava:guava:18.0)
-   ]]></notes>
-    <packageUrl regex="true">^pkg:maven/com\.google\.guava/guava@.*$</packageUrl>
-    <cve>CVE-2018-10237</cve>
-  </suppress>
-  <suppress>
-    <notes><![CDATA[
-   file name: canal.client-1.1.4.jar (shaded: com.google.guava:guava:18.0)
-   ]]></notes>
-    <packageUrl regex="true">^pkg:maven/com\.google\.guava/guava@.*$</packageUrl>
-    <cve>CVE-2020-8908</cve>
-  </suppress>
-  <suppress>
-    <notes><![CDATA[
-   file name: logback-core-1.1.3.jar
-   ]]></notes>
-    <packageUrl regex="true">^pkg:maven/ch\.qos\.logback/logback\-core@.*$</packageUrl>
-    <cpe>cpe:/a:qos:logback</cpe>
-  </suppress>
-
+    <suppress>
+        <notes><![CDATA[
+       file name: canal.client-1.1.5.jar (shaded: com.google.guava:guava:22.0)
+       ]]></notes>
+        <packageUrl regex="true">^pkg:maven/com\.google\.guava/guava@22.0$</packageUrl>
+        <cve>CVE-2018-10237</cve>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[
+       file name: canal.client-1.1.5.jar (shaded: com.google.guava:guava:22.0)
+       ]]></notes>
+        <packageUrl regex="true">^pkg:maven/com\.google\.guava/guava@22.0$</packageUrl>
+        <cve>CVE-2020-8908</cve>
+    </suppress>
 
   <!-- clickhouse: security scan matches client lib to the server CVEs -->
   <suppress>

--- a/src/owasp-dependency-check-suppressions.xml
+++ b/src/owasp-dependency-check-suppressions.xml
@@ -137,4 +137,46 @@
     <packageUrl regex="true">^pkg:maven/ru\.yandex\.clickhouse/clickhouse\-jdbc@.*$</packageUrl>
     <cve>CVE-2021-25263</cve>
   </suppress>
+  <suppress>
+     <notes><![CDATA[
+     file name: logback-core-1.1.3.jar
+     ]]></notes>
+     <packageUrl regex="true">^pkg:maven/ch\.qos\.logback/logback\-core@.*$</packageUrl>
+     <cpe>cpe:/a:qos:logback</cpe>
+  </suppress>
+  <suppress>
+     <notes><![CDATA[
+     file name: rocketmq-acl-4.5.2.jar
+     ]]></notes>
+     <packageUrl regex="true">^pkg:maven/org\.apache\.rocketmq/rocketmq\-acl@.*$</packageUrl>
+     <cpe>cpe:/a:apache:rocketmq</cpe>
+  </suppress>
+  <suppress>
+     <notes><![CDATA[
+     file name: spring-core-3.2.18.RELEASE.jar
+     ]]></notes>
+     <packageUrl regex="true">^pkg:maven/org\.springframework/spring\-core@.*$</packageUrl>
+     <cpe>cpe:/a:pivotal_software:spring_framework</cpe>
+   </suppress>
+  <suppress>
+     <notes><![CDATA[
+     file name: spring-core-3.2.18.RELEASE.jar
+     ]]></notes>
+     <packageUrl regex="true">^pkg:maven/org\.springframework/spring\-core@.*$</packageUrl>
+     <cpe>cpe:/a:springsource:spring_framework</cpe>
+  </suppress>
+  <suppress>
+     <notes><![CDATA[
+     file name: spring-core-3.2.18.RELEASE.jar
+     ]]></notes>
+     <packageUrl regex="true">^pkg:maven/org\.springframework/spring\-core@.*$</packageUrl>
+     <cpe>cpe:/a:vmware:spring_framework</cpe>
+  </suppress>
+  <suppress>
+     <notes><![CDATA[
+     file name: spring-core-3.2.18.RELEASE.jar
+     ]]></notes>
+     <packageUrl regex="true">^pkg:maven/org\.springframework/spring\-core@.*$</packageUrl>
+     <cpe>cpe:/a:vmware:springsource_spring_framework</cpe>
+  </suppress>
 </suppressions>

--- a/src/owasp-dependency-check-suppressions.xml
+++ b/src/owasp-dependency-check-suppressions.xml
@@ -179,4 +179,32 @@
      <packageUrl regex="true">^pkg:maven/org\.springframework/spring\-core@.*$</packageUrl>
      <cpe>cpe:/a:vmware:springsource_spring_framework</cpe>
   </suppress>
+  <suppress>
+     <notes><![CDATA[
+     file name: logback-classic-1.1.3.jar
+     ]]></notes>
+     <packageUrl regex="true">^pkg:maven/ch\.qos\.logback/logback\-classic@.*$</packageUrl>
+     <cpe>cpe:/a:qos:logback</cpe>
+  </suppress>
+  <suppress>
+     <notes><![CDATA[
+     file name: logback-core-1.1.3.jar
+     ]]></notes>
+     <packageUrl regex="true">^pkg:maven/ch\.qos\.logback/logback\-core@.*$</packageUrl>
+     <vulnerabilityName>CVE-2017-5929</vulnerabilityName>
+   </suppress>
+  <suppress>
+     <notes><![CDATA[
+     file name: logback-classic-1.1.3.jar
+     ]]></notes>
+     <packageUrl regex="true">^pkg:maven/ch\.qos\.logback/logback\-classic@.*$</packageUrl>
+     <cve>CVE-2017-5929</cve>
+  </suppress>
+  <suppress>
+     <notes><![CDATA[
+     file name: logback-classic-1.1.3.jar
+     ]]></notes>
+     <packageUrl regex="true">^pkg:maven/ch\.qos\.logback/logback\-classic@.*$</packageUrl>
+     <cve>CVE-2021-42550</cve>
+  </suppress>   
 </suppressions>

--- a/src/owasp-dependency-check-suppressions.xml
+++ b/src/owasp-dependency-check-suppressions.xml
@@ -42,6 +42,30 @@
     <vulnerabilityName regex="true">.*</vulnerabilityName>
   </suppress>
 
+  <!-- see https://github.com/alibaba/canal/issues/4010 -->
+  <suppress>
+    <notes><![CDATA[
+   file name: canal.client-1.1.4.jar (shaded: com.google.guava:guava:18.0)
+   ]]></notes>
+    <packageUrl regex="true">^pkg:maven/com\.google\.guava/guava@.*$</packageUrl>
+    <cve>CVE-2018-10237</cve>
+  </suppress>
+  <suppress>
+    <notes><![CDATA[
+   file name: canal.client-1.1.4.jar (shaded: com.google.guava:guava:18.0)
+   ]]></notes>
+    <packageUrl regex="true">^pkg:maven/com\.google\.guava/guava@.*$</packageUrl>
+    <cve>CVE-2020-8908</cve>
+  </suppress>
+  <suppress>
+    <notes><![CDATA[
+   file name: logback-core-1.1.3.jar
+   ]]></notes>
+    <packageUrl regex="true">^pkg:maven/ch\.qos\.logback/logback\-core@.*$</packageUrl>
+    <cpe>cpe:/a:qos:logback</cpe>
+  </suppress>
+
+
   <!-- clickhouse: security scan matches client lib to the server CVEs -->
   <suppress>
     <notes><![CDATA[

--- a/tiered-storage/file-system/pom.xml
+++ b/tiered-storage/file-system/pom.xml
@@ -141,16 +141,6 @@
         </dependency>
     </dependencies>
 
-    <dependencyManagement>
-      <dependencies>
-        <dependency>
-          <groupId>com.google.guava</groupId>
-          <artifactId>guava</artifactId>
-          <version>21.0</version>
-        </dependency>
-      </dependencies>
-    </dependencyManagement>
-
     <build>
         <plugins>
             <plugin>


### PR DESCRIPTION
Updating dependencies (guava and what brought in older guava) to get rid of the guava-related CVE-2018-10237 and CVE-2020-8908

pulsar-io/canal is excluded (no fix available and guava is bundled into
fatjar), tracked at https://github.com/alibaba/canal/issues/4010

### Motivation

`mvn clean install verify -Powasp-dependency-check -DskipTests` found various CVEs

### Modifications

Upgraded guava, dependencies that were forcing (ir bundling in a fatjar) older guava.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is already covered by existing tests

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): *YES*
  - The public API: (yes / no)
  - The schema: (yes / no / don't know)
  - The default values of configurations: (yes / no)
  - The wire protocol: (yes / no)
  - The rest endpoints: (yes / no)
  - The admin cli options: (yes / no)
  - Anything that affects deployment: (yes / no / don't know)

### Documentation

Check the box below or label this PR directly (if you have committer privilege).

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)


