### PR TITLE
[Broker] Fix call sync method in async rest api for ``internalDeletePartitionedTopic``

### DIFF
--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authorization/AuthorizationService.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authorization/AuthorizationService.java
@@ -448,21 +448,6 @@ public class AuthorizationService {
         }
     }
 
-    public boolean allowNamespaceOperation(NamespaceName namespaceName,
-                                           NamespaceOperation operation,
-                                           String originalRole,
-                                           String role,
-                                           AuthenticationDataSource authData) {
-        try {
-            return allowNamespaceOperationAsync(
-                    namespaceName, operation, originalRole, role, authData).get();
-        } catch (InterruptedException e) {
-            throw new RestException(e);
-        } catch (ExecutionException e) {
-            throw new RestException(e.getCause());
-        }
-    }
-
     /**
      * Grant authorization-action permission on a namespace to the given client.
      *

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
@@ -574,10 +574,10 @@ public class PersistentTopicsBase extends AdminResource {
                                 return pulsar().getBrokerService()
                                         .deleteSchemaStorage(topicName.getPartition(0).toString())
                                         .thenCompose(unused ->
-                                                internalRemovePartitionsAuthenticationPolicies(numPartitions))
+                                                internalRemovePartitionsAuthenticationPoliciesAsync(numPartitions))
                                         .thenCompose(unused2 -> internalRemovePartitionsTopicAsync(numPartitions, force));
                             }
-                            return internalRemovePartitionsAuthenticationPolicies(numPartitions)
+                            return internalRemovePartitionsAuthenticationPoliciesAsync(numPartitions)
                                     .thenCompose(unused -> internalRemovePartitionsTopicAsync(numPartitions, force));
                         })
                 // Only tries to delete the znode for partitioned topic when all its partitions are successfully deleted
@@ -659,7 +659,7 @@ public class PersistentTopicsBase extends AdminResource {
                 }).collect(Collectors.toList()));
     }
 
-    private CompletableFuture<Void> internalRemovePartitionsAuthenticationPolicies(int numPartitions) {
+    private CompletableFuture<Void> internalRemovePartitionsAuthenticationPoliciesAsync(int numPartitions) {
         CompletableFuture<Void> future = new CompletableFuture<>();
         pulsar().getPulsarResources().getNamespaceResources()
                 .setPoliciesAsync(topicName.getNamespaceObject(), p -> {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
@@ -662,9 +662,9 @@ public class PersistentTopicsBase extends AdminResource {
     private CompletableFuture<Void> internalRemovePartitionsAuthenticationPolicies(int numPartitions) {
         return pulsar().getPulsarResources().getNamespaceResources()
                 .setPoliciesAsync(topicName.getNamespaceObject(), p -> {
-                    for (int i = 0; i < numPartitions; i++) {
-                        p.auth_policies.getTopicAuthentication().remove(topicName.getPartition(i).toString());
-                    }
+                    IntStream.range(0, numPartitions)
+                            .forEach(i -> p.auth_policies.getTopicAuthentication()
+                                    .remove(topicName.getPartition(i).toString()));
                     p.auth_policies.getTopicAuthentication().remove(topicName.toString());
                     return p;
                 }).thenAccept(v ->

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
@@ -562,7 +562,7 @@ public class PersistentTopicsBase extends AdminResource {
                                                   boolean force, boolean deleteSchema) {
         CompletableFuture<PartitionedTopicMetadata> partitionedTopicMetadataCompletableFuture =
                 validateNamespaceOperationAsync(topicName.getNamespaceObject(), NamespaceOperation.DELETE_TOPIC)
-                .thenAccept(__ -> validateTopicOwnershipAsync(topicName, authoritative))
+                .thenCompose(__ -> validateTopicOwnershipAsync(topicName, authoritative))
                 .thenCompose(__ -> pulsar().getBrokerService().fetchPartitionedTopicMetadataAsync(topicName));
         final CompletableFuture<Void> future = new CompletableFuture<>();
         partitionedTopicMetadataCompletableFuture.thenAccept(partitionMeta -> {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
@@ -560,154 +560,145 @@ public class PersistentTopicsBase extends AdminResource {
 
     protected void internalDeletePartitionedTopic(AsyncResponse asyncResponse, boolean authoritative,
                                                   boolean force, boolean deleteSchema) {
-        validateNamespaceOperationAsync(topicName.getNamespaceObject(), NamespaceOperation.DELETE_TOPIC)
-                .thenAccept(__ -> validateTopicOwnershipAsync(topicName, authoritative))
-                .thenAccept(__ -> {
-                    final CompletableFuture<Void> future = new CompletableFuture<>();
-                    pulsar().getBrokerService().fetchPartitionedTopicMetadataAsync(topicName)
-                            .thenAccept(partitionMeta -> {
-                        final int numPartitions = partitionMeta.partitions;
-                        if (numPartitions > 0) {
-                            final AtomicInteger count = new AtomicInteger(numPartitions);
-                            if (deleteSchema) {
-                                count.incrementAndGet();
-                                pulsar().getBrokerService().deleteSchemaStorage(topicName.getPartition(0).toString())
-                                        .whenComplete((r, ex) -> {
-                                            if (ex != null) {
-                                                log.warn("Failed to delete schema storage of topic: {}", topicName);
-                                            }
-                                            if (count.decrementAndGet() == 0) {
-                                                future.complete(null);
-                                            }
-                                        });
-                            }
-                            // delete authentication policies of the partitioned topic
-                            CompletableFuture<Void> deleteAuthFuture = new CompletableFuture<>();
-                            pulsar().getPulsarResources().getNamespaceResources()
-                                    .setPoliciesAsync(topicName.getNamespaceObject(), p -> {
-                                        for (int i = 0; i < numPartitions; i++) {
-                                            p.auth_policies.getTopicAuthentication()
-                                                    .remove(topicName.getPartition(i).toString());
-                                        }
-                                        p.auth_policies.getTopicAuthentication().remove(topicName.toString());
-                                        return p;
-                                    }).thenAccept(v -> {
-                                        log.info("Successfully delete authentication policies" +
-                                                " for partitioned topic {}", topicName);
-                                        deleteAuthFuture.complete(null);
-                                    }).exceptionally(ex -> {
-                                        if (ex.getCause() instanceof MetadataStoreException.NotFoundException) {
-                                            log.warn("Namespace policies of {} not found",
-                                                    topicName.getNamespaceObject());
-                                            deleteAuthFuture.complete(null);
-                                        } else {
-                                            log.error("Failed to delete authentication policies " +
-                                                            "for partitioned topic {}", topicName, ex);
-                                            deleteAuthFuture.completeExceptionally(ex);
-                                        }
-                                        return null;
-                                    });
-
-                            deleteAuthFuture.whenComplete((r, ex) -> {
+        CompletableFuture<PartitionedTopicMetadata> partitionedTopicMetadataCompletableFuture =
+                validateNamespaceOperationAsync(topicName.getNamespaceObject(), NamespaceOperation.DELETE_TOPIC)
+                .thenApply(__ -> validateTopicOwnershipAsync(topicName, authoritative))
+                .thenCompose(__ -> pulsar().getBrokerService().fetchPartitionedTopicMetadataAsync(topicName));
+        final CompletableFuture<Void> future = new CompletableFuture<>();
+        partitionedTopicMetadataCompletableFuture.thenAccept(partitionMeta -> {
+            final int numPartitions = partitionMeta.partitions;
+            if (numPartitions > 0) {
+                final AtomicInteger count = new AtomicInteger(numPartitions);
+                if (deleteSchema) {
+                    count.incrementAndGet();
+                    pulsar().getBrokerService().deleteSchemaStorage(topicName.getPartition(0).toString())
+                            .whenComplete((r, ex) -> {
                                 if (ex != null) {
-                                    future.completeExceptionally(ex);
-                                    return;
+                                    log.warn("Failed to delete schema storage of topic: {}", topicName);
                                 }
-                                for (int i = 0; i < numPartitions; i++) {
-                                    TopicName topicNamePartition = topicName.getPartition(i);
-                                    try {
-                                        pulsar().getAdminClient().topics()
-                                                .deleteAsync(topicNamePartition.toString(), force)
-                                                .whenComplete((r1, ex1) -> {
-                                                    if (ex1 != null) {
-                                                        if (ex1 instanceof NotFoundException) {
-                                                    // if the sub-topic is not found, the client might not have called
-                                                    // create producer or it might have been deleted earlier,
-                                                    //so we ignore the 404 error.
-                                                    // For all other exception,
-                                                    //we fail the delete partition method even if a single
-                                                    // partition is failed to be deleted
-                                                            if (log.isDebugEnabled()) {
-                                                                log.debug("[{}] Partition not found: {}", clientAppId(),
-                                                                        topicNamePartition);
-                                                            }
-                                                        } else {
-                                                            log.error("[{}] Failed to delete partition {}",
-                                                                    clientAppId(), topicNamePartition, ex1);
-                                                            future.completeExceptionally(ex1);
-                                                            return;
-                                                        }
-                                                    } else {
-                                                        log.info("[{}] Deleted partition {}", clientAppId(),
-                                                                topicNamePartition);
-                                                    }
-                                                    if (count.decrementAndGet() == 0) {
-                                                        future.complete(null);
-                                                    }
-                                                });
-                                    } catch (Exception e) {
-                                        log.error("[{}] Failed to delete partition {}", clientAppId(),
-                                                topicNamePartition, e);
-                                        future.completeExceptionally(e);
-                                    }
+                                if (count.decrementAndGet() == 0) {
+                                    future.complete(null);
                                 }
                             });
-                        } else {
-                            future.complete(null);
-                        }
-                    }).exceptionally(ex -> {
-                        future.completeExceptionally(ex);
-                        return null;
-                    });
-
-                    future.whenComplete((r, ex) -> {
-                        if (ex != null) {
-                            if (ex instanceof PreconditionFailedException) {
-                                asyncResponse.resume(
-                                        new RestException(Status.PRECONDITION_FAILED,
-                                                "Topic has active producers/subscriptions"));
-                                return;
-                            } else if (ex instanceof PulsarAdminException) {
-                                asyncResponse.resume(new RestException((PulsarAdminException) ex));
-                                return;
-                            } else if (ex instanceof WebApplicationException) {
-                                asyncResponse.resume(ex);
-                                return;
-                            } else {
-                                asyncResponse.resume(new RestException(ex));
-                                return;
+                }
+                // delete authentication policies of the partitioned topic
+                CompletableFuture<Void> deleteAuthFuture = new CompletableFuture<>();
+                pulsar().getPulsarResources().getNamespaceResources()
+                        .setPoliciesAsync(topicName.getNamespaceObject(), p -> {
+                            for (int i = 0; i < numPartitions; i++) {
+                                p.auth_policies.getTopicAuthentication().remove(topicName.getPartition(i).toString());
                             }
-                        }
-                // Only tries to delete the znode for partitioned topic when all its partitions are successfully deleted
+                            p.auth_policies.getTopicAuthentication().remove(topicName.toString());
+                            return p;
+                        }).thenAccept(v -> {
+                            log.info("Successfully delete authentication policies for partitioned topic {}", topicName);
+                            deleteAuthFuture.complete(null);
+                        }).exceptionally(ex -> {
+                            if (ex.getCause() instanceof MetadataStoreException.NotFoundException) {
+                                log.warn("Namespace policies of {} not found", topicName.getNamespaceObject());
+                                deleteAuthFuture.complete(null);
+                            } else {
+                                log.error("Failed to delete authentication policies for partitioned topic {}",
+                                        topicName, ex);
+                                deleteAuthFuture.completeExceptionally(ex);
+                            }
+                            return null;
+                        });
+
+                deleteAuthFuture.whenComplete((r, ex) -> {
+                    if (ex != null) {
+                        future.completeExceptionally(ex);
+                        return;
+                    }
+                    for (int i = 0; i < numPartitions; i++) {
+                        TopicName topicNamePartition = topicName.getPartition(i);
                         try {
-                            namespaceResources().getPartitionedTopicResources()
-                                    .deletePartitionedTopicAsync(topicName).thenAccept(r2 -> {
-                                        log.info("[{}] Deleted partitioned topic {}", clientAppId(), topicName);
-                                        asyncResponse.resume(Response.noContent().build());
-                                    }).exceptionally(ex1 -> {
-                                        log.error("[{}] Failed to delete partitioned topic {}", clientAppId(),
-                                                topicName, ex1.getCause());
-                                        if (ex1.getCause() instanceof MetadataStoreException.NotFoundException) {
-                                            asyncResponse.resume(new RestException(
-                                                    new RestException(Status.NOT_FOUND,
-                                                            "Partitioned topic does not exist")));
-                                        } else if (ex1
-                                                .getCause()
-                                                instanceof MetadataStoreException.BadVersionException) {
-                                            asyncResponse.resume(
-                                                    new RestException(new RestException(Status.CONFLICT,
-                                                            "Concurrent modification")));
+                            pulsar().getAdminClient().topics()
+                                    .deleteAsync(topicNamePartition.toString(), force)
+                                    .whenComplete((r1, ex1) -> {
+                                        if (ex1 != null) {
+                                            if (ex1 instanceof NotFoundException) {
+                                                // if the sub-topic is not found, the client might not have called
+                                                // create producer or it might have been deleted earlier,
+                                                //so we ignore the 404 error.
+                                                // For all other exception,
+                                                //we fail the delete partition method even if a single
+                                                // partition is failed to be deleted
+                                                if (log.isDebugEnabled()) {
+                                                    log.debug("[{}] Partition not found: {}", clientAppId(),
+                                                            topicNamePartition);
+                                                }
+                                            } else {
+                                                log.error("[{}] Failed to delete partition {}", clientAppId(),
+                                                        topicNamePartition, ex1);
+                                                future.completeExceptionally(ex1);
+                                                return;
+                                            }
                                         } else {
-                                            asyncResponse.resume(new RestException((ex1.getCause())));
+                                            log.info("[{}] Deleted partition {}", clientAppId(), topicNamePartition);
                                         }
-                                        return null;
+                                        if (count.decrementAndGet() == 0) {
+                                            future.complete(null);
+                                        }
                                     });
-                        } catch (Exception e1) {
-                            log.error("[{}] Failed to delete partitioned topic {}", clientAppId(), topicName, e1);
-                            asyncResponse.resume(new RestException(e1));
+                        } catch (Exception e) {
+                            log.error("[{}] Failed to delete partition {}", clientAppId(), topicNamePartition, e);
+                            future.completeExceptionally(e);
                         }
-                    });
-                }).exceptionally(ex ->{
+                    }
+                });
+            } else {
+                future.complete(null);
+            }
+        }).exceptionally(ex -> {
+            future.completeExceptionally(ex);
+            return null;
+        });
+
+        future.whenComplete((r, ex) -> {
+            if (ex != null) {
+                if (ex instanceof PreconditionFailedException) {
+                    asyncResponse.resume(
+                            new RestException(Status.PRECONDITION_FAILED, "Topic has active producers/subscriptions"));
+                    return;
+                } else if (ex instanceof PulsarAdminException) {
+                    asyncResponse.resume(new RestException((PulsarAdminException) ex));
+                    return;
+                } else if (ex instanceof WebApplicationException) {
+                    asyncResponse.resume(ex);
+                    return;
+                } else {
+                    asyncResponse.resume(new RestException(ex));
+                    return;
+                }
+            }
+            // Only tries to delete the znode for partitioned topic when all its partitions are successfully deleted
+            try {
+                namespaceResources().getPartitionedTopicResources()
+                        .deletePartitionedTopicAsync(topicName).thenAccept(r2 -> {
+                            log.info("[{}] Deleted partitioned topic {}", clientAppId(), topicName);
+                            asyncResponse.resume(Response.noContent().build());
+                }).exceptionally(ex1 -> {
+                    log.error("[{}] Failed to delete partitioned topic {}", clientAppId(), topicName, ex1.getCause());
+                    if (ex1.getCause()
+                            instanceof org.apache.pulsar.metadata.api.MetadataStoreException.NotFoundException) {
+                        asyncResponse.resume(new RestException(
+                                new RestException(Status.NOT_FOUND, "Partitioned topic does not exist")));
+                    } else if (ex1
+                            .getCause()
+                            instanceof org.apache.pulsar.metadata.api.MetadataStoreException.BadVersionException) {
+                        asyncResponse.resume(
+                                new RestException(new RestException(Status.CONFLICT, "Concurrent modification")));
+                    } else {
+                        asyncResponse.resume(new RestException((ex1.getCause())));
+                    }
+                    return null;
+                });
+            } catch (Exception e1) {
+                log.error("[{}] Failed to delete partitioned topic {}", clientAppId(), topicName, e1);
+                asyncResponse.resume(new RestException(e1));
+            }
+        }).exceptionally(ex ->{
             Throwable cause = ex.getCause();
             if (cause instanceof  WebApplicationException && ((WebApplicationException) cause).getResponse().getStatus()
                     == Status.TEMPORARY_REDIRECT.getStatusCode()) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
@@ -587,7 +587,7 @@ public class PersistentTopicsBase extends AdminResource {
                     log.info("[{}] Deleted partitioned topic {}", clientAppId(), topicName);
                     asyncResponse.resume(Response.noContent().build());
                 }).exceptionally(ex -> {
-                    Throwable realCause = FutureUtil.unwrapException(ex);
+                    Throwable realCause = FutureUtil.unwrapCompletionException(ex);
                     if (realCause instanceof
                             WebApplicationException && ((WebApplicationException) realCause).getResponse().getStatus()
                             == Status.TEMPORARY_REDIRECT.getStatusCode()) {
@@ -628,7 +628,7 @@ public class PersistentTopicsBase extends AdminResource {
                                 .deleteAsync(topicNamePartition.toString(), force)
                                 .whenComplete((r, ex) -> {
                                     if (ex != null) {
-                                        Throwable realCause = FutureUtil.unwrapException(ex);
+                                        Throwable realCause = FutureUtil.unwrapCompletionException(ex);
                                         if (realCause instanceof NotFoundException){
                                             // if the sub-topic is not found, the client might not have called
                                             // create producer or it might have been deleted earlier,

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
@@ -562,7 +562,7 @@ public class PersistentTopicsBase extends AdminResource {
                                                   boolean force, boolean deleteSchema) {
         CompletableFuture<PartitionedTopicMetadata> partitionedTopicMetadataCompletableFuture =
                 validateNamespaceOperationAsync(topicName.getNamespaceObject(), NamespaceOperation.DELETE_TOPIC)
-                .thenApply(__ -> validateTopicOwnershipAsync(topicName, authoritative))
+                .thenAccept(__ -> validateTopicOwnershipAsync(topicName, authoritative))
                 .thenCompose(__ -> pulsar().getBrokerService().fetchPartitionedTopicMetadataAsync(topicName));
         final CompletableFuture<Void> future = new CompletableFuture<>();
         partitionedTopicMetadataCompletableFuture.thenAccept(partitionMeta -> {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
@@ -588,8 +588,8 @@ public class PersistentTopicsBase extends AdminResource {
                     asyncResponse.resume(Response.noContent().build());
                 }).exceptionally(ex -> {
                     Throwable realCause = FutureUtil.unwrapCompletionException(ex);
-                    if (realCause instanceof
-                            WebApplicationException && ((WebApplicationException) realCause).getResponse().getStatus()
+                    if (realCause instanceof WebApplicationException
+                            && ((WebApplicationException) realCause).getResponse().getStatus()
                             == Status.TEMPORARY_REDIRECT.getStatusCode()) {
                         if (log.isDebugEnabled()) {
                             log.debug("[{}] Failed to delete partitioned topic {}, redirecting to other brokers.",

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
@@ -575,10 +575,10 @@ public class PersistentTopicsBase extends AdminResource {
                                         .deleteSchemaStorage(topicName.getPartition(0).toString())
                                         .thenCompose(unused ->
                                                 internalRemovePartitionsAuthenticationPolicies(numPartitions))
-                                        .thenCompose(unused2 -> internalRemovePartitionsTopic(numPartitions, force));
+                                        .thenCompose(unused2 -> internalRemovePartitionsTopicAsync(numPartitions, force));
                             }
                             return internalRemovePartitionsAuthenticationPolicies(numPartitions)
-                                    .thenCompose(unused -> internalRemovePartitionsTopic(numPartitions, force));
+                                    .thenCompose(unused -> internalRemovePartitionsTopicAsync(numPartitions, force));
                         })
                 // Only tries to delete the znode for partitioned topic when all its partitions are successfully deleted
                 ).thenCompose(__ -> namespaceResources()
@@ -618,7 +618,7 @@ public class PersistentTopicsBase extends AdminResource {
                 });
     }
 
-    private CompletableFuture<Void> internalRemovePartitionsTopic(int numPartitions, boolean force) {
+    private CompletableFuture<Void> internalRemovePartitionsTopicAsync(int numPartitions, boolean force) {
         return FutureUtil.waitForAll(IntStream.range(0, numPartitions)
                 .mapToObj(i -> {
                     TopicName topicNamePartition = topicName.getPartition(i);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
@@ -575,7 +575,8 @@ public class PersistentTopicsBase extends AdminResource {
                                         .deleteSchemaStorage(topicName.getPartition(0).toString())
                                         .thenCompose(unused ->
                                                 internalRemovePartitionsAuthenticationPoliciesAsync(numPartitions))
-                                        .thenCompose(unused2 -> internalRemovePartitionsTopicAsync(numPartitions, force));
+                                        .thenCompose(unused2 ->
+                                                internalRemovePartitionsTopicAsync(numPartitions, force));
                             }
                             return internalRemovePartitionsAuthenticationPoliciesAsync(numPartitions)
                                     .thenCompose(unused -> internalRemovePartitionsTopicAsync(numPartitions, force));

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
@@ -44,6 +44,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiConsumer;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.container.AsyncResponse;
 import javax.ws.rs.core.Response;
@@ -560,158 +561,114 @@ public class PersistentTopicsBase extends AdminResource {
 
     protected void internalDeletePartitionedTopic(AsyncResponse asyncResponse, boolean authoritative,
                                                   boolean force, boolean deleteSchema) {
-        CompletableFuture<PartitionedTopicMetadata> partitionedTopicMetadataCompletableFuture =
-                validateNamespaceOperationAsync(topicName.getNamespaceObject(), NamespaceOperation.DELETE_TOPIC)
+        validateNamespaceOperationAsync(topicName.getNamespaceObject(), NamespaceOperation.DELETE_TOPIC)
                 .thenCompose(__ -> validateTopicOwnershipAsync(topicName, authoritative))
-                .thenCompose(__ -> pulsar().getBrokerService().fetchPartitionedTopicMetadataAsync(topicName));
-        final CompletableFuture<Void> future = new CompletableFuture<>();
-        partitionedTopicMetadataCompletableFuture.thenAccept(partitionMeta -> {
-            final int numPartitions = partitionMeta.partitions;
-            if (numPartitions > 0) {
-                final AtomicInteger count = new AtomicInteger(numPartitions);
-                if (deleteSchema) {
-                    count.incrementAndGet();
-                    pulsar().getBrokerService().deleteSchemaStorage(topicName.getPartition(0).toString())
-                            .whenComplete((r, ex) -> {
-                                if (ex != null) {
-                                    log.warn("Failed to delete schema storage of topic: {}", topicName);
-                                }
-                                if (count.decrementAndGet() == 0) {
-                                    future.complete(null);
-                                }
-                            });
-                }
-                // delete authentication policies of the partitioned topic
-                CompletableFuture<Void> deleteAuthFuture = new CompletableFuture<>();
-                pulsar().getPulsarResources().getNamespaceResources()
-                        .setPoliciesAsync(topicName.getNamespaceObject(), p -> {
-                            for (int i = 0; i < numPartitions; i++) {
-                                p.auth_policies.getTopicAuthentication().remove(topicName.getPartition(i).toString());
+                .thenCompose(__ -> pulsar().getBrokerService()
+                        .fetchPartitionedTopicMetadataAsync(topicName)
+                        .thenCompose(partitionedMeta -> {
+                            final int numPartitions = partitionedMeta.partitions;
+                            if (numPartitions < 1){
+                                return CompletableFuture.completedFuture(null);
                             }
-                            p.auth_policies.getTopicAuthentication().remove(topicName.toString());
-                            return p;
-                        }).thenAccept(v -> {
-                            log.info("Successfully delete authentication policies for partitioned topic {}", topicName);
-                            deleteAuthFuture.complete(null);
-                        }).exceptionally(ex -> {
-                            if (ex.getCause() instanceof MetadataStoreException.NotFoundException) {
-                                log.warn("Namespace policies of {} not found", topicName.getNamespaceObject());
-                                deleteAuthFuture.complete(null);
-                            } else {
-                                log.error("Failed to delete authentication policies for partitioned topic {}",
-                                        topicName, ex);
-                                deleteAuthFuture.completeExceptionally(ex);
+                            if (deleteSchema) {
+                                return pulsar().getBrokerService()
+                                        .deleteSchemaStorage(topicName.getPartition(0).toString())
+                                        .thenCompose(unused ->
+                                                internalRemovePartitionsAuthenticationPolicies(numPartitions))
+                                        .thenCompose(unused2 -> internalRemovePartitionsTopic(numPartitions, force));
                             }
-                            return null;
-                        });
-
-                deleteAuthFuture.whenComplete((r, ex) -> {
-                    if (ex != null) {
-                        future.completeExceptionally(ex);
-                        return;
-                    }
-                    for (int i = 0; i < numPartitions; i++) {
-                        TopicName topicNamePartition = topicName.getPartition(i);
-                        try {
-                            pulsar().getAdminClient().topics()
-                                    .deleteAsync(topicNamePartition.toString(), force)
-                                    .whenComplete((r1, ex1) -> {
-                                        if (ex1 != null) {
-                                            if (ex1 instanceof NotFoundException) {
-                                                // if the sub-topic is not found, the client might not have called
-                                                // create producer or it might have been deleted earlier,
-                                                //so we ignore the 404 error.
-                                                // For all other exception,
-                                                //we fail the delete partition method even if a single
-                                                // partition is failed to be deleted
-                                                if (log.isDebugEnabled()) {
-                                                    log.debug("[{}] Partition not found: {}", clientAppId(),
-                                                            topicNamePartition);
-                                                }
-                                            } else {
-                                                log.error("[{}] Failed to delete partition {}", clientAppId(),
-                                                        topicNamePartition, ex1);
-                                                future.completeExceptionally(ex1);
-                                                return;
-                                            }
-                                        } else {
-                                            log.info("[{}] Deleted partition {}", clientAppId(), topicNamePartition);
-                                        }
-                                        if (count.decrementAndGet() == 0) {
-                                            future.complete(null);
-                                        }
-                                    });
-                        } catch (Exception e) {
-                            log.error("[{}] Failed to delete partition {}", clientAppId(), topicNamePartition, e);
-                            future.completeExceptionally(e);
+                            return internalRemovePartitionsAuthenticationPolicies(numPartitions)
+                                    .thenCompose(unused -> internalRemovePartitionsTopic(numPartitions, force));
+                        })
+                // Only tries to delete the znode for partitioned topic when all its partitions are successfully deleted
+                ).thenCompose(__ -> namespaceResources()
+                                .getPartitionedTopicResources().deletePartitionedTopicAsync(topicName))
+                .thenAccept(__ -> {
+                    log.info("[{}] Deleted partitioned topic {}", clientAppId(), topicName);
+                    asyncResponse.resume(Response.noContent().build());
+                }).exceptionally(ex -> {
+                    Throwable realCause = FutureUtil.unwrapException(ex);
+                    if (realCause instanceof
+                            WebApplicationException && ((WebApplicationException) realCause).getResponse().getStatus()
+                            == Status.TEMPORARY_REDIRECT.getStatusCode()) {
+                        if (log.isDebugEnabled()) {
+                            log.debug("[{}] Failed to delete partitioned topic {}, redirecting to other brokers.",
+                                    clientAppId(), topicName, realCause);
                         }
-                    }
-                });
-            } else {
-                future.complete(null);
-            }
-        }).exceptionally(ex -> {
-            future.completeExceptionally(ex);
-            return null;
-        });
-
-        future.whenComplete((r, ex) -> {
-            if (ex != null) {
-                if (ex instanceof PreconditionFailedException) {
-                    asyncResponse.resume(
-                            new RestException(Status.PRECONDITION_FAILED, "Topic has active producers/subscriptions"));
-                    return;
-                } else if (ex instanceof PulsarAdminException) {
-                    asyncResponse.resume(new RestException((PulsarAdminException) ex));
-                    return;
-                } else if (ex instanceof WebApplicationException) {
-                    asyncResponse.resume(ex);
-                    return;
-                } else {
-                    asyncResponse.resume(new RestException(ex));
-                    return;
-                }
-            }
-            // Only tries to delete the znode for partitioned topic when all its partitions are successfully deleted
-            try {
-                namespaceResources().getPartitionedTopicResources()
-                        .deletePartitionedTopicAsync(topicName).thenAccept(r2 -> {
-                            log.info("[{}] Deleted partitioned topic {}", clientAppId(), topicName);
-                            asyncResponse.resume(Response.noContent().build());
-                }).exceptionally(ex1 -> {
-                    log.error("[{}] Failed to delete partitioned topic {}", clientAppId(), topicName, ex1.getCause());
-                    if (ex1.getCause()
-                            instanceof org.apache.pulsar.metadata.api.MetadataStoreException.NotFoundException) {
+                    } else if (realCause instanceof PreconditionFailedException) {
+                        asyncResponse.resume(
+                                new RestException(Status.PRECONDITION_FAILED,
+                                        "Topic has active producers/subscriptions"));
+                    } else if (realCause instanceof WebApplicationException){
+                        asyncResponse.resume(realCause);
+                    } else if (realCause instanceof MetadataStoreException.NotFoundException) {
+                        log.warn("Namespace policies of {} not found", topicName.getNamespaceObject());
                         asyncResponse.resume(new RestException(
                                 new RestException(Status.NOT_FOUND, "Partitioned topic does not exist")));
-                    } else if (ex1
-                            .getCause()
-                            instanceof org.apache.pulsar.metadata.api.MetadataStoreException.BadVersionException) {
-                        asyncResponse.resume(
-                                new RestException(new RestException(Status.CONFLICT, "Concurrent modification")));
+                    } else if (realCause instanceof PulsarAdminException) {
+                        asyncResponse.resume(new RestException((PulsarAdminException) realCause));
+                    } else if (realCause instanceof MetadataStoreException.BadVersionException) {
+                        asyncResponse.resume(new RestException(
+                                new RestException(Status.CONFLICT, "Concurrent modification")));
                     } else {
-                        asyncResponse.resume(new RestException((ex1.getCause())));
+                        log.warn("[{}] Fail to Delete partitioned topic {}", clientAppId(), topicName, realCause);
+                        asyncResponse.resume(new RestException(realCause));
                     }
                     return null;
                 });
-            } catch (Exception e1) {
-                log.error("[{}] Failed to delete partitioned topic {}", clientAppId(), topicName, e1);
-                asyncResponse.resume(new RestException(e1));
-            }
-        }).exceptionally(ex -> {
-            Throwable cause = FutureUtil.getOriginalException(ex);
-            if (cause instanceof WebApplicationException && ((WebApplicationException) cause).getResponse().getStatus()
-                    == Status.TEMPORARY_REDIRECT.getStatusCode()) {
-                if (log.isDebugEnabled()) {
-                    log.debug("[{}] Failed to delete partitioned topic {}, redirecting to other brokers.",
-                            clientAppId(), topicName, cause);
-                }
-            } else {
-                log.error("[{}] Failed to delete partitioned topic {}", clientAppId(), topicName, cause);
-            }
-            resumeAsyncResponseExceptionally(asyncResponse, cause);
-            return null;
-        });
+    }
+
+    private CompletableFuture<Void> internalRemovePartitionsTopic(int numPartitions, boolean force) {
+        return FutureUtil.waitForAll(IntStream.range(0, numPartitions)
+                .mapToObj(i -> {
+                    TopicName topicNamePartition = topicName.getPartition(i);
+                    try {
+                        CompletableFuture<Void> deleteFutures = new CompletableFuture<>();
+                        pulsar().getAdminClient().topics()
+                                .deleteAsync(topicNamePartition.toString(), force)
+                                .whenComplete((r, ex) -> {
+                                    if (ex != null) {
+                                        Throwable realCause = FutureUtil.unwrapException(ex);
+                                        if (realCause instanceof NotFoundException){
+                                            // if the sub-topic is not found, the client might not have called
+                                            // create producer or it might have been deleted earlier,
+                                            // so we ignore the 404 error.
+                                            // For all other exception,
+                                            // we fail the delete partition method even if a single
+                                            // partition is failed to be deleted
+                                            if (log.isDebugEnabled()) {
+                                                log.debug("[{}] Partition not found: {}", clientAppId(),
+                                                        topicNamePartition);
+                                            }
+                                            deleteFutures.complete(null);
+                                        } else {
+                                            log.error("[{}] Failed to delete partition {}", clientAppId(),
+                                                    topicNamePartition, realCause);
+                                            deleteFutures.completeExceptionally(realCause);
+                                        }
+                                    } else {
+                                        deleteFutures.complete(null);
+                                    }
+                                });
+                        return deleteFutures;
+                    } catch (PulsarServerException ex) {
+                        log.error("[{}] Failed to get admin client while delete partition {}",
+                                clientAppId(), topicNamePartition, ex);
+                        return FutureUtil.failedFuture(ex);
+                    }
+                }).collect(Collectors.toList()));
+    }
+
+    private CompletableFuture<Void> internalRemovePartitionsAuthenticationPolicies(int numPartitions) {
+        return pulsar().getPulsarResources().getNamespaceResources()
+                .setPoliciesAsync(topicName.getNamespaceObject(), p -> {
+                    for (int i = 0; i < numPartitions; i++) {
+                        p.auth_policies.getTopicAuthentication().remove(topicName.getPartition(i).toString());
+                    }
+                    p.auth_policies.getTopicAuthentication().remove(topicName.toString());
+                    return p;
+                }).thenAccept(v ->
+                        log.info("Successfully delete authentication policies for partitioned topic {}", topicName));
     }
 
     protected void internalUnloadTopic(AsyncResponse asyncResponse, boolean authoritative) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
@@ -698,9 +698,9 @@ public class PersistentTopicsBase extends AdminResource {
                 log.error("[{}] Failed to delete partitioned topic {}", clientAppId(), topicName, e1);
                 asyncResponse.resume(new RestException(e1));
             }
-        }).exceptionally(ex ->{
+        }).exceptionally(ex -> {
             Throwable cause = FutureUtil.getOriginalException(ex);
-            if (cause instanceof  WebApplicationException && ((WebApplicationException) cause).getResponse().getStatus()
+            if (cause instanceof WebApplicationException && ((WebApplicationException) cause).getResponse().getStatus()
                     == Status.TEMPORARY_REDIRECT.getStatusCode()) {
                 if (log.isDebugEnabled()) {
                     log.debug("[{}] Failed to delete partitioned topic {}, redirecting to other brokers.",

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
@@ -699,7 +699,7 @@ public class PersistentTopicsBase extends AdminResource {
                 asyncResponse.resume(new RestException(e1));
             }
         }).exceptionally(ex ->{
-            Throwable cause = ex.getCause();
+            Throwable cause = FutureUtil.getOriginalException(ex);
             if (cause instanceof  WebApplicationException && ((WebApplicationException) cause).getResponse().getStatus()
                     == Status.TEMPORARY_REDIRECT.getStatusCode()) {
                 if (log.isDebugEnabled()) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/PulsarWebResource.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/PulsarWebResource.java
@@ -888,7 +888,8 @@ public abstract class PulsarWebResource {
             && pulsar().getBrokerService().isAuthorizationEnabled()) {
             if (!isClientAuthenticated(clientAppId())) {
                 return FutureUtil
-                        .failedFuture(new RestException(Status.FORBIDDEN, "Need to authenticate to perform the request"));
+                        .failedFuture(new RestException(Status.FORBIDDEN,
+                                "Need to authenticate to perform the request"));
             }
 
             return pulsar().getBrokerService().getAuthorizationService()
@@ -898,7 +899,7 @@ public abstract class PulsarWebResource {
                         if (!isAuthorized) {
                             throw new RestException(Status.FORBIDDEN,
                                     String.format("Unauthorized to validateNamespaceOperation for"
-                                            + " operation [%s] on namespace [%s]", operation.toString(), namespaceName));
+                                        + " operation [%s] on namespace [%s]", operation.toString(), namespaceName));
                         }
                     });
         }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/PulsarWebResource.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/PulsarWebResource.java
@@ -887,9 +887,7 @@ public abstract class PulsarWebResource {
         if (pulsar().getConfiguration().isAuthenticationEnabled()
             && pulsar().getBrokerService().isAuthorizationEnabled()) {
             if (!isClientAuthenticated(clientAppId())) {
-                return FutureUtil
-                        .failedFuture(new RestException(Status.FORBIDDEN,
-                                "Need to authenticate to perform the request"));
+                throw new RestException(Status.FORBIDDEN, "Need to authenticate to perform the request");
             }
 
             return pulsar().getBrokerService().getAuthorizationService()

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/PulsarWebResource.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/PulsarWebResource.java
@@ -1072,7 +1072,7 @@ public abstract class PulsarWebResource {
         try {
             validateTopicOperationAsync(topicName, operation, subscription).get();
         } catch (InterruptedException | ExecutionException e) {
-            Throwable cause = e.getCause();
+            Throwable cause = FutureUtil.getOriginalException(e);
             if (cause instanceof WebApplicationException){
                 throw (WebApplicationException) cause;
             } else {
@@ -1090,7 +1090,8 @@ public abstract class PulsarWebResource {
         if (pulsar().getConfiguration().isAuthenticationEnabled()
                 && pulsar().getBrokerService().isAuthorizationEnabled()) {
             if (!isClientAuthenticated(clientAppId())) {
-                throw new RestException(Status.UNAUTHORIZED, "Need to authenticate to perform the request");
+                return FutureUtil.failedFuture(
+                        new RestException(Status.UNAUTHORIZED, "Need to authenticate to perform the request"));
             }
             AuthenticationDataHttps authData = clientAuthData();
             authData.setSubscription(subscription);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/PulsarWebResource.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/PulsarWebResource.java
@@ -887,7 +887,8 @@ public abstract class PulsarWebResource {
         if (pulsar().getConfiguration().isAuthenticationEnabled()
             && pulsar().getBrokerService().isAuthorizationEnabled()) {
             if (!isClientAuthenticated(clientAppId())) {
-                throw new RestException(Status.FORBIDDEN, "Need to authenticate to perform the request");
+                return FutureUtil.failedFuture(
+                        new RestException(Status.FORBIDDEN, "Need to authenticate to perform the request"));
             }
 
             return pulsar().getBrokerService().getAuthorizationService()

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/PulsarWebResource.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/PulsarWebResource.java
@@ -868,8 +868,9 @@ public abstract class PulsarWebResource {
 
     public void validateNamespaceOperation(NamespaceName namespaceName, NamespaceOperation operation) {
         try {
-            validateNamespaceOperationAsync(namespaceName, operation).get();
-        } catch (InterruptedException e) {
+            int timeout = pulsar().getConfiguration().getZooKeeperOperationTimeoutSeconds();
+            validateNamespaceOperationAsync(namespaceName, operation).get(timeout, SECONDS);
+        } catch (InterruptedException | TimeoutException e) {
             throw new RestException(e);
         } catch (ExecutionException e) {
             Throwable cause = e.getCause();

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/PulsarWebResource.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/PulsarWebResource.java
@@ -1073,7 +1073,7 @@ public abstract class PulsarWebResource {
         try {
             validateTopicOperationAsync(topicName, operation, subscription).get();
         } catch (InterruptedException | ExecutionException e) {
-            Throwable cause = FutureUtil.getOriginalException(e);
+            Throwable cause = FutureUtil.unwrapException(e);
             if (cause instanceof WebApplicationException){
                 throw (WebApplicationException) cause;
             } else {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/PulsarWebResource.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/PulsarWebResource.java
@@ -894,7 +894,7 @@ public abstract class PulsarWebResource {
             return pulsar().getBrokerService().getAuthorizationService()
                     .allowNamespaceOperationAsync(namespaceName, operation, originalPrincipal(),
                              clientAppId(), clientAuthData())
-                    .thenAccept(isAuthorized ->{
+                    .thenAccept(isAuthorized -> {
                         if (!isAuthorized) {
                             throw new RestException(Status.FORBIDDEN,
                                     String.format("Unauthorized to validateNamespaceOperation for"

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/PulsarWebResource.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/PulsarWebResource.java
@@ -1074,7 +1074,7 @@ public abstract class PulsarWebResource {
         try {
             validateTopicOperationAsync(topicName, operation, subscription).get();
         } catch (InterruptedException | ExecutionException e) {
-            Throwable cause = FutureUtil.unwrapException(e);
+            Throwable cause = FutureUtil.unwrapCompletionException(e);
             if (cause instanceof WebApplicationException){
                 throw (WebApplicationException) cause;
             } else {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/PulsarWebResource.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/PulsarWebResource.java
@@ -866,23 +866,43 @@ public abstract class PulsarWebResource {
         }
     }
 
-    public void validateNamespaceOperation(NamespaceName namespaceName, NamespaceOperation operation) {
+    public void validateNamespaceOperation(NamespaceName namespaceName, NamespaceOperation operation){
+        try {
+            validateNamespaceOperationAsync(namespaceName, operation).get();
+        } catch (InterruptedException e) {
+            throw new RestException(e);
+        } catch (ExecutionException e) {
+            Throwable cause = e.getCause();
+            if (cause instanceof WebApplicationException){
+                throw (WebApplicationException) cause;
+            } else {
+                throw new RestException(cause);
+            }
+        }
+    }
+
+
+    public CompletableFuture<Void> validateNamespaceOperationAsync(NamespaceName namespaceName,
+                                                              NamespaceOperation operation) {
         if (pulsar().getConfiguration().isAuthenticationEnabled()
             && pulsar().getBrokerService().isAuthorizationEnabled()) {
             if (!isClientAuthenticated(clientAppId())) {
-                throw new RestException(Status.FORBIDDEN, "Need to authenticate to perform the request");
+                return FutureUtil
+                        .failedFuture(new RestException(Status.FORBIDDEN, "Need to authenticate to perform the request"));
             }
 
-            boolean isAuthorized = pulsar().getBrokerService().getAuthorizationService()
-                    .allowNamespaceOperation(namespaceName, operation, originalPrincipal(),
-                        clientAppId(), clientAuthData());
-
-            if (!isAuthorized) {
-                throw new RestException(Status.FORBIDDEN,
-                        String.format("Unauthorized to validateNamespaceOperation for"
-                                + " operation [%s] on namespace [%s]", operation.toString(), namespaceName));
-            }
+            return pulsar().getBrokerService().getAuthorizationService()
+                    .allowNamespaceOperationAsync(namespaceName, operation, originalPrincipal(),
+                             clientAppId(), clientAuthData())
+                    .thenAccept(isAuthorized ->{
+                        if (!isAuthorized) {
+                            throw new RestException(Status.FORBIDDEN,
+                                    String.format("Unauthorized to validateNamespaceOperation for"
+                                            + " operation [%s] on namespace [%s]", operation.toString(), namespaceName));
+                        }
+                    });
         }
+        return CompletableFuture.completedFuture(null);
     }
 
     public void validateNamespacePolicyOperation(NamespaceName namespaceName,

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/PulsarWebResource.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/PulsarWebResource.java
@@ -866,7 +866,7 @@ public abstract class PulsarWebResource {
         }
     }
 
-    public void validateNamespaceOperation(NamespaceName namespaceName, NamespaceOperation operation){
+    public void validateNamespaceOperation(NamespaceName namespaceName, NamespaceOperation operation) {
         try {
             validateNamespaceOperationAsync(namespaceName, operation).get();
         } catch (InterruptedException e) {

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
@@ -673,7 +673,7 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
                                         .orElse(Schema.BYTES.getSchemaInfo());
         getOrCreateSchemaAsync(cnx, schemaInfo).handle((v, ex) -> {
             if (ex != null) {
-                Throwable t = FutureUtil.unwrapException(ex);
+                Throwable t = FutureUtil.unwrapCompletionException(ex);
                 log.warn("[{}] [{}] GetOrCreateSchema error", topic, producerName, t);
                 if (t instanceof PulsarClientException.IncompatibleSchemaException) {
                     msg.setSchemaState(MessageImpl.SchemaState.Broken);

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
@@ -673,7 +673,7 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
                                         .orElse(Schema.BYTES.getSchemaInfo());
         getOrCreateSchemaAsync(cnx, schemaInfo).handle((v, ex) -> {
             if (ex != null) {
-                Throwable t = FutureUtil.unwrapCompletionException(ex);
+                Throwable t = FutureUtil.unwrapException(ex);
                 log.warn("[{}] [{}] GetOrCreateSchema error", topic, producerName, t);
                 if (t instanceof PulsarClientException.IncompatibleSchemaException) {
                     msg.setSchemaState(MessageImpl.SchemaState.Broken);

--- a/pulsar-common/pom.xml
+++ b/pulsar-common/pom.xml
@@ -206,6 +206,12 @@
       <groupId>com.beust</groupId>
       <artifactId>jcommander</artifactId>
     </dependency>
+
+    <dependency>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/util/FutureUtil.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/util/FutureUtil.java
@@ -99,14 +99,6 @@ public class FutureUtil {
         return future;
     }
 
-    public static Throwable unwrapCompletionException(Throwable t) {
-        if (t instanceof CompletionException) {
-            return unwrapCompletionException(t.getCause());
-        } else {
-            return t;
-        }
-    }
-
     /**
      * Creates a new {@link CompletableFuture} instance with timeout handling.
      *

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/util/FutureUtil.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/util/FutureUtil.java
@@ -174,7 +174,7 @@ public class FutureUtil {
         }
     }
 
-    public static Throwable getOriginalException(Throwable ex) {
+    public static Throwable unwrapException(Throwable ex) {
         if (ex instanceof CompletionException) {
             return ex.getCause();
         } else if (ex instanceof ExecutionException) {

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/util/FutureUtil.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/util/FutureUtil.java
@@ -174,6 +174,16 @@ public class FutureUtil {
         }
     }
 
+    public static Throwable getOriginalException(Throwable ex) {
+        if (ex instanceof CompletionException) {
+            return ex.getCause();
+        } else if (ex instanceof ExecutionException) {
+            return ex.getCause();
+        } else {
+            return ex;
+        }
+    }
+
     public static <T> Optional<Throwable> getException(CompletableFuture<T> future) {
         if (future != null && future.isCompletedExceptionally()) {
             try {

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/util/FutureUtil.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/util/FutureUtil.java
@@ -166,7 +166,7 @@ public class FutureUtil {
         }
     }
 
-    public static Throwable unwrapException(Throwable ex) {
+    public static Throwable unwrapCompletionException(Throwable ex) {
         if (ex instanceof CompletionException) {
             return ex.getCause();
         } else if (ex instanceof ExecutionException) {

--- a/pulsar-common/src/test/java/org/apache/pulsar/common/util/FutureUtilTest.java
+++ b/pulsar-common/src/test/java/org/apache/pulsar/common/util/FutureUtilTest.java
@@ -19,19 +19,23 @@
 
 package org.apache.pulsar.common.util;
 
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertNotNull;
-import static org.testng.Assert.fail;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.time.Duration;
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeoutException;
 import lombok.Cleanup;
+import org.assertj.core.util.Lists;
+import org.awaitility.Awaitility;
 import org.testng.annotations.Test;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
 
 public class FutureUtilTest {
 
@@ -90,5 +94,46 @@ public class FutureUtilTest {
         } catch (ExecutionException executionException) {
             assertEquals(executionException.getCause(), e);
         }
+    }
+
+    @Test
+    public void testGetOriginalException(){
+        CompletableFuture<Void> future = CompletableFuture.completedFuture(null);
+        CompletableFuture<Void> exceptionFuture = future.thenAccept(__ -> {
+            throw new IllegalStateException("Illegal state");
+        });
+        assertTrue(exceptionFuture.isCompletedExceptionally());
+        try {
+            exceptionFuture.get();
+        } catch (InterruptedException | ExecutionException e) {
+            Throwable originalException = FutureUtil.getOriginalException(e);
+            assertTrue(originalException instanceof IllegalStateException);
+        }
+        CompletableFuture<Object> exceptionFuture2 = new CompletableFuture<>();
+        exceptionFuture2.completeExceptionally(new IllegalStateException("Completed exception"));
+        final List<Throwable> future2Exception = Lists.newArrayList();
+        exceptionFuture2.exceptionally(ex ->{
+            future2Exception.add(FutureUtil.getOriginalException(ex));
+            return null;
+        });
+        Awaitility.await()
+                .untilAsserted(() -> {
+                    assertEquals(future2Exception.size(), 1);
+                    assertTrue(future2Exception.get(0) instanceof IllegalStateException);
+                });
+        final List<Throwable> future3Exception = Lists.newArrayList();
+        CompletableFuture.completedFuture(null)
+                .thenAccept(__ -> {
+                    throw new IllegalStateException("Throw illegal exception");
+                })
+                .exceptionally(ex -> {
+                    future3Exception.add(FutureUtil.getOriginalException(ex));
+                    return null;
+                });
+        Awaitility.await()
+                .untilAsserted(() -> {
+                    assertEquals(future3Exception.size(), 1);
+                    assertTrue(future3Exception.get(0) instanceof IllegalStateException);
+                });
     }
 }

--- a/pulsar-common/src/test/java/org/apache/pulsar/common/util/FutureUtilTest.java
+++ b/pulsar-common/src/test/java/org/apache/pulsar/common/util/FutureUtilTest.java
@@ -97,7 +97,7 @@ public class FutureUtilTest {
     }
 
     @Test
-    public void testGetOriginalException(){
+    public void testGetOriginalException() {
         CompletableFuture<Void> future = CompletableFuture.completedFuture(null);
         CompletableFuture<Void> exceptionFuture = future.thenAccept(__ -> {
             throw new IllegalStateException("Illegal state");
@@ -112,7 +112,7 @@ public class FutureUtilTest {
         CompletableFuture<Object> exceptionFuture2 = new CompletableFuture<>();
         exceptionFuture2.completeExceptionally(new IllegalStateException("Completed exception"));
         final List<Throwable> future2Exception = Lists.newArrayList();
-        exceptionFuture2.exceptionally(ex ->{
+        exceptionFuture2.exceptionally(ex -> {
             future2Exception.add(FutureUtil.getOriginalException(ex));
             return null;
         });

--- a/pulsar-common/src/test/java/org/apache/pulsar/common/util/FutureUtilTest.java
+++ b/pulsar-common/src/test/java/org/apache/pulsar/common/util/FutureUtilTest.java
@@ -106,14 +106,14 @@ public class FutureUtilTest {
         try {
             exceptionFuture.get();
         } catch (InterruptedException | ExecutionException e) {
-            Throwable originalException = FutureUtil.getOriginalException(e);
+            Throwable originalException = FutureUtil.unwrapException(e);
             assertTrue(originalException instanceof IllegalStateException);
         }
         CompletableFuture<Object> exceptionFuture2 = new CompletableFuture<>();
         exceptionFuture2.completeExceptionally(new IllegalStateException("Completed exception"));
         final List<Throwable> future2Exception = Lists.newArrayList();
         exceptionFuture2.exceptionally(ex -> {
-            future2Exception.add(FutureUtil.getOriginalException(ex));
+            future2Exception.add(FutureUtil.unwrapException(ex));
             return null;
         });
         Awaitility.await()
@@ -127,7 +127,7 @@ public class FutureUtilTest {
                     throw new IllegalStateException("Throw illegal exception");
                 })
                 .exceptionally(ex -> {
-                    future3Exception.add(FutureUtil.getOriginalException(ex));
+                    future3Exception.add(FutureUtil.unwrapException(ex));
                     return null;
                 });
         Awaitility.await()

--- a/pulsar-common/src/test/java/org/apache/pulsar/common/util/FutureUtilTest.java
+++ b/pulsar-common/src/test/java/org/apache/pulsar/common/util/FutureUtilTest.java
@@ -106,14 +106,14 @@ public class FutureUtilTest {
         try {
             exceptionFuture.get();
         } catch (InterruptedException | ExecutionException e) {
-            Throwable originalException = FutureUtil.unwrapException(e);
+            Throwable originalException = FutureUtil.unwrapCompletionException(e);
             assertTrue(originalException instanceof IllegalStateException);
         }
         CompletableFuture<Object> exceptionFuture2 = new CompletableFuture<>();
         exceptionFuture2.completeExceptionally(new IllegalStateException("Completed exception"));
         final List<Throwable> future2Exception = Lists.newArrayList();
         exceptionFuture2.exceptionally(ex -> {
-            future2Exception.add(FutureUtil.unwrapException(ex));
+            future2Exception.add(FutureUtil.unwrapCompletionException(ex));
             return null;
         });
         Awaitility.await()
@@ -127,7 +127,7 @@ public class FutureUtilTest {
                     throw new IllegalStateException("Throw illegal exception");
                 })
                 .exceptionally(ex -> {
-                    future3Exception.add(FutureUtil.unwrapException(ex));
+                    future3Exception.add(FutureUtil.unwrapCompletionException(ex));
                     return null;
                 });
         Awaitility.await()


### PR DESCRIPTION
### Motivation

Avoid call sync method in async rest API for PersistentTopicsBase#internalDeletePartitionedTopic.

### Modifications

- Use async instead of sync method.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: ( no)
  - The schema: ( no )
  - The default values of configurations: ( no)
  - The wire protocol: ( no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

- [x] `no-need-doc` 
  
