### PR TITLE
Upgrade Netty to 4.1.73.Final

### DIFF
--- a/buildtools/pom.xml
+++ b/buildtools/pom.xml
@@ -133,7 +133,7 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-common</artifactId>
-      <version>4.1.72.Final</version>
+      <version>4.1.73.Final</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -352,24 +352,24 @@ The Apache Software License, Version 2.0
     - org.apache.commons-commons-compress-1.21.jar
     - org.apache.commons-commons-lang3-3.11.jar
  * Netty
-    - io.netty-netty-buffer-4.1.72.Final.jar
-    - io.netty-netty-codec-4.1.72.Final.jar
-    - io.netty-netty-codec-dns-4.1.72.Final.jar
-    - io.netty-netty-codec-http-4.1.72.Final.jar
-    - io.netty-netty-codec-http2-4.1.72.Final.jar
-    - io.netty-netty-codec-socks-4.1.72.Final.jar
-    - io.netty-netty-codec-haproxy-4.1.72.Final.jar
-    - io.netty-netty-common-4.1.72.Final.jar
-    - io.netty-netty-handler-4.1.72.Final.jar
-    - io.netty-netty-handler-proxy-4.1.72.Final.jar
-    - io.netty-netty-resolver-4.1.72.Final.jar
-    - io.netty-netty-resolver-dns-4.1.72.Final.jar
-    - io.netty-netty-transport-4.1.72.Final.jar
-    - io.netty-netty-transport-classes-epoll-4.1.72.Final.jar
-    - io.netty-netty-transport-native-epoll-4.1.72.Final-linux-x86_64.jar
-    - io.netty-netty-transport-native-epoll-4.1.72.Final.jar
-    - io.netty-netty-transport-native-unix-common-4.1.72.Final.jar
-    - io.netty-netty-transport-native-unix-common-4.1.72.Final-linux-x86_64.jar
+    - io.netty-netty-buffer-4.1.73.Final.jar
+    - io.netty-netty-codec-4.1.73.Final.jar
+    - io.netty-netty-codec-dns-4.1.73.Final.jar
+    - io.netty-netty-codec-http-4.1.73.Final.jar
+    - io.netty-netty-codec-http2-4.1.73.Final.jar
+    - io.netty-netty-codec-socks-4.1.73.Final.jar
+    - io.netty-netty-codec-haproxy-4.1.73.Final.jar
+    - io.netty-netty-common-4.1.73.Final.jar
+    - io.netty-netty-handler-4.1.73.Final.jar
+    - io.netty-netty-handler-proxy-4.1.73.Final.jar
+    - io.netty-netty-resolver-4.1.73.Final.jar
+    - io.netty-netty-resolver-dns-4.1.73.Final.jar
+    - io.netty-netty-transport-4.1.73.Final.jar
+    - io.netty-netty-transport-classes-epoll-4.1.73.Final.jar
+    - io.netty-netty-transport-native-epoll-4.1.73.Final-linux-x86_64.jar
+    - io.netty-netty-transport-native-epoll-4.1.73.Final.jar
+    - io.netty-netty-transport-native-unix-common-4.1.73.Final.jar
+    - io.netty-netty-transport-native-unix-common-4.1.73.Final-linux-x86_64.jar
     - io.netty-netty-tcnative-boringssl-static-2.0.46.Final.jar
     - io.netty-netty-tcnative-classes-2.0.46.Final.jar
  * Prometheus client

--- a/pom.xml
+++ b/pom.xml
@@ -108,7 +108,7 @@ flexible messaging model and an intuitive client API.</description>
     <snappy.version>1.1.7</snappy.version> <!-- ZooKeeper server -->
     <dropwizardmetrics.version>3.2.5</dropwizardmetrics.version> <!-- ZooKeeper server -->
     <curator.version>5.1.0</curator.version>
-    <netty.version>4.1.72.Final</netty.version>
+    <netty.version>4.1.73.Final</netty.version>
     <netty-tc-native.version>2.0.46.Final</netty-tc-native.version>
     <jetty.version>9.4.44.v20210927</jetty.version>
     <conscrypt.version>2.5.2</conscrypt.version>

--- a/pulsar-sql/presto-distribution/LICENSE
+++ b/pulsar-sql/presto-distribution/LICENSE
@@ -233,26 +233,26 @@ The Apache Software License, Version 2.0
     - commons-lang3-3.11.jar
  * Netty
     - netty-3.10.6.Final.jar
-    - netty-buffer-4.1.72.Final.jar
-    - netty-codec-4.1.72.Final.jar
-    - netty-codec-dns-4.1.72.Final.jar
-    - netty-codec-http-4.1.72.Final.jar
-    - netty-codec-haproxy-4.1.72.Final.jar
-    - netty-codec-socks-4.1.72.Final.jar
-    - netty-handler-proxy-4.1.72.Final.jar
-    - netty-common-4.1.72.Final.jar
-    - netty-handler-4.1.72.Final.jar
+    - netty-buffer-4.1.73.Final.jar
+    - netty-codec-4.1.73.Final.jar
+    - netty-codec-dns-4.1.73.Final.jar
+    - netty-codec-http-4.1.73.Final.jar
+    - netty-codec-haproxy-4.1.73.Final.jar
+    - netty-codec-socks-4.1.73.Final.jar
+    - netty-handler-proxy-4.1.73.Final.jar
+    - netty-common-4.1.73.Final.jar
+    - netty-handler-4.1.73.Final.jar
     - netty-reactive-streams-2.0.4.jar
-    - netty-resolver-4.1.72.Final.jar
-    - netty-resolver-dns-4.1.72.Final.jar
+    - netty-resolver-4.1.73.Final.jar
+    - netty-resolver-dns-4.1.73.Final.jar
     - netty-tcnative-boringssl-static-2.0.46.Final.jar
     - netty-tcnative-classes-2.0.46.Final.jar
-    - netty-transport-4.1.72.Final.jar
-    - netty-transport-classes-epoll-4.1.72.Final.jar
-    - netty-transport-native-epoll-4.1.72.Final-linux-x86_64.jar
-    - netty-transport-native-unix-common-4.1.72.Final.jar
-    - netty-transport-native-unix-common-4.1.72.Final-linux-x86_64.jar
-    - netty-codec-http2-4.1.72.Final.jar
+    - netty-transport-4.1.73.Final.jar
+    - netty-transport-classes-epoll-4.1.73.Final.jar
+    - netty-transport-native-epoll-4.1.73.Final-linux-x86_64.jar
+    - netty-transport-native-unix-common-4.1.73.Final.jar
+    - netty-transport-native-unix-common-4.1.73.Final-linux-x86_64.jar
+    - netty-codec-http2-4.1.73.Final.jar
  * GRPC
     - grpc-api-1.42.1.jar
     - grpc-context-1.42.1.jar


### PR DESCRIPTION
### Motivation

Changelog: https://netty.io/news/2022/01/12/4-1-73-Final.html

The main reason to upgrade is because of an [intensive I/O disk scheduled task](https://github.com/netty/netty/pull/11943) introduced in 4.1.72.Final which is synchronous and can cause EventLoop to blocked very often. 



### Modifications

* Upgrade Netty from 4.1.72.Final to 4.1.73.Final
* [Netty 4.1.73.Final depends on netty-tc-native 2.0.46](https://github.com/netty/netty/blob/b5219aeb4ee62f15d5dfb2b9c29d0c694aca05be/pom.xml#L545) as Netty 4.1.72.Final, so no need to upgrade

### Documentation

- [x] `no-need-doc` 
  
