### PR TITLE
[C++] Change AutoOldest to AutoAckOldest in consumer configuration

### DIFF
--- a/pulsar-client-cpp/include/pulsar/ConsumerConfiguration.h
+++ b/pulsar-client-cpp/include/pulsar/ConsumerConfiguration.h
@@ -450,7 +450,7 @@ class PULSAR_PUBLIC ConsumerConfiguration {
      * Buffering large number of outstanding uncompleted chunked messages can create memory pressure and it
      * can be guarded by providing this maxPendingChunkedMessage threshold. Once, consumer reaches this
      * threshold, it drops the outstanding unchunked-messages by silently acking or asking broker to redeliver
-     * later by marking it unacked. See setAutoOldestChunkedMessageOnQueueFull.
+     * later by marking it unacked. See setAutoAckOldestChunkedMessageOnQueueFull.
      *
      * If it's zero, the pending chunked messages will not be limited.
      *
@@ -475,13 +475,13 @@ class PULSAR_PUBLIC ConsumerConfiguration {
      *
      * @param autoAckOldestChunkedMessageOnQueueFull whether to ack the discarded chunked message
      */
-    ConsumerConfiguration& setAutoOldestChunkedMessageOnQueueFull(
+    ConsumerConfiguration& setAutoAckOldestChunkedMessageOnQueueFull(
         bool autoAckOldestChunkedMessageOnQueueFull);
 
     /**
-     * The associated getter of setAutoOldestChunkedMessageOnQueueFull
+     * The associated getter of setAutoAckOldestChunkedMessageOnQueueFull
      */
-    bool isAutoOldestChunkedMessageOnQueueFull() const;
+    bool isAutoAckOldestChunkedMessageOnQueueFull() const;
 
     friend class PulsarWrapper;
 

--- a/pulsar-client-cpp/lib/ConsumerConfiguration.cc
+++ b/pulsar-client-cpp/lib/ConsumerConfiguration.cc
@@ -238,13 +238,13 @@ ConsumerConfiguration& ConsumerConfiguration::setMaxPendingChunkedMessage(size_t
 
 size_t ConsumerConfiguration::getMaxPendingChunkedMessage() const { return impl_->maxPendingChunkedMessage; }
 
-ConsumerConfiguration& ConsumerConfiguration::setAutoOldestChunkedMessageOnQueueFull(
+ConsumerConfiguration& ConsumerConfiguration::setAutoAckOldestChunkedMessageOnQueueFull(
     bool autoAckOldestChunkedMessageOnQueueFull) {
     impl_->autoAckOldestChunkedMessageOnQueueFull = autoAckOldestChunkedMessageOnQueueFull;
     return *this;
 }
 
-bool ConsumerConfiguration::isAutoOldestChunkedMessageOnQueueFull() const {
+bool ConsumerConfiguration::isAutoAckOldestChunkedMessageOnQueueFull() const {
     return impl_->autoAckOldestChunkedMessageOnQueueFull;
 }
 

--- a/pulsar-client-cpp/lib/ConsumerImpl.cc
+++ b/pulsar-client-cpp/lib/ConsumerImpl.cc
@@ -65,7 +65,7 @@ ConsumerImpl::ConsumerImpl(const ClientImplPtr client, const std::string& topic,
       readCompacted_(conf.isReadCompacted()),
       startMessageId_(startMessageId),
       maxPendingChunkedMessage_(conf.getMaxPendingChunkedMessage()),
-      autoAckOldestChunkedMessageOnQueueFull_(conf.isAutoOldestChunkedMessageOnQueueFull()) {
+      autoAckOldestChunkedMessageOnQueueFull_(conf.isAutoAckOldestChunkedMessageOnQueueFull()) {
     std::stringstream consumerStrStream;
     consumerStrStream << "[" << topic_ << ", " << subscription_ << ", " << consumerId_ << "] ";
     consumerStr_ = consumerStrStream.str();

--- a/pulsar-client-cpp/tests/ConsumerConfigurationTest.cc
+++ b/pulsar-client-cpp/tests/ConsumerConfigurationTest.cc
@@ -60,7 +60,7 @@ TEST(ConsumerConfigurationTest, testDefaultConfig) {
     ASSERT_EQ(conf.getProperties().empty(), true);
     ASSERT_EQ(conf.getPriorityLevel(), 0);
     ASSERT_EQ(conf.getMaxPendingChunkedMessage(), 100);
-    ASSERT_EQ(conf.isAutoOldestChunkedMessageOnQueueFull(), false);
+    ASSERT_EQ(conf.isAutoAckOldestChunkedMessageOnQueueFull(), false);
 }
 
 TEST(ConsumerConfigurationTest, testCustomConfig) {
@@ -145,8 +145,8 @@ TEST(ConsumerConfigurationTest, testCustomConfig) {
     conf.setMaxPendingChunkedMessage(500);
     ASSERT_EQ(conf.getMaxPendingChunkedMessage(), 500);
 
-    conf.setAutoOldestChunkedMessageOnQueueFull(true);
-    ASSERT_TRUE(conf.isAutoOldestChunkedMessageOnQueueFull());
+    conf.setAutoAckOldestChunkedMessageOnQueueFull(true);
+    ASSERT_TRUE(conf.isAutoAckOldestChunkedMessageOnQueueFull());
 }
 
 TEST(ConsumerConfigurationTest, testReadCompactPersistentExclusive) {


### PR DESCRIPTION
### Motivation

https://github.com/apache/pulsar/pull/13627 supports chunking messages for C++ client. However, the consumer configuration `AutoOldestChunkedMessageOnQueueFull` has a typo that it doesn't contain the `Ack`. See the corresponding Java configuration: https://github.com/apache/pulsar/blob/d11147616aa6cc7888420f6325bb71cd7f7ab065/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/ConsumerBuilder.java#L733

Since #13627 is not included in any release now, we should include this fix before 2.10.0 release.

### Modifications

- Change `setAutoOldestChunkedMessageOnQueueFull` to `setAutoAckOldestChunkedMessageOnQueueFull`.
- Change `isAutoOldestChunkedMessageOnQueueFull` to `isAutoAckOldestChunkedMessageOnQueueFull`.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API: (**yes**)
  - The schema: (yes / no / don't know)
  - The default values of configurations: (yes / no)
  - The wire protocol: (yes / no)
  - The rest endpoints: (yes / no)
  - The admin cli options: (yes / no)
  - Anything that affects deployment: (yes / no / don't know)