### PR TITLE
[cpp][pulsar-client]Add auth http headers

### DIFF
--- a/pulsar-client-cpp/lib/auth/AuthAthenz.cc
+++ b/pulsar-client-cpp/lib/auth/AuthAthenz.cc
@@ -37,7 +37,8 @@ AuthDataAthenz::AuthDataAthenz(ParamMap& params) {
 bool AuthDataAthenz::hasDataForHttp() { return true; }
 
 std::string AuthDataAthenz::getHttpHeaders() {
-    return ztsClient_->getHeader() + ": " + ztsClient_->getRoleToken();
+    return ztsClient_->getHeader() + ": " + ztsClient_->getRoleToken()
+            + ";X-Pulsar-Auth-Method-Name:" + getAuthMethodName();
 }
 
 bool AuthDataAthenz::hasDataFromCommand() { return true; }

--- a/pulsar-client-cpp/lib/auth/AuthOauth2.cc
+++ b/pulsar-client-cpp/lib/auth/AuthOauth2.cc
@@ -38,7 +38,9 @@ AuthDataOauth2::~AuthDataOauth2() {}
 
 bool AuthDataOauth2::hasDataForHttp() { return true; }
 
-std::string AuthDataOauth2::getHttpHeaders() { return "Authorization: Bearer " + accessToken_; }
+std::string AuthDataOauth2::getHttpHeaders() {
+    return "Authorization: Bearer " + accessToken_ + ";X-Pulsar-Auth-Method-Name:" + getAuthMethodName();
+}
 
 bool AuthDataOauth2::hasDataFromCommand() { return true; }
 

--- a/pulsar-client-cpp/lib/auth/AuthTls.cc
+++ b/pulsar-client-cpp/lib/auth/AuthTls.cc
@@ -28,6 +28,10 @@ AuthDataTls::~AuthDataTls() {}
 
 bool AuthDataTls::hasDataForTls() { return true; }
 
+std::string AuthDataTls::getHttpHeaders() {
+    return "X-Pulsar-Auth-Method-Name:" + getAuthMethodName();
+}
+
 std::string AuthDataTls::getTlsCertificates() { return tlsCertificate_; }
 
 std::string AuthDataTls::getTlsPrivateKey() { return tlsPrivateKey_; }

--- a/pulsar-client-cpp/lib/auth/AuthToken.cc
+++ b/pulsar-client-cpp/lib/auth/AuthToken.cc
@@ -35,7 +35,9 @@ AuthDataToken::~AuthDataToken() {}
 
 bool AuthDataToken::hasDataForHttp() { return true; }
 
-std::string AuthDataToken::getHttpHeaders() { return "Authorization: Bearer " + tokenSupplier_(); }
+std::string AuthDataToken::getHttpHeaders() {
+    return "Authorization: Bearer " + tokenSupplier_() + ";X-Pulsar-Auth-Method-Name:" + getAuthMethodName();
+}
 
 bool AuthDataToken::hasDataFromCommand() { return true; }
 


### PR DESCRIPTION


Fixes #<xyz>

*(or if this PR is one task of a github issue, please add `Master Issue: #<xyz>` to link to the master issue.)*

Master Issue: #<xyz>

### Motivation

On the broker side, `X-Pulsar-Auth-Method` https://github.com/apache/pulsar/blob/4dcb166e0bfcce7fc85fd8d59a25b881f6f9c6fa/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authentication/AuthenticationService.java#L90 is currently used to determine the authentication method of the client, so add the auth method header for the cpp client

### Modifications

* Add header `X-Pulsar-Auth-Method-Name`

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API: (yes / no)
  - The schema: (yes / no / don't know)
  - The default values of configurations: (yes / no)
  - The wire protocol: (yes / no)
  - The rest endpoints: (yes / no)
  - The admin cli options: (yes / no)
  - Anything that affects deployment: (yes / no / don't know)

### Documentation

Check the box below or label this PR directly (if you have committer privilege).

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [ ] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)


