### PR TITLE
[C++] Fix hasMessageAvailable returns wrong value for last message

### DIFF
--- a/pulsar-client-cpp/lib/ClientConnection.cc
+++ b/pulsar-client-cpp/lib/ClientConnection.cc
@@ -37,6 +37,7 @@
 #include "ProducerImpl.h"
 #include "ConsumerImpl.h"
 #include "checksum/ChecksumProvider.h"
+#include "MessageIdUtil.h"
 
 DECLARE_LOG_OBJECT()
 
@@ -1072,7 +1073,7 @@ void ClientConnection::handleIncomingCommand() {
                         PendingGetLastMessageIdRequestsMap::iterator it =
                             pendingGetLastMessageIdRequests_.find(error.request_id());
                         if (it != pendingGetLastMessageIdRequests_.end()) {
-                            Promise<Result, MessageId> getLastMessageIdPromise = it->second;
+                            auto getLastMessageIdPromise = it->second;
                             pendingGetLastMessageIdRequests_.erase(it);
                             lock.unlock();
 
@@ -1191,15 +1192,18 @@ void ClientConnection::handleIncomingCommand() {
                         pendingGetLastMessageIdRequests_.find(getLastMessageIdResponse.request_id());
 
                     if (it != pendingGetLastMessageIdRequests_.end()) {
-                        Promise<Result, MessageId> getLastMessageIdPromise = it->second;
+                        auto getLastMessageIdPromise = it->second;
                         pendingGetLastMessageIdRequests_.erase(it);
                         lock.unlock();
 
-                        MessageIdData messageIdData = getLastMessageIdResponse.last_message_id();
-                        MessageId messageId = MessageId(messageIdData.partition(), messageIdData.ledgerid(),
-                                                        messageIdData.entryid(), messageIdData.batch_index());
-
-                        getLastMessageIdPromise.setValue(messageId);
+                        if (getLastMessageIdResponse.has_consumer_mark_delete_position()) {
+                            getLastMessageIdPromise.setValue(
+                                {toMessageId(getLastMessageIdResponse.last_message_id()),
+                                 toMessageId(getLastMessageIdResponse.consumer_mark_delete_position())});
+                        } else {
+                            getLastMessageIdPromise.setValue(
+                                {toMessageId(getLastMessageIdResponse.last_message_id())});
+                        }
                     } else {
                         lock.unlock();
                         LOG_WARN(
@@ -1610,9 +1614,10 @@ Commands::ChecksumType ClientConnection::getChecksumType() const {
     return getServerProtocolVersion() >= proto::v6 ? Commands::Crc32c : Commands::None;
 }
 
-Future<Result, MessageId> ClientConnection::newGetLastMessageId(uint64_t consumerId, uint64_t requestId) {
+Future<Result, GetLastMessageIdResponse> ClientConnection::newGetLastMessageId(uint64_t consumerId,
+                                                                               uint64_t requestId) {
     Lock lock(mutex_);
-    Promise<Result, MessageId> promise;
+    Promise<Result, GetLastMessageIdResponse> promise;
     if (isClosed()) {
         lock.unlock();
         LOG_ERROR(cnxString_ << " Client is not connected to the broker");

--- a/pulsar-client-cpp/lib/ClientConnection.h
+++ b/pulsar-client-cpp/lib/ClientConnection.h
@@ -46,6 +46,7 @@
 #include <set>
 #include <lib/BrokerConsumerStatsImpl.h>
 #include "lib/PeriodicTask.h"
+#include "lib/GetLastMessageIdResponse.h"
 
 using namespace pulsar;
 
@@ -156,7 +157,7 @@ class PULSAR_PUBLIC ClientConnection : public std::enable_shared_from_this<Clien
 
     Future<Result, BrokerConsumerStatsImpl> newConsumerStats(uint64_t consumerId, uint64_t requestId);
 
-    Future<Result, MessageId> newGetLastMessageId(uint64_t consumerId, uint64_t requestId);
+    Future<Result, GetLastMessageIdResponse> newGetLastMessageId(uint64_t consumerId, uint64_t requestId);
 
     Future<Result, NamespaceTopicsPtr> newGetTopicsOfNamespace(const std::string& nsName, uint64_t requestId);
 
@@ -306,7 +307,7 @@ class PULSAR_PUBLIC ClientConnection : public std::enable_shared_from_this<Clien
     typedef std::map<uint64_t, Promise<Result, BrokerConsumerStatsImpl>> PendingConsumerStatsMap;
     PendingConsumerStatsMap pendingConsumerStatsMap_;
 
-    typedef std::map<long, Promise<Result, MessageId>> PendingGetLastMessageIdRequestsMap;
+    typedef std::map<long, Promise<Result, GetLastMessageIdResponse>> PendingGetLastMessageIdRequestsMap;
     PendingGetLastMessageIdRequestsMap pendingGetLastMessageIdRequests_;
 
     typedef std::map<long, Promise<Result, NamespaceTopicsPtr>> PendingGetNamespaceTopicsMap;

--- a/pulsar-client-cpp/lib/ConsumerImpl.h
+++ b/pulsar-client-cpp/lib/ConsumerImpl.h
@@ -33,6 +33,7 @@
 #include "lib/UnAckedMessageTrackerDisabled.h"
 #include "MessageCrypto.h"
 #include "AckGroupingTracker.h"
+#include "GetLastMessageIdResponse.h"
 
 #include "CompressionCodec.h"
 #include <boost/dynamic_bitset.hpp>
@@ -54,7 +55,7 @@ class ExecutorService;
 class ConsumerImpl;
 class BatchAcknowledgementTracker;
 typedef std::shared_ptr<MessageCrypto> MessageCryptoPtr;
-typedef std::function<void(Result result, MessageId messageId)> BrokerGetLastMessageIdCallback;
+typedef std::function<void(Result, const GetLastMessageIdResponse&)> BrokerGetLastMessageIdCallback;
 
 enum ConsumerTopicType
 {

--- a/pulsar-client-cpp/lib/GetLastMessageIdResponse.h
+++ b/pulsar-client-cpp/lib/GetLastMessageIdResponse.h
@@ -1,0 +1,56 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+#pragma once
+
+#include <pulsar/MessageId.h>
+#include <iostream>
+
+namespace pulsar {
+
+class GetLastMessageIdResponse {
+    friend std::ostream& operator<<(std::ostream& os, const GetLastMessageIdResponse& response) {
+        os << "lastMessageId: " << response.lastMessageId_;
+        if (response.hasMarkDeletePosition_) {
+            os << ", markDeletePosition: " << response.markDeletePosition_;
+        }
+        return os;
+    }
+
+   public:
+    GetLastMessageIdResponse() = default;
+
+    GetLastMessageIdResponse(const MessageId& lastMessageId)
+        : lastMessageId_(lastMessageId), hasMarkDeletePosition_{false} {}
+
+    GetLastMessageIdResponse(const MessageId& lastMessageId, const MessageId& markDeletePosition)
+        : lastMessageId_(lastMessageId),
+          markDeletePosition_(markDeletePosition),
+          hasMarkDeletePosition_(true) {}
+
+    const MessageId& getLastMessageId() const noexcept { return lastMessageId_; }
+    const MessageId& getMarkDeletePosition() const noexcept { return markDeletePosition_; }
+    bool hasMarkDeletePosition() const noexcept { return hasMarkDeletePosition_; }
+
+   private:
+    MessageId lastMessageId_;
+    MessageId markDeletePosition_;
+    bool hasMarkDeletePosition_;
+};
+
+}  // namespace pulsar

--- a/pulsar-client-cpp/lib/MessageIdUtil.h
+++ b/pulsar-client-cpp/lib/MessageIdUtil.h
@@ -1,0 +1,44 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+#include <pulsar/MessageId.h>
+#include "PulsarApi.pb.h"
+
+namespace pulsar {
+
+inline MessageId toMessageId(const proto::MessageIdData& messageIdData) {
+    return MessageId{messageIdData.partition(), static_cast<int64_t>(messageIdData.ledgerid()),
+                     static_cast<int64_t>(messageIdData.entryid()), messageIdData.batch_index()};
+}
+
+namespace internal {
+template <typename T>
+static int compare(T lhs, T rhs) {
+    return (lhs < rhs) ? -1 : ((lhs == rhs) ? 0 : 1);
+}
+}  // namespace internal
+
+inline int compareLedgerAndEntryId(const MessageId& lhs, const MessageId& rhs) {
+    auto result = internal::compare(lhs.ledgerId(), rhs.ledgerId());
+    if (result != 0) {
+        return result;
+    }
+    return internal::compare(lhs.entryId(), rhs.entryId());
+}
+
+}  // namespace pulsar

--- a/pulsar-client-cpp/lib/ReaderImpl.cc
+++ b/pulsar-client-cpp/lib/ReaderImpl.cc
@@ -139,7 +139,9 @@ void ReaderImpl::seekAsync(uint64_t timestamp, ResultCallback callback) {
 }
 
 void ReaderImpl::getLastMessageIdAsync(GetLastMessageIdCallback callback) {
-    consumer_->getLastMessageIdAsync(callback);
+    consumer_->getLastMessageIdAsync([callback](Result result, const GetLastMessageIdResponse& response) {
+        callback(result, response.getLastMessageId());
+    });
 }
 
 ReaderImplWeakPtr ReaderImpl::getReaderImplWeakPtr() { return readerImplWeakPtr_; }

--- a/pulsar-client-cpp/tests/MessageIdTest.cc
+++ b/pulsar-client-cpp/tests/MessageIdTest.cc
@@ -17,6 +17,7 @@
  * under the License.
  */
 #include <pulsar/MessageId.h>
+#include "lib/MessageIdUtil.h"
 #include "PulsarFriend.h"
 
 #include <gtest/gtest.h>
@@ -34,4 +35,25 @@ TEST(MessageIdTest, testSerialization) {
     MessageId deserialized = MessageId::deserialize(serialized);
 
     ASSERT_EQ(msgId, deserialized);
+}
+
+TEST(MessageIdTest, testCompareLedgerAndEntryId) {
+    MessageId id1(-1, 2L, 1L, 0);
+    MessageId id2(-1, 2L, 1L, 1);
+    MessageId id3(-1, 2L, 2L, 0);
+    MessageId id4(-1, 3L, 0L, 0);
+    ASSERT_EQ(compareLedgerAndEntryId(id1, id2), 0);
+    ASSERT_EQ(compareLedgerAndEntryId(id1, id2), 0);
+
+    ASSERT_EQ(compareLedgerAndEntryId(id1, id3), -1);
+    ASSERT_EQ(compareLedgerAndEntryId(id3, id1), 1);
+
+    ASSERT_EQ(compareLedgerAndEntryId(id1, id4), -1);
+    ASSERT_EQ(compareLedgerAndEntryId(id4, id1), 1);
+
+    ASSERT_EQ(compareLedgerAndEntryId(id2, id4), -1);
+    ASSERT_EQ(compareLedgerAndEntryId(id4, id2), 1);
+
+    ASSERT_EQ(compareLedgerAndEntryId(id3, id4), -1);
+    ASSERT_EQ(compareLedgerAndEntryId(id4, id3), 1);
 }


### PR DESCRIPTION
### Motivation

In C++ client, there is a corner case that when a reader's start message ID is the last message of a topic, `hasMessageAvailable` returns true. However, it should return false because the start message ID is exclusive and in this case `readNext` would never return a message unless new messages arrived.

### Modifications

The current C++ implementation of `hasMessageAvailable` is from long days ago and has many problems. So this PR migrates the Java implementation of `hasMessageAvailable` to C++ client.

Since after the modifications we need to access `startMessageId` in `hasMessageAvailable`, which is called in a different thread from `connectionOpened` that might modify `startMessageId`. We use a common mutex `mutexForMessageIds` to protect the access to `lastDequedMessageId_` and `lastMessageIdInBroker_`.

To fix the original tests when `startMessageId` is latest, this PR adds a `GetLastMessageIdResponse` as the response of `GetLastMessageId` request. The  `GetLastMessageIdResponse` contains the `consumer_mark_delete_position` introduced from https://github.com/apache/pulsar/pull/9652 to compare with `last_message_id` when `startMessageId` is latest.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change added tests `ReaderTest#testHasMessageAvailableWhenCreated` and `MessageIdTest# testCompareLedgerAndEntryId`.