### PR TITLE
[Doc] Add doc for init sub config in DLQ policy and producer

### DIFF
--- a/site2/docs/client-libraries-java.md
+++ b/site2/docs/client-libraries-java.md
@@ -208,7 +208,7 @@ Name| Type |  <div style="width:300px">Description</div>|  Default
 `batchingMaxMessages` |int|The maximum number of messages permitted in a batch.|1000
 `batchingEnabled`| boolean|Enable batching of messages. |true
 `compressionType`|CompressionType|Message data compression type used by a producer. <br />Available options:<li>[`LZ4`](https://github.com/lz4/lz4)</li><li>[`ZLIB`](https://zlib.net/)<br /><li>[`ZSTD`](https://facebook.github.io/zstd/)</li><li>[`SNAPPY`](https://google.github.io/snappy/)</li>| No compression
-`initialSubscriptionName`|string|Use this config to automatically create an initial subscription when creating the topic. If this field is not set, the initial subscription will not be created.|null
+`initialSubscriptionName`|string|Use this configuration to automatically create an initial subscription when creating a topic. If this field is not set, the initial subscription is not created.|null
 
 You can configure parameters if you do not want to use the default configuration.
 

--- a/site2/docs/client-libraries-java.md
+++ b/site2/docs/client-libraries-java.md
@@ -208,6 +208,7 @@ Name| Type |  <div style="width:300px">Description</div>|  Default
 `batchingMaxMessages` |int|The maximum number of messages permitted in a batch.|1000
 `batchingEnabled`| boolean|Enable batching of messages. |true
 `compressionType`|CompressionType|Message data compression type used by a producer. <br />Available options:<li>[`LZ4`](https://github.com/lz4/lz4)</li><li>[`ZLIB`](https://zlib.net/)<br /><li>[`ZSTD`](https://facebook.github.io/zstd/)</li><li>[`SNAPPY`](https://google.github.io/snappy/)</li>| No compression
+`initialSubscriptionName`|string|Use this config to automatically create an initial subscription when creating the topic. If this field is not set, the initial subscription will not be created.|null
 
 You can configure parameters if you do not want to use the default configuration.
 

--- a/site2/docs/concepts-messaging.md
+++ b/site2/docs/concepts-messaging.md
@@ -302,7 +302,7 @@ Consumer<byte[]> consumer = pulsarClient.newConsumer(Schema.BYTES)
                 
 ```
 
-By default, there is no subscription during a DLQ topic creation. Without a just-in-time subscription to the DLQ topic, you may lose messages. To automatically create the initial subscription for the DLQ, you can specify the initialSubscriptionName parameter.
+By default, there is no subscription during a DLQ topic creation. Without a just-in-time subscription to the DLQ topic, you may lose messages. To automatically create an initial subscription for the DLQ, you can specify the `initialSubscriptionName` parameter.
 
 ```java
 Consumer<byte[]> consumer = pulsarClient.newConsumer(Schema.BYTES)

--- a/site2/docs/concepts-messaging.md
+++ b/site2/docs/concepts-messaging.md
@@ -302,6 +302,22 @@ Consumer<byte[]> consumer = pulsarClient.newConsumer(Schema.BYTES)
                 
 ```
 
+When creating a DLQ topic, there is no subscription by default, so if you don't subscribe to this topic in time, you may lose some messages in the DLQ. You can specify the `initSubscriptionName` to make it automatically create the initial subscription on the DLQ.
+
+```java
+Consumer<byte[]> consumer = pulsarClient.newConsumer(Schema.BYTES)
+                .topic(topic)
+                .subscriptionName("my-subscription")
+                .subscriptionType(SubscriptionType.Shared)
+                .deadLetterPolicy(DeadLetterPolicy.builder()
+                      .maxRedeliverCount(maxRedeliveryCount)
+                      .deadLetterTopic("your-topic-name")
+                      .initSubscriptionName("init-sub")
+                      .build())
+                .subscribe();
+                
+```
+
 Dead letter topic depends on message redelivery. Messages are redelivered either due to [acknowledgement timeout](#acknowledgement-timeout) or [negative acknowledgement](#negative-acknowledgement). If you are going to use negative acknowledgement on a message, make sure it is negatively acknowledged before the acknowledgement timeout. 
 
 > **Note**    

--- a/site2/docs/concepts-messaging.md
+++ b/site2/docs/concepts-messaging.md
@@ -302,7 +302,7 @@ Consumer<byte[]> consumer = pulsarClient.newConsumer(Schema.BYTES)
                 
 ```
 
-By default, there is no subscription during a DLQ topic creation. Without a just-in-time subscription to the DLQ topic, you may lose messages. To automatically create the initial subscription for the DLQ, you can specify the initSubscriptionName parameter.
+By default, there is no subscription during a DLQ topic creation. Without a just-in-time subscription to the DLQ topic, you may lose messages. To automatically create the initial subscription for the DLQ, you can specify the initialSubscriptionName parameter.
 
 ```java
 Consumer<byte[]> consumer = pulsarClient.newConsumer(Schema.BYTES)
@@ -312,7 +312,7 @@ Consumer<byte[]> consumer = pulsarClient.newConsumer(Schema.BYTES)
                 .deadLetterPolicy(DeadLetterPolicy.builder()
                       .maxRedeliverCount(maxRedeliveryCount)
                       .deadLetterTopic("your-topic-name")
-                      .initSubscriptionName("init-sub")
+                      .initialSubscriptionName("init-sub")
                       .build())
                 .subscribe();
                 

--- a/site2/docs/concepts-messaging.md
+++ b/site2/docs/concepts-messaging.md
@@ -302,7 +302,7 @@ Consumer<byte[]> consumer = pulsarClient.newConsumer(Schema.BYTES)
                 
 ```
 
-When creating a DLQ topic, there is no subscription by default, so if you don't subscribe to this topic in time, you may lose some messages in the DLQ. You can specify the `initSubscriptionName` to make it automatically create the initial subscription on the DLQ.
+By default, there is no subscription during a DLQ topic creation. Without a just-in-time subscription to the DLQ topic, you may lose messages. To automatically create the initial subscription for the DLQ, you can specify the initSubscriptionName parameter.
 
 ```java
 Consumer<byte[]> consumer = pulsarClient.newConsumer(Schema.BYTES)


### PR DESCRIPTION
### Motivation

This PR is the doc for #13355

### Modifications

* Add doc for init sub config in DLQ policy and producer

### Documentation

- [x] `doc` 
  
