### PR TITLE
[owasp] make CI fails if distribution/offloaders check does not pass

### DIFF
--- a/.github/workflows/ci-owasp-dep-check.yaml
+++ b/.github/workflows/ci-owasp-dep-check.yaml
@@ -83,7 +83,7 @@ jobs:
       # Projects dependent on flume, hdfs, hbase, and presto currently excluded from the scan.
       - name: run "clean install verify" to trigger dependency check
         if: ${{ steps.changes.outputs.poms == 'true' }}
-        run: mvn -q -B -ntp clean install verify -PskipDocker,owasp-dependency-check -DskipTests -pl '!pulsar-sql,!distribution/io,!distribution/offloaders,!tiered-storage/file-system,!pulsar-io/flume,!pulsar-io/hbase,!pulsar-io/hdfs2,!pulsar-io/hdfs3,!pulsar-io/docs'
+        run: mvn -q -B -ntp clean install verify -PskipDocker,owasp-dependency-check -DskipTests -pl '!pulsar-sql,!distribution/io,!pulsar-io/flume,!pulsar-io/hbase,!pulsar-io/hdfs2,!pulsar-io/hdfs3,!pulsar-io/docs'
 
       - name: Upload report
         uses: actions/upload-artifact@v2

--- a/.github/workflows/ci-owasp-dependency-check.yaml
+++ b/.github/workflows/ci-owasp-dependency-check.yaml
@@ -75,8 +75,17 @@ jobs:
       - name: run OWASP Dependency Check for distribution/server (-DfailBuildOnAnyVulnerability=true)
         run: mvn -B -ntp -Pmain,skip-all,skipDocker,owasp-dependency-check initialize verify -pl distribution/server -DfailBuildOnAnyVulnerability=true
 
+      - name: run OWASP Dependency Check for distribution/offloaders (-DfailBuildOnAnyVulnerability=true)
+        run: mvn -B -ntp -Pmain,skip-all,skipDocker,owasp-dependency-check initialize verify -pl distribution/offloaders -DfailBuildOnAnyVulnerability=true
+        if: ${{ matrix.checkout_branch == "master" }}
+
+      - name: run OWASP Dependency Check for distribution/io and pulsar-sql/presto-distribution
+        run: mvn -B -ntp -Pmain,skip-all,skipDocker,owasp-dependency-check initialize verify -pl distribution/io,pulsar-sql/presto-distribution
+        if: ${{ matrix.checkout_branch == "master" }}
+
       - name: run OWASP Dependency Check for distribution/offloaders, distribution/io and pulsar-sql/presto-distribution
         run: mvn -B -ntp -Pmain,skip-all,skipDocker,owasp-dependency-check initialize verify -pl distribution/offloaders,distribution/io,pulsar-sql/presto-distribution
+        if: ${{ matrix.checkout_branch != "master" }}
 
       - name: Upload OWASP Dependency Check reports
         uses: actions/upload-artifact@v2


### PR DESCRIPTION
### Motivation
Offloaders now passes the OWASP check. Let make the CI fails if a new vulnerability comes out. This let us to quickly notice there's a fix to do 

### Modifications

* Added -DfailBuildOnAnyVulnerability=true to the distribution/offloaders command (only for master)

### Documentation

- [x] `no-need-doc` 