### PR TITLE
[security] pulsar-io-kafka: upgrade jersey-bean-validation to get rid of CVE-2017-7536 (brought in by Hibernate Validator 5.x)

### DIFF
--- a/pulsar-io/kafka/pom.xml
+++ b/pulsar-io/kafka/pom.xml
@@ -30,6 +30,16 @@
   <artifactId>pulsar-io-kafka</artifactId>
   <name>Pulsar IO :: Kafka</name>
 
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.glassfish.jersey.ext</groupId>
+        <artifactId>jersey-bean-validation</artifactId>
+        <version>${jersey.version}</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
   <dependencies>
 
     <dependency>


### PR DESCRIPTION
### Motivation
Pulsar IO Kafka connector depends from kafka client which, in turn, depends on `jersey-bean-validation:2.27`.

`jersey-bean-validation:2.27` depends on `hibernate-validator:5.1.3` which is vulnerable to CVE-2017-7536

`jersey-bean-validation:2.27` uses Hibernate 6.x which is safe.

### Modifications

* Fixed `jersey-bean-validation` to 2.34 (same used in the rest of the codebase) 

### Verifying this change

The tests are passing. Because of this change is only a patch version, there shouldn't be breaking changes at runtime
(I haven't found anything potentially problematic in all the [release notes](https://eclipse-ee4j.github.io/jersey.github.io/release-notes/2.28.html)

### Does this pull request potentially affect one of the following parts:

Dependencies (does it add or upgrade a dependency): yes

### Documentation

- [x] `no-need-doc` 