### PR TITLE
[C++] Disable consistent hashing to avoid flaky test

### DIFF
--- a/pulsar-client-cpp/test-conf/standalone-ssl.conf
+++ b/pulsar-client-cpp/test-conf/standalone-ssl.conf
@@ -304,3 +304,6 @@ brokerServicePurgeInactiveFrequencyInSeconds=60
 
 # Given a specific limit of the max message size
 maxMessageSize=1024000
+
+# Disable consistent hashing to fix flaky `KeySharedConsumerTest#testMultiTopics`.
+subscriptionKeySharedUseConsistentHashing=false


### PR DESCRIPTION
Fixes #13955

### Motivation

[PIP-119](https://github.com/apache/pulsar/pull/13352) changes the default value of `subscriptionKeySharedUseConsistentHashing` with true, which makes the C++ test `KeySharedConsumerTest.testMultiTopics` flaky that not all messages can be received with 3 seconds receive timeout. It can be reproduce easily in my local env.

I tried to use three Java consumers with `Key_Shared` subscription to consume the topic produced by C++ test `KeySharedConsumerTest.testMultiTopics`. Sometimes not all messages can be received as well. It looks like there is something wrong with the consistent hashing implementation of `Key_Shared` dispatcher.

### Modifications

Since C++ UT is based on the standalone of config file `pulsar-client-cpp/test-conf/standalone-ssl.conf`, this PR disables the `subscriptionKeySharedUseConsistentHashing` in that configuration file.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage. BTW, after applying the latest config, the test doesn't fail anymore in my local env.