### PR TITLE
Upgraded debezium to 1.7.2 (+ fixed CVE-2021-20328, + suppressed OWASP misdetections)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -157,7 +157,7 @@ flexible messaging model and an intuitive client API.</description>
     <presto.version>332</presto.version>
     <scala.binary.version>2.13</scala.binary.version>
     <scala-library.version>2.13.6</scala-library.version>
-    <debezium.version>1.7.1.Final</debezium.version>
+    <debezium.version>1.7.2.Final</debezium.version>
     <jsonwebtoken.version>0.11.1</jsonwebtoken.version>
     <opencensus.version>0.18.0</opencensus.version>
     <hbase.version>2.4.9</hbase.version>

--- a/pulsar-io/debezium/mongodb/pom.xml
+++ b/pulsar-io/debezium/mongodb/pom.xml
@@ -39,6 +39,13 @@
         </dependency>
 
         <dependency>
+            <!-- CVE-2021-20328, check if can be safely removed with the next debezium upgrade -->
+            <groupId>org.mongodb</groupId>
+            <artifactId>mongodb-driver-sync</artifactId>
+            <version>4.2.2</version>
+        </dependency>
+
+        <dependency>
             <groupId>io.debezium</groupId>
             <artifactId>debezium-connector-mongodb</artifactId>
             <version>${debezium.version}</version>

--- a/src/owasp-dependency-check-suppressions.xml
+++ b/src/owasp-dependency-check-suppressions.xml
@@ -290,7 +290,7 @@
         <sha1>3f8f54bbcb73608ac8b66f186a824b75065eb413</sha1>
         <cve>CVE-2017-8761</cve>
     </suppress>
-
+    
     <suppress>
         <notes><![CDATA[
        file name: openstack-keystone-2.4.0.jar
@@ -351,6 +351,98 @@
        ]]></notes>
         <packageUrl regex="true">^pkg:maven/org\.apache\.pulsar/pulsar\-io\-solr@.*-SNAPSHOT$</packageUrl>
         <cpe>cpe:/a:apache:solr</cpe>
+    </suppress>
+
+    <!-- debezium-related misdetections -->
+    <suppress>
+        <notes><![CDATA[
+       file name: debezium-connector-mysql-1.7.2.Final.jar
+       ]]></notes>
+        <sha1>a501bd758344d60fd400f5ce58694d52b2dbc6d8</sha1>
+        <cve>CVE-2010-1626</cve>
+        <cve>CVE-2009-4028</cve>
+        <cve>CVE-2007-1420</cve>
+        <cve>CVE-2007-5925</cve>
+        <cve>CVE-2007-2691</cve>
+        <cve>CVE-2009-0819</cve>
+        <cve>CVE-2010-1621</cve>
+        <cve>CVE-2010-3677</cve>
+        <cve>CVE-2010-3682</cve>
+        <cve>CVE-2012-5627</cve>
+        <cve>CVE-2015-2575</cve>
+        <cve>CVE-2017-15945</cve>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[
+       file name: mysql-binlog-connector-java-0.25.3.jar
+       ]]></notes>
+        <sha1>45b3fdd0b953d744a8570f74eb5e1016f8ed5ca9</sha1>
+        <cve>CVE-2007-1420</cve>
+        <cve>CVE-2007-2691</cve>
+        <cve>CVE-2007-5925</cve>
+        <cve>CVE-2009-0819</cve>
+        <cve>CVE-2009-4028</cve>
+        <cve>CVE-2010-1621</cve>
+        <cve>CVE-2010-1626</cve>
+        <cve>CVE-2010-3677</cve>
+        <cve>CVE-2010-3682</cve>
+        <cve>CVE-2012-5627</cve>
+        <cve>CVE-2015-2575</cve>
+        <cve>CVE-2017-15945</cve>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[
+       file name: debezium-connector-postgres-1.7.2.Final.jar
+       ]]></notes>
+        <sha1>69c1edfa7d89531af511fcd07e8516fa450f746a</sha1>
+        <cve>CVE-2007-2138</cve>
+        <cve>CVE-2010-0733</cve>
+        <cve>CVE-2014-0060</cve>
+        <cve>CVE-2014-0061</cve>
+        <cve>CVE-2014-0062</cve>
+        <cve>CVE-2014-0063</cve>
+        <cve>CVE-2014-0064</cve>
+        <cve>CVE-2014-0065</cve>
+        <cve>CVE-2014-0066</cve>
+        <cve>CVE-2014-0067</cve>
+        <cve>CVE-2014-8161</cve>
+        <cve>CVE-2015-0241</cve>
+        <cve>CVE-2015-0242</cve>
+        <cve>CVE-2015-0243</cve>
+        <cve>CVE-2015-0244</cve>
+        <cve>CVE-2015-3165</cve>
+        <cve>CVE-2015-3166</cve>
+        <cve>CVE-2015-3167</cve>
+        <cve>CVE-2015-5288</cve>
+        <cve>CVE-2015-5289</cve>
+        <cve>CVE-2016-0766</cve>
+        <cve>CVE-2016-0768</cve>
+        <cve>CVE-2016-0773</cve>
+        <cve>CVE-2016-5423</cve>
+        <cve>CVE-2016-5424</cve>
+        <cve>CVE-2016-7048</cve>
+        <cve>CVE-2017-14798</cve>
+        <cve>CVE-2017-7484</cve>
+        <cve>CVE-2018-1115</cve>
+        <cve>CVE-2019-10127</cve>
+        <cve>CVE-2019-10128</cve>
+        <cve>CVE-2019-10210</cve>
+        <cve>CVE-2019-10211</cve>
+        <cve>CVE-2020-25694</cve>
+        <cve>CVE-2020-25695</cve>
+        <cve>CVE-2021-3393</cve>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[
+       file name: protostream-types-4.4.1.Final.jar
+       ]]></notes>
+        <sha1>29b45ebea1e4ce62ab3ec5eb76fa9771f98941b0</sha1>
+        <cve>CVE-2016-0750</cve>
+        <cve>CVE-2017-15089</cve>
+        <cve>CVE-2017-2638</cve>
+        <cve>CVE-2019-10158</cve>
+        <cve>CVE-2019-10174</cve>
+        <cve>CVE-2020-25711</cve>
     </suppress>
 
 </suppressions>


### PR DESCRIPTION
Upgraded debezium to 1.7.2 (+ fixed CVE-2021-20328, + suppressed OWASP misdetections)


### Motivation

Upgraded debezium mostly to pick up perf fix https://issues.redhat.com/browse/DBZ-4309
`mvn clean install verify -Powasp-dependency-check -DskipTests -pl '!pulsar-sql,!distribution,!tiered-storage/file-system,!pulsar-io/flume,!pulsar-io/hbase,!pulsar-io/hdfs2,!pulsar-io/hdfs3,!pulsar-io/docs'` reported CVEs in debezium connectors, most are misdetected.

### Modifications

Upgraded debezium.
CVE-2021-20328 from mongo lib fixed by forcing newer version.
Updated suppressions.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change is already covered by existing tests

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): *YES*
  - The public API: (yes / no)
  - The schema: (yes / no / don't know)
  - The default values of configurations: (yes / no)
  - The wire protocol: (yes / no)
  - The rest endpoints: (yes / no)
  - The admin cli options: (yes / no)
  - Anything that affects deployment: (yes / no / don't know)

### Documentation

Check the box below or label this PR directly (if you have committer privilege).

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)


