### PR TITLE
Support specifying Ubuntu mirror for docker image builds

### DIFF
--- a/.github/workflows/ci-integration-backwards-compatibility.yaml
+++ b/.github/workflows/ci-integration-backwards-compatibility.yaml
@@ -28,6 +28,7 @@ on:
 
 env:
   MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.class=standard -Dmaven.wagon.http.retryHandler.count=3
+  UBUNTU_MIRROR: http://azure.archive.ubuntu.com/ubuntu/
 
 jobs:
 

--- a/.github/workflows/ci-integration-cli.yaml
+++ b/.github/workflows/ci-integration-cli.yaml
@@ -28,6 +28,7 @@ on:
 
 env:
   MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.class=standard -Dmaven.wagon.http.retryHandler.count=3
+  UBUNTU_MIRROR: http://azure.archive.ubuntu.com/ubuntu/
 
 jobs:
 

--- a/.github/workflows/ci-integration-function.yaml
+++ b/.github/workflows/ci-integration-function.yaml
@@ -28,6 +28,7 @@ on:
 
 env:
   MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.class=standard -Dmaven.wagon.http.retryHandler.count=3
+  UBUNTU_MIRROR: http://azure.archive.ubuntu.com/ubuntu/
 
 jobs:
 

--- a/.github/workflows/ci-integration-messaging.yaml
+++ b/.github/workflows/ci-integration-messaging.yaml
@@ -28,6 +28,7 @@ on:
 
 env:
   MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.class=standard -Dmaven.wagon.http.retryHandler.count=3
+  UBUNTU_MIRROR: http://azure.archive.ubuntu.com/ubuntu/
 
 jobs:
 

--- a/.github/workflows/ci-integration-process.yaml
+++ b/.github/workflows/ci-integration-process.yaml
@@ -28,6 +28,7 @@ on:
 
 env:
   MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.class=standard -Dmaven.wagon.http.retryHandler.count=3
+  UBUNTU_MIRROR: http://azure.archive.ubuntu.com/ubuntu/
 
 jobs:
 

--- a/.github/workflows/ci-integration-pulsar-io-ora.yaml
+++ b/.github/workflows/ci-integration-pulsar-io-ora.yaml
@@ -28,6 +28,7 @@ on:
 
 env:
   MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.class=standard -Dmaven.wagon.http.retryHandler.count=3
+  UBUNTU_MIRROR: http://azure.archive.ubuntu.com/ubuntu/
 
 jobs:
 

--- a/.github/workflows/ci-integration-pulsar-io.yaml
+++ b/.github/workflows/ci-integration-pulsar-io.yaml
@@ -28,6 +28,7 @@ on:
 
 env:
   MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.class=standard -Dmaven.wagon.http.retryHandler.count=3
+  UBUNTU_MIRROR: http://azure.archive.ubuntu.com/ubuntu/
 
 jobs:
 

--- a/.github/workflows/ci-integration-schema.yaml
+++ b/.github/workflows/ci-integration-schema.yaml
@@ -28,6 +28,7 @@ on:
 
 env:
   MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.class=standard -Dmaven.wagon.http.retryHandler.count=3
+  UBUNTU_MIRROR: http://azure.archive.ubuntu.com/ubuntu/
 
 jobs:
 

--- a/.github/workflows/ci-integration-sql.yaml
+++ b/.github/workflows/ci-integration-sql.yaml
@@ -28,6 +28,7 @@ on:
 
 env:
   MAVEN_OPTS: -Xmx768m -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.class=standard -Dmaven.wagon.http.retryHandler.count=3
+  UBUNTU_MIRROR: http://azure.archive.ubuntu.com/ubuntu/
   MALLOC_ARENA_MAX: "1"
 
 jobs:

--- a/.github/workflows/ci-integration-standalone.yaml
+++ b/.github/workflows/ci-integration-standalone.yaml
@@ -28,6 +28,7 @@ on:
 
 env:
   MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.class=standard -Dmaven.wagon.http.retryHandler.count=3
+  UBUNTU_MIRROR: http://azure.archive.ubuntu.com/ubuntu/
 
 jobs:
 

--- a/.github/workflows/ci-integration-thread.yaml
+++ b/.github/workflows/ci-integration-thread.yaml
@@ -28,6 +28,7 @@ on:
 
 env:
   MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.class=standard -Dmaven.wagon.http.retryHandler.count=3
+  UBUNTU_MIRROR: http://azure.archive.ubuntu.com/ubuntu/
 
 jobs:
 

