### PR TITLE
Remove development packages from Pulsar's docker images

### DIFF
--- a/docker/pulsar/Dockerfile
+++ b/docker/pulsar/Dockerfile
@@ -49,7 +49,7 @@ RUN sed -i "s|http://archive\.ubuntu\.com/ubuntu/|${UBUNTU_MIRROR:-mirror://mirr
      && apt-get -y dist-upgrade \
      && apt-get -y install --no-install-recommends openjdk-11-jdk-headless netcat dnsutils less procps iputils-ping \
                  python3 python3-yaml python3-kazoo python3-pip \
-                 curl \
+                 curl ca-certificates \
      && apt-get -y --purge autoremove \
      && apt-get autoclean \
      && apt-get clean \

--- a/docker/pulsar/Dockerfile
+++ b/docker/pulsar/Dockerfile
@@ -48,16 +48,12 @@ RUN sed -i "s|http://archive\.ubuntu\.com/ubuntu/|${UBUNTU_MIRROR:-mirror://mirr
      && apt-get update \
      && apt-get -y dist-upgrade \
      && apt-get -y install openjdk-11-jdk-headless netcat dnsutils less procps iputils-ping \
-                 python3 python3-dev python3-setuptools python3-yaml python3-kazoo \
-                 libreadline-gplv2-dev libncursesw5-dev libssl-dev libsqlite3-dev tk-dev libgdbm-dev libc6-dev libbz2-dev \
+                 python3 python3-yaml python3-kazoo python3-pip \
                  curl \
      && apt-get -y --purge autoremove \
      && apt-get autoclean \
      && apt-get clean \
      && rm -rf /var/lib/apt/lists/*
-
-RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
-RUN python3 get-pip.py
 
 RUN update-alternatives --install /usr/bin/python python /usr/bin/python3 10
 

--- a/docker/pulsar/Dockerfile
+++ b/docker/pulsar/Dockerfile
@@ -47,7 +47,7 @@ ARG UBUNTU_MIRROR=mirror://mirrors.ubuntu.com/mirrors.txt
 RUN sed -i "s|http://archive\.ubuntu\.com/ubuntu/|${UBUNTU_MIRROR:-mirror://mirrors.ubuntu.com/mirrors.txt}|g" /etc/apt/sources.list \
      && apt-get update \
      && apt-get -y dist-upgrade \
-     && apt-get -y install openjdk-11-jdk-headless netcat dnsutils less procps iputils-ping \
+     && apt-get -y install --no-install-recommends openjdk-11-jdk-headless netcat dnsutils less procps iputils-ping \
                  python3 python3-yaml python3-kazoo python3-pip \
                  curl \
      && apt-get -y --purge autoremove \

--- a/tests/docker-images/latest-version-image/Dockerfile
+++ b/tests/docker-images/latest-version-image/Dockerfile
@@ -24,7 +24,7 @@ FROM apachepulsar/pulsar:latest as pulsar-function-go
 USER root
 
 RUN rm -rf /var/lib/apt/lists/* && apt-get update
-RUN apt-get install -y procps curl git
+RUN apt-get install -y procps curl git build-essential
 
 ENV GOLANG_VERSION 1.13.3
 


### PR DESCRIPTION
Fixes #14092

### Motivation

There's a lot of unnecessary tooling that gets installed in the Pulsar docker images.

### Modifications

- remove dev packages
- use python3-pip package for installing pip