### PR TITLE
Add a default timeout for OAuth2 Metadata Resolver

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/auth/oauth2/protocol/DefaultMetadataResolver.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/auth/oauth2/protocol/DefaultMetadataResolver.java
@@ -33,6 +33,9 @@ import java.time.Duration;
  */
 public class DefaultMetadataResolver implements MetadataResolver {
 
+    protected static final int DEFAULT_CONNECT_TIMEOUT_IN_SECONDS = 10;
+    protected static final int DEFAULT_READ_TIMEOUT_IN_SECONDS = 30;
+
     private final URL metadataUrl;
     private final ObjectReader objectReader;
     private Duration connectTimeout;
@@ -41,6 +44,9 @@ public class DefaultMetadataResolver implements MetadataResolver {
     public DefaultMetadataResolver(URL metadataUrl) {
         this.metadataUrl = metadataUrl;
         this.objectReader = new ObjectMapper().readerFor(Metadata.class);
+        // set a default timeout to ensure that this doesn't block
+        this.connectTimeout = Duration.ofSeconds(DEFAULT_CONNECT_TIMEOUT_IN_SECONDS);
+        this.readTimeout = Duration.ofSeconds(DEFAULT_READ_TIMEOUT_IN_SECONDS);
     }
 
     public DefaultMetadataResolver withConnectTimeout(Duration connectTimeout) {


### PR DESCRIPTION
Currently, there is no timeout on the metadata resolver in oauth2
clients.

This can result in a connection hanging indefintely.

We should add sane defaults here.

These defaults match the defaults of the TokenClient and generally the
Pulsar defaults of 10s connect timeout and 30s read timeout

## Test

This seems to primarily depend on testing timeout of the java HTTP lib, so no test is likely needed.

## Doc

This is a trivial change and doesn't require docs