--- a/.github/workflows/ci-integration-tiered-filesystem.yaml
+++ b/.github/workflows/ci-integration-tiered-filesystem.yaml
@@ -28,6 +28,7 @@ on:
 
 env:
   MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.class=standard -Dmaven.wagon.http.retryHandler.count=3
+  UBUNTU_MIRROR: http://azure.archive.ubuntu.com/ubuntu/
 
 jobs:
 

--- a/.github/workflows/ci-integration-tiered-jcloud.yaml
+++ b/.github/workflows/ci-integration-tiered-jcloud.yaml
@@ -28,6 +28,7 @@ on:
 
 env:
   MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.class=standard -Dmaven.wagon.http.retryHandler.count=3
+  UBUNTU_MIRROR: http://azure.archive.ubuntu.com/ubuntu/
 
 jobs:
 

--- a/.github/workflows/ci-integration-transaction.yaml
+++ b/.github/workflows/ci-integration-transaction.yaml
@@ -28,6 +28,7 @@ on:
 
 env:
   MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.class=standard -Dmaven.wagon.http.retryHandler.count=3
+  UBUNTU_MIRROR: http://azure.archive.ubuntu.com/ubuntu/
 
 jobs:
 

--- a/.github/workflows/ci-shade-test.yaml
+++ b/.github/workflows/ci-shade-test.yaml
@@ -28,6 +28,7 @@ on:
 
 env:
   MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.class=standard -Dmaven.wagon.http.retryHandler.count=3
+  UBUNTU_MIRROR: http://azure.archive.ubuntu.com/ubuntu/
 
 jobs:
 

--- a/docker/pulsar/Dockerfile
+++ b/docker/pulsar/Dockerfile
@@ -41,9 +41,11 @@ RUN mkdir /pulsar/data
 FROM ubuntu:20.04
 
 ARG DEBIAN_FRONTEND=noninteractive
+ARG UBUNTU_MIRROR=mirror://mirrors.ubuntu.com/mirrors.txt
 
 # Install some utilities
-RUN apt-get update \
+RUN sed -i "s|http://archive\.ubuntu\.com/ubuntu/|${UBUNTU_MIRROR:-mirror://mirrors.ubuntu.com/mirrors.txt}|g" /etc/apt/sources.list \
+     && apt-get update \
      && apt-get -y dist-upgrade \
      && apt-get -y install openjdk-11-jdk-headless netcat dnsutils less procps iputils-ping \
                  python3 python3-dev python3-setuptools python3-yaml python3-kazoo \

--- a/docker/pulsar/pom.xml
+++ b/docker/pulsar/pom.xml
@@ -151,6 +151,7 @@
               <tag>${project.version}</tag>
               <buildArgs>
                 <PULSAR_TARBALL>target/pulsar-server-distribution-${project.version}-bin.tar.gz</PULSAR_TARBALL>
+                <UBUNTU_MIRROR>${env.UBUNTU_MIRROR}</UBUNTU_MIRROR>
               </buildArgs>
             </configuration>
           </plugin>

--- a/tests/docker-images/java-test-image/Dockerfile
+++ b/tests/docker-images/java-test-image/Dockerfile
@@ -33,8 +33,10 @@ RUN chmod a+rx /pulsar/bin/*
 WORKDIR /pulsar
 
 ARG DEBIAN_FRONTEND=noninteractive
+ARG UBUNTU_MIRROR=mirror://mirrors.ubuntu.com/mirrors.txt
 
-RUN apt-get update \
+RUN sed -i "s|http://archive\.ubuntu\.com/ubuntu/|${UBUNTU_MIRROR:-mirror://mirrors.ubuntu.com/mirrors.txt}|g" /etc/apt/sources.list \
+     && apt-get update \
      && apt-get -y dist-upgrade \
      && apt-get -y install openjdk-11-jdk-headless
 

--- a/tests/docker-images/java-test-image/pom.xml
+++ b/tests/docker-images/java-test-image/pom.xml
@@ -165,6 +165,7 @@
               <noCache>true</noCache>
               <buildArgs>
                 <PULSAR_TARBALL>target/pulsar-server-distribution-bin.tar.gz</PULSAR_TARBALL>
+                <UBUNTU_MIRROR>${env.UBUNTU_MIRROR}</UBUNTU_MIRROR>
               </buildArgs>
             </configuration>
           </plugin>


### PR DESCRIPTION
### Motivation

- Ubuntu's `archive.ubuntu.com` doesn't seem to be responding and is slow.

### Modifications

- Support specifying Ubuntu mirror for docker image builds
  - use UBUNTU_MIRROR environment variable to specify
  - default to closest mirrors (http://mirrors.ubuntu.com/mirrors.txt)
   - use Azure's Ubuntu mirror in CI
