### PR TITLE
Fixed handling of consumers with equal names on on key shared selector with consistent hashing

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ConsistentHashingStickyKeyConsumerSelector.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ConsistentHashingStickyKeyConsumerSelector.java
@@ -90,7 +90,7 @@ public class ConsistentHashingStickyKeyConsumerSelector implements StickyKeyCons
                     if (v == null) {
                         return null;
                     } else {
-                        v.removeIf(c -> c.consumerName().equals(consumer.consumerName()));
+                        v.removeIf(c -> c.equals(consumer));
                         if (v.isEmpty()) {
                             v = null;
                         }


### PR DESCRIPTION
### Motivation

Fixes #10750

When removing consumers from the key-shared selector based on the consistent hashing, we were removing by consumer name, although there can be duplicated consumer names (even though is not recommended).