### PR TITLE
Add OWASP Dependency Checker to the GH CI workflows

### DIFF
--- a/.github/workflows/ci-owasp-dep-check.yaml
+++ b/.github/workflows/ci-owasp-dep-check.yaml
@@ -43,18 +43,17 @@ jobs:
       - name: Tune Runner VM
         uses: ./.github/actions/tune-runner-vm
 
-      - name: Detect changed files
-        id:   changes
+      - name: Detect changed pom files
+        id: changes
         uses: apache/pulsar-test-infra/paths-filter@master
         with:
-          filters: .github/changes-filter.yaml
-
-      - name: Check changed files
-        id: check_changes
-        run: echo "::set-output name=docs_only::${{ fromJSON(steps.changes.outputs.all_count) == fromJSON(steps.changes.outputs.docs_count) && fromJSON(steps.changes.outputs.docs_count) > 0 }}"
+          filters: |
+            poms:
+              - 'pom.xml'
+              - '**/pom.xml'
 
       - name: Cache local Maven repository
-        if: ${{ steps.check_changes.outputs.docs_only != 'true' }}
+        if: ${{ steps.changes.outputs.poms == 'true' }}
         uses: actions/cache@v2
         with:
           path: |
@@ -67,13 +66,13 @@ jobs:
 
       - name: Set up JDK 11
         uses: actions/setup-java@v2
-        if: ${{ steps.check_changes.outputs.docs_only != 'true' }}
+        if: ${{ steps.changes.outputs.poms == 'true' }}
         with:
           distribution: 'temurin'
           java-version: 11
 
       - name: clean disk
-        if: ${{ steps.check_changes.outputs.docs_only != 'true' }}
+        if: ${{ steps.changes.outputs.poms == 'true' }}
         run: |
           sudo swapoff -a
           sudo rm -rf /swapfile /usr/share/dotnet /usr/local/lib/android /opt/ghc
@@ -83,7 +82,7 @@ jobs:
 
       # Projects dependent on flume, hdfs, hbase, and presto currently excluded from the scan.
       - name: run "clean install verify" to trigger dependency check
-        if: ${{ steps.check_changes.outputs.docs_only != 'true' }}
+        if: ${{ steps.changes.outputs.poms == 'true' }}
         run: mvn -q -B -ntp clean install verify -PskipDocker,owasp-dependency-check -DskipTests -pl '!pulsar-sql,!distribution/io,!distribution/offloaders,!tiered-storage/file-system,!pulsar-io/flume,!pulsar-io/hbase,!pulsar-io/hdfs2,!pulsar-io/hdfs3,!pulsar-io/docs'
 
       - name: Upload report

--- a/.github/workflows/ci-owasp-dep-check.yaml
+++ b/.github/workflows/ci-owasp-dep-check.yaml
@@ -1,0 +1,95 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+name: CI - Misc - OWASP Dependency Check
+on:
+  pull_request:
+    branches:
+      - master
+  push:
+    branches:
+      - branch-*
+
+env:
+  MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.class=standard -Dmaven.wagon.http.retryHandler.count=3
+
+jobs:
+
+  owasp-dep-check:
+    name:
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+
+      - name: Tune Runner VM
+        uses: ./.github/actions/tune-runner-vm
+
+      - name: Detect changed files
+        id:   changes
+        uses: apache/pulsar-test-infra/paths-filter@master
+        with:
+          filters: .github/changes-filter.yaml
+
+      - name: Check changed files
+        id: check_changes
+        run: echo "::set-output name=docs_only::${{ fromJSON(steps.changes.outputs.all_count) == fromJSON(steps.changes.outputs.docs_count) && fromJSON(steps.changes.outputs.docs_count) > 0 }}"
+
+      - name: Cache local Maven repository
+        if: ${{ steps.check_changes.outputs.docs_only != 'true' }}
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.m2/repository/*/*/*
+            !~/.m2/repository/org/apache/pulsar
+          key: ${{ runner.os }}-m2-dependencies-all-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-m2-dependencies-core-modules-${{ hashFiles('**/pom.xml') }}
+            ${{ runner.os }}-m2-dependencies-core-modules-
+
+      - name: Set up JDK 11
+        uses: actions/setup-java@v2
+        if: ${{ steps.check_changes.outputs.docs_only != 'true' }}
+        with:
+          distribution: 'temurin'
+          java-version: 11
+
+      - name: clean disk
+        if: ${{ steps.check_changes.outputs.docs_only != 'true' }}
+        run: |
+          sudo swapoff -a
+          sudo rm -rf /swapfile /usr/share/dotnet /usr/local/lib/android /opt/ghc
+          sudo apt clean
+          docker rmi $(docker images -q) -f
+          df -h
+
+      # Projects dependent on flume, hdfs, hbase, and presto currently excluded from the scan.
+      - name: run "clean install verify" to trigger dependency check
+        if: ${{ steps.check_changes.outputs.docs_only != 'true' }}
+        run: mvn -q -B -ntp clean install verify -PskipDocker,owasp-dependency-check -DskipTests -pl '!pulsar-sql,!distribution/io,!distribution/offloaders,!tiered-storage/file-system,!pulsar-io/flume,!pulsar-io/hbase,!pulsar-io/hdfs2,!pulsar-io/hdfs3,!pulsar-io/docs'
+
+      - name: Upload report
+        uses: actions/upload-artifact@v2
+        if: ${{ cancelled() || failure() }}
+        continue-on-error: true
+        with:
+          name: dependency report
+          path: target/dependency-check-report.html

