### PR TITLE
[Security] Use dependencyManagement to enforce snakeyaml version to 1.30

### DIFF
--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -445,7 +445,7 @@ The Apache Software License, Version 2.0
     - org.eclipse.jetty.websocket-websocket-servlet-9.4.43.v20210629.jar
     - org.eclipse.jetty-jetty-alpn-conscrypt-server-9.4.43.v20210629.jar
     - org.eclipse.jetty-jetty-alpn-server-9.4.43.v20210629.jar
- * SnakeYaml -- org.yaml-snakeyaml-1.27.jar
+ * SnakeYaml -- org.yaml-snakeyaml-1.30.jar
  * RocksDB - org.rocksdb-rocksdbjni-6.10.2.jar
  * Google Error Prone Annotations - com.google.errorprone-error_prone_annotations-2.5.1.jar
  * Apache Thrift - org.apache.thrift-libthrift-0.14.2.jar

--- a/pom.xml
+++ b/pom.xml
@@ -201,6 +201,7 @@ flexible messaging model and an intuitive client API.</description>
     <cron-utils.version>9.1.3</cron-utils.version>
     <spring-context.version>5.3.1</spring-context.version>
     <apache-http-client.version>4.5.13</apache-http-client.version>
+    <snakeyaml.version>1.30</snakeyaml.version>
 
     <!-- test dependencies -->
     <cassandra.version>3.6.0</cassandra.version>
@@ -1177,6 +1178,12 @@ flexible messaging model and an intuitive client API.</description>
         <groupId>com.google.j2objc</groupId>
         <artifactId>j2objc-annotations</artifactId>
         <version>${j2objc-annotations.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.yaml</groupId>
+        <artifactId>snakeyaml</artifactId>
+        <version>${snakeyaml.version}</version>
       </dependency>
 
       <dependency>

--- a/pulsar-sql/presto-distribution/LICENSE
+++ b/pulsar-sql/presto-distribution/LICENSE
@@ -394,7 +394,7 @@ The Apache Software License, Version 2.0
   * RocksDB JNI
     - rocksdbjni-6.10.2.jar
   * SnakeYAML
-    - snakeyaml-1.27.jar
+    - snakeyaml-1.30.jar
   * Bean Validation API
     - validation-api-2.0.1.Final.jar
   * Objectsize


### PR DESCRIPTION
### Motivation

- Pulsar Offloaders contained vulnerable version 1.21

### Modifications

- add  dependencyManagement rule in maven pom.xml to enforce snakeyaml version to 1.30

### Additional context

- snakeyaml changelog https://bitbucket.org/snakeyaml/snakeyaml/wiki/Changes