### PR TITLE
[test] enable build with JDK17+

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1404,6 +1404,7 @@ flexible messaging model and an intuitive client API.</description>
             -Dpulsar.allocator.exit_on_oom=false
             -Dpulsar.allocator.out_of_memory_policy=FallbackToHeap
             -Dio.netty.tryReflectionSetAccessible=true
+            --add-opens java.base/java.lang=ALL-UNNAMED
             ${test.additional.args}
           </argLine>
           <reuseForks>${testReuseFork}</reuseForks>

--- a/pom.xml
+++ b/pom.xml
@@ -1404,7 +1404,6 @@ flexible messaging model and an intuitive client API.</description>
             -Dpulsar.allocator.exit_on_oom=false
             -Dpulsar.allocator.out_of_memory_policy=FallbackToHeap
             -Dio.netty.tryReflectionSetAccessible=true
-            --add-opens java.base/java.lang=ALL-UNNAMED
             ${test.additional.args}
           </argLine>
           <reuseForks>${testReuseFork}</reuseForks>
@@ -1880,7 +1879,10 @@ flexible messaging model and an intuitive client API.</description>
         <!-- see https://github.com/apache/pulsar/issues/8445 -->
         <maven.compiler.release>${maven.compiler.target}</maven.compiler.release>
         <!-- required for running tests on JDK11+ -->
-        <test.additional.args> --add-opens java.base/jdk.internal.loader=ALL-UNNAMED </test.additional.args>
+        <test.additional.args>
+          --add-opens java.base/jdk.internal.loader=ALL-UNNAMED
+          --add-opens java.base/java.lang=ALL-UNNAMED <!--Mockito-->
+        </test.additional.args>
       </properties>
       <build>
         <pluginManagement>


### PR DESCRIPTION
### Motivation
Since JDK17 the illegal accesses to the JDK classes are forbidden. Mockito needs to access those classes.

### Modifications

* Changed test runtime options with a minimal configuration to let Mockito work

### Documentation

- [x] `no-need-doc` 