### PR TITLE
[security] remove Jackson ASL from kafka-connect-avro-converter-shaded

### DIFF
--- a/kafka-connect-avro-converter-shaded/pom.xml
+++ b/kafka-connect-avro-converter-shaded/pom.xml
@@ -40,16 +40,6 @@
             <artifactId>kafka-connect-avro-converter</artifactId>
             <version>${confluent.version}</version>
         </dependency>
-        <dependency>
-            <groupId>org.codehaus.jackson</groupId>
-            <artifactId>jackson-core-asl</artifactId>
-            <version>${kafka-avro-convert-jackson.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.codehaus.jackson</groupId>
-            <artifactId>jackson-mapper-asl</artifactId>
-            <version>${kafka-avro-convert-jackson.version}</version>
-        </dependency>
     </dependencies>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -167,7 +167,6 @@ flexible messaging model and an intuitive client API.</description>
     <confluent.version>7.0.1</confluent.version>
     <kafka.confluent.schemaregistryclient.version>5.3.0</kafka.confluent.schemaregistryclient.version>
     <kafka.confluent.avroserializer.version>5.3.0</kafka.confluent.avroserializer.version>
-    <kafka-avro-convert-jackson.version>1.9.13</kafka-avro-convert-jackson.version>
     <aircompressor.version>0.20</aircompressor.version>
     <asynchttpclient.version>2.12.1</asynchttpclient.version>
     <jcommander.version>1.78</jcommander.version>


### PR DESCRIPTION
### Motivation
The Jackson ASL is an abandoned project and has many CVEs open. 
After [upgrading Confluent version](https://github.com/apache/pulsar/commit/808333360cf8ed86c71f3f85a404ddb27008b198#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8R167), `kafka-connect-avro-converter` doesn't need Jackson ASL anymore. 

```
[INFO] +- io.confluent:kafka-connect-avro-converter:jar:7.0.1:compile
[INFO] |  +- org.apache.avro:avro:jar:1.10.1:compile
[INFO] |  |  +- com.fasterxml.jackson.core:jackson-core:jar:2.12.6:compile
[INFO] |  |  \- com.fasterxml.jackson.core:jackson-databind:jar:2.12.6:compile
[INFO] |  |     \- com.fasterxml.jackson.core:jackson-annotations:jar:2.12.6:compile
```

We can safely remove the import and shading

### Modifications

Removed Jackson asl dependency

  - Dependencies (does it add or upgrade a dependency): yes
 
### Documentation

- [x] `no-need-doc` 
 