### PR TITLE
[build] Remove net.jodah.failsafe dependency (fix JDK17 build)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -221,7 +221,7 @@ flexible messaging model and an intuitive client API.</description>
     <mockito.version>3.12.4</mockito.version>
     <powermock.version>2.0.9</powermock.version>
     <javassist.version>3.25.0-GA</javassist.version>
-    <failsafe.version>2.3.1</failsafe.version>
+    <failsafe.version>3.2.0</failsafe.version>
     <skyscreamer.version>1.5.0</skyscreamer.version>
     <objenesis.version>3.1</objenesis.version>
     <awaitility.version>4.0.3</awaitility.version>

--- a/pom.xml
+++ b/pom.xml
@@ -221,7 +221,6 @@ flexible messaging model and an intuitive client API.</description>
     <mockito.version>3.12.4</mockito.version>
     <powermock.version>2.0.9</powermock.version>
     <javassist.version>3.25.0-GA</javassist.version>
-    <failsafe.version>3.2.0</failsafe.version>
     <skyscreamer.version>1.5.0</skyscreamer.version>
     <objenesis.version>3.1</objenesis.version>
     <awaitility.version>4.0.3</awaitility.version>

--- a/tests/integration/pom.xml
+++ b/tests/integration/pom.xml
@@ -172,7 +172,7 @@
     </dependency>
 
     <dependency>
-      <groupId>net.jodah</groupId>
+      <groupId>dev.failsafe</groupId>
       <artifactId>failsafe</artifactId>
       <version>${failsafe.version}</version>
       <scope>test</scope>

--- a/tests/integration/pom.xml
+++ b/tests/integration/pom.xml
@@ -172,13 +172,6 @@
     </dependency>
 
     <dependency>
-      <groupId>dev.failsafe</groupId>
-      <artifactId>failsafe</artifactId>
-      <version>${failsafe.version}</version>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
       <groupId>org.awaitility</groupId>
       <artifactId>awaitility</artifactId>
       <scope>test</scope>

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/sources/AvroKafkaSourceTest.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/sources/AvroKafkaSourceTest.java
@@ -19,11 +19,11 @@
 package org.apache.pulsar.tests.integration.io.sources;
 
 import com.google.gson.Gson;
+import dev.failsafe.Failsafe;
+import dev.failsafe.RetryPolicy;
 import lombok.Cleanup;
 import lombok.Data;
 import lombok.extern.slf4j.Slf4j;
-import net.jodah.failsafe.Failsafe;
-import net.jodah.failsafe.RetryPolicy;
 import org.apache.avro.io.DatumWriter;
 import org.apache.avro.io.EncoderFactory;
 import org.apache.avro.io.JsonEncoder;
@@ -78,10 +78,11 @@ public class AvroKafkaSourceTest extends PulsarFunctionsTestBase {
     final Duration ONE_MINUTE = Duration.ofMinutes(1);
     final Duration TEN_SECONDS = Duration.ofSeconds(10);
 
-    final RetryPolicy statusRetryPolicy = new RetryPolicy()
+    final RetryPolicy statusRetryPolicy = dev.failsafe.RetryPolicy.builder()
             .withMaxDuration(ONE_MINUTE)
             .withDelay(TEN_SECONDS)
-            .onRetry(e -> log.error("Retry ... "));
+            .onRetry(e -> log.error("Retry ... "))
+            .build();
 
     private final String kafkaTopicName = "kafkasourcetopic";
 

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/sources/AvroKafkaSourceTest.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/sources/AvroKafkaSourceTest.java
@@ -78,7 +78,7 @@ public class AvroKafkaSourceTest extends PulsarFunctionsTestBase {
     final Duration ONE_MINUTE = Duration.ofMinutes(1);
     final Duration TEN_SECONDS = Duration.ofSeconds(10);
 
-    final RetryPolicy statusRetryPolicy = dev.failsafe.RetryPolicy.builder()
+    final RetryPolicy statusRetryPolicy = RetryPolicy.builder()
             .withMaxDuration(ONE_MINUTE)
             .withDelay(TEN_SECONDS)
             .onRetry(e -> log.error("Retry ... "))

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/sources/AvroKafkaSourceTest.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/sources/AvroKafkaSourceTest.java
@@ -236,7 +236,7 @@ public class AvroKafkaSourceTest extends PulsarFunctionsTestBase {
                         waitForProcessingSourceMessages(tenant, namespace, sourceName, numMessages);
                         return true;
                     } catch (Throwable ex) {
-                        log.error("Error while getting source status, will retry", ex);
+                        log.error("Error while processing source messages, will retry", ex);
                         return false;
                     }
                 });


### PR DESCRIPTION
### Motivation

Java compiler fails due to a weird exception `ClosedFileSystemException`. The cause is the usage of net.jodah.failsafe (I haven't found any doc/issue on the failsafe repo, but still)

### Modifications

 * Replaced the usage with Awaitility

### Documentation

- [x] `no-need-doc` 