### PR TITLE
[Transaction] Fix individual ack with transaction decrease unAckMessageCounnt

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Consumer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Consumer.java
@@ -414,16 +414,7 @@ public class Consumer {
                 }
             } else {
                 position = PositionImpl.get(msgId.getLedgerId(), msgId.getEntryId());
-                if (Subscription.isIndividualAckMode(subType) && isAcknowledgmentAtBatchIndexLevelEnabled) {
-                    long[] cursorAckSet = getCursorAckSet(position);
-                    if (cursorAckSet != null) {
-                        ackedCount = getAckedCountForBatchIndexLevelEnabled(position, batchSize, EMPTY_ACK_SET);
-                    } else {
-                        ackedCount = batchSize;
-                    }
-                } else {
-                    ackedCount = batchSize;
-                }
+                ackedCount = getAckedCountForMsgIdNoAckSets(batchSize, position);
             }
 
             addAndGetUnAckedMsgs(ackOwnerConsumer, -(int) ackedCount);
@@ -477,16 +468,7 @@ public class Consumer {
                 ackedCount = getAckedCountForBatchIndexLevelEnabled(position, batchSize, ackSets);
             } else {
                 position = PositionImpl.get(msgId.getLedgerId(), msgId.getEntryId());
-                if (isAcknowledgmentAtBatchIndexLevelEnabled) {
-                    long[] cursorAckSet = getCursorAckSet(position);
-                    if (cursorAckSet != null) {
-                        ackedCount = batchSize - BitSet.valueOf(cursorAckSet).cardinality();
-                    } else {
-                        ackedCount = batchSize;
-                    }
-                } else {
-                    ackedCount = batchSize;
-                }
+                ackedCount = getAckedCountForMsgIdNoAckSets(batchSize, position);
             }
 
             if (msgId.hasBatchIndex()) {
@@ -531,6 +513,16 @@ public class Consumer {
                 }
             } else {
                 batchSize = longPair.first;
+            }
+        }
+        return batchSize;
+    }
+
+    private long getAckedCountForMsgIdNoAckSets(long batchSize, PositionImpl position) {
+        if (Subscription.isIndividualAckMode(subType) && isAcknowledgmentAtBatchIndexLevelEnabled) {
+            long[] cursorAckSet = getCursorAckSet(position);
+            if (cursorAckSet != null) {
+                return getAckedCountForBatchIndexLevelEnabled(position, batchSize, EMPTY_ACK_SET);
             }
         }
         return batchSize;


### PR DESCRIPTION
link https://github.com/apache/pulsar/pull/13383
## Motivation
#13383 has fixed  the batch message ack does not decrease the unacked-msg count, but ack with transaction don't fix
because decrease unAckMessageCount move to another method. ack with transaction can't decrease unackMessageCount.

### Modifications
change ack with transaction decrease unackMessageCount to normal ack(ack no transaction).
### Verifying this change
Add the tests for it

Does this pull request potentially affect one of the following parts:
If yes was chosen, please highlight the changes

Dependencies (does it add or upgrade a dependency): (no)
The public API: (no)
The schema: (no)
The default values of configurations: (no)
The wire protocol: (no)
The rest endpoints: (no)
The admin cli options: (no)
Anything that affects deployment: (no)

