### PR TITLE
[Doc] Fix doc for the wrong default value of `maxPendingChunkedMessage`

### DIFF
--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/ConsumerBuilder.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/ConsumerBuilder.java
@@ -687,7 +687,7 @@ public interface ConsumerBuilder<T> extends Cloneable {
      * the outstanding unchunked-messages by silently acking or asking broker to redeliver later by marking it unacked.
      * This behavior can be controlled by configuration: @autoAckOldestChunkedMessageOnQueueFull
      *
-     * @default 100
+     * The default value is 10.
      *
      * @param maxPendingChuckedMessage
      * @return
@@ -712,7 +712,7 @@ public interface ConsumerBuilder<T> extends Cloneable {
      * the outstanding unchunked-messages by silently acking or asking broker to redeliver later by marking it unacked.
      * This behavior can be controlled by configuration: @autoAckOldestChunkedMessageOnQueueFull
      *
-     * @default 100
+     * The default value is 10.
      *
      * @param maxPendingChunkedMessage
      * @return


### PR DESCRIPTION
### Motivation

There are inconsistencies between the code and the documentation regarding the default value of maxPendingChunkedMessage.

Here is the discussion thread in the mailing list: https://lists.apache.org/thread/w4vfb5jd5xo9dndhrt7655pbhxn5xdvk

### Modifications

* Fix the wrong default value of `maxPendingChunkedMessage`. Use `10` as the default value.

### Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

### Documentation
  
- [x] `doc` 
  

