### PR TITLE
[Issue 14013] Make ``PersistentTopics#getPartitionedTopicList`` to  pure async.

### DIFF
--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/resources/NamespaceResources.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/resources/NamespaceResources.java
@@ -105,7 +105,7 @@ public class NamespaceResources extends BaseResources<Policies> {
                     if (!exists) {
                         return CompletableFuture.completedFuture(false);
                     } else {
-                        return getChildrenAsync(path).thenApply(children -> children.isEmpty());
+                        return getChildrenAsync(path).thenApply(List::isEmpty);
                     }
                 });
     }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/AdminResource.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/AdminResource.java
@@ -551,18 +551,6 @@ public abstract class AdminResource extends PulsarWebResource {
         }
     }
 
-    protected List<String> getPartitionedTopicList(TopicDomain topicDomain) {
-        try {
-            return namespaceResources().getPartitionedTopicResources()
-                    .listPartitionedTopicsAsync(namespaceName, topicDomain)
-                    .join();
-        } catch (Exception e) {
-            log.error("[{}] Failed to get partitioned topic list for namespace {}", clientAppId(),
-                    namespaceName.toString(), e);
-            throw new RestException(e);
-        }
-    }
-
     protected List<String> getTopicPartitionList(TopicDomain topicDomain) {
         try {
             return getPulsarResources().getTopicResources().getExistingPartitions(topicName)

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/AdminResource.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/AdminResource.java
@@ -222,29 +222,6 @@ public abstract class AdminResource extends PulsarWebResource {
         }
     }
 
-    protected CompletableFuture<Void> validateNamespaceNameAsync(String tenant, String namespace) {
-        try {
-            this.namespaceName = NamespaceName.get(tenant, namespace);
-            return CompletableFuture.completedFuture(null);
-        } catch (IllegalArgumentException e) {
-            log.warn("[{}] Failed to create namespace with invalid name {}", clientAppId(), namespace, e);
-            return FutureUtil
-                    .failedFuture(new RestException(Status.PRECONDITION_FAILED, "Namespace name is not valid"));
-        }
-    }
-
-    @Deprecated
-    protected CompletableFuture<Void> validateNamespaceNameAsync(String property, String cluster, String namespace) {
-        try {
-            this.namespaceName = NamespaceName.get(property, cluster, namespace);
-            return CompletableFuture.completedFuture(null);
-        } catch (IllegalArgumentException e) {
-            log.warn("[{}] Failed to create namespace with invalid name {}", clientAppId(), namespace, e);
-            return FutureUtil
-                    .failedFuture(new RestException(Status.PRECONDITION_FAILED, "Namespace name is not valid"));
-        }
-    }
-
     protected void validateTopicName(String property, String namespace, String encodedTopic) {
         String topic = Codec.decode(encodedTopic);
         try {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/AdminResource.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/AdminResource.java
@@ -222,6 +222,29 @@ public abstract class AdminResource extends PulsarWebResource {
         }
     }
 
+    protected CompletableFuture<Void> validateNamespaceNameAsync(String tenant, String namespace) {
+        try {
+            this.namespaceName = NamespaceName.get(tenant, namespace);
+            return CompletableFuture.completedFuture(null);
+        } catch (IllegalArgumentException e) {
+            log.warn("[{}] Failed to create namespace with invalid name {}", clientAppId(), namespace, e);
+            return FutureUtil
+                    .failedFuture(new RestException(Status.PRECONDITION_FAILED, "Namespace name is not valid"));
+        }
+    }
+
+    @Deprecated
+    protected CompletableFuture<Void> validateNamespaceNameAsync(String property, String cluster, String namespace) {
+        try {
+            this.namespaceName = NamespaceName.get(property, cluster, namespace);
+            return CompletableFuture.completedFuture(null);
+        } catch (IllegalArgumentException e) {
+            log.warn("[{}] Failed to create namespace with invalid name {}", clientAppId(), namespace, e);
+            return FutureUtil
+                    .failedFuture(new RestException(Status.PRECONDITION_FAILED, "Namespace name is not valid"));
+        }
+    }
+
     protected void validateTopicName(String property, String namespace, String encodedTopic) {
         String topic = Codec.decode(encodedTopic);
         try {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
@@ -180,8 +180,8 @@ public class PersistentTopicsBase extends AdminResource {
                 .thenCompose(__ -> namespaceResources().namespaceExistsAsync(namespaceName))
                 .thenCompose(namespaceExists -> {
                     if (!namespaceExists) {
-                        log.warn("[{}] Failed to get partitioned topic list {}: Namespace does not exist", clientAppId(),
-                                namespaceName);
+                        log.warn("[{}] Failed to get partitioned topic list {}: Namespace does not exist",
+                                clientAppId(), namespaceName);
                         throw new RestException(Status.NOT_FOUND, "Namespace does not exist");
                     } else {
                         return namespaceResources().getPartitionedTopicResources()

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
@@ -175,8 +175,8 @@ public class PersistentTopicsBase extends AdminResource {
         }
     }
 
-    protected void internalGetPartitionedTopicList(AsyncResponse asyncResponse) {
-        validateNamespaceOperationAsync(namespaceName, NamespaceOperation.GET_TOPICS)
+    protected CompletableFuture<List<String>> internalGetPartitionedTopicList() {
+        return validateNamespaceOperationAsync(namespaceName, NamespaceOperation.GET_TOPICS)
                 .thenCompose(__ -> namespaceResources().namespaceExistsAsync(namespaceName))
                 .thenCompose(namespaceExists -> {
                     if (!namespaceExists) {
@@ -185,15 +185,8 @@ public class PersistentTopicsBase extends AdminResource {
                         throw new RestException(Status.NOT_FOUND, "Namespace does not exist");
                     } else {
                         return namespaceResources().getPartitionedTopicResources()
-                                .listPartitionedTopicsAsync(namespaceName, TopicDomain.getEnum(domain()))
-                                .thenAccept(asyncResponse::resume);
+                                .listPartitionedTopicsAsync(namespaceName, TopicDomain.getEnum(domain()));
                     }
-                }).exceptionally(ex -> {
-                    Throwable realCause = FutureUtil.unwrapCompletionException(ex);
-                    log.error("[{}] Failed to get partitioned topic list {}: {}", clientAppId(),
-                            namespaceName, realCause.getMessage());
-                    resumeAsyncResponseExceptionally(asyncResponse, realCause);
-                    return null;
                 });
     }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v1/PersistentTopics.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v1/PersistentTopics.java
@@ -100,7 +100,7 @@ public class PersistentTopics extends PersistentTopicsBase {
                             clientAppId(), cluster, namespace);
                     asyncResponse.resume(partitionedTopicList);
                 }).exceptionally(ex -> {
-                    log.error("[{}] Failed to get partitioned topic list {}: {}", clientAppId(),
+                    log.error("[{}] Failed to get partitioned topic list {}", clientAppId(),
                             namespaceName, ex);
                     return handleCommonRestAsyncException(asyncResponse, ex);
                 });

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v1/PersistentTopics.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v1/PersistentTopics.java
@@ -95,9 +95,9 @@ public class PersistentTopics extends PersistentTopicsBase {
                                         @PathParam("namespace") String namespace) {
         try {
             validateNamespaceName(property, cluster, namespace);
-        } catch (RestException ex) {
-            // the namespace name validate fail.
-            asyncResponse.resume(ex);
+        } catch (Exception ex) {
+            // validate namespace fail.
+            resumeAsyncResponseExceptionally(asyncResponse, ex);
             return;
         }
         internalGetPartitionedTopicList()

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v1/PersistentTopics.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v1/PersistentTopics.java
@@ -24,7 +24,6 @@ import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import javax.ws.rs.DELETE;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v1/PersistentTopics.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v1/PersistentTopics.java
@@ -90,10 +90,12 @@ public class PersistentTopics extends PersistentTopicsBase {
     @ApiResponses(value = {
             @ApiResponse(code = 403, message = "Don't have admin or operate permission on the namespace"),
             @ApiResponse(code = 404, message = "Namespace doesn't exist")})
-    public List<String> getPartitionedTopicList(@PathParam("property") String property,
-            @PathParam("cluster") String cluster, @PathParam("namespace") String namespace) {
+    public void getPartitionedTopicList(@Suspended AsyncResponse asyncResponse,
+                                        @PathParam("property") String property,
+                                        @PathParam("cluster") String cluster,
+                                        @PathParam("namespace") String namespace) {
         validateNamespaceName(property, cluster, namespace);
-        return internalGetPartitionedTopicList();
+        internalGetPartitionedTopicList(asyncResponse);
     }
 
     @GET

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v1/PersistentTopics.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v1/PersistentTopics.java
@@ -96,7 +96,8 @@ public class PersistentTopics extends PersistentTopicsBase {
         validateNamespaceNameAsync(property, cluster, namespace)
                 .thenCompose(__ -> internalGetPartitionedTopicList())
                 .thenAccept(partitionedTopicList -> {
-                    log.info("[{}] Successfully to get partitioned topic list {}/{}",clientAppId(), cluster, namespace);
+                    log.info("[{}] Successfully to get partitioned topic list {}/{}",
+                            clientAppId(), cluster, namespace);
                     asyncResponse.resume(partitionedTopicList);
                 }).exceptionally(ex -> {
                     log.error("[{}] Failed to get partitioned topic list {}: {}", clientAppId(),

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/PersistentTopics.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/PersistentTopics.java
@@ -128,7 +128,7 @@ public class PersistentTopics extends PersistentTopicsBase {
                     log.info("[{}] Successfully to get partitioned topic list {}/{}", clientAppId(), tenant, namespace);
                     asyncResponse.resume(partitionedTopicList);
                 }).exceptionally(ex -> {
-                    log.error("[{}] Failed to get partitioned topic list {}: {}", clientAppId(),
+                    log.error("[{}] Failed to get partitioned topic list {}", clientAppId(),
                             namespaceName, ex);
                     return handleCommonRestAsyncException(asyncResponse, ex);
                 });

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/PersistentTopics.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/PersistentTopics.java
@@ -116,13 +116,14 @@ public class PersistentTopics extends PersistentTopicsBase {
             @ApiResponse(code = 404, message = "tenant/namespace/topic doesn't exit"),
             @ApiResponse(code = 412, message = "Namespace name is not valid"),
             @ApiResponse(code = 500, message = "Internal server error")})
-    public List<String> getPartitionedTopicList(
+    public void getPartitionedTopicList(
+            @Suspended AsyncResponse asyncResponse,
             @ApiParam(value = "Specify the tenant", required = true)
             @PathParam("tenant") String tenant,
             @ApiParam(value = "Specify the namespace", required = true)
             @PathParam("namespace") String namespace) {
         validateNamespaceName(tenant, namespace);
-        return internalGetPartitionedTopicList();
+        internalGetPartitionedTopicList(asyncResponse);
     }
 
     @GET

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/PersistentTopics.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/PersistentTopics.java
@@ -122,8 +122,16 @@ public class PersistentTopics extends PersistentTopicsBase {
             @PathParam("tenant") String tenant,
             @ApiParam(value = "Specify the namespace", required = true)
             @PathParam("namespace") String namespace) {
-        validateNamespaceName(tenant, namespace);
-        internalGetPartitionedTopicList(asyncResponse);
+        validateNamespaceNameAsync(tenant, namespace)
+                .thenCompose(__ -> internalGetPartitionedTopicList())
+                .thenAccept(partitionedTopicList -> {
+                    log.info("[{}] Successfully to get partitioned topic list {}/{}",clientAppId(), tenant, namespace);
+                    asyncResponse.resume(partitionedTopicList);
+                }).exceptionally(ex -> {
+                    log.error("[{}] Failed to get partitioned topic list {}: {}", clientAppId(),
+                            namespaceName, ex);
+                    return handleCommonRestAsyncException(asyncResponse, ex);
+                });
     }
 
     @GET

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/PersistentTopics.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/PersistentTopics.java
@@ -125,7 +125,7 @@ public class PersistentTopics extends PersistentTopicsBase {
         validateNamespaceNameAsync(tenant, namespace)
                 .thenCompose(__ -> internalGetPartitionedTopicList())
                 .thenAccept(partitionedTopicList -> {
-                    log.info("[{}] Successfully to get partitioned topic list {}/{}",clientAppId(), tenant, namespace);
+                    log.info("[{}] Successfully to get partitioned topic list {}/{}", clientAppId(), tenant, namespace);
                     asyncResponse.resume(partitionedTopicList);
                 }).exceptionally(ex -> {
                     log.error("[{}] Failed to get partitioned topic list {}: {}", clientAppId(),

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminTest.java
@@ -760,15 +760,19 @@ public class AdminTest extends MockedPulsarServiceBaseTest {
         persistentTopics.getList(response, property, cluster, namespace);
         verify(response, times(1)).resume(Lists.newArrayList());
         // create topic
-        assertEquals(persistentTopics.getPartitionedTopicList(property, cluster, namespace), Lists.newArrayList());
+        response = mock(AsyncResponse.class);
+        persistentTopics.getPartitionedTopicList(response, property, cluster, namespace);
+        verify(response, timeout(5000).times(1)).resume(Lists.newArrayList());
         response = mock(AsyncResponse.class);
         ArgumentCaptor<Response> responseCaptor = ArgumentCaptor.forClass(Response.class);
         persistentTopics.createPartitionedTopic(response, property, cluster, namespace, topic, 5, false);
         verify(response, timeout(5000).times(1)).resume(responseCaptor.capture());
         assertEquals(responseCaptor.getValue().getStatus(), Response.Status.NO_CONTENT.getStatusCode());
-        assertEquals(persistentTopics.getPartitionedTopicList(property, cluster, namespace), Lists
-                .newArrayList(String.format("persistent://%s/%s/%s/%s", property, cluster, namespace, topic)));
-
+        response = mock(AsyncResponse.class);
+        persistentTopics.getPartitionedTopicList(response, property, cluster, namespace);
+        verify(response, timeout(5000).times(1))
+                .resume(Lists.newArrayList(
+                        String.format("persistent://%s/%s/%s/%s", property, cluster, namespace, topic)));
         TopicName topicName = TopicName.get("persistent", property, cluster, namespace, topic);
         assertEquals(persistentTopics.getPartitionedTopicMetadata(topicName, true, false).partitions, 5);
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/PersistentTopicsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/PersistentTopicsTest.java
@@ -552,6 +552,7 @@ public class PersistentTopicsTest extends MockedPulsarServiceBaseTest {
     }
 
     @Test
+    @SuppressWarnings("unchecked")
     public void testGetPartitionedTopicsList() throws KeeperException, InterruptedException, PulsarAdminException {
         AsyncResponse response = mock(AsyncResponse.class);
         ArgumentCaptor<Response> responseCaptor = ArgumentCaptor.forClass(Response.class);
@@ -565,12 +566,19 @@ public class PersistentTopicsTest extends MockedPulsarServiceBaseTest {
         verify(response, timeout(5000).times(1)).resume(responseCaptor.capture());
         Assert.assertEquals(responseCaptor.getValue().getStatus(), Response.Status.NO_CONTENT.getStatusCode());
 
-        List<String> persistentPartitionedTopics = persistentTopics.getPartitionedTopicList(testTenant, testNamespace);
+        response = mock(AsyncResponse.class);
+        responseCaptor = ArgumentCaptor.forClass(Response.class);
+        persistentTopics.getPartitionedTopicList(response, testTenant, testNamespace);
+        verify(response, timeout(5000).times(1)).resume(responseCaptor.capture());
+        List<String> entities = (List<String>) responseCaptor.getValue();
+        Assert.assertEquals(entities.size(), 1);
+        Assert.assertEquals(TopicName.get(entities.get(0)).getDomain().value(), TopicDomain.persistent.value());
 
-        Assert.assertEquals(persistentPartitionedTopics.size(), 1);
-        Assert.assertEquals(TopicName.get(persistentPartitionedTopics.get(0)).getDomain().value(), TopicDomain.persistent.value());
-
-        List<String> nonPersistentPartitionedTopics = nonPersistentTopic.getPartitionedTopicList(testTenant, testNamespace);
+        response = mock(AsyncResponse.class);
+        responseCaptor = ArgumentCaptor.forClass(Response.class);
+        nonPersistentTopic.getPartitionedTopicList(response, testTenant, testNamespace);
+        verify(response, timeout(5000).times(1)).resume(responseCaptor.capture());
+        List<String> nonPersistentPartitionedTopics = (List<String>) responseCaptor.getValue();
         Assert.assertEquals(nonPersistentPartitionedTopics.size(), 1);
         Assert.assertEquals(TopicName.get(nonPersistentPartitionedTopics.get(0)).getDomain().value(), TopicDomain.non_persistent.value());
     }


### PR DESCRIPTION
Master Issue: #14013

### Motivation

Make Rest API ``getPartitionedTopicList`` to async and to refactor code style to make it more clear.

### Modifications

- Make the ``getPartitionedTopicList`` method from sync to async.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Documentation

none.

Need to update docs? 

- [x] `no-need-doc` 
  