### PR TITLE
[elasticsearch-sink] add native support for CQL 'varint' and CQL 'decimal' types

### DIFF
--- a/pulsar-io/elastic-search/src/main/java/org/apache/pulsar/io/elasticsearch/JsonConverter.java
+++ b/pulsar-io/elastic-search/src/main/java/org/apache/pulsar/io/elasticsearch/JsonConverter.java
@@ -112,8 +112,8 @@ public class JsonConverter {
                     throw new UnsupportedOperationException("Unknown AVRO schema type=" + schema.getType());
             }
         } catch (ClassCastException error) {
-            throw new IllegalArgumentException("Error while converting a value of type " + value.getClass() + " to a " + schema.getType()
-                    + ": " + error, error);
+            throw new IllegalArgumentException("Error while converting a value of type "
+                    + value.getClass() + " to a " + schema.getType() + ": " + error, error);
         }
     }
 
@@ -123,10 +123,12 @@ public class JsonConverter {
 
     private static void checkTypeAndNotNull(Object value, String name, Class expected) {
         if (value == null) {
-            throw new IllegalArgumentException("Invalid type for " + name + ", expected " + expected.getName() + " but was NULL");
+            throw new IllegalArgumentException("Invalid type for " + name
+                    + ", expected " + expected.getName() + " but was NULL");
         }
         if (!expected.isInstance(value)) {
-            throw new IllegalArgumentException("Invalid type for " + name + ", expected " + expected.getName() + " but was " + value.getClass());
+            throw new IllegalArgumentException("Invalid type for " + name
+                    + ", expected " + expected.getName() + " but was " + value.getClass());
         }
     }
 


### PR DESCRIPTION
### Motivation

Currently there is no support for CQL types in ElasticSearch sink when using Avro schema to parse data. 

### Modifications
Added two [CQL field types](https://cassandra.apache.org/doc/latest/cassandra/cql/types.html) to handle simple numeric cases 

* Added 'cql_varint'. It accepts BYTES and then it convert the value to a BigDecimal
* Added 'cql_decimal'. It accepts a Avro generic record with 'bigint' and 'scale' fields. then it convert the whole record to a BigDecimal

### Documentation

- [x] `no-need-doc` 
  The elastic-search sink doc does not refer to the supported logical types. It would be useful but it requires a dedicated pull