### PR TITLE
[Broker] Do not create missing topic when loading namespace

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
@@ -1077,7 +1077,7 @@ public class PulsarService implements AutoCloseable, ShutdownService {
             LOG.info("Loading all topics on bundle: {}", bundle);
 
             NamespaceName nsName = bundle.getNamespaceObject();
-            List<CompletableFuture<Topic>> persistentTopics = Lists.newArrayList();
+            List<CompletableFuture<Optional<Topic>>> persistentTopics = Lists.newArrayList();
             long topicLoadStart = System.nanoTime();
 
             for (String topic : getNamespaceService().getListOfPersistentTopics(nsName)
@@ -1085,7 +1085,7 @@ public class PulsarService implements AutoCloseable, ShutdownService {
                 try {
                     TopicName topicName = TopicName.get(topic);
                     if (bundle.includes(topicName) && !isTransactionSystemTopic(topicName)) {
-                        CompletableFuture<Topic> future = brokerService.getOrCreateTopic(topic);
+                        CompletableFuture<Optional<Topic>> future = brokerService.getTopicIfExists(topic);
                         if (future != null) {
                             persistentTopics.add(future);
                         }
@@ -1099,7 +1099,10 @@ public class PulsarService implements AutoCloseable, ShutdownService {
                 FutureUtil.waitForAll(persistentTopics).thenRun(() -> {
                     double topicLoadTimeSeconds = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - topicLoadStart)
                             / 1000.0;
-                    LOG.info("Loaded {} topics on {} -- time taken: {} seconds", persistentTopics.size(), bundle,
+                    long numTopicsLoaded = persistentTopics.stream()
+                            .filter(optionalTopicFuture -> optionalTopicFuture.getNow(Optional.empty()).isPresent())
+                            .count();
+                    LOG.info("Loaded {} topics on {} -- time taken: {} seconds", numTopicsLoaded, bundle,
                             topicLoadTimeSeconds);
                 });
             }


### PR DESCRIPTION
### Motivation

Based on my reading of the `PulsarService#loadNamespaceTopics` method, it appears that there is a data race that could lead to the broker recreating a topic that was just deleted. Currently, we do the following when loading a namespace bundle:

1. Get all topics for a namespace bundle from the metadata store.
2. Asynchronously call `getOrCreateTopic` for each of the topics.

If a topic was deleted after step 1 and before step 2, the topic will get recreated (assuming that auto topic creation is enabled).

### Modifications

* Use `getTopicIfExists` to load a namespace bundle instead of `getOrCreateTopic`.
* Only log the count of actually loaded topics.

### Verifying this change

From my perspective, this is a minor change that should remove the possibility of a very specific race condition. I don't see an easy way to test this behavior. However, the `getTopics` method, which backs both `getTopicIfExists` and `getOrCreateTopic` is well tested, so I think it is okay to skip adding a test here. Let me know if you disagree.

### Does this pull request potentially affect one of the following parts:

This change is not breaking in any way.

### Documentation
  
- [x] `no-need-doc` 
  
This internal change doesn't need docs.


