### PR TITLE
[owasp] suppress false positive Avro CVE-2021-43045

### DIFF
--- a/src/owasp-dependency-check-false-positives.xml
+++ b/src/owasp-dependency-check-false-positives.xml
@@ -47,6 +47,11 @@
     <gav regex="true">org\.apache\.avro:.*</gav>
     <cve>CVE-2019-17195</cve>
   </suppress>
+  <suppress>
+    <notes>CVE-2021-43045 affects only .NET distro, see https://github.com/apache/avro/pull/1357</notes>
+    <gav regex="true">org\.apache\.avro:.*</gav>
+    <cve>CVE-2021-43045</cve>
+  </suppress>
   <suppress base="true">
     <notes><![CDATA[
         FP per #3889


### PR DESCRIPTION
### Motivation
OWASP check now fails because of 

```
avro-1.10.2.jar (pkg:maven/org.apache.avro/avro@1.10.2, cpe:2.3:a:apache:avro:1.10.2:*:*:*:*:*:*:*) : CVE-2021-43045
```


As mentioned [here](https://nvd.nist.gov/vuln/detail/CVE-2021-43045) the vulnerability only affects the .NET distribution 

Also see the PR https://github.com/apache/avro/pull/1357


### Modifications

* Added suppression for this CVE on Avro packages


### Documentation

- [x] `no-need-doc` 
 