### PR TITLE
[security] Upgrade Postgre driver to 42.2.25 to get rid of CVE-2022-21724

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -149,7 +149,7 @@ flexible messaging model and an intuitive client API.</description>
     <guice.version>5.0.1</guice.version>
     <sqlite-jdbc.version>3.8.11.2</sqlite-jdbc.version>
     <mysql-jdbc.version>8.0.11</mysql-jdbc.version>
-    <postgresql-jdbc.version>42.2.24</postgresql-jdbc.version>
+    <postgresql-jdbc.version>42.2.25</postgresql-jdbc.version>
     <clickhouse-jdbc.version>0.3.2</clickhouse-jdbc.version>
     <mariadb-jdbc.version>2.6.0</mariadb-jdbc.version>
     <hdfs-offload-version3>3.3.1</hdfs-offload-version3>

--- a/pulsar-io/debezium/postgres/pom.xml
+++ b/pulsar-io/debezium/postgres/pom.xml
@@ -44,6 +44,12 @@
       <version>${debezium.version}</version>
     </dependency>
 
+    <dependency>
+      <groupId>org.postgresql</groupId>
+      <artifactId>postgresql</artifactId>
+      <version>42.2.25</version>
+    </dependency>
+
   </dependencies>
 
   <build>


### PR DESCRIPTION
### Motivation

http://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2022-21724

### Modifications

Upgrade both `jdbc` and `debezium` Postgre java driver dependency to 42.2.25 (from 42.2.24 and 42.2.22).
Note: the version is not shared on purpose because we should leave the driver dependencies separated since the two connectors are used in different ways. (For example, when we'll upgrade Debezium to 1.8.x we'll need to remove the override and keep the 42.3.x version)

For cherry-picks, branch-2.9 and branch-2.8 are compatible since:
* branch-2.9 has the same debezium version
* branch-2.8 has 1.0.0 but it uses [pg driver 42.2.x](https://search.maven.org/artifact/io.debezium/debezium-parent/1.0.0.Final/pom) as well 

### Documentation

- [x] `no-need-doc` 
