### PR TITLE
Make Backoff class thread-safe

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/Backoff.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/Backoff.java
@@ -22,17 +22,13 @@ import com.google.common.annotations.VisibleForTesting;
 import java.time.Clock;
 import java.util.Random;
 import java.util.concurrent.TimeUnit;
-import lombok.EqualsAndHashCode;
 import lombok.Getter;
-import lombok.ToString;
 
 /**
  * Thread-safe utility to provide an exponential backoff.
  *
  * All variables are in {@link TimeUnit#MILLISECONDS}, by default.
  */
-@ToString
-@EqualsAndHashCode
 public class Backoff {
     public static final long DEFAULT_INTERVAL_IN_NANOSECONDS = TimeUnit.MILLISECONDS.toNanos(100);
     public static final long MAX_BACKOFF_INTERVAL_NANOSECONDS = TimeUnit.SECONDS.toNanos(30);

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/Backoff.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/Backoff.java
@@ -22,13 +22,17 @@ import com.google.common.annotations.VisibleForTesting;
 import java.time.Clock;
 import java.util.Random;
 import java.util.concurrent.TimeUnit;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
+import lombok.ToString;
 
 /**
  * Thread-safe utility to provide an exponential backoff.
  *
  * All variables are in {@link TimeUnit#MILLISECONDS}, by default.
  */
+@ToString
+@EqualsAndHashCode
 public class Backoff {
     public static final long DEFAULT_INTERVAL_IN_NANOSECONDS = TimeUnit.MILLISECONDS.toNanos(100);
     public static final long MAX_BACKOFF_INTERVAL_NANOSECONDS = TimeUnit.SECONDS.toNanos(30);

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/Backoff.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/Backoff.java
@@ -68,10 +68,10 @@ public class Backoff {
     Backoff(long initial, TimeUnit unitInitial, long max, TimeUnit unitMax, long mandatoryStop,
             TimeUnit unitMandatoryStop, Clock clock) {
         if (initial <= 0) {
-            throw new IllegalArgumentException("Illegal initial time");
+            throw new IllegalArgumentException("Illegal initial time: " + initial);
         }
         if (max <= 0) {
-            throw new IllegalArgumentException("Illegal max retry time");
+            throw new IllegalArgumentException("Illegal max retry time: " + max);
         }
         this.initial = unitInitial.toMillis(initial);
         this.max = unitMax.toMillis(max);

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/BackoffBuilder.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/BackoffBuilder.java
@@ -21,6 +21,9 @@ package org.apache.pulsar.client.impl;
 import java.time.Clock;
 import java.util.concurrent.TimeUnit;
 
+/**
+ * Builder for the {@link Backoff} class. This builder is not thread-safe.
+ */
 public class BackoffBuilder {
     private long initial;
     private TimeUnit unitInitial;
@@ -54,7 +57,6 @@ public class BackoffBuilder {
         this.unitMandatoryStop = unitMandatoryStop;
         return this;
     }
-
 
     public Backoff create() {
         return new Backoff(initial, unitInitial, max, unitMax, mandatoryStop, unitMandatoryStop, clock);

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/util/RetryUtil.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/util/RetryUtil.java
@@ -32,12 +32,6 @@ public class RetryUtil {
     public static <T> void retryAsynchronously(Supplier<CompletableFuture<T>> supplier, Backoff backoff,
                                                ScheduledExecutorService scheduledExecutorService,
                                                CompletableFuture<T> callback) {
-        if (backoff.getMax() <= 0) {
-            throw new IllegalArgumentException("Illegal max retry time");
-        }
-        if (backoff.getInitial() <= 0) {
-            throw new IllegalArgumentException("Illegal initial time");
-        }
         scheduledExecutorService.execute(() ->
                 executeWithRetry(supplier, backoff, scheduledExecutorService, callback));
     }

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/PartitionedProducerImplTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/PartitionedProducerImplTest.java
@@ -72,7 +72,7 @@ public class PartitionedProducerImplTest {
         schema = mock(Schema.class);
         producerInterceptors = mock(ProducerInterceptors.class);
         producerCreatedFuture = new CompletableFuture<>();
-        ClientConfigurationData clientConfigurationData = new ClientConfigurationData();
+        ClientConfigurationData clientConfigurationData = mock(ClientConfigurationData.class);
         Timer timer = mock(Timer.class);
 
         producerBuilderImpl = new ProducerBuilderImpl(client, Schema.BYTES);

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/PartitionedProducerImplTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/PartitionedProducerImplTest.java
@@ -72,7 +72,7 @@ public class PartitionedProducerImplTest {
         schema = mock(Schema.class);
         producerInterceptors = mock(ProducerInterceptors.class);
         producerCreatedFuture = new CompletableFuture<>();
-        ClientConfigurationData clientConfigurationData = mock(ClientConfigurationData.class);
+        ClientConfigurationData clientConfigurationData = new ClientConfigurationData();
         Timer timer = mock(Timer.class);
 
         producerBuilderImpl = new ProducerBuilderImpl(client, Schema.BYTES);


### PR DESCRIPTION
### Motivation

In preparing https://github.com/apache/pulsar/pull/13951 (still a draft at this time), I noticed that the `Backoff` class is not thread safe, but it is accessed as if it were because we pass it to multiple threads and call `.next()` to get the next backoff delay.

### Modifications

* Move assertions for `initial` and `max` values to constructor and remove them from the `RetryUtil` class.
* Remove the `@Data` annotation on the `Backoff` class. It allowed for unsafe access to internal state.
* Add Javadocs to improve documentation of the class.
* Remove unsafe initialization for the `next` variable. Here is my source showing that this initialization is unsafe: https://shipilev.net/blog/2014/safe-public-construction/.

### Verifying this change

There is already test coverage for this class. The primary changes just add `synchronized` keywords to methods that get or update mutable state.

### Does this pull request potentially affect one of the following parts:

It's possible that removing the `@Data` annotation on the class will break client applications since `Backoff` is a public class in the java client. I'll need guidance on how we should proceed here.

### Documentation
  
- [x] `doc` 
  
This PR contains Javadocs for relevant documentation. There is no need to document this change elsewhere.


