### PR TITLE
Pulsar IO: implement --retain-key-ordering (KEY_SHARED subscription) for Sinks

### DIFF
--- a/pulsar-client-admin-api/src/main/java/org/apache/pulsar/common/io/SinkConfig.java
+++ b/pulsar-client-admin-api/src/main/java/org/apache/pulsar/common/io/SinkConfig.java
@@ -72,6 +72,7 @@ public class SinkConfig {
     private Integer parallelism;
     private FunctionConfig.ProcessingGuarantees processingGuarantees;
     private Boolean retainOrdering;
+    private Boolean retainKeyOrdering;
     private Resources resources;
     private Boolean autoAck;
     private Long timeoutMs;

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdSinks.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdSinks.java
@@ -352,6 +352,9 @@ public class CmdSinks extends CmdBase {
         @Parameter(names = "--parallelism",
                 description = "The sink's parallelism factor (i.e. the number of sink instances to run)")
         protected Integer parallelism;
+        @Parameter(names = "--retain-key-ordering",
+                description = "Sink consumes and processes messages in key order")
+        protected Boolean retainKeyOrdering;
         @Parameter(names = {"-a", "--archive"}, description = "Path to the archive file for the sink. It also supports "
                 + "url-path [http/https/file (file protocol assumes that file already exists on worker host)] from "
                 + "which worker can download the package.", listConverter = StringConverter.class)
@@ -458,6 +461,10 @@ public class CmdSinks extends CmdBase {
 
             if (retainOrdering != null) {
                 sinkConfig.setRetainOrdering(retainOrdering);
+            }
+
+            if (retainKeyOrdering != null) {
+                sinkConfig.setRetainKeyOrdering(retainKeyOrdering);
             }
 
             if (null != inputs) {

--- a/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/SinkConfigUtils.java
+++ b/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/SinkConfigUtils.java
@@ -161,10 +161,16 @@ public class SinkConfigUtils {
             sourceSpecBuilder.setSubscriptionName(sinkConfig.getSourceSubscriptionName());
         }
 
-        Function.SubscriptionType subType = ((sinkConfig.getRetainOrdering() != null && sinkConfig.getRetainOrdering())
-                || FunctionConfig.ProcessingGuarantees.EFFECTIVELY_ONCE.equals(sinkConfig.getProcessingGuarantees()))
-                ? Function.SubscriptionType.FAILOVER
-                : Function.SubscriptionType.SHARED;
+        // Set subscription type
+        Function.SubscriptionType subType;
+        if ((sinkConfig.getRetainOrdering() != null && sinkConfig.getRetainOrdering())
+                || FunctionConfig.ProcessingGuarantees.EFFECTIVELY_ONCE.equals(sinkConfig.getProcessingGuarantees())) {
+            subType = Function.SubscriptionType.FAILOVER;
+        } else if (sinkConfig.getRetainKeyOrdering() != null && sinkConfig.getRetainKeyOrdering()) {
+            subType = Function.SubscriptionType.KEY_SHARED;
+        } else {
+            subType = Function.SubscriptionType.SHARED;
+        }
         sourceSpecBuilder.setSubscriptionType(subType);
 
         if (sinkConfig.getAutoAck() != null) {
@@ -285,13 +291,13 @@ public class SinkConfigUtils {
         if (!isEmpty(functionDetails.getSource().getSubscriptionName())) {
             sinkConfig.setSourceSubscriptionName(functionDetails.getSource().getSubscriptionName());
         }
-
-        switch (functionDetails.getSource().getSubscriptionType()) {
-            case FAILOVER:
-                sinkConfig.setRetainOrdering(true);
-                break;
-            default:
-                sinkConfig.setRetainOrdering(false);
+        if (functionDetails.getSource().getSubscriptionType() == Function.SubscriptionType.FAILOVER) {
+            sinkConfig.setRetainOrdering(true);
+        } else if (functionDetails.getSource().getSubscriptionType() == Function.SubscriptionType.KEY_SHARED) {
+            sinkConfig.setRetainOrdering(false);
+            sinkConfig.setRetainKeyOrdering(true);
+        } else {
+            sinkConfig.setRetainOrdering(false);
         }
 
         sinkConfig.setProcessingGuarantees(convertProcessingGuarantee(functionDetails.getProcessingGuarantees()));
@@ -568,6 +574,9 @@ public class SinkConfigUtils {
         if (newConfig.getRetainOrdering() != null && !newConfig.getRetainOrdering().equals(existingConfig.getRetainOrdering())) {
             throw new IllegalArgumentException("Retain Ordering cannot be altered");
         }
+        if (newConfig.getRetainKeyOrdering() != null && !newConfig.getRetainKeyOrdering().equals(existingConfig.getRetainKeyOrdering())) {
+            throw new IllegalArgumentException("Retain Key Ordering cannot be altered");
+        }
         if (newConfig.getAutoAck() != null && !newConfig.getAutoAck().equals(existingConfig.getAutoAck())) {
             throw new IllegalArgumentException("AutoAck cannot be altered");
         }
@@ -597,6 +606,19 @@ public class SinkConfigUtils {
     }
 
     public static void validateSinkConfig(SinkConfig sinkConfig, NarClassLoader narClassLoader) {
+
+        if (sinkConfig.getRetainKeyOrdering() != null
+                && sinkConfig.getRetainKeyOrdering()
+                && sinkConfig.getProcessingGuarantees() != null
+                && sinkConfig.getProcessingGuarantees() == FunctionConfig.ProcessingGuarantees.EFFECTIVELY_ONCE) {
+            throw new IllegalArgumentException("When effectively once processing guarantee is specified, retain Key ordering cannot be set");
+        }
+
+        if (sinkConfig.getRetainKeyOrdering() != null && sinkConfig.getRetainKeyOrdering()
+                && sinkConfig.getRetainOrdering() != null && sinkConfig.getRetainOrdering()) {
+            throw new IllegalArgumentException("Only one of retain ordering or retain key ordering can be set");
+        }
+
         try {
             ConnectorDefinition defn = ConnectorUtils.getConnectorDefinition(narClassLoader);
             if (defn.getSinkConfigClass() != null) {

--- a/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/SinkConfigUtils.java
+++ b/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/SinkConfigUtils.java
@@ -293,11 +293,13 @@ public class SinkConfigUtils {
         }
         if (functionDetails.getSource().getSubscriptionType() == Function.SubscriptionType.FAILOVER) {
             sinkConfig.setRetainOrdering(true);
+            sinkConfig.setRetainKeyOrdering(false);
         } else if (functionDetails.getSource().getSubscriptionType() == Function.SubscriptionType.KEY_SHARED) {
             sinkConfig.setRetainOrdering(false);
             sinkConfig.setRetainKeyOrdering(true);
         } else {
             sinkConfig.setRetainOrdering(false);
+            sinkConfig.setRetainKeyOrdering(false);
         }
 
         sinkConfig.setProcessingGuarantees(convertProcessingGuarantee(functionDetails.getProcessingGuarantees()));


### PR DESCRIPTION
### Motivation
Currently (2.9) you cannot use a KEY_SHARED subscription for Pulsar Sinks.
You can already do it for Functions, by using `--retain-key-ordering`

### Modifications

This patch implements `--retain-key-ordering` for Sinks, the same way we do for Functions

### Verifying this change

This patch added tests

### Documentation

- [x] `doc-required` 
