### PR TITLE
[Flaky-test] BacklogQuotaManagerTest#testConsumerBacklogEvictionTimeQuota

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BacklogQuotaManagerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BacklogQuotaManagerTest.java
@@ -35,8 +35,10 @@ import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import lombok.Cleanup;
+import org.apache.bookkeeper.mledger.impl.ManagedLedgerImpl;
 import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.broker.ServiceConfiguration;
+import org.apache.pulsar.broker.service.persistent.PersistentTopic;
 import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.api.Consumer;
 import org.apache.pulsar.client.api.Message;
@@ -475,10 +477,12 @@ public class BacklogQuotaManagerTest {
         rolloverStats();
 
         stats = admin.topics().getStats(topic1);
+        PersistentTopic topic1Reference = (PersistentTopic) pulsar.getBrokerService().getTopicReference(topic1).get();
+        ManagedLedgerImpl ml = (ManagedLedgerImpl) topic1Reference.getManagedLedger();
         // Messages on first 2 ledgers should be expired, backlog is number of
-        // message in current ledger which should be 4.
-        assertEquals(stats.getSubscriptions().get(subName1).getMsgBacklog(), 4);
-        assertEquals(stats.getSubscriptions().get(subName2).getMsgBacklog(), 4);
+        // message in current ledger.
+        assertEquals(stats.getSubscriptions().get(subName1).getMsgBacklog(), ml.getNumberOfEntries());
+        assertEquals(stats.getSubscriptions().get(subName2).getMsgBacklog(), ml.getNumberOfEntries());
         client.close();
     }
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BacklogQuotaManagerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BacklogQuotaManagerTest.java
@@ -481,8 +481,8 @@ public class BacklogQuotaManagerTest {
         ManagedLedgerImpl ml = (ManagedLedgerImpl) topic1Reference.getManagedLedger();
         // Messages on first 2 ledgers should be expired, backlog is number of
         // message in current ledger.
-        assertEquals(stats.getSubscriptions().get(subName1).getMsgBacklog(), ml.getNumberOfEntries());
-        assertEquals(stats.getSubscriptions().get(subName2).getMsgBacklog(), ml.getNumberOfEntries());
+        assertEquals(stats.getSubscriptions().get(subName1).getMsgBacklog(), ml.getCurrentLedgerEntries());
+        assertEquals(stats.getSubscriptions().get(subName2).getMsgBacklog(), ml.getCurrentLedgerEntries());
         client.close();
     }
 


### PR DESCRIPTION

### Motivation

Fixes #13952

### Modifications
MAX_ENTRIES_PER_LEDGER = 5,  it will be  uncertain that  the num of entries in last ledger is 4.
Use ManagedLedgerImpl. getNumberOfEntries to get the num of entries in last opened ledger



### Documentation

Check the box below or label this PR directly (if you have committer privilege).

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)


