### PR TITLE
[Issue 11070][Zookeeper] Fix netcat returning early for probe

### DIFF
--- a/docker/pulsar/scripts/pulsar-zookeeper-ruok.sh
+++ b/docker/pulsar/scripts/pulsar-zookeeper-ruok.sh
@@ -20,7 +20,7 @@
 
 # Check ZK server status
 
-status=$(echo ruok | nc localhost 2181)
+status=$(echo ruok | nc -q 1 localhost 2181)
 if [ "$status" == "imok" ]; then
     exit 0
 else


### PR DESCRIPTION
Netcat returns before zookeeper is able to reply leading to a failed check even if the reply would arrive shortly thereafter.

Fixes #11070

### Motivation

Readiness and liveness probes in Kubernetes fail in Kubernetes in some cases because the check does not wait for a response.

### Modifications

The check script now waits for 1 seconds for a response.

### Verifying this change

Since this problem is caused by a race condition, testing is a bit complicated.

### Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API: no
  - The schema: no
  - The default values of configurations: no
  - The wire protocol: no
  - The rest endpoints: no
  - The admin cli options: no
  - Anything that affects deployment: don't know

### Documentation

Check the box below or label this PR directly (if you have committer privilege).

Need to update docs? 

- [ x ] `no-need-doc` 
  
  The actual intention of the script does not change.
  
