### PR TITLE
[Broker] Fix call sync method in async rest api for internalTriggerCompaction

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
@@ -3598,12 +3598,17 @@ public class PersistentTopicsBase extends AdminResource {
                     }
                 }).exceptionally(ex -> {
                     Throwable cause = ex.getCause();
-                    log.error("[{}] Failed to validate global namespace ownership to trigger compaction on topic {}",
-                            clientAppId(), topicName, cause);
+                    log.error("[{}] Failed to trigger compaction on topic {}", clientAppId(), topicName, cause);
                     resumeAsyncResponseExceptionally(asyncResponse, cause);
                     return null;
                 });
             }
+        }).exceptionally(ex -> {
+            Throwable cause = ex.getCause();
+            log.error("[{}] Failed to validate global namespace ownership to trigger compaction on topic {}",
+                    clientAppId(), topicName, cause);
+            resumeAsyncResponseExceptionally(asyncResponse, cause);
+            return null;
         });
     }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
@@ -3622,7 +3622,7 @@ public class PersistentTopicsBase extends AdminResource {
                     } catch (Exception e) {
                         log.error("[{}] Failed to trigger compaction on topic {}", clientAppId(),
                                 topicName, e);
-                        resumeAsyncResponseExceptionally(asyncResponse, new RestException(new RestException(e)));
+                        resumeAsyncResponseExceptionally(asyncResponse, new RestException(e));
                         return;
                     }
                 }).exceptionally(ex -> {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
@@ -3543,98 +3543,88 @@ public class PersistentTopicsBase extends AdminResource {
 
     protected void internalTriggerCompaction(AsyncResponse asyncResponse, boolean authoritative) {
         log.info("[{}] Trigger compaction on topic {}", clientAppId(), topicName);
-        try {
-            if (topicName.isGlobal()) {
-                validateGlobalNamespaceOwnership(namespaceName);
-            }
-        } catch (Exception e) {
-            if (e instanceof WebApplicationException) {
-                if (log.isDebugEnabled()) {
-                    log.debug("[{}] Failed to trigger compaction on topic {}, redirecting to other brokers.",
-                            clientAppId(), topicName, e);
-                }
-                resumeAsyncResponseExceptionally(asyncResponse, e);
-                return;
-            }
-            log.error("[{}] Failed to trigger compaction on topic {}", clientAppId(), topicName, e);
-            resumeAsyncResponseExceptionally(asyncResponse, e);
-            return;
-        }
-
-        // If the topic name is a partition name, no need to get partition topic metadata again
-        if (topicName.isPartitioned()) {
-            try {
-                internalTriggerCompactionNonPartitionedTopic(authoritative);
-            } catch (Exception e) {
-                log.error("[{}] Failed to trigger compaction on topic {}", clientAppId(), topicName, e);
-                resumeAsyncResponseExceptionally(asyncResponse, e);
-                return;
-            }
-            asyncResponse.resume(Response.noContent().build());
+        CompletableFuture<Void> future;
+        if (topicName.isGlobal()) {
+            future = validateGlobalNamespaceOwnershipAsync(namespaceName);
         } else {
-            getPartitionedTopicMetadataAsync(topicName, authoritative, false).thenAccept(partitionMetadata -> {
-                final int numPartitions = partitionMetadata.partitions;
-                if (numPartitions > 0) {
-                    final List<CompletableFuture<Void>> futures = Lists.newArrayList();
+            future = CompletableFuture.completedFuture(null);
+        }
+        future.thenAccept(__ -> {
+            // If the topic name is a partition name, no need to get partition topic metadata again
+            if (topicName.isPartitioned()) {
+                try {
+                    internalTriggerCompactionNonPartitionedTopic(authoritative);
+                } catch (Exception e) {
+                    log.error("[{}] Failed to trigger compaction on topic {}", clientAppId(), topicName, e);
+                    resumeAsyncResponseExceptionally(asyncResponse, e);
+                    return;
+                }
+                asyncResponse.resume(Response.noContent().build());
+            } else {
+                getPartitionedTopicMetadataAsync(topicName, authoritative, false).thenAccept(partitionMetadata -> {
+                    final int numPartitions = partitionMetadata.partitions;
+                    if (numPartitions > 0) {
+                        final List<CompletableFuture<Void>> futures = Lists.newArrayList();
 
-                    for (int i = 0; i < numPartitions; i++) {
-                        TopicName topicNamePartition = topicName.getPartition(i);
-                        try {
-                            futures.add(pulsar()
-                                    .getAdminClient()
-                                    .topics()
-                                    .triggerCompactionAsync(topicNamePartition.toString()));
-                        } catch (Exception e) {
-                            log.error("[{}] Failed to trigger compaction on topic {}",
-                                    clientAppId(), topicNamePartition, e);
-                            asyncResponse.resume(new RestException(e));
-                            return;
-                        }
-                    }
-
-                    FutureUtil.waitForAll(futures).handle((result, exception) -> {
-                        if (exception != null) {
-                            Throwable th = exception.getCause();
-                            if (th instanceof NotFoundException) {
-                                asyncResponse.resume(new RestException(Status.NOT_FOUND, th.getMessage()));
-                                return null;
-                            } else if (th instanceof WebApplicationException) {
-                                asyncResponse.resume(th);
-                                return null;
-                            } else {
+                        for (int i = 0; i < numPartitions; i++) {
+                            TopicName topicNamePartition = topicName.getPartition(i);
+                            try {
+                                futures.add(pulsar()
+                                        .getAdminClient()
+                                        .topics()
+                                        .triggerCompactionAsync(topicNamePartition.toString()));
+                            } catch (Exception e) {
                                 log.error("[{}] Failed to trigger compaction on topic {}",
-                                        clientAppId(), topicName, exception);
-                                asyncResponse.resume(new RestException(exception));
-                                return null;
+                                        clientAppId(), topicNamePartition, e);
+                                asyncResponse.resume(new RestException(e));
+                                return;
                             }
                         }
-                        asyncResponse.resume(Response.noContent().build());
-                        return null;
-                    });
-                } else {
-                    try {
-                        internalTriggerCompactionNonPartitionedTopic(authoritative);
-                    } catch (Exception e) {
-                        if (e instanceof WebApplicationException) {
-                            if (log.isDebugEnabled()) {
-                                log.debug("[{}] Failed to trigger compaction on topic {}, "
-                                        + "redirecting to other brokers.", clientAppId(), topicName, e);
+
+                        FutureUtil.waitForAll(futures).handle((result, exception) -> {
+                            if (exception != null) {
+                                Throwable th = exception.getCause();
+                                if (th instanceof NotFoundException) {
+                                    asyncResponse.resume(new RestException(Status.NOT_FOUND, th.getMessage()));
+                                    return null;
+                                } else if (th instanceof WebApplicationException) {
+                                    asyncResponse.resume(th);
+                                    return null;
+                                } else {
+                                    log.error("[{}] Failed to trigger compaction on topic {}",
+                                            clientAppId(), topicName, exception);
+                                    asyncResponse.resume(new RestException(exception));
+                                    return null;
+                                }
                             }
+                            asyncResponse.resume(Response.noContent().build());
+                            return null;
+                        });
+                    } else {
+                        try {
+                            internalTriggerCompactionNonPartitionedTopic(authoritative);
+                        } catch (Exception e) {
+                            if (e instanceof WebApplicationException) {
+                                if (log.isDebugEnabled()) {
+                                    log.debug("[{}] Failed to trigger compaction on topic {}, "
+                                            + "redirecting to other brokers.", clientAppId(), topicName, e);
+                                }
+                                resumeAsyncResponseExceptionally(asyncResponse, e);
+                                return;
+                            }
+                            log.error("[{}] Failed to trigger compaction on topic {}", clientAppId(), topicName, e);
                             resumeAsyncResponseExceptionally(asyncResponse, e);
                             return;
                         }
-                        log.error("[{}] Failed to trigger compaction on topic {}", clientAppId(), topicName, e);
-                        resumeAsyncResponseExceptionally(asyncResponse, e);
-                        return;
+                        asyncResponse.resume(Response.noContent().build());
                     }
-                    asyncResponse.resume(Response.noContent().build());
-                }
-            }).exceptionally(ex -> {
-                log.error("[{}] Failed to trigger compaction on topic {}", clientAppId(), topicName, ex);
-                resumeAsyncResponseExceptionally(asyncResponse, ex);
-                return null;
-            });
-        }
+                }).exceptionally(ex -> {
+                    log.error("[{}] Failed to trigger compaction on topic {}", clientAppId(), topicName, ex);
+                    resumeAsyncResponseExceptionally(asyncResponse, ex);
+                    return null;
+                });
+            }
+        });
     }
 
     protected void internalTriggerCompactionNonPartitionedTopic(boolean authoritative) {


### PR DESCRIPTION
### Motivation

Avoid call sync method in async rest API for PersistentTopicsBase#internalTriggerCompaction.

### Modifications

- *Use async instead of sync method.*

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

Need to update docs? 
  
- [x] `no-need-doc` 
 


