### PR TITLE
Updated dependencies to get rid of pulsar-io/jdbc related CVE-2020-13692

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -147,8 +147,8 @@ flexible messaging model and an intuitive client API.</description>
     <jclouds.version>2.3.0</jclouds.version>
     <sqlite-jdbc.version>3.8.11.2</sqlite-jdbc.version>
     <mysql-jdbc.version>8.0.11</mysql-jdbc.version>
-    <postgresql-jdbc.version>42.2.12</postgresql-jdbc.version>
-    <clickhouse-jdbc.version>0.2.4</clickhouse-jdbc.version>
+    <postgresql-jdbc.version>42.2.24</postgresql-jdbc.version>
+    <clickhouse-jdbc.version>0.3.2</clickhouse-jdbc.version>
     <mariadb-jdbc.version>2.6.0</mariadb-jdbc.version>
     <hdfs-offload-version3>3.3.0</hdfs-offload-version3>
     <elasticsearch.version>7.9.1</elasticsearch.version>

--- a/src/owasp-dependency-check-suppressions.xml
+++ b/src/owasp-dependency-check-suppressions.xml
@@ -43,11 +43,74 @@
   </suppress>
 
   <!-- clickhouse: security scan matches client lib to the server CVEs -->
-<suppress>
-   <notes><![CDATA[
-   file name: clickhouse-jdbc-0.3.2.jar
-   ]]></notes>
-   <packageUrl regex="true">^pkg:maven/ru\.yandex\.clickhouse/clickhouse\-jdbc@.*$</packageUrl>
-   <cpe>cpe:/a:yandex:clickhouse</cpe>
-</suppress>
+  <suppress>
+    <notes><![CDATA[
+    file name: avro-1.10.2.jar
+    ]]></notes>
+    <packageUrl regex="true">^pkg:maven/org\.apache\.avro/avro@.*$</packageUrl>
+    <cve>CVE-2021-43045</cve>
+  </suppress>
+  <suppress>
+    <notes><![CDATA[
+    file name: clickhouse-jdbc-0.3.2.jar
+    ]]></notes>
+    <packageUrl regex="true">^pkg:maven/ru\.yandex\.clickhouse/clickhouse\-jdbc@.*$</packageUrl>
+    <cve>CVE-2018-14668</cve>
+  </suppress>
+  <suppress>
+    <notes><![CDATA[
+    file name: clickhouse-jdbc-0.3.2.jar
+    ]]></notes>
+    <packageUrl regex="true">^pkg:maven/ru\.yandex\.clickhouse/clickhouse\-jdbc@.*$</packageUrl>
+    <cve>CVE-2018-14669</cve>
+  </suppress>
+  <suppress>
+    <notes><![CDATA[
+    file name: clickhouse-jdbc-0.3.2.jar
+    ]]></notes>
+    <packageUrl regex="true">^pkg:maven/ru\.yandex\.clickhouse/clickhouse\-jdbc@.*$</packageUrl>
+    <cve>CVE-2018-14670</cve>
+  </suppress>
+  <suppress>
+    <notes><![CDATA[
+    file name: clickhouse-jdbc-0.3.2.jar
+    ]]></notes>
+    <packageUrl regex="true">^pkg:maven/ru\.yandex\.clickhouse/clickhouse\-jdbc@.*$</packageUrl>
+    <cve>CVE-2018-14671</cve>
+  </suppress>
+  <suppress>
+    <notes><![CDATA[
+    file name: clickhouse-jdbc-0.3.2.jar
+    ]]></notes>
+    <packageUrl regex="true">^pkg:maven/ru\.yandex\.clickhouse/clickhouse\-jdbc@.*$</packageUrl>
+    <cve>CVE-2018-14672</cve>
+  </suppress>
+  <suppress>
+    <notes><![CDATA[
+    file name: clickhouse-jdbc-0.3.2.jar
+    ]]></notes>
+    <packageUrl regex="true">^pkg:maven/ru\.yandex\.clickhouse/clickhouse\-jdbc@.*$</packageUrl>
+    <cve>CVE-2019-15024</cve>
+  </suppress>
+  <suppress>
+    <notes><![CDATA[
+    file name: clickhouse-jdbc-0.3.2.jar
+    ]]></notes>
+    <packageUrl regex="true">^pkg:maven/ru\.yandex\.clickhouse/clickhouse\-jdbc@.*$</packageUrl>
+    <cve>CVE-2019-16535</cve>
+  </suppress>
+  <suppress>
+    <notes><![CDATA[
+    file name: clickhouse-jdbc-0.3.2.jar
+    ]]></notes>
+    <packageUrl regex="true">^pkg:maven/ru\.yandex\.clickhouse/clickhouse\-jdbc@.*$</packageUrl>
+    <cve>CVE-2019-18657</cve>
+  </suppress> 
+  <suppress>
+    <notes><![CDATA[
+    file name: clickhouse-jdbc-0.3.2.jar
+    ]]></notes>
+    <packageUrl regex="true">^pkg:maven/ru\.yandex\.clickhouse/clickhouse\-jdbc@.*$</packageUrl>
+    <cve>CVE-2021-25263</cve>
+  </suppress>
 </suppressions>

--- a/src/owasp-dependency-check-suppressions.xml
+++ b/src/owasp-dependency-check-suppressions.xml
@@ -41,4 +41,13 @@
     <gav regex="true">org\.apache\.zookeeper:.*:3\.6\.2</gav>
     <vulnerabilityName regex="true">.*</vulnerabilityName>
   </suppress>
+
+  <!-- clickhouse: security scan matches client lib to the server CVEs -->
+<suppress>
+   <notes><![CDATA[
+   file name: clickhouse-jdbc-0.3.2.jar
+   ]]></notes>
+   <packageUrl regex="true">^pkg:maven/ru\.yandex\.clickhouse/clickhouse\-jdbc@.*$</packageUrl>
+   <cpe>cpe:/a:yandex:clickhouse</cpe>
+</suppress>
 </suppressions>


### PR DESCRIPTION
### Motivation

`mvn clean install verify -Powasp-dependency-check -DskipTests` found various CVEs

### Modifications

Updated dependencies to get rid of pulsar-io/jdbc related CVE-2020-13692

Also upgraded clickhouse lib and suppressed wrongly detected clickhouse
CVEs (client lib matched to server CVEs)

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change is already covered by existing tests

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): *YES*
  - The public API: (yes / no)
  - The schema: (yes / no / don't know)
  - The default values of configurations: (yes / no)
  - The wire protocol: (yes / no)
  - The rest endpoints: (yes / no)
  - The admin cli options: (yes / no)
  - Anything that affects deployment: (yes / no / don't know)

### Documentation

Check the box below or label this PR directly (if you have committer privilege).

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)


