### PR TITLE
Add threshold for each unload round for uniform load shedder

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/UniformLoadShedder.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/UniformLoadShedder.java
@@ -21,6 +21,7 @@ package org.apache.pulsar.broker.loadbalance.impl;
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.Multimap;
 import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.mutable.MutableDouble;
 import org.apache.commons.lang3.mutable.MutableInt;
 import org.apache.commons.lang3.mutable.MutableObject;
@@ -32,21 +33,22 @@ import org.apache.pulsar.broker.TimeAverageMessageData;
 import org.apache.pulsar.broker.loadbalance.LoadData;
 import org.apache.pulsar.broker.loadbalance.LoadSheddingStrategy;
 import org.apache.pulsar.policies.data.loadbalancer.LocalBrokerData;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
- * This strategy tends to distribute load uniformly across all brokers. This strategy checks laod difference between
+ * This strategy tends to distribute load uniformly across all brokers. This strategy checks load difference between
  * broker with highest load and broker with lowest load. If the difference is higher than configured thresholds
  * {@link ServiceConfiguration#getLoadBalancerMsgRateDifferenceShedderThreshold()} and
  * {@link ServiceConfiguration#getLoadBalancerMsgRateDifferenceShedderThreshold()} then it finds out bundles which can
  * be unloaded to distribute traffic evenly across all brokers.
  *
  */
+@Slf4j
 public class UniformLoadShedder implements LoadSheddingStrategy {
 
-    private static final Logger log = LoggerFactory.getLogger(UniformLoadShedder.class);
-
+    private static final int MB = 1024 * 1024;
+    private static final double MAX_UNLOAD_PERCENTAGE = 0.2;
+    private static final int MIN_UNLOAD_MESSAGE = 1000;
+    private static final int MIN_UNLOAD_THROUGHPUT = 1 * MB;
     private final Multimap<String, String> selectedBundlesCache = ArrayListMultimap.create();
     private static final double EPS = 1e-6;
 
@@ -125,12 +127,14 @@ public class UniformLoadShedder implements LoadSheddingStrategy {
                         underloadedBroker.getValue(), minMsgRate.getValue(), minThroughputRate.getValue());
             }
             MutableInt msgRateRequiredFromUnloadedBundles = new MutableInt(
-                    (int) ((maxMsgRate.getValue() - minMsgRate.getValue()) / 2));
+                    (int) ((maxMsgRate.getValue() - minMsgRate.getValue()) * MAX_UNLOAD_PERCENTAGE));
             MutableInt msgThroughputRequiredFromUnloadedBundles = new MutableInt(
-                    (int) ((maxThroughputRate.getValue() - minThroughputRate.getValue()) / 2));
+                    (int) ((maxThroughputRate.getValue() - minThroughputRate.getValue()) * MAX_UNLOAD_PERCENTAGE));
             LocalBrokerData overloadedBrokerData = brokersData.get(overloadedBroker.getValue()).getLocalData();
 
-            if (overloadedBrokerData.getBundles().size() > 1) {
+            if (overloadedBrokerData.getBundles().size() > 1
+                && (msgRateRequiredFromUnloadedBundles.getValue() >= MIN_UNLOAD_MESSAGE
+                    || msgThroughputRequiredFromUnloadedBundles.getValue() >= MIN_UNLOAD_THROUGHPUT)) {
                 // Sort bundles by throughput, then pick the bundle which can help to reduce load uniformly with
                 // under-loaded broker
                 loadBundleData.entrySet().stream()


### PR DESCRIPTION
### Motivation
For current uniform load shedder, it will unload 50% of `(max throughput - min throughput)` or (max message rate - min message rate). If the max throughput is 500MB/s, and the min throughput is 0MB/s, it will unload 250MB/s throughput at a time, which will lead the broker into high load for unloading a lot of bundles and cause the broker unstable.

Another problem is that the current implementation has no min unload threshold limit. For example, if the max broker throughput is 1MB/s and the min broker throughput is 0MB/s, it will unload 0.5MB/s throughput from the max throughput broker, which is unnecessary and will cause bundle frequently unload.

### Modification
1. Change the default unload percentage from 50% to 20%, aiming to make the unload process smooth.
2. Add `MIN_UNLOAD_MESSAGE=1000` and `MIN_UNLOAD_THROUGHPUT=1 * MB`, which will skip the low throughput bundle unload and decrease the bundle unload frequency.

### Documentation

Check the box below or label this PR directly (if you have committer privilege).

Need to update docs? 

- [x] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [ ] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)


