### PR TITLE
[pulsar-proxy] Fix auto-cert refresh when proxy connects to broker

### DIFF
--- a/pulsar-common/src/main/java/org/apache/pulsar/common/util/NettyClientSslContextRefresher.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/util/NettyClientSslContextRefresher.java
@@ -47,9 +47,11 @@ public class NettyClientSslContextRefresher extends SslContextAutoRefreshBuilder
         super(delayInSeconds);
         this.tlsAllowInsecureConnection = allowInsecure;
         this.tlsTrustCertsFilePath = new FileModifiedTimeUpdater(trustCertsFilePath);
-        this.tlsCertsFilePath = new FileModifiedTimeUpdater(authData.getTlsCerificateFilePath());
-        this.tlsPrivateKeyFilePath = new FileModifiedTimeUpdater(authData.getTlsPrivateKeyFilePath());
         this.authData = authData;
+        this.tlsCertsFilePath = new FileModifiedTimeUpdater(
+                authData != null ? authData.getTlsCerificateFilePath() : null);
+        this.tlsPrivateKeyFilePath = new FileModifiedTimeUpdater(
+                authData != null ? authData.getTlsPrivateKeyFilePath() : null);
     }
 
     @Override

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/util/NettyClientSslContextRefresher.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/util/NettyClientSslContextRefresher.java
@@ -35,6 +35,8 @@ public class NettyClientSslContextRefresher extends SslContextAutoRefreshBuilder
     private volatile SslContext sslNettyContext;
     private boolean tlsAllowInsecureConnection;
     protected final FileModifiedTimeUpdater tlsTrustCertsFilePath;
+    protected final FileModifiedTimeUpdater tlsCertsFilePath;
+    protected final FileModifiedTimeUpdater tlsPrivateKeyFilePath;
     private AuthenticationDataProvider authData;
 
     public NettyClientSslContextRefresher(boolean allowInsecure,
@@ -45,6 +47,8 @@ public class NettyClientSslContextRefresher extends SslContextAutoRefreshBuilder
         super(delayInSeconds);
         this.tlsAllowInsecureConnection = allowInsecure;
         this.tlsTrustCertsFilePath = new FileModifiedTimeUpdater(trustCertsFilePath);
+        this.tlsCertsFilePath = new FileModifiedTimeUpdater(authData.getTlsCerificateFilePath());
+        this.tlsPrivateKeyFilePath = new FileModifiedTimeUpdater(authData.getTlsPrivateKeyFilePath());
         this.authData = authData;
     }
 
@@ -73,6 +77,8 @@ public class NettyClientSslContextRefresher extends SslContextAutoRefreshBuilder
 
     @Override
     public boolean needUpdate() {
-        return  tlsTrustCertsFilePath.checkAndRefresh();
+        return tlsTrustCertsFilePath.checkAndRefresh() || tlsCertsFilePath.checkAndRefresh()
+                || tlsPrivateKeyFilePath.checkAndRefresh();
+
     }
 }


### PR DESCRIPTION
### Motivation

Pulsar proxy doesn't do auto cert refresh which it uses to connect with broker and after cached cert expiry proxy is not able to create a new connection with broker and fails with exception
```
21:22:06.439 [pulsar-proxy-io-2-4] WARN  o.a.p.p.server.DirectProxyHandler    - [[id: 0x34d151f2, L:/1.1.1.1:6651 - R:/2.2.2.2:63017]] Caught exception: javax.net.ssl.SSLHandshakeException: error:10000415:SSL routines:OPENSSL_internal:SSLV3_ALERT_CERTIFICATE_EXPIRED
io.netty.handler.codec.DecoderException: javax.net.ssl.SSLHandshakeException: error:10000415:SSL routines:OPENSSL_internal:SSLV3_ALERT_CERTIFICATE_EXPIRED
        at io.netty.handler.codec.ByteToMessageDecoder.callDecode(ByteToMessageDecoder.java:478)
        at io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:276)
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379)
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365)
        at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357)
        at io.netty.channel.DefaultChannelPipeline$HeadContext.channelRead(DefaultChannelPipeline.java:1410)
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379)
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365)
        at io.netty.channel.DefaultChannelPipeline.fireChannelRead(DefaultChannelPipeline.java:919)
        at io.netty.channel.epoll.AbstractEpollStreamChannel$EpollStreamUnsafe.epollInReady(AbstractEpollStreamChannel.java:795)
        at io.netty.channel.epoll.EpollEventLoop.processReady(EpollEventLoop.java:480)
        at io.netty.channel.epoll.EpollEventLoop.run(EpollEventLoop.java:378)
        at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:989)
        at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
        at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
        at java.base/java.lang.Thread.run(Thread.java:834)
Caused by: javax.net.ssl.SSLHandshakeException: error:10000415:SSL routines:OPENSSL_internal:SSLV3_ALERT_CERTIFICATE_EXPIRED
        at io.netty.handler.ssl.ReferenceCountedOpenSslEngine.shutdownWithError(ReferenceCountedOpenSslEngine.java:1069)
        at io.netty.handler.ssl.ReferenceCountedOpenSslEngine.sslReadErrorResult(ReferenceCountedOpenSslEngine.java:1359)
        at io.netty.handler.ssl.ReferenceCountedOpenSslEngine.unwrap(ReferenceCountedOpenSslEngine.java:1308)
        at io.netty.handler.ssl.ReferenceCountedOpenSslEngine.unwrap(ReferenceCountedOpenSslEngine.java:1384)
        at io.netty.handler.ssl.ReferenceCountedOpenSslEngine.unwrap(ReferenceCountedOpenSslEngine.java:1427)
        at io.netty.handler.ssl.SslHandler$SslEngineType$1.unwrap(SslHandler.java:207)
        at io.netty.handler.ssl.SslHandler.unwrap(SslHandler.java:1388)
        at io.netty.handler.ssl.SslHandler.decodeNonJdkCompatible(SslHandler.java:1295)
        at io.netty.handler.ssl.SslHandler.decode(SslHandler.java:1332)
        at io.netty.handler.codec.ByteToMessageDecoder.decodeRemovalReentryProtection(ByteToMessageDecoder.java:508)
        at io.netty.handler.codec.ByteToMessageDecoder.callDecode(ByteToMessageDecoder.java:447)
        ... 15 common frames omitted 
```

### Modification
Pulsar proxy auto refresh certs if cert files are changed and connect with broker with refreshed cert.

