### PR TITLE
[Transaction] Remove subscription when Transaction pending ack replay failed

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/exception/pendingack/TransactionPendingAckException.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/exception/pendingack/TransactionPendingAckException.java
@@ -49,4 +49,16 @@ public abstract class TransactionPendingAckException extends TransactionExceptio
         }
 
     }
+
+    /**
+     * Transaction pending ack store replay pending ack to recover
+     * the pending ack subscription pending ack state exception.
+     */
+    public static class TransactionPendingAckReplayException extends TransactionPendingAckException {
+
+        public TransactionPendingAckReplayException(String message) {
+            super(message);
+        }
+
+    }
 }


### PR DESCRIPTION
### Motivation

When the transactionpending ack replay fails, the current corresponding `PersistentSubscription` is still in the cache. Since the `PendingAckHandleImpl` is only initialized when the `PersistentSubscription` is created, the client still cannot recover after retrying.

### Modifications

We should remove the problematic `PendingAckHandleImpl`. For example, we will encounter `PendingAckHandleImpl init fail ` due to `ManagedLedger has already been closed`(You can see this situation from this issue https://github.com/apache/pulsar/issues/13654), so we should allow the client to recover by retrying instead of having to replace the subscription name to resume consumption.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API: (yes / no)
  - The schema: (yes / no / don't know)
  - The default values of configurations: (yes / no)
  - The wire protocol: (yes / no)
  - The rest endpoints: (yes / no)
  - The admin cli options: (yes / no)
  - Anything that affects deployment: (yes / no / don't know)

### Documentation

Check the box below or label this PR directly (if you have committer privilege).

Need to update docs? 
  
- [x] `no-need-doc` 
  


