### PR TITLE
[Tests] Workaround flakiness issue in EndToEndMetadataTest.testPublishConsume

### DIFF
--- a/pulsar-broker/pom.xml
+++ b/pulsar-broker/pom.xml
@@ -463,6 +463,9 @@
             <pulsar-io-data-generator.nar.path>${project.build.directory}/pulsar-io-data-generator.nar</pulsar-io-data-generator.nar.path>
             <pulsar-functions-api-examples.jar.path>${project.build.directory}/pulsar-functions-api-examples.jar</pulsar-functions-api-examples.jar.path>
             <pulsar-io-batch-data-generator.nar.path>${project.build.directory}/pulsar-io-batch-data-generator.nar</pulsar-io-batch-data-generator.nar.path>
+            <!-- workaround issue #13750 which gets triggered if org.apache.bookkeeper.meta.MetadataDrivers class gets loaded before org.apache.pulsar.metadata.bookkeeper.BKCluster constructor is called -->
+            <bookkeeper.metadata.bookie.drivers>org.apache.pulsar.metadata.bookkeeper.PulsarMetadataBookieDriver</bookkeeper.metadata.bookie.drivers>
+            <bookkeeper.metadata.client.drivers>org.apache.pulsar.metadata.bookkeeper.PulsarMetadataClientDriver</bookkeeper.metadata.client.drivers>
           </systemPropertyVariables>
         </configuration>
       </plugin>


### PR DESCRIPTION
Fixes #13750

### Motivation

- If the org.apache.bookkeeper.meta.MetadataDrivers class got loaded before org.apache.pulsar.metadata.bookkeeper.BKCluster constructor is called, things would fail.

### Modifications

- Set the system properties for metadata-store backend in pom.xml for all pulsar-broker tests as a workaround