### PR TITLE
Remove --illegal-access errors resulting from Google Guice (upgrade to 5.0.1 and JClouds to 2.4.0)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -144,7 +144,8 @@ flexible messaging model and an intuitive client API.</description>
     <aws-sdk.version>1.11.774</aws-sdk.version>
     <avro.version>1.10.2</avro.version>
     <joda.version>2.10.5</joda.version>
-    <jclouds.version>2.3.0</jclouds.version>
+    <jclouds.version>2.4.0</jclouds.version>
+    <guice.version>5.0.1</guice.version>
     <sqlite-jdbc.version>3.8.11.2</sqlite-jdbc.version>
     <mysql-jdbc.version>8.0.11</mysql-jdbc.version>
     <postgresql-jdbc.version>42.2.24</postgresql-jdbc.version>

--- a/pulsar-io/data-generator/pom.xml
+++ b/pulsar-io/data-generator/pom.xml
@@ -49,6 +49,18 @@
             <artifactId>jfairy</artifactId>
             <version>0.5.9</version>
         </dependency>
+        <dependency>
+            <groupId>com.google.inject</groupId>
+            <artifactId>guice</artifactId>
+            <version>${guice.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.google.inject.extensions</groupId>
+            <artifactId>guice-assistedinject</artifactId>
+            <version>${guice.version}</version>
+            <scope>provided</scope>
+        </dependency>
 
         <dependency>
             <groupId>org.apache.avro</groupId>

--- a/tiered-storage/jcloud/pom.xml
+++ b/tiered-storage/jcloud/pom.xml
@@ -99,6 +99,19 @@
       <version>${jclouds.version}</version>
       <scope>provided</scope>
     </dependency>
+    <!-- https://github.com/apache/jclouds/pull/123/files-->
+    <dependency>
+      <groupId>com.google.inject</groupId>
+      <artifactId>guice</artifactId>
+      <version>${guice.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.inject.extensions</groupId>
+      <artifactId>guice-assistedinject</artifactId>
+      <version>${guice.version}</version>
+      <scope>provided</scope>
+    </dependency>
 
     <dependency>
       <groupId>javax.xml.bind</groupId>


### PR DESCRIPTION
### Motivation

In few components there is the Google Guice transitive dependency to Guice 4.x. This library does not support JDK16+ modules encapsulation.
The components affected are:
* Data Generator Source
* JClouds offloader

When running the Data Generator source with jdk16+ this fatal error comes out
```
2022-01-18T08:50:27,941+0000 [public/default/data-generator-source-0] ERROR org.apache.pulsar.functions.instance.JavaInstanceRunnable - [public/default/data-generator-source:0] Uncaught exception in Java Instance
com.google.common.util.concurrent.ExecutionError: com.google.common.util.concurrent.ExecutionError: java.lang.ExceptionInInitializerError
	at com.google.common.cache.LocalCache$Segment.get(LocalCache.java:2049) ~[java-instance.jar:?]
	at com.google.common.cache.LocalCache.get(LocalCache.java:3951) ~[java-instance.jar:?]
	at com.google.common.cache.LocalCache.getOrLoad(LocalCache.java:3974) ~[java-instance.jar:?]
	at com.google.common.cache.LocalCache$LocalLoadingCache.get(LocalCache.java:4935) ~[java-instance.jar:?]
	at com.google.common.cache.LocalCache$LocalLoadingCache.getUnchecked(LocalCache.java:4941) ~[java-instance.jar:?]
	at com.google.inject.internal.FailableCache.get(FailableCache.java:48) ~[?:?]
	at com.google.inject.internal.ConstructorInjectorStore.get(ConstructorInjectorStore.java:50) ~[?:?]
	at com.google.inject.internal.ConstructorBindingImpl.initialize(ConstructorBindingImpl.java:138) ~[?:?]
	at com.google.inject.internal.InjectorImpl.initializeJitBinding(InjectorImpl.java:550) ~[?:?]
	at com.google.inject.internal.InjectorImpl.createJustInTimeBinding(InjectorImpl.java:887) ~[?:?]
	at com.google.inject.internal.InjectorImpl.createJustInTimeBindingRecursive(InjectorImpl.java:808) ~[?:?]
	at com.google.inject.internal.InjectorImpl.getJustInTimeBinding(InjectorImpl.java:285) ~[?:?]
	at com.google.inject.internal.InjectorImpl.getBindingOrThrow(InjectorImpl.java:217) ~[?:?]
	at com.google.inject.internal.InjectorImpl.getProviderOrThrow(InjectorImpl.java:1009) ~[?:?]
	at com.google.inject.internal.InjectorImpl.getProvider(InjectorImpl.java:1041) ~[?:?]
	at com.google.inject.internal.InjectorImpl.getProvider(InjectorImpl.java:1004) ~[?:?]
	at com.google.inject.internal.InjectorImpl.getInstance(InjectorImpl.java:1054) ~[?:?]
	at io.codearte.jfairy.Bootstrap$Builder.getDefaultDataMaster(Bootstrap.java:164) ~[?:?]
	at io.codearte.jfairy.Bootstrap$Builder.build(Bootstrap.java:224) ~[?:?]
	at io.codearte.jfairy.Bootstrap.create(Bootstrap.java:82) ~[?:?]
	at io.codearte.jfairy.Fairy.create(Fairy.java:48) ~[?:?]
	at org.apache.pulsar.io.datagenerator.DataGeneratorSource.open(DataGeneratorSource.java:36) ~[?:?]
	at org.apache.pulsar.functions.instance.JavaInstanceRunnable.setupInput(JavaInstanceRunnable.java:752) ~[org.apache.pulsar-pulsar-functions-instance-2.10.0-SNAPSHOT.jar:2.10.0-SNAPSHOT]
	at org.apache.pulsar.functions.instance.JavaInstanceRunnable.setup(JavaInstanceRunnable.java:227) ~[org.apache.pulsar-pulsar-functions-instance-2.10.0-SNAPSHOT.jar:2.10.0-SNAPSHOT]
	at org.apache.pulsar.functions.instance.JavaInstanceRunnable.run(JavaInstanceRunnable.java:255) [org.apache.pulsar-pulsar-functions-instance-2.10.0-SNAPSHOT.jar:2.10.0-SNAPSHOT]
	at java.lang.Thread.run(Thread.java:833) [?:?]
Caused by: com.google.common.util.concurrent.ExecutionError: java.lang.ExceptionInInitializerError
	at com.google.common.cache.LocalCache$Segment.get(LocalCache.java:2049) ~[java-instance.jar:?]
	at com.google.common.cache.LocalCache.get(LocalCache.java:3951) ~[java-instance.jar:?]
	at com.google.common.cache.LocalCache.getOrLoad(LocalCache.java:3974) ~[java-instance.jar:?]
	at com.google.common.cache.LocalCache$LocalLoadingCache.get(LocalCache.java:4935) ~[java-instance.jar:?]
	at com.google.common.cache.LocalCache$LocalLoadingCache.getUnchecked(LocalCache.java:4941) ~[java-instance.jar:?]
	at com.google.inject.internal.FailableCache.get(FailableCache.java:48) ~[?:?]
	at com.google.inject.internal.ConstructorInjectorStore.get(ConstructorInjectorStore.java:50) ~[?:?]
	at com.google.inject.internal.ConstructorBindingImpl.initialize(ConstructorBindingImpl.java:138) ~[?:?]
	at com.google.inject.internal.InjectorImpl.initializeJitBinding(InjectorImpl.java:550) ~[?:?]
	at com.google.inject.internal.InjectorImpl.createJustInTimeBinding(InjectorImpl.java:887) ~[?:?]
	at com.google.inject.internal.InjectorImpl.createJustInTimeBindingRecursive(InjectorImpl.java:808) ~[?:?]
	at com.google.inject.internal.InjectorImpl.getJustInTimeBinding(InjectorImpl.java:285) ~[?:?]
	at com.google.inject.internal.InjectorImpl.getBindingOrThrow(InjectorImpl.java:217) ~[?:?]
	at com.google.inject.internal.InjectorImpl.createParameterInjector(InjectorImpl.java:965) ~[?:?]
	at com.google.inject.internal.InjectorImpl.getParametersInjectors(InjectorImpl.java:953) ~[?:?]
	at com.google.inject.internal.ConstructorInjectorStore.createConstructor(ConstructorInjectorStore.java:71) ~[?:?]
	at com.google.inject.internal.ConstructorInjectorStore.access$000(ConstructorInjectorStore.java:29) ~[?:?]
	at com.google.inject.internal.ConstructorInjectorStore$1.create(ConstructorInjectorStore.java:37) ~[?:?]
	at com.google.inject.internal.ConstructorInjectorStore$1.create(ConstructorInjectorStore.java:33) ~[?:?]
	at com.google.inject.internal.FailableCache$1.load(FailableCache.java:37) ~[?:?]
	at com.google.common.cache.LocalCache$LoadingValueReference.loadFuture(LocalCache.java:3529) ~[java-instance.jar:?]
	at com.google.common.cache.LocalCache$Segment.loadSync(LocalCache.java:2278) ~[java-instance.jar:?]
	at com.google.common.cache.LocalCache$Segment.lockedGetOrLoad(LocalCache.java:2155) ~[java-instance.jar:?]
	at com.google.common.cache.LocalCache$Segment.get(LocalCache.java:2045) ~[java-instance.jar:?]
	... 25 more
Caused by: java.lang.ExceptionInInitializerError
	at com.google.inject.internal.cglib.reflect.$FastClass$Generator.getProtectionDomain(FastClass.java:73) ~[?:?]
	at com.google.inject.internal.cglib.core.$AbstractClassGenerator.create(AbstractClassGenerator.java:206) ~[?:?]
	at com.google.inject.internal.cglib.reflect.$FastClass$Generator.create(FastClass.java:65) ~[?:?]
	at com.google.inject.internal.BytecodeGen.newFastClassForMember(BytecodeGen.java:252) ~[?:?]
	at com.google.inject.internal.BytecodeGen.newFastClassForMember(BytecodeGen.java:203) ~[?:?]
	at com.google.inject.internal.DefaultConstructionProxyFactory.create(DefaultConstructionProxyFactory.java:53) ~[?:?]
	at com.google.inject.internal.ProxyFactory.create(ProxyFactory.java:158) ~[?:?]
	at com.google.inject.internal.ConstructorInjectorStore.createConstructor(ConstructorInjectorStore.java:90) ~[?:?]
	at com.google.inject.internal.ConstructorInjectorStore.access$000(ConstructorInjectorStore.java:29) ~[?:?]
	at com.google.inject.internal.ConstructorInjectorStore$1.create(ConstructorInjectorStore.java:37) ~[?:?]
	at com.google.inject.internal.ConstructorInjectorStore$1.create(ConstructorInjectorStore.java:33) ~[?:?]
	at com.google.inject.internal.FailableCache$1.load(FailableCache.java:37) ~[?:?]
	at com.google.common.cache.LocalCache$LoadingValueReference.loadFuture(LocalCache.java:3529) ~[java-instance.jar:?]
	at com.google.common.cache.LocalCache$Segment.loadSync(LocalCache.java:2278) ~[java-instance.jar:?]
	at com.google.common.cache.LocalCache$Segment.lockedGetOrLoad(LocalCache.java:2155) ~[java-instance.jar:?]
	at com.google.common.cache.LocalCache$Segment.get(LocalCache.java:2045) ~[java-instance.jar:?]
	at com.google.common.cache.LocalCache.get(LocalCache.java:3951) ~[java-instance.jar:?]
	at com.google.common.cache.LocalCache.getOrLoad(LocalCache.java:3974) ~[java-instance.jar:?]
	at com.google.common.cache.LocalCache$LocalLoadingCache.get(LocalCache.java:4935) ~[java-instance.jar:?]
	at com.google.common.cache.LocalCache$LocalLoadingCache.getUnchecked(LocalCache.java:4941) ~[java-instance.jar:?]
	at com.google.inject.internal.FailableCache.get(FailableCache.java:48) ~[?:?]
	at com.google.inject.internal.ConstructorInjectorStore.get(ConstructorInjectorStore.java:50) ~[?:?]
	at com.google.inject.internal.ConstructorBindingImpl.initialize(ConstructorBindingImpl.java:138) ~[?:?]
	at com.google.inject.internal.InjectorImpl.initializeJitBinding(InjectorImpl.java:550) ~[?:?]
	at com.google.inject.internal.InjectorImpl.createJustInTimeBinding(InjectorImpl.java:887) ~[?:?]
	at com.google.inject.internal.InjectorImpl.createJustInTimeBindingRecursive(InjectorImpl.java:808) ~[?:?]
	at com.google.inject.internal.InjectorImpl.getJustInTimeBinding(InjectorImpl.java:285) ~[?:?]
	at com.google.inject.internal.InjectorImpl.getBindingOrThrow(InjectorImpl.java:217) ~[?:?]
	at com.google.inject.internal.InjectorImpl.createParameterInjector(InjectorImpl.java:965) ~[?:?]
	at com.google.inject.internal.InjectorImpl.getParametersInjectors(InjectorImpl.java:953) ~[?:?]
	at com.google.inject.internal.ConstructorInjectorStore.createConstructor(ConstructorInjectorStore.java:71) ~[?:?]
	at com.google.inject.internal.ConstructorInjectorStore.access$000(ConstructorInjectorStore.java:29) ~[?:?]
	at com.google.inject.internal.ConstructorInjectorStore$1.create(ConstructorInjectorStore.java:37) ~[?:?]
	at com.google.inject.internal.ConstructorInjectorStore$1.create(ConstructorInjectorStore.java:33) ~[?:?]
	at com.google.inject.internal.FailableCache$1.load(FailableCache.java:37) ~[?:?]
	at com.google.common.cache.LocalCache$LoadingValueReference.loadFuture(LocalCache.java:3529) ~[java-instance.jar:?]
	at com.google.common.cache.LocalCache$Segment.loadSync(LocalCache.java:2278) ~[java-instance.jar:?]
	at com.google.common.cache.LocalCache$Segment.lockedGetOrLoad(LocalCache.java:2155) ~[java-instance.jar:?]
	at com.google.common.cache.LocalCache$Segment.get(LocalCache.java:2045) ~[java-instance.jar:?]
	... 25 more
Caused by: java.lang.reflect.InaccessibleObjectException: Unable to make protected final java.lang.Class java.lang.ClassLoader.defineClass(java.lang.String,byte[],int,int,java.security.ProtectionDomain) throws java.lang.ClassFormatError accessible: module java.base does not "opens java.lang" to unnamed module @313642e1
	at java.lang.reflect.AccessibleObject.checkCanSetAccessible(AccessibleObject.java:354) ~[?:?]
	at java.lang.reflect.AccessibleObject.checkCanSetAccessible(AccessibleObject.java:297) ~[?:?]
	at java.lang.reflect.Method.checkCanSetAccessible(Method.java:199) ~[?:?]
	at java.lang.reflect.Method.setAccessible(Method.java:193) ~[?:?]
	at com.google.inject.internal.cglib.core.$ReflectUtils$1.run(ReflectUtils.java:52) ~[?:?]
	at java.security.AccessController.doPrivileged(AccessController.java:318) ~[?:?]
	at com.google.inject.internal.cglib.core.$ReflectUtils.<clinit>(ReflectUtils.java:42) ~[?:?]
	at com.google.inject.internal.cglib.reflect.$FastClass$Generator.getProtectionDomain(FastClass.java:73) ~[?:?]
	at com.google.inject.internal.cglib.core.$AbstractClassGenerator.create(AbstractClassGenerator.java:206) ~[?:?]
	at com.google.inject.internal.cglib.reflect.$FastClass$Generator.create(FastClass.java:65) ~[?:?]
	at com.google.inject.internal.BytecodeGen.newFastClassForMember(BytecodeGen.java:252) ~[?:?]
	at com.google.inject.internal.BytecodeGen.newFastClassForMember(BytecodeGen.java:203) ~[?:?]
	at com.google.inject.internal.DefaultConstructionProxyFactory.create(DefaultConstructionProxyFactory.java:53) ~[?:?]
	at com.google.inject.internal.ProxyFactory.create(ProxyFactory.java:158) ~[?:?]
	at com.google.inject.internal.ConstructorInjectorStore.createConstructor(ConstructorInjectorStore.java:90) ~[?:?]
	at com.google.inject.internal.ConstructorInjectorStore.access$000(ConstructorInjectorStore.java:29) ~[?:?]
	at com.google.inject.internal.ConstructorInjectorStore$1.create(ConstructorInjectorStore.java:37) ~[?:?]
	at com.google.inject.internal.ConstructorInjectorStore$1.create(ConstructorInjectorStore.java:33) ~[?:?]
	at com.google.inject.internal.FailableCache$1.load(FailableCache.java:37) ~[?:?]
	at com.google.common.cache.LocalCache$LoadingValueReference.loadFuture(LocalCache.java:3529) ~[java-instance.jar:?]
	at com.google.common.cache.LocalCache$Segment.loadSync(LocalCache.java:2278) ~[java-instance.jar:?]
	at com.google.common.cache.LocalCache$Segment.lockedGetOrLoad(LocalCache.java:2155) ~[java-instance.jar:?]
	at com.google.common.cache.LocalCache$Segment.get(LocalCache.java:2045) ~[java-instance.jar:?]
	at com.google.common.cache.LocalCache.get(LocalCache.java:3951) ~[java-instance.jar:?]
	at com.google.common.cache.LocalCache.getOrLoad(LocalCache.java:3974) ~[java-instance.jar:?]
	at com.google.common.cache.LocalCache$LocalLoadingCache.get(LocalCache.java:4935) ~[java-instance.jar:?]
	at com.google.common.cache.LocalCache$LocalLoadingCache.getUnchecked(LocalCache.java:4941) ~[java-instance.jar:?]
	at com.google.inject.internal.FailableCache.get(FailableCache.java:48) ~[?:?]
	at com.google.inject.internal.ConstructorInjectorStore.get(ConstructorInjectorStore.java:50) ~[?:?]
	at com.google.inject.internal.ConstructorBindingImpl.initialize(ConstructorBindingImpl.java:138) ~[?:?]
	at com.google.inject.internal.InjectorImpl.initializeJitBinding(InjectorImpl.java:550) ~[?:?]
	at com.google.inject.internal.InjectorImpl.createJustInTimeBinding(InjectorImpl.java:887) ~[?:?]
	at com.google.inject.internal.InjectorImpl.createJustInTimeBindingRecursive(InjectorImpl.java:808) ~[?:?]
	at com.google.inject.internal.InjectorImpl.getJustInTimeBinding(InjectorImpl.java:285) ~[?:?]
	at com.google.inject.internal.InjectorImpl.getBindingOrThrow(InjectorImpl.java:217) ~[?:?]
	at com.google.inject.internal.InjectorImpl.createParameterInjector(InjectorImpl.java:965) ~[?:?]
	at com.google.inject.internal.InjectorImpl.getParametersInjectors(InjectorImpl.java:953) ~[?:?]
	at com.google.inject.internal.ConstructorInjectorStore.createConstructor(ConstructorInjectorStore.java:71) ~[?:?]
	at com.google.inject.internal.ConstructorInjectorStore.access$000(ConstructorInjectorStore.java:29) ~[?:?]
	at com.google.inject.internal.ConstructorInjectorStore$1.create(ConstructorInjectorStore.java:37) ~[?:?]
	at com.google.inject.internal.ConstructorInjectorStore$1.create(ConstructorInjectorStore.java:33) ~[?:?]
	at com.google.inject.internal.FailableCache$1.load(FailableCache.java:37) ~[?:?]
	at com.google.common.cache.LocalCache$LoadingValueReference.loadFuture(LocalCache.java:3529) ~[java-instance.jar:?]
	at com.google.common.cache.LocalCache$Segment.loadSync(LocalCache.java:2278) ~[java-instance.jar:?]
	at com.google.common.cache.LocalCache$Segment.lockedGetOrLoad(LocalCache.java:2155) ~[java-instance.jar:?]
	at com.google.common.cache.LocalCache$Segment.get(LocalCache.java:2045) ~[java-instance.jar:?]
	... 25 more

```


As stated [here](https://github.com/google/guice/wiki/Guice501) Guice 5.x supports JDK16+ environments
 
### Modifications
* Upgrade JClouds to 2.4.0. This version still use Google Guice 5.0.1 but in the current JCloud master there is the same upgrade. See https://github.com/apache/jclouds/pull/123
* Upgrade Google Guice to 5.0.1 for JClouds offloader and Data Generator connector


### Documentation

- [x] `no-need-doc` 
 