### PR TITLE
[Authorization] Remove unnecessary authz provider null checks

### DIFF
--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authorization/AuthorizationService.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authorization/AuthorizationService.java
@@ -275,7 +275,6 @@ public class AuthorizationService {
                 return provider.canLookupAsync(topicName, role, authenticationData);
             }
         });
-
     }
 
     public CompletableFuture<Boolean> allowFunctionOpsAsync(NamespaceName namespaceName, String role,

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authorization/AuthorizationService.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authorization/AuthorizationService.java
@@ -37,7 +37,6 @@ import org.apache.pulsar.common.policies.data.PolicyOperation;
 import org.apache.pulsar.common.policies.data.TenantInfo;
 import org.apache.pulsar.common.policies.data.TenantOperation;
 import org.apache.pulsar.common.policies.data.TopicOperation;
-import org.apache.pulsar.common.util.FutureUtil;
 import org.apache.pulsar.common.util.RestException;
 import org.apache.pulsar.metadata.api.MetadataStoreException;
 import org.slf4j.Logger;
@@ -50,7 +49,7 @@ import org.slf4j.LoggerFactory;
 public class AuthorizationService {
     private static final Logger log = LoggerFactory.getLogger(AuthorizationService.class);
 
-    private AuthorizationProvider provider;
+    private final AuthorizationProvider provider;
     private final ServiceConfiguration conf;
 
     public AuthorizationService(ServiceConfiguration conf, PulsarResources pulsarResources)
@@ -74,18 +73,12 @@ public class AuthorizationService {
     }
 
     public CompletableFuture<Boolean> isSuperUser(String user, AuthenticationDataSource authenticationData) {
-        if (provider != null) {
-            return provider.isSuperUser(user, authenticationData, conf);
-        }
-        return FutureUtil.failedFuture(new IllegalStateException("No authorization provider configured"));
+        return provider.isSuperUser(user, authenticationData, conf);
     }
 
     public CompletableFuture<Boolean> isTenantAdmin(String tenant, String role, TenantInfo tenantInfo,
                                                     AuthenticationDataSource authenticationData) {
-        if (provider != null) {
-            return provider.isTenantAdmin(tenant, role, tenantInfo, authenticationData);
-        }
-        return FutureUtil.failedFuture(new IllegalStateException("No authorization provider configured"));
+        return provider.isTenantAdmin(tenant, role, tenantInfo, authenticationData);
     }
 
     /**
@@ -105,11 +98,7 @@ public class AuthorizationService {
      */
     public CompletableFuture<Void> grantPermissionAsync(NamespaceName namespace, Set<AuthAction> actions, String role,
                                                         String authDataJson) {
-
-        if (provider != null) {
-            return provider.grantPermissionAsync(namespace, actions, role, authDataJson);
-        }
-        return FutureUtil.failedFuture(new IllegalStateException("No authorization provider configured"));
+        return provider.grantPermissionAsync(namespace, actions, role, authDataJson);
     }
 
     /**
@@ -124,11 +113,7 @@ public class AuthorizationService {
      */
     public CompletableFuture<Void> grantSubscriptionPermissionAsync(NamespaceName namespace, String subscriptionName,
                                                                     Set<String> roles, String authDataJson) {
-
-        if (provider != null) {
-            return provider.grantSubscriptionPermissionAsync(namespace, subscriptionName, roles, authDataJson);
-        }
-        return FutureUtil.failedFuture(new IllegalStateException("No authorization provider configured"));
+        return provider.grantSubscriptionPermissionAsync(namespace, subscriptionName, roles, authDataJson);
     }
 
     /**
@@ -141,10 +126,7 @@ public class AuthorizationService {
      */
     public CompletableFuture<Void> revokeSubscriptionPermissionAsync(NamespaceName namespace, String subscriptionName,
                                                                      String role, String authDataJson) {
-        if (provider != null) {
-            return provider.revokeSubscriptionPermissionAsync(namespace, subscriptionName, role, authDataJson);
-        }
-        return FutureUtil.failedFuture(new IllegalStateException("No authorization provider configured"));
+        return provider.revokeSubscriptionPermissionAsync(namespace, subscriptionName, role, authDataJson);
     }
 
     /**
@@ -162,12 +144,7 @@ public class AuthorizationService {
      */
     public CompletableFuture<Void> grantPermissionAsync(TopicName topicname, Set<AuthAction> actions, String role,
                                                         String authDataJson) {
-
-        if (provider != null) {
-            return provider.grantPermissionAsync(topicname, actions, role, authDataJson);
-        }
-        return FutureUtil.failedFuture(new IllegalStateException("No authorization provider configured"));
-
+        return provider.grantPermissionAsync(topicname, actions, role, authDataJson);
     }
 
     /**
@@ -184,16 +161,13 @@ public class AuthorizationService {
         if (!this.conf.isAuthorizationEnabled()) {
             return CompletableFuture.completedFuture(true);
         }
-        if (provider != null) {
-            return provider.isSuperUser(role, authenticationData, conf).thenComposeAsync(isSuperUser -> {
-                if (isSuperUser) {
-                    return CompletableFuture.completedFuture(true);
-                } else {
-                    return provider.canProduceAsync(topicName, role, authenticationData);
-                }
-            });
-        }
-        return FutureUtil.failedFuture(new IllegalStateException("No authorization provider configured"));
+        return provider.isSuperUser(role, authenticationData, conf).thenComposeAsync(isSuperUser -> {
+            if (isSuperUser) {
+                return CompletableFuture.completedFuture(true);
+            } else {
+                return provider.canProduceAsync(topicName, role, authenticationData);
+            }
+        });
     }
 
     /**
@@ -212,16 +186,13 @@ public class AuthorizationService {
         if (!this.conf.isAuthorizationEnabled()) {
             return CompletableFuture.completedFuture(true);
         }
-        if (provider != null) {
-            return provider.isSuperUser(role, authenticationData, conf).thenComposeAsync(isSuperUser -> {
-                if (isSuperUser) {
-                    return CompletableFuture.completedFuture(true);
-                } else {
-                    return provider.canConsumeAsync(topicName, role, authenticationData, subscription);
-                }
-            });
-        }
-        return FutureUtil.failedFuture(new IllegalStateException("No authorization provider configured"));
+        return provider.isSuperUser(role, authenticationData, conf).thenComposeAsync(isSuperUser -> {
+            if (isSuperUser) {
+                return CompletableFuture.completedFuture(true);
+            } else {
+                return provider.canConsumeAsync(topicName, role, authenticationData, subscription);
+            }
+        });
     }
 
     public boolean canProduce(TopicName topicName, String role, AuthenticationDataSource authenticationData)
@@ -297,16 +268,14 @@ public class AuthorizationService {
         if (!this.conf.isAuthorizationEnabled()) {
             return CompletableFuture.completedFuture(true);
         }
-        if (provider != null) {
-            return provider.isSuperUser(role, authenticationData, conf).thenComposeAsync(isSuperUser -> {
-                if (isSuperUser) {
-                    return CompletableFuture.completedFuture(true);
-                } else {
-                    return provider.canLookupAsync(topicName, role, authenticationData);
-                }
-            });
-        }
-        return FutureUtil.failedFuture(new IllegalStateException("No authorization provider configured"));
+        return provider.isSuperUser(role, authenticationData, conf).thenComposeAsync(isSuperUser -> {
+            if (isSuperUser) {
+                return CompletableFuture.completedFuture(true);
+            } else {
+                return provider.canLookupAsync(topicName, role, authenticationData);
+            }
+        });
+
     }
 
     public CompletableFuture<Boolean> allowFunctionOpsAsync(NamespaceName namespaceName, String role,
@@ -363,13 +332,7 @@ public class AuthorizationService {
         if (!this.conf.isAuthorizationEnabled()) {
             return CompletableFuture.completedFuture(true);
         }
-
-        if (provider != null) {
-            return provider.allowTenantOperationAsync(tenantName, role, operation, authData);
-        }
-
-        return FutureUtil.failedFuture(new IllegalStateException("No authorization provider configured for "
-                + "allowTenantOperationAsync"));
+        return provider.allowTenantOperationAsync(tenantName, role, operation, authData);
     }
 
     public CompletableFuture<Boolean> allowTenantOperationAsync(String tenantName,
@@ -424,13 +387,7 @@ public class AuthorizationService {
         if (!this.conf.isAuthorizationEnabled()) {
             return CompletableFuture.completedFuture(true);
         }
-
-        if (provider != null) {
-            return provider.allowNamespaceOperationAsync(namespaceName, role, operation, authData);
-        }
-
-        return FutureUtil.failedFuture(new IllegalStateException("No authorization provider configured for "
-                + "allowNamespaceOperationAsync"));
+        return provider.allowNamespaceOperationAsync(namespaceName, role, operation, authData);
     }
 
     public CompletableFuture<Boolean> allowNamespaceOperationAsync(NamespaceName namespaceName,
@@ -486,13 +443,7 @@ public class AuthorizationService {
         if (!this.conf.isAuthorizationEnabled()) {
             return CompletableFuture.completedFuture(true);
         }
-
-        if (provider != null) {
-            return provider.allowNamespacePolicyOperationAsync(namespaceName, policy, operation, role, authData);
-        }
-
-        return FutureUtil.failedFuture(new IllegalStateException("No authorization provider configured for "
-                + "allowNamespacePolicyOperationAsync"));
+        return provider.allowNamespacePolicyOperationAsync(namespaceName, policy, operation, role, authData);
     }
 
     public CompletableFuture<Boolean> allowNamespacePolicyOperationAsync(NamespaceName namespaceName,
@@ -548,13 +499,7 @@ public class AuthorizationService {
         if (!this.conf.isAuthorizationEnabled()) {
             return CompletableFuture.completedFuture(true);
         }
-
-        if (provider != null) {
-            return provider.allowTopicPolicyOperationAsync(topicName, role, policy, operation, authData);
-        }
-
-        return FutureUtil.failedFuture(new IllegalStateException("No authorization provider configured for "
-                + "allowTopicPolicyOperationAsync"));
+        return provider.allowTopicPolicyOperationAsync(topicName, role, policy, operation, authData);
     }
 
     public CompletableFuture<Boolean> allowTopicPolicyOperationAsync(TopicName topicName,
@@ -618,32 +563,27 @@ public class AuthorizationService {
             return CompletableFuture.completedFuture(true);
         }
 
-        if (provider != null) {
-            CompletableFuture<Boolean> allowFuture =
-                    provider.allowTopicOperationAsync(topicName, role, operation, authData);
-            if (log.isDebugEnabled()) {
-                return allowFuture.whenComplete((allowed, exception) -> {
-                    if (exception == null) {
-                        if (allowed) {
-                            log.debug("Topic operation {} on topic {} is allowed: role = {}",
-                                    operation, topicName, role);
-                        } else {
-                            log.debug("Topic operation {} on topic {} is NOT allowed: role = {}",
-                                    operation, topicName, role);
-                        }
+        CompletableFuture<Boolean> allowFuture =
+                provider.allowTopicOperationAsync(topicName, role, operation, authData);
+        if (log.isDebugEnabled()) {
+            return allowFuture.whenComplete((allowed, exception) -> {
+                if (exception == null) {
+                    if (allowed) {
+                        log.debug("Topic operation {} on topic {} is allowed: role = {}",
+                                operation, topicName, role);
                     } else {
-                        log.debug("Failed to check if topic operation {} on topic {} is allowed:"
-                                        + " role = {}",
-                                operation, topicName, role, exception);
+                        log.debug("Topic operation {} on topic {} is NOT allowed: role = {}",
+                                operation, topicName, role);
                     }
-                });
-            } else {
-                return allowFuture;
-            }
+                } else {
+                    log.debug("Failed to check if topic operation {} on topic {} is allowed:"
+                                    + " role = {}",
+                            operation, topicName, role, exception);
+                }
+            });
+        } else {
+            return allowFuture;
         }
-
-        return FutureUtil.failedFuture(new IllegalStateException("No authorization provider configured for "
-                + "allowTopicOperationAsync"));
     }
 
     public CompletableFuture<Boolean> allowTopicOperationAsync(TopicName topicName,


### PR DESCRIPTION
### Motivation

Clean up the `AuthorizationService` class. The `provider` in the `AuthorizationService` is never null. The class fails to initialize if it is null. Therefore, we can drop the null checks. This cleans up the code and will help simplify future refactors, which I plan to contribute.

### Modifications

* Remove null checks.
* Make `AuthorizationService#provider` final.
* Update white space.
* Remove unused import.

### Verifying this change

This is a trivial revision of the class.

### Does this pull request potentially affect one of the following parts:

It does not break any behavior.

### Documentation

- [x] `no-need-doc` 
  
This is a completely internal change.


