### PR TITLE
Upgrade commons-cli to 1.5.0

### DIFF
--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -341,7 +341,7 @@ The Apache Software License, Version 2.0
     - com.yahoo.datasketches-memory-0.8.3.jar
     - com.yahoo.datasketches-sketches-core-0.8.3.jar
  * Apache Commons
-    - commons-cli-commons-cli-1.2.jar
+    - commons-cli-commons-cli-1.5.0.jar
     - commons-codec-commons-codec-1.15.jar
     - commons-collections-commons-collections-3.2.2.jar
     - commons-configuration-commons-configuration-1.10.jar

--- a/pom.xml
+++ b/pom.xml
@@ -105,6 +105,7 @@ flexible messaging model and an intuitive client API.</description>
 
     <bookkeeper.version>4.14.4</bookkeeper.version>
     <zookeeper.version>3.6.3</zookeeper.version>
+    <commons-cli.version>1.5.0</commons-cli.version>
     <snappy.version>1.1.7</snappy.version> <!-- ZooKeeper server -->
     <dropwizardmetrics.version>3.2.5</dropwizardmetrics.version> <!-- ZooKeeper server -->
     <curator.version>5.1.0</curator.version>
@@ -345,6 +346,11 @@ flexible messaging model and an intuitive client API.</description>
         <groupId>org.apache.zookeeper</groupId>
         <artifactId>zookeeper-jute</artifactId>
         <version>${zookeeper.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>commons-cli</groupId>
+        <artifactId>commons-cli</artifactId>
+        <version>${commons-cli.version}</version>
       </dependency>
       <dependency>
         <groupId>io.dropwizard.metrics</groupId>

--- a/pulsar-sql/presto-distribution/LICENSE
+++ b/pulsar-sql/presto-distribution/LICENSE
@@ -443,7 +443,7 @@ The Apache Software License, Version 2.0
     - prometheus-metrics-provider-4.14.4.jar
     - codahale-metrics-provider-4.14.4.jar
   * Apache Commons
-    - commons-cli-1.2.jar
+    - commons-cli-1.5.0.jar
     - commons-codec-1.15.jar
     - commons-collections4-4.1.jar
     - commons-configuration-1.10.jar


### PR DESCRIPTION
### Motivation

- commons-cli 1.3+ is required by Zookeeper 3.7.0+
  - https://github.com/apache/zookeeper/commit/492fd79b
  - commons-cli versions <1.3 fail with error:
   ` java.lang.NoClassDefFoundError: org/apache/commons/cli/DefaultParser`

### Modification

Upgrade commons-cli to 1.5.0