### PR TITLE
Trim configuration value string which contains blank prefix or suffix

### DIFF
--- a/pulsar-common/src/main/java/org/apache/pulsar/common/util/FieldParser.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/util/FieldParser.java
@@ -141,7 +141,7 @@ public final class FieldParser {
                     f.setAccessible(true);
                     String v = properties.get(f.getName());
                     if (!StringUtils.isBlank(v)) {
-                        f.set(obj, value(v, f));
+                        f.set(obj, value(trim(v), f));
                     } else {
                         setEmptyValue(v, f, obj);
                     }
@@ -316,7 +316,7 @@ public final class FieldParser {
     public static <T> List<T> stringToList(String val, Class<T> type) {
         String[] tokens = trim(val).split(",");
         return Arrays.stream(tokens).map(t -> {
-            return convert(t, type);
+            return convert(trim(t), type);
         }).collect(Collectors.toList());
     }
 
@@ -332,7 +332,7 @@ public final class FieldParser {
     public static <T> Set<T> stringToSet(String val, Class<T> type) {
         String[] tokens = trim(val).split(",");
         return Arrays.stream(tokens).map(t -> {
-            return convert(t, type);
+            return convert(trim(t), type);
         }).collect(Collectors.toSet());
     }
 
@@ -343,7 +343,7 @@ public final class FieldParser {
             String[] keyValue = trim(token).split("=");
             checkArgument(keyValue.length == 2,
                     strValue + " map-value is not in correct format key1=value,key2=value2");
-            map.put(convert(keyValue[0], keyType), convert(keyValue[1], valueType));
+            map.put(convert(trim(keyValue[0]), keyType), convert(trim(keyValue[1]), valueType));
         }
         return map;
     }

--- a/pulsar-common/src/test/java/org/apache/pulsar/common/util/FieldParserTest.java
+++ b/pulsar-common/src/test/java/org/apache/pulsar/common/util/FieldParserTest.java
@@ -19,10 +19,13 @@
 package org.apache.pulsar.common.util;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
+import java.util.Set;
 import org.testng.annotations.Test;
 
 public class FieldParserTest {
@@ -34,6 +37,7 @@ public class FieldParserTest {
         properties.put("stringStringMap", "key1=value1,key2=value2");
         properties.put("stringIntMap", "key1=1,key2=2");
         properties.put("longStringMap", "1=value1,2=value2");
+
         MyConfig config = new MyConfig();
         FieldParser.update(properties, config);
         assertEquals(config.name, "config");
@@ -48,11 +52,46 @@ public class FieldParserTest {
 
     }
 
+    @Test
+    public void testWithBlankVallueConfig() {
+        Map<String, String> properties = new HashMap<>();
+        properties.put("name", "  config   ");
+        properties.put("stringStringMap", "key1=value1  , key2=   value2  ");
+        properties.put("stringIntMap", "key1 = 1, key2 =  2 ");
+        properties.put("longStringMap", " 1 =value1  ,2  =value2    ");
+        properties.put("longList", " 1, 3,  8 , 0  ,9   ");
+        properties.put("stringList", "  aa, bb   ,  cc, ee  ");
+        properties.put("longSet", " 1, 3,  8 , 0 , 3, 1   ,9   ");
+        properties.put("stringSet", "  aa, bb   ,  cc, ee , bb,  aa ");
+
+        MyConfig config = new MyConfig();
+        FieldParser.update(properties, config);
+        assertEquals(config.name, "config");
+        assertEquals(config.stringStringMap.get("key1"), "value1");
+        assertEquals(config.stringStringMap.get("key2"), "value2");
+
+        assertEquals((int) config.stringIntMap.get("key1"), 1);
+        assertEquals((int) config.stringIntMap.get("key2"), 2);
+
+        assertEquals(config.longStringMap.get(1L), "value1");
+        assertEquals(config.longStringMap.get(2L), "value2");
+
+        assertEquals((long)config.longList.get(2), 8);
+        assertEquals(config.stringList.get(1), "bb");
+
+        assertTrue(config.longSet.contains(3L));
+        assertTrue(config.stringSet.contains("bb"));
+    }
+
     public static class MyConfig {
         public String name;
         public Map<String, String> stringStringMap;
         public Map<String, Integer> stringIntMap;
         public Map<Long, String> longStringMap;
+        public List<Long> longList;
+        public List<String> stringList;
+        public Set<Long> longSet;
+        public Set<String> stringSet;
     }
 
 }


### PR DESCRIPTION
### Motivation
For `broker.conf` and `proxy.conf`, if user configure value string which contains blank prefix or suffix, it will parse failed for related configuration and cause broker startup failed. 

For example, if user configure the `metadataStoreUrl="   zk:my-zk-1:2181,my-zk-2:2181,my-zk-3:2181    "`, we will connect to zookeeper server failed due to the blank suffix, and it's hard to debug.


### Modifications

1. Trim the value string on PulsarConfigurationLoader load process.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API: (yes / no)
  - The schema: (yes / no / don't know)
  - The default values of configurations: (yes / no)
  - The wire protocol: (yes / no)
  - The rest endpoints: (yes / no)
  - The admin cli options: (yes / no)
  - Anything that affects deployment: (yes / no / don't know)

### Documentation

Check the box below or label this PR directly (if you have committer privilege).

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)


