### PR TITLE
Fix call sync method in async rest API for ``internalGetSubscriptionsForNonPartitionedTopic``

### DIFF
--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/bookie/rackawareness/BookieRackAffinityMapping.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/bookie/rackawareness/BookieRackAffinityMapping.java
@@ -18,7 +18,6 @@
  */
 package org.apache.pulsar.bookie.rackawareness;
 
-import com.google.api.client.util.Strings;
 import java.net.InetAddress;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -35,6 +34,7 @@ import org.apache.bookkeeper.net.BookieNode;
 import org.apache.bookkeeper.net.BookieSocketAddress;
 import org.apache.bookkeeper.proto.BookieAddressResolver;
 import org.apache.commons.configuration.Configuration;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.pulsar.common.policies.data.BookieInfo;
 import org.apache.pulsar.common.policies.data.BookiesRackConfiguration;
 import org.apache.pulsar.metadata.api.MetadataCache;
@@ -161,7 +161,7 @@ public class BookieRackAffinityMapping extends AbstractDNSToSwitchMapping
         }
 
         if (bi != null
-                && !Strings.isNullOrEmpty(bi.getRack())
+                && !StringUtils.isEmpty(bi.getRack())
                 && !bi.getRack().trim().equals("/")) {
             String rack = bi.getRack();
             if (!rack.startsWith("/")) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/AdminResource.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/AdminResource.java
@@ -749,7 +749,7 @@ public abstract class AdminResource extends PulsarWebResource {
 
     protected void resumeAsyncResponseExceptionally(AsyncResponse asyncResponse, Throwable throwable) {
         if (throwable instanceof WebApplicationException) {
-            asyncResponse.resume((WebApplicationException) throwable);
+            asyncResponse.resume(throwable);
         } else {
             asyncResponse.resume(new RestException(throwable));
         }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/AdminResource.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/AdminResource.java
@@ -38,6 +38,7 @@ import org.apache.bookkeeper.client.BookKeeper;
 import org.apache.bookkeeper.mledger.ManagedLedgerException;
 import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.broker.ServiceConfiguration;
+import org.apache.pulsar.broker.service.BrokerServiceException;
 import org.apache.pulsar.broker.systopic.SystemTopicClient;
 import org.apache.pulsar.broker.web.PulsarWebResource;
 import org.apache.pulsar.broker.web.RestException;
@@ -750,6 +751,8 @@ public abstract class AdminResource extends PulsarWebResource {
     protected void resumeAsyncResponseExceptionally(AsyncResponse asyncResponse, Throwable throwable) {
         if (throwable instanceof WebApplicationException) {
             asyncResponse.resume(throwable);
+        } else if (throwable instanceof BrokerServiceException.NotAllowedException) {
+            asyncResponse.resume(new RestException(Status.CONFLICT, throwable));
         } else {
             asyncResponse.resume(new RestException(throwable));
         }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
@@ -1157,7 +1157,7 @@ public class PersistentTopicsBase extends AdminResource {
                                     clientAppId(), topicName, cause);
                         }
                     } else {
-                        log.error("[{}] Failed to get list of subscriptions for {}", clientAppId(), topicName, ex);
+                        log.error("[{}] Failed to get list of subscriptions for {}", clientAppId(), topicName, cause);
                     }
                     resumeAsyncResponseExceptionally(asyncResponse, ex);
                     return null;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
@@ -1159,7 +1159,7 @@ public class PersistentTopicsBase extends AdminResource {
                     } else {
                         log.error("[{}] Failed to get list of subscriptions for {}", clientAppId(), topicName, cause);
                     }
-                    resumeAsyncResponseExceptionally(asyncResponse, ex);
+                    resumeAsyncResponseExceptionally(asyncResponse, cause);
                     return null;
                 });
     }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
