### PR TITLE
fix violation checkstyle

### DIFF
--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/bookie/rackawareness/BookieRackAffinityMapping.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/bookie/rackawareness/BookieRackAffinityMapping.java
@@ -18,7 +18,6 @@
  */
 package org.apache.pulsar.bookie.rackawareness;
 
-import com.google.api.client.util.Strings;
 import java.net.InetAddress;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -35,6 +34,7 @@ import org.apache.bookkeeper.net.BookieNode;
 import org.apache.bookkeeper.net.BookieSocketAddress;
 import org.apache.bookkeeper.proto.BookieAddressResolver;
 import org.apache.commons.configuration.Configuration;
+import org.apache.commons.lang.StringUtils;
 import org.apache.pulsar.common.policies.data.BookieInfo;
 import org.apache.pulsar.common.policies.data.BookiesRackConfiguration;
 import org.apache.pulsar.metadata.api.MetadataCache;
@@ -161,7 +161,7 @@ public class BookieRackAffinityMapping extends AbstractDNSToSwitchMapping
         }
 
         if (bi != null
-                && !Strings.isNullOrEmpty(bi.getRack())
+                && !StringUtils.isBlank(bi.getRack())
                 && !bi.getRack().trim().equals("/")) {
             String rack = bi.getRack();
             if (!rack.startsWith("/")) {


### PR DESCRIPTION
Fixes #13683 check style violation:
```
Error:  src/main/java/org/apache/pulsar/bookie/rackawareness/BookieRackAffinityMapping.java:[21] (regexp) 

RegexpSinglelineJava: Line matches the illegal pattern 'com\.google\.api\.client\.util\.(ByteStreams|Charsets|Collections2|Joiner|Lists|Maps|Objects|Preconditions|Sets|Strings|Throwables)'.
```
### Documentation

Check the box below or label this PR directly (if you have committer privilege).

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)
