### PR TITLE
Fix annotations for function WorkerConfig fields

### DIFF
--- a/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/worker/WorkerConfig.java
+++ b/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/worker/WorkerConfig.java
@@ -187,12 +187,12 @@ public class WorkerConfig implements Serializable, PulsarConfiguration {
     private Boolean validateConnectorConfig = false;
     @FieldContext(
         category = CATEGORY_FUNCTIONS,
-        doc = "The path to the location to locate builtin functions"
+        doc = "Should the builtin sources/sinks be uploaded for the externally managed runtimes?"
     )
     private Boolean uploadBuiltinSinksSources = true;
     @FieldContext(
             category = CATEGORY_FUNCTIONS,
-            doc = "Should the builtin sources/sinks be uploaded for the externally managed runtimes?"
+            doc = "The path to the location to locate builtin functions"
     )
     private String functionsDirectory = "./functions";
     @FieldContext(


### PR DESCRIPTION
In https://github.com/apache/pulsar/pull/12947, the annotation was added in the wrong place. This PR fixes the ordering.