### PR TITLE
[Proxy] Use shared internal and external executor for broker clients

### DIFF
--- a/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/ProxyConfiguration.java
+++ b/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/ProxyConfiguration.java
@@ -286,6 +286,13 @@ public class ProxyConfiguration implements PulsarConfiguration {
     private int maxConcurrentLookupRequests = 50000;
 
     @FieldContext(
+            category = CATEGORY_SERVER,
+            doc = "Number of shared threads to use for broker clients."
+                    + " Default is set to `2 * Runtime.getRuntime().availableProcessors()`"
+    )
+    private int brokerClientNumIOThreads = 2 * Runtime.getRuntime().availableProcessors();
+
+    @FieldContext(
         category = CATEGORY_CLIENT_AUTHENTICATION,
         doc = "The authentication plugin used by the Pulsar proxy to authenticate with Pulsar brokers"
     )

--- a/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/ProxyConnection.java
+++ b/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/ProxyConnection.java
@@ -301,10 +301,7 @@ public class ProxyConnection extends PulsarHandler implements FutureListener<Voi
 
             // authn not enabled, complete
             if (!service.getConfiguration().isAuthenticationEnabled()) {
-                this.connectionPool = new ProxyConnectionPool(clientConf, service.getWorkerGroup(),
-                        () -> new ClientCnx(clientConf, service.getWorkerGroup(), protocolVersion));
-                this.client =
-                        new PulsarClientImpl(clientConf, service.getWorkerGroup(), connectionPool, service.getTimer());
+                this.client = createClientNoAuthentication(protocolVersion);
 
                 completeConnect();
                 return;
@@ -441,7 +438,13 @@ public class ProxyConnection extends PulsarHandler implements FutureListener<Voi
         this.connectionPool = new ProxyConnectionPool(clientConf, service.getWorkerGroup(),
                 () -> new ProxyClientCnx(clientConf, service.getWorkerGroup(), clientAuthRole, clientAuthData,
                         clientAuthMethod, protocolVersion));
-        return new PulsarClientImpl(clientConf, service.getWorkerGroup(), connectionPool, service.getTimer());
+        return service.createClientImpl(clientConf, this.connectionPool);
+    }
+
+    private PulsarClientImpl createClientNoAuthentication(int protocolVersion) throws PulsarClientException {
+        this.connectionPool = new ProxyConnectionPool(clientConf, service.getWorkerGroup(),
+                () -> new ClientCnx(clientConf, service.getWorkerGroup(), protocolVersion));
+        return service.createClientImpl(clientConf, this.connectionPool);
     }
 
     private static int getProtocolVersionToAdvertise(CommandConnect connect) {

--- a/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/ProxyService.java
+++ b/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/ProxyService.java
@@ -57,7 +57,11 @@ import org.apache.pulsar.broker.resources.PulsarResources;
 import org.apache.pulsar.broker.web.plugin.servlet.AdditionalServlets;
 import org.apache.pulsar.client.api.Authentication;
 import org.apache.pulsar.client.api.AuthenticationFactory;
+import org.apache.pulsar.client.api.PulsarClientException;
+import org.apache.pulsar.client.impl.ConnectionPool;
+import org.apache.pulsar.client.impl.PulsarClientImpl;
 import org.apache.pulsar.client.impl.auth.AuthenticationDisabled;
+import org.apache.pulsar.client.impl.conf.ClientConfigurationData;
 import org.apache.pulsar.common.allocator.PulsarByteBufAllocator;
 import org.apache.pulsar.common.configuration.PulsarConfigurationLoader;
 import org.apache.pulsar.common.util.netty.EventLoopUtil;
@@ -295,6 +299,16 @@ public class ProxyService implements Closeable {
             throw new IOException("Failed to bind extension `" + extensionName + "` on " + address, e);
         }
         LOG.info("Successfully bound extension `{}` on {}", extensionName, address);
+    }
+
+    public PulsarClientImpl createClientImpl(ClientConfigurationData clientConf, ConnectionPool connectionPool)
+            throws PulsarClientException {
+        return PulsarClientImpl.builder()
+                .conf(clientConf)
+                .eventLoopGroup(getWorkerGroup())
+                .connectionPool(connectionPool)
+                .timer(getTimer())
+                .build();
     }
 
     public BrokerDiscoveryProvider getDiscoveryProvider() {


### PR DESCRIPTION
### Motivation

Pulsar Proxy will create a new Pulsar Client instance for each and every proxied connection. 

Currently 2 threads will be created for every Pulsar Client instance for the internal/IO and external/listener  executors. This causes a lot of overhead and inefficiency in the Pulsar Proxy. 

In the current solution, it's already possible to share the EventLoopGroup and HashedWheelTimer instances. Support for sharing the timer was added by #9802.

A recently merged PR, #12037, added support for sharing the the internal/IO and external/listener  executors in PulsarClientImpl instances. This feature has been used in this PR to share the executors across all PulsarClientImpl instances created in the Pulsar Proxy.

### Modifications

- add new configuration key `brokerClientNumIOThreads` which can be used to configure the number of threads for the internal/IO executor. It defaults to 2 * number of available processors.
- create shared executors in ProxyService
- add method for creating PulsarClientImpl to ProxyService that uses the shared executors
- refactor ProxyConnection to use this method for PulsarClientImpl instantiation
