### PR TITLE
Fix arithmetic exception for uniform load shedder

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/UniformLoadShedder.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/UniformLoadShedder.java
@@ -34,7 +34,6 @@ import org.apache.pulsar.broker.loadbalance.LoadSheddingStrategy;
 import org.apache.pulsar.policies.data.loadbalancer.LocalBrokerData;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import static java.lang.Math.abs;
 
 /**
  * This strategy tends to distribute load uniformly across all brokers. This strategy checks laod difference between

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/UniformLoadShedder.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/UniformLoadShedder.java
@@ -97,10 +97,10 @@ public class UniformLoadShedder implements LoadSheddingStrategy {
         // find the difference between two brokers based on msgRate and throughout and check if the load distribution
         // discrepancy is higher than threshold. if that matches then try to unload bundle from overloaded brokers to
         // give chance of uniform load distribution.
-        if (abs(minMsgRate.getValue()) <= EPS) {
+        if (minMsgRate.getValue() <= EPS && minMsgRate.getValue() >= -EPS) {
             minMsgRate.setValue(1.0);
         }
-        if (abs(minThroughputRate.getValue()) <= EPS) {
+        if (minThroughputRate.getValue() <= EPS && minThroughputRate.getValue() >= -EPS) {
             minThroughputRate.setValue(1.0);
         }
         double msgRateDifferencePercentage = ((maxMsgRate.getValue() - minMsgRate.getValue()) * 100)

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/UniformLoadShedder.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/UniformLoadShedder.java
@@ -34,6 +34,7 @@ import org.apache.pulsar.broker.loadbalance.LoadSheddingStrategy;
 import org.apache.pulsar.policies.data.loadbalancer.LocalBrokerData;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import static java.lang.Math.abs;
 
 /**
  * This strategy tends to distribute load uniformly across all brokers. This strategy checks laod difference between
@@ -48,6 +49,7 @@ public class UniformLoadShedder implements LoadSheddingStrategy {
     private static final Logger log = LoggerFactory.getLogger(UniformLoadShedder.class);
 
     private final Multimap<String, String> selectedBundlesCache = ArrayListMultimap.create();
+    private static final double EPS = 1e-6;
 
     /**
      * Attempt to shed some bundles off every broker which is overloaded.
@@ -70,31 +72,40 @@ public class UniformLoadShedder implements LoadSheddingStrategy {
         MutableDouble maxMsgRate = new MutableDouble(-1);
         MutableDouble maxThroughputRate = new MutableDouble(-1);
         MutableDouble minMsgRate = new MutableDouble(Integer.MAX_VALUE);
-        MutableDouble minThroughputgRate = new MutableDouble(Integer.MAX_VALUE);
+        MutableDouble minThroughputRate = new MutableDouble(Integer.MAX_VALUE);
         brokersData.forEach((broker, data) -> {
+            //broker with one bundle can't be considered for bundle unloading
+            if (data.getLocalData().getBundles().size() <= 1) {
+                return;
+            }
+
             double msgRate = data.getLocalData().getMsgRateIn() + data.getLocalData().getMsgRateOut();
             double throughputRate = data.getLocalData().getMsgThroughputIn()
                     + data.getLocalData().getMsgThroughputOut();
-            if (data.getLocalData().getBundles().size() > 1 // broker with one bundle can't be considered for
-                                                            // bundle unloading
-                    && (msgRate > maxMsgRate.getValue() || throughputRate > maxThroughputRate.getValue())) {
+            if (msgRate > maxMsgRate.getValue() || throughputRate > maxThroughputRate.getValue()) {
                 overloadedBroker.setValue(broker);
                 maxMsgRate.setValue(msgRate);
                 maxThroughputRate.setValue(throughputRate);
             }
-            if (msgRate < minMsgRate.getValue() || throughputRate < minThroughputgRate.getValue()) {
+            if (msgRate < minMsgRate.getValue() || throughputRate < minThroughputRate.getValue()) {
                 underloadedBroker.setValue(broker);
                 minMsgRate.setValue(msgRate);
-                minThroughputgRate.setValue(throughputRate);
+                minThroughputRate.setValue(throughputRate);
             }
         });
 
         // find the difference between two brokers based on msgRate and throughout and check if the load distribution
         // discrepancy is higher than threshold. if that matches then try to unload bundle from overloaded brokers to
         // give chance of uniform load distribution.
+        if (abs(minMsgRate.getValue()) <= EPS) {
+            minMsgRate.setValue(1.0);
+        }
+        if (abs(minThroughputRate.getValue()) <= EPS) {
+            minThroughputRate.setValue(1.0);
+        }
         double msgRateDifferencePercentage = ((maxMsgRate.getValue() - minMsgRate.getValue()) * 100)
                 / (minMsgRate.getValue());
-        double msgThroughputDifferenceRate = maxThroughputRate.getValue() / minThroughputgRate.getValue();
+        double msgThroughputDifferenceRate = maxThroughputRate.getValue() / minThroughputRate.getValue();
 
         // if the threshold matches then find out how much load needs to be unloaded by considering number of msgRate
         // and throughput.
@@ -112,12 +123,12 @@ public class UniformLoadShedder implements LoadSheddingStrategy {
                                 + "overloaded broker {} with (msgRate,throughput)= ({},{}) "
                                 + "and underloaded broker {} with (msgRate,throughput)= ({},{})",
                         overloadedBroker.getValue(), maxMsgRate.getValue(), maxThroughputRate.getValue(),
-                        underloadedBroker.getValue(), minMsgRate.getValue(), minThroughputgRate.getValue());
+                        underloadedBroker.getValue(), minMsgRate.getValue(), minThroughputRate.getValue());
             }
             MutableInt msgRateRequiredFromUnloadedBundles = new MutableInt(
                     (int) ((maxMsgRate.getValue() - minMsgRate.getValue()) / 2));
-            MutableInt msgThroughtputRequiredFromUnloadedBundles = new MutableInt(
-                    (int) ((maxThroughputRate.getValue() - minThroughputgRate.getValue()) / 2));
+            MutableInt msgThroughputRequiredFromUnloadedBundles = new MutableInt(
+                    (int) ((maxThroughputRate.getValue() - minThroughputRate.getValue()) / 2));
             LocalBrokerData overloadedBrokerData = brokersData.get(overloadedBroker.getValue()).getLocalData();
 
             if (overloadedBrokerData.getBundles().size() > 1) {
@@ -150,9 +161,9 @@ public class UniformLoadShedder implements LoadSheddingStrategy {
                                     selectedBundlesCache.put(overloadedBroker.getValue(), bundle);
                                 }
                             } else {
-                                if (throughput <= (msgThroughtputRequiredFromUnloadedBundles.getValue())) {
+                                if (throughput <= (msgThroughputRequiredFromUnloadedBundles.getValue())) {
                                     log.info("Found bundle to unload with throughput {}", throughput);
-                                    msgThroughtputRequiredFromUnloadedBundles.add(-throughput);
+                                    msgThroughputRequiredFromUnloadedBundles.add(-throughput);
                                     selectedBundlesCache.put(overloadedBroker.getValue(), bundle);
                                 }
                             }


### PR DESCRIPTION
### Motivation
For a new joined broker, it doesn't has any message and throughput. It will lead to `minMsgRate` or `minThroughputRate` to 0, and cause arithmetic exception when executing the following code.
```java
double msgRateDifferencePercentage = ((maxMsgRate.getValue() - minMsgRate.getValue()) * 100)
                / (minMsgRate.getValue());
double msgThroughputDifferenceRate = maxThroughputRate.getValue() / minThroughputgRate.getValue();
```

### Modification
1. check whether `minMsgRate` and `minThroughputRate` is 0, if it is 0, set it to 1.0

### Documentation

Check the box below or label this PR directly (if you have committer privilege).

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)


