### PR TITLE
Getting rid of CVEs in batch-data-generator

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -199,8 +199,8 @@ flexible messaging model and an intuitive client API.</description>
     <!-- override kotlin-stdlib used by okio in order to address CVE-2020-29582 -->
     <kotlin-stdlib.version>1.4.32</kotlin-stdlib.version>
     <nsq-client.version>1.0</nsq-client.version>
-    <cron-utils.version>9.1.3</cron-utils.version>
-    <spring-context.version>5.3.1</spring-context.version>
+    <cron-utils.version>9.1.6</cron-utils.version>
+    <spring-context.version>5.3.15</spring-context.version>
     <apache-http-client.version>4.5.13</apache-http-client.version>
     <snakeyaml.version>1.30</snakeyaml.version>
 

--- a/pulsar-io/batch-data-generator/pom.xml
+++ b/pulsar-io/batch-data-generator/pom.xml
@@ -45,6 +45,12 @@
         </dependency>
 
         <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-context</artifactId>
+            <version>${spring-context.version}</version>
+        </dependency>
+
+        <dependency>
             <groupId>io.codearte.jfairy</groupId>
             <artifactId>jfairy</artifactId>
             <version>0.5.9</version>


### PR DESCRIPTION
Getting rid of CVEs in batch-data-generator

CVE-2021-41269
CVE-2021-22060
CVE-2021-22096
CVE-2021-22118

### Motivation

`mvn clean install verify -Powasp-dependency-check -DskipTests` found various CVEs

### Modifications

Upgraded dependencies

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change is already covered by existing tests

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): *YES*
  - The public API: (yes / no)
  - The schema: (yes / no / don't know)
  - The default values of configurations: (yes / no)
  - The wire protocol: (yes / no)
  - The rest endpoints: (yes / no)
  - The admin cli options: (yes / no)
  - Anything that affects deployment: (yes / no / don't know)

### Documentation

Check the box below or label this PR directly (if you have committer privilege).

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)


