### PR TITLE
[DO NOT MERGE][Doc] add explanations for setting bookie rack name

### DIFF
--- a/site2/docs/administration-isolation.md
+++ b/site2/docs/administration-isolation.md
@@ -73,6 +73,10 @@ bin/pulsar-admin namespaces set-bookie-affinity-group public/default \
 --primary-group group-bookie1
 ```
 
+> **Note**
+> 
+> Do not set a bookie rack name to slash (`/`) or an empty string (`""`) if you use Pulsar earlier than 2.7.5, 2.8.3, and 2.9.2. For the bookie rack name restrictions, see [reference-cli-tools.md](#set-bookie-rack).
+
 <!--REST API-->
 
 [POST /admin/v2/namespaces/{tenant}/{namespace}/persistence/bookieAffinity](https://pulsar.apache.org/admin-rest-api/?version=master&apiversion=v2#operation/setBookieAffinityGroup)

--- a/site2/docs/reference-cli-tools.md
+++ b/site2/docs/reference-cli-tools.md
@@ -8,6 +8,7 @@ Pulsar offers several command-line tools that you can use for managing Pulsar in
 
 All Pulsar command-line tools can be run from the `bin` directory of your [installed Pulsar package](getting-started-standalone.md). The following tools are currently documented:
 
+* [`pulsar-admin`](#pulsar-admin)
 * [`pulsar`](#pulsar)
 * [`pulsar-client`](#pulsar-client)
 * [`pulsar-daemon`](#pulsar-daemon)
@@ -17,13 +18,33 @@ All Pulsar command-line tools can be run from the `bin` directory of your [insta
 
 > **Important** 
 >
-> - This page only shows **some frequently used commands**. For the latest information about `pulsar`, `pulsar-client`, and `pulsar-perf`, including commands, flags, descriptions, and more information, see [Pulsar tools](https://pulsar.apache.org/tools/).
+> - This page only shows **some frequently used commands**. For the latest information about `pulsar-admin`, `pulsar`, `pulsar-client`, `pulsar-perf`, and more, including commands, flags, descriptions, and more information, see [Pulsar tools](https://pulsar.apache.org/tools/).
 >  
 > - You can get help for any CLI tool, command, or subcommand using the `--help` flag, or `-h` for short. Here's an example:
 > 
 > ```shell
 > $ bin/pulsar broker --help
 > ```
+
+## `pulsar-admin`
+
+The `pulsar-admin` tool enables you to manage Pulsar entities, such as clusters, brokers, namespaces, tenants, and more. `pulsar-admin` uses the `conf/client.conf` file.
+
+### Usage
+
+```bash
+pulsar-admin bookies [command] [command options]
+```
+### Commands
+
+Below are commands for `pulsar-admin bookies`.
+#### set-bookie-rack
+
+Options
+
+|Flag|Description|Default|
+|---|---|---|
+`-r, --rack`|Bookie rack name. <br /><br />If you set a bookie rack name to slash (`/`) or an empty string (`""`): <li>If you use Pulsar earlier than 2.7.5, 2.8.3, and 2.9.2, an exception is thrown.</li> <li>If you use Pulsar later than 2.7.5, 2.8.3, and 2.9.2, it falls back to `/default-rack` or `/default-region/default-rack`.</li> 
 
 ## `pulsar`
 


### PR DESCRIPTION
1. Add docs for https://github.com/apache/pulsar/pull/13683

    This doc should be added to the [code file](pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdNamespaces.java) and shown on the [pulsar-admin website](https://pulsar.apache.org/tools/pulsar-admin) automatically.

    However, `pulsar-admin bookies` are not rendered successfully. I've [reported the issue](https://github.com/apache/pulsar/issues/13857) and @urfreespace is investigating it. 

    Consequently:

    - I add the docs to the [CLI tool page](https://pulsar.apache.org/docs/en/next/reference-cli-tools/) first. If `pulsar-admin bookies` can be shown on the pulsar-admin website, I'll add the explanations to the code file and delete the explanations on the CLI tool page.
    - Though there are many other commands and flags, I only add explanations for the `set-bookie-rack` command and `rack` flag since this kind of content should be generated automatically rather than updating manually. Adding them here is to show an important reminder to users.

2. Preview looks good:
![image](https://user-images.githubusercontent.com/50226895/150457947-10d13941-fa68-4e52-961f-426f572baaaa.png)

![image](https://user-images.githubusercontent.com/50226895/150458170-3ce2b6d1-1f4f-430c-9cef-f1f1d65a40f4.png)
