### PR TITLE
[Build] Upgrade maven-compiler-plugin to 3.9.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -233,6 +233,7 @@ flexible messaging model and an intuitive client API.</description>
     <!-- do not upgrade surefire.version to 3.0.0-M5 since it runs slowly and breaks tests. -->
     <surefire.version>3.0.0-M3</surefire.version>
     <maven-assembly-plugin.version>3.3.0</maven-assembly-plugin.version>
+    <maven-compiler-plugin.version>3.9.0</maven-compiler-plugin.version>
     <maven-dependency-plugin.version>3.1.2</maven-dependency-plugin.version>
     <maven-modernizer-plugin.version>2.3.0</maven-modernizer-plugin.version>
     <maven-shade-plugin>3.2.4</maven-shade-plugin>
@@ -1694,6 +1695,11 @@ flexible messaging model and an intuitive client API.</description>
 
     <pluginManagement>
       <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <version>${maven-compiler-plugin.version}</version>
+        </plugin>
         <plugin>
           <groupId>org.gaul</groupId>
           <artifactId>modernizer-maven-plugin</artifactId>


### PR DESCRIPTION
### Motivation

- sometimes maven compilation fails with very hard to diagnose problems. Some problems have been fixes in recently released maven-compiler-plugin 3.9.0
- announcement of maven-compiler-plugin 3.9.0 with release notes:
  https://lists.apache.org/thread/8bm3powmfy46z25k9jgrbkf1kxf5j6yk

### Modifications

- upgrade maven-compiler-plugin to 3.9.0 . Overrides maven-compiler-plugin defined in https://github.com/apache/maven-apache-parent/blob/99592e229c20f079c1998875e5c24556d217b491/pom.xml#L138-L142 .

### Additional context

The release notes for 3.9.0 don't list https://issues.apache.org/jira/browse/MCOMPILER-346 as fixed. The workaround for that issue is described in #13126 as well as in the Stack overflow answer https://stackoverflow.com/a/70739212 .