### PR TITLE
[Pulsar-Perf] Allow configuring `metadataStoreUrl` in `pulsar-perf managed-ledger`

### DIFF
--- a/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/ManagedLedgerWriter.java
+++ b/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/ManagedLedgerWriter.java
@@ -99,7 +99,8 @@ public class ManagedLedgerWriter {
         public int numThreads = 1;
 
         @Parameter(names = {"-zk", "--zookeeperServers"},
-                description = "ZooKeeper connection string")
+                description = "ZooKeeper connection string",
+                hidden = true)
         public String zookeeperServers;
 
         @Parameter(names = {"-md",

--- a/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/ManagedLedgerWriter.java
+++ b/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/ManagedLedgerWriter.java
@@ -98,6 +98,7 @@ public class ManagedLedgerWriter {
                 description = "Number of threads writing", validateWith = PositiveNumberParameterValidator.class)
         public int numThreads = 1;
 
+        @Deprecated
         @Parameter(names = {"-zk", "--zookeeperServers"},
                 description = "ZooKeeper connection string",
                 hidden = true)

--- a/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/ManagedLedgerWriter.java
+++ b/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/ManagedLedgerWriter.java
@@ -156,6 +156,12 @@ public class ManagedLedgerWriter {
             PerfClientUtils.exit(-1);
         }
 
+        if (arguments.metadataStoreUrl == null && arguments.zookeeperServers == null) {
+            System.err.println("Metadata store address argument is required (--metadata-store)");
+            jc.usage();
+            PerfClientUtils.exit(1);
+        }
+
         // Dump config variables
         PerfClientUtils.printJVMInformation(log);
         ObjectMapper m = new ObjectMapper();


### PR DESCRIPTION
Master Issue: #13760

### Motivation

As per #13760, `zookeeperServers` need to be renamed to `metadataStoreUrl`.

### Modifications

* Add `metadataStoreUrl` parameter to ManagedLedgerWriter of the pulsar perf.

### Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

- [x] `doc-required` 
  

