### PR TITLE
[Doc] Add information for RocksDB and ETCD

### DIFF
--- a/site2/docs/concepts-architecture-overview.md
+++ b/site2/docs/concepts-architecture-overview.md
@@ -47,6 +47,9 @@ Clusters can replicate amongst themselves using [geo-replication](concepts-repli
 
 The Pulsar metadata store maintains all the metadata of a Pulsar cluster, such as topic metadata, schema, broker load data, and so on. Pulsar uses [Apache ZooKeeper](https://zookeeper.apache.org/) for metadata storage, cluster configuration, and coordination. The Pulsar metadata store can be deployed on a separate ZooKeeper cluster or deployed on an existing ZooKeeper cluster. You can use one ZooKeeper cluster for both Pulsar metadata store and [BookKeeper metadata store](https://bookkeeper.apache.org/docs/latest/getting-started/concepts/#metadata-storage). If you want to deploy Pulsar brokers connected to an existing BookKeeper cluster, you need to deploy separate ZooKeeper clusters for Pulsar metadata store and BookKeeper metadata store respectively.
 
+> Pulsar also supports more metadata backend services, including [ETCD](https://etcd.io/) and [RocksDB](http://rocksdb.org/) (for standalone Pulsar only). 
+
+
 In a Pulsar instance:
 
 * A configuration store quorum stores configuration for tenants, namespaces, and other entities that need to be globally consistent.

--- a/site2/docs/getting-started-standalone.md
+++ b/site2/docs/getting-started-standalone.md
@@ -4,7 +4,7 @@ title: Set up a standalone Pulsar locally
 sidebar_label: Run Pulsar locally
 ---
 
-For local development and testing, you can run Pulsar in standalone mode on your machine. The standalone mode includes a Pulsar broker, the necessary ZooKeeper and BookKeeper components running inside of a single Java Virtual Machine (JVM) process.
+For local development and testing, you can run Pulsar in standalone mode on your machine. The standalone mode includes a Pulsar broker, the necessary [RocksDB](http://rocksdb.org/) and BookKeeper components running inside of a single Java Virtual Machine (JVM) process.
 
 > **Pulsar in production?**  
 > If you're looking to run a full production Pulsar installation, see the [Deploying a Pulsar instance](deploy-bare-metal.md) guide.
@@ -53,7 +53,7 @@ The Pulsar binary package initially contains the following directories:
 Directory | Contains
 :---------|:--------
 `bin` | Pulsar's command-line tools, such as [`pulsar`](reference-cli-tools.md#pulsar) and [`pulsar-admin`](https://pulsar.apache.org/tools/pulsar-admin/).
-`conf` | Configuration files for Pulsar, including [broker configuration](reference-configuration.md#broker), [ZooKeeper configuration](reference-configuration.md#zookeeper), and more.
+`conf` | Configuration files for Pulsar, including [broker configuration](reference-configuration.md#broker), [RocksDB configuration](reference-configuration.md#rocksdb), and more.
 `examples` | A Java JAR file containing [Pulsar Functions](functions-overview.md) example.
 `instances` | Artifacts created for [Pulsar Functions](functions-overview.md).
 `lib` | The [JAR](https://en.wikipedia.org/wiki/JAR_(file_format)) files used by Pulsar.
@@ -63,7 +63,7 @@ These directories are created once you begin running Pulsar.
 
 Directory | Contains
 :---------|:--------
-`data` | The data storage directory used by ZooKeeper and BookKeeper.
+`data` | The data storage directory used by RocksDB and BookKeeper.
 `logs` | Logs created by the installation.
 
 > **Tip**  

--- a/site2/docs/getting-started-standalone.md
+++ b/site2/docs/getting-started-standalone.md
@@ -53,7 +53,7 @@ The Pulsar binary package initially contains the following directories:
 Directory | Contains
 :---------|:--------
 `bin` | Pulsar's command-line tools, such as [`pulsar`](reference-cli-tools.md#pulsar) and [`pulsar-admin`](https://pulsar.apache.org/tools/pulsar-admin/).
-`conf` | Configuration files for Pulsar, including [broker configuration](reference-configuration.md#broker), [RocksDB configuration](reference-configuration.md#rocksdb), and more.
+`conf` | Configuration files for Pulsar, including [broker configuration](reference-configuration.md#broker) and more.<br />**Note:** Pulsar standalone uses RocksDB as the local metadata store and its configuration file path [`metadataStoreConfigPath`](reference-configuration.md) is configurable in the `standalone.conf` file. For more information about the configurations of RocksDB, see [here](https://github.com/facebook/rocksdb/blob/main/examples/rocksdb_option_file_example.ini) and related [documentation](https://github.com/facebook/rocksdb/wiki/RocksDB-Tuning-Guide).
 `examples` | A Java JAR file containing [Pulsar Functions](functions-overview.md) example.
 `instances` | Artifacts created for [Pulsar Functions](functions-overview.md).
 `lib` | The [JAR](https://en.wikipedia.org/wiki/JAR_(file_format)) files used by Pulsar.

--- a/site2/docs/reference-configuration.md
+++ b/site2/docs/reference-configuration.md
@@ -775,3 +775,12 @@ server.3=zk3.us-west.example.com:2888:3888
 ```
 
 > We strongly recommend consulting the [ZooKeeper Administrator's Guide](https://zookeeper.apache.org/doc/current/zookeeperAdmin.html) for a more thorough and comprehensive introduction to ZooKeeper configuration
+
+
+## RocksDB
+
+Standalone Pulsar uses [RocksDB](http://rocksdb.org/) rather than ZooKeeper. The default configuration file for RocksDB is in the `conf/rocksdb.conf` file in your Pulsar installation. The following parameters are available:
+
+
+|Name|Description|Default|
+|---|---|---|

--- a/site2/docs/reference-configuration.md
+++ b/site2/docs/reference-configuration.md
@@ -659,6 +659,8 @@ You can set the log level and configuration in the  [log4j2.yaml](https://github
 |haProxyProtocolEnabled | Enable or disable the [HAProxy](http://www.haproxy.org/) protocol. |false|
 |bookieId | If you want to custom a bookie ID or use a dynamic network address for a bookie, you can set the `bookieId`. <br><br>Bookie advertises itself using the `bookieId` rather than the `BookieSocketAddress` (`hostname:port` or `IP:port`).<br><br> The `bookieId` is a non-empty string that can contain ASCII digits and letters ([a-zA-Z9-0]), colons, dashes, and dots. <br><br>For more information about `bookieId`, see [here](http://bookkeeper.apache.org/bps/BP-41-bookieid/).|/|
 | maxTopicsPerNamespace | The maximum number of persistent topics that can be created in the namespace. When the number of topics reaches this threshold, the broker rejects the request of creating a new topic, including the auto-created topics by the producer or consumer, until the number of connected consumers decreases. The default value 0 disables the check. | 0 |
+| metadataStoreConfigPath | The configuration file path of the local metadata store. Standalone Pulsar uses [RocksDB](http://rocksdb.org/) as the local metadata store. The format is `/xxx/xx/rocksdb.ini`. |N/A|
+
 
 ## WebSocket
 
@@ -775,12 +777,3 @@ server.3=zk3.us-west.example.com:2888:3888
 ```
 
 > We strongly recommend consulting the [ZooKeeper Administrator's Guide](https://zookeeper.apache.org/doc/current/zookeeperAdmin.html) for a more thorough and comprehensive introduction to ZooKeeper configuration
-
-
-## RocksDB
-
-Standalone Pulsar uses [RocksDB](http://rocksdb.org/) rather than ZooKeeper. The default configuration file for RocksDB is in the `conf/rocksdb.conf` file in your Pulsar installation. The following parameters are available:
-
-
-|Name|Description|Default|
-|---|---|---|


### PR DESCRIPTION
This update works for https://github.com/apache/pulsar/pull/12776 and https://github.com/apache/pulsar/pull/13225.

### Modifications
1. Add RocksDB (standalone only) and ETCD as alternative metadata backend services in the "Architecture" topic.
    **Preview**
    ![image](https://user-images.githubusercontent.com/60642177/151118439-1e65efa3-90a6-4153-a868-6115fc60c896.png)

2. Replace "ZooKeeper" with "RocksDB" in the "Set up a standalone Pulsar" topic, and add reference information about configurations of Rocksdb.
    **Preview**
    ![image](https://user-images.githubusercontent.com/60642177/151554131-edd9e2f4-9d6f-4e55-8574-a1e300eb1e5e.png)

3. Add the `metadataStoreConfigPath` parameter of RocksDB in the Standalone configurations.
    **Preview**
    ![image](https://user-images.githubusercontent.com/60642177/151544601-df9b0562-c4ba-4c2e-b48f-cf0ae472115f.png)


### Documentation
- [x] `doc` 
  



