### PR TITLE
[Flaky-test] BacklogQuotaManagerTest.testConsumerBacklogEvictionTimeQuotaWithEmptyLedger

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BacklogQuotaManagerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BacklogQuotaManagerTest.java
@@ -503,6 +503,7 @@ public class BacklogQuotaManagerTest {
         consumer.receive();
 
         admin.topics().unload(topic);
+        Awaitility.await().until(consumer::isConnected);
         PersistentTopicInternalStats internalStats = admin.topics().getInternalStats(topic);
         assertEquals(internalStats.ledgers.size(), 2);
         assertEquals(internalStats.ledgers.get(1).entries, 0);


### PR DESCRIPTION
Fixes flaky test #13697

### Documentation

Check the box below or label this PR directly (if you have committer privilege).

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)


