### PR TITLE
[Broker] Make PersistentTopicsBase#internalSetBacklogQuota async

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
@@ -41,7 +41,6 @@ import java.util.concurrent.CompletionException;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiConsumer;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
@@ -2869,11 +2869,10 @@ public class PersistentTopicsBase extends AdminResource {
                                                               BacklogQuotaImpl backlogQuota, boolean isGlobal) {
         BacklogQuota.BacklogQuotaType finalBacklogQuotaType = backlogQuotaType == null
                 ? BacklogQuota.BacklogQuotaType.destination_storage : backlogQuotaType;
-        CompletableFuture<Void> future =
-                validateTopicPolicyOperationAsync(topicName, PolicyName.BACKLOG, PolicyOperation.WRITE);
-        future.thenAccept(__ -> validatePoliciesReadOnlyAccess());
 
-        return future.thenCompose(__ -> getTopicPoliciesAsyncWithRetry(topicName, isGlobal))
+        return validateTopicPolicyOperationAsync(topicName, PolicyName.BACKLOG, PolicyOperation.WRITE)
+                .thenAccept(__ -> validatePoliciesReadOnlyAccess())
+                .thenCompose(__ -> getTopicPoliciesAsyncWithRetry(topicName, isGlobal))
                 .thenCompose(op -> {
                     TopicPolicies topicPolicies = op.orElseGet(TopicPolicies::new);
                     return getRetentionPoliciesAsync(topicName, topicPolicies)
@@ -2900,7 +2899,7 @@ public class PersistentTopicsBase extends AdminResource {
                                             try {
                                                 log.info(
                                                         "[{}] Successfully updated backlog quota map: namespace={}, "
-                                                        + "topic={}, map={}",
+                                                                + "topic={}, map={}",
                                                         clientAppId(),
                                                         namespaceName,
                                                         topicName.getLocalName(),


### PR DESCRIPTION
Master Issue: #13854 

### Motivation
See #13854

### Modifications

* Make PersistentTopicsBase#internalSetBacklogQuota async.
* Change getRetentionPolicies to getRetentionPoliciesAsync

### Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

### Documentation

Check the box below or label this PR directly (if you have committer privilege).

Need to update docs? 

- [x] `no-need-doc` 
  


