### PR TITLE
[Broker] Fix call sync method in async rest api for internalGetManagedLedgerInfo

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
@@ -1218,8 +1218,7 @@ public class PersistentTopicsBase extends AdminResource {
                         for (int i = 0; i < partitionMetadata.partitions; i++) {
                             TopicName topicNamePartition = topicName.getPartition(i);
                             try {
-                                futures.add(pulsar()
-                                        .getAdminClient().topics()
+                                futures.add(pulsar().getAdminClient().topics()
                                         .getInternalInfoAsync( topicNamePartition.toString())
                                         .whenComplete((response, throwable) -> {
                                             if (throwable != null) {
@@ -1233,10 +1232,10 @@ public class PersistentTopicsBase extends AdminResource {
                                                                 .readValue(response, ManagedLedgerInfo.class));
                                             } catch (JsonProcessingException ex) {
                                                 log.error("[{}] Failed to parse ManagedLedgerInfo for {} from [{}]",
-                                                        clientAppId(),
-                                                        topicNamePartition, response, ex);
+                                                        clientAppId(), topicNamePartition, response, ex);
                                             }
-                                        }));
+                                        })
+                                );
                             } catch (Exception e) {
                                 log.error("[{}] Failed to get managed info for {}", clientAppId(),
                                         topicNamePartition, e);
@@ -1268,7 +1267,7 @@ public class PersistentTopicsBase extends AdminResource {
                     return null;
                 });
             }
-        }).exceptionally(ex ->{
+        }).exceptionally(ex -> {
             Throwable cause = ex.getCause();
             log.error("[{}] Failed to get managed info for {}", clientAppId(), topicName, cause);
             resumeAsyncResponseExceptionally(asyncResponse, cause);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
@@ -1238,8 +1238,8 @@ public class PersistentTopicsBase extends AdminResource {
                                         })
                                 );
                             } catch (PulsarServerException e) {
-                                log.error("[{}] Failed to get admin client while get managed info for {}", clientAppId(),
-                                        topicNamePartition, e);
+                                log.error("[{}] Failed to get admin client while get managed info for {}" ,
+                                        clientAppId(), topicNamePartition, e);
                                 throw new RestException(e);
                             }
                         }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
