### PR TITLE
[Doc] Update the C# client page to use newer version of the client library

### DIFF
--- a/site2/docs/client-libraries-dotnet.md
+++ b/site2/docs/client-libraries-dotnet.md
@@ -44,7 +44,7 @@ To install the Pulsar C# client library, following these steps:
 
         ```xml
         <ItemGroup>
-          <PackageReference Include="DotPulsar" Version="0.11.0" />
+          <PackageReference Include="DotPulsar" Version="2.0.1" />
         </ItemGroup>
         ```
 
@@ -57,6 +57,8 @@ This section describes some configuration examples for the Pulsar C# client.
 This example shows how to create a Pulsar C# client connected to localhost.
 
 ```c#
+using DotPulsar;
+
 var client = PulsarClient.Builder().Build();
 ```
 
@@ -74,7 +76,10 @@ This section describes how to create a producer.
 - Create a producer by using the builder.
 
     ```c#
-    var producer = client.NewProducer()
+    using DotPulsar;
+    using DotPulsar.Extensions;
+
+    var producer = client.NewProducer())
                          .Topic("persistent://public/default/mytopic")
                          .Create();
     ```
@@ -82,7 +87,9 @@ This section describes how to create a producer.
 - Create a producer without using the builder.
 
     ```c#
-    var options = new ProducerOptions("persistent://public/default/mytopic");
+    using DotPulsar;
+
+    var options = new ProducerOptions<byte[]>("persistent://public/default/mytopic", Schema.ByteArray);
     var producer = client.CreateProducer(options);
     ```
 
@@ -93,6 +100,9 @@ This section describes how to create a consumer.
 - Create a consumer by using the builder.
 
     ```c#
+    using DotPulsar;
+    using DotPulsar.Extensions;
+
     var consumer = client.NewConsumer()
                          .SubscriptionName("MySubscription")
                          .Topic("persistent://public/default/mytopic")
@@ -102,7 +112,9 @@ This section describes how to create a consumer.
 - Create a consumer without using the builder.
 
     ```c#
-    var options = new ConsumerOptions("MySubscription", "persistent://public/default/mytopic");
+    using DotPulsar;
+
+    var options = new ConsumerOptions<byte[]>("MySubscription", "persistent://public/default/mytopic", Schema.ByteArray);
     var consumer = client.CreateConsumer(options);
     ```
 
@@ -113,6 +125,9 @@ This section describes how to create a reader.
 - Create a reader by using the builder.
 
     ```c#
+    using DotPulsar;
+    using DotPulsar.Extensions;
+
     var reader = client.NewReader()
                        .StartMessageId(MessageId.Earliest)
                        .Topic("persistent://public/default/mytopic")
@@ -122,7 +137,9 @@ This section describes how to create a reader.
 - Create a reader without using the builder.
 
     ```c#
-    var options = new ReaderOptions(MessageId.Earliest, "persistent://public/default/mytopic");
+    using DotPulsar;
+
+    var options = new ReaderOptions<byte[]>(MessageId.Earliest, "persistent://public/default/mytopic", Schema.ByteArray);
     var reader = client.CreateReader(options);
     ```
 
@@ -138,6 +155,8 @@ The Pulsar C# client supports four kinds of encryption policies:
 This example shows how to set the `EnforceUnencrypted` encryption policy.
 
 ```c#
+using DotPulsar;
+
 var client = PulsarClient.Builder()
                          .ConnectionSecurity(EncryptionPolicy.EnforceEncrypted)
                          .Build();
@@ -158,6 +177,9 @@ If you have followed [Authentication using TLS](security-tls-authentication.md),
 2. Use the admin.pfx file to create an X509Certificate2 and pass it to the Pulsar C# client.
 
     ```c#
+    using System.Security.Cryptography.X509Certificates;
+    using DotPulsar;
+
     var clientCertificate = new X509Certificate2("admin.pfx");
     var client = PulsarClient.Builder()
                              .AuthenticateUsingClientCertificate(clientCertificate)
@@ -182,7 +204,6 @@ await producer.Send(data);
 - Send messages with customized metadata by using the builder.
 
     ```c#
-    var data = Encoding.UTF8.GetBytes("Hello World");
     var messageId = await producer.NewMessage()
                                   .Property("SomeKey", "SomeValue")
                                   .Send(data);
@@ -270,6 +291,7 @@ The following table lists states available for the producer.
 | Connected | All is well. |
 | Disconnected | The connection is lost and attempts are being made to reconnect. |
 | Faulted | An unrecoverable error has occurred. |
+| PartiallyConnected | Some of the sub-producers are disconnected. |
 
 This example shows how to monitor the producer state.
 
@@ -280,7 +302,7 @@ private static async ValueTask Monitor(IProducer producer, CancellationToken can
 
     while (!cancellationToken.IsCancellationRequested)
     {
-        state = await producer.StateChangedFrom(state, cancellationToken);
+        state = (await producer.StateChangedFrom(state, cancellationToken)).ProducerState;
 
         var stateMessage = state switch
         {
@@ -288,6 +310,7 @@ private static async ValueTask Monitor(IProducer producer, CancellationToken can
             ProducerState.Disconnected => $"The producer is disconnected",
             ProducerState.Closed => $"The producer has closed",
             ProducerState.Faulted => $"The producer has faulted",
+            ProducerState.PartiallyConnected => $"The producer is partially connected.",
             _ => $"The producer has an unknown state '{state}'"
         };
 
@@ -311,6 +334,7 @@ The following table lists states available for the consumer.
 | Disconnected | The connection is lost and attempts are being made to reconnect. |
 | Faulted | An unrecoverable error has occurred. |
 | ReachedEndOfTopic | No more messages are delivered. |
+| Unsubscribed | The consumer has unsubscribed. |
 
 This example shows how to monitor the consumer state.
 
@@ -321,7 +345,7 @@ private static async ValueTask Monitor(IConsumer consumer, CancellationToken can
 
     while (!cancellationToken.IsCancellationRequested)
     {
-        state = await consumer.StateChangedFrom(state, cancellationToken);
+        state = (await consumer.StateChangedFrom(state, cancellationToken)).ConsumerState;
 
         var stateMessage = state switch
         {
@@ -331,6 +355,7 @@ private static async ValueTask Monitor(IConsumer consumer, CancellationToken can
             ConsumerState.Closed => "The consumer has closed",
             ConsumerState.ReachedEndOfTopic => "The consumer has reached end of topic",
             ConsumerState.Faulted => "The consumer has faulted",
+            ConsumerState.Unsubscribed => "The consumer is unsubscribed.",
             _ => $"The consumer has an unknown state '{state}'"
         };
 
@@ -363,7 +388,7 @@ private static async ValueTask Monitor(IReader reader, CancellationToken cancell
 
     while (!cancellationToken.IsCancellationRequested)
     {
-        state = await reader.StateChangedFrom(state, cancellationToken);
+        state = (await reader.StateChangedFrom(state, cancellationToken)).ReaderState;
 
         var stateMessage = state switch
         {


### PR DESCRIPTION
Fixes #13730

### Motivation

The current version of the docs uses version 0.11 of the C# client library, and the newest version of that library is now 2.0.1.
We need to update the c# client doc to match the new version.

### Modifications

* Update the c# client doc
* Add import codes where necessary

### Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

### Documentation

- [x] `doc` 
  
This is the doc PR


