### PR TITLE
[functions-worker] fix `getTlsTrustChainBytes` not work in when functions worker not run with broker

### DIFF
--- a/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/worker/WorkerConfig.java
+++ b/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/worker/WorkerConfig.java
@@ -604,9 +604,10 @@ public class WorkerConfig implements Serializable, PulsarConfiguration {
     }
 
     public byte[] getTlsTrustChainBytes() {
-        if (StringUtils.isNotEmpty(getTlsTrustCertsFilePath()) && Files.exists(Paths.get(getTlsTrustCertsFilePath()))) {
+        if (StringUtils.isNotEmpty(getBrokerClientTrustCertsFilePath())
+                && Files.exists(Paths.get(getBrokerClientTrustCertsFilePath()))) {
             try {
-                return Files.readAllBytes(Paths.get(getTlsTrustCertsFilePath()));
+                return Files.readAllBytes(Paths.get(getBrokerClientTrustCertsFilePath()));
             } catch (IOException e) {
                 throw new IllegalStateException("Failed to read CA bytes", e);
             }


### PR DESCRIPTION
### Motivation

In Pulsar 2.6, the `tlsTrustCertsFilePath` is inhert from `broker.conf`, but with this PR (https://github.com/apache/pulsar/pull/7424/files#diff-9d5cf1f55e402efce5e6863e1a06a0aab5f53dede8b9f14476102f7e949c47b2R194) the `tlsTrustCertsFilePath` is replaced with `brokerClientTrustCertsFilePath`. 
​
In later Pulsar versions, the Kubernetes runtime calls `getTlsTrustChainBytes()` (https://github.com/apache/pulsar/blob/master/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/worker/WorkerConfig.java#L606-L616) to create function's auth secret, but the `getTlsTrustChainBytes()` uses `tlsTrustCertsFilePath` and if the user is not set `tlsTrustCertsFilePath` in functions_worker.yml, then it will always get `null`.

### Modifications

use `getBrokerClientTrustCertsFilePath` in `getTlsTrustChainBytes`

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API: (yes / no)
  - The schema: (yes / no / don't know)
  - The default values of configurations: (yes / no)
  - The wire protocol: (yes / no)
  - The rest endpoints: (yes / no)
  - The admin cli options: (yes / no)
  - Anything that affects deployment: (yes / no / don't know)

### Documentation

Check the box below or label this PR directly (if you have committer privilege).

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  internal bug fix
  
- [ ] `doc` 
  
  (If this PR contains doc changes)


