### PR TITLE
Allow to configure metadata store URL in functions_worker.yml

### DIFF
--- a/conf/functions_worker.yml
+++ b/conf/functions_worker.yml
@@ -26,8 +26,12 @@ workerHostname: localhost
 workerPort: 6750
 workerPortTls: 6751
 
-# Configuration Store connection string
-configurationStoreServers: localhost:2181
+# The Configuration metadata store url
+# Examples:
+# * zk:my-zk-1:2181,my-zk-2:2181,my-zk-3:2181
+# * my-zk-1:2181,my-zk-2:2181,my-zk-3:2181 (will default to ZooKeeper when the schema is not specified)
+# * zk:my-zk-1:2181,my-zk-2:2181,my-zk-3:2181/my-chroot-path (to add a ZK chroot path)
+configurationMetadataStoreUrl: zk:localhost:2181
 # ZooKeeper session timeout in milliseconds
 zooKeeperSessionTimeoutMillis: 30000
 # ZooKeeper operation timeout in seconds
@@ -328,3 +332,6 @@ validateConnectorConfig: false
 # Whether to initialize distributed log metadata by runtime.
 # If it is set to true, you must ensure that it has been initialized by "bin/pulsar initialize-cluster-metadata" command.
 initializedDlogMetadata: false
+
+### --- Deprecated settings --- ###
+configurationStoreServers: localhost:2181

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
@@ -1605,7 +1605,7 @@ public class PulsarService implements AutoCloseable, ShutdownService {
         workerConfig.setAuthenticationProviders(brokerConfig.getAuthenticationProviders());
         workerConfig.setAuthorizationEnabled(brokerConfig.isAuthorizationEnabled());
         workerConfig.setAuthorizationProvider(brokerConfig.getAuthorizationProvider());
-        workerConfig.setConfigurationStoreServers(brokerConfig.getConfigurationMetadataStoreUrl());
+        workerConfig.setConfigurationMetadataStoreUrl(brokerConfig.getConfigurationMetadataStoreUrl());
         workerConfig.setZooKeeperSessionTimeoutMillis(brokerConfig.getZooKeeperSessionTimeoutMillis());
         workerConfig.setZooKeeperOperationTimeoutSeconds(brokerConfig.getZooKeeperOperationTimeoutSeconds());
 

--- a/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/worker/WorkerConfig.java
+++ b/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/worker/WorkerConfig.java
@@ -149,6 +149,12 @@ public class WorkerConfig implements Serializable, PulsarConfiguration {
     private String configurationStoreServers;
     @FieldContext(
             category = CATEGORY_WORKER,
+            required = false,
+            doc = "Configuration store connection string (as a comma-separated list)"
+    )
+    private String configurationMetadataStoreUrl;
+    @FieldContext(
+            category = CATEGORY_WORKER,
             doc = "ZooKeeper session timeout in milliseconds"
     )
     private long zooKeeperSessionTimeoutMillis = 30000;
@@ -630,6 +636,14 @@ public class WorkerConfig implements Serializable, PulsarConfiguration {
             return InetAddress.getLocalHost().getCanonicalHostName();
         } catch (UnknownHostException ex) {
             throw new IllegalStateException("Failed to resolve localhost name.", ex);
+        }
+    }
+
+    public String getConfigurationMetadataStoreUrl() {
+        if (StringUtils.isNotBlank(configurationMetadataStoreUrl)) {
+            return configurationMetadataStoreUrl;
+        } else  {
+            return configurationStoreServers;
         }
     }
 

--- a/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/worker/WorkerConfig.java
+++ b/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/worker/WorkerConfig.java
@@ -144,8 +144,10 @@ public class WorkerConfig implements Serializable, PulsarConfiguration {
     @FieldContext(
             category = CATEGORY_WORKER,
             required = false,
+            deprecated = true,
             doc = "Configuration store connection string (as a comma-separated list)"
     )
+    @Deprecated
     private String configurationStoreServers;
     @FieldContext(
             category = CATEGORY_WORKER,

--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/Worker.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/Worker.java
@@ -73,7 +73,8 @@ public class Worker {
 
             log.info("starting configuration cache service");
             try {
-                configMetadataStore = PulsarResources.createMetadataStore(workerConfig.getConfigurationStoreServers(),
+                configMetadataStore = PulsarResources.createMetadataStore(
+                        workerConfig.getConfigurationMetadataStoreUrl(),
                         (int) workerConfig.getZooKeeperSessionTimeoutMillis());
             } catch (IOException e) {
                 throw new PulsarServerException(e);

--- a/site2/docs/functions-runtime.md
+++ b/site2/docs/functions-runtime.md
@@ -270,7 +270,7 @@ For example, if you use token authentication, you need to configure the followin
 ```Yaml
 clientAuthenticationPlugin: org.apache.pulsar.client.impl.auth.AuthenticationToken
 clientAuthenticationParameters: file:///etc/pulsar/token/admin-token.txt
-configurationStoreServers: zookeeper-cluster:2181 # auth requires a connection to zookeeper
+configurationMetadataStoreUrl: zookeeper-cluster:2181 # auth requires a connection to zookeeper
 authenticationProviders:
  - "org.apache.pulsar.broker.authentication.AuthenticationProviderToken"
 authorizationEnabled: true

--- a/site2/docs/functions-runtime.md
+++ b/site2/docs/functions-runtime.md
@@ -270,7 +270,7 @@ For example, if you use token authentication, you need to configure the followin
 ```Yaml
 clientAuthenticationPlugin: org.apache.pulsar.client.impl.auth.AuthenticationToken
 clientAuthenticationParameters: file:///etc/pulsar/token/admin-token.txt
-configurationMetadataStoreUrl: zookeeper-cluster:2181 # auth requires a connection to zookeeper
+configurationMetadataStoreUrl: zk:zookeeper-cluster:2181 # auth requires a connection to zookeeper
 authenticationProviders:
  - "org.apache.pulsar.broker.authentication.AuthenticationProviderToken"
 authorizationEnabled: true

--- a/site2/docs/functions-worker.md
+++ b/site2/docs/functions-worker.md
@@ -221,7 +221,7 @@ To enable authorization on Functions Worker, you need to configure `authorizatio
 ```yaml
 authorizationEnabled: true
 authorizationProvider: org.apache.pulsar.broker.authorization.PulsarAuthorizationProvider
-configurationMetadataStoreUrl: <configuration-store-servers>
+configurationMetadataStoreUrl: <meta-type>:<configuration-metadata-store-url>
 ```
 
 You should also configure a list of superuser roles. The superuser roles are able to access any admin API. The following is a configuration example.

--- a/site2/docs/functions-worker.md
+++ b/site2/docs/functions-worker.md
@@ -216,12 +216,12 @@ properties:
 
 ##### Enable Authorization Provider
 
-To enable authorization on Functions Worker, you need to configure `authorizationEnabled`, `authorizationProvider` and `configurationStoreServers`. The authentication provider connects to `configurationStoreServers` to receive namespace policies.
+To enable authorization on Functions Worker, you need to configure `authorizationEnabled`, `authorizationProvider` and `configurationMetadataStoreUrl`. The authentication provider connects to `configurationMetadataStoreUrl` to receive namespace policies.
 
 ```yaml
 authorizationEnabled: true
 authorizationProvider: org.apache.pulsar.broker.authorization.PulsarAuthorizationProvider
-configurationStoreServers: <configuration-store-servers>
+configurationMetadataStoreUrl: <configuration-store-servers>
 ```
 
 You should also configure a list of superuser roles. The superuser roles are able to access any admin API. The following is a configuration example.

--- a/site2/website-next/docs/functions-runtime.md
+++ b/site2/website-next/docs/functions-runtime.md
@@ -292,7 +292,7 @@ For example, if you use token authentication, you need to configure the followin
 
 clientAuthenticationPlugin: org.apache.pulsar.client.impl.auth.AuthenticationToken
 clientAuthenticationParameters: file:///etc/pulsar/token/admin-token.txt
-configurationStoreServers: zookeeper-cluster:2181 # auth requires a connection to zookeeper
+configurationMetadataStoreUrl: zookeeper-cluster:2181 # auth requires a connection to zookeeper
 authenticationProviders:
  - "org.apache.pulsar.broker.authentication.AuthenticationProviderToken"
 authorizationEnabled: true

--- a/site2/website-next/docs/functions-runtime.md
+++ b/site2/website-next/docs/functions-runtime.md
@@ -292,7 +292,7 @@ For example, if you use token authentication, you need to configure the followin
 
 clientAuthenticationPlugin: org.apache.pulsar.client.impl.auth.AuthenticationToken
 clientAuthenticationParameters: file:///etc/pulsar/token/admin-token.txt
-configurationMetadataStoreUrl: zookeeper-cluster:2181 # auth requires a connection to zookeeper
+configurationMetadataStoreUrl: zk:zookeeper-cluster:2181 # auth requires a connection to zookeeper
 authenticationProviders:
  - "org.apache.pulsar.broker.authentication.AuthenticationProviderToken"
 authorizationEnabled: true

--- a/site2/website-next/docs/functions-worker.md
+++ b/site2/website-next/docs/functions-worker.md
@@ -241,7 +241,7 @@ To enable authorization on Functions Worker, you need to configure `authorizatio
 
 authorizationEnabled: true
 authorizationProvider: org.apache.pulsar.broker.authorization.PulsarAuthorizationProvider
-configurationMetadataStoreUrl: <configuration-store-servers>
+configurationMetadataStoreUrl: <meta-type>:<configuration-metadata-store-url>
 
 ```
 

--- a/site2/website-next/docs/functions-worker.md
+++ b/site2/website-next/docs/functions-worker.md
@@ -235,13 +235,13 @@ properties:
 
 ##### Enable Authorization Provider
 
-To enable authorization on Functions Worker, you need to configure `authorizationEnabled`, `authorizationProvider` and `configurationStoreServers`. The authentication provider connects to `configurationStoreServers` to receive namespace policies.
+To enable authorization on Functions Worker, you need to configure `authorizationEnabled`, `authorizationProvider` and `configurationMetadataStoreUrl`. The authentication provider connects to `configurationMetadataStoreUrl` to receive namespace policies.
 
 ```yaml
 
 authorizationEnabled: true
 authorizationProvider: org.apache.pulsar.broker.authorization.PulsarAuthorizationProvider
-configurationStoreServers: <configuration-store-servers>
+configurationMetadataStoreUrl: <configuration-store-servers>
 
 ```
 


### PR DESCRIPTION
Master Issue: #13077

### Motivation


Allow to configure the metadata store endpoint in functions_worker.yml


### Modifications

Deprecated few config options:
configurationStoreServers --> configurationMetadataStoreUrl
Moved all deprecated settings at the end of functions_worker.yml


### Documentation

Check the box below or label this PR directly (if you have committer privilege).

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [ ] `no-need-doc` 
  
  (Please explain why)
  
- [x] `doc` 
   
site2/docs/functions-runtime.md 
site2/docs/functions-worker.md
site2/website-next/docs/functions-runtime.md 
site2/website-next/docs/functions-worker.md