### PR TITLE
Getting rid of CVEs reported in testmocks and buildtools

### DIFF
--- a/buildtools/pom.xml
+++ b/buildtools/pom.xml
@@ -46,6 +46,10 @@
     <maven-shade-plugin.version>3.2.4</maven-shade-plugin.version>
     <puppycrawl.checkstyle.version>8.37</puppycrawl.checkstyle.version>
     <maven-checkstyle-plugin.version>3.1.2</maven-checkstyle-plugin.version>
+    <guice.version>4.2.3</guice.version>
+    <guava.version>31.0.1-jre</guava.version>
+    <ant.version>1.10.12</ant.version>
+    <snakeyaml.version>1.30</snakeyaml.version>
   </properties>
 
   <dependencyManagement>
@@ -61,6 +65,28 @@
   </dependencyManagement>
 
   <dependencies>
+
+    <dependency>
+      <groupId>org.yaml</groupId>
+      <artifactId>snakeyaml</artifactId>
+      <version>${snakeyaml.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.ant</groupId>
+      <artifactId>ant</artifactId>
+      <version>${ant.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <version>${guava.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.google.inject</groupId>
+      <artifactId>guice</artifactId>
+      <version>${guice.version}</version>
+    </dependency>
+
     <dependency>
       <groupId>org.testng</groupId>
       <artifactId>testng</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -204,6 +204,7 @@ flexible messaging model and an intuitive client API.</description>
     <spring-context.version>5.3.15</spring-context.version>
     <apache-http-client.version>4.5.13</apache-http-client.version>
     <snakeyaml.version>1.30</snakeyaml.version>
+    <ant.version>1.10.12</ant.version>
 
     <!-- test dependencies -->
     <cassandra.version>3.6.0</cassandra.version>
@@ -1171,6 +1172,12 @@ flexible messaging model and an intuitive client API.</description>
         <groupId>org.yaml</groupId>
         <artifactId>snakeyaml</artifactId>
         <version>${snakeyaml.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.apache.ant</groupId>
+        <artifactId>ant</artifactId>
+        <version>${ant.version}</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
Getting rid of CVEs reported in testmocks and buildtools

CVE-2020-1945
CVE-2021-36373
CVE-2021-36374
CVE-2020-8908
CVE-2017-18640

buildtools sets dependency version/properties independently of the root
pom.

### Motivation

`mvn clean install verify -Powasp-dependency-check -DskipTests` found various CVEs

### Modifications

Upgraded dependencies

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change is already covered by existing tests

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): *YES*
  - The public API: (yes / no)
  - The schema: (yes / no / don't know)
  - The default values of configurations: (yes / no)
  - The wire protocol: (yes / no)
  - The rest endpoints: (yes / no)
  - The admin cli options: (yes / no)
  - Anything that affects deployment: (yes / no / don't know)

### Documentation

Check the box below or label this PR directly (if you have committer privilege).

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)



