### PR TITLE
[Issue 11577][Python Functions] Fixing get functions for output topic and serde classname

### DIFF
--- a/pulsar-functions/instance/src/main/python/contextimpl.py
+++ b/pulsar-functions/instance/src/main/python/contextimpl.py
@@ -139,10 +139,10 @@ class ContextImpl(pulsar.Context):
     return list(self.instance_config.function_details.source.inputSpecs.keys())
 
   def get_output_topic(self):
-    return self.instance_config.function_details.output
+    return self.instance_config.function_details.sink.topic
 
   def get_output_serde_class_name(self):
-    return self.instance_config.function_details.outputSerdeClassName
+    return self.instance_config.function_details.sink.serDeClassName
 
   def callback_wrapper(self, callback, topic, message_id, result, msg):
     if result != pulsar.Result.Ok:


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - Name the pull request in the form "[Issue XYZ][component] Title of the pull request", where *XYZ* should be replaced by the actual issue number.
    Skip *Issue XYZ* if there is no associated github issue for this pull request.
    Skip *component* if you are unsure about which is the best component. E.g. `[docs] Fix typo in produce method`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.

**(The sections below can be removed for hotfixes of typos)**
-->

Fixes #11577

### Motivation

2 get functions documented [here](https://pulsar.apache.org/api/python/functions/context.m.html#pulsar.functions.context.Context.get_output_serde_class_name) always return `None` and this fixes that.


### Modifications

I looked up the correct location in [Function_pb2.py](https://github.com/apache/pulsar/blob/master/pulsar-functions/instance/src/main/python/Function_pb2.py#L1144). You can also access the instance_config on the context in a function. `context.instance_config.function_details.sink.topic` and `context.instance_config.function_details.sink.serDeClassName` give me the results I was expecting to get from these functions. But this is undocumented so I wouldn't want to rely on that.


### Verifying this change

This change is a trivial rework / code cleanup without any test coverage.


### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): no
  - The public API: **yes**
  - The schema: no
  - The default values of configurations: no
  - The wire protocol: no
  - The rest endpoints: no
  - The admin cli options: no
  - Anything that affects deployment: no

### Documentation

Need to update docs? 

- [ ] `doc-required` 
  
- [x] `no-need-doc` 
  This is aligning the code with the existing docs.
  
- [ ] `doc` 



