### PR TITLE
[fix][managed-ledger] Fix when nextValidLedger is null caused NPE

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
@@ -1710,7 +1710,8 @@ public class ManagedCursorImpl implements ManagedCursor {
             try {
                 long ledgerEntries = ledger.getLedgerInfo(markDeletePosition.getLedgerId()).get().getEntries();
                 Long nextValidLedger = ledger.getNextValidLedger(ledger.getLastConfirmedEntry().getLedgerId());
-                shouldCursorMoveForward = (markDeletePosition.getEntryId() + 1 >= ledgerEntries)
+                shouldCursorMoveForward = nextValidLedger != null
+                        && (markDeletePosition.getEntryId() + 1 >= ledgerEntries)
                         && (newPosition.getLedgerId() == nextValidLedger);
             } catch (Exception e) {
                 log.warn("Failed to get ledger entries while setting mark-delete-position", e);


### PR DESCRIPTION
### Motivation

When the `nextValidLedger` is null, `newPosition.getLedgerId() == nextValidLedger` will unboxing of 'nextValidLedger' may produce 'NullPointerException'.

Fortunately, it doesn't cause any behavior bug, it just prints into the log.

NPE log:
```java
2022-01-27T12:34:39,239+0800 [pulsar-io-6-1] WARN  org.apache.bookkeeper.mledger.impl.ManagedCursorImpl - Failed to get ledger entries while setting mark-delete-position
java.lang.NullPointerException: null
	at org.apache.bookkeeper.mledger.impl.ManagedCursorImpl.asyncMarkDelete(ManagedCursorImpl.java:1699) [classes/:?]
	at org.apache.pulsar.broker.service.persistent.PersistentSubscription.acknowledgeMessage(PersistentSubscription.java:395) [classes/:?]
	at org.apache.pulsar.broker.service.Consumer.messageAcked(Consumer.java:379) [classes/:?]
	at org.apache.pulsar.broker.service.ServerCnx.handleAck(ServerCnx.java:1449) [classes/:?]
	at org.apache.pulsar.common.protocol.PulsarDecoder.channelRead(PulsarDecoder.java:145) [classes/:?]
```
### Modifications

Check `nextValidLedger ` is null.

### Documentation

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
This is a bug fix, no need doc.
  
- [ ] `doc` 
  
  (If this PR contains doc changes)


