### PR TITLE
Fixed flaky test LockManagerTest.revalidateLockOnDifferentSession

### DIFF
--- a/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/LockManagerTest.java
+++ b/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/LockManagerTest.java
@@ -280,7 +280,8 @@ public class LockManagerTest extends BaseMetadataStoreTest {
 
         // Simulate existing lock with same content. The 2nd acquirer will steal the lock
         String path2 = newKey();
-        store1.put(path2, ObjectMapperFactory.getThreadLocal().writeValueAsBytes("value-1"), Optional.of(-1L));
+        store1.put(path2, ObjectMapperFactory.getThreadLocal().writeValueAsBytes("value-1"), Optional.of(-1L),
+                EnumSet.of(CreateOption.Ephemeral)).join();
 
         ResourceLock<String> rl2 = lm2.acquireLock(path2, "value-1").join();
 


### PR DESCRIPTION
### Motivation

Fix #13910

The test was not waiting for the put() operation to complete, therefore it was flaky. Also, for the test purpose, the key needs to be created as "ephemeral", otherwise the lock is not going to be "stealed" which is what the test is checking. 
