### PR TITLE
[PIP-132] Include message header size when check maxMessageSize for non-batch message on the client side.

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/MaxMessageSizeTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/MaxMessageSizeTest.java
@@ -215,6 +215,14 @@ public class MaxMessageSizeTest {
         @Cleanup
         Consumer<byte[]> consumer = client.newConsumer().topic(topicName).subscriptionName("test1").subscribe();
 
+        // 12 MB metadata, should fail
+        try {
+            producer.newMessage().orderingKey(new byte[12 * 1024 * 1024]).send();
+            Assert.fail("Shouldn't send out this message");
+        } catch (PulsarClientException e) {
+            //no-op
+        }
+
         // 12 MB payload, there should be 2 chunks
         byte[] data = new byte[12 * 1024 * 1024];
         try {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/MaxMessageSizeTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/MaxMessageSizeTest.java
@@ -19,11 +19,10 @@
 package org.apache.pulsar.broker.service;
 
 import com.google.common.collect.Sets;
-
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
-
 import lombok.Cleanup;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.bookkeeper.conf.ServerConfiguration;
 import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.broker.ServiceConfiguration;
@@ -32,6 +31,7 @@ import org.apache.pulsar.client.api.Consumer;
 import org.apache.pulsar.client.api.Producer;
 import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.client.api.PulsarClientException;
+import org.apache.pulsar.client.impl.MessageImpl;
 import org.apache.pulsar.common.policies.data.ClusterData;
 import org.apache.pulsar.common.policies.data.TenantInfoImpl;
 import org.apache.pulsar.zookeeper.LocalBookkeeperEnsemble;
@@ -41,6 +41,7 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 @Test(groups = "broker")
+@Slf4j
 public class MaxMessageSizeTest {
 
     PulsarService pulsar;
@@ -55,7 +56,7 @@ public class MaxMessageSizeTest {
         try {
             bkEnsemble = new LocalBookkeeperEnsemble(3, 0, () -> 0);
             ServerConfiguration conf = new ServerConfiguration();
-            conf.setNettyMaxFrameSizeBytes(10 * 1024 * 1024);
+            conf.setNettyMaxFrameSizeBytes(10 * 1024 * 1024 + 10 * 1024);
             bkEnsemble.startStandalone(conf, false);
 
             configuration = new ServiceConfiguration();
@@ -78,7 +79,8 @@ public class MaxMessageSizeTest {
             admin = PulsarAdmin.builder().serviceHttpUrl(url).build();
             admin.clusters().createCluster("max_message_test", ClusterData.builder().serviceUrl(url).build());
             admin.tenants()
-                 .createTenant("test", new TenantInfoImpl(Sets.newHashSet("appid1"), Sets.newHashSet("max_message_test")));
+                    .createTenant("test",
+                            new TenantInfoImpl(Sets.newHashSet("appid1"), Sets.newHashSet("max_message_test")));
             admin.namespaces().createNamespace("test/message", Sets.newHashSet("max_message_test"));
         } catch (Exception e) {
             e.printStackTrace();
@@ -101,8 +103,8 @@ public class MaxMessageSizeTest {
         @Cleanup
         PulsarClient client = PulsarClient.builder().serviceUrl(pulsar.getBrokerServiceUrl()).build();
         String topicName = "persistent://test/message/topic1";
-        Producer producer = client.newProducer().topic(topicName).sendTimeout(60, TimeUnit.SECONDS).create();
-        Consumer consumer = client.newConsumer().topic(topicName).subscriptionName("test1").subscribe();
+        Producer<byte[]> producer = client.newProducer().topic(topicName).sendTimeout(60, TimeUnit.SECONDS).create();
+        Consumer<byte[]> consumer = client.newConsumer().topic(topicName).subscriptionName("test1").subscribe();
 
         // less than 5MB message
 
@@ -139,6 +141,14 @@ public class MaxMessageSizeTest {
         byte[] consumerNewNormalMsg = consumer.receive().getData();
         Assert.assertEquals(newNormalMsg, consumerNewNormalMsg);
 
+        // 2MB metadata and 8 MB payload
+        try {
+            producer.newMessage().keyBytes(new byte[2 * 1024 * 1024]).value(newNormalMsg).send();
+            Assert.fail("Shouldn't send out this message");
+        } catch (PulsarClientException e) {
+            //no-op
+        }
+
         // equals 10MB message
         byte[] newLimitMsg = new byte[10 * 1024 * 1024];
         try {
@@ -151,6 +161,79 @@ public class MaxMessageSizeTest {
         consumer.unsubscribe();
         consumer.close();
         producer.close();
+    }
 
+    @Test
+    public void testNonBatchingMaxMessageSize() throws Exception {
+        @Cleanup
+        PulsarClient client = PulsarClient.builder().serviceUrl(pulsar.getBrokerServiceUrl()).build();
+        String topicName = "persistent://test/message/testNonBatchingMaxMessageSize";
+        @Cleanup
+        Producer<byte[]> producer = client.newProducer()
+                .topic(topicName)
+                .enableBatching(false)
+                .sendTimeout(30, TimeUnit.SECONDS).create();
+        @Cleanup
+        Consumer<byte[]> consumer = client.newConsumer().topic(topicName).subscriptionName("test1").subscribe();
+
+        byte[] data = new byte[8 * 1024 * 1024];
+        try {
+            producer.newMessage().value(data).send();
+        } catch (PulsarClientException e) {
+            Assert.fail("Shouldn't have exception at here", e);
+        }
+        Assert.assertEquals(consumer.receive().getData(), data);
+
+        // 1MB metadata and 8 MB payload
+        try {
+            producer.newMessage().property("P", new String(new byte[1024 * 1024])).value(data).send();
+        } catch (PulsarClientException e) {
+            Assert.fail("Shouldn't have exception at here", e);
+        }
+        Assert.assertEquals(consumer.receive().getData(), data);
+
+        // 2MB metadata and 8 MB payload, should fail.
+        try {
+            producer.newMessage().property("P", new String(new byte[2 * 1024 * 1024])).value(data).send();
+            Assert.fail("Shouldn't send out this message");
+        } catch (PulsarClientException e) {
+            //no-op
+        }
+    }
+
+    @Test
+    public void testChunkingMaxMessageSize() throws Exception {
+        @Cleanup
+        PulsarClient client = PulsarClient.builder().serviceUrl(pulsar.getBrokerServiceUrl()).build();
+        String topicName = "persistent://test/message/testChunkingMaxMessageSize";
+        @Cleanup
+        Producer<byte[]> producer = client.newProducer()
+                .topic(topicName)
+                .enableBatching(false)
+                .enableChunking(true)
+                .sendTimeout(30, TimeUnit.SECONDS).create();
+        @Cleanup
+        Consumer<byte[]> consumer = client.newConsumer().topic(topicName).subscriptionName("test1").subscribe();
+
+        // 12 MB payload, there should be 2 chunks
+        byte[] data = new byte[12 * 1024 * 1024];
+        try {
+            producer.newMessage().value(data).send();
+        } catch (PulsarClientException e) {
+            Assert.fail("Shouldn't have exception at here", e);
+        }
+        MessageImpl<byte[]> msg = (MessageImpl<byte[]>) consumer.receive();
+        Assert.assertEquals(msg.getData(), data);
+        Assert.assertEquals(msg.getMessageBuilder().getNumChunksFromMsg(), 2);
+
+        // 5MB metadata and 12 MB payload, there should be 3 chunks
+        try {
+            producer.newMessage().property("P", new String(new byte[5 * 1024 * 1024])).value(data).send();
+        } catch (PulsarClientException e) {
+            Assert.fail("Shouldn't have exception at here", e);
+        }
+        msg = (MessageImpl<byte[]>) consumer.receive();
+        Assert.assertEquals(msg.getData(), data);
+        Assert.assertEquals(msg.getMessageBuilder().getNumChunksFromMsg(), 3);
     }
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/MessageChunkingTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/MessageChunkingTest.java
@@ -108,7 +108,7 @@ public class MessageChunkingTest extends ProducerConsumerBase {
     public void testLargeMessage(boolean ackReceiptEnabled) throws Exception {
 
         log.info("-- Starting {} test --", methodName);
-        this.conf.setMaxMessageSize(5);
+        this.conf.setMaxMessageSize(50);
         final int totalMessages = 5;
         final String topicName = "persistent://my-property/my-ns/my-topic1";
 
@@ -125,7 +125,7 @@ public class MessageChunkingTest extends ProducerConsumerBase {
 
         List<String> publishedMessages = Lists.newArrayList();
         for (int i = 0; i < totalMessages; i++) {
-            String message = createMessagePayload(i * 10);
+            String message = createMessagePayload(i * 100);
             publishedMessages.add(message);
             producer.send(message.getBytes());
         }
@@ -196,7 +196,7 @@ public class MessageChunkingTest extends ProducerConsumerBase {
     public void testLargeMessageAckTimeOut(boolean ackReceiptEnabled) throws Exception {
 
         log.info("-- Starting {} test --", methodName);
-        this.conf.setMaxMessageSize(5);
+        this.conf.setMaxMessageSize(50);
         final int totalMessages = 5;
         final String topicName = "persistent://my-property/my-ns/my-topic1";
 
@@ -213,7 +213,7 @@ public class MessageChunkingTest extends ProducerConsumerBase {
 
         List<String> publishedMessages = Lists.newArrayList();
         for (int i = 0; i < totalMessages; i++) {
-            String message = createMessagePayload(i * 10);
+            String message = createMessagePayload(i * 100);
             publishedMessages.add(message);
             producer.send(message.getBytes());
         }
@@ -263,7 +263,7 @@ public class MessageChunkingTest extends ProducerConsumerBase {
     @Test
     public void testPublishWithFailure() throws Exception {
         log.info("-- Starting {} test --", methodName);
-        this.conf.setMaxMessageSize(5);
+        this.conf.setMaxMessageSize(50);
         final String topicName = "persistent://my-property/my-ns/my-topic1";
 
         ProducerBuilder<byte[]> producerBuilder = pulsarClient.newProducer().topic(topicName);
@@ -274,7 +274,7 @@ public class MessageChunkingTest extends ProducerConsumerBase {
         stopBroker();
 
         try {
-            producer.send(createMessagePayload(100).getBytes());
+            producer.send(createMessagePayload(1000).getBytes());
             fail("should have failed with timeout exception");
         } catch (PulsarClientException.TimeoutException e) {
             // Ok
@@ -403,7 +403,7 @@ public class MessageChunkingTest extends ProducerConsumerBase {
     public void testChunksEnqueueFailed() throws Exception {
         final String topicName = "persistent://my-property/my-ns/test-chunks-enqueue-failed";
         log.info("-- Starting {} test --", methodName);
-        this.conf.setMaxMessageSize(5);
+        this.conf.setMaxMessageSize(50);
 
         final MemoryLimitController controller = ((PulsarClientImpl) pulsarClient).getMemoryLimitController();
         assertEquals(controller.currentUsage(), 0);
@@ -423,7 +423,7 @@ public class MessageChunkingTest extends ProducerConsumerBase {
         assertEquals(semaphore.availablePermits(), maxPendingMessages);
         producer.send(createMessagePayload(1).getBytes());
         try {
-            producer.send(createMessagePayload(100).getBytes(StandardCharsets.UTF_8));
+            producer.send(createMessagePayload(1000).getBytes(StandardCharsets.UTF_8));
             fail("It should fail with ProducerQueueIsFullError");
         } catch (PulsarClientException e) {
             assertTrue(e instanceof PulsarClientException.ProducerQueueIsFullError);
@@ -440,7 +440,7 @@ public class MessageChunkingTest extends ProducerConsumerBase {
     @Test
     public void testSeekChunkMessages() throws PulsarClientException {
         log.info("-- Starting {} test --", methodName);
-        this.conf.setMaxMessageSize(5);
+        this.conf.setMaxMessageSize(50);
         final int totalMessages = 5;
         final String topicName = "persistent://my-property/my-ns/test-seek-chunk";
 
@@ -463,7 +463,7 @@ public class MessageChunkingTest extends ProducerConsumerBase {
                 .subscribe();
 
         for (int i = 0; i < totalMessages; i++) {
-            String message = createMessagePayload(10);
+            String message = createMessagePayload(100);
             producer.send(message.getBytes());
         }
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/MessageChunkingTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/MessageChunkingTest.java
@@ -171,7 +171,7 @@ public class MessageChunkingTest extends ProducerConsumerBase {
 
     @Test
     public void testChunkingWithOrderingKey() throws Exception {
-        this.conf.setMaxMessageSize(5);
+        this.conf.setMaxMessageSize(100);
 
         final String topicName = "persistent://my-property/my-ns/testChunkingWithOrderingKey";
 
@@ -183,8 +183,8 @@ public class MessageChunkingTest extends ProducerConsumerBase {
         Producer<byte[]> producer = pulsarClient.newProducer().topic(topicName).enableChunking(true)
                 .enableBatching(false).create();
 
-        byte[] data = RandomUtils.nextBytes(20);
-        byte[] ok = RandomUtils.nextBytes(10);
+        byte[] data = RandomUtils.nextBytes(200);
+        byte[] ok = RandomUtils.nextBytes(50);
         producer.newMessage().value(data).orderingKey(ok).send();
 
         Message<byte[]> msg = consumer.receive();

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
@@ -485,8 +485,9 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
             if (payloadChunkSize <= 0) {
                 PulsarClientException.InvalidMessageException invalidMessageException =
                         new PulsarClientException.InvalidMessageException(
-                                format("The producer %s of the topic %s sends a message with %d bytes metadata that exceeds %d bytes",
-                                        producerName, topic, msgMetadata.getSerializedSize(), ClientCnx.getMaxMessageSize()));
+                                format("The producer %s of the topic %s sends a message with %d bytes metadata that "
+                                                + "exceeds %d bytes", producerName, topic,
+                                        msgMetadata.getSerializedSize(), ClientCnx.getMaxMessageSize()));
                 completeCallbackAndReleaseSemaphore(uncompressedSize, callback, invalidMessageException);
                 compressedPayload.release();
                 return;

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
@@ -2017,7 +2017,7 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
             if (op.msg != null && isBatchMessagingEnabled()) {
                 batchMessageAndSend();
             }
-            if (checkMaxMessageSize(op)) {
+            if (isMessageSizeExceeded(op)) {
                 return;
             }
             pendingMessages.add(op);
@@ -2087,7 +2087,7 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
             if (op.cmd == null) {
                 checkState(op.rePopulate != null);
                 op.rePopulate.run();
-                if (checkMaxMessageSize(op)) {
+                if (isMessageSizeExceeded(op)) {
                     continue;
                 }
             }
@@ -2116,9 +2116,9 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
     }
 
     /**
-     *  Check final message size for non-batch and non-chunked messages only.
+     *  Check if final message size for non-batch and non-chunked messages is larger than max message size.
      */
-    public boolean checkMaxMessageSize(OpSendMsg op) {
+    public boolean isMessageSizeExceeded(OpSendMsg op) {
         if (op.msg != null && op.totalChunks <= 1) {
             int messageSize = op.getMessageHeaderAndPayloadSize();
             if (messageSize > ClientCnx.getMaxMessageSize()) {

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/util/MathUtilsTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/util/MathUtilsTest.java
@@ -16,37 +16,25 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+
 package org.apache.pulsar.client.util;
 
-import lombok.experimental.UtilityClass;
+import static org.testng.Assert.*;
+import org.testng.annotations.Test;
 
-@UtilityClass
-public class MathUtils {
-    /**
-     * Compute sign safe mod.
-     *
-     * @param dividend
-     * @param divisor
-     * @return
-     */
-    public static int signSafeMod(long dividend, int divisor) {
-        int mod = (int) (dividend % divisor);
+public class MathUtilsTest {
 
-        if (mod < 0) {
-            mod += divisor;
-        }
+    @Test
+    public void testCeilDiv() {
+        assertEquals(MathUtils.ceilDiv(0, 1024), 0);
+        assertEquals(MathUtils.ceilDiv(1, 1024), 1);
+        assertEquals(MathUtils.ceilDiv(1023, 1024), 1);
+        assertEquals(MathUtils.ceilDiv(1024, 1024), 1);
+        assertEquals(MathUtils.ceilDiv(1025, 1024), 2);
 
-        return mod;
-    }
-
-    /**
-     * Ceil version of Math.floorDiv().
-     * @param x the dividend
-     * @param y the divisor
-     * @return the smallest value that is larger than or equal to the algebraic quotient.
-     *
-     */
-    public static int ceilDiv(int x, int y) {
-        return -Math.floorDiv(-x, y);
+        assertEquals(MathUtils.ceilDiv(0, Integer.MAX_VALUE), 0);
+        assertEquals(MathUtils.ceilDiv(1, Integer.MAX_VALUE), 1);
+        assertEquals(MathUtils.ceilDiv(Integer.MAX_VALUE - 1, Integer.MAX_VALUE), 1);
+        assertEquals(MathUtils.ceilDiv(Integer.MAX_VALUE, Integer.MAX_VALUE), 1);
     }
 }

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/util/MathUtilsTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/util/MathUtilsTest.java
@@ -19,22 +19,23 @@
 
 package org.apache.pulsar.client.util;
 
-import static org.testng.Assert.*;
+
+import org.testng.Assert;
 import org.testng.annotations.Test;
 
 public class MathUtilsTest {
 
     @Test
     public void testCeilDiv() {
-        assertEquals(MathUtils.ceilDiv(0, 1024), 0);
-        assertEquals(MathUtils.ceilDiv(1, 1024), 1);
-        assertEquals(MathUtils.ceilDiv(1023, 1024), 1);
-        assertEquals(MathUtils.ceilDiv(1024, 1024), 1);
-        assertEquals(MathUtils.ceilDiv(1025, 1024), 2);
+        Assert.assertEquals(MathUtils.ceilDiv(0, 1024), 0);
+        Assert.assertEquals(MathUtils.ceilDiv(1, 1024), 1);
+        Assert.assertEquals(MathUtils.ceilDiv(1023, 1024), 1);
+        Assert.assertEquals(MathUtils.ceilDiv(1024, 1024), 1);
+        Assert.assertEquals(MathUtils.ceilDiv(1025, 1024), 2);
 
-        assertEquals(MathUtils.ceilDiv(0, Integer.MAX_VALUE), 0);
-        assertEquals(MathUtils.ceilDiv(1, Integer.MAX_VALUE), 1);
-        assertEquals(MathUtils.ceilDiv(Integer.MAX_VALUE - 1, Integer.MAX_VALUE), 1);
-        assertEquals(MathUtils.ceilDiv(Integer.MAX_VALUE, Integer.MAX_VALUE), 1);
+        Assert.assertEquals(MathUtils.ceilDiv(0, Integer.MAX_VALUE), 0);
+        Assert.assertEquals(MathUtils.ceilDiv(1, Integer.MAX_VALUE), 1);
+        Assert.assertEquals(MathUtils.ceilDiv(Integer.MAX_VALUE - 1, Integer.MAX_VALUE), 1);
+        Assert.assertEquals(MathUtils.ceilDiv(Integer.MAX_VALUE, Integer.MAX_VALUE), 1);
     }
 }


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - Name the pull request in the form "[Issue XYZ][component] Title of the pull request", where *XYZ* should be replaced by the actual issue number.
    Skip *Issue XYZ* if there is no associated github issue for this pull request.
    Skip *component* if you are unsure about which is the best component. E.g. `[docs] Fix typo in produce method`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.

**(The sections below can be removed for hotfixes of typos)**
-->

Master Issue: #13591

### Motivation

See #13591

### Modifications

1. Add max message size check before sending request for non-batch and non-chunked messages.
2. Decrease chunk size by metadata size  for chunked messages.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change added tests and can be verified as follows:
  -  pulsar-broker/src/test/java/org/apache/pulsar/broker/service/MaxMessageSizeTest.java

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

Check the box below and label this PR (if you have committer privilege).

Need to update docs? 
  
- [x] `no-need-doc` 


