### PR TITLE
send with progress

### DIFF
--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/Producer.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/Producer.java
@@ -77,6 +77,8 @@ public interface Producer<T> extends Closeable {
      */
     CompletableFuture<MessageId> sendAsync(T message);
 
+    CompletableFuture<MessageId> sendAsync(T message, Progress progress);
+
     /**
      * Flush all the messages buffered in the client and wait until all messages have been successfully persisted.
      *
@@ -194,4 +196,16 @@ public interface Producer<T> extends Closeable {
      * @return The last disconnected timestamp of the producer
      */
     long getLastDisconnectedTimestamp();
+
+    /**
+     * @return the number of partitions per topic.
+     */
+    int getNumOfPartitions();
+
+    void loadProgress(byte[] progressBuf);
+
+    byte[] saveProgress();
+
+    Progress queryMinProgress();
+
 }

--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/Progress.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/Progress.java
@@ -1,0 +1,11 @@
+package org.apache.pulsar.client.api;
+
+public interface Progress {
+
+    int compare(Progress progress);
+
+    byte[] serialize();
+
+    Progress deserialize(byte[] progressBuf);
+
+}

--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/TypedMessageBuilder.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/TypedMessageBuilder.java
@@ -113,6 +113,8 @@ public interface TypedMessageBuilder<T> extends Serializable {
      */
     TypedMessageBuilder<T> orderingKey(byte[] orderingKey);
 
+    TypedMessageBuilder<T> progress(Progress progress);
+
     /**
      * Set a domain object on the message.
      *

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/BatchMessageContainerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/BatchMessageContainerImpl.java
@@ -18,11 +18,10 @@
  */
 package org.apache.pulsar.client.impl;
 
-import com.google.common.collect.Lists;
-
 import io.netty.buffer.ByteBuf;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
@@ -52,7 +51,7 @@ class BatchMessageContainerImpl extends AbstractBatchMessageContainer {
     private long lowestSequenceId = -1L;
     private long highestSequenceId = -1L;
     private ByteBuf batchedMessageMetadataAndPayload;
-    private List<MessageImpl<?>> messages = Lists.newArrayList();
+    private List<MessageImpl<?>> messages = new ArrayList<>();
     protected SendCallback previousCallback = null;
     // keep track of callbacks for individual messages being published in a batch
     protected SendCallback firstCallback;
@@ -147,7 +146,7 @@ class BatchMessageContainerImpl extends AbstractBatchMessageContainer {
 
     @Override
     public void clear() {
-        messages = Lists.newArrayList();
+        messages = new ArrayList<>();
         firstCallback = null;
         previousCallback = null;
         messageMetadata.clear();
@@ -204,7 +203,7 @@ class BatchMessageContainerImpl extends AbstractBatchMessageContainer {
                 messageMetadata.getHighestSequenceId(), numMessagesInBatch, messageMetadata, encryptedPayload);
 
         OpSendMsg op = OpSendMsg.create(messages, cmd, messageMetadata.getSequenceId(),
-                messageMetadata.getHighestSequenceId(), firstCallback);
+                messageMetadata.getHighestSequenceId(), firstCallback, previousCallback);
 
         op.setNumMessagesInBatch(numMessagesInBatch);
         op.setBatchSizeByte(currentBatchSizeBytes);

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/BatchMessageKeyBasedContainer.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/BatchMessageKeyBasedContainer.java
@@ -19,7 +19,6 @@
 package org.apache.pulsar.client.impl;
 
 import com.google.common.collect.ComparisonChain;
-import com.google.common.collect.Lists;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.util.ReferenceCountUtil;
@@ -142,7 +141,8 @@ class BatchMessageKeyBasedContainer extends AbstractBatchMessageContainer {
         ByteBufPair cmd = producer.sendMessage(producer.producerId, keyedBatch.sequenceId, numMessagesInBatch,
                 keyedBatch.messageMetadata, encryptedPayload);
 
-        ProducerImpl.OpSendMsg op = ProducerImpl.OpSendMsg.create(keyedBatch.messages, cmd, keyedBatch.sequenceId, keyedBatch.firstCallback);
+        ProducerImpl.OpSendMsg op = ProducerImpl.OpSendMsg.create(keyedBatch.messages, cmd, keyedBatch.sequenceId,
+                keyedBatch.firstCallback, keyedBatch.previousCallback);
 
         op.setNumMessagesInBatch(numMessagesInBatch);
         op.setBatchSizeByte(currentBatchSizeBytes);
@@ -191,7 +191,7 @@ class BatchMessageKeyBasedContainer extends AbstractBatchMessageContainer {
         // sequence id for this batch which will be persisted as a single entry by broker
         private long sequenceId = -1;
         private ByteBuf batchedMessageMetadataAndPayload;
-        private List<MessageImpl<?>> messages = Lists.newArrayList();
+        private List<MessageImpl<?>> messages = new ArrayList<>();
         private SendCallback previousCallback = null;
         private CompressionType compressionType;
         private CompressionCodec compressor;
@@ -249,7 +249,7 @@ class BatchMessageKeyBasedContainer extends AbstractBatchMessageContainer {
         }
 
         public void clear() {
-            messages = Lists.newArrayList();
+            messages = new ArrayList<>();
             firstCallback = null;
             previousCallback = null;
             messageMetadata.clear();

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerBase.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerBase.java
@@ -22,13 +22,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 
 import java.util.concurrent.CompletableFuture;
 
-import org.apache.pulsar.client.api.Message;
-import org.apache.pulsar.client.api.MessageId;
-import org.apache.pulsar.client.api.Producer;
-import org.apache.pulsar.client.api.PulsarClientException;
-import org.apache.pulsar.client.api.Schema;
-import org.apache.pulsar.client.api.SchemaSerializationException;
-import org.apache.pulsar.client.api.TypedMessageBuilder;
+import org.apache.pulsar.client.api.*;
 import org.apache.pulsar.client.api.transaction.Transaction;
 import org.apache.pulsar.client.impl.conf.ProducerConfigurationData;
 import org.apache.pulsar.client.impl.transaction.TransactionImpl;
@@ -67,6 +61,18 @@ public abstract class ProducerBase<T> extends HandlerState implements Producer<T
     public CompletableFuture<MessageId> sendAsync(T message) {
         try {
             return newMessage().value(message).sendAsync();
+        } catch (SchemaSerializationException e) {
+            return FutureUtil.failedFuture(e);
+        }
+    }
+
+    @Override
+    public CompletableFuture<MessageId> sendAsync(T message, Progress progress) {
+        if (!conf.isNeedProgress()) {
+            // exception
+        }
+        try {
+            return newMessage().value(message).progress(progress).sendAsync();
         } catch (SchemaSerializationException e) {
             return FutureUtil.failedFuture(e);
         }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProgressInfo.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProgressInfo.java
@@ -1,0 +1,10 @@
+package org.apache.pulsar.client.impl;
+
+import lombok.Data;
+import org.apache.pulsar.client.api.Progress;
+
+@Data
+public class ProgressInfo {
+    private Progress progress;
+    private long sequenceId;
+}

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProgressManager.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProgressManager.java
@@ -1,0 +1,39 @@
+package org.apache.pulsar.client.impl;
+
+import org.apache.pulsar.client.api.Progress;
+
+public class ProgressManager {
+
+    public ProgressInfo persistentProgressInfos;
+
+    public ProgressInfo pushedProgressInfos;
+
+    public void updatePersistentProgress(Progress progress, long sequenceId) {
+        persistentProgressInfos.setProgress(progress);
+        persistentProgressInfos.setSequenceId(sequenceId);
+    }
+
+    public void updatePushedProgress(Progress progress, long sequenceId) {
+        pushedProgressInfos.setProgress(progress);
+        pushedProgressInfos.setSequenceId(sequenceId);
+    }
+
+    public ProgressInfo getPublishedProgressInfos() {
+        return pushedProgressInfos;
+    }
+
+    public ProgressInfo getPersistentProgressInfos() {
+        return persistentProgressInfos;
+    }
+
+    public ProgressInfo loadProgress(byte[] progressBuf){
+        // recover progress from progressbuf
+        persistentProgressInfos = persistentProgressInfos = null;
+        return persistentProgressInfos;
+    }
+
+    public byte[] saveProgress(){
+        return null;
+    }
+
+}

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProgressMessageImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProgressMessageImpl.java
@@ -1,0 +1,162 @@
+package org.apache.pulsar.client.impl;
+
+import org.apache.pulsar.client.api.Message;
+import org.apache.pulsar.client.api.MessageId;
+import org.apache.pulsar.client.api.Progress;
+import org.apache.pulsar.common.api.EncryptionContext;
+
+import java.util.Map;
+import java.util.Optional;
+
+
+public class ProgressMessageImpl<T> implements Message<T> {
+
+    private final Message<T> msg;
+
+    public Progress progress;
+
+    public ProgressMessageImpl(Message<T> msg, Progress progress) {
+        this.msg = msg;
+        this.progress = progress;
+    }
+
+    @Override
+    public Map<String, String> getProperties() {
+        return null;
+    }
+
+    @Override
+    public boolean hasProperty(String name) {
+        return false;
+    }
+
+    @Override
+    public String getProperty(String name) {
+        return null;
+    }
+
+    @Override
+    public byte[] getData() {
+        return new byte[0];
+    }
+
+    @Override
+    public int size() {
+        return 0;
+    }
+
+    @Override
+    public T getValue() {
+        return null;
+    }
+
+    @Override
+    public MessageId getMessageId() {
+        return null;
+    }
+
+    @Override
+    public long getPublishTime() {
+        return 0;
+    }
+
+    @Override
+    public long getEventTime() {
+        return 0;
+    }
+
+    @Override
+    public long getSequenceId() {
+        return 0;
+    }
+
+    @Override
+    public String getProducerName() {
+        return null;
+    }
+
+    @Override
+    public boolean hasKey() {
+        return false;
+    }
+
+    @Override
+    public String getKey() {
+        return null;
+    }
+
+    @Override
+    public boolean hasBase64EncodedKey() {
+        return false;
+    }
+
+    @Override
+    public byte[] getKeyBytes() {
+        return new byte[0];
+    }
+
+    @Override
+    public boolean hasOrderingKey() {
+        return false;
+    }
+
+    @Override
+    public byte[] getOrderingKey() {
+        return new byte[0];
+    }
+
+    @Override
+    public String getTopicName() {
+        return null;
+    }
+
+    @Override
+    public Optional<EncryptionContext> getEncryptionCtx() {
+        return Optional.empty();
+    }
+
+    @Override
+    public int getRedeliveryCount() {
+        return 0;
+    }
+
+    @Override
+    public byte[] getSchemaVersion() {
+        return new byte[0];
+    }
+
+    @Override
+    public boolean isReplicated() {
+        return false;
+    }
+
+    @Override
+    public String getReplicatedFrom() {
+        return null;
+    }
+
+    @Override
+    public void release() {
+
+    }
+
+    @Override
+    public boolean hasBrokerPublishTime() {
+        return false;
+    }
+
+    @Override
+    public Optional<Long> getBrokerPublishTime() {
+        return Optional.empty();
+    }
+
+    @Override
+    public boolean hasIndex() {
+        return false;
+    }
+
+    @Override
+    public Optional<Long> getIndex() {
+        return Optional.empty();
+    }
+}

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProgressSendCallback.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProgressSendCallback.java
@@ -1,0 +1,43 @@
+package org.apache.pulsar.client.impl;
+
+import org.apache.pulsar.client.api.MessageId;
+import org.apache.pulsar.client.api.Progress;
+
+import java.util.concurrent.CompletableFuture;
+
+public class ProgressSendCallback implements SendCallback{
+    private Progress progress;
+
+    public void setProgress(Progress progress) {
+        this.progress = progress;
+    }
+
+    public Progress getProgress() {
+        return this.progress;
+    }
+
+    @Override
+    public void sendComplete(Exception e) {
+
+    }
+
+    @Override
+    public void addCallback(MessageImpl<?> msg, SendCallback scb) {
+
+    }
+
+    @Override
+    public SendCallback getNextSendCallback() {
+        return null;
+    }
+
+    @Override
+    public MessageImpl<?> getNextMessage() {
+        return null;
+    }
+
+    @Override
+    public CompletableFuture<MessageId> getFuture() {
+        return null;
+    }
+}

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ProducerConfigurationData.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ProducerConfigurationData.java
@@ -39,7 +39,6 @@ import org.apache.pulsar.client.api.ProducerAccessMode;
 import org.apache.pulsar.client.api.ProducerCryptoFailureAction;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 
 import lombok.Data;
@@ -106,6 +105,8 @@ public class ProducerConfigurationData implements Serializable, Cloneable {
 
     private SortedMap<String, String> properties = new TreeMap<>();
 
+    private boolean needProgress = false;
+
     /**
      *
      * Returns true if encryption keys are added
@@ -120,7 +121,7 @@ public class ProducerConfigurationData implements Serializable, Cloneable {
         try {
             ProducerConfigurationData c = (ProducerConfigurationData) super.clone();
             c.encryptionKeys = Sets.newTreeSet(this.encryptionKeys);
-            c.properties = Maps.newTreeMap(this.properties);
+            c.properties = new TreeMap<>(this.properties);
             return c;
         } catch (CloneNotSupportedException e) {
             throw new RuntimeException("Failed to clone ProducerConfigurationData", e);


### PR DESCRIPTION


### Motivation

How to implement exactly once? Pulsar provides an implementation based on sequenceid, which requires users to maintain the mapping relationship between sequenceid and MSG. This requires development costs for users。
User data often has some characteristics, such as time, location, etc. we want to provide a way to convert the mapping relationship between maintenance sequenceid and MSG into the mapping relationship between data characteristics and MSG, so as to reduce user development costs.

### Modifications