--- a/distribution/io/pom.xml
+++ b/distribution/io/pom.xml
@@ -125,6 +125,31 @@
         </plugins>
       </build>
     </profile>
+    <!--
+    The only working way for OWASP dependency checker plugin
+    to exclude module when failBuildOnCVSS is used
+    in the root pom's plugin.
+    -->
+    <profile>
+      <id>owasp-dependency-check</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.owasp</groupId>
+            <artifactId>dependency-check-maven</artifactId>
+            <version>${dependency-check-maven.version}</version>
+            <executions>
+              <execution>
+                <goals>
+                  <goal>aggregate</goal>
+                </goals>
+                <phase>none</phase>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
   </profiles>
 
 </project>

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -53,7 +53,6 @@
         <module>server</module>
       </modules>
     </profile>
-
   </profiles>
 
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -2326,6 +2326,7 @@ flexible messaging model and an intuitive client API.</description>
                 <suppressionFile>${pulsar.basedir}/src/owasp-dependency-check-false-positives.xml</suppressionFile>
                 <suppressionFile>${pulsar.basedir}/src/owasp-dependency-check-suppressions.xml</suppressionFile>
               </suppressionFiles>
+              <failBuildOnCVSS>7</failBuildOnCVSS>
               <msbuildAnalyzerEnabled>false</msbuildAnalyzerEnabled>
               <nodeAnalyzerEnabled>false</nodeAnalyzerEnabled>
               <yarnAuditAnalyzerEnabled>false</yarnAuditAnalyzerEnabled>

--- a/pulsar-io/docs/pom.xml
+++ b/pulsar-io/docs/pom.xml
@@ -215,5 +215,32 @@
       </plugin>
     </plugins>
   </build>
+  <profiles>
+    <!--
+    The only working way for OWASP dependency checker plugin
+    to exclude module when failBuildOnCVSS is used
+    in the root pom's plugin.
+    -->
+    <profile>
+      <id>owasp-dependency-check</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.owasp</groupId>
+            <artifactId>dependency-check-maven</artifactId>
+            <version>${dependency-check-maven.version}</version>
+            <executions>
+              <execution>
+                <goals>
+                  <goal>aggregate</goal>
+                </goals>
+                <phase>none</phase>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 
 </project>

--- a/pulsar-io/flume/pom.xml
+++ b/pulsar-io/flume/pom.xml
@@ -138,5 +138,32 @@
             </plugin>
         </plugins>
     </build>
+    <profiles>
+        <!--
+        The only working way for OWASP dependency checker plugin
+        to exclude module when failBuildOnCVSS is used
+        in the root pom's plugin.
+        -->
+        <profile>
+            <id>owasp-dependency-check</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.owasp</groupId>
+                        <artifactId>dependency-check-maven</artifactId>
+                        <version>${dependency-check-maven.version}</version>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>aggregate</goal>
+                                </goals>
+                                <phase>none</phase>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 
 </project>

