### PR TITLE
Bump sketches version from 0.8.3 to 0.13.4

### DIFF
--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -338,8 +338,8 @@ The Apache Software License, Version 2.0
     - io.swagger-swagger-core-1.6.2.jar
     - io.swagger-swagger-models-1.6.2.jar
  * DataSketches
-    - com.yahoo.datasketches-memory-0.8.3.jar
-    - com.yahoo.datasketches-sketches-core-0.8.3.jar
+    - com.yahoo.datasketches-memory-0.13.4.jar
+    - com.yahoo.datasketches-sketches-core-0.13.4.jar
  * Apache Commons
     - commons-cli-commons-cli-1.5.0.jar
     - commons-codec-commons-codec-1.15.jar

--- a/pom.xml
+++ b/pom.xml
@@ -136,7 +136,7 @@ flexible messaging model and an intuitive client API.</description>
     <perfmark.version>0.19.0</perfmark.version>
     <protoc-gen-grpc-java.version>${grpc.version}</protoc-gen-grpc-java.version>
     <gson.version>2.8.9</gson.version>
-    <sketches.version>0.8.3</sketches.version>
+    <sketches.version>0.13.4</sketches.version>
     <hbc-core.version>2.2.0</hbc-core.version>
     <cassandra-driver-core.version>3.6.0</cassandra-driver-core.version>
     <aerospike-client.version>4.4.20</aerospike-client.version>

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/metrics/DataSketchesOpStatsLogger.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/metrics/DataSketchesOpStatsLogger.java
@@ -22,6 +22,7 @@ import com.yahoo.sketches.quantiles.DoublesSketch;
 import com.yahoo.sketches.quantiles.DoublesSketchBuilder;
 import com.yahoo.sketches.quantiles.DoublesUnion;
 import com.yahoo.sketches.quantiles.DoublesUnionBuilder;
+import com.yahoo.sketches.quantiles.UpdateDoublesSketch;
 import io.netty.util.concurrent.FastThreadLocal;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -173,8 +174,8 @@ public class DataSketchesOpStatsLogger implements OpStatsLogger {
     }
 
     private static class LocalData {
-        private final DoublesSketch successSketch = new DoublesSketchBuilder().build();
-        private final DoublesSketch failSketch = new DoublesSketchBuilder().build();
+        private final UpdateDoublesSketch successSketch = new DoublesSketchBuilder().build();
+        private final UpdateDoublesSketch failSketch = new DoublesSketchBuilder().build();
         private final StampedLock lock = new StampedLock();
     }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/metrics/DataSketchesSummaryLogger.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/metrics/DataSketchesSummaryLogger.java
@@ -22,6 +22,7 @@ import com.yahoo.sketches.quantiles.DoublesSketch;
 import com.yahoo.sketches.quantiles.DoublesSketchBuilder;
 import com.yahoo.sketches.quantiles.DoublesUnion;
 import com.yahoo.sketches.quantiles.DoublesUnionBuilder;
+import com.yahoo.sketches.quantiles.UpdateDoublesSketch;
 import io.netty.util.concurrent.FastThreadLocal;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -99,7 +100,7 @@ public class DataSketchesSummaryLogger {
     }
 
     private static class LocalData {
-        private final DoublesSketch successSketch = new DoublesSketchBuilder().build();
+        private final UpdateDoublesSketch successSketch = new DoublesSketchBuilder().build();
         private final StampedLock lock = new StampedLock();
     }
 

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerStatsRecorderImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerStatsRecorderImpl.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.yahoo.sketches.quantiles.DoublesSketch;
+import com.yahoo.sketches.quantiles.UpdateDoublesSketch;
 import io.netty.util.Timeout;
 import io.netty.util.TimerTask;
 import java.io.IOException;

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerStatsRecorderImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerStatsRecorderImpl.java
@@ -52,7 +52,7 @@ public class ProducerStatsRecorderImpl implements ProducerStatsRecorder {
     private final LongAdder totalAcksReceived;
     private static final DecimalFormat DEC = new DecimalFormat("0.000");
     private static final DecimalFormat THROUGHPUT_FORMAT = new DecimalFormat("0.00");
-    private final transient DoublesSketch ds;
+    private final transient UpdateDoublesSketch ds;
 
     private volatile double sendMsgsRate;
     private volatile double sendBytesRate;
@@ -69,7 +69,7 @@ public class ProducerStatsRecorderImpl implements ProducerStatsRecorder {
         totalBytesSent = new LongAdder();
         totalSendFailed = new LongAdder();
         totalAcksReceived = new LongAdder();
-        ds = DoublesSketch.builder().build(256);
+        ds = DoublesSketch.builder().setK(256).build();
     }
 
     public ProducerStatsRecorderImpl(PulsarClientImpl pulsarClient, ProducerConfigurationData conf,
@@ -85,7 +85,7 @@ public class ProducerStatsRecorderImpl implements ProducerStatsRecorder {
         totalBytesSent = new LongAdder();
         totalSendFailed = new LongAdder();
         totalAcksReceived = new LongAdder();
-        ds = DoublesSketch.builder().build(256);
+        ds = DoublesSketch.builder().setK(256).build();
         init(conf);
     }
 

--- a/pulsar-sql/presto-distribution/LICENSE
+++ b/pulsar-sql/presto-distribution/LICENSE
@@ -463,8 +463,8 @@ The Apache Software License, Version 2.0
   * Java Object Layout: Core
     - jol-core-0.2.jar
   * Yahoo Datasketches
-    - memory-0.8.3.jar
-    - sketches-core-0.8.3.jar
+    - memory-0.13.4.jar
+    - sketches-core-0.13.4.jar
   * Apache Zookeeper
     - zookeeper-3.6.3.jar
     - zookeeper-jute-3.6.3.jar


### PR DESCRIPTION
### Motivation

`sketches-core` has broken api, it makes `pulsar-client-origin` can not well used with other libraries

### Modifications

Bump sketches version from 0.8.3 to 0.13.4

### Verifying this change

This change is already covered by existing tests, such as `org.apache.pulsar.client.impl.ProducerStatsRecorderImplTest`


