### PR TITLE
Consumer not able to consume message outside of a transaction if `enableTransaction=false` (client) and `TransactionCoordinatorEnabled=true` (broker) after 2.9.0

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/TopicTransactionBuffer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/TopicTransactionBuffer.java
@@ -174,6 +174,9 @@ public class TopicTransactionBuffer extends TopicTransactionBufferState implemen
     @Override
     public CompletableFuture<Void> checkIfTBRecoverCompletely(boolean isTxnEnabled) {
         if (!isTxnEnabled) {
+            if (!changeToNoSnapshotState()) {
+                log.error("[{}]Transaction buffer recover fail with transaction disabled", topic.getName());
+            }
             return CompletableFuture.completedFuture(null);
         } else {
             CompletableFuture<Void> completableFuture = new CompletableFuture<>();

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/TopicTransactionBuffer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/TopicTransactionBuffer.java
@@ -174,8 +174,12 @@ public class TopicTransactionBuffer extends TopicTransactionBufferState implemen
     @Override
     public CompletableFuture<Void> checkIfTBRecoverCompletely(boolean isTxnEnabled) {
         if (!isTxnEnabled) {
-            if (!changeToNoSnapshotState()) {
-                log.error("[{}]Transaction buffer recover fail with transaction disabled", topic.getName());
+            if (!checkIfNoSnapshot() && !changeToNoSnapshotState()) {
+                log.error("[{}] Transaction buffer recover fail with transaction disabled", topic.getName());
+                CompletableFuture<Void> completableFuture = new CompletableFuture<>();
+                completableFuture.completeExceptionally(new Exception("Topic " + topic.getName()
+                        + ": Transaction buffer recover fail with transaction disabled"));
+                return completableFuture;
             }
             return CompletableFuture.completedFuture(null);
         } else {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/coordinator/TransactionMetaStoreTestBase.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/coordinator/TransactionMetaStoreTestBase.java
@@ -32,8 +32,8 @@ import org.apache.pulsar.zookeeper.LocalBookkeeperEnsemble;
 import org.mockito.Mockito;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.testng.annotations.AfterClass;
-import org.testng.annotations.BeforeClass;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
 
 public abstract class TransactionMetaStoreTestBase extends TestRetrySupport {
 
@@ -48,7 +48,7 @@ public abstract class TransactionMetaStoreTestBase extends TestRetrySupport {
 
     protected TransactionCoordinatorClient transactionCoordinatorClient;
 
-    @BeforeClass(alwaysRun = true)
+    @BeforeMethod(alwaysRun = true)
     protected final void setup() throws Exception {
         log.info("---- Initializing {} -----", getClass().getSimpleName());
         // Start local bookkeeper ensemble
@@ -112,7 +112,7 @@ public abstract class TransactionMetaStoreTestBase extends TestRetrySupport {
         // template methods to override in subclasses
     }
 
-    @AfterClass(alwaysRun = true)
+    @AfterMethod(alwaysRun = true)
     public final void shutdownAll() throws Exception {
         cleanup();
     }


### PR DESCRIPTION
### Motivation

Consumer is not able to consume messages if you don't explicitly enable the transactions on the client side (even if you don't want to use them) using `enableTransaction`flag.
https://github.com/apache/pulsar/blob/3b8250d755a896c6f8837d59db74e56c7059caad/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/ClientBuilder.java#L539
I'm able to easily reproduce it and the test I added repeatedly fail without the fix. Anyway, I'm not sure if it happens always. 

A common scenario is that the broker admins enable the transactions on the broker side (`transactionCoordinatorEnabled=true`). Currently, the client must call `enableTransaction(true)` in ClientBuilder in order to get the consumers work. 
**This is a breaking change between Pulsar 2.8.x and 2.9.0+**

The PR that introduced this behaviour is https://github.com/apache/pulsar/pull/12219.

When the Server receive the Producer command, if enableTransaction is false, it will not update the `TopicTransactionBufferState` state until a new snapshot recovery is performed (every 5 sec by default `takeSnapshotIntervalTime`. The problem is that if a write happens before the snapshot, the `maxReadPosition` is blocked to -1 (that means it will never get entries), until a new write to the topic happens.

https://github.com/apache/pulsar/blob/186cd412022b3f95ce7de04ea67dc17415bb64d0/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/TopicTransactionBuffer.java#L449-L463
This method will called after the ledger write and, since the state is equals to Initialized, the `maxReadPosition` won't be updated.

### Modifications

* Added a reproducer
* Set the State to `NoSnapshot` immediately before giving a client a successful response for the producer creation 

### Documentation
 
- [x] `no-need-doc` 