--- a/pulsar-io/hbase/pom.xml
+++ b/pulsar-io/hbase/pom.xml
@@ -95,5 +95,32 @@
             </plugin>
         </plugins>
     </build>
+    <profiles>
+        <!--
+        The only working way for OWASP dependency checker plugin
+        to exclude module when failBuildOnCVSS is used
+        in the root pom's plugin.
+        -->
+        <profile>
+            <id>owasp-dependency-check</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.owasp</groupId>
+                        <artifactId>dependency-check-maven</artifactId>
+                        <version>${dependency-check-maven.version}</version>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>aggregate</goal>
+                                </goals>
+                                <phase>none</phase>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 
 </project>

--- a/pulsar-io/hdfs2/pom.xml
+++ b/pulsar-io/hdfs2/pom.xml
@@ -92,5 +92,32 @@
       </plugin>
     </plugins>
   </build>
-  
+    <profiles>
+        <!--
+        The only working way for OWASP dependency checker plugin
+        to exclude module when failBuildOnCVSS is used
+        in the root pom's plugin.
+        -->
+        <profile>
+            <id>owasp-dependency-check</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.owasp</groupId>
+                        <artifactId>dependency-check-maven</artifactId>
+                        <version>${dependency-check-maven.version}</version>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>aggregate</goal>
+                                </goals>
+                                <phase>none</phase>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+
 </project>

--- a/pulsar-io/hdfs3/pom.xml
+++ b/pulsar-io/hdfs3/pom.xml
@@ -97,5 +97,32 @@
       </plugin>
     </plugins>
   </build>
-  
+  <profiles>
+    <!--
+    The only working way for OWASP dependency checker plugin
+    to exclude module when failBuildOnCVSS is used
+    in the root pom's plugin.
+    -->
+    <profile>
+      <id>owasp-dependency-check</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.owasp</groupId>
+            <artifactId>dependency-check-maven</artifactId>
+            <version>${dependency-check-maven.version}</version>
+            <executions>
+              <execution>
+                <goals>
+                  <goal>aggregate</goal>
+                </goals>
+                <phase>none</phase>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+
 </project>

--- a/pulsar-io/pom.xml
+++ b/pulsar-io/pom.xml
@@ -88,7 +88,6 @@
         <module>data-generator</module>
       </modules>
     </profile>
-
   </profiles>
 
   <build>

--- a/pulsar-sql/pom.xml
+++ b/pulsar-sql/pom.xml
@@ -167,4 +167,32 @@
         </plugins>
     </build>
 
+    <profiles>
+        <!--
+        The only working way for OWASP dependency checker plugin
+        to exclude module when failBuildOnCVSS is used
+        in the root pom's plugin.
+        -->
+        <profile>
+            <id>owasp-dependency-check</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.owasp</groupId>
+                        <artifactId>dependency-check-maven</artifactId>
+                        <version>${dependency-check-maven.version}</version>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>aggregate</goal>
+                                </goals>
+                                <phase>none</phase>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+
 </project>

--- a/tiered-storage/file-system/pom.xml
+++ b/tiered-storage/file-system/pom.xml
@@ -179,4 +179,31 @@
             </plugin>
         </plugins>
     </build>
+    <profiles>
+        <!--
+        The only working way for OWASP dependency checker plugin
+        to exclude module when failBuildOnCVSS is used
+        in the root pom's plugin.
+        -->
+        <profile>
+            <id>owasp-dependency-check</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.owasp</groupId>
+                        <artifactId>dependency-check-maven</artifactId>
+                        <version>${dependency-check-maven.version}</version>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>aggregate</goal>
+                                </goals>
+                                <phase>none</phase>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>


### PR DESCRIPTION
### Motivation

Detect CVEs early and make them visible to the committers

### Modifications

Added GH workflow that will fail if new CVE with level > 7 detected. The plan is to not treat it as blocking merge.
Currently some projects that will not pass the check and aren't included into the suppressions for variety of reasons are excluded.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API: (yes / no)
  - The schema: (yes / no / don't know)
  - The default values of configurations: (yes / no)
  - The wire protocol: (yes / no)
  - The rest endpoints: (yes / no)
  - The admin cli options: (yes / no)
  - Anything that affects deployment: (yes / no / don't know)

### Documentation

Check the box below or label this PR directly (if you have committer privilege).

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)


