### PR TITLE
[security] Offloaders - get rid of several CVEs (including Log4J 2.17)

### DIFF
--- a/jclouds-shaded/pom.xml
+++ b/jclouds-shaded/pom.xml
@@ -34,6 +34,7 @@
   <name>Apache Pulsar :: Jclouds shaded</name>
 
   <dependencies>
+
     <dependency>
       <groupId>org.apache.jclouds</groupId>
       <artifactId>jclouds-allblobstore</artifactId>
@@ -122,6 +123,15 @@
                 <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
                 <transformer implementation="org.apache.maven.plugins.shade.resource.PluginXmlResourceTransformer"/>
               </transformers>
+              <filters>
+              <filter>
+                <artifact>org.apache.jclouds:jclouds-core</artifact>
+                <excludes>
+                  <!-- jclouds-core is a mixed uber jar containing a gson vulnerable version-->
+                  <exclude>lib/gson*jar</exclude>
+                </excludes>
+              </filter>
+            </filters>
             </configuration>
           </execution>
         </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -150,7 +150,8 @@ flexible messaging model and an intuitive client API.</description>
     <postgresql-jdbc.version>42.2.12</postgresql-jdbc.version>
     <clickhouse-jdbc.version>0.2.4</clickhouse-jdbc.version>
     <mariadb-jdbc.version>2.6.0</mariadb-jdbc.version>
-    <hdfs-offload-version3>3.3.0</hdfs-offload-version3>
+    <hdfs-offload-version3>3.3.1</hdfs-offload-version3>
+    <json-smart.version>2.4.7</json-smart.version>
     <elasticsearch.version>7.9.1</elasticsearch.version>
     <presto.version>332</presto.version>
     <scala.binary.version>2.13</scala.binary.version>

--- a/tiered-storage/file-system/pom.xml
+++ b/tiered-storage/file-system/pom.xml
@@ -39,13 +39,55 @@
         </dependency>
         <dependency>
             <groupId>org.apache.hadoop</groupId>
-            <artifactId>hadoop-hdfs-client</artifactId>
-            <version>${hdfs-offload-version3}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-common</artifactId>
             <version>${hdfs-offload-version3}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>log4j</groupId>
+                    <artifactId>log4j</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-log4j12</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <!-- fix hadoop-commons vulnerable dependencies -->
+        <dependency>
+            <groupId>com.sun.jersey</groupId>
+            <artifactId>jersey-json</artifactId>
+            <!-- same version used by hadoop-common-->
+            <version>1.19</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.codehaus.jackson</groupId>
+                    <artifactId>jackson-core-asl</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.codehaus.jackson</groupId>
+                    <artifactId>jackson-mapper-asl</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.codehaus.jackson</groupId>
+                    <artifactId>jackson-jaxrs</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.codehaus.jackson</groupId>
+                    <artifactId>jackson-xc</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <!-- fix hadoop-commons vulnerable dependencies -->
+        <dependency>
+            <groupId>org.apache.avro</groupId>
+            <artifactId>avro</artifactId>
+            <version>${avro.version}</version>
+        </dependency>
+        <!-- fix hadoop-commons vulnerable dependencies -->
+        <dependency>
+            <groupId>net.minidev</groupId>
+            <artifactId>json-smart</artifactId>
+            <version>${json-smart.version}</version>
         </dependency>
         <dependency>
             <groupId>com.google.protobuf</groupId>


### PR DESCRIPTION
### Motivation

The offloaders Nar files contain dependecies with open CVEs

#### tiered-storage-file-system

`hadoop-commons:3.3.0`  brings several vulnerable transitive dependencies: (severity >= 7.5)
* com.faster.xml.woodstox:woodstox-core:5.0.3 -> CVE-2020-15250
* log4j:log4j:2.17
* net.minidev:json-smart:2.3 -> CVE-2021-27568
* jackson-mapper-asl:1.9.2 
* okhttp 2.7.5
* jetty 9.4.20
* Avro 1.7.7

###  tiered-storage-jcloud
the dependency `org.apache.jclouds:jclouds-core` looks like an uber jar containing only a dependency inside the `lib` directory: gson:2.8.5 which is vulnerable to `sonatype-2021-1694`

### Modifications

#### tiered-storage-file-system
* Upgraded hadoop packages to from 3.3.0 to 3.3.1
* Fixed Log4j transitive dependency
* excluded deprecated Jackson from Jetty 1 (transitive dependency of hadoop-commons)
* forced Avro to 1.10.2
* forced json-smart to 2.4.7


####  tiered-storage-jcloud
* excluded the exceeding gson jar and added the correct latest one (2.8.9)

### Verifying this change

This change is already covered by existing tests, such as *(please describe tests)*.

* integrations test about offloading

### Does this pull request potentially affect one of the following parts:

- Dependencies (does it add or upgrade a dependency): (yes)

### Documentation

- [x] `no-need-doc` 
