### PR TITLE
[Broker] Fix call sync method in async rest api for internalGetBacklogSizeByMessageId

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
@@ -2818,6 +2818,11 @@ public class PersistentTopicsBase extends AdminResource {
                                         } else {
                                             asyncResponse.resume(managedLedger.getEstimatedBacklogSize(pos));
                                         }
+                                    }).exceptionally(ex -> {
+                                        Throwable cause = ex.getCause();
+                                        log.error("[{}] Failed to get backlog size for topic {}", clientAppId(), topicName, ex);
+                                        resumeAsyncResponseExceptionally(asyncResponse, cause);
+                                        return null;
                                     });
                         }
                     }).exceptionally(ex -> {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
@@ -2820,7 +2820,8 @@ public class PersistentTopicsBase extends AdminResource {
                                         }
                                     }).exceptionally(ex -> {
                                         Throwable cause = ex.getCause();
-                                        log.error("[{}] Failed to get backlog size for topic {}", clientAppId(), topicName, ex);
+                                        log.error("[{}] Failed to get backlog size for topic {}", clientAppId(),
+                                                topicName, ex);
                                         resumeAsyncResponseExceptionally(asyncResponse, cause);
                                         return null;
                                     });

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
@@ -2783,49 +2783,55 @@ public class PersistentTopicsBase extends AdminResource {
 
     protected void internalGetBacklogSizeByMessageId(AsyncResponse asyncResponse,
                                                      MessageIdImpl messageId, boolean authoritative) {
+        CompletableFuture<Void> future;
         if (topicName.isGlobal()) {
-            try {
-                validateGlobalNamespaceOwnership(namespaceName);
-            } catch (Exception e) {
-                log.error("[{}] Failed to get backlog size for topic {}", clientAppId(), topicName, e);
-                resumeAsyncResponseExceptionally(asyncResponse, e);
-                return;
-            }
-        }
-        PartitionedTopicMetadata partitionMetadata = getPartitionedTopicMetadata(topicName,
-                authoritative, false);
-        if (!topicName.isPartitioned() && partitionMetadata.partitions > 0) {
-            log.warn("[{}] Not supported calculate backlog size operation on partitioned-topic {}",
-                    clientAppId(), topicName);
-            asyncResponse.resume(new RestException(Status.METHOD_NOT_ALLOWED,
-                    "calculate backlog size is not allowed for partitioned-topic"));
+            future = validateGlobalNamespaceOwnershipAsync(namespaceName);
         } else {
-            validateTopicOwnership(topicName, authoritative);
-            validateTopicOperation(topicName, TopicOperation.GET_BACKLOG_SIZE);
-            PersistentTopic topic = (PersistentTopic) getTopicReference(topicName);
-            PositionImpl pos = new PositionImpl(messageId.getLedgerId(), messageId.getEntryId());
-            if (topic == null) {
-                asyncResponse.resume(new RestException(Status.NOT_FOUND, "Topic not found"));
-                return;
-            }
-            try {
-                ManagedLedgerImpl managedLedger = (ManagedLedgerImpl) topic.getManagedLedger();
-                if (messageId.getLedgerId() == -1) {
-                    asyncResponse.resume(managedLedger.getTotalSize());
-                } else {
-                    asyncResponse.resume(managedLedger.getEstimatedBacklogSize(pos));
-                }
-            } catch (WebApplicationException wae) {
-                if (log.isDebugEnabled()) {
-                    log.debug("[{}] Failed to get backlog size for topic {}, redirecting to other brokers.",
-                            clientAppId(), topicName, wae);
-                }
-                resumeAsyncResponseExceptionally(asyncResponse, wae);
-            } catch (Exception e) {
-                log.error("[{}] Failed to get backlog size for topic {}", clientAppId(), topicName, e);
-                resumeAsyncResponseExceptionally(asyncResponse, e);
-            }
+            future = CompletableFuture.completedFuture(null);
         }
+        future.thenAccept(__ -> {
+            getPartitionedTopicMetadataAsync(topicName, authoritative, false)
+                    .thenAccept(partitionMetadata -> {
+                        if (!topicName.isPartitioned() && partitionMetadata.partitions > 0) {
+                            log.warn("[{}] Not supported calculate backlog size operation on partitioned-topic {}",
+                                    clientAppId(), topicName);
+                            asyncResponse.resume(new RestException(Status.METHOD_NOT_ALLOWED,
+                                    "calculate backlog size is not allowed for partitioned-topic"));
+                        } else {
+                            validateTopicOwnership(topicName, authoritative);
+                            validateTopicOperation(topicName, TopicOperation.GET_BACKLOG_SIZE);
+                            PersistentTopic topic = (PersistentTopic) getTopicReference(topicName);
+                            PositionImpl pos = new PositionImpl(messageId.getLedgerId(), messageId.getEntryId());
+                            if (topic == null) {
+                                asyncResponse.resume(new RestException(Status.NOT_FOUND, "Topic not found"));
+                                return;
+                            }
+                            try {
+                                ManagedLedgerImpl managedLedger = (ManagedLedgerImpl) topic.getManagedLedger();
+                                if (messageId.getLedgerId() == -1) {
+                                    asyncResponse.resume(managedLedger.getTotalSize());
+                                } else {
+                                    asyncResponse.resume(managedLedger.getEstimatedBacklogSize(pos));
+                                }
+                            } catch (WebApplicationException wae) {
+                                if (log.isDebugEnabled()) {
+                                    log.debug("[{}] Failed to get backlog size for topic {}, redirecting to other "
+                                                + "brokers.", clientAppId(), topicName, wae);
+                                }
+                                resumeAsyncResponseExceptionally(asyncResponse, wae);
+                            } catch (Exception e) {
+                                log.error("[{}] Failed to get backlog size for topic {}", clientAppId(), topicName, e);
+                                resumeAsyncResponseExceptionally(asyncResponse, e);
+                            }
+                        }
+                    }).exceptionally(ex -> {
+                        Throwable cause = ex.getCause();
+                        log.error("[{}] Failed to validate global namespace ownership to get backlog size for topic "
+                                + "{}", clientAppId(), topicName, cause);
+                        resumeAsyncResponseExceptionally(asyncResponse, cause);
+                        return null;
+            });
+        });
     }
 
     protected CompletableFuture<Void> internalSetBacklogQuota(BacklogQuota.BacklogQuotaType backlogQuotaType,


### PR DESCRIPTION
### Motivation

Avoid call sync method in async rest API for PersistentTopicsBase#internalGetBacklogSizeByMessageId.

### Modifications

- *Use async instead of sync method.*

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

Need to update docs? 
  
- [x] `no-need-doc` 
 


