### PR TITLE
[Broker] Set default value of applied to false in getSchemaCompatibilityStrategy

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/PersistentTopics.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/PersistentTopics.java
@@ -3583,7 +3583,7 @@ public class PersistentTopics extends PersistentTopicsBase {
             @PathParam("namespace") String namespace,
             @ApiParam(value = "Specify topic name", required = true)
             @PathParam("topic") @Encoded String encodedTopic,
-            @QueryParam("applied") boolean applied,
+            @QueryParam("applied") @DefaultValue("false") boolean applied,
             @ApiParam(value = "Is authentication required to perform this operation")
             @QueryParam("authoritative") @DefaultValue("false") boolean authoritative) {
         validateTopicName(tenant, namespace, encodedTopic);


### PR DESCRIPTION
### Motivation
In #13297, we should set default value of applied to `false` in [getSchemaCompatibilityStrategy](https://github.com/apache/pulsar/pull/13297/files#diff-f37aee2b7a1b61a339394b5ff47d7bd53133b58ec4c6faabea5375f5294d6048R3578)

### Documentation
- [x] `no-need-doc` 
