### PR TITLE
[Doc] Add content for topic-level schema compatibility check strategy

### DIFF
--- a/site2/docs/schema-evolution-compatibility.md
+++ b/site2/docs/schema-evolution-compatibility.md
@@ -628,7 +628,7 @@ In some data formats, for example, Avro, you can define fields with default valu
 
 > **Tip**
 > 
-> You can set schema compatibility check strategy at namespace or broker level. For how to set the strategy, see [here](schema-manage.md/#set-schema-compatibility-check-strategy).
+> You can set schema compatibility check strategy at the topic, namespace or broker level. For how to set the strategy, see [here](schema-manage.md/#set-schema-compatibility-check-strategy).
 
 ## Schema verification
 

--- a/site2/docs/schema-manage.md
+++ b/site2/docs/schema-manage.md
@@ -817,7 +817,7 @@ The schema compatibility check strategy set at different levels has priority: to
 
 - If you set the strategy at both namespace and broker level, it uses the namespace-level strategy.
 
-- If you do not set the strategy at any level, it uses the `FULL` strategy.
+- If you do not set the strategy at any level, it uses the `FULL` strategy. For all available values, see [here](schema-evolution-compatibility.md#schema-compatibility-check-strategy).
 
 
 ### Topic level
@@ -826,7 +826,7 @@ To set a schema compatibility check strategy at the topic level, use one of the 
 
 <!--DOCUSAURUS_CODE_TABS-->
 
-<!--admin CLI-->
+<!--Admin CLI-->
 
 Use the [`pulsar-admin topics set-schema-compatibility-strategy`](https://pulsar.apache.org/tools/pulsar-admin/) command. 
 
@@ -857,7 +857,7 @@ To get the topic-level schema compatibility check strategy, use one of the follo
 
 <!--DOCUSAURUS_CODE_TABS-->
 
-<!--admin CLI-->
+<!--Admin CLI-->
 
 Use the [`pulsar-admin topics get-schema-compatibility-strategy`](https://pulsar.apache.org/tools/pulsar-admin/) command. 
 
@@ -892,7 +892,7 @@ To remove the topic-level schema compatibility check strategy, use one of the fo
 
 <!--DOCUSAURUS_CODE_TABS-->
 
-<!--admin CLI-->
+<!--Admin CLI-->
 
 Use the [`pulsar-admin topics remove-schema-compatibility-strategy`](https://pulsar.apache.org/tools/pulsar-admin/) command. 
 
@@ -926,7 +926,7 @@ You can set schema compatibility check strategy at namespace level using one of 
 
 <!--DOCUSAURUS_CODE_TABS-->
 
-<!--pulsar-admin-->
+<!--Admin CLI-->
 
 Use the [`pulsar-admin namespaces set-schema-compatibility-strategy`](https://pulsar.apache.org/tools/pulsar-admin/) command. 
 
@@ -937,7 +937,7 @@ pulsar-admin namespaces set-schema-compatibility-strategy options
 
 Send a `PUT` request to this endpoint: {@inject: endpoint|PUT|/admin/v2/namespaces/:tenant/:namespace|operation/schemaCompatibilityStrategy?version=[[pulsar:version_number]]}
 
-<!--Java-->
+<!--Java Admin CLI-->
 
 Use the [`setSchemaCompatibilityStrategy`](https://pulsar.apache.org/api/admin/)method.
 

--- a/site2/docs/schema-manage.md
+++ b/site2/docs/schema-manage.md
@@ -809,17 +809,46 @@ To use your custom schema storage implementation, perform the following steps.
 
 ## Set schema compatibility check strategy 
 
-You can set [schema compatibility check strategy](schema-evolution-compatibility.md#schema-compatibility-check-strategy) at namespace or broker level. 
+You can set [schema compatibility check strategy](schema-evolution-compatibility.md#schema-compatibility-check-strategy) at the topic, namespace or broker level. 
 
-- If you set schema compatibility check strategy at both namespace or broker level, it uses the strategy set for the namespace level.
+The schema compatibility check strategy set at different levels has priority: topic level > namespace level > broker level. 
 
-- If you do not set schema compatibility check strategy at both namespace or broker level, it uses the `FULL` strategy.
+- If you set the strategy at both topic and namespace level, it uses the topic-level strategy. 
 
-- If you set schema compatibility check strategy at broker level rather than namespace level, it uses the strategy set for the broker level.
+- If you set the strategy at both namespace and broker level, it uses the namespace-level strategy.
 
-- If you set schema compatibility check strategy at namespace level rather than broker level, it uses the strategy set for the namespace level.
+- If you do not set the strategy at any level, it uses the `FULL` strategy.
 
-### Namespace 
+
+### Topic level
+
+You can set schema compatibility check strategy at topic level using one of the following methods.
+
+<!--DOCUSAURUS_CODE_TABS-->
+
+<!--pulsar-admin-->
+
+Use the [`pulsar-admin namespaces set-schema-compatibility-strategy`](https://pulsar.apache.org/tools/pulsar-admin/) command. 
+
+```shell
+pulsar-admin namespaces set-schema-compatibility-strategy options
+```
+<!--REST API-->
+
+Send a `PUT` request to this endpoint: {@inject: endpoint|PUT|/admin/v2/namespaces/:tenant/:namespace|operation/schemaCompatibilityStrategy?version=[[pulsar:version_number]]}
+
+<!--Java-->
+
+Use the [`setSchemaCompatibilityStrategy`](https://pulsar.apache.org/api/admin/)method.
+
+```java
+admin.namespaces().setSchemaCompatibilityStrategy("test", SchemaCompatibilityStrategy.FULL);
+```
+
+<!--END_DOCUSAURUS_CODE_TABS-->
+
+
+### Namespace level
 
 You can set schema compatibility check strategy at namespace level using one of the following methods.
 
@@ -846,7 +875,7 @@ admin.namespaces().setSchemaCompatibilityStrategy("test", SchemaCompatibilityStr
 
 <!--END_DOCUSAURUS_CODE_TABS-->
 
-### Broker 
+### Broker level
 
 You can set schema compatibility check strategy at broker level by setting `schemaCompatibilityStrategy` in [`broker.conf`](https://github.com/apache/pulsar/blob/f24b4890c278f72a67fe30e7bf22dc36d71aac6a/conf/broker.conf#L1240) or [`standalone.conf`](https://github.com/apache/pulsar/blob/master/conf/standalone.conf) file.
 

--- a/site2/docs/schema-manage.md
+++ b/site2/docs/schema-manage.md
@@ -822,27 +822,99 @@ The schema compatibility check strategy set at different levels has priority: to
 
 ### Topic level
 
-You can set schema compatibility check strategy at topic level using one of the following methods.
+To set a schema compatibility check strategy at the topic level, use one of the following methods.
 
 <!--DOCUSAURUS_CODE_TABS-->
 
-<!--pulsar-admin-->
+<!--admin CLI-->
 
-Use the [`pulsar-admin namespaces set-schema-compatibility-strategy`](https://pulsar.apache.org/tools/pulsar-admin/) command. 
+Use the [`pulsar-admin topics set-schema-compatibility-strategy`](https://pulsar.apache.org/tools/pulsar-admin/) command. 
 
 ```shell
-pulsar-admin namespaces set-schema-compatibility-strategy options
+pulsar-admin topics set-schema-compatibility-strategy <strategy> <topicName>
 ```
 <!--REST API-->
 
-Send a `PUT` request to this endpoint: {@inject: endpoint|PUT|/admin/v2/namespaces/:tenant/:namespace|operation/schemaCompatibilityStrategy?version=[[pulsar:version_number]]}
+Send a `PUT` request to this endpoint: {@inject: endpoint|PUT|/admin/v2/topics/:tenant/:namespace/:topic|operation/schemaCompatibilityStrategy?version=[[pulsar:version_number]]}
 
-<!--Java-->
-
-Use the [`setSchemaCompatibilityStrategy`](https://pulsar.apache.org/api/admin/)method.
+<!--Java Admin API-->
 
 ```java
-admin.namespaces().setSchemaCompatibilityStrategy("test", SchemaCompatibilityStrategy.FULL);
+void setSchemaCompatibilityStrategy(String topic, SchemaCompatibilityStrategy strategy)
+```
+
+Here is an example of setting a schema compatibility check strategy at the topic level.
+
+```java
+PulsarAdmin admin = …;
+
+admin.topicPolicies().setSchemaCompatibilityStrategy("my-tenant/my-ns/my-topic", SchemaCompatibilityStrategy.ALWAYS_INCOMPATIBLE);
+```
+
+<!--END_DOCUSAURUS_CODE_TABS-->
+<br />
+To get the topic-level schema compatibility check strategy, use one of the following methods.
+
+<!--DOCUSAURUS_CODE_TABS-->
+
+<!--admin CLI-->
+
+Use the [`pulsar-admin topics get-schema-compatibility-strategy`](https://pulsar.apache.org/tools/pulsar-admin/) command. 
+
+```shell
+pulsar-admin topics get-schema-compatibility-strategy <topicName>
+```
+<!--REST API-->
+
+Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v2/topics/:tenant/:namespace/:topic|operation/schemaCompatibilityStrategy?version=[[pulsar:version_number]]}
+
+<!--Java Admin API-->
+
+```java
+SchemaCompatibilityStrategy getSchemaCompatibilityStrategy(String topic, boolean applied)
+```
+
+Here is an example of getting the topic-level schema compatibility check strategy.
+
+```java
+PulsarAdmin admin = …;
+
+// get the current applied schema compatibility strategy
+admin.topicPolicies().getSchemaCompatibilityStrategy("my-tenant/my-ns/my-topic", true);
+
+// only get the schema compatibility strategy from topic policies
+admin.topicPolicies().getSchemaCompatibilityStrategy("my-tenant/my-ns/my-topic", false);
+```
+
+<!--END_DOCUSAURUS_CODE_TABS-->
+<br />
+To remove the topic-level schema compatibility check strategy, use one of the following methods.
+
+<!--DOCUSAURUS_CODE_TABS-->
+
+<!--admin CLI-->
+
+Use the [`pulsar-admin topics remove-schema-compatibility-strategy`](https://pulsar.apache.org/tools/pulsar-admin/) command. 
+
+```shell
+pulsar-admin topics remove-schema-compatibility-strategy <topicName>
+```
+<!--REST API-->
+
+Send a `DELETE` request to this endpoint: {@inject: endpoint|DELETE|/admin/v2/topics/:tenant/:namespace/:topic|operation/schemaCompatibilityStrategy?version=[[pulsar:version_number]]}
+
+<!--Java Admin API-->
+
+```java
+void removeSchemaCompatibilityStrategy(String topic)
+```
+
+Here is an example of removing the topic-level schema compatibility check strategy.
+
+```java
+PulsarAdmin admin = …;
+
+admin.removeSchemaCompatibilityStrategy("my-tenant/my-ns/my-topic");
 ```
 
 <!--END_DOCUSAURUS_CODE_TABS-->


### PR DESCRIPTION
Doc updates for https://github.com/apache/pulsar/pull/13297.

### Modifications
1. Simplify the description of strategy priority set at different levels.
![image](https://user-images.githubusercontent.com/60642177/151645525-3432b87d-e5e8-4295-9ad1-eb7230e39c1c.png)

2. Add set/get/remove methods for topic-level schema compatibility check strategy in three ways.
2.1) admin CLI
![image](https://user-images.githubusercontent.com/60642177/151645551-382f1ce6-7b2c-46cd-826b-f5a49ce0b9e0.png)

2.2) Rest API
![image](https://user-images.githubusercontent.com/60642177/151645577-7e56fb2b-c08c-4812-896b-6670f5d41b4b.png)

  2.3) Java Admin API
![image](https://user-images.githubusercontent.com/60642177/151645587-2b96b440-fccc-4aac-a9c9-4ded1152287c.png)
![image](https://user-images.githubusercontent.com/60642177/151645654-5ce514db-68b0-48ba-8f2e-245d8bc51dd9.png)


### Documentation
- [x] `doc` 

