### PR TITLE
Improve file URI/URL handling in broker, client and functions code

### DIFF
--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authentication/utils/AuthTokenUtils.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authentication/utils/AuthTokenUtils.java
@@ -26,7 +26,6 @@ import io.jsonwebtoken.io.DecodingException;
 import io.jsonwebtoken.io.Encoders;
 import io.jsonwebtoken.security.Keys;
 import java.io.IOException;
-import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.security.Key;
@@ -41,6 +40,7 @@ import javax.crypto.SecretKey;
 import lombok.experimental.UtilityClass;
 import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.io.IOUtils;
+import org.apache.pulsar.client.api.url.URL;
 
 @UtilityClass
 public class AuthTokenUtils {
@@ -102,7 +102,7 @@ public class AuthTokenUtils {
     public static byte[] readKeyFromUrl(String keyConfUrl) throws IOException {
         if (keyConfUrl.startsWith("data:") || keyConfUrl.startsWith("file:")) {
             try {
-                return IOUtils.toByteArray(URI.create(keyConfUrl));
+                return IOUtils.toByteArray(URL.createURL(keyConfUrl));
             } catch (IOException e) {
                 throw e;
             } catch (Exception e) {

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authentication/utils/AuthTokenUtils.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authentication/utils/AuthTokenUtils.java
@@ -18,7 +18,6 @@
  */
 package org.apache.pulsar.broker.authentication.utils;
 
-import com.google.common.io.ByteStreams;
 import io.jsonwebtoken.JwtBuilder;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
@@ -27,7 +26,7 @@ import io.jsonwebtoken.io.DecodingException;
 import io.jsonwebtoken.io.Encoders;
 import io.jsonwebtoken.security.Keys;
 import java.io.IOException;
-import java.io.InputStream;
+import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.security.Key;
@@ -41,7 +40,7 @@ import java.util.Optional;
 import javax.crypto.SecretKey;
 import lombok.experimental.UtilityClass;
 import org.apache.commons.codec.binary.Base64;
-import org.apache.pulsar.client.api.url.URL;
+import org.apache.commons.io.IOUtils;
 
 @UtilityClass
 public class AuthTokenUtils {
@@ -103,17 +102,15 @@ public class AuthTokenUtils {
     public static byte[] readKeyFromUrl(String keyConfUrl) throws IOException {
         if (keyConfUrl.startsWith("data:") || keyConfUrl.startsWith("file:")) {
             try {
-                return ByteStreams.toByteArray((InputStream) new URL(keyConfUrl).getContent());
+                return IOUtils.toByteArray(URI.create(keyConfUrl));
+            } catch (IOException e) {
+                throw e;
             } catch (Exception e) {
                 throw new IOException(e);
             }
         } else if (Files.exists(Paths.get(keyConfUrl))) {
             // Assume the key content was passed in a valid file path
-            try {
-                return Files.readAllBytes(Paths.get(keyConfUrl));
-            } catch (IOException e) {
-                throw new IOException(e);
-            }
+            return Files.readAllBytes(Paths.get(keyConfUrl));
         } else if (Base64.isBase64(keyConfUrl.getBytes())) {
             // Assume the key content was passed in base64
             try {

--- a/pulsar-broker-common/src/test/java/org/apache/pulsar/broker/authentication/AuthenticationProviderTokenTest.java
+++ b/pulsar-broker-common/src/test/java/org/apache/pulsar/broker/authentication/AuthenticationProviderTokenTest.java
@@ -241,7 +241,8 @@ public class AuthenticationProviderTokenTest {
         AuthenticationProviderToken provider = new AuthenticationProviderToken();
 
         Properties properties = new Properties();
-        properties.setProperty(AuthenticationProviderToken.CONF_TOKEN_SECRET_KEY, "file:///" + secretKeyFile.toString().replace('\\', '/'));
+        String secretKeyFileUri = secretKeyFile.toURI().toString();
+        properties.setProperty(AuthenticationProviderToken.CONF_TOKEN_SECRET_KEY, secretKeyFileUri);
 
         ServiceConfiguration conf = new ServiceConfiguration();
         conf.setProperties(properties);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/TokenOauth2AuthenticatedProducerConsumerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/TokenOauth2AuthenticatedProducerConsumerTest.java
@@ -95,7 +95,7 @@ public class TokenOauth2AuthenticatedProducerConsumerTest extends ProducerConsum
         // AuthenticationOAuth2
         Authentication authentication = AuthenticationFactoryOAuth2.clientCredentials(
                 new URL("https://dev-kt-aa9ne.us.auth0.com"),
-                new URL("file://" + path.toString()),  // key file path
+                path.toUri().toURL(),  // key file path
                 "https://dev-kt-aa9ne.us.auth0.com/api/v2/"
         );
 

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/DefaultCryptoKeyReader.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/DefaultCryptoKeyReader.java
@@ -93,12 +93,16 @@ public class DefaultCryptoKeyReader implements CryptoKeyReader {
     private byte[] loadKey(String keyUrl) throws IOException, IllegalAccessException, InstantiationException {
         try {
             URLConnection urlConnection = new URL(keyUrl).openConnection();
-            String protocol = urlConnection.getURL().getProtocol();
-            if ("data".equals(protocol) && !APPLICATION_X_PEM_FILE.equals(urlConnection.getContentType())) {
-                throw new IllegalArgumentException(
-                        "Unsupported media type or encoding format: " + urlConnection.getContentType());
+            try {
+                String protocol = urlConnection.getURL().getProtocol();
+                if ("data".equals(protocol) && !APPLICATION_X_PEM_FILE.equals(urlConnection.getContentType())) {
+                    throw new IllegalArgumentException(
+                            "Unsupported media type or encoding format: " + urlConnection.getContentType());
+                }
+                return IOUtils.toByteArray(urlConnection);
+            } finally {
+                IOUtils.close(urlConnection);
             }
-            return IOUtils.toByteArray(urlConnection);
         } catch (URISyntaxException e) {
             throw new IllegalArgumentException("Invalid key format");
         }

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/auth/AuthenticationTokenTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/auth/AuthenticationTokenTest.java
@@ -196,7 +196,7 @@ public class AuthenticationTokenTest {
     }
 
     private String getTokenFileUri(File file) {
-        return "file:///" + file.toString().replace('\\', '/');
+        return file.toURI().toString();
     }
 
     public static class SerializableSupplier implements Supplier<String>, Serializable {

--- a/pulsar-common/src/main/java/org/apache/pulsar/client/api/url/URL.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/client/api/url/URL.java
@@ -42,6 +42,17 @@ public class URL {
         }
     }
 
+    /**
+     * Creates java.net.URL with data protocol support.
+     *
+     * @param spec the input URL as String
+     * @return java.net.URL instance
+     */
+    public static final java.net.URL createURL(String spec)
+            throws MalformedURLException, URISyntaxException, InstantiationException, IllegalAccessException {
+        return new URL(spec).url;
+    }
+
     public URLConnection openConnection() throws IOException {
         return this.url.openConnection();
     }

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/nar/NarClassLoader.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/nar/NarClassLoader.java
@@ -33,7 +33,6 @@ import java.net.URL;
 import java.net.URLClassLoader;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
-import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
@@ -192,13 +191,7 @@ public class NarClassLoader extends URLClassLoader {
         updateClasspath(narWorkingDirectory);
 
         for (String jar : additionalJars) {
-            if (jar.startsWith("/")) {
-                addURL(new URL("file://" + jar));
-            } else {
-                Path currentRelativePath = Paths.get("");
-                String cwd = currentRelativePath.toAbsolutePath().toString();
-                addURL(new URL("file://" + cwd + "/" + jar));
-            }
+            addURL(Paths.get(jar).toUri().toURL());
         }
 
         if (log.isDebugEnabled()) {

--- a/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/auth/KubernetesSecretsTokenAuthProvider.java
+++ b/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/auth/KubernetesSecretsTokenAuthProvider.java
@@ -28,6 +28,7 @@ import io.kubernetes.client.openapi.models.V1SecretVolumeSource;
 import io.kubernetes.client.openapi.models.V1StatefulSet;
 import io.kubernetes.client.openapi.models.V1Volume;
 import io.kubernetes.client.openapi.models.V1VolumeMount;
+import java.nio.file.Paths;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.pulsar.broker.authentication.AuthenticationDataSource;
@@ -115,7 +116,8 @@ public class KubernetesSecretsTokenAuthProvider implements KubernetesFunctionAut
             authConfig.setClientAuthenticationParameters(null);
         } else {
             authConfig.setClientAuthenticationPlugin(AuthenticationToken.class.getName());
-            authConfig.setClientAuthenticationParameters(String.format("file://%s/%s", DEFAULT_SECRET_MOUNT_DIR, FUNCTION_AUTH_TOKEN));
+            authConfig.setClientAuthenticationParameters(Paths.get(DEFAULT_SECRET_MOUNT_DIR, FUNCTION_AUTH_TOKEN)
+                    .toUri().toString());
             // if we have ca bytes, update the new path for the CA
             if (this.caBytes != null) {
                 authConfig.setTlsTrustCertsFilePath(String.format("%s/%s", DEFAULT_SECRET_MOUNT_DIR, FUNCTION_CA_CERT));


### PR DESCRIPTION
### Motivation

- In certain cases, it seemed that the reading of the JWT public key failed on the proxy and subsequent calls would fail in JTW token validation. This lead to checking how the token is read

https://github.com/apache/pulsar/blob/3b13081bf323a5599de9a44f10be76fecb675a45/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authentication/utils/AuthTokenUtils.java#L105-L109

I noticed that this code could be improved since it doesn't close the InputStream,

I also spotted code like this:

https://github.com/apache/pulsar/blob/3b13081bf323a5599de9a44f10be76fecb675a45/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/auth/KubernetesSecretsTokenAuthProvider.java#L118

This is error prone. It's better to use Java's APIs for creating file URIs/URLs.

### Modifications

- Use Java to form file URIs/URLs instead of concatenating a string ("file://" + ...)
- Properly close UrlConnection after usage
- Use Commons IO IOUtils.toByteArray for reading an URI/URL when applicable
- Avoid unnecessary wrapping of IOExceptions