### PR TITLE
correct uploadBuiltinSinksSources in the functions_worker.yml

### DIFF
--- a/conf/functions_worker.yml
+++ b/conf/functions_worker.yml
@@ -151,6 +151,9 @@ functionRuntimeFactoryConfigs:
 #### Kubernetes Runtime ####
 # Pulsar function are deployed to Kubernetes
 
+# Upload the builtin sources/sinks to BookKeeper.
+# True by default.
+# uploadBuiltinSinksSources: true
 #functionRuntimeFactoryClassName: org.apache.pulsar.functions.runtime.kubernetes.KubernetesRuntimeFactory
 #functionRuntimeFactoryConfigs:
 #    # uri to kubernetes cluster, leave it to empty and it will use the kubernetes settings in function worker
@@ -219,9 +222,6 @@ functionRuntimeFactoryConfigs:
 #    narExtractionDirectory:
 #    # The classpath where function instance files stored
 #    functionInstanceClassPath:
-#    # Upload the builtin sources/sinks to BookKeeper.
-#    # True by default.
-#    uploadBuiltinSinksSources: true
 #    # the directory for dropping extra function dependencies
 #    # if it is not an absolute path, it is relative to `pulsarRootDir`
 #    extraFunctionDependenciesDir:


### PR DESCRIPTION
The current `uploadBuiltinSinksSources` config is placed in the wrong place. It is part of WorkerConfig.java. It should be part of first level key in functions_worker.yml.

The current config results in this exception and the function in Kubernetes Runtime failed to start 
````
Exception in thread "main" com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException: Unrecognized field "uploadBuiltinSinksSources" (class org.apache.pulsar.functions.worker.WorkerConfig$KubernetesContainerFactory), not marked as ignorable (27 known properties: "submittingInsidePod", "pulsarDockerImageName", "percentMemoryPadding", "pulsarRootDir", "customLabels", "changeConfigMapNamespace", "imagePullPolicy", "pulsarServiceUrl", "cpuOverCommitRatio", "installUserCodeDependencies", "jobNamespace", "memoryOverCommitRatio", "metricsPort", "gracePeriodSeconds", "narExtractionDirectory", "jobName", "pythonExtraDependencyRepository", "changeConfigMap", "functionDockerImages", "pythonDependencyRepository", "configAdminCLI", "extraFunctionDependenciesDir", "pulsarAdminUrl", "k8Uri", "expectedMetricsCollectionInterval", "functionInstanceClassPath", "grpcPort"])
 at [Source: (File); line: 36, column: 35] (through reference chain: org.apache.pulsar.functions.worker.WorkerConfig["kubernetesContainerFactory"]->org.apache.pulsar.functions.worker.WorkerConfig$KubernetesContainerFactory["uploadBuiltinSinksSources"])
```

### Modifications

The fix is to move the config in the first level config.

### Verifying this change

Function worker in kubernetes is able to start.


This change is a trivial rework

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): no
  - The public API: no
  - The schema: no
  - The default values of configurations: no
  - The wire protocol: no
  - The rest endpoints: no
  - The admin cli options: no
  - Anything that affects deployment: no

### Documentation

Check the box below or label this PR directly (if you have committer privilege).

Need to update docs? 
  
- [x] `no-need-doc` 
  
  


