### PR TITLE
[Broker] Fix call sync method in async rest api for get tenant namespaces

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v1/Namespaces.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v1/Namespaces.java
@@ -84,8 +84,8 @@ public class Namespaces extends NamespacesBase {
             response = String.class, responseContainer = "Set")
     @ApiResponses(value = {@ApiResponse(code = 403, message = "Don't have admin permission"),
             @ApiResponse(code = 404, message = "Property doesn't exist")})
-    public List<String> getTenantNamespaces(@PathParam("property") String property) {
-        return internalGetTenantNamespaces(property);
+    public void getTenantNamespaces(@PathParam("property") String property, @Suspended AsyncResponse asyncResponse) {
+        internalGetTenantNamespaces(asyncResponse, property);
     }
 
     @GET

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/Namespaces.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/Namespaces.java
@@ -85,8 +85,8 @@ public class Namespaces extends NamespacesBase {
             response = String.class, responseContainer = "Set")
     @ApiResponses(value = {@ApiResponse(code = 403, message = "Don't have admin permission"),
             @ApiResponse(code = 404, message = "Tenant doesn't exist")})
-    public List<String> getTenantNamespaces(@PathParam("tenant") String tenant) {
-        return internalGetTenantNamespaces(tenant);
+    public void getTenantNamespaces(@PathParam("tenant") String tenant, @Suspended AsyncResponse asyncResponse) {
+        internalGetTenantNamespaces(asyncResponse, tenant);
     }
 
     @GET


### PR DESCRIPTION
### Motivation

Remove call sync method in async rest api for get tenant namespaces to avoid thread block.

### Modifications

- Cover the sync method to async method

### Documentation

- [x] `no-need-doc` 
  


Signed-off-by: Zixuan Liu <nodeces@gmail.com>
