### PR TITLE
Support graceful shutdown for Broker

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
@@ -395,7 +395,11 @@ public class PulsarService implements AutoCloseable, ShutdownService {
 
             // close the service in reverse order v.s. in which they are started
             if (this.resourceUsageTransportManager != null) {
-                this.resourceUsageTransportManager.close();
+                try {
+                    this.resourceUsageTransportManager.close();
+                } catch (Exception e) {
+                    LOG.warn("ResourceUsageTransportManager closing failed {}", e.getMessage());
+                }
                 this.resourceUsageTransportManager = null;
             }
 
@@ -443,7 +447,11 @@ public class PulsarService implements AutoCloseable, ShutdownService {
             }
 
             if (this.managedLedgerClientFactory != null) {
-                this.managedLedgerClientFactory.close();
+                try {
+                    this.managedLedgerClientFactory.close();
+                } catch (Exception e) {
+                    LOG.warn("ManagedLedgerClientFactory closing failed {}", e.getMessage());
+                }
                 this.managedLedgerClientFactory = null;
             }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/BrokersBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/BrokersBase.java
@@ -467,7 +467,7 @@ public class BrokersBase extends PulsarWebResource {
     private void doShutDownBrokerGracefully(int maxConcurrentUnloadPerSec,
                                             boolean forcedTerminateTopic) {
         pulsar().getBrokerService().unloadNamespaceBundlesGracefully(maxConcurrentUnloadPerSec, forcedTerminateTopic);
-        pulsar().getBrokerService().closeAsync();
+        pulsar().closeAsync();
     }
 }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/BrokersBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/BrokersBase.java
@@ -457,6 +457,8 @@ public class BrokersBase extends PulsarWebResource {
             @ApiResponse(code = 403, message = "You don't have admin permission to update service-configuration"),
             @ApiResponse(code = 500, message = "Internal server error")})
     public void shutDownBrokerGracefully(
+            @ApiParam(name = "maxConcurrentUnloadPerSec",
+                    value = "if the value absent(value=0) means no concurrent limitation.")
             @QueryParam("maxConcurrentUnloadPerSec") int maxConcurrentUnloadPerSec,
             @QueryParam("forcedTerminateTopic") @DefaultValue("true") boolean forcedTerminateTopic
     ) throws Exception {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/NamespaceService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/NamespaceService.java
@@ -703,12 +703,18 @@ public class NamespaceService implements AutoCloseable {
     }
 
     public CompletableFuture<Void> unloadNamespaceBundle(NamespaceBundle bundle, long timeout, TimeUnit timeoutUnit) {
+        return unloadNamespaceBundle(bundle, timeout, timeoutUnit, true);
+    }
+
+    public CompletableFuture<Void> unloadNamespaceBundle(NamespaceBundle bundle, long timeout,
+                                                         TimeUnit timeoutUnit,
+                                                         boolean closeWithoutWaitingClientDisconnect) {
         // unload namespace bundle
         OwnedBundle ob = ownershipCache.getOwnedBundle(bundle);
         if (ob == null) {
             return FutureUtil.failedFuture(new IllegalStateException("Bundle " + bundle + " is not currently owned"));
         } else {
-            return ob.handleUnloadRequest(pulsar, timeout, timeoutUnit);
+            return ob.handleUnloadRequest(pulsar, timeout, timeoutUnit, closeWithoutWaitingClientDisconnect);
         }
     }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
@@ -157,6 +157,7 @@ import org.apache.pulsar.common.protocol.schema.SchemaVersion;
 import org.apache.pulsar.common.stats.Metrics;
 import org.apache.pulsar.common.util.FieldParser;
 import org.apache.pulsar.common.util.FutureUtil;
+import org.apache.pulsar.common.util.RateLimiter;
 import org.apache.pulsar.common.util.RestException;
 import org.apache.pulsar.common.util.collections.ConcurrentOpenHashMap;
 import org.apache.pulsar.common.util.collections.ConcurrentOpenHashSet;
@@ -859,6 +860,10 @@ public class BrokerService implements Closeable {
      * </ul>
      */
     public void unloadNamespaceBundlesGracefully() {
+        unloadNamespaceBundlesGracefully(0, true);
+    }
+
+    public void unloadNamespaceBundlesGracefully(int maxConcurrentUnload, boolean closeWithoutWaitingClientDisconnect) {
         try {
             log.info("Unloading namespace-bundles...");
             // make broker-node unavailable from the cluster
@@ -875,16 +880,25 @@ public class BrokerService implements Closeable {
             long closeTopicsStartTime = System.nanoTime();
             Set<NamespaceBundle> serviceUnits = pulsar.getNamespaceService().getOwnedServiceUnits();
             if (serviceUnits != null) {
-                serviceUnits.forEach(su -> {
-                    if (su instanceof NamespaceBundle) {
-                        try {
-                            pulsar.getNamespaceService().unloadNamespaceBundle(su, pulsar.getConfiguration()
-                                    .getNamespaceBundleUnloadingTimeoutMs(), TimeUnit.MILLISECONDS).get();
-                        } catch (Exception e) {
-                            log.warn("Failed to unload namespace bundle {}", su, e);
+                try (RateLimiter rateLimiter = maxConcurrentUnload > 0 ? RateLimiter.builder()
+                        .scheduledExecutorService(pulsar.getExecutor())
+                        .rateTime(1).timeUnit(TimeUnit.SECONDS)
+                        .permits(maxConcurrentUnload).build() : null) {
+                    serviceUnits.forEach(su -> {
+                        if (su != null) {
+                            try {
+                                if (rateLimiter != null) {
+                                    rateLimiter.acquire(1);
+                                }
+                                pulsar.getNamespaceService().unloadNamespaceBundle(su, pulsar.getConfiguration()
+                                                .getNamespaceBundleUnloadingTimeoutMs(), TimeUnit.MILLISECONDS,
+                                        closeWithoutWaitingClientDisconnect).get();
+                            } catch (Exception e) {
+                                log.warn("Failed to unload namespace bundle {}", su, e);
+                            }
                         }
-                    }
-                });
+                    });
+                }
             }
 
             double closeTopicsTimeSeconds = TimeUnit.NANOSECONDS.toMillis((System.nanoTime() - closeTopicsStartTime))

--- a/pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/admin/Brokers.java
+++ b/pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/admin/Brokers.java
@@ -291,6 +291,15 @@ public interface Brokers {
     CompletableFuture<Void> healthcheckAsync(TopicVersion topicVersion);
 
     /**
+     * Shutdown current broker gracefully.
+     * @param maxConcurrentUnloadPerSec
+     * @param forcedTerminateTopic
+     * @return
+     */
+    CompletableFuture<Void> shutDownBrokerGracefully(int maxConcurrentUnloadPerSec,
+                                                     boolean forcedTerminateTopic);
+
+    /**
      * Get version of broker.
      * @return version of broker.
      */

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/BrokersImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/BrokersImpl.java
@@ -303,6 +303,15 @@ public class BrokersImpl extends BaseResource implements Brokers {
     }
 
     @Override
+    public CompletableFuture<Void> shutDownBrokerGracefully(int maxConcurrentUnloadPerSec,
+                                                            boolean forcedTerminateTopic) {
+        WebTarget path = adminBrokers.path("shutdown")
+                .queryParam("maxConcurrentUnloadPerSec", maxConcurrentUnloadPerSec)
+                .queryParam("forcedTerminateTopic", forcedTerminateTopic);
+        return asyncPostRequest(path, Entity.entity("", MediaType.APPLICATION_JSON));
+    }
+
+    @Override
     public String getVersion() throws PulsarAdminException {
         return sync(() -> getVersionAsync());
     }

--- a/pulsar-client-tools-test/src/test/java/org/apache/pulsar/admin/cli/PulsarAdminToolTest.java
+++ b/pulsar-client-tools-test/src/test/java/org/apache/pulsar/admin/cli/PulsarAdminToolTest.java
@@ -146,6 +146,9 @@ public class PulsarAdminToolTest {
 
         brokers.run(split("version"));
         verify(mockBrokers).getVersion();
+
+        brokers.run(split("shutdown -m 10 -f"));
+        verify(mockBrokers).shutDownBrokerGracefully(10,true);
     }
 
     @Test

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdBrokers.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdBrokers.java
@@ -137,6 +137,25 @@ public class CmdBrokers extends CmdBase {
 
     }
 
+    @Parameters(commandDescription = "Shutdown broker gracefully.")
+    private class ShutDownBrokerGracefully extends CliCommand {
+
+        @Parameter(names = {"--max-concurrent-unload-per-sec", "-m"},
+                description = "Max concurrent unload per second, " +
+                        "if the value absent(value=0) means no concurrent limitation")
+        private int maxConcurrentUnloadPerSec;
+
+        @Parameter(names = {"--forced-terminate-topic", "-f"}, description = "Force terminate all topics on Broker")
+        private boolean forcedTerminateTopic;
+
+        @Override
+        void run() throws Exception {
+            getAdmin().brokers().shutDownBrokerGracefully(maxConcurrentUnloadPerSec, forcedTerminateTopic);
+            System.out.println("Successfully trigger broker shutdown gracefully");
+        }
+
+    }
+
     @Parameters(commandDescription = "Manually trigger backlogQuotaCheck")
     private class BacklogQuotaCheckCmd extends CliCommand {
 
@@ -171,5 +190,6 @@ public class CmdBrokers extends CmdBase {
         jcommander.addCommand("healthcheck", new HealthcheckCmd());
         jcommander.addCommand("backlog-quota-check", new BacklogQuotaCheckCmd());
         jcommander.addCommand("version", new PulsarVersion());
+        jcommander.addCommand("shutdown", new ShutDownBrokerGracefully());
     }
 }

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdBrokers.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdBrokers.java
@@ -141,8 +141,8 @@ public class CmdBrokers extends CmdBase {
     private class ShutDownBrokerGracefully extends CliCommand {
 
         @Parameter(names = {"--max-concurrent-unload-per-sec", "-m"},
-                description = "Max concurrent unload per second, " +
-                        "if the value absent(value=0) means no concurrent limitation")
+                description = "Max concurrent unload per second, "
+                        + "if the value absent(value=0) means no concurrent limitation")
         private int maxConcurrentUnloadPerSec;
 
         @Parameter(names = {"--forced-terminate-topic", "-f"}, description = "Force terminate all topics on Broker")


### PR DESCRIPTION
### Motivation
Now the following problems exist when the broker is closing:
1. When there are many topics on the Broker that is being closed, there will be a large number of concurrent lookup requests, which will eventually cause the Lookup to time out.
2. When `broker.close()` is running, it directly sets the Topic state to terminated without waiting for the client connection to be closed, resulting in an exception on the client side and obvious perception.

### Modifications
1. Add a REST API for graceful shutdown
2. The rate of unload per second can be controlled in the API
3. When closing the broker, we can wait for the client connection to close, thereby making the broker switching smoother

### Documentation
- [ x ] `no-need-doc` 



