### PR TITLE
[#14101] [schema] making schema registry configurable

### DIFF
--- a/conf/standalone.conf
+++ b/conf/standalone.conf
@@ -180,6 +180,8 @@ maxTopicsPerNamespace=0
 # 'is_allow_auto_update_schema' of namespace policy.
 isAllowAutoUpdateSchemaEnabled=true
 
+schemaRegistryClassName=
+
 # Enable check for minimum allowed client library version
 clientLibraryVersionCheckEnabled=false
 

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -2185,6 +2185,13 @@ public class ServiceConfiguration implements PulsarConfiguration {
             + ".BookkeeperSchemaStorageFactory";
 
     @FieldContext(
+          category = CATEGORY_SCHEMA,
+          doc = "The schema registry implementation used by this broker"
+    )
+    private String schemaRegistryClassName = "org.apache.pulsar.broker.service.schema"
+          + ".SchemaRegistryServiceImpl";
+
+    @FieldContext(
         category = CATEGORY_SCHEMA,
         doc = "The list compatibility checkers to be used in schema registry"
     )

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
@@ -666,7 +666,7 @@ public class PulsarService implements AutoCloseable, ShutdownService {
             this.startNamespaceService();
 
             schemaStorage = createAndStartSchemaStorage();
-            schemaRegistryService = SchemaRegistryService.create(
+            schemaRegistryService = SchemaRegistryService.create(config.getSchemaRegistryClassName(),
                     schemaStorage, config.getSchemaRegistryCompatibilityCheckers());
 
             this.defaultOffloader = createManagedLedgerOffloader(

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/SchemaRegistryService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/SchemaRegistryService.java
@@ -42,13 +42,18 @@ public interface SchemaRegistryService extends SchemaRegistry {
         return checkers;
     }
 
-    static SchemaRegistryService create(SchemaStorage schemaStorage, Set<String> schemaRegistryCompatibilityCheckers) {
+    static SchemaRegistryService create(String schemaRegistryName, SchemaStorage schemaStorage, Set<String> schemaRegistryCompatibilityCheckers) {
         if (schemaStorage != null) {
             try {
                 Map<SchemaType, SchemaCompatibilityCheck> checkers = getCheckers(schemaRegistryCompatibilityCheckers);
                 checkers.put(SchemaType.KEY_VALUE, new KeyValueSchemaCompatibilityCheck(checkers));
-                return SchemaRegistryServiceWithSchemaDataValidator.of(
-                        new SchemaRegistryServiceImpl(schemaStorage, checkers));
+
+                if (schemaRegistryName == null) {
+                return SchemaRegistryServiceWithSchemaDataValidator
+                      .of(new SchemaRegistryServiceImpl(schemaStorage, checkers));
+                } else {
+                    return (SchemaRegistryService) Class.forName(schemaRegistryName).getDeclaredConstructor(SchemaStorage.class, Map.class).newInstance(schemaStorage, checkers);
+                }
             } catch (Exception e) {
                 LOG.warn("Unable to create schema registry storage, defaulting to empty storage", e);
             }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/SchemaRegistryService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/SchemaRegistryService.java
@@ -42,7 +42,8 @@ public interface SchemaRegistryService extends SchemaRegistry {
         return checkers;
     }
 
-    static SchemaRegistryService create(String schemaRegistryName, SchemaStorage schemaStorage, Set<String> schemaRegistryCompatibilityCheckers) {
+    static SchemaRegistryService create(String schemaRegistryName, SchemaStorage schemaStorage,
+          Set<String> schemaRegistryCompatibilityCheckers) {
         if (schemaStorage != null) {
             try {
                 Map<SchemaType, SchemaCompatibilityCheck> checkers = getCheckers(schemaRegistryCompatibilityCheckers);
@@ -52,7 +53,9 @@ public interface SchemaRegistryService extends SchemaRegistry {
                 return SchemaRegistryServiceWithSchemaDataValidator
                       .of(new SchemaRegistryServiceImpl(schemaStorage, checkers));
                 } else {
-                    return (SchemaRegistryService) Class.forName(schemaRegistryName).getDeclaredConstructor(SchemaStorage.class, Map.class).newInstance(schemaStorage, checkers);
+                    return (SchemaRegistryService) Class.forName(schemaRegistryName)
+                          .getDeclaredConstructor(SchemaStorage.class, Map.class)
+                          .newInstance(schemaStorage, checkers);
                 }
             } catch (Exception e) {
                 LOG.warn("Unable to create schema registry storage, defaulting to empty storage", e);


### PR DESCRIPTION


Fixes #14101 

### Motivation


SchemaRegistryService is hardcoded to use SchemaRegistryServiceImpl in org.apache.pulsar.broker.service.schema.SchemaRegistryService#create

### Modifications

broker.conf has a new config called schemaRegistryClassName which will have the name of the class to be used. the class is instantiated in SchemaRegistryService interface's static create method via reflection.



### Verifying this change

- [ ] Make sure that the change passes the CI checks.


This change is already covered by existing tests which create a producer or consumer successfully.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): no
  - The public API: no
  - The schema: yes
  - The default values of configurations: yes
  - The wire protocol: no
  - The rest endpoints: no
  - The admin cli options: no
  - Anything that affects deployment: no

### Documentation

Check the box below or label this PR directly (if you have committer privilege).

Need to update docs? 

- [x] `doc-required` 
  this PR adds a new config which needs to be explained in the docs


