### PR TITLE
Fix flaky test ZKSessionTest.testDisconnection

### DIFF
--- a/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/TestZKServer.java
+++ b/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/TestZKServer.java
@@ -65,6 +65,7 @@ public class TestZKServer implements AutoCloseable {
 
     public void start() throws Exception {
         this.zks = new ZooKeeperServer(zkDataDir, zkDataDir, TICK_TIME);
+        this.zks.setMaxSessionTimeout(300_000);
         this.serverFactory = new NIOServerCnxnFactory();
         this.serverFactory.configure(new InetSocketAddress(zkPort), 1000);
         this.serverFactory.startup(zks, true);

--- a/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/ZKSessionTest.java
+++ b/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/ZKSessionTest.java
@@ -48,7 +48,7 @@ public class ZKSessionTest extends BaseMetadataStoreTest {
         @Cleanup
         MetadataStoreExtended store = MetadataStoreExtended.create(zks.getConnectionString(),
                 MetadataStoreConfig.builder()
-                        .sessionTimeoutMillis(30_000)
+                        .sessionTimeoutMillis(300_000)
                         .build());
 
         BlockingQueue<SessionEvent> sessionEvents = new LinkedBlockingQueue<>();


### PR DESCRIPTION
### Motivation

Fix #13008

Increase the session timeout for `testDisconnection` since we're testing that session does not get expired when we are within the limits of the session timeout.