### PR TITLE
Using the consistent metadata store scheme name.

### DIFF
--- a/managed-ledger/src/test/java/org/apache/bookkeeper/test/MockedBookKeeperTestCase.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/test/MockedBookKeeperTestCase.java
@@ -67,7 +67,7 @@ public abstract class MockedBookKeeperTestCase {
     public final void setUp(Method method) throws Exception {
         LOG.info(">>>>>> starting {}", method);
         metadataStore = new FaultInjectionMetadataStore(
-                MetadataStoreExtended.create("memory://local", MetadataStoreConfig.builder().build()));
+                MetadataStoreExtended.create("memory:local", MetadataStoreConfig.builder().build()));
 
         try {
             // start bookkeeper service

--- a/pulsar-broker-common/src/test/java/org/apache/pulsar/bookie/rackawareness/BookieRackAffinityMappingTest.java
+++ b/pulsar-broker-common/src/test/java/org/apache/pulsar/bookie/rackawareness/BookieRackAffinityMappingTest.java
@@ -49,7 +49,7 @@ public class BookieRackAffinityMappingTest {
 
     @BeforeMethod
     public void setUp() throws Exception {
-        store = MetadataStoreFactory.create("memory://local", MetadataStoreConfig.builder().build());
+        store = MetadataStoreFactory.create("memory:local", MetadataStoreConfig.builder().build());
         BOOKIE1 = new BookieSocketAddress("127.0.0.1:3181");
         BOOKIE2 = new BookieSocketAddress("127.0.0.2:3181");
         BOOKIE3 = new BookieSocketAddress("127.0.0.3:3181");

--- a/pulsar-broker-common/src/test/java/org/apache/pulsar/bookie/rackawareness/IsolatedBookieEnsemblePlacementPolicyTest.java
+++ b/pulsar-broker-common/src/test/java/org/apache/pulsar/bookie/rackawareness/IsolatedBookieEnsemblePlacementPolicyTest.java
@@ -70,7 +70,7 @@ public class IsolatedBookieEnsemblePlacementPolicyTest {
     @BeforeMethod
     public void setUp() throws Exception {
         timer = new HashedWheelTimer();
-        store = MetadataStoreFactory.create("memory://local", MetadataStoreConfig.builder().build());
+        store = MetadataStoreFactory.create("memory:local", MetadataStoreConfig.builder().build());
 
         writableBookies.add(new BookieSocketAddress(BOOKIE1).toBookieId());
         writableBookies.add(new BookieSocketAddress(BOOKIE2).toBookieId());

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/cache/BundlesQuotasTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/cache/BundlesQuotasTest.java
@@ -44,7 +44,7 @@ public class BundlesQuotasTest {
 
     @BeforeMethod
     public void setup() throws Exception {
-        store = MetadataStoreFactory.create("memory://local", MetadataStoreConfig.builder().build());
+        store = MetadataStoreFactory.create("memory:local", MetadataStoreConfig.builder().build());
 
         PulsarService pulsar = mock(PulsarService.class);
         when(pulsar.getLocalMetadataStore()).thenReturn(mock(MetadataStoreExtended.class));

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/DistributedIdGeneratorTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/DistributedIdGeneratorTest.java
@@ -46,7 +46,7 @@ public class DistributedIdGeneratorTest {
 
     @BeforeMethod(alwaysRun = true)
     public void setup() throws Exception {
-        store  = MetadataStoreExtended.create("memory://local", MetadataStoreConfig.builder().build());
+        store  = MetadataStoreExtended.create("memory:local", MetadataStoreConfig.builder().build());
         coordinationService = new CoordinationServiceImpl(store);
     }
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentDispatcherFailoverConsumerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentDispatcherFailoverConsumerTest.java
@@ -125,7 +125,7 @@ public class PersistentDispatcherFailoverConsumerTest {
                 .when(pulsar).getBookKeeperClient();
         eventLoopGroup = new NioEventLoopGroup();
 
-        store = MetadataStoreFactory.create("memory://local", MetadataStoreConfig.builder().build());
+        store = MetadataStoreFactory.create("memory:local", MetadataStoreConfig.builder().build());
         doReturn(store).when(pulsar).getLocalMetadataStore();
         doReturn(store).when(pulsar).getConfigurationMetadataStore();
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/functions/worker/PulsarFunctionMetadataStoreTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/functions/worker/PulsarFunctionMetadataStoreTest.java
@@ -34,7 +34,7 @@ public class PulsarFunctionMetadataStoreTest extends PulsarFunctionLocalRunTest 
     protected WorkerConfig createWorkerConfig(ServiceConfiguration config) {
         WorkerConfig wc = super.createWorkerConfig(config);
         wc.setStateStorageProviderImplementation(PulsarMetadataStateStoreProviderImpl.class.getName());
-        wc.setStateStorageServiceUrl("memory://local");
+        wc.setStateStorageServiceUrl("memory:local");
         return wc;
     }
 

--- a/pulsar-functions/instance/src/test/java/org/apache/pulsar/functions/instance/state/PulsarMetadataStateStoreImplTest.java
+++ b/pulsar-functions/instance/src/test/java/org/apache/pulsar/functions/instance/state/PulsarMetadataStateStoreImplTest.java
@@ -50,7 +50,7 @@ public class PulsarMetadataStateStoreImplTest {
 
     @BeforeMethod
     public void setup() throws Exception {
-        this.store = MetadataStoreFactory.create("memory://local", MetadataStoreConfig.builder().build());
+        this.store = MetadataStoreFactory.create("memory:local", MetadataStoreConfig.builder().build());
         this.countersCache = store.getMetadataCache(Long.class);
         this.stateContext = new PulsarMetadataStateStoreImpl(store, "/prefix", TENANT, NS, NAME);
     }

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/LocalMemoryMetadataStore.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/LocalMemoryMetadataStore.java
@@ -51,6 +51,8 @@ import org.apache.pulsar.metadata.api.extended.MetadataStoreExtended;
 @Slf4j
 public class LocalMemoryMetadataStore extends AbstractMetadataStore implements MetadataStoreExtended {
 
+    static final String MEMORY_SCHEME_IDENTIFIER = "memory:";
+
     @Data
     private static class Value {
         final long version;

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/LocalMemoryMetadataStore.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/LocalMemoryMetadataStore.java
@@ -19,8 +19,6 @@
 package org.apache.pulsar.metadata.impl;
 
 import com.google.common.collect.MapMaker;
-import java.net.URI;
-import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.HashSet;

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/LocalMemoryMetadataStore.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/LocalMemoryMetadataStore.java
@@ -75,20 +75,13 @@ public class LocalMemoryMetadataStore extends AbstractMetadataStore implements M
 
     public LocalMemoryMetadataStore(String metadataURL, MetadataStoreConfig metadataStoreConfig)
             throws MetadataStoreException {
-        URI uri;
-        try {
-            uri = new URI(metadataURL);
-        } catch (URISyntaxException e) {
-            throw new MetadataStoreException(e);
-        }
-
+        String name = metadataURL.substring(MEMORY_SCHEME_IDENTIFIER.length());
         // Local means a private data set
-        if ("local".equals(uri.getHost())) {
+        if ("local".equals(name)) {
             map = new TreeMap<>();
             sequentialIdGenerator = new AtomicLong();
         } else {
             // Use a reference from a shared data set
-            String name = uri.getHost();
             map = STATIC_MAPS.computeIfAbsent(name, __ -> new TreeMap<>());
             STATIC_INSTANCE.compute(name, (key, value) -> {
                 if (value == null) {

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/MetadataStoreFactoryImpl.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/MetadataStoreFactoryImpl.java
@@ -52,6 +52,9 @@ public class MetadataStoreFactoryImpl {
             return RocksdbMetadataStore.get(metadataURL, metadataStoreConfig);
         } else if (metadataURL.startsWith(EtcdMetadataStore.ETCD_SCHEME_IDENTIFIER)) {
             return new EtcdMetadataStore(metadataURL, metadataStoreConfig, enableSessionWatcher);
+        } else if (metadataURL.startsWith(ZKMetadataStore.ZK_SCHEME_IDENTIFIER)) {
+            return new ZKMetadataStore(metadataURL.substring(ZKMetadataStore.ZK_SCHEME_IDENTIFIER.length()),
+                    metadataStoreConfig, enableSessionWatcher);
         } else {
             return new ZKMetadataStore(metadataURL, metadataStoreConfig, enableSessionWatcher);
         }

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/MetadataStoreFactoryImpl.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/MetadataStoreFactoryImpl.java
@@ -46,9 +46,9 @@ public class MetadataStoreFactoryImpl {
                                              boolean enableSessionWatcher)
             throws MetadataStoreException {
 
-        if (metadataURL.startsWith("memory://")) {
+        if (metadataURL.startsWith(LocalMemoryMetadataStore.MEMORY_SCHEME_IDENTIFIER)) {
             return new LocalMemoryMetadataStore(metadataURL, metadataStoreConfig);
-        } else if (metadataURL.startsWith("rocksdb://")) {
+        } else if (metadataURL.startsWith(RocksdbMetadataStore.ROCKSDB_SCHEME_IDENTIFIER)) {
             return RocksdbMetadataStore.get(metadataURL, metadataStoreConfig);
         } else if (metadataURL.startsWith(EtcdMetadataStore.ETCD_SCHEME_IDENTIFIER)) {
             return new EtcdMetadataStore(metadataURL, metadataStoreConfig, enableSessionWatcher);

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/RocksdbMetadataStore.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/RocksdbMetadataStore.java
@@ -72,6 +72,9 @@ import org.rocksdb.WriteOptions;
  */
 @Slf4j
 public class RocksdbMetadataStore extends AbstractMetadataStore {
+
+    static final String ROCKSDB_SCHEME_IDENTIFIER = "rocksdb:";
+
     private static final byte[] SEQUENTIAL_ID_KEY = toBytes("__metadata_sequentialId_key");
     private static final byte[] INSTANCE_ID_KEY = toBytes("__metadata_instanceId_key");
 
@@ -200,7 +203,7 @@ public class RocksdbMetadataStore extends AbstractMetadataStore {
     private final String metadataUrl;
 
     /**
-     * @param metadataURL         format "rocksdb://{storePath}"
+     * @param metadataURL         format "rocksdb:{storePath}"
      * @param metadataStoreConfig
      * @throws MetadataStoreException
      */
@@ -213,7 +216,7 @@ public class RocksdbMetadataStore extends AbstractMetadataStore {
             throw new MetadataStoreException("Failed to load RocksDB JNI library", t);
         }
 
-        String dataDir = metadataURL.substring("rocksdb://".length());
+        String dataDir = metadataURL.substring("rocksdb:".length());
         Path dataPath = FileSystems.getDefault().getPath(dataDir);
         try {
             Files.createDirectories(dataPath);

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/ZKMetadataStore.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/ZKMetadataStore.java
@@ -68,6 +68,8 @@ import org.apache.zookeeper.ZooKeeper;
 public class ZKMetadataStore extends AbstractBatchedMetadataStore
         implements MetadataStoreExtended, MetadataStoreLifecycle {
 
+    static final String ZK_SCHEME_IDENTIFIER = "zk:";
+
     private final String metadataURL;
     private final MetadataStoreConfig metadataStoreConfig;
     private final boolean isZkManaged;

--- a/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/BaseMetadataStoreTest.java
+++ b/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/BaseMetadataStoreTest.java
@@ -75,8 +75,8 @@ public abstract class BaseMetadataStoreTest extends TestRetrySupport {
         // Supplier<String> lambda is used for providing the value.
         return new Object[][]{
                 { "ZooKeeper", stringSupplier(() -> zks.getConnectionString()) },
-                { "Memory", stringSupplier(() -> "memory://" + UUID.randomUUID()) },
-                { "RocksDB", stringSupplier(() -> "rocksdb://" + createTempFolder()) },
+                { "Memory", stringSupplier(() -> "memory:" + UUID.randomUUID()) },
+                { "RocksDB", stringSupplier(() -> "rocksdb:" + createTempFolder()) },
                 {"Etcd", stringSupplier(() -> "etcd:" + etcdCluster.getClientEndpoints().stream().map(x -> x.toString())
                         .collect(Collectors.joining(",")))},
         };

--- a/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/impl/LocalMemoryMetadataStoreTest.java
+++ b/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/impl/LocalMemoryMetadataStoreTest.java
@@ -35,11 +35,11 @@ public class LocalMemoryMetadataStoreTest {
     @Test
     public void testPrivateInstance() throws Exception {
         @Cleanup
-        MetadataStore store1 = MetadataStoreFactory.create("memory://local",
+        MetadataStore store1 = MetadataStoreFactory.create("memory:local",
                 MetadataStoreConfig.builder().build());
 
         @Cleanup
-        MetadataStore store2 = MetadataStoreFactory.create("memory://local",
+        MetadataStore store2 = MetadataStoreFactory.create("memory:local",
                 MetadataStoreConfig.builder().build());
 
         store1.put("/test", "value".getBytes(StandardCharsets.UTF_8), Optional.empty()).join();
@@ -50,7 +50,7 @@ public class LocalMemoryMetadataStoreTest {
 
     @Test
     public void testSharedInstance() throws Exception {
-        String url = "memory://" + UUID.randomUUID();
+        String url = "memory:" + UUID.randomUUID();
 
         @Cleanup
         MetadataStore store1 = MetadataStoreFactory.create(url,

--- a/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/impl/RocksdbMetadataStoreTest.java
+++ b/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/impl/RocksdbMetadataStoreTest.java
@@ -70,7 +70,7 @@ public class RocksdbMetadataStoreTest {
         String optionFilePath =
                 getClass().getClassLoader().getResource("rocksdb_option_file_example.ini").getPath();
         log.info("optionFilePath={}", optionFilePath);
-        store = MetadataStoreFactory.create("rocksdb://" + tempDir.toAbsolutePath(),
+        store = MetadataStoreFactory.create("rocksdb:" + tempDir.toAbsolutePath(),
                 MetadataStoreConfig.builder().configFilePath(optionFilePath).build());
         Assert.assertTrue(store instanceof RocksdbMetadataStore);
 
@@ -97,7 +97,7 @@ public class RocksdbMetadataStoreTest {
 
         //reopen db
         store.close();
-        store = MetadataStoreFactory.create("rocksdb://" + tempDir.toAbsolutePath(),
+        store = MetadataStoreFactory.create("rocksdb:" + tempDir.toAbsolutePath(),
                 MetadataStoreConfig.builder().configFilePath(optionFilePath).build());
 
         //test get
@@ -118,10 +118,10 @@ public class RocksdbMetadataStoreTest {
 
         Path tempDir = Files.createTempDirectory("RocksdbMetadataStoreTest");
         log.info("Temp dir:{}", tempDir.toAbsolutePath());
-        MetadataStore store1 = MetadataStoreFactory.create("rocksdb://" + tempDir.toAbsolutePath(),
+        MetadataStore store1 = MetadataStoreFactory.create("rocksdb:" + tempDir.toAbsolutePath(),
                 MetadataStoreConfig.builder().build());
 
-        MetadataStore store2 = MetadataStoreFactory.create("rocksdb://" + tempDir.toAbsolutePath(),
+        MetadataStore store2 = MetadataStoreFactory.create("rocksdb:" + tempDir.toAbsolutePath(),
                 MetadataStoreConfig.builder().build());
 
         // We should get the same instance

--- a/pulsar-package-management/bookkeeper-storage/src/test/java/org/apache/pulsar/packages/management/storage/bookkeeper/bookkeeper/test/MockedBookKeeperTestCase.java
+++ b/pulsar-package-management/bookkeeper-storage/src/test/java/org/apache/pulsar/packages/management/storage/bookkeeper/bookkeeper/test/MockedBookKeeperTestCase.java
@@ -70,7 +70,7 @@ public abstract class MockedBookKeeperTestCase {
     @BeforeMethod(alwaysRun = true)
     public void setUp(Method method) throws Exception {
         LOG.info(">>>>>> starting {}", method);
-        metadataStore = new FaultInjectionMetadataStore(MetadataStoreExtended.create("memory://local",
+        metadataStore = new FaultInjectionMetadataStore(MetadataStoreExtended.create("memory:local",
                 MetadataStoreConfig.builder().build()));
         try {
             // start bookkeeper service

--- a/pulsar-transaction/coordinator/src/test/java/org/apache/pulsar/transaction/coordinator/test/MockedBookKeeperTestCase.java
+++ b/pulsar-transaction/coordinator/src/test/java/org/apache/pulsar/transaction/coordinator/test/MockedBookKeeperTestCase.java
@@ -70,7 +70,7 @@ public abstract class MockedBookKeeperTestCase {
     @BeforeMethod(alwaysRun = true)
     public void setUp(Method method) throws Exception {
         LOG.info(">>>>>> starting {}", method);
-        metadataStore = new FaultInjectionMetadataStore(MetadataStoreExtended.create("memory://local",
+        metadataStore = new FaultInjectionMetadataStore(MetadataStoreExtended.create("memory:local",
                 MetadataStoreConfig.builder().build()));
         try {
             // start bookkeeper service

--- a/pulsar-websocket/src/test/resources/websocket.conf
+++ b/pulsar-websocket/src/test/resources/websocket.conf
@@ -20,7 +20,7 @@
 ### --- Web Socket proxy settings --- ###
 
 # Configuration Store connection string
-configurationStoreServers=memory://127.0.0.1:2181
+configurationStoreServers=memory:127.0.0.1:2181
 
 # Zookeeper session timeout in milliseconds
 zooKeeperSessionTimeoutMillis=30000


### PR DESCRIPTION
Using the consistent metadata store scheme name.

- RocksDB -> rocksdb:
- ZooKeeper -> zk:
- Memory -> memory:
- Ectd -> etcd:

Context: https://github.com/apache/pulsar/pull/13225#discussion_r787695755

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

Check the box below or label this PR directly (if you have committer privilege).

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)


