### PR TITLE
[Issue 14046] Fixes ``AsyncResponse``does not resume when redirected.

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
@@ -611,6 +611,7 @@ public class PersistentTopicsBase extends AdminResource {
                             log.debug("[{}] Failed to delete partitioned topic {}, redirecting to other brokers.",
                                     clientAppId(), topicName, realCause);
                         }
+                        asyncResponse.resume(realCause);
                     } else if (realCause instanceof PreconditionFailedException) {
                         asyncResponse.resume(
                                 new RestException(Status.PRECONDITION_FAILED,


### PR DESCRIPTION
Fixes #14046

### Motivation

Fixes ``AsyncResponse``does not resume when redirected.

### Modifications

- Add ``AsyncResponse#resume`` when redirected.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Documentation

Check the box below or label this PR directly (if you have committer privilege).

- [x] `no-need-doc` 