@@ -1154,7 +1154,7 @@ public class PersistentTopicsBase extends AdminResource {
                                 == Status.TEMPORARY_REDIRECT.getStatusCode()) {
                             log.debug("[{}] Failed to get subscriptions for non-partitioned topic {},"
                                             + " redirecting to other brokers.",
-                                    clientAppId(), topicName, ex);
+                                    clientAppId(), topicName, cause);
                         }
                     } else {
                         log.error("[{}] Failed to get list of subscriptions for {}", clientAppId(), topicName, ex);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
@@ -1149,7 +1149,7 @@ public class PersistentTopicsBase extends AdminResource {
                     asyncResponse.resume(subscriptions);
                 }).exceptionally(ex -> {
                     Throwable cause = ex.getCause();
-                    if (ex instanceof WebApplicationException) {
+                    if (cause instanceof WebApplicationException) {
                         if (log.isDebugEnabled() && ((WebApplicationException) cause).getResponse().getStatus()
                                 == Status.TEMPORARY_REDIRECT.getStatusCode()) {
                             log.debug("[{}] Failed to get subscriptions for non-partitioned topic {},"

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
@@ -1139,13 +1139,11 @@ public class PersistentTopicsBase extends AdminResource {
     }
 
     private void internalGetSubscriptionsForNonPartitionedTopic(AsyncResponse asyncResponse, boolean authoritative) {
-        validateTopicOwnershipAsync(topicName, authoritative).thenCompose(__ -> {
-                    validateTopicOperation(topicName, TopicOperation.GET_SUBSCRIPTIONS);
-                    return getTopicReferenceAsync(topicName);
-                }).thenAccept(topic -> {
-                    final List<String> subscriptions = new ArrayList<>(topic.getSubscriptions().keys());
-                    asyncResponse.resume(subscriptions);
-                }).exceptionally(ex -> {
+        validateTopicOwnershipAsync(topicName, authoritative)
+                .thenCompose(__ -> validateTopicOperationAsync(topicName, TopicOperation.GET_SUBSCRIPTIONS))
+                .thenCompose(__ -> getTopicReferenceAsync(topicName))
+                .thenAccept(topic -> asyncResponse.resume(Lists.newArrayList(topic.getSubscriptions().keys())))
+                .exceptionally(ex -> {
                     Throwable cause = ex.getCause();
                     if (cause instanceof WebApplicationException
                             && ((WebApplicationException) cause).getResponse().getStatus()

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
@@ -1140,8 +1140,10 @@ public class PersistentTopicsBase extends AdminResource {
 
     private void internalGetSubscriptionsForNonPartitionedTopic(AsyncResponse asyncResponse, boolean authoritative) {
         validateTopicOwnershipAsync(topicName, authoritative)
-                .thenRun(() -> validateTopicOperation(topicName, TopicOperation.GET_SUBSCRIPTIONS))
-                .thenCompose(__ -> getTopicReferenceAsync(topicName))
+                .thenCompose(__ -> {
+                    validateTopicOperation(topicName, TopicOperation.GET_SUBSCRIPTIONS);
+                    return getTopicReferenceAsync(topicName);
+                })
                 .thenAccept(topic -> {
                     final List<String> subscriptions = new ArrayList<>(topic.getSubscriptions().keys());
                     asyncResponse.resume(subscriptions);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
@@ -3762,13 +3762,9 @@ public class PersistentTopicsBase extends AdminResource {
 
     private CompletableFuture<Topic> getTopicReferenceAsync(TopicName topicName) {
         return pulsar().getBrokerService().getTopicIfExists(topicName.toString())
-                .thenCompose(optTopic -> {
-                    if (optTopic.isPresent()) {
-                        return CompletableFuture.completedFuture(optTopic.get());
-                    } else {
-                        return topicNotFoundReasonAsync(topicName);
-                    }
-                });
+                .thenCompose(optTopic -> optTopic
+                        .map(CompletableFuture::completedFuture)
+                        .orElseGet(() -> topicNotFoundReasonAsync(topicName)));
     }
 
     private RestException topicNotFoundReason(TopicName topicName) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/PulsarWebResource.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/PulsarWebResource.java
@@ -1053,8 +1053,13 @@ public abstract class PulsarWebResource {
         try {
             validateTopicOperationAsync(topicName, operation, subscription).get();
         } catch (InterruptedException | ExecutionException e) {
-            log.error("Validate Topic [%s] operation [%s] got server internal error.", e);
-            throw new RestException(e);
+            Throwable cause = e.getCause();
+            log.error("Validate Topic [%s] operation [%s] got server internal error.", cause);
+            if (cause instanceof WebApplicationException){
+                throw (WebApplicationException) cause;
+            } else {
+                throw new RestException(cause);
+            }
         }
     }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/PulsarWebResource.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/PulsarWebResource.java
@@ -1054,7 +1054,6 @@ public abstract class PulsarWebResource {
             validateTopicOperationAsync(topicName, operation, subscription).get();
         } catch (InterruptedException | ExecutionException e) {
             Throwable cause = e.getCause();
-            log.error("Validate Topic [%s] operation [%s] got server internal error.", cause);
             if (cause instanceof WebApplicationException){
                 throw (WebApplicationException) cause;
             } else {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/PulsarWebResource.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/PulsarWebResource.java
@@ -1050,22 +1050,38 @@ public abstract class PulsarWebResource {
     }
 
     public void validateTopicOperation(TopicName topicName, TopicOperation operation, String subscription) {
+        try {
+            validateTopicOperationAsync(topicName, operation, subscription).get();
+        } catch (InterruptedException | ExecutionException e) {
+            log.error("Validate Topic [%s] operation [%s] got server internal error.", e);
+            throw new RestException(e);
+        }
+    }
+
+    public CompletableFuture<Void> validateTopicOperationAsync(TopicName topicName, TopicOperation operation) {
+       return validateTopicOperationAsync(topicName, operation, null);
+    }
+
+    public CompletableFuture<Void> validateTopicOperationAsync(TopicName topicName,
+                                                               TopicOperation operation, String subscription) {
         if (pulsar().getConfiguration().isAuthenticationEnabled()
                 && pulsar().getBrokerService().isAuthorizationEnabled()) {
             if (!isClientAuthenticated(clientAppId())) {
                 throw new RestException(Status.UNAUTHORIZED, "Need to authenticate to perform the request");
             }
-
             AuthenticationDataHttps authData = clientAuthData();
             authData.setSubscription(subscription);
-
-            Boolean isAuthorized = pulsar().getBrokerService().getAuthorizationService()
-                    .allowTopicOperation(topicName, operation, originalPrincipal(), clientAppId(), authData);
-
-            if (!isAuthorized) {
-                throw new RestException(Status.UNAUTHORIZED, String.format("Unauthorized to validateTopicOperation for"
-                        + " operation [%s] on topic [%s]", operation.toString(), topicName));
-            }
+            return pulsar().getBrokerService().getAuthorizationService()
+                    .allowTopicOperationAsync(topicName, operation, originalPrincipal(), clientAppId(), authData)
+                    .thenAccept(isAuthorized -> {
+                        if (!isAuthorized) {
+                            throw new RestException(Status.UNAUTHORIZED, String.format(
+                                    "Unauthorized to validateTopicOperation for operation [%s] on topic [%s]",
+                                    operation.toString(), topicName));
+                        }
+                    });
+        } else {
+            return CompletableFuture.completedFuture(null);
         }
     }
 


### PR DESCRIPTION
### Motivation

Avoid call sync method in async rest API for ``PersistentTopicsBase#internalGetSubscriptionsForNonPartitionedTopic``.

### Modifications

- Use async instead of sync method.


### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

- [x] `no-need-doc` 
  

