### PR TITLE
[Broker] Avoid thread deadlock problem when creating topic policy reader

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/SystemTopicBasedTopicPoliciesService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/SystemTopicBasedTopicPoliciesService.java
@@ -249,7 +249,7 @@ public class SystemTopicBasedTopicPoliciesService implements TopicPoliciesServic
     private void prepareInitPoliciesCache(NamespaceName namespace, CompletableFuture<Void> result) {
         if (policyCacheInitMap.putIfAbsent(namespace, false) == null) {
             CompletableFuture<SystemTopicClient.Reader<PulsarEvent>> readerCompletableFuture =
-                    creatSystemTopicClientWithRetry(namespace);
+                    createSystemTopicClientWithRetry(namespace);
             readerCaches.put(namespace, readerCompletableFuture);
             readerCompletableFuture.whenComplete((reader, ex) -> {
                 if (ex != null) {
@@ -265,7 +265,7 @@ public class SystemTopicBasedTopicPoliciesService implements TopicPoliciesServic
         }
     }
 
-    protected CompletableFuture<SystemTopicClient.Reader<PulsarEvent>> creatSystemTopicClientWithRetry(
+    protected CompletableFuture<SystemTopicClient.Reader<PulsarEvent>> createSystemTopicClientWithRetry(
             NamespaceName namespace) {
         CompletableFuture<SystemTopicClient.Reader<PulsarEvent>> result = new CompletableFuture<>();
         try {
@@ -277,13 +277,7 @@ public class SystemTopicBasedTopicPoliciesService implements TopicPoliciesServic
         SystemTopicClient<PulsarEvent> systemTopicClient = namespaceEventsSystemTopicFactory
                 .createTopicPoliciesSystemTopicClient(namespace);
         Backoff backoff = new Backoff(1, TimeUnit.SECONDS, 3, TimeUnit.SECONDS, 10, TimeUnit.SECONDS);
-        RetryUtil.retryAsynchronously(() -> {
-            try {
-                return systemTopicClient.newReader();
-            } catch (PulsarClientException e) {
-                throw new RuntimeException(e);
-            }
-        }, backoff, pulsarService.getExecutor(), result);
+        RetryUtil.retryAsynchronously(systemTopicClient::newReaderAsync, backoff, pulsarService.getExecutor(), result);
         return result;
     }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/TopicPoliciesService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/TopicPoliciesService.java
@@ -95,11 +95,13 @@ public interface TopicPoliciesService {
                 .create() : backoff;
         try {
             RetryUtil.retryAsynchronously(() -> {
+                CompletableFuture<Optional<TopicPolicies>> future = new CompletableFuture<>();
                 try {
-                    return Optional.ofNullable(getTopicPolicies(topicName, isGlobal));
+                    future.complete(Optional.ofNullable(getTopicPolicies(topicName, isGlobal)));
                 } catch (BrokerServiceException.TopicPoliciesCacheNotInitException exception) {
-                    throw new RuntimeException(exception);
+                    future.completeExceptionally(exception);
                 }
+                return future;
             }, usedBackoff, scheduledExecutorService, response);
         } catch (Exception e) {
             response.completeExceptionally(e);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/SystemTopicBasedTopicPoliciesServiceTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/SystemTopicBasedTopicPoliciesServiceTest.java
@@ -332,7 +332,7 @@ public class SystemTopicBasedTopicPoliciesServiceTest extends MockedPulsarServic
         // Throw an exception first, create successfully after retrying
         doThrow(new PulsarClientException("test")).doReturn(reader).when(client).newReader();
 
-        SystemTopicClient.Reader<PulsarEvent> reader1 = service.creatSystemTopicClientWithRetry(null).get();
+        SystemTopicClient.Reader<PulsarEvent> reader1 = service.createSystemTopicClientWithRetry(null).get();
 
         assertEquals(reader1, reader);
     }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/SystemTopicBasedTopicPoliciesServiceTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/SystemTopicBasedTopicPoliciesServiceTest.java
@@ -20,7 +20,6 @@ package org.apache.pulsar.broker.service;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.testng.AssertJUnit.assertEquals;
@@ -53,6 +52,7 @@ import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.policies.data.ClusterData;
 import org.apache.pulsar.common.policies.data.TenantInfoImpl;
 import org.apache.pulsar.common.policies.data.TopicPolicies;
+import org.apache.pulsar.common.util.FutureUtil;
 import org.awaitility.Awaitility;
 import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
@@ -310,7 +310,7 @@ public class SystemTopicBasedTopicPoliciesServiceTest extends MockedPulsarServic
         try {
             service.getTopicPoliciesAsyncWithRetry(TOPIC1, backoff, pulsar.getExecutor(), false).get();
         } catch (Exception e) {
-            assertTrue(e.getCause().getCause() instanceof TopicPoliciesCacheNotInitException);
+            assertTrue(e.getCause() instanceof TopicPoliciesCacheNotInitException);
         }
         long cost = System.currentTimeMillis() - start;
         assertTrue("actual:" + cost, cost >= 5000 - 1000);
@@ -330,7 +330,8 @@ public class SystemTopicBasedTopicPoliciesServiceTest extends MockedPulsarServic
 
         SystemTopicClient.Reader<PulsarEvent> reader = mock(SystemTopicClient.Reader.class);
         // Throw an exception first, create successfully after retrying
-        doThrow(new PulsarClientException("test")).doReturn(reader).when(client).newReader();
+        doReturn(FutureUtil.failedFuture(new PulsarClientException("test")))
+                .doReturn(CompletableFuture.completedFuture(reader)).when(client).newReaderAsync();
 
         SystemTopicClient.Reader<PulsarEvent> reader1 = service.createSystemTopicClientWithRetry(null).get();
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/RetryUtilTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/RetryUtilTest.java
@@ -45,11 +45,13 @@ public class RetryUtilTest {
                 .setMandatoryStop(5000, TimeUnit.MILLISECONDS)
                 .create();
         RetryUtil.retryAsynchronously(() -> {
+            CompletableFuture<Boolean> future = new CompletableFuture<>();
             atomicInteger.incrementAndGet();
             if (atomicInteger.get() < 5) {
-                throw new RuntimeException("fail");
+                future.completeExceptionally(new RuntimeException("fail"));
             }
-            return true;
+            future.complete(true);
+            return future;
         }, backoff, executor, callback);
         assertTrue(callback.get());
         assertEquals(atomicInteger.get(), 5);
@@ -67,7 +69,9 @@ public class RetryUtilTest {
                 .create();
         long start = System.currentTimeMillis();
         RetryUtil.retryAsynchronously(() -> {
-            throw new RuntimeException("fail");
+            CompletableFuture<Boolean> future = new CompletableFuture<>();
+            future.completeExceptionally(new RuntimeException("fail"));
+            return future;
         }, backoff, executor, callback);
         try {
             callback.get();

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/util/RetryUtil.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/util/RetryUtil.java
@@ -30,7 +30,7 @@ import java.util.function.Supplier;
 public class RetryUtil {
     private static final Logger log = LoggerFactory.getLogger(RetryUtil.class);
 
-    public static <T> void retryAsynchronously(Supplier<T> supplier, Backoff backoff,
+    public static <T> void retryAsynchronously(Supplier<CompletableFuture<T>> supplier, Backoff backoff,
                                                ScheduledExecutorService scheduledExecutorService,
                                                CompletableFuture<T> callback) {
         if (backoff.getMax() <= 0) {
@@ -43,26 +43,27 @@ public class RetryUtil {
                 executeWithRetry(supplier, backoff, scheduledExecutorService, callback));
     }
 
-    private static <T> void executeWithRetry(Supplier<T> supplier, Backoff backoff,
+    private static <T> void executeWithRetry(Supplier<CompletableFuture<T>> supplier, Backoff backoff,
                                              ScheduledExecutorService scheduledExecutorService,
                                              CompletableFuture<T> callback) {
-        try {
-            T result = supplier.get();
-            callback.complete(result);
-        } catch (Exception e) {
-            long next = backoff.next();
-            boolean isMandatoryStop = backoff.isMandatoryStopMade();
-            if (isMandatoryStop) {
-                callback.completeExceptionally(e);
-            } else {
-                if (log.isDebugEnabled()) {
-                    log.debug("execute with retry fail, will retry in {} ms", next, e);
-                }
-                log.info("Because of {}, will retry in {} ms", e.getMessage(), next);
-                scheduledExecutorService.schedule(() ->
-                                executeWithRetry(supplier, backoff, scheduledExecutorService, callback),
-                        next, TimeUnit.MILLISECONDS);
-            }
+        if (supplier.get() == null) {
+            throw new RuntimeException("Miss retry execution supplier.");
         }
+        supplier.get().whenComplete((obj, e) -> {
+            if (e != null) {
+                long next = backoff.next();
+                boolean isMandatoryStop = backoff.isMandatoryStopMade();
+                if (isMandatoryStop) {
+                    callback.completeExceptionally(e);
+                } else {
+                    log.info("Execution with retry fail, because of {}, will retry in {} ms", e.getMessage(), next);
+                    scheduledExecutorService.schedule(() ->
+                                    executeWithRetry(supplier, backoff, scheduledExecutorService, callback),
+                            next, TimeUnit.MILLISECONDS);
+                }
+                return;
+            }
+            callback.complete(obj);
+        });
     }
 }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/util/RetryUtil.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/util/RetryUtil.java
@@ -46,9 +46,6 @@ public class RetryUtil {
     private static <T> void executeWithRetry(Supplier<CompletableFuture<T>> supplier, Backoff backoff,
                                              ScheduledExecutorService scheduledExecutorService,
                                              CompletableFuture<T> callback) {
-        if (supplier == null || supplier.get() == null) {
-            throw new RuntimeException("Miss retry execution supplier.");
-        }
         supplier.get().whenComplete((result, e) -> {
             if (e != null) {
                 long next = backoff.next();


### PR DESCRIPTION
### Motivation

Currently, the topic policy reader creation thread is the `executor` of the `PulsarService`, this thread is also used to search the candidate broker. If they use the same thread in some conditions, the lookup request will be blocked and result in a lookup request timeout.

![image](https://user-images.githubusercontent.com/15029908/150124902-c4318182-56f2-4b31-9149-ae64a9919aa4.png)

![image](https://user-images.githubusercontent.com/15029908/150124952-66a9f095-bab2-40fa-9370-76d3f2158dac.png)

We could find out that the lookup request was blocked 1 minute until the lookup request timeout. The thread `pulsar-2-8` was blocked by topic policy reader creation.

### Modifications

Change the topic policy reader creation to be asynchronous. Modify the method `RetryUtil.retryAsynchronously` to handle asynchronous execution.

### Verifying this change

Add a new test to verify consumer creations can be successful when enabling the topic policy feature.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

Check the box below or label this PR directly (if you have committer privilege).

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)


