### PR TITLE
[Rest API] Change ``BrokersBase`` api ``getActiveBrokers`` and ``getLeaderBroker`` to pure async.

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/BrokersBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/BrokersBase.java
@@ -27,7 +27,6 @@ import java.time.Duration;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import javax.ws.rs.DELETE;
@@ -36,6 +35,7 @@ import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.QueryParam;
+import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.container.AsyncResponse;
 import javax.ws.rs.container.Suspended;
 import javax.ws.rs.core.Response;
@@ -85,16 +85,21 @@ public class BrokersBase extends PulsarWebResource {
             @ApiResponse(code = 401, message = "Authentication required"),
             @ApiResponse(code = 403, message = "This operation requires super-user access"),
             @ApiResponse(code = 404, message = "Cluster does not exist: cluster={clustername}") })
-    public Set<String> getActiveBrokers(@PathParam("cluster") String cluster) throws Exception {
-        validateSuperUserAccess();
-        validateClusterOwnership(cluster);
-
-        try {
-            return pulsar().getLoadManager().get().getAvailableBrokers();
-        } catch (Exception e) {
-            LOG.error("[{}] Failed to get active broker list: cluster={}", clientAppId(), cluster, e);
-            throw new RestException(e);
-        }
+    public void getActiveBrokers(@Suspended final AsyncResponse asyncResponse,
+                                 @PathParam("cluster") String cluster) {
+        validateSuperUserAccessAsync()
+                .thenCompose(__ -> validateClusterOwnershipAsync(cluster))
+                .thenCompose(__ -> pulsar().getLoadManager().get().getAvailableBrokersAsync())
+                .thenAccept(asyncResponse::resume)
+                .exceptionally(ex ->{
+                    Throwable realCause = FutureUtil.unwrapCompletionException(ex);
+                    if (realCause instanceof WebApplicationException){
+                        asyncResponse.resume(realCause);
+                    } else {
+                        asyncResponse.resume(new RestException(realCause));
+                    }
+                    return null;
+                });
     }
 
     @GET
@@ -107,17 +112,23 @@ public class BrokersBase extends PulsarWebResource {
                     @ApiResponse(code = 401, message = "Authentication required"),
                     @ApiResponse(code = 403, message = "This operation requires super-user access"),
                     @ApiResponse(code = 404, message = "Leader broker not found") })
