### PR TITLE
kubernetesRuntime read metricsPort from kuberbetesRuntimeFactoryConfig

### DIFF
--- a/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/kubernetes/KubernetesRuntime.java
+++ b/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/kubernetes/KubernetesRuntime.java
@@ -190,6 +190,7 @@ public class KubernetesRuntime implements Runtime {
                       Optional<KubernetesFunctionAuthProvider> functionAuthDataCacheProvider,
                       boolean authenticationEnabled,
                       Integer grpcPort,
+                      Integer metricsPort,
                       String narExtractionDirectory,
                       Optional<KubernetesManifestCustomizer> manifestCustomizer,
                       String functionInstanceClassPath,
@@ -239,7 +240,9 @@ public class KubernetesRuntime implements Runtime {
         this.functionAuthDataCacheProvider = functionAuthDataCacheProvider;
 
         this.grpcPort = grpcPort;
-        this.metricsPort = instanceConfig.hasValidMetricsPort() ? instanceConfig.getMetricsPort() : null;
+        // metricsPort is from kubernetes' functionRuntimeFactoryConfig
+        this.metricsPort = metricsPort;
+        instanceConfig.setMetricsPort(this.metricsPort);
         this.narExtractionDirectory = narExtractionDirectory;
 
         this.processArgs = new LinkedList<>();

--- a/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/kubernetes/KubernetesRuntimeFactory.java
+++ b/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/kubernetes/KubernetesRuntimeFactory.java
@@ -324,6 +324,7 @@ public class KubernetesRuntimeFactory implements RuntimeFactory {
             authProvider,
             authenticationEnabled,
             grpcPort,
+            metricsPort,
             narExtractionDirectory,
             manifestCustomizer,
             functionInstanceClassPath,


### PR DESCRIPTION
# Fixes 

The bug is Kubernetes function runtime's prometheus metrics port always binds to a random available port instead of using the `metricsPort` specified in FunctionRuntimeFactoryConfig from the functions_worker.yaml or default to 9094 from the KubernetesRuntimeFactoryConfig class.

This is a fix to address a bug introduced by this PR (https://github.com/apache/pulsar/pull/9610) 


### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation
  
- [x] `no-need-doc` 
  