@@ -1199,103 +1199,107 @@ public class PersistentTopicsBase extends AdminResource {
     }
 
     protected void internalGetManagedLedgerInfo(AsyncResponse asyncResponse, boolean authoritative) {
+        CompletableFuture<Void> future = CompletableFuture.completedFuture(null);
         if (topicName.isGlobal()) {
-            try {
-                validateGlobalNamespaceOwnership(namespaceName);
-            } catch (Exception e) {
-                log.error("[{}] Failed to get managed info for {}", clientAppId(), topicName, e);
-                resumeAsyncResponseExceptionally(asyncResponse, e);
-                return;
-            }
+            future = validateGlobalNamespaceOwnershipAsync(namespaceName);
         }
+        future.thenAccept(__ -> {
+            // If the topic name is a partition name, no need to get partition topic metadata again
+            if (topicName.isPartitioned()) {
+                internalGetManagedLedgerInfoForNonPartitionedTopic(asyncResponse);
+            } else {
+                getPartitionedTopicMetadataAsync(topicName, authoritative, false)
+                        .thenAccept(partitionMetadata -> {
+                    if (partitionMetadata.partitions > 0) {
+                        final List<CompletableFuture<String>> futures = Lists.newArrayList();
 
-        // If the topic name is a partition name, no need to get partition topic metadata again
-        if (topicName.isPartitioned()) {
-            internalGetManagedLedgerInfoForNonPartitionedTopic(asyncResponse);
-        } else {
-            getPartitionedTopicMetadataAsync(topicName,
-                    authoritative, false).thenAccept(partitionMetadata -> {
-                if (partitionMetadata.partitions > 0) {
-                    final List<CompletableFuture<String>> futures = Lists.newArrayList();
+                        PartitionedManagedLedgerInfo partitionedManagedLedgerInfo = new PartitionedManagedLedgerInfo();
 
-                    PartitionedManagedLedgerInfo partitionedManagedLedgerInfo = new PartitionedManagedLedgerInfo();
-
-                    for (int i = 0; i < partitionMetadata.partitions; i++) {
-                        TopicName topicNamePartition = topicName.getPartition(i);
-                        try {
-                            futures.add(pulsar().getAdminClient().topics()
-                                    .getInternalInfoAsync(
-                                            topicNamePartition.toString()).whenComplete((response, throwable) -> {
-                                        if (throwable != null) {
-                                            log.error("[{}] Failed to get managed info for {}",
-                                                    clientAppId(), topicNamePartition, throwable);
-                                            asyncResponse.resume(new RestException(throwable));
-                                        }
-                                        try {
-                                            partitionedManagedLedgerInfo.partitions.put(topicNamePartition.toString(),
-                                                    jsonMapper().readValue(response,
-                                                            ManagedLedgerInfo.class));
-                                        } catch (JsonProcessingException ex) {
-                                            log.error("[{}] Failed to parse ManagedLedgerInfo for {} from [{}]",
-                                                    clientAppId(),
-                                                    topicNamePartition, response, ex);
-                                        }
-                                    }));
-                        } catch (Exception e) {
-                            log.error("[{}] Failed to get managed info for {}", clientAppId(), topicNamePartition, e);
-                            throw new RestException(e);
-                        }
-                    }
-
-                    FutureUtil.waitForAll(futures).handle((result, exception) -> {
-                        if (exception != null) {
-                            Throwable t = exception.getCause();
-                            if (t instanceof NotFoundException) {
-                                asyncResponse.resume(new RestException(Status.NOT_FOUND, "Topic not found"));
-                            } else {
-                                log.error("[{}] Failed to get managed info for {}", clientAppId(), topicName, t);
-                                asyncResponse.resume(new RestException(t));
+                        for (int i = 0; i < partitionMetadata.partitions; i++) {
+                            TopicName topicNamePartition = topicName.getPartition(i);
+                            try {
+                                futures.add(pulsar()
+                                        .getAdminClient().topics()
+                                        .getInternalInfoAsync( topicNamePartition.toString())
+                                        .whenComplete((response, throwable) -> {
+                                            if (throwable != null) {
+                                                log.error("[{}] Failed to get managed info for {}",
+                                                        clientAppId(), topicNamePartition, throwable);
+                                                asyncResponse.resume(new RestException(throwable));
+                                            }
+                                            try {
+                                                partitionedManagedLedgerInfo.partitions
+                                                        .put(topicNamePartition.toString(), jsonMapper()
+                                                                .readValue(response, ManagedLedgerInfo.class));
+                                            } catch (JsonProcessingException ex) {
+                                                log.error("[{}] Failed to parse ManagedLedgerInfo for {} from [{}]",
+                                                        clientAppId(),
+                                                        topicNamePartition, response, ex);
+                                            }
+                                        }));
+                            } catch (Exception e) {
+                                log.error("[{}] Failed to get managed info for {}", clientAppId(),
+                                        topicNamePartition, e);
+                                throw new RestException(e);
                             }
                         }
-                        asyncResponse.resume((StreamingOutput) output -> {
-                            jsonMapper().writer().writeValue(output, partitionedManagedLedgerInfo);
+
+                        FutureUtil.waitForAll(futures).handle((result, exception) -> {
+                            if (exception != null) {
+                                Throwable t = exception.getCause();
+                                if (t instanceof NotFoundException) {
+                                    asyncResponse.resume(new RestException(Status.NOT_FOUND, "Topic not found"));
+                                } else {
+                                    log.error("[{}] Failed to get managed info for {}", clientAppId(), topicName, t);
+                                    asyncResponse.resume(new RestException(t));
+                                }
+                            }
+                            asyncResponse.resume((StreamingOutput) output -> {
+                                jsonMapper().writer().writeValue(output, partitionedManagedLedgerInfo);
+                            });
+                            return null;
                         });
-                        return null;
-                    });
-                } else {
-                    internalGetManagedLedgerInfoForNonPartitionedTopic(asyncResponse);
-                }
-            }).exceptionally(ex -> {
-                log.error("[{}] Failed to get managed info for {}", clientAppId(), topicName, ex);
-                resumeAsyncResponseExceptionally(asyncResponse, ex);
-                return null;
-            });
-        }
+                    } else {
+                        internalGetManagedLedgerInfoForNonPartitionedTopic(asyncResponse);
+                    }
+                }).exceptionally(ex -> {
+                    log.error("[{}] Failed to get managed info for {}", clientAppId(), topicName, ex);
+                    resumeAsyncResponseExceptionally(asyncResponse, ex);
+                    return null;
+                });
+            }
+        }).exceptionally(ex ->{
+            Throwable cause = ex.getCause();
+            log.error("[{}] Failed to get managed info for {}", clientAppId(), topicName, cause);
+            resumeAsyncResponseExceptionally(asyncResponse, cause);
+            return null;
+        });
     }
 
     protected void internalGetManagedLedgerInfoForNonPartitionedTopic(AsyncResponse asyncResponse) {
-        String managedLedger;
-        try {
-            validateTopicOperation(topicName, TopicOperation.GET_STATS);
-            managedLedger = topicName.getPersistenceNamingEncoding();
-        } catch (Exception e) {
-            log.error("[{}] Failed to get managed info for {}", clientAppId(), topicName, e);
-            resumeAsyncResponseExceptionally(asyncResponse, e);
-            return;
-        }
-        pulsar().getManagedLedgerFactory().asyncGetManagedLedgerInfo(managedLedger, new ManagedLedgerInfoCallback() {
-            @Override
-            public void getInfoComplete(ManagedLedgerInfo info, Object ctx) {
-                asyncResponse.resume((StreamingOutput) output -> {
-                    jsonMapper().writer().writeValue(output, info);
+        validateTopicOperationAsync(topicName, TopicOperation.GET_STATS)
+                .thenAccept(__ ->{
+                    String managedLedger = topicName.getPersistenceNamingEncoding();
+                    pulsar().getManagedLedgerFactory()
+                            .asyncGetManagedLedgerInfo(managedLedger, new ManagedLedgerInfoCallback() {
+                        @Override
+                        public void getInfoComplete(ManagedLedgerInfo info, Object ctx) {
+                            asyncResponse.resume((StreamingOutput) output -> {
+                                jsonMapper().writer().writeValue(output, info);
+                            });
+                        }
+                        @Override
+                        public void getInfoFailed(ManagedLedgerException exception, Object ctx) {
+                            asyncResponse.resume(exception);
+                        }
+                    }, null);
+                }).exceptionally(ex -> {
+                    Throwable cause = ex.getCause();
+                    log.error("[{}] Failed to get managed info for {}", clientAppId(), topicName, cause);
+                    resumeAsyncResponseExceptionally(asyncResponse, cause);
+                    return null;
                 });
-            }
 
-            @Override
-            public void getInfoFailed(ManagedLedgerException exception, Object ctx) {
-                asyncResponse.resume(exception);
-            }
-        }, null);
     }
 
     protected void internalGetPartitionedStats(AsyncResponse asyncResponse, boolean authoritative, boolean perPartition,

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
@@ -1213,8 +1213,8 @@ public class PersistentTopicsBase extends AdminResource {
                 getPartitionedTopicMetadataAsync(topicName, authoritative, false)
                         .thenAccept(partitionMetadata -> {
                     if (partitionMetadata.partitions > 0) {
-                        final List<CompletableFuture<String>> futures
-                                = Lists.newArrayListWithCapacity(partitionMetadata.partitions);
+                        final List<CompletableFuture<String>> futures =
+                                Lists.newArrayListWithCapacity(partitionMetadata.partitions);
                         PartitionedManagedLedgerInfo partitionedManagedLedgerInfo = new PartitionedManagedLedgerInfo();
                         for (int i = 0; i < partitionMetadata.partitions; i++) {
                             TopicName topicNamePartition = topicName.getPartition(i);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
@@ -1237,8 +1237,8 @@ public class PersistentTopicsBase extends AdminResource {
                                             }
                                         })
                                 );
-                            } catch (Exception e) {
-                                log.error("[{}] Failed to get managed info for {}", clientAppId(),
+                            } catch (PulsarServerException e) {
+                                log.error("[{}] Failed to get admin client while get managed info for {}", clientAppId(),
                                         topicNamePartition, e);
                                 throw new RestException(e);
                             }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
@@ -1219,7 +1219,7 @@ public class PersistentTopicsBase extends AdminResource {
                             TopicName topicNamePartition = topicName.getPartition(i);
                             try {
                                 futures.add(pulsar().getAdminClient().topics()
-                                        .getInternalInfoAsync( topicNamePartition.toString())
+                                        .getInternalInfoAsync(topicNamePartition.toString())
                                         .whenComplete((response, throwable) -> {
                                             if (throwable != null) {
                                                 log.error("[{}] Failed to get managed info for {}",

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
@@ -1281,7 +1281,7 @@ public class PersistentTopicsBase extends AdminResource {
 
     protected void internalGetManagedLedgerInfoForNonPartitionedTopic(AsyncResponse asyncResponse) {
         validateTopicOperationAsync(topicName, TopicOperation.GET_STATS)
-                .thenAccept(__ ->{
+                .thenAccept(__ -> {
                     String managedLedger = topicName.getPersistenceNamingEncoding();
                     pulsar().getManagedLedgerFactory()
                             .asyncGetManagedLedgerInfo(managedLedger, new ManagedLedgerInfoCallback() {


### PR DESCRIPTION
### Motivation

Avoid call sync method in async rest API for PersistentTopicsBase#internalGetManagedLedgerInfo.

### Modifications

- Use async instead of sync method.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: ( no)
  - The schema: ( no )
  - The default values of configurations: ( no)
  - The wire protocol: ( no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

- [x] `no-need-doc` 
  
