### PR TITLE
Make PulsarAuthorizationProvider#grantPermissionAsync actually async

### DIFF
--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authorization/AuthorizationProvider.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authorization/AuthorizationProvider.java
@@ -188,15 +188,18 @@ public interface AuthorizationProvider extends Closeable {
      *
      * Grant authorization-action permission on a namespace to the given client.
      *
+     * NOTE: used to complete with {@link IllegalArgumentException} when namespace not found or with
+     * {@link IllegalStateException} when failed to grant permission. This behavior is now deprecated.
+     * Please use the appropriate {@link MetadataStoreException}.
+     *
      * @param namespace
      * @param actions
      * @param role
      * @param authDataJson
      *            additional authdata in json format
      * @return CompletableFuture
-     * @completesWith <br/>
-     *                IllegalArgumentException when namespace not found<br/>
-     *                IllegalStateException when failed to grant permission
+     * @completesWith null once the permissions are updated successfully.
+     * @completesWith {@link MetadataStoreException} when the MetadataStore is not updated.
      */
     CompletableFuture<Void> grantPermissionAsync(NamespaceName namespace, Set<AuthAction> actions, String role,
             String authDataJson);

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authorization/AuthorizationService.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authorization/AuthorizationService.java
@@ -92,16 +92,16 @@ public class AuthorizationService {
      *
      * Grant authorization-action permission on a namespace to the given client.
      *
+     * NOTE: used to complete with {@link IllegalArgumentException} when namespace not found or with
+     * {@link IllegalStateException} when failed to grant permission.
+     *
      * @param namespace
      * @param actions
      * @param role
      * @param authDataJson
      *            additional authdata in json for targeted authorization provider
-     * @return
-     * @throws IllegalArgumentException
-     *             when namespace not found
-     * @throws IllegalStateException
-     *             when failed to grant permission
+     * @completesWith null when the permissions are updated successfully.
+     * @completesWith {@link MetadataStoreException} when the MetadataStore is not updated.
      */
     public CompletableFuture<Void> grantPermissionAsync(NamespaceName namespace, Set<AuthAction> actions, String role,
                                                         String authDataJson) {

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authorization/PulsarAuthorizationProvider.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authorization/PulsarAuthorizationProvider.java
@@ -291,7 +291,7 @@ public class PulsarAuthorizationProvider implements AuthorizationProvider {
                 }).whenComplete((__, throwable) -> {
                     if (throwable != null) {
                         log.error("[{}] Failed to set permissions for role {} on topic {}", role, role, topicName,
-                                throwable.getCause());
+                                throwable);
                     } else {
                         log.info("[{}] Successfully granted access for role {}: {} - topic {}", role, role, actions,
                                 topicUri);
@@ -315,7 +315,7 @@ public class PulsarAuthorizationProvider implements AuthorizationProvider {
                 }).whenComplete((__, throwable) -> {
                     if (throwable != null) {
                         log.error("[{}] Failed to set permissions for role {} namespace {}", role, role, namespaceName,
-                                throwable.getCause());
+                                throwable);
                     } else {
                         log.info("[{}] Successfully granted access for role {}: {} - namespace {}", role, role, actions,
                                 namespaceName);
@@ -363,7 +363,7 @@ public class PulsarAuthorizationProvider implements AuthorizationProvider {
                 }).whenComplete((__, throwable) -> {
                     if (throwable != null) {
                         log.error("[{}] Failed to get permissions for role {} on namespace {}", subscriptionName, roles,
-                                namespace, throwable.getCause());
+                                namespace, throwable);
                     } else {
                         log.info("[{}] Successfully granted access for role {} for sub = {}", namespace,
                                 subscriptionName, roles);

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authorization/PulsarAuthorizationProvider.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authorization/PulsarAuthorizationProvider.java
@@ -44,7 +44,6 @@ import org.apache.pulsar.common.policies.data.TenantOperation;
 import org.apache.pulsar.common.policies.data.TopicOperation;
 import org.apache.pulsar.common.util.FutureUtil;
 import org.apache.pulsar.common.util.RestException;
-import org.apache.pulsar.metadata.api.MetadataStoreException.BadVersionException;
 import org.apache.pulsar.metadata.api.MetadataStoreException.NotFoundException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/NamespacesBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/NamespacesBase.java
@@ -98,6 +98,7 @@ import org.apache.pulsar.common.policies.data.TenantOperation;
 import org.apache.pulsar.common.policies.data.impl.AutoTopicCreationOverrideImpl;
 import org.apache.pulsar.common.policies.data.impl.DispatchRateImpl;
 import org.apache.pulsar.common.util.FutureUtil;
+import org.apache.pulsar.metadata.api.MetadataStoreException;
 import org.apache.pulsar.metadata.api.MetadataStoreException.AlreadyExistsException;
 import org.apache.pulsar.metadata.api.MetadataStoreException.BadVersionException;
 import org.apache.pulsar.metadata.api.MetadataStoreException.NotFoundException;
@@ -683,11 +684,15 @@ public abstract class NamespacesBase extends AdminResource {
             log.error("[{}] Failed to get permissions for namespace {}", clientAppId(), namespaceName, e);
             throw new RestException(e);
         } catch (ExecutionException e) {
-            if (e.getCause() instanceof IllegalArgumentException) {
+            // The IllegalArgumentException and the IllegalStateException were historically thrown by the
+            // grantPermissionAsync method, so we catch them here to ensure backwards compatibility.
+            if (e.getCause() instanceof MetadataStoreException.NotFoundException
+                    || e.getCause() instanceof IllegalArgumentException) {
                 log.warn("[{}] Failed to set permissions for namespace {}: does not exist", clientAppId(),
                         namespaceName, e);
                 throw new RestException(Status.NOT_FOUND, "Namespace does not exist");
-            } else if (e.getCause() instanceof IllegalStateException) {
+            } else if (e.getCause() instanceof MetadataStoreException.BadVersionException
+                    || e.getCause() instanceof IllegalStateException) {
                 log.warn("[{}] Failed to set permissions for namespace {}: {}",
                         clientAppId(), namespaceName, e.getCause().getMessage(), e);
                 throw new RestException(Status.CONFLICT, "Concurrent modification");


### PR DESCRIPTION
### Motivation

This PR is based on an observation from https://github.com/apache/pulsar/pull/12515. The content is essentially the same, and the goal is to make an async method _actually_ asynchronous.

### Modifications

* Make `PulsarAuthorizationProvider#grantPermissionAsync` actually async
* Update the exception handling to ensure correctness
* Switch from `thenRun` to `whenComplete` for handling future completion in several methods in `PulsarAuthorizationProvider`.

### Verifying this change

There are already tests that cover this section of the code.

### Does this pull request potentially affect one of the following parts:

This is only an optimization, it does not include any breaking changes.

### Documentation

- [x] `no-need-doc` 



