### PR TITLE
[Broker] Fix call sync method in async rest api for internalGetMessageById.

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
@@ -2423,13 +2423,9 @@ public class PersistentTopicsBase extends AdminResource {
                     });
                 }).exceptionally(ex -> {
                     Throwable cause = ex.getCause();
-                    if (cause instanceof NullPointerException) {
-                        asyncResponse.resume(new RestException(Status.NOT_FOUND, "Message not found"));
-                    } else {
-                        log.error("[{}] Failed to get message with ledgerId {} entryId {} from {}",
-                                clientAppId(), ledgerId, entryId, topicName, cause);
-                        asyncResponse.resume(new RestException(cause));
-                    }
+                    log.error("[{}] Failed to get message with ledgerId {} entryId {} from {}",
+                            clientAppId(), ledgerId, entryId, topicName, cause);
+                    asyncResponse.resume(new RestException(cause));
                     return null;
                 });
     }


### PR DESCRIPTION
### Motivation
Avoid call sync method in async rest API for PersistentTopicsBase#internalGetMessageById.

### Documentation
  
- [x] `no-need-doc` 

