### PR TITLE
Getting rid of CVEs in Solr connector

### DIFF
--- a/pulsar-io/solr/pom.xml
+++ b/pulsar-io/solr/pom.xml
@@ -29,7 +29,7 @@
     </parent>
 
     <properties>
-        <solr.version>8.6.3</solr.version>
+        <solr.version>8.11.1</solr.version>
     </properties>
 
     <artifactId>pulsar-io-solr</artifactId>


### PR DESCRIPTION
Getting rid of CVEs in Solr connector

CVE-2019-17638
CVE-2020-27216
CVE-2020-27218
CVE-2020-27223
CVE-2021-28165
CVE-2021-28169
CVE-2021-34428
CVE-2021-27905
CVE-2021-29262
CVE-2021-29943
CVE-2021-44548

### Motivation

`mvn clean install verify -Powasp-dependency-check -DskipTests` found various CVEs

### Modifications

Upgraded dependencies

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change is already covered by existing tests

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): *YES*
  - The public API: (yes / no)
  - The schema: (yes / no / don't know)
  - The default values of configurations: (yes / no)
  - The wire protocol: (yes / no)
  - The rest endpoints: (yes / no)
  - The admin cli options: (yes / no)
  - Anything that affects deployment: (yes / no / don't know)

### Documentation

Check the box below or label this PR directly (if you have committer privilege).

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)


