### PR TITLE
Fix mutex name in comment out

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
@@ -1504,7 +1504,7 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
                             // Return ManagedLedgerFencedException to addFailed callback
                             // to indicate that the ledger is now fenced and topic needs to be closed
                             clearPendingAddEntries(new ManagedLedgerFencedException(e));
-                            // Do not need to unlock ledgersListMutex here because we are going to close to topic
+                            // Do not need to unlock metadataMutex here because we are going to close to topic
                             // anyways
                             return;
                         }


### PR DESCRIPTION
### Motivation
* Renamed `ledgersListMutex` to `metadataMutex` by https://github.com/apache/pulsar/pull/7357
* But still used `ledgersListMutex` in comment out.


### Modifications

* Renamed `ledgersListMutex` to `metadataMutex` in comment out.

### Documentation

Check the box below and label this PR (if you have committer privilege).

Need to update docs? 


- [x] `no-need-doc` 