### PR TITLE
Fix unit test testSharedInstance fail

### DIFF
--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/LocalMemoryMetadataStore.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/LocalMemoryMetadataStore.java
@@ -92,7 +92,10 @@ public class LocalMemoryMetadataStore extends AbstractMetadataStore implements M
                 if (value == null) {
                     value = new HashSet<>();
                 }
-                value.forEach(v -> registerListener(v));
+                value.forEach(v -> {
+                    registerListener(v);
+                    v.registerListener(this);
+                });
                 value.add(this);
                 return value;
             });


### PR DESCRIPTION
### Motivation

#13907 

In this unit test, Two MetadataStore do not share a listener. when executed store2.delete, store1 existsCache is not invalidate.

https://github.com/apache/pulsar/blob/11bfc0e95dc210c0dce70d1f53eb6eb43dbe835d/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/impl/LocalMemoryMetadataStoreTest.java#L51-L62


### Modifications

1. Let `LocalMemoryMetadataStore` instances with the same address register on the same listener

### Documentation

- [x] `no-need-doc` 



