### PR TITLE
[security] pulsar-io-kafka: upgrade jakarta.el to 3.0.4 to get rid of CVE-2021-28170

### DIFF
--- a/pulsar-io/kafka/pom.xml
+++ b/pulsar-io/kafka/pom.xml
@@ -37,6 +37,11 @@
         <artifactId>jersey-bean-validation</artifactId>
         <version>${jersey.version}</version>
       </dependency>
+      <dependency>
+        <groupId>org.glassfish</groupId>
+        <artifactId>jakarta.el</artifactId>
+        <version>3.0.4</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 


### PR DESCRIPTION
### Motivation
`org.glassfish:jakarta.el:3.0.3` is vulnerable to CVE-2021-28170.

Links: 
* https://nvd.nist.gov/vuln/detail/CVE-2021-28170
* https://github.com/jakartaee/expression-language/pull/160


### Modifications

Forced 3.0.4 version in pulsar-io/kafka

### Documentation

- [x] `no-need-doc` 
