### PR TITLE
[Broker] Fix typo in setSchemaCompatibilityStrategy

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/PersistentTopics.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/PersistentTopics.java
@@ -3599,7 +3599,7 @@ public class PersistentTopics extends PersistentTopicsBase {
 
     @PUT
     @Path("/{tenant}/{namespace}/{topic}/schemaCompatibilityStrategy")
-    @ApiOperation(value = "Get schema compatibility strategy on a topic")
+    @ApiOperation(value = "Set schema compatibility strategy on a topic")
     @ApiResponses(value = {
             @ApiResponse(code = 307, message = "Current broker doesn't serve the namespace of this topic"),
             @ApiResponse(code = 403, message = "Don't have admin permission"),
@@ -3624,7 +3624,7 @@ public class PersistentTopics extends PersistentTopicsBase {
                 .thenRun(() -> {
                     log.info(
                             "[{}] Successfully set topic schema compatibility strategy: tenant={}, namespace={}, "
-                                    + "topic={}, shemaCompatibilityStrategy = {}",
+                                    + "topic={}, schemaCompatibilityStrategy={}",
                             clientAppId(),
                             tenant,
                             namespace,


### PR DESCRIPTION
### Motivation

There are has typos in the setSchemaCompatibilityStrategy API.

### Documentation

- [x] `no-need-doc` 

