### PR TITLE
Improve issue template for flaky tests

### DIFF
--- a/.github/ISSUE_TEMPLATE/flaky_test.md
+++ b/.github/ISSUE_TEMPLATE/flaky_test.md
@@ -1,23 +1,23 @@
 ---
 name: Flaky test
 about: Report a flaky test failure
-title: 'Flaky-test: [test class].[test method]'
-labels: component/test flaky-tests type/bug
+title: 'Flaky-test: test_class.test_method'
+labels: ["component/test", "flaky-tests"]
 assignees: ''
 ---
 <!--- 
 
 Instructions for reporting a flaky test using this issue template:
 
-1. Replace [test class] in title and body with the test class name
-2. Replace [test method] in title and body with the test method that failed. Multiple methods are flaky, remove the content that refers to the test method.
+1. Replace test_class in title and body with the short test class name WITHOUT the package name.
+2. Replace test_method in title and body with the test method that failed. Multiple methods are flaky, remove the content that refers to the test method.
 3. Replace "url here" with a url to an example failure. In the Github Actions workflow run logs, you can right click on the line number to copy a link to the line. Example of such url is https://github.com/apache/pulsar/pull/8892/checks?check_run_id=1531075794#step:9:377 . The logs are available for a limited amount of time (usually for a few weeks).
 4. Replace "relevant parts of the exception stacktrace here" with the a few lines of the stack trace that shows at least the exception message and the line of test code where the stacktrace occurred.
 5. Replace "full exception stacktrace here" with the full exception stacktrace from logs. This section will be hidden by default.
 6. Remove all unused fields / content to unclutter the reported issue. Remove this comment too.
 
 -->
-[test class] is flaky. The [test method] test method fails sporadically.
+test_class.test_method is flaky. It fails sporadically.
 
 [example failure](url here)
 
@@ -25,6 +25,7 @@ Instructions for reporting a flaky test using this issue template:
 [relevant parts of the exception stacktrace here]
 ```
 
+<!-- optionally provide the full stacktrace ->
 <details>
 <summary>Full exception stacktrace</summary>
 <code><pre>


### PR DESCRIPTION
### Motivation

- it currently causes a misinterpretation that the brackets should be left in the actual report
  - the extra brackets in reported issues make it hard to find the reported issues by classname and/or test method name
- label assignment doesn't work

### Modifications

- remove brackets from template so that it reduces misinterpretation
- add instructions to omit package name from class name
- fix label assignment
- simplify body text to ease copy-pasting classname+methodname together

