### PR TITLE
[Broker] Fix call sync method in async rest api for internalGetSubscriptions

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
@@ -1113,9 +1113,10 @@ public class PersistentTopicsBase extends AdminResource {
                                 internalGetSubscriptionsForNonPartitionedTopic(asyncResponse, authoritative);
                             }
                         }).exceptionally(ex -> {
+                            Throwable cause = ex.getCause();
                             log.error("[{}] Failed to get partitioned topic metadata while get" +
-                                    " subscriptions for topic {}", clientAppId(), topicName, ex);
-                            resumeAsyncResponseExceptionally(asyncResponse, ex);
+                            " subscriptions for topic {}", clientAppId(), topicName, cause);
+                            resumeAsyncResponseExceptionally(asyncResponse, cause);
                             return null;
                         });
                     }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
@@ -1067,7 +1067,7 @@ public class PersistentTopicsBase extends AdminResource {
                                     final List<CompletableFuture<Object>> subscriptionFutures = Lists.newArrayList();
                                     if (topicName.getDomain() == TopicDomain.persistent) {
                                         final Map<Integer, CompletableFuture<Boolean>> existsFutures =
-                                                Maps.newConcurrentMap();
+                                                new ConcurrentHashMap<>(partitionMetadata.partitions);
                                         for (int i = 0; i < partitionMetadata.partitions; i++) {
                                             existsFutures.put(i,
                                                     topicResources().persistentTopicExists(topicName.getPartition(i)));

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
@@ -1048,7 +1048,7 @@ public class PersistentTopicsBase extends AdminResource {
         CompletableFuture<Void> future;
         if (topicName.isGlobal()) {
             future = validateGlobalNamespaceOwnershipAsync(namespaceName);
-        }else {
+        } else {
             future = CompletableFuture.completedFuture(null);
         }
         future.thenAccept(__ -> validateTopicOwnershipAsync(topicName, authoritative))
@@ -1114,16 +1114,16 @@ public class PersistentTopicsBase extends AdminResource {
                             }
                         }).exceptionally(ex -> {
                             Throwable cause = ex.getCause();
-                            log.error("[{}] Failed to get partitioned topic metadata while get" +
-                            " subscriptions for topic {}", clientAppId(), topicName, cause);
+                            log.error("[{}] Failed to get partitioned topic metadata while get"
+                                    + " subscriptions for topic {}", clientAppId(), topicName, cause);
                             resumeAsyncResponseExceptionally(asyncResponse, cause);
                             return null;
                         });
                     }
                 }).exceptionally(ex -> {
                     Throwable cause = ex.getCause();
-                    log.error("[{}] Failed to validate the global namespace/topic ownership while get subscriptions" +
-                            " for topic {}", clientAppId(), topicName, cause);
+                    log.error("[{}] Failed to validate the global namespace/topic ownership while get subscriptions"
+                            + " for topic {}", clientAppId(), topicName, cause);
                     resumeAsyncResponseExceptionally(asyncResponse, cause);
                     return null;
                 });

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
@@ -1051,7 +1051,7 @@ public class PersistentTopicsBase extends AdminResource {
         } else {
             future = CompletableFuture.completedFuture(null);
         }
-        future.thenAccept(__ -> validateTopicOwnershipAsync(topicName, authoritative))
+        future.thenCompose(__ -> validateTopicOwnershipAsync(topicName, authoritative))
                 .thenAccept(unused -> {
                     // If the topic name is a partition name, no need to get partition topic metadata again
                     if (topicName.isPartitioned()) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
@@ -1112,8 +1112,8 @@ public class PersistentTopicsBase extends AdminResource {
                             resumeAsyncResponseExceptionally(asyncResponse, ex);
                             return null;
                         });
-                    }})
-                .exceptionally(ex -> {
+                    }
+                }).exceptionally(ex -> {
                     Throwable cause = ex.getCause();
                     log.error("[{}] Failed to get subscriptions for topic {}", clientAppId(), topicName, cause);
                     resumeAsyncResponseExceptionally(asyncResponse, cause);


### PR DESCRIPTION
### Motivation

Avoid call sync method in async rest API for PersistentTopicsBase#internalGetSubscriptions.

### Modifications

- Use async instead of sync method.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: ( no)
  - The schema: ( no )
  - The default values of configurations: ( no)
  - The wire protocol: ( no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

- [x] `no-need-doc` 
  
