### PR TITLE
[Broker] Fix no value present when updating dispatch rate

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/DispatchRateLimiter.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/DispatchRateLimiter.java
@@ -177,10 +177,10 @@ public class DispatchRateLimiter {
                 }
                 updateDispatchRate(dispatchRateOp.get());
                 if (type == Type.BROKER) {
-                  log.info("configured broker message-dispatch rate {}", dispatchRate.get());
+                  log.info("configured broker message-dispatch rate {}", dispatchRateOp.get());
                 } else {
                   log.info("[{}] configured {} message-dispatch rate at broker {}",
-                          this.topicName, type, dispatchRate.get());
+                          this.topicName, type, dispatchRateOp.get());
                 }
             }).exceptionally(ex -> {
                 log.error("[{}] failed to get the dispatch rate policy from the namespace resource for type {}",


### PR DESCRIPTION
### Motivation

The `updateDispatchRate` will cause `java.util.NoSuchElementException: No value present`

### Modifications

Fix no value present issue when updating dispatch rate

### Documentation

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
This is a bug fix, no need doc.
  
- [ ] `doc` 
  
  (If this PR contains doc changes)