-    public BrokerInfo getLeaderBroker() throws Exception {
-        validateSuperUserAccess();
-
-        try {
-            LeaderBroker leaderBroker = pulsar().getLeaderElectionService().getCurrentLeader()
-                    .orElseThrow(() -> new RestException(Status.NOT_FOUND, "Couldn't find leader broker"));
-            return BrokerInfo.builder().serviceUrl(leaderBroker.getServiceUrl()).build();
-        } catch (Exception e) {
-            LOG.error("[{}] Failed to get the information of the leader broker.", clientAppId(), e);
-            throw new RestException(e);
-        }
+    public void getLeaderBroker(@Suspended final AsyncResponse asyncResponse) {
+        validateSuperUserAccessAsync().thenAccept(__ -> {
+                    LeaderBroker leaderBroker = pulsar().getLeaderElectionService().getCurrentLeader()
+                            .orElseThrow(() -> new RestException(Status.NOT_FOUND, "Couldn't find leader broker"));
+                    BrokerInfo brokerInfo = BrokerInfo.builder().serviceUrl(leaderBroker.getServiceUrl()).build();
+                    asyncResponse.resume(brokerInfo);
+                })
+                .exceptionally(ex -> {
+                    Throwable realCause = FutureUtil.unwrapCompletionException(ex);
+                    LOG.error("[{}] Failed to get the information of the leader broker.", clientAppId(), realCause);
+                    if (realCause instanceof WebApplicationException) {
+                        asyncResponse.resume(realCause);
+                    } else {
+                        asyncResponse.resume(new RestException(realCause));
+                    }
+                    return null;
+                });
     }
 
     @GET

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/BrokersBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/BrokersBase.java
@@ -93,7 +93,7 @@ public class BrokersBase extends PulsarWebResource {
                 .thenAccept(asyncResponse::resume)
                 .exceptionally(ex ->{
                     Throwable realCause = FutureUtil.unwrapCompletionException(ex);
-                    if (realCause instanceof WebApplicationException){
+                    if (realCause instanceof WebApplicationException) {
                         asyncResponse.resume(realCause);
                     } else {
                         asyncResponse.resume(new RestException(realCause));

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/BrokersBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/BrokersBase.java
@@ -91,7 +91,7 @@ public class BrokersBase extends PulsarWebResource {
                 .thenCompose(__ -> validateClusterOwnershipAsync(cluster))
                 .thenCompose(__ -> pulsar().getLoadManager().get().getAvailableBrokersAsync())
                 .thenAccept(asyncResponse::resume)
-                .exceptionally(ex ->{
+                .exceptionally(ex -> {
                     Throwable realCause = FutureUtil.unwrapCompletionException(ex);
                     if (realCause instanceof WebApplicationException) {
                         asyncResponse.resume(realCause);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/LoadManager.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/LoadManager.java
@@ -21,6 +21,7 @@ package org.apache.pulsar.broker.loadbalance;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
 import org.apache.pulsar.broker.PulsarServerException;
 import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.broker.ServiceConfiguration;
@@ -114,6 +115,8 @@ public interface LoadManager {
      * @throws Exception
      */
     Set<String> getAvailableBrokers() throws Exception;
+
+    CompletableFuture<Set<String>> getAvailableBrokersAsync();
 
     void stop() throws PulsarServerException;
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/ModularLoadManager.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/ModularLoadManager.java
@@ -21,6 +21,7 @@ package org.apache.pulsar.broker.loadbalance;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
 import org.apache.pulsar.broker.BundleData;
 import org.apache.pulsar.broker.PulsarServerException;
 import org.apache.pulsar.broker.PulsarService;
@@ -111,6 +112,11 @@ public interface ModularLoadManager {
      * @return
      */
     Set<String> getAvailableBrokers();
+
+    /**
+     * Get available broker list in cluster by async invoke.
+     */
+    CompletableFuture<Set<String>> getAvailableBrokersAsync();
 
     /**
      * Fetch local-broker data from load-manager broker cache.

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/NoopLoadManager.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/NoopLoadManager.java
@@ -22,6 +22,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.broker.PulsarServerException;
@@ -130,6 +131,11 @@ public class NoopLoadManager implements LoadManager {
     @Override
     public Set<String> getAvailableBrokers() throws Exception {
         return Collections.singleton(lookupServiceAddress);
+    }
+
+    @Override
+    public CompletableFuture<Set<String>> getAvailableBrokersAsync() {
+        return CompletableFuture.completedFuture(Collections.singleton(lookupServiceAddress));
     }
 
     @Override

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/ModularLoadManagerImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/ModularLoadManagerImpl.java
@@ -359,17 +359,18 @@ public class ModularLoadManagerImpl implements ModularLoadManager {
 
     @Override
     public CompletableFuture<Set<String>> getAvailableBrokersAsync() {
-        CompletableFuture<Set<String>> getAvailableBrokersAsync = new CompletableFuture<>();
+        CompletableFuture<Set<String>> future = new CompletableFuture<>();
         brokersData.listLocks(LoadManager.LOADBALANCE_BROKERS_ROOT)
                 .whenComplete((listLocks, ex) -> {
                     if (ex != null){
                         Throwable realCause = FutureUtil.unwrapCompletionException(ex);
                         log.warn("Error when trying to get active brokers", realCause);
-                        getAvailableBrokersAsync.complete(loadData.getBrokerData().keySet());
+                        future.complete(loadData.getBrokerData().keySet());
+                    } else {
+                        future.complete(Sets.newHashSet(listLocks));
                     }
-                    getAvailableBrokersAsync.complete(Sets.newHashSet(listLocks));
                 });
-        return getAvailableBrokersAsync;
+        return future;
     }
 
     // Attempt to local the data for the given bundle in metadata store

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/ModularLoadManagerWrapper.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/ModularLoadManagerWrapper.java
@@ -21,6 +21,7 @@ package org.apache.pulsar.broker.loadbalance.impl;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
 import org.apache.pulsar.broker.PulsarServerException;
 import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.broker.loadbalance.LoadManager;
@@ -129,5 +130,10 @@ public class ModularLoadManagerWrapper implements LoadManager {
     @Override
     public Set<String> getAvailableBrokers() throws Exception {
         return loadManager.getAvailableBrokers();
+    }
+
+    @Override
+    public CompletableFuture<Set<String>> getAvailableBrokersAsync() {
+        return loadManager.getAvailableBrokersAsync();
     }
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/SimpleLoadManagerImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/SimpleLoadManagerImpl.java
@@ -314,8 +314,9 @@ public class SimpleLoadManagerImpl implements LoadManager, Consumer<Notification
                         Throwable realCause = FutureUtil.unwrapCompletionException(ex);
                         log.warn("Error when trying to get active brokers", realCause);
                         getAvailableBrokersAsync.completeExceptionally(realCause);
+                    } else {
+                        getAvailableBrokersAsync.complete(Sets.newHashSet(listLocks));
                     }
-                    getAvailableBrokersAsync.complete(Sets.newHashSet(listLocks));
                 });
         return getAvailableBrokersAsync;
     }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/SimpleLoadManagerImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/SimpleLoadManagerImpl.java
@@ -40,6 +40,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.TreeMap;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
@@ -59,6 +60,7 @@ import org.apache.pulsar.common.naming.NamespaceName;
 import org.apache.pulsar.common.naming.ServiceUnitId;
 import org.apache.pulsar.common.policies.data.ResourceQuota;
 import org.apache.pulsar.common.stats.Metrics;
+import org.apache.pulsar.common.util.FutureUtil;
 import org.apache.pulsar.common.util.collections.ConcurrentOpenHashMap;
 import org.apache.pulsar.common.util.collections.ConcurrentOpenHashSet;
 import org.apache.pulsar.metadata.api.MetadataCache;
@@ -301,6 +303,21 @@ public class SimpleLoadManagerImpl implements LoadManager, Consumer<Notification
     @Override
     public Set<String> getAvailableBrokers() throws Exception {
         return new HashSet<>(loadReports.listLocks(LOADBALANCE_BROKERS_ROOT).join());
+    }
+
+    @Override
+    public CompletableFuture<Set<String>> getAvailableBrokersAsync() {
+        CompletableFuture<Set<String>> getAvailableBrokersAsync = new CompletableFuture<>();
+        loadReports.listLocks(LoadManager.LOADBALANCE_BROKERS_ROOT)
+                .whenComplete((listLocks, ex) -> {
+                    if (ex != null){
+                        Throwable realCause = FutureUtil.unwrapCompletionException(ex);
+                        log.warn("Error when trying to get active brokers", realCause);
+                        getAvailableBrokersAsync.completeExceptionally(realCause);
+                    }
+                    getAvailableBrokersAsync.complete(Sets.newHashSet(listLocks));
+                });
+        return getAvailableBrokersAsync;
     }
 
     private void setDynamicConfigurationToStore(String path, Map<String, String> settings) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/PulsarWebResource.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/PulsarWebResource.java
@@ -378,7 +378,7 @@ public abstract class PulsarWebResource {
     protected CompletableFuture<Void> validateClusterOwnershipAsync(String cluster){
         return getClusterDataIfDifferentCluster(pulsar(), cluster, clientAppId())
                 .thenAccept(differentClusterData -> {
-                    if (differentClusterData != null){
+                    if (differentClusterData != null) {
                         try {
                             URI redirect = getRedirectionUrl(differentClusterData);
                             // redirect to the cluster requested

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/PulsarWebResource.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/PulsarWebResource.java
@@ -375,7 +375,7 @@ public abstract class PulsarWebResource {
         log.info("Successfully validated clusters on tenant [{}]", tenant);
     }
 
-    protected CompletableFuture<Void> validateClusterOwnershipAsync(String cluster){
+    protected CompletableFuture<Void> validateClusterOwnershipAsync(String cluster) {
         return getClusterDataIfDifferentCluster(pulsar(), cluster, clientAppId())
                 .thenAccept(differentClusterData -> {
                     if (differentClusterData != null) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/PulsarWebResource.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/PulsarWebResource.java
@@ -433,9 +433,9 @@ public abstract class PulsarWebResource {
                                                                                      String cluster,
                                                                                      String clientAppId) {
         CompletableFuture<ClusterData> clusterDataFuture = new CompletableFuture<>();
-        if (isValidCluster(pulsar, cluster) ||
+        if (isValidCluster(pulsar, cluster)
                 // this code should only happen with a v1 namespace format prop/cluster/namespaces
-                pulsar.getConfiguration().getClusterName().equals(cluster)) {
+                || pulsar.getConfiguration().getClusterName().equals(cluster)) {
             clusterDataFuture.complete(null);
             return clusterDataFuture;
         }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/PulsarWebResource.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/PulsarWebResource.java
@@ -63,6 +63,7 @@ import org.apache.pulsar.broker.resources.PulsarResources;
 import org.apache.pulsar.broker.resources.ResourceGroupResources;
 import org.apache.pulsar.broker.resources.TenantResources;
 import org.apache.pulsar.broker.resources.TopicResources;
+import org.apache.pulsar.broker.service.BrokerService;
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.impl.PulsarServiceNameResolver;
 import org.apache.pulsar.common.naming.Constants;
@@ -172,6 +173,57 @@ public abstract class PulsarWebResource {
         return true;
     }
 
+    public CompletableFuture<Void> validateSuperUserAccessAsync(){
+        if (!config().isAuthenticationEnabled()) {
+            return CompletableFuture.completedFuture(null);
+        }
+        String appId = clientAppId();
+        if (log.isDebugEnabled()) {
+            log.debug("[{}] Check super user access: Authenticated: {} -- Role: {}", uri.getRequestUri(),
+                    isClientAuthenticated(appId), appId);
+        }
+        String originalPrincipal = originalPrincipal();
+        validateOriginalPrincipal(pulsar.getConfiguration().getProxyRoles(), appId, originalPrincipal);
+
+        if (pulsar.getConfiguration().getProxyRoles().contains(appId)) {
+            BrokerService brokerService = pulsar.getBrokerService();
+            return brokerService.getAuthorizationService().isSuperUser(appId, clientAuthData())
+                    .thenCompose(proxyAuthorizationSuccess -> {
+                        if (!proxyAuthorizationSuccess){
+                            throw new RestException(Status.UNAUTHORIZED,
+                                    String.format("Proxy not authorized for super-user "
+                                            + "operation (proxy:%s)", appId));
+                        }
+                        return pulsar.getBrokerService()
+                                .getAuthorizationService()
+                                .isSuperUser(originalPrincipal, clientAuthData());
+                    }).thenAccept(originalPrincipalAuthorizationSuccess -> {
+                        if (!originalPrincipalAuthorizationSuccess){
+                            throw new RestException(Status.UNAUTHORIZED,
+                                    String.format("Original principal not authorized for super-user operation "
+                                                    + "(original:%s)", originalPrincipal));
+                        }
+                        log.debug("Successfully authorized {} (proxied by {}) as super-user",
+                                originalPrincipal, appId);
+                    });
+        } else {
+            if (config().isAuthorizationEnabled()) {
+                return pulsar.getBrokerService()
+                        .getAuthorizationService()
+                        .isSuperUser(appId, clientAuthData())
+                        .thenAccept(proxyAuthorizationSuccess -> {
+                            if (!proxyAuthorizationSuccess) {
+                                throw new RestException(Status.UNAUTHORIZED,
+                                        "This operation requires super-user access");
+                            }
+                        });
+            }
+            log.debug("Successfully authorized {} as super-user",
+                    appId);
+            return CompletableFuture.completedFuture(null);
+        }
+    }
+
     /**
      * Checks whether the user has Pulsar Super-User access to the system.
      *
@@ -179,49 +231,14 @@ public abstract class PulsarWebResource {
      *             if not authorized
      */
     public void validateSuperUserAccess() {
-        if (config().isAuthenticationEnabled()) {
-            String appId = clientAppId();
-            if (log.isDebugEnabled()) {
-                log.debug("[{}] Check super user access: Authenticated: {} -- Role: {}", uri.getRequestUri(),
-                        isClientAuthenticated(appId), appId);
-            }
-            String originalPrincipal = originalPrincipal();
-            validateOriginalPrincipal(pulsar.getConfiguration().getProxyRoles(), appId, originalPrincipal);
-
-            if (pulsar.getConfiguration().getProxyRoles().contains(appId)) {
-
-                CompletableFuture<Boolean> proxyAuthorizedFuture;
-                CompletableFuture<Boolean> originalPrincipalAuthorizedFuture;
-
-                try {
-                    proxyAuthorizedFuture = pulsar.getBrokerService()
-                            .getAuthorizationService()
-                            .isSuperUser(appId, clientAuthData());
-
-                    originalPrincipalAuthorizedFuture = pulsar.getBrokerService()
-                            .getAuthorizationService()
-                            .isSuperUser(originalPrincipal, clientAuthData());
-
-                    if (!proxyAuthorizedFuture.get() || !originalPrincipalAuthorizedFuture.get()) {
-                        throw new RestException(Status.UNAUTHORIZED,
-                                String.format("Proxy not authorized for super-user operation (proxy:%s,original:%s)",
-                                              appId, originalPrincipal));
-                    }
-                } catch (InterruptedException | ExecutionException e) {
-                    log.error("Error validating super-user access : " + e.getMessage(), e);
-                    throw new RestException(Status.INTERNAL_SERVER_ERROR, e.getMessage());
-                }
-                log.debug("Successfully authorized {} (proxied by {}) as super-user",
-                          originalPrincipal, appId);
+        try {
+            validateSuperUserAccessAsync().get(config().getZooKeeperOperationTimeoutSeconds(), SECONDS);
+        } catch (InterruptedException | ExecutionException | TimeoutException e) {
+            Throwable realCause = FutureUtil.unwrapCompletionException(e);
+            if (realCause instanceof WebApplicationException){
+                throw (WebApplicationException) realCause;
             } else {
-                if (config().isAuthorizationEnabled() && !pulsar.getBrokerService()
-                        .getAuthorizationService()
-                        .isSuperUser(appId, clientAuthData())
-                        .join()) {
-                    throw new RestException(Status.UNAUTHORIZED, "This operation requires super-user access");
-                }
-                log.debug("Successfully authorized {} as super-user",
-                          appId);
+                throw new RestException(realCause);
             }
         }
     }
@@ -358,6 +375,25 @@ public abstract class PulsarWebResource {
         log.info("Successfully validated clusters on tenant [{}]", tenant);
     }
 
+    protected CompletableFuture<Void> validateClusterOwnershipAsync(String cluster){
+        return getClusterDataIfDifferentCluster(pulsar(), cluster, clientAppId())
+                .thenAccept(differentClusterData -> {
+                    if (differentClusterData != null){
+                        try {
+                            URI redirect = getRedirectionUrl(differentClusterData);
+                            // redirect to the cluster requested
+                            if (log.isDebugEnabled()) {
+                                log.debug("[{}] Redirecting the rest call to {}: cluster={}",
+                                        clientAppId(), redirect, cluster);
+                            }
+                            throw new WebApplicationException(Response.temporaryRedirect(redirect).build());
+                        } catch (MalformedURLException ex) {
+                            throw new RestException(ex);
+                        }
+                    }
+                });
+    }
+
     /**
      * Check if the cluster exists and redirect the call to the owning cluster.
      *
@@ -366,26 +402,15 @@ public abstract class PulsarWebResource {
      */
     protected void validateClusterOwnership(String cluster) throws WebApplicationException {
         try {
-            ClusterData differentClusterData =
-                    getClusterDataIfDifferentCluster(pulsar(), cluster, clientAppId()).get();
-            if (differentClusterData != null) {
-                URI redirect = getRedirectionUrl(differentClusterData);
-                // redirect to the cluster requested
-                if (log.isDebugEnabled()) {
-                    log.debug("[{}] Redirecting the rest call to {}: cluster={}", clientAppId(), redirect, cluster);
-                }
-                throw new WebApplicationException(Response.temporaryRedirect(redirect).build());
+            validateClusterOwnershipAsync(cluster).get(config().getZooKeeperOperationTimeoutSeconds(), SECONDS);
+        } catch (InterruptedException | ExecutionException | TimeoutException ex) {
+            Throwable realCause = FutureUtil.unwrapCompletionException(ex);
+            if (realCause instanceof WebApplicationException){
+                throw (WebApplicationException) realCause;
+            } else {
+                throw new RestException(realCause);
             }
-        } catch (WebApplicationException wae) {
-            throw wae;
-        } catch (Exception e) {
-            if (e.getCause() instanceof WebApplicationException) {
-                throw (WebApplicationException) e.getCause();
-            }
-            throw new RestException(Status.SERVICE_UNAVAILABLE, String
-                    .format("Failed to validate Cluster configuration : cluster=%s  emsg=%s", cluster, e.getMessage()));
         }
-
     }
 
     private URI getRedirectionUrl(ClusterData differentClusterData) throws MalformedURLException {
@@ -407,36 +432,28 @@ public abstract class PulsarWebResource {
     protected static CompletableFuture<ClusterData> getClusterDataIfDifferentCluster(PulsarService pulsar,
                                                                                      String cluster,
                                                                                      String clientAppId) {
-
         CompletableFuture<ClusterData> clusterDataFuture = new CompletableFuture<>();
-
-        if (!isValidCluster(pulsar, cluster)) {
-            try {
+        if (isValidCluster(pulsar, cluster) ||
                 // this code should only happen with a v1 namespace format prop/cluster/namespaces
-                if (!pulsar.getConfiguration().getClusterName().equals(cluster)) {
-                    // redirect to the cluster requested
-                    pulsar.getPulsarResources().getClusterResources().getClusterAsync(cluster)
-                            .thenAccept(clusterDataResult -> {
-                                if (clusterDataResult.isPresent()) {
-                                    clusterDataFuture.complete(clusterDataResult.get());
-                                } else {
-                                    log.warn("[{}] Cluster does not exist: requested={}", clientAppId, cluster);
-                                    clusterDataFuture.completeExceptionally(new RestException(Status.NOT_FOUND,
-                                            "Cluster does not exist: cluster=" + cluster));
-                                }
-                            }).exceptionally(ex -> {
-                                clusterDataFuture.completeExceptionally(ex);
-                                return null;
-                            });
-                } else {
-                    clusterDataFuture.complete(null);
-                }
-            } catch (Exception e) {
-                clusterDataFuture.completeExceptionally(e);
-            }
-        } else {
+                pulsar.getConfiguration().getClusterName().equals(cluster)) {
             clusterDataFuture.complete(null);
+            return clusterDataFuture;
         }
+        // redirect to the cluster requested
+        pulsar.getPulsarResources().getClusterResources().getClusterAsync(cluster)
+                .whenComplete((clusterDataResult, ex) -> {
+                    if (ex != null){
+                        clusterDataFuture.completeExceptionally(FutureUtil.unwrapCompletionException(ex));
+                        return;
+                    }
+                    if (clusterDataResult.isPresent()) {
+                        clusterDataFuture.complete(clusterDataResult.get());
+                    } else {
+                        log.warn("[{}] Cluster does not exist: requested={}", clientAppId, cluster);
+                        clusterDataFuture.completeExceptionally(new RestException(Status.NOT_FOUND,
+                                "Cluster does not exist: cluster=" + cluster));
+                    }
+                });
         return clusterDataFuture;
     }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/PulsarWebResource.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/PulsarWebResource.java
@@ -442,7 +442,7 @@ public abstract class PulsarWebResource {
         // redirect to the cluster requested
         pulsar.getPulsarResources().getClusterResources().getClusterAsync(cluster)
                 .whenComplete((clusterDataResult, ex) -> {
-                    if (ex != null){
+                    if (ex != null) {
                         clusterDataFuture.completeExceptionally(FutureUtil.unwrapCompletionException(ex));
                         return;
                     }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminTest.java
@@ -626,6 +626,7 @@ public class AdminTest extends MockedPulsarServiceBaseTest {
     }
 
     @Test
+    @SuppressWarnings("unchecked")
     public void brokers() throws Exception {
         clusters.createCluster("use", ClusterDataImpl.builder()
                 .serviceUrl("http://broker.messaging.use.example.com")
@@ -639,12 +640,14 @@ public class AdminTest extends MockedPulsarServiceBaseTest {
         Field uriField = PulsarWebResource.class.getDeclaredField("uri");
         uriField.setAccessible(true);
         uriField.set(brokers, mockUri);
-
-        Set<String> activeBrokers = brokers.getActiveBrokers("use");
+        Object res = asynRequests(ctx -> brokers.getActiveBrokers(ctx, "use"));
+        assertTrue(res instanceof Set);
+        Set<String> activeBrokers = (Set<String>) res;
         assertEquals(activeBrokers.size(), 1);
         assertEquals(activeBrokers, Sets.newHashSet(pulsar.getAdvertisedAddress() + ":" + pulsar.getListenPortHTTP().get()));
-
-        BrokerInfo leaderBroker = brokers.getLeaderBroker();
+        Object leaderBrokerRes = asynRequests(ctx -> brokers.getLeaderBroker(ctx));
+        assertTrue(leaderBrokerRes instanceof BrokerInfo);
+        BrokerInfo leaderBroker = (BrokerInfo)leaderBrokerRes;
         assertEquals(leaderBroker.getServiceUrl(), pulsar.getLeaderElectionService().getCurrentLeader().map(LeaderBroker::getServiceUrl).get());
     }
 

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/util/FutureUtil.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/util/FutureUtil.java
@@ -99,6 +99,16 @@ public class FutureUtil {
         return future;
     }
 
+    public static Throwable unwrapCompletionException(Throwable ex) {
+        if (ex instanceof CompletionException) {
+            return ex.getCause();
+        } else if (ex instanceof ExecutionException) {
+            return ex.getCause();
+        } else {
+            return ex;
+        }
+    }
+
     /**
      * Creates a new {@link CompletableFuture} instance with timeout handling.
      *
@@ -163,16 +173,6 @@ public class FutureUtil {
         @Override
         public synchronized Throwable fillInStackTrace() {
             return this;
-        }
-    }
-
-    public static Throwable unwrapCompletionException(Throwable ex) {
-        if (ex instanceof CompletionException) {
-            return ex.getCause();
-        } else if (ex instanceof ExecutionException) {
-            return ex.getCause();
-        } else {
-            return ex;
         }
     }
 


### PR DESCRIPTION
### Motivation

Async rest api is more efficient than sync. I think we could refactor all sync api to async.

### Modification

- Change ``getLeaderBroker`` from sync to async.
- Change ``getActiveBrokers`` from sync to async.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

- [x] `no-need-doc` 
  