### PR TITLE
[Flaky-test] BrokerServiceLookupTest#testPartitionTopicLookup

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/BrokerServiceLookupTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/BrokerServiceLookupTest.java
@@ -402,8 +402,6 @@ public class BrokerServiceLookupTest extends ProducerConsumerBase {
         producer.close();
         consumer.unsubscribe();
         consumer.close();
-        admin.topics().deletePartitionedTopic(topicName.toString());
-
         loadManager2 = null;
 
         log.info("-- Exiting {} test --", methodName);


### PR DESCRIPTION

### Motivation


Fixes #13996

### Modifications

testPartitionTopicLookup always timeout, I found, it stuck  in  `deletePartitionedTopic`, And, I found no necessary to delete topic.

### Documentation

Check the box below or label this PR directly (if you have committer privilege).

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)


