### PR TITLE
PIP 45: Deprecate zookeeper settings

### DIFF
--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -121,14 +121,14 @@ maxTenants=0
 # Enable cluster's failure-domain which can distribute brokers into logical region
 failureDomainsEnabled=false
 
-# Zookeeper session timeout in milliseconds
-zooKeeperSessionTimeoutMillis=30000
+# Metadata store session timeout in milliseconds
+metadataStoreSessionTimeoutMillis=30000
 
-# ZooKeeper operation timeout in seconds
-zooKeeperOperationTimeoutSeconds=30
+# Metadata store operation timeout in seconds
+metadataStoreOperationTimeoutSeconds=30
 
-# ZooKeeper cache expiry time in seconds
-zooKeeperCacheExpirySeconds=300
+# Metadata store cache expiry time in seconds
+metadataStoreCacheExpirySeconds=300
 
 # Time to wait for broker graceful shutdown. After this time elapses, the process will be killed
 brokerShutdownTimeoutMs=60000
@@ -1403,6 +1403,17 @@ zookeeperServers=
 globalZookeeperServers=
 configurationStoreServers=
 
+# Zookeeper session timeout in milliseconds
+# Deprecated: use metadataStoreSessionTimeoutMillis
+zooKeeperSessionTimeoutMillis=30000
+
+# ZooKeeper operation timeout in seconds
+# Deprecated: use metadataStoreOperationTimeoutSeconds
+zooKeeperOperationTimeoutSeconds=30
+
+# ZooKeeper cache expiry time in seconds
+# Deprecated: use metadataStoreCacheExpirySeconds
+zooKeeperCacheExpirySeconds=300
 
 # Deprecated - Enable TLS when talking with other clusters to replicate messages
 replicationTlsEnabled=false

--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -1405,15 +1405,15 @@ configurationStoreServers=
 
 # Zookeeper session timeout in milliseconds
 # Deprecated: use metadataStoreSessionTimeoutMillis
-zooKeeperSessionTimeoutMillis=30000
+zooKeeperSessionTimeoutMillis=-1
 
 # ZooKeeper operation timeout in seconds
 # Deprecated: use metadataStoreOperationTimeoutSeconds
-zooKeeperOperationTimeoutSeconds=30
+zooKeeperOperationTimeoutSeconds=-1
 
 # ZooKeeper cache expiry time in seconds
 # Deprecated: use metadataStoreCacheExpirySeconds
-zooKeeperCacheExpirySeconds=300
+zooKeeperCacheExpirySeconds=-1
 
 # Deprecated - Enable TLS when talking with other clusters to replicate messages
 replicationTlsEnabled=false

--- a/conf/functions_worker.yml
+++ b/conf/functions_worker.yml
@@ -343,8 +343,8 @@ configurationStoreServers: localhost:2181
 
 # ZooKeeper session timeout in milliseconds
 # Deprecated: use metadataStoreSessionTimeoutMillis
-zooKeeperSessionTimeoutMillis: 30000
+zooKeeperSessionTimeoutMillis: -1
 
 # ZooKeeper operation timeout in seconds
 # Deprecated: use metadataStoreOperationTimeoutSeconds
-zooKeeperOperationTimeoutSeconds: 30
+zooKeeperOperationTimeoutSeconds: -1

--- a/conf/functions_worker.yml
+++ b/conf/functions_worker.yml
@@ -32,10 +32,15 @@ workerPortTls: 6751
 # * my-zk-1:2181,my-zk-2:2181,my-zk-3:2181 (will default to ZooKeeper when the schema is not specified)
 # * zk:my-zk-1:2181,my-zk-2:2181,my-zk-3:2181/my-chroot-path (to add a ZK chroot path)
 configurationMetadataStoreUrl: zk:localhost:2181
-# ZooKeeper session timeout in milliseconds
-zooKeeperSessionTimeoutMillis: 30000
-# ZooKeeper operation timeout in seconds
-zooKeeperOperationTimeoutSeconds: 30
+
+# Metadata store session timeout in milliseconds
+metadataStoreSessionTimeoutMillis: 30000
+
+# Metadata store operation timeout in seconds
+metadataStoreOperationTimeoutSeconds: 30
+
+# Metadata store cache expiry time in seconds
+metadataStoreCacheExpirySeconds: 300
 
 ################################
 # Function package management
@@ -335,3 +340,11 @@ initializedDlogMetadata: false
 
 ### --- Deprecated settings --- ###
 configurationStoreServers: localhost:2181
+
+# ZooKeeper session timeout in milliseconds
+# Deprecated: use metadataStoreSessionTimeoutMillis
+zooKeeperSessionTimeoutMillis: 30000
+
+# ZooKeeper operation timeout in seconds
+# Deprecated: use metadataStoreOperationTimeoutSeconds
+zooKeeperOperationTimeoutSeconds: 30

--- a/conf/proxy.conf
+++ b/conf/proxy.conf
@@ -41,11 +41,11 @@ brokerWebServiceURLTLS=
 functionWorkerWebServiceURL=
 functionWorkerWebServiceURLTLS=
 
-# ZooKeeper session timeout (in milliseconds)
-zookeeperSessionTimeoutMs=30000
+# Metadata store session timeout in milliseconds
+metadataStoreSessionTimeoutMillis=30000
 
-# ZooKeeper cache expiry time in seconds
-zooKeeperCacheExpirySeconds=300
+# Metadata store cache expiry time in seconds
+metadataStoreCacheExpirySeconds=300
 
 ### --- Server --- ###
 
@@ -262,3 +262,11 @@ zookeeperServers=
 
 # Configuration store connection string (as a comma-separated list)
 configurationStoreServers=
+
+# ZooKeeper session timeout (in milliseconds)
+# Deprecated: use metadataStoreSessionTimeoutMillis
+zookeeperSessionTimeoutMs=30000
+
+# ZooKeeper cache expiry time in seconds
+# Deprecated: use metadataStoreCacheExpirySeconds
+zooKeeperCacheExpirySeconds=300

--- a/conf/proxy.conf
+++ b/conf/proxy.conf
@@ -265,8 +265,8 @@ configurationStoreServers=
 
 # ZooKeeper session timeout (in milliseconds)
 # Deprecated: use metadataStoreSessionTimeoutMillis
-zookeeperSessionTimeoutMs=30000
+zookeeperSessionTimeoutMs=-1
 
 # ZooKeeper cache expiry time in seconds
 # Deprecated: use metadataStoreCacheExpirySeconds
-zooKeeperCacheExpirySeconds=300
+zooKeeperCacheExpirySeconds=-1

--- a/conf/standalone.conf
+++ b/conf/standalone.conf
@@ -72,14 +72,14 @@ clusterName=standalone
 # Enable cluster's failure-domain which can distribute brokers into logical region
 failureDomainsEnabled=false
 
-# Zookeeper session timeout in milliseconds
-zooKeeperSessionTimeoutMillis=30000
+# Metadata store session timeout in milliseconds
+metadataStoreSessionTimeoutMillis=30000
 
-# ZooKeeper operation timeout in seconds
-zooKeeperOperationTimeoutSeconds=30
+# Metadata store operation timeout in seconds
+metadataStoreOperationTimeoutSeconds=30
 
-# ZooKeeper cache expiry time in seconds
-zooKeeperCacheExpirySeconds=300
+# Metadata store cache expiry time in seconds
+metadataStoreCacheExpirySeconds=300
 
 # Time to wait for broker graceful shutdown. After this time elapses, the process will be killed
 brokerShutdownTimeoutMs=60000
@@ -1044,3 +1044,19 @@ packagesReplicas=1
 packagesManagementLedgerRootPath=/ledgers
 
 ### --- Packages management service configuration variables (end) --- ###
+
+### --- Deprecated settings --- ###
+
+# These settings are left here for compatibility
+
+# Zookeeper session timeout in milliseconds
+# Deprecated: use metadataStoreSessionTimeoutMillis
+zooKeeperSessionTimeoutMillis=-1
+
+# ZooKeeper operation timeout in seconds
+# Deprecated: use metadataStoreOperationTimeoutSeconds
+zooKeeperOperationTimeoutSeconds=-1
+
+# ZooKeeper cache expiry time in seconds
+# Deprecated: use metadataStoreCacheExpirySeconds
+zooKeeperCacheExpirySeconds=-1

--- a/conf/websocket.conf
+++ b/conf/websocket.conf
@@ -130,8 +130,8 @@ configurationStoreServers=
 
 # Zookeeper session timeout in milliseconds
 # Deprecated: use metadataStoreSessionTimeoutMillis
-zooKeeperSessionTimeoutMillis=30000
+zooKeeperSessionTimeoutMillis=-1
 
 # ZooKeeper cache expiry time in seconds
 # Deprecated: use metadataStoreCacheExpirySeconds
-zooKeeperCacheExpirySeconds=300
+zooKeeperCacheExpirySeconds=-1

--- a/conf/websocket.conf
+++ b/conf/websocket.conf
@@ -22,10 +22,11 @@
 # Configuration Store connection string
 configurationMetadataStoreUrl=
 
-# Zookeeper session timeout in milliseconds
-zooKeeperSessionTimeoutMillis=30000
-# ZooKeeper cache expiry time in seconds
-zooKeeperCacheExpirySeconds=300
+# Metadata store session timeout in milliseconds
+metadataStoreSessionTimeoutMillis=30000
+
+# Metadata store cache expiry time in seconds
+metadataStoreCacheExpirySeconds=300
 
 # Pulsar cluster url to connect to broker (optional if configurationStoreServers present)
 serviceUrl=
@@ -126,3 +127,11 @@ globalZookeeperServers=
 
 # Deprecated. Use configurationMetadataStoreUrl
 configurationStoreServers=
+
+# Zookeeper session timeout in milliseconds
+# Deprecated: use metadataStoreSessionTimeoutMillis
+zooKeeperSessionTimeoutMillis=30000
+
+# ZooKeeper cache expiry time in seconds
+# Deprecated: use metadataStoreCacheExpirySeconds
+zooKeeperCacheExpirySeconds=300

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -2676,37 +2676,16 @@ public class ServiceConfiguration implements PulsarConfiguration {
         }
     }
 
-    @Deprecated
-    public void setZooKeeperOperationTimeoutSeconds(int zooKeeperOperationTimeoutSeconds) {
-        if (zooKeeperOperationTimeoutSeconds > 0) {
-            this.zooKeeperOperationTimeoutSeconds = zooKeeperOperationTimeoutSeconds;
-            this.metadataStoreOperationTimeoutSeconds = zooKeeperOperationTimeoutSeconds;
-        }
+    public long getMetadataStoreSessionTimeoutMillis() {
+        return zooKeeperSessionTimeoutMillis > 0 ? zooKeeperSessionTimeoutMillis : metadataStoreSessionTimeoutMillis;
     }
 
-    @Deprecated
-    public void setZooKeeperCacheExpirySeconds(int zooKeeperCacheExpirySeconds) {
-        if (zooKeeperCacheExpirySeconds > 0) {
-            this.zooKeeperCacheExpirySeconds = zooKeeperCacheExpirySeconds;
-            this.metadataStoreCacheExpirySeconds = zooKeeperCacheExpirySeconds;
-        }
+    public int getMetadataStoreOperationTimeoutSeconds() {
+        return zooKeeperOperationTimeoutSeconds > 0 ? zooKeeperOperationTimeoutSeconds
+                : metadataStoreOperationTimeoutSeconds;
     }
 
-    public void setMetadataStoreSessionTimeoutMillis(long metadataStoreSessionTimeoutMillis) {
-        if (zooKeeperSessionTimeoutMillis == -1) {
-            this.metadataStoreSessionTimeoutMillis = metadataStoreSessionTimeoutMillis;
-        }
-    }
-
-    public void setMetadataStoreOperationTimeoutSeconds(int metadataStoreOperationTimeoutSeconds) {
-        if (zooKeeperOperationTimeoutSeconds == -1) {
-            this.metadataStoreOperationTimeoutSeconds = metadataStoreOperationTimeoutSeconds;
-        }
-    }
-
-    public void setMetadataStoreCacheExpirySeconds(int metadataStoreCacheExpirySeconds) {
-        if (zooKeeperCacheExpirySeconds == -1) {
-            this.metadataStoreCacheExpirySeconds = metadataStoreCacheExpirySeconds;
-        }
+    public int getMetadataStoreCacheExpirySeconds() {
+        return zooKeeperCacheExpirySeconds > 0 ? zooKeeperCacheExpirySeconds : metadataStoreCacheExpirySeconds;
     }
 }

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -2668,14 +2668,6 @@ public class ServiceConfiguration implements PulsarConfiguration {
         return schemaCompatibilityStrategy;
     }
 
-    @Deprecated
-    public void setZooKeeperSessionTimeoutMillis(long zooKeeperSessionTimeoutMillis) {
-        if (zooKeeperSessionTimeoutMillis > 0) {
-            this.zooKeeperSessionTimeoutMillis = zooKeeperSessionTimeoutMillis;
-            this.metadataStoreSessionTimeoutMillis = zooKeeperSessionTimeoutMillis;
-        }
-    }
-
     public long getMetadataStoreSessionTimeoutMillis() {
         return zooKeeperSessionTimeoutMillis > 0 ? zooKeeperSessionTimeoutMillis : metadataStoreSessionTimeoutMillis;
     }

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -329,6 +329,7 @@ public class ServiceConfiguration implements PulsarConfiguration {
         doc = "Name of the cluster to which this broker belongs to"
     )
     private String clusterName;
+
     @FieldContext(
         category = CATEGORY_SERVER,
         dynamic = true,
@@ -336,39 +337,70 @@ public class ServiceConfiguration implements PulsarConfiguration {
                 + "This configuration is not precise control, in a concurrent scenario, the threshold will be exceeded."
     )
     private int maxTenants = 0;
+
     @FieldContext(
         category = CATEGORY_SERVER,
         dynamic = true,
         doc = "Enable cluster's failure-domain which can distribute brokers into logical region"
     )
     private boolean failureDomainsEnabled = false;
+
+    @Deprecated
     @FieldContext(
         category = CATEGORY_SERVER,
-        doc = "ZooKeeper session timeout in milliseconds"
+        doc = "ZooKeeper session timeout in milliseconds. "
+                + "@deprecated - Use metadataStoreSessionTimeoutMillis instead."
     )
     private long zooKeeperSessionTimeoutMillis = 30000;
+
+    @Deprecated
     @FieldContext(
             category = CATEGORY_SERVER,
-            doc = "ZooKeeper operation timeout in seconds"
+            doc = "ZooKeeper operation timeout in seconds. "
+                    + "@deprecated - Use metadataStoreOperationTimeoutSeconds instead."
         )
     private int zooKeeperOperationTimeoutSeconds = 30;
+
+    @Deprecated
     @FieldContext(
             category = CATEGORY_SERVER,
-            doc = "ZooKeeper cache expiry time in seconds"
+            doc = "ZooKeeper cache expiry time in seconds. "
+                    + "@deprecated - Use metadataStoreCacheExpirySeconds instead."
         )
     private int zooKeeperCacheExpirySeconds = 300;
+
+    @FieldContext(
+            category = CATEGORY_SERVER,
+            doc = "Metadata store session timeout in milliseconds."
+    )
+    private long metadataStoreSessionTimeoutMillis = 30000;
+
+    @FieldContext(
+            category = CATEGORY_SERVER,
+            doc = "Metadata store operation timeout in seconds."
+    )
+    private int metadataStoreOperationTimeoutSeconds = 30;
+
+    @FieldContext(
+            category = CATEGORY_SERVER,
+            doc = "Metadata store cache expiry time in seconds."
+    )
+    private int metadataStoreCacheExpirySeconds = 300;
+
     @FieldContext(
         category = CATEGORY_SERVER,
         dynamic = true,
         doc = "Time to wait for broker graceful shutdown. After this time elapses, the process will be killed"
     )
     private long brokerShutdownTimeoutMs = 60000;
+
     @FieldContext(
         category = CATEGORY_SERVER,
         dynamic = true,
         doc = "Flag to skip broker shutdown when broker handles Out of memory error"
     )
     private boolean skipBrokerShutdownOnOOM = false;
+
     @FieldContext(
             category = CATEGORY_SERVER,
             doc = "Amount of seconds to timeout when loading a topic. In situations with many geo-replicated clusters, "
@@ -2631,5 +2663,17 @@ public class ServiceConfiguration implements PulsarConfiguration {
             return SchemaCompatibilityStrategy.FULL;
         }
         return schemaCompatibilityStrategy;
+    }
+
+    public void setZooKeeperSessionTimeoutMillis(long zooKeeperSessionTimeoutMillis) {
+        this.metadataStoreSessionTimeoutMillis = zooKeeperSessionTimeoutMillis;
+    }
+
+    public void setZooKeeperOperationTimeoutSeconds(int zooKeeperOperationTimeoutSeconds) {
+        this.metadataStoreOperationTimeoutSeconds = zooKeeperOperationTimeoutSeconds;
+    }
+
+    public void setZooKeeperCacheExpirySeconds(int zooKeeperCacheExpirySeconds) {
+        this.metadataStoreCacheExpirySeconds = zooKeeperCacheExpirySeconds;
     }
 }

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -345,35 +345,11 @@ public class ServiceConfiguration implements PulsarConfiguration {
     )
     private boolean failureDomainsEnabled = false;
 
-    @Deprecated
-    @FieldContext(
-        category = CATEGORY_SERVER,
-        doc = "ZooKeeper session timeout in milliseconds. "
-                + "@deprecated - Use metadataStoreSessionTimeoutMillis instead."
-    )
-    private long zooKeeperSessionTimeoutMillis = 30000;
-
-    @Deprecated
-    @FieldContext(
-            category = CATEGORY_SERVER,
-            doc = "ZooKeeper operation timeout in seconds. "
-                    + "@deprecated - Use metadataStoreOperationTimeoutSeconds instead."
-        )
-    private int zooKeeperOperationTimeoutSeconds = 30;
-
-    @Deprecated
-    @FieldContext(
-            category = CATEGORY_SERVER,
-            doc = "ZooKeeper cache expiry time in seconds. "
-                    + "@deprecated - Use metadataStoreCacheExpirySeconds instead."
-        )
-    private int zooKeeperCacheExpirySeconds = 300;
-
     @FieldContext(
             category = CATEGORY_SERVER,
             doc = "Metadata store session timeout in milliseconds."
     )
-    private long metadataStoreSessionTimeoutMillis = 30000;
+    private long metadataStoreSessionTimeoutMillis = 30_000;
 
     @FieldContext(
             category = CATEGORY_SERVER,
@@ -386,6 +362,33 @@ public class ServiceConfiguration implements PulsarConfiguration {
             doc = "Metadata store cache expiry time in seconds."
     )
     private int metadataStoreCacheExpirySeconds = 300;
+
+    @Deprecated
+    @FieldContext(
+        category = CATEGORY_SERVER,
+        deprecated = true,
+        doc = "ZooKeeper session timeout in milliseconds. "
+                + "@deprecated - Use metadataStoreSessionTimeoutMillis instead."
+    )
+    private long zooKeeperSessionTimeoutMillis = -1;
+
+    @Deprecated
+    @FieldContext(
+            category = CATEGORY_SERVER,
+            deprecated = true,
+            doc = "ZooKeeper operation timeout in seconds. "
+                    + "@deprecated - Use metadataStoreOperationTimeoutSeconds instead."
+        )
+    private int zooKeeperOperationTimeoutSeconds = -1;
+
+    @Deprecated
+    @FieldContext(
+            category = CATEGORY_SERVER,
+            deprecated = true,
+            doc = "ZooKeeper cache expiry time in seconds. "
+                    + "@deprecated - Use metadataStoreCacheExpirySeconds instead."
+        )
+    private int zooKeeperCacheExpirySeconds = -1;
 
     @FieldContext(
         category = CATEGORY_SERVER,
@@ -2665,15 +2668,45 @@ public class ServiceConfiguration implements PulsarConfiguration {
         return schemaCompatibilityStrategy;
     }
 
+    @Deprecated
     public void setZooKeeperSessionTimeoutMillis(long zooKeeperSessionTimeoutMillis) {
-        this.metadataStoreSessionTimeoutMillis = zooKeeperSessionTimeoutMillis;
+        if (zooKeeperSessionTimeoutMillis > 0) {
+            this.zooKeeperSessionTimeoutMillis = zooKeeperSessionTimeoutMillis;
+            this.metadataStoreSessionTimeoutMillis = zooKeeperSessionTimeoutMillis;
+        }
     }
 
+    @Deprecated
     public void setZooKeeperOperationTimeoutSeconds(int zooKeeperOperationTimeoutSeconds) {
-        this.metadataStoreOperationTimeoutSeconds = zooKeeperOperationTimeoutSeconds;
+        if (zooKeeperOperationTimeoutSeconds > 0) {
+            this.zooKeeperOperationTimeoutSeconds = zooKeeperOperationTimeoutSeconds;
+            this.metadataStoreOperationTimeoutSeconds = zooKeeperOperationTimeoutSeconds;
+        }
     }
 
+    @Deprecated
     public void setZooKeeperCacheExpirySeconds(int zooKeeperCacheExpirySeconds) {
-        this.metadataStoreCacheExpirySeconds = zooKeeperCacheExpirySeconds;
+        if (zooKeeperCacheExpirySeconds > 0) {
+            this.zooKeeperCacheExpirySeconds = zooKeeperCacheExpirySeconds;
+            this.metadataStoreCacheExpirySeconds = zooKeeperCacheExpirySeconds;
+        }
+    }
+
+    public void setMetadataStoreSessionTimeoutMillis(long metadataStoreSessionTimeoutMillis) {
+        if (zooKeeperSessionTimeoutMillis == -1) {
+            this.metadataStoreSessionTimeoutMillis = metadataStoreSessionTimeoutMillis;
+        }
+    }
+
+    public void setMetadataStoreOperationTimeoutSeconds(int metadataStoreOperationTimeoutSeconds) {
+        if (zooKeeperOperationTimeoutSeconds == -1) {
+            this.metadataStoreOperationTimeoutSeconds = metadataStoreOperationTimeoutSeconds;
+        }
+    }
+
+    public void setMetadataStoreCacheExpirySeconds(int metadataStoreCacheExpirySeconds) {
+        if (zooKeeperCacheExpirySeconds == -1) {
+            this.metadataStoreCacheExpirySeconds = metadataStoreCacheExpirySeconds;
+        }
     }
 }

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authorization/AuthorizationService.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authorization/AuthorizationService.java
@@ -199,11 +199,11 @@ public class AuthorizationService {
     public boolean canProduce(TopicName topicName, String role, AuthenticationDataSource authenticationData)
             throws Exception {
         try {
-            return canProduceAsync(topicName, role, authenticationData).get(conf.getZooKeeperOperationTimeoutSeconds(),
-                    SECONDS);
+            return canProduceAsync(topicName, role, authenticationData).get(
+                    conf.getMetadataStoreOperationTimeoutSeconds(), SECONDS);
         } catch (InterruptedException e) {
-            log.warn("Time-out {} sec while checking authorization on {} ", conf.getZooKeeperOperationTimeoutSeconds(),
-                    topicName);
+            log.warn("Time-out {} sec while checking authorization on {} ",
+                    conf.getMetadataStoreOperationTimeoutSeconds(), topicName);
             throw e;
         } catch (Exception e) {
             log.warn("Producer-client  with Role - {} failed to get permissions for topic - {}. {}", role, topicName,
@@ -216,10 +216,10 @@ public class AuthorizationService {
                               String subscription) throws Exception {
         try {
             return canConsumeAsync(topicName, role, authenticationData, subscription)
-                    .get(conf.getZooKeeperOperationTimeoutSeconds(), SECONDS);
+                    .get(conf.getMetadataStoreOperationTimeoutSeconds(), SECONDS);
         } catch (InterruptedException e) {
-            log.warn("Time-out {} sec while checking authorization on {} ", conf.getZooKeeperOperationTimeoutSeconds(),
-                    topicName);
+            log.warn("Time-out {} sec while checking authorization on {} ",
+                    conf.getMetadataStoreOperationTimeoutSeconds(), topicName);
             throw e;
         } catch (Exception e) {
             log.warn("Consumer-client  with Role - {} failed to get permissions for topic - {}. {}", role, topicName,
@@ -242,10 +242,10 @@ public class AuthorizationService {
             throws Exception {
         try {
             return canLookupAsync(topicName, role, authenticationData)
-                    .get(conf.getZooKeeperOperationTimeoutSeconds(), SECONDS);
+                    .get(conf.getMetadataStoreOperationTimeoutSeconds(), SECONDS);
         } catch (InterruptedException e) {
-            log.warn("Time-out {} sec while checking authorization on {} ", conf.getZooKeeperOperationTimeoutSeconds(),
-                    topicName);
+            log.warn("Time-out {} sec while checking authorization on {} ",
+                    conf.getMetadataStoreOperationTimeoutSeconds(), topicName);
             throw e;
         } catch (Exception e) {
             log.warn("Role - {} failed to get lookup permissions for topic - {}. {}", role, topicName,

--- a/pulsar-broker-common/src/test/java/org/apache/pulsar/common/configuration/PulsarConfigurationLoaderTest.java
+++ b/pulsar-broker-common/src/test/java/org/apache/pulsar/common/configuration/PulsarConfigurationLoaderTest.java
@@ -172,10 +172,51 @@ public class PulsarConfigurationLoaderTest {
         }
         testConfigFile.deleteOnExit();
         InputStream stream = new FileInputStream(testConfigFile);
-        final ServiceConfiguration serviceConfig = PulsarConfigurationLoader.create(stream, ServiceConfiguration.class);
+        ServiceConfiguration serviceConfig = PulsarConfigurationLoader.create(stream, ServiceConfiguration.class);
+        stream.close();
         assertEquals(serviceConfig.getMetadataStoreSessionTimeoutMillis(), 60);
         assertEquals(serviceConfig.getMetadataStoreOperationTimeoutSeconds(), 600);
         assertEquals(serviceConfig.getMetadataStoreCacheExpirySeconds(), 500);
+
+        testConfigFile = new File("tmp." + System.currentTimeMillis() + ".properties");
+        if (testConfigFile.exists()) {
+            testConfigFile.delete();
+        }
+        try (PrintWriter printWriter = new PrintWriter(new OutputStreamWriter(new FileOutputStream(testConfigFile)))) {
+            printWriter.println("metadataStoreSessionTimeoutMillis=60");
+            printWriter.println("metadataStoreOperationTimeoutSeconds=600");
+            printWriter.println("metadataStoreCacheExpirySeconds=500");
+            printWriter.println("zooKeeperSessionTimeoutMillis=-1");
+            printWriter.println("zooKeeperOperationTimeoutSeconds=-1");
+            printWriter.println("zooKeeperCacheExpirySeconds=-1");
+        }
+        testConfigFile.deleteOnExit();
+        stream = new FileInputStream(testConfigFile);
+        serviceConfig = PulsarConfigurationLoader.create(stream, ServiceConfiguration.class);
+        stream.close();
+        assertEquals(serviceConfig.getMetadataStoreSessionTimeoutMillis(), 60);
+        assertEquals(serviceConfig.getMetadataStoreOperationTimeoutSeconds(), 600);
+        assertEquals(serviceConfig.getMetadataStoreCacheExpirySeconds(), 500);
+
+        testConfigFile = new File("tmp." + System.currentTimeMillis() + ".properties");
+        if (testConfigFile.exists()) {
+            testConfigFile.delete();
+        }
+        try (PrintWriter printWriter = new PrintWriter(new OutputStreamWriter(new FileOutputStream(testConfigFile)))) {
+            printWriter.println("metadataStoreSessionTimeoutMillis=10");
+            printWriter.println("metadataStoreOperationTimeoutSeconds=20");
+            printWriter.println("metadataStoreCacheExpirySeconds=30");
+            printWriter.println("zooKeeperSessionTimeoutMillis=100");
+            printWriter.println("zooKeeperOperationTimeoutSeconds=200");
+            printWriter.println("zooKeeperCacheExpirySeconds=300");
+        }
+        testConfigFile.deleteOnExit();
+        stream = new FileInputStream(testConfigFile);
+        serviceConfig = PulsarConfigurationLoader.create(stream, ServiceConfiguration.class);
+        stream.close();
+        assertEquals(serviceConfig.getMetadataStoreSessionTimeoutMillis(), 100);
+        assertEquals(serviceConfig.getMetadataStoreOperationTimeoutSeconds(), 200);
+        assertEquals(serviceConfig.getMetadataStoreCacheExpirySeconds(), 300);
     }
 
     @Test

--- a/pulsar-broker-common/src/test/java/org/apache/pulsar/common/configuration/PulsarConfigurationLoaderTest.java
+++ b/pulsar-broker-common/src/test/java/org/apache/pulsar/common/configuration/PulsarConfigurationLoaderTest.java
@@ -28,6 +28,7 @@ import static org.testng.Assert.fail;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
+import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
@@ -109,6 +110,9 @@ public class PulsarConfigurationLoaderTest {
         printWriter.println("managedLedgerDigestType=CRC32C");
         printWriter.println("managedLedgerCacheSizeMB=");
         printWriter.println("bookkeeperDiskWeightBasedPlacementEnabled=true");
+        printWriter.println("metadataStoreSessionTimeoutMillis=60");
+        printWriter.println("metadataStoreOperationTimeoutSeconds=600");
+        printWriter.println("metadataStoreCacheExpirySeconds=500");
         printWriter.close();
         testConfigFile.deleteOnExit();
         InputStream stream = new FileInputStream(testConfigFile);
@@ -126,6 +130,9 @@ public class PulsarConfigurationLoaderTest {
         assertEquals(serviceConfig.getManagedLedgerDigestType(), DigestType.CRC32C);
         assertTrue(serviceConfig.getManagedLedgerCacheSizeMB() > 0);
         assertTrue(serviceConfig.isBookkeeperDiskWeightBasedPlacementEnabled());
+        assertEquals(serviceConfig.getMetadataStoreSessionTimeoutMillis(), 60);
+        assertEquals(serviceConfig.getMetadataStoreOperationTimeoutSeconds(), 600);
+        assertEquals(serviceConfig.getMetadataStoreCacheExpirySeconds(), 500);
     }
 
     @Test
@@ -150,6 +157,25 @@ public class PulsarConfigurationLoaderTest {
         } catch (IllegalArgumentException e) {
             // Ok
         }
+    }
+
+    @Test
+    public void testBackwardCompatibility() throws IOException {
+        File testConfigFile = new File("tmp." + System.currentTimeMillis() + ".properties");
+        if (testConfigFile.exists()) {
+            testConfigFile.delete();
+        }
+        try (PrintWriter printWriter = new PrintWriter(new OutputStreamWriter(new FileOutputStream(testConfigFile)))) {
+            printWriter.println("zooKeeperSessionTimeoutMillis=60");
+            printWriter.println("zooKeeperOperationTimeoutSeconds=600");
+            printWriter.println("zooKeeperCacheExpirySeconds=500");
+        }
+        testConfigFile.deleteOnExit();
+        InputStream stream = new FileInputStream(testConfigFile);
+        final ServiceConfiguration serviceConfig = PulsarConfigurationLoader.create(stream, ServiceConfiguration.class);
+        assertEquals(serviceConfig.getMetadataStoreSessionTimeoutMillis(), 60);
+        assertEquals(serviceConfig.getMetadataStoreOperationTimeoutSeconds(), 600);
+        assertEquals(serviceConfig.getMetadataStoreCacheExpirySeconds(), 500);
     }
 
     @Test

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
@@ -340,7 +340,7 @@ public class PulsarService implements AutoCloseable, ShutdownService {
     public MetadataStore createConfigurationMetadataStore() throws MetadataStoreException {
         return MetadataStoreFactory.create(config.getConfigurationMetadataStoreUrl(),
                 MetadataStoreConfig.builder()
-                        .sessionTimeoutMillis((int) config.getZooKeeperSessionTimeoutMillis())
+                        .sessionTimeoutMillis((int) config.getMetadataStoreSessionTimeoutMillis())
                         .allowReadOnlyOperations(false)
                         .configFilePath(config.getMetadataStoreConfigPath())
                         .batchingEnabled(config.isMetadataStoreBatchingEnabled())
@@ -636,7 +636,7 @@ public class PulsarService implements AutoCloseable, ShutdownService {
                 shouldShutdownConfigurationMetadataStore = false;
             }
             pulsarResources = new PulsarResources(localMetadataStore, configurationMetadataStore,
-                    config.getZooKeeperOperationTimeoutSeconds());
+                    config.getMetadataStoreOperationTimeoutSeconds());
 
             pulsarResources.getClusterResources().getStore().registerListener(this::handleDeleteCluster);
 
@@ -930,7 +930,7 @@ public class PulsarService implements AutoCloseable, ShutdownService {
     public MetadataStoreExtended createLocalMetadataStore() throws MetadataStoreException {
         return MetadataStoreExtended.create(config.getMetadataStoreUrl(),
                 MetadataStoreConfig.builder()
-                        .sessionTimeoutMillis((int) config.getZooKeeperSessionTimeoutMillis())
+                        .sessionTimeoutMillis((int) config.getMetadataStoreSessionTimeoutMillis())
                         .allowReadOnlyOperations(false)
                         .configFilePath(config.getMetadataStoreConfigPath())
                         .batchingEnabled(config.isMetadataStoreBatchingEnabled())
@@ -1080,7 +1080,7 @@ public class PulsarService implements AutoCloseable, ShutdownService {
             long topicLoadStart = System.nanoTime();
 
             for (String topic : getNamespaceService().getListOfPersistentTopics(nsName)
-                    .get(config.getZooKeeperOperationTimeoutSeconds(), TimeUnit.SECONDS)) {
+                    .get(config.getMetadataStoreOperationTimeoutSeconds(), TimeUnit.SECONDS)) {
                 try {
                     TopicName topicName = TopicName.get(topic);
                     if (bundle.includes(topicName) && !isTransactionSystemTopic(topicName)) {
@@ -1402,7 +1402,7 @@ public class PulsarService implements AutoCloseable, ShutdownService {
 
                 // most of the admin request requires to make zk-call so, keep the max read-timeout based on
                 // zk-operation timeout
-                builder.readTimeout(conf.getZooKeeperOperationTimeoutSeconds(), TimeUnit.SECONDS);
+                builder.readTimeout(conf.getMetadataStoreOperationTimeoutSeconds(), TimeUnit.SECONDS);
 
                 this.adminClient = builder.build();
                 LOG.info("created admin with url {} ", adminApiUrl);
@@ -1609,9 +1609,6 @@ public class PulsarService implements AutoCloseable, ShutdownService {
         workerConfig.setAuthorizationEnabled(brokerConfig.isAuthorizationEnabled());
         workerConfig.setAuthorizationProvider(brokerConfig.getAuthorizationProvider());
         workerConfig.setConfigurationMetadataStoreUrl(brokerConfig.getConfigurationMetadataStoreUrl());
-        workerConfig.setZooKeeperSessionTimeoutMillis(brokerConfig.getZooKeeperSessionTimeoutMillis());
-        workerConfig.setZooKeeperOperationTimeoutSeconds(brokerConfig.getZooKeeperOperationTimeoutSeconds());
-
         workerConfig.setTlsAllowInsecureConnection(brokerConfig.isTlsAllowInsecureConnection());
         workerConfig.setTlsEnabled(brokerConfig.isTlsEnabled());
         workerConfig.setTlsEnableHostnameVerification(false);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
@@ -1609,6 +1609,9 @@ public class PulsarService implements AutoCloseable, ShutdownService {
         workerConfig.setAuthorizationEnabled(brokerConfig.isAuthorizationEnabled());
         workerConfig.setAuthorizationProvider(brokerConfig.getAuthorizationProvider());
         workerConfig.setConfigurationMetadataStoreUrl(brokerConfig.getConfigurationMetadataStoreUrl());
+        workerConfig.setMetadataStoreSessionTimeoutMillis(brokerConfig.getMetadataStoreSessionTimeoutMillis());
+        workerConfig.setMetadataStoreOperationTimeoutSeconds(brokerConfig.getMetadataStoreOperationTimeoutSeconds());
+        workerConfig.setMetadataStoreCacheExpirySeconds(brokerConfig.getMetadataStoreCacheExpirySeconds());
         workerConfig.setTlsAllowInsecureConnection(brokerConfig.isTlsAllowInsecureConnection());
         workerConfig.setTlsEnabled(brokerConfig.isTlsEnabled());
         workerConfig.setTlsEnableHostnameVerification(false);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/AdminResource.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/AdminResource.java
@@ -566,7 +566,7 @@ public abstract class AdminResource extends PulsarWebResource {
     protected List<String> getTopicPartitionList(TopicDomain topicDomain) {
         try {
             return getPulsarResources().getTopicResources().getExistingPartitions(topicName)
-                    .get(config().getZooKeeperOperationTimeoutSeconds(), TimeUnit.SECONDS);
+                    .get(config().getMetadataStoreOperationTimeoutSeconds(), TimeUnit.SECONDS);
         } catch (Exception e) {
             log.error("[{}] Failed to get topic partition list for namespace {}", clientAppId(),
                     namespaceName.toString(), e);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/NamespacesBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/NamespacesBase.java
@@ -222,7 +222,7 @@ public abstract class NamespacesBase extends AdminResource {
         List<String> topics;
         try {
             topics = pulsar().getNamespaceService().getListOfPersistentTopics(namespaceName)
-                    .get(config().getZooKeeperOperationTimeoutSeconds(), TimeUnit.SECONDS);
+                    .get(config().getMetadataStoreOperationTimeoutSeconds(), TimeUnit.SECONDS);
             topics.addAll(getPartitionedTopicList(TopicDomain.persistent));
             topics.addAll(getPartitionedTopicList(TopicDomain.non_persistent));
             isEmpty = topics.isEmpty();
@@ -401,7 +401,7 @@ public abstract class NamespacesBase extends AdminResource {
         List<String> topics;
         try {
             topics = pulsar().getNamespaceService().getFullListOfTopics(namespaceName)
-                    .get(config().getZooKeeperOperationTimeoutSeconds(), TimeUnit.SECONDS);
+                    .get(config().getMetadataStoreOperationTimeoutSeconds(), TimeUnit.SECONDS);
         } catch (Exception e) {
             asyncResponse.resume(new RestException(e));
             return;
@@ -581,7 +581,7 @@ public abstract class NamespacesBase extends AdminResource {
             NamespaceBundle bundle = validateNamespaceBundleOwnership(namespaceName, policies.bundles, bundleRange,
                 authoritative, true);
             List<String> topics = pulsar().getNamespaceService().getListOfPersistentTopics(namespaceName)
-                    .get(config().getZooKeeperOperationTimeoutSeconds(), TimeUnit.SECONDS);
+                    .get(config().getMetadataStoreOperationTimeoutSeconds(), TimeUnit.SECONDS);
             for (String topic : topics) {
                 NamespaceBundle topicBundle = pulsar().getNamespaceService()
                         .getBundle(TopicName.get(topic));

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
@@ -3865,7 +3865,7 @@ public class PersistentTopicsBase extends AdminResource {
     private Topic getTopicReference(TopicName topicName) {
         try {
             return pulsar().getBrokerService().getTopicIfExists(topicName.toString())
-                    .get(pulsar().getConfiguration().getZooKeeperOperationTimeoutSeconds(), TimeUnit.SECONDS)
+                    .get(pulsar().getConfiguration().getMetadataStoreOperationTimeoutSeconds(), TimeUnit.SECONDS)
                     .orElseThrow(() -> topicNotFoundReason(topicName));
         } catch (RestException e) {
             throw e;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/ResourceQuotasBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/ResourceQuotasBase.java
@@ -32,7 +32,7 @@ public abstract class ResourceQuotasBase extends NamespacesBase {
         validateSuperUserAccess();
         try {
             return pulsar().getBrokerService().getBundlesQuotas().getDefaultResourceQuota()
-                    .get(config().getZooKeeperOperationTimeoutSeconds(), TimeUnit.SECONDS);
+                    .get(config().getMetadataStoreOperationTimeoutSeconds(), TimeUnit.SECONDS);
         } catch (Exception e) {
             log.error("[{}] Failed to get default resource quota", clientAppId());
             throw new RestException(e);
@@ -44,7 +44,7 @@ public abstract class ResourceQuotasBase extends NamespacesBase {
         validatePoliciesReadOnlyAccess();
         try {
             pulsar().getBrokerService().getBundlesQuotas().setDefaultResourceQuota(quota)
-                    .get(config().getZooKeeperOperationTimeoutSeconds(), TimeUnit.SECONDS);
+                    .get(config().getMetadataStoreOperationTimeoutSeconds(), TimeUnit.SECONDS);
         } catch (Exception e) {
             log.error("[{}] Failed to get default resource quota", clientAppId());
             throw new RestException(e);
@@ -66,7 +66,7 @@ public abstract class ResourceQuotasBase extends NamespacesBase {
 
         try {
             return pulsar().getBrokerService().getBundlesQuotas().getResourceQuota(nsBundle)
-                    .get(config().getZooKeeperOperationTimeoutSeconds(), TimeUnit.SECONDS);
+                    .get(config().getMetadataStoreOperationTimeoutSeconds(), TimeUnit.SECONDS);
         } catch (Exception e) {
             log.error("[{}] Failed to get resource quota for namespace bundle {}", clientAppId(), nsBundle.toString());
             throw new RestException(e);
@@ -89,7 +89,7 @@ public abstract class ResourceQuotasBase extends NamespacesBase {
 
         try {
             pulsar().getBrokerService().getBundlesQuotas().setResourceQuota(nsBundle, quota)
-                    .get(config().getZooKeeperOperationTimeoutSeconds(), TimeUnit.SECONDS);
+                    .get(config().getMetadataStoreOperationTimeoutSeconds(), TimeUnit.SECONDS);
             log.info("[{}] Successfully set resource quota for namespace bundle {}", clientAppId(),
                     nsBundle.toString());
         } catch (Exception e) {
@@ -115,7 +115,7 @@ public abstract class ResourceQuotasBase extends NamespacesBase {
 
         try {
             pulsar().getBrokerService().getBundlesQuotas().resetResourceQuota(nsBundle)
-                    .get(config().getZooKeeperOperationTimeoutSeconds(), TimeUnit.SECONDS);
+                    .get(config().getMetadataStoreOperationTimeoutSeconds(), TimeUnit.SECONDS);
             log.info("[{}] Successfully unset resource quota for namespace bundle {}", clientAppId(),
                     nsBundle.toString());
         } catch (Exception e) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v1/NonPersistentTopics.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v1/NonPersistentTopics.java
@@ -276,7 +276,7 @@ public class NonPersistentTopics extends PersistentTopics {
         NamespaceName fqnn = NamespaceName.get(property, cluster, namespace);
         try {
             if (!isBundleOwnedByAnyBroker(fqnn, policies.bundles, bundleRange)
-                .get(pulsar().getConfig().getZooKeeperOperationTimeoutSeconds(), TimeUnit.SECONDS)) {
+                .get(pulsar().getConfig().getMetadataStoreOperationTimeoutSeconds(), TimeUnit.SECONDS)) {
                 log.info("[{}] Namespace bundle is not owned by any broker {}/{}/{}/{}", clientAppId(), property,
                     cluster, namespace, bundleRange);
                 return null;
@@ -302,7 +302,7 @@ public class NonPersistentTopics extends PersistentTopics {
     private Topic getTopicReference(TopicName topicName) {
         try {
             return pulsar().getBrokerService().getTopicIfExists(topicName.toString())
-                    .get(config().getZooKeeperOperationTimeoutSeconds(), TimeUnit.SECONDS)
+                    .get(config().getMetadataStoreOperationTimeoutSeconds(), TimeUnit.SECONDS)
                     .orElseThrow(() -> new RestException(Status.NOT_FOUND, "Topic not found"));
         } catch (ExecutionException e) {
             throw new RuntimeException(e.getCause());

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/NonPersistentTopics.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/NonPersistentTopics.java
@@ -539,7 +539,7 @@ public class NonPersistentTopics extends PersistentTopics {
     private Topic getTopicReference(TopicName topicName) {
         try {
             return pulsar().getBrokerService().getTopicIfExists(topicName.toString())
-                    .get(config().getZooKeeperOperationTimeoutSeconds(), TimeUnit.SECONDS)
+                    .get(config().getMetadataStoreOperationTimeoutSeconds(), TimeUnit.SECONDS)
                     .orElseThrow(() -> new RestException(Status.NOT_FOUND, "Topic not found"));
         } catch (ExecutionException e) {
             throw new RestException(e.getCause());

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/NamespaceService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/NamespaceService.java
@@ -259,7 +259,7 @@ public class NamespaceService implements AutoCloseable {
      */
     public Optional<URL> getWebServiceUrl(ServiceUnitId suName, LookupOptions options) throws Exception {
         return getWebServiceUrlAsync(suName, options)
-                .get(pulsar.getConfiguration().getZooKeeperOperationTimeoutSeconds(), SECONDS);
+                .get(pulsar.getConfiguration().getMetadataStoreOperationTimeoutSeconds(), SECONDS);
     }
 
     private CompletableFuture<Optional<URL>> internalGetWebServiceUrl(NamespaceBundle bundle, LookupOptions options) {
@@ -1011,8 +1011,8 @@ public class NamespaceService implements AutoCloseable {
     }
 
     public void removeOwnedServiceUnit(NamespaceBundle nsBundle) throws Exception {
-        ownershipCache.removeOwnership(nsBundle).get(pulsar.getConfiguration().getZooKeeperOperationTimeoutSeconds(),
-                SECONDS);
+        ownershipCache.removeOwnership(nsBundle).get(
+                pulsar.getConfiguration().getMetadataStoreOperationTimeoutSeconds(), SECONDS);
         bundleFactory.invalidateBundleCache(nsBundle.getNamespaceObject());
     }
 
@@ -1247,7 +1247,7 @@ public class NamespaceService implements AutoCloseable {
 
     public Optional<NamespaceEphemeralData> getOwner(NamespaceBundle bundle) throws Exception {
         // if there is no znode for the service unit, it is not owned by any broker
-        return getOwnerAsync(bundle).get(pulsar.getConfiguration().getZooKeeperOperationTimeoutSeconds(), SECONDS);
+        return getOwnerAsync(bundle).get(pulsar.getConfiguration().getMetadataStoreOperationTimeoutSeconds(), SECONDS);
     }
 
     public CompletableFuture<Optional<NamespaceEphemeralData>> getOwnerAsync(NamespaceBundle bundle) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/OwnershipCache.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/OwnershipCache.java
@@ -266,7 +266,8 @@ public class OwnershipCache {
 
         if (future != null && future.isDone() && !future.isCompletedExceptionally()) {
             try {
-                return future.get(pulsar.getConfiguration().getZooKeeperOperationTimeoutSeconds(), TimeUnit.SECONDS);
+                return future.get(pulsar.getConfiguration().getMetadataStoreOperationTimeoutSeconds(),
+                        TimeUnit.SECONDS);
             } catch (InterruptedException | TimeoutException e) {
                 throw new RuntimeException(e);
             } catch (ExecutionException e) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
@@ -1264,7 +1264,7 @@ public class BrokerService implements Closeable {
 
                 // most of the admin request requires to make zk-call so, keep the max read-timeout based on
                 // zk-operation timeout
-                builder.readTimeout(conf.getZooKeeperOperationTimeoutSeconds(), TimeUnit.SECONDS);
+                builder.readTimeout(conf.getMetadataStoreOperationTimeoutSeconds(), TimeUnit.SECONDS);
 
                 PulsarAdmin adminClient = builder.build();
                 log.info("created admin with url {} ", adminApiUrl);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/PulsarWebResource.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/PulsarWebResource.java
@@ -233,7 +233,7 @@ public abstract class PulsarWebResource {
      */
     public void validateSuperUserAccess() {
         try {
-            validateSuperUserAccessAsync().get(config().getZooKeeperOperationTimeoutSeconds(), SECONDS);
+            validateSuperUserAccessAsync().get(config().getMetadataStoreOperationTimeoutSeconds(), SECONDS);
         } catch (InterruptedException | ExecutionException | TimeoutException e) {
             Throwable realCause = FutureUtil.unwrapCompletionException(e);
             if (realCause instanceof WebApplicationException){
@@ -403,7 +403,7 @@ public abstract class PulsarWebResource {
      */
     protected void validateClusterOwnership(String cluster) throws WebApplicationException {
         try {
-            validateClusterOwnershipAsync(cluster).get(config().getZooKeeperOperationTimeoutSeconds(), SECONDS);
+            validateClusterOwnershipAsync(cluster).get(config().getMetadataStoreOperationTimeoutSeconds(), SECONDS);
         } catch (InterruptedException | ExecutionException | TimeoutException ex) {
             Throwable realCause = FutureUtil.unwrapCompletionException(ex);
             if (realCause instanceof WebApplicationException){
@@ -696,7 +696,7 @@ public abstract class PulsarWebResource {
      * @throws Exception
      */
     protected void validateGlobalNamespaceOwnership(NamespaceName namespace) {
-        int timeout = pulsar().getConfiguration().getZooKeeperOperationTimeoutSeconds();
+        int timeout = pulsar().getConfiguration().getMetadataStoreOperationTimeoutSeconds();
         try {
             ClusterDataImpl peerClusterData = checkLocalOrGetPeerReplicationCluster(pulsar(), namespace)
                     .get(timeout, SECONDS);
@@ -865,7 +865,7 @@ public abstract class PulsarWebResource {
 
     public void validateTenantOperation(String tenant, TenantOperation operation) {
         try {
-            int timeout = pulsar().getConfiguration().getZooKeeperOperationTimeoutSeconds();
+            int timeout = pulsar().getConfiguration().getMetadataStoreOperationTimeoutSeconds();
             validateTenantOperationAsync(tenant, operation).get(timeout, SECONDS);
         } catch (InterruptedException | TimeoutException e) {
             throw new RestException(e);
@@ -904,7 +904,7 @@ public abstract class PulsarWebResource {
 
     public void validateNamespaceOperation(NamespaceName namespaceName, NamespaceOperation operation) {
         try {
-            int timeout = pulsar().getConfiguration().getZooKeeperOperationTimeoutSeconds();
+            int timeout = pulsar().getConfiguration().getMetadataStoreOperationTimeoutSeconds();
             validateNamespaceOperationAsync(namespaceName, operation).get(timeout, SECONDS);
         } catch (InterruptedException | TimeoutException e) {
             throw new RestException(e);
@@ -1085,7 +1085,7 @@ public abstract class PulsarWebResource {
 
     public void validateTopicPolicyOperation(TopicName topicName, PolicyName policy, PolicyOperation operation) {
         try {
-            int timeout = pulsar().getConfiguration().getZooKeeperOperationTimeoutSeconds();
+            int timeout = pulsar().getConfiguration().getMetadataStoreOperationTimeoutSeconds();
             validateTopicPolicyOperationAsync(topicName, policy, operation).get(timeout, SECONDS);
         } catch (InterruptedException | TimeoutException e) {
             throw new RestException(e);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/compaction/CompactorTool.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/compaction/CompactorTool.java
@@ -133,7 +133,7 @@ public class CompactorTool {
         @Cleanup
         MetadataStoreExtended store = MetadataStoreExtended.create(brokerConfig.getMetadataStoreUrl(),
                 MetadataStoreConfig.builder()
-                        .sessionTimeoutMillis((int) brokerConfig.getZooKeeperSessionTimeoutMillis())
+                        .sessionTimeoutMillis((int) brokerConfig.getMetadataStoreSessionTimeoutMillis())
                         .build());
 
         @Cleanup

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BkEnsemblesTestBase.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BkEnsemblesTestBase.java
@@ -88,7 +88,7 @@ public abstract class BkEnsemblesTestBase extends TestRetrySupport {
             config.setManagedLedgerMinLedgerRolloverTimeMinutes(0);
             config.setAdvertisedAddress("127.0.0.1");
             config.setAllowAutoTopicCreationType("non-partitioned");
-            config.setZooKeeperOperationTimeoutSeconds(10);
+            config.setMetadataStoreOperationTimeoutSeconds(10);
             config.setNumIOThreads(1);
             Properties properties = new Properties();
             properties.put("bookkeeper_numWorkerThreads", "1");

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/util/FieldParser.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/util/FieldParser.java
@@ -141,7 +141,12 @@ public final class FieldParser {
                     f.setAccessible(true);
                     String v = properties.get(f.getName());
                     if (!StringUtils.isBlank(v)) {
-                        f.set(obj, value(trim(v), f));
+                        try {
+                            Method method = Reflections.getSetMethod(obj.getClass(), f);
+                            method.invoke(obj, value(v, f));
+                        } catch (NoSuchMethodException e) {
+                            f.set(obj, value(trim(v), f));
+                        }
                     } else {
                         setEmptyValue(v, f, obj);
                     }

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/util/FieldParser.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/util/FieldParser.java
@@ -141,12 +141,7 @@ public final class FieldParser {
                     f.setAccessible(true);
                     String v = properties.get(f.getName());
                     if (!StringUtils.isBlank(v)) {
-                        try {
-                            Method method = Reflections.getSetMethod(obj.getClass(), f);
-                            method.invoke(obj, value(trim(v), f));
-                        } catch (NoSuchMethodException e) {
-                            f.set(obj, value(trim(v), f));
-                        }
+                        f.set(obj, value(trim(v), f));
                     } else {
                         setEmptyValue(v, f, obj);
                     }

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/util/FieldParser.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/util/FieldParser.java
@@ -143,7 +143,7 @@ public final class FieldParser {
                     if (!StringUtils.isBlank(v)) {
                         try {
                             Method method = Reflections.getSetMethod(obj.getClass(), f);
-                            method.invoke(obj, value(v, f));
+                            method.invoke(obj, value(trim(v), f));
                         } catch (NoSuchMethodException e) {
                             f.set(obj, value(trim(v), f));
                         }

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/util/Reflections.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/util/Reflections.java
@@ -43,8 +43,6 @@ public class Reflections {
 
     private static final Map PRIMITIVE_NAME_TYPE_MAP = new HashMap();
 
-    private static final String SET_PREFIX = "set";
-
     static {
         PRIMITIVE_NAME_TYPE_MAP.put("boolean", Boolean.TYPE);
         PRIMITIVE_NAME_TYPE_MAP.put("byte", Byte.TYPE);
@@ -337,12 +335,5 @@ public class Reflections {
         }
 
         return fields;
-    }
-
-    public static Method getSetMethod(Class<?> clazz, Field f) throws NoSuchMethodException {
-        String setMethod = SET_PREFIX
-                + f.getName().substring(0, 1).toUpperCase()
-                + f.getName().substring(1);
-        return clazz.getDeclaredMethod(setMethod, f.getType());
     }
 }

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/util/Reflections.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/util/Reflections.java
@@ -24,6 +24,7 @@ import java.lang.reflect.Array;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.net.URLClassLoader;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -41,6 +42,8 @@ public class Reflections {
         new ConcurrentHashMap<>();
 
     private static final Map PRIMITIVE_NAME_TYPE_MAP = new HashMap();
+
+    private static final String SET_PREFIX = "set";
 
     static {
         PRIMITIVE_NAME_TYPE_MAP.put("boolean", Boolean.TYPE);
@@ -334,5 +337,12 @@ public class Reflections {
         }
 
         return fields;
+    }
+
+    public static Method getSetMethod(Class<?> clazz, Field f) throws NoSuchMethodException {
+        String setMethod = SET_PREFIX
+                + f.getName().substring(0, 1).toUpperCase()
+                + f.getName().substring(1);
+        return clazz.getDeclaredMethod(setMethod, f.getType());
     }
 }

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/util/Reflections.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/util/Reflections.java
@@ -24,7 +24,6 @@ import java.lang.reflect.Array;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
 import java.net.URLClassLoader;
 import java.util.Arrays;
 import java.util.HashMap;

--- a/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/worker/WorkerConfig.java
+++ b/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/worker/WorkerConfig.java
@@ -764,46 +764,16 @@ public class WorkerConfig implements Serializable, PulsarConfiguration {
         }
     }
 
-    @Deprecated
-    public void setZooKeeperSessionTimeoutMillis(long zooKeeperSessionTimeoutMillis) {
-        if (zooKeeperSessionTimeoutMillis > 0) {
-            this.zooKeeperSessionTimeoutMillis = zooKeeperSessionTimeoutMillis;
-            this.metadataStoreSessionTimeoutMillis = zooKeeperSessionTimeoutMillis;
-        }
+    public long getMetadataStoreSessionTimeoutMillis() {
+        return zooKeeperSessionTimeoutMillis > 0 ? zooKeeperSessionTimeoutMillis : metadataStoreSessionTimeoutMillis;
     }
 
-    @Deprecated
-    public void setZooKeeperOperationTimeoutSeconds(int zooKeeperOperationTimeoutSeconds) {
-        if (zooKeeperOperationTimeoutSeconds > 0) {
-            this.zooKeeperOperationTimeoutSeconds = zooKeeperOperationTimeoutSeconds;
-            this.metadataStoreOperationTimeoutSeconds = zooKeeperOperationTimeoutSeconds;
-        }
+    public int getMetadataStoreOperationTimeoutSeconds() {
+        return zooKeeperOperationTimeoutSeconds > 0 ? zooKeeperOperationTimeoutSeconds
+                : metadataStoreOperationTimeoutSeconds;
     }
 
-    @Deprecated
-    public void setZooKeeperCacheExpirySeconds(int zooKeeperCacheExpirySeconds) {
-        if (zooKeeperCacheExpirySeconds > 0) {
-            this.zooKeeperCacheExpirySeconds = zooKeeperCacheExpirySeconds;
-            this.metadataStoreCacheExpirySeconds = zooKeeperCacheExpirySeconds;
-        }
-    }
-
-    public void setMetadataStoreSessionTimeoutMillis(long metadataStoreSessionTimeoutMillis) {
-        if (zooKeeperSessionTimeoutMillis == -1) {
-            this.metadataStoreSessionTimeoutMillis = metadataStoreSessionTimeoutMillis;
-        }
-    }
-
-    public void setMetadataStoreOperationTimeoutSeconds(int metadataStoreOperationTimeoutSeconds) {
-        if (zooKeeperOperationTimeoutSeconds == -1) {
-            this.metadataStoreOperationTimeoutSeconds = metadataStoreOperationTimeoutSeconds;
-        }
-    }
-
-    public void setMetadataStoreCacheExpirySeconds(int metadataStoreCacheExpirySeconds) {
-        if (zooKeeperCacheExpirySeconds == -1) {
-            this.metadataStoreCacheExpirySeconds = metadataStoreCacheExpirySeconds;
-        }
-
+    public int getMetadataStoreCacheExpirySeconds() {
+        return zooKeeperCacheExpirySeconds > 0 ? zooKeeperCacheExpirySeconds : metadataStoreCacheExpirySeconds;
     }
 }

--- a/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/worker/WorkerConfig.java
+++ b/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/worker/WorkerConfig.java
@@ -155,21 +155,47 @@ public class WorkerConfig implements Serializable, PulsarConfiguration {
             doc = "Configuration store connection string (as a comma-separated list)"
     )
     private String configurationMetadataStoreUrl;
+    @Deprecated
     @FieldContext(
             category = CATEGORY_WORKER,
-            doc = "ZooKeeper session timeout in milliseconds"
+            doc = "ZooKeeper session timeout in milliseconds. "
+                    + "@deprecated - Use metadataStoreSessionTimeoutMillis instead."
     )
     private long zooKeeperSessionTimeoutMillis = 30000;
+
+    @Deprecated
     @FieldContext(
             category = CATEGORY_WORKER,
-            doc = "ZooKeeper operation timeout in seconds"
+            doc = "ZooKeeper operation timeout in seconds. "
+                    + "@deprecated - Use metadataStoreOperationTimeoutSeconds instead."
     )
     private int zooKeeperOperationTimeoutSeconds = 30;
+
+    @Deprecated
     @FieldContext(
             category = CATEGORY_WORKER,
-            doc = "ZooKeeper cache expiry time in seconds"
-        )
+            doc = "ZooKeeper cache expiry time in seconds. "
+                    + "@deprecated - Use metadataStoreCacheExpirySeconds instead."
+    )
     private int zooKeeperCacheExpirySeconds = 300;
+
+    @FieldContext(
+            category = CATEGORY_WORKER,
+            doc = "Metadata store session timeout in milliseconds."
+    )
+    private long metadataStoreSessionTimeoutMillis = 30000;
+
+    @FieldContext(
+            category = CATEGORY_WORKER,
+            doc = "Metadata store operation timeout in seconds."
+    )
+    private int metadataStoreOperationTimeoutSeconds = 30;
+
+    @FieldContext(
+            category = CATEGORY_WORKER,
+            doc = "Metadata store cache expiry time in seconds."
+    )
+    private int metadataStoreCacheExpirySeconds = 300;
     @FieldContext(
         category = CATEGORY_CONNECTORS,
         doc = "The path to the location to locate builtin connectors"
@@ -731,5 +757,17 @@ public class WorkerConfig implements Serializable, PulsarConfiguration {
         } else {
             return brokerClientAuthenticationParameters;
         }
+    }
+
+    public void setZooKeeperSessionTimeoutMillis(long zooKeeperSessionTimeoutMillis) {
+        this.metadataStoreSessionTimeoutMillis = zooKeeperSessionTimeoutMillis;
+    }
+
+    public void setZooKeeperOperationTimeoutSeconds(int zooKeeperOperationTimeoutSeconds) {
+        this.metadataStoreOperationTimeoutSeconds = zooKeeperOperationTimeoutSeconds;
+    }
+
+    public void setZooKeeperCacheExpirySeconds(int zooKeeperCacheExpirySeconds) {
+        this.metadataStoreCacheExpirySeconds = zooKeeperCacheExpirySeconds;
     }
 }

--- a/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/worker/WorkerConfig.java
+++ b/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/worker/WorkerConfig.java
@@ -155,35 +155,12 @@ public class WorkerConfig implements Serializable, PulsarConfiguration {
             doc = "Configuration store connection string (as a comma-separated list)"
     )
     private String configurationMetadataStoreUrl;
-    @Deprecated
-    @FieldContext(
-            category = CATEGORY_WORKER,
-            doc = "ZooKeeper session timeout in milliseconds. "
-                    + "@deprecated - Use metadataStoreSessionTimeoutMillis instead."
-    )
-    private long zooKeeperSessionTimeoutMillis = 30000;
-
-    @Deprecated
-    @FieldContext(
-            category = CATEGORY_WORKER,
-            doc = "ZooKeeper operation timeout in seconds. "
-                    + "@deprecated - Use metadataStoreOperationTimeoutSeconds instead."
-    )
-    private int zooKeeperOperationTimeoutSeconds = 30;
-
-    @Deprecated
-    @FieldContext(
-            category = CATEGORY_WORKER,
-            doc = "ZooKeeper cache expiry time in seconds. "
-                    + "@deprecated - Use metadataStoreCacheExpirySeconds instead."
-    )
-    private int zooKeeperCacheExpirySeconds = 300;
 
     @FieldContext(
             category = CATEGORY_WORKER,
             doc = "Metadata store session timeout in milliseconds."
     )
-    private long metadataStoreSessionTimeoutMillis = 30000;
+    private long metadataStoreSessionTimeoutMillis = 30_000;
 
     @FieldContext(
             category = CATEGORY_WORKER,
@@ -196,6 +173,34 @@ public class WorkerConfig implements Serializable, PulsarConfiguration {
             doc = "Metadata store cache expiry time in seconds."
     )
     private int metadataStoreCacheExpirySeconds = 300;
+
+    @Deprecated
+    @FieldContext(
+            category = CATEGORY_WORKER,
+            deprecated = true,
+            doc = "ZooKeeper session timeout in milliseconds. "
+                    + "@deprecated - Use metadataStoreSessionTimeoutMillis instead."
+    )
+    private long zooKeeperSessionTimeoutMillis = -1;
+
+    @Deprecated
+    @FieldContext(
+            category = CATEGORY_WORKER,
+            deprecated = true,
+            doc = "ZooKeeper operation timeout in seconds. "
+                    + "@deprecated - Use metadataStoreOperationTimeoutSeconds instead."
+    )
+    private int zooKeeperOperationTimeoutSeconds = -1;
+
+    @Deprecated
+    @FieldContext(
+            category = CATEGORY_WORKER,
+            deprecated = true,
+            doc = "ZooKeeper cache expiry time in seconds. "
+                    + "@deprecated - Use metadataStoreCacheExpirySeconds instead."
+    )
+    private int zooKeeperCacheExpirySeconds = -1;
+
     @FieldContext(
         category = CATEGORY_CONNECTORS,
         doc = "The path to the location to locate builtin connectors"
@@ -759,15 +764,46 @@ public class WorkerConfig implements Serializable, PulsarConfiguration {
         }
     }
 
+    @Deprecated
     public void setZooKeeperSessionTimeoutMillis(long zooKeeperSessionTimeoutMillis) {
-        this.metadataStoreSessionTimeoutMillis = zooKeeperSessionTimeoutMillis;
+        if (zooKeeperSessionTimeoutMillis > 0) {
+            this.zooKeeperSessionTimeoutMillis = zooKeeperSessionTimeoutMillis;
+            this.metadataStoreSessionTimeoutMillis = zooKeeperSessionTimeoutMillis;
+        }
     }
 
+    @Deprecated
     public void setZooKeeperOperationTimeoutSeconds(int zooKeeperOperationTimeoutSeconds) {
-        this.metadataStoreOperationTimeoutSeconds = zooKeeperOperationTimeoutSeconds;
+        if (zooKeeperOperationTimeoutSeconds > 0) {
+            this.zooKeeperOperationTimeoutSeconds = zooKeeperOperationTimeoutSeconds;
+            this.metadataStoreOperationTimeoutSeconds = zooKeeperOperationTimeoutSeconds;
+        }
     }
 
+    @Deprecated
     public void setZooKeeperCacheExpirySeconds(int zooKeeperCacheExpirySeconds) {
-        this.metadataStoreCacheExpirySeconds = zooKeeperCacheExpirySeconds;
+        if (zooKeeperCacheExpirySeconds > 0) {
+            this.zooKeeperCacheExpirySeconds = zooKeeperCacheExpirySeconds;
+            this.metadataStoreCacheExpirySeconds = zooKeeperCacheExpirySeconds;
+        }
+    }
+
+    public void setMetadataStoreSessionTimeoutMillis(long metadataStoreSessionTimeoutMillis) {
+        if (zooKeeperSessionTimeoutMillis == -1) {
+            this.metadataStoreSessionTimeoutMillis = metadataStoreSessionTimeoutMillis;
+        }
+    }
+
+    public void setMetadataStoreOperationTimeoutSeconds(int metadataStoreOperationTimeoutSeconds) {
+        if (zooKeeperOperationTimeoutSeconds == -1) {
+            this.metadataStoreOperationTimeoutSeconds = metadataStoreOperationTimeoutSeconds;
+        }
+    }
+
+    public void setMetadataStoreCacheExpirySeconds(int metadataStoreCacheExpirySeconds) {
+        if (zooKeeperCacheExpirySeconds == -1) {
+            this.metadataStoreCacheExpirySeconds = metadataStoreCacheExpirySeconds;
+        }
+
     }
 }

--- a/pulsar-functions/runtime/src/test/java/org/apache/pulsar/functions/config/TestWorkerConfig.java
+++ b/pulsar-functions/runtime/src/test/java/org/apache/pulsar/functions/config/TestWorkerConfig.java
@@ -75,9 +75,50 @@ public class TestWorkerConfig {
         }
         testConfigFile.deleteOnExit();
         InputStream stream = new FileInputStream(testConfigFile);
-        final WorkerConfig serviceConfig = PulsarConfigurationLoader.create(stream, WorkerConfig.class);
+        WorkerConfig serviceConfig = PulsarConfigurationLoader.create(stream, WorkerConfig.class);
+        stream.close();
         assertEquals(serviceConfig.getMetadataStoreSessionTimeoutMillis(), 60);
         assertEquals(serviceConfig.getMetadataStoreOperationTimeoutSeconds(), 600);
         assertEquals(serviceConfig.getMetadataStoreCacheExpirySeconds(), 500);
+
+        testConfigFile = new File("tmp." + System.currentTimeMillis() + ".properties");
+        if (testConfigFile.exists()) {
+            testConfigFile.delete();
+        }
+        try (PrintWriter printWriter = new PrintWriter(new OutputStreamWriter(new FileOutputStream(testConfigFile)))) {
+            printWriter.println("metadataStoreSessionTimeoutMillis=60");
+            printWriter.println("metadataStoreOperationTimeoutSeconds=600");
+            printWriter.println("metadataStoreCacheExpirySeconds=500");
+            printWriter.println("zooKeeperSessionTimeoutMillis=-1");
+            printWriter.println("zooKeeperOperationTimeoutSeconds=-1");
+            printWriter.println("zooKeeperCacheExpirySeconds=-1");
+        }
+        testConfigFile.deleteOnExit();
+        stream = new FileInputStream(testConfigFile);
+        serviceConfig = PulsarConfigurationLoader.create(stream, WorkerConfig.class);
+        stream.close();
+        assertEquals(serviceConfig.getMetadataStoreSessionTimeoutMillis(), 60);
+        assertEquals(serviceConfig.getMetadataStoreOperationTimeoutSeconds(), 600);
+        assertEquals(serviceConfig.getMetadataStoreCacheExpirySeconds(), 500);
+
+        testConfigFile = new File("tmp." + System.currentTimeMillis() + ".properties");
+        if (testConfigFile.exists()) {
+            testConfigFile.delete();
+        }
+        try (PrintWriter printWriter = new PrintWriter(new OutputStreamWriter(new FileOutputStream(testConfigFile)))) {
+            printWriter.println("metadataStoreSessionTimeoutMillis=10");
+            printWriter.println("metadataStoreOperationTimeoutSeconds=20");
+            printWriter.println("metadataStoreCacheExpirySeconds=30");
+            printWriter.println("zooKeeperSessionTimeoutMillis=100");
+            printWriter.println("zooKeeperOperationTimeoutSeconds=200");
+            printWriter.println("zooKeeperCacheExpirySeconds=300");
+        }
+        testConfigFile.deleteOnExit();
+        stream = new FileInputStream(testConfigFile);
+        serviceConfig = PulsarConfigurationLoader.create(stream, WorkerConfig.class);
+        stream.close();
+        assertEquals(serviceConfig.getMetadataStoreSessionTimeoutMillis(), 100);
+        assertEquals(serviceConfig.getMetadataStoreOperationTimeoutSeconds(), 200);
+        assertEquals(serviceConfig.getMetadataStoreCacheExpirySeconds(), 300);
     }
 }

--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/Worker.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/Worker.java
@@ -75,7 +75,7 @@ public class Worker {
             try {
                 configMetadataStore = PulsarResources.createMetadataStore(
                         workerConfig.getConfigurationMetadataStoreUrl(),
-                        (int) workerConfig.getZooKeeperSessionTimeoutMillis());
+                        (int) workerConfig.getMetadataStoreSessionTimeoutMillis());
             } catch (IOException e) {
                 throw new PulsarServerException(e);
             }

--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/api/ComponentImpl.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/api/ComponentImpl.java
@@ -1553,10 +1553,10 @@ public abstract class ComponentImpl implements Component<PulsarWorkerService> {
                     return true;
                 }
                 return worker().getAuthorizationService().isSuperUser(clientRole, authenticationData)
-                    .get(worker().getWorkerConfig().getZooKeeperOperationTimeoutSeconds(), SECONDS);
+                    .get(worker().getWorkerConfig().getMetadataStoreOperationTimeoutSeconds(), SECONDS);
             } catch (InterruptedException e) {
                 log.warn("Time-out {} sec while checking the role {} is a super user role ",
-                    worker().getWorkerConfig().getZooKeeperOperationTimeoutSeconds(), clientRole);
+                    worker().getWorkerConfig().getMetadataStoreOperationTimeoutSeconds(), clientRole);
                 throw new RestException(Status.INTERNAL_SERVER_ERROR, e.getMessage());
             } catch (Exception e) {
                 log.warn("Admin-client with Role - failed to check the role {} is a super user role {} ", clientRole,
@@ -1573,17 +1573,17 @@ public abstract class ComponentImpl implements Component<PulsarWorkerService> {
             switch (componentType) {
                 case SINK:
                     return worker().getAuthorizationService().allowSinkOpsAsync(
-                            namespaceName, role, authenticationData).get(worker().getWorkerConfig().getZooKeeperOperationTimeoutSeconds(), SECONDS);
+                            namespaceName, role, authenticationData).get(worker().getWorkerConfig().getMetadataStoreOperationTimeoutSeconds(), SECONDS);
                 case SOURCE:
                     return worker().getAuthorizationService().allowSourceOpsAsync(
-                            namespaceName, role, authenticationData).get(worker().getWorkerConfig().getZooKeeperOperationTimeoutSeconds(), SECONDS);
+                            namespaceName, role, authenticationData).get(worker().getWorkerConfig().getMetadataStoreOperationTimeoutSeconds(), SECONDS);
                 case FUNCTION:
                 default:
                     return worker().getAuthorizationService().allowFunctionOpsAsync(
-                            namespaceName, role, authenticationData).get(worker().getWorkerConfig().getZooKeeperOperationTimeoutSeconds(), SECONDS);
+                            namespaceName, role, authenticationData).get(worker().getWorkerConfig().getMetadataStoreOperationTimeoutSeconds(), SECONDS);
             }
         } catch (InterruptedException e) {
-            log.warn("Time-out {} sec while checking function authorization on {} ", worker().getWorkerConfig().getZooKeeperOperationTimeoutSeconds(), namespaceName);
+            log.warn("Time-out {} sec while checking function authorization on {} ", worker().getWorkerConfig().getMetadataStoreOperationTimeoutSeconds(), namespaceName);
             throw new RestException(Status.INTERNAL_SERVER_ERROR, e.getMessage());
         } catch (Exception e) {
             log.warn("Admin-client with Role - {} failed to get function permissions for namespace - {}. {}", role, namespaceName,

--- a/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/BrokerDiscoveryProvider.java
+++ b/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/BrokerDiscoveryProvider.java
@@ -67,7 +67,7 @@ public class BrokerDiscoveryProvider implements Closeable {
         try {
             this.pulsarResources = pulsarResources;
             this.metadataStoreCacheLoader = new MetadataStoreCacheLoader(pulsarResources,
-                    config.getZookeeperSessionTimeoutMs());
+                    config.getMetadataStoreSessionTimeoutMillis());
         } catch (Exception e) {
             LOG.error("Failed to start ZooKeeper {}", e.getMessage(), e);
             throw new PulsarServerException("Failed to start zookeeper :" + e.getMessage(), e);

--- a/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/ProxyConfiguration.java
+++ b/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/ProxyConfiguration.java
@@ -116,22 +116,6 @@ public class ProxyConfiguration implements PulsarConfiguration {
     )
     private String configurationMetadataStoreUrl;
 
-    @Deprecated
-    @FieldContext(
-        category = CATEGORY_BROKER_DISCOVERY,
-            doc = "ZooKeeper session timeout in milliseconds. "
-                    + "@deprecated - Use metadataStoreSessionTimeoutMillis instead."
-    )
-    private int zookeeperSessionTimeoutMs = 30_000;
-
-    @Deprecated
-    @FieldContext(
-            category = CATEGORY_BROKER_DISCOVERY,
-            doc = "ZooKeeper cache expiry time in seconds. "
-                    + "@deprecated - Use metadataStoreCacheExpirySeconds instead."
-    )
-    private int zooKeeperCacheExpirySeconds = 300;
-
     @FieldContext(
             category = CATEGORY_SERVER,
             doc = "Metadata store session timeout in milliseconds."
@@ -143,6 +127,24 @@ public class ProxyConfiguration implements PulsarConfiguration {
             doc = "Metadata store cache expiry time in seconds."
     )
     private int metadataStoreCacheExpirySeconds = 300;
+
+    @Deprecated
+    @FieldContext(
+        category = CATEGORY_BROKER_DISCOVERY,
+        deprecated = true,
+        doc = "ZooKeeper session timeout in milliseconds. "
+                + "@deprecated - Use metadataStoreSessionTimeoutMillis instead."
+    )
+    private int zookeeperSessionTimeoutMs = -1;
+
+    @Deprecated
+    @FieldContext(
+        category = CATEGORY_BROKER_DISCOVERY,
+        deprecated = true,
+        doc = "ZooKeeper cache expiry time in seconds. "
+                + "@deprecated - Use metadataStoreCacheExpirySeconds instead."
+    )
+    private int zooKeeperCacheExpirySeconds = -1;
 
     @FieldContext(
         category = CATEGORY_BROKER_DISCOVERY,
@@ -774,11 +776,31 @@ public class ProxyConfiguration implements PulsarConfiguration {
         }
     }
 
+    @Deprecated
     public void setZookeeperSessionTimeoutMs(int zookeeperSessionTimeoutMs) {
-        this.metadataStoreSessionTimeoutMillis = zookeeperSessionTimeoutMs;
+        if (zookeeperSessionTimeoutMs > 0) {
+            this.zookeeperSessionTimeoutMs = zookeeperSessionTimeoutMs;
+            this.metadataStoreSessionTimeoutMillis = zookeeperSessionTimeoutMs;
+        }
     }
 
+    @Deprecated
     public void setZooKeeperCacheExpirySeconds(int zooKeeperCacheExpirySeconds) {
-        this.metadataStoreCacheExpirySeconds = zooKeeperCacheExpirySeconds;
+        if (zooKeeperCacheExpirySeconds > 0) {
+            this.zooKeeperCacheExpirySeconds = zooKeeperCacheExpirySeconds;
+            this.metadataStoreCacheExpirySeconds = zooKeeperCacheExpirySeconds;
+        }
+    }
+
+    public void setMetadataStoreSessionTimeoutMillis(int metadataStoreSessionTimeoutMillis) {
+        if (zookeeperSessionTimeoutMs == -1) {
+            this.metadataStoreSessionTimeoutMillis = metadataStoreSessionTimeoutMillis;
+        }
+    }
+
+    public void setMetadataStoreCacheExpirySeconds(int metadataStoreCacheExpirySeconds) {
+        if (zooKeeperCacheExpirySeconds == -1) {
+            this.metadataStoreCacheExpirySeconds = metadataStoreCacheExpirySeconds;
+        }
     }
 }

--- a/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/ProxyConfiguration.java
+++ b/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/ProxyConfiguration.java
@@ -116,16 +116,33 @@ public class ProxyConfiguration implements PulsarConfiguration {
     )
     private String configurationMetadataStoreUrl;
 
+    @Deprecated
     @FieldContext(
         category = CATEGORY_BROKER_DISCOVERY,
-        doc = "ZooKeeper session timeout (in milliseconds)"
+            doc = "ZooKeeper session timeout in milliseconds. "
+                    + "@deprecated - Use metadataStoreSessionTimeoutMillis instead."
     )
     private int zookeeperSessionTimeoutMs = 30_000;
+
+    @Deprecated
     @FieldContext(
             category = CATEGORY_BROKER_DISCOVERY,
-            doc = "ZooKeeper cache expiry time in seconds"
-        )
+            doc = "ZooKeeper cache expiry time in seconds. "
+                    + "@deprecated - Use metadataStoreCacheExpirySeconds instead."
+    )
     private int zooKeeperCacheExpirySeconds = 300;
+
+    @FieldContext(
+            category = CATEGORY_SERVER,
+            doc = "Metadata store session timeout in milliseconds."
+    )
+    private int metadataStoreSessionTimeoutMillis = 30_000;
+
+    @FieldContext(
+            category = CATEGORY_SERVER,
+            doc = "Metadata store cache expiry time in seconds."
+    )
+    private int metadataStoreCacheExpirySeconds = 300;
 
     @FieldContext(
         category = CATEGORY_BROKER_DISCOVERY,
@@ -755,5 +772,13 @@ public class ProxyConfiguration implements PulsarConfiguration {
         public String toString() {
             return String.format("HttpReverseProxyConfig(%s, path=%s, proxyTo=%s)", name, path, proxyTo);
         }
+    }
+
+    public void setZookeeperSessionTimeoutMs(int zookeeperSessionTimeoutMs) {
+        this.metadataStoreSessionTimeoutMillis = zookeeperSessionTimeoutMs;
+    }
+
+    public void setZooKeeperCacheExpirySeconds(int zooKeeperCacheExpirySeconds) {
+        this.metadataStoreCacheExpirySeconds = zooKeeperCacheExpirySeconds;
     }
 }

--- a/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/ProxyConfiguration.java
+++ b/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/ProxyConfiguration.java
@@ -776,31 +776,11 @@ public class ProxyConfiguration implements PulsarConfiguration {
         }
     }
 
-    @Deprecated
-    public void setZookeeperSessionTimeoutMs(int zookeeperSessionTimeoutMs) {
-        if (zookeeperSessionTimeoutMs > 0) {
-            this.zookeeperSessionTimeoutMs = zookeeperSessionTimeoutMs;
-            this.metadataStoreSessionTimeoutMillis = zookeeperSessionTimeoutMs;
-        }
+    public int getMetadataStoreSessionTimeoutMillis() {
+        return zookeeperSessionTimeoutMs > 0 ? zookeeperSessionTimeoutMs : metadataStoreSessionTimeoutMillis;
     }
 
-    @Deprecated
-    public void setZooKeeperCacheExpirySeconds(int zooKeeperCacheExpirySeconds) {
-        if (zooKeeperCacheExpirySeconds > 0) {
-            this.zooKeeperCacheExpirySeconds = zooKeeperCacheExpirySeconds;
-            this.metadataStoreCacheExpirySeconds = zooKeeperCacheExpirySeconds;
-        }
-    }
-
-    public void setMetadataStoreSessionTimeoutMillis(int metadataStoreSessionTimeoutMillis) {
-        if (zookeeperSessionTimeoutMs == -1) {
-            this.metadataStoreSessionTimeoutMillis = metadataStoreSessionTimeoutMillis;
-        }
-    }
-
-    public void setMetadataStoreCacheExpirySeconds(int metadataStoreCacheExpirySeconds) {
-        if (zooKeeperCacheExpirySeconds == -1) {
-            this.metadataStoreCacheExpirySeconds = metadataStoreCacheExpirySeconds;
-        }
+    public int getMetadataStoreCacheExpirySeconds() {
+        return zooKeeperCacheExpirySeconds > 0 ? zooKeeperCacheExpirySeconds : metadataStoreCacheExpirySeconds;
     }
 }

--- a/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/ProxyService.java
+++ b/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/ProxyService.java
@@ -385,12 +385,12 @@ public class ProxyService implements Closeable {
 
     public MetadataStoreExtended createLocalMetadataStore() throws MetadataStoreException {
         return PulsarResources.createMetadataStore(proxyConfig.getMetadataStoreUrl(),
-                proxyConfig.getZookeeperSessionTimeoutMs());
+                proxyConfig.getMetadataStoreSessionTimeoutMillis());
     }
 
     public MetadataStoreExtended createConfigurationMetadataStore() throws MetadataStoreException {
         return PulsarResources.createMetadataStore(proxyConfig.getConfigurationMetadataStoreUrl(),
-                proxyConfig.getZookeeperSessionTimeoutMs());
+                proxyConfig.getMetadataStoreSessionTimeoutMillis());
     }
 
     public Authentication getProxyClientAuthenticationPlugin() {

--- a/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyConfigurationTest.java
+++ b/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyConfigurationTest.java
@@ -71,8 +71,43 @@ public class ProxyConfigurationTest {
         }
         testConfigFile.deleteOnExit();
         InputStream stream = new FileInputStream(testConfigFile);
-        final ProxyConfiguration serviceConfig = PulsarConfigurationLoader.create(stream, ProxyConfiguration.class);
+        ProxyConfiguration serviceConfig = PulsarConfigurationLoader.create(stream, ProxyConfiguration.class);
+        stream.close();
         assertEquals(serviceConfig.getMetadataStoreSessionTimeoutMillis(), 60);
         assertEquals(serviceConfig.getMetadataStoreCacheExpirySeconds(), 500);
+
+        testConfigFile = new File("tmp." + System.currentTimeMillis() + ".properties");
+        if (testConfigFile.exists()) {
+            testConfigFile.delete();
+        }
+        try (PrintWriter printWriter = new PrintWriter(new OutputStreamWriter(new FileOutputStream(testConfigFile)))) {
+            printWriter.println("metadataStoreSessionTimeoutMillis=60");
+            printWriter.println("metadataStoreCacheExpirySeconds=500");
+            printWriter.println("zooKeeperSessionTimeoutMillis=-1");
+            printWriter.println("zooKeeperCacheExpirySeconds=-1");
+        }
+        testConfigFile.deleteOnExit();
+        stream = new FileInputStream(testConfigFile);
+        serviceConfig = PulsarConfigurationLoader.create(stream, ProxyConfiguration.class);
+        stream.close();
+        assertEquals(serviceConfig.getMetadataStoreSessionTimeoutMillis(), 60);
+        assertEquals(serviceConfig.getMetadataStoreCacheExpirySeconds(), 500);
+
+        testConfigFile = new File("tmp." + System.currentTimeMillis() + ".properties");
+        if (testConfigFile.exists()) {
+            testConfigFile.delete();
+        }
+        try (PrintWriter printWriter = new PrintWriter(new OutputStreamWriter(new FileOutputStream(testConfigFile)))) {
+            printWriter.println("metadataStoreSessionTimeoutMillis=10");
+            printWriter.println("metadataStoreCacheExpirySeconds=30");
+            printWriter.println("zookeeperSessionTimeoutMs=100");
+            printWriter.println("zooKeeperCacheExpirySeconds=300");
+        }
+        testConfigFile.deleteOnExit();
+        stream = new FileInputStream(testConfigFile);
+        serviceConfig = PulsarConfigurationLoader.create(stream, ProxyConfiguration.class);
+        stream.close();
+        assertEquals(serviceConfig.getMetadataStoreSessionTimeoutMillis(), 100);
+        assertEquals(serviceConfig.getMetadataStoreCacheExpirySeconds(), 300);
     }
 }

--- a/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/WebSocketService.java
+++ b/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/WebSocketService.java
@@ -93,7 +93,7 @@ public class WebSocketService implements Closeable {
         if (isNotBlank(config.getConfigurationMetadataStoreUrl())) {
             try {
                 configMetadataStore = createMetadataStore(config.getConfigurationMetadataStoreUrl(),
-                        (int) config.getZooKeeperSessionTimeoutMillis());
+                        (int) config.getMetadataStoreSessionTimeoutMillis());
             } catch (MetadataStoreException e) {
                 throw new PulsarServerException(e);
             }

--- a/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/service/WebSocketProxyConfiguration.java
+++ b/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/service/WebSocketProxyConfiguration.java
@@ -72,11 +72,19 @@ public class WebSocketProxyConfiguration implements PulsarConfiguration {
     @FieldContext(doc = "Connection string of configuration metadata store servers")
     private String configurationMetadataStoreUrl;
 
-    @FieldContext(doc = "ZooKeeper session timeout in milliseconds")
+    @FieldContext(doc = "ZooKeeper session timeout in milliseconds. "
+            + "@deprecated - Use metadataStoreSessionTimeoutMillis instead.")
     private long zooKeeperSessionTimeoutMillis = 30000;
 
-    @FieldContext(doc = "ZooKeeper cache expiry time in seconds")
+    @FieldContext(doc = "ZooKeeper cache expiry time in seconds. "
+            + "@deprecated - Use metadataStoreCacheExpirySeconds instead.")
     private int zooKeeperCacheExpirySeconds = 300;
+
+    @FieldContext(doc = "Metadata store session timeout in milliseconds.")
+    private long metadataStoreSessionTimeoutMillis = 30000;
+
+    @FieldContext(doc = "Metadata store cache expiry time in seconds.")
+    private int metadataStoreCacheExpirySeconds = 300;
 
     @FieldContext(doc = "Port to use to server HTTP request")
     private Optional<Integer> webServicePort = Optional.of(8080);
@@ -163,4 +171,12 @@ public class WebSocketProxyConfiguration implements PulsarConfiguration {
 
     @FieldContext(doc = "Key-value properties. Types are all String")
     private Properties properties = new Properties();
+
+    public void setZooKeeperSessionTimeoutMillis(long zooKeeperSessionTimeoutMillis) {
+        this.metadataStoreSessionTimeoutMillis = zooKeeperSessionTimeoutMillis;
+    }
+
+    public void setZooKeeperCacheExpirySeconds(int zooKeeperCacheExpirySeconds) {
+        this.metadataStoreCacheExpirySeconds = zooKeeperCacheExpirySeconds;
+    }
 }

--- a/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/service/WebSocketProxyConfiguration.java
+++ b/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/service/WebSocketProxyConfiguration.java
@@ -66,25 +66,31 @@ public class WebSocketProxyConfiguration implements PulsarConfiguration {
     private String globalZookeeperServers;
 
     @Deprecated
-    @FieldContext(doc = "Connection string of configuration store servers")
+    @FieldContext(
+            deprecated = true,
+            doc = "Connection string of configuration store servers")
     private String configurationStoreServers;
 
     @FieldContext(doc = "Connection string of configuration metadata store servers")
     private String configurationMetadataStoreUrl;
 
-    @FieldContext(doc = "ZooKeeper session timeout in milliseconds. "
-            + "@deprecated - Use metadataStoreSessionTimeoutMillis instead.")
-    private long zooKeeperSessionTimeoutMillis = 30000;
-
-    @FieldContext(doc = "ZooKeeper cache expiry time in seconds. "
-            + "@deprecated - Use metadataStoreCacheExpirySeconds instead.")
-    private int zooKeeperCacheExpirySeconds = 300;
-
     @FieldContext(doc = "Metadata store session timeout in milliseconds.")
-    private long metadataStoreSessionTimeoutMillis = 30000;
+    private long metadataStoreSessionTimeoutMillis = 30_000;
 
     @FieldContext(doc = "Metadata store cache expiry time in seconds.")
     private int metadataStoreCacheExpirySeconds = 300;
+
+    @FieldContext(
+            deprecated = true,
+            doc = "ZooKeeper session timeout in milliseconds. "
+                        + "@deprecated - Use metadataStoreSessionTimeoutMillis instead.")
+    private long zooKeeperSessionTimeoutMillis = -1;
+
+    @FieldContext(
+            deprecated = true,
+            doc = "ZooKeeper cache expiry time in seconds. "
+                        + "@deprecated - Use metadataStoreCacheExpirySeconds instead.")
+    private int zooKeeperCacheExpirySeconds = -1;
 
     @FieldContext(doc = "Port to use to server HTTP request")
     private Optional<Integer> webServicePort = Optional.of(8080);
@@ -172,11 +178,31 @@ public class WebSocketProxyConfiguration implements PulsarConfiguration {
     @FieldContext(doc = "Key-value properties. Types are all String")
     private Properties properties = new Properties();
 
+    @Deprecated
     public void setZooKeeperSessionTimeoutMillis(long zooKeeperSessionTimeoutMillis) {
-        this.metadataStoreSessionTimeoutMillis = zooKeeperSessionTimeoutMillis;
+        if (zooKeeperSessionTimeoutMillis > 0) {
+            this.zooKeeperSessionTimeoutMillis = zooKeeperSessionTimeoutMillis;
+            this.metadataStoreSessionTimeoutMillis = zooKeeperSessionTimeoutMillis;
+        }
     }
 
+    @Deprecated
     public void setZooKeeperCacheExpirySeconds(int zooKeeperCacheExpirySeconds) {
-        this.metadataStoreCacheExpirySeconds = zooKeeperCacheExpirySeconds;
+        if (zooKeeperCacheExpirySeconds > 0) {
+            this.zooKeeperCacheExpirySeconds = zooKeeperCacheExpirySeconds;
+            this.metadataStoreCacheExpirySeconds = zooKeeperCacheExpirySeconds;
+        }
+    }
+
+    public void setMetadataStoreSessionTimeoutMillis(long metadataStoreSessionTimeoutMillis) {
+        if (zooKeeperSessionTimeoutMillis == -1) {
+            this.metadataStoreSessionTimeoutMillis = metadataStoreSessionTimeoutMillis;
+        }
+    }
+
+    public void setMetadataStoreCacheExpirySeconds(int metadataStoreCacheExpirySeconds) {
+        if (zooKeeperCacheExpirySeconds == -1) {
+            this.metadataStoreCacheExpirySeconds = metadataStoreCacheExpirySeconds;
+        }
     }
 }

--- a/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/service/WebSocketProxyConfiguration.java
+++ b/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/service/WebSocketProxyConfiguration.java
@@ -178,31 +178,11 @@ public class WebSocketProxyConfiguration implements PulsarConfiguration {
     @FieldContext(doc = "Key-value properties. Types are all String")
     private Properties properties = new Properties();
 
-    @Deprecated
-    public void setZooKeeperSessionTimeoutMillis(long zooKeeperSessionTimeoutMillis) {
-        if (zooKeeperSessionTimeoutMillis > 0) {
-            this.zooKeeperSessionTimeoutMillis = zooKeeperSessionTimeoutMillis;
-            this.metadataStoreSessionTimeoutMillis = zooKeeperSessionTimeoutMillis;
-        }
+    public long getMetadataStoreSessionTimeoutMillis() {
+        return zooKeeperSessionTimeoutMillis > 0 ? zooKeeperSessionTimeoutMillis : metadataStoreSessionTimeoutMillis;
     }
 
-    @Deprecated
-    public void setZooKeeperCacheExpirySeconds(int zooKeeperCacheExpirySeconds) {
-        if (zooKeeperCacheExpirySeconds > 0) {
-            this.zooKeeperCacheExpirySeconds = zooKeeperCacheExpirySeconds;
-            this.metadataStoreCacheExpirySeconds = zooKeeperCacheExpirySeconds;
-        }
-    }
-
-    public void setMetadataStoreSessionTimeoutMillis(long metadataStoreSessionTimeoutMillis) {
-        if (zooKeeperSessionTimeoutMillis == -1) {
-            this.metadataStoreSessionTimeoutMillis = metadataStoreSessionTimeoutMillis;
-        }
-    }
-
-    public void setMetadataStoreCacheExpirySeconds(int metadataStoreCacheExpirySeconds) {
-        if (zooKeeperCacheExpirySeconds == -1) {
-            this.metadataStoreCacheExpirySeconds = metadataStoreCacheExpirySeconds;
-        }
+    public int getMetadataStoreCacheExpirySeconds() {
+        return zooKeeperCacheExpirySeconds > 0 ? zooKeeperCacheExpirySeconds : metadataStoreCacheExpirySeconds;
     }
 }

--- a/pulsar-websocket/src/test/java/org/apache/pulsar/websocket/WebSocketProxyConfigurationTest.java
+++ b/pulsar-websocket/src/test/java/org/apache/pulsar/websocket/WebSocketProxyConfigurationTest.java
@@ -47,9 +47,44 @@ public class WebSocketProxyConfigurationTest {
         }
         testConfigFile.deleteOnExit();
         InputStream stream = new FileInputStream(testConfigFile);
-        final WebSocketProxyConfiguration serviceConfig = PulsarConfigurationLoader.create(stream,
+        WebSocketProxyConfiguration serviceConfig = PulsarConfigurationLoader.create(stream,
                 WebSocketProxyConfiguration.class);
+        stream.close();
         assertEquals(serviceConfig.getMetadataStoreSessionTimeoutMillis(), 60);
         assertEquals(serviceConfig.getMetadataStoreCacheExpirySeconds(), 500);
+
+        testConfigFile = new File("tmp." + System.currentTimeMillis() + ".properties");
+        if (testConfigFile.exists()) {
+            testConfigFile.delete();
+        }
+        try (PrintWriter printWriter = new PrintWriter(new OutputStreamWriter(new FileOutputStream(testConfigFile)))) {
+            printWriter.println("metadataStoreSessionTimeoutMillis=60");
+            printWriter.println("metadataStoreCacheExpirySeconds=500");
+            printWriter.println("zooKeeperSessionTimeoutMillis=-1");
+            printWriter.println("zooKeeperCacheExpirySeconds=-1");
+        }
+        testConfigFile.deleteOnExit();
+        stream = new FileInputStream(testConfigFile);
+        serviceConfig = PulsarConfigurationLoader.create(stream, WebSocketProxyConfiguration.class);
+        stream.close();
+        assertEquals(serviceConfig.getMetadataStoreSessionTimeoutMillis(), 60);
+        assertEquals(serviceConfig.getMetadataStoreCacheExpirySeconds(), 500);
+
+        testConfigFile = new File("tmp." + System.currentTimeMillis() + ".properties");
+        if (testConfigFile.exists()) {
+            testConfigFile.delete();
+        }
+        try (PrintWriter printWriter = new PrintWriter(new OutputStreamWriter(new FileOutputStream(testConfigFile)))) {
+            printWriter.println("metadataStoreSessionTimeoutMillis=10");
+            printWriter.println("metadataStoreCacheExpirySeconds=30");
+            printWriter.println("zooKeeperSessionTimeoutMillis=100");
+            printWriter.println("zooKeeperCacheExpirySeconds=300");
+        }
+        testConfigFile.deleteOnExit();
+        stream = new FileInputStream(testConfigFile);
+        serviceConfig = PulsarConfigurationLoader.create(stream, WebSocketProxyConfiguration.class);
+        stream.close();
+        assertEquals(serviceConfig.getMetadataStoreSessionTimeoutMillis(), 100);
+        assertEquals(serviceConfig.getMetadataStoreCacheExpirySeconds(), 300);
     }
 }

--- a/pulsar-websocket/src/test/java/org/apache/pulsar/websocket/WebSocketProxyConfigurationTest.java
+++ b/pulsar-websocket/src/test/java/org/apache/pulsar/websocket/WebSocketProxyConfigurationTest.java
@@ -16,14 +16,11 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.pulsar.functions.config;
+package org.apache.pulsar.websocket;
 
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertFalse;
-import static org.testng.Assert.assertTrue;
 
 import org.apache.pulsar.common.configuration.PulsarConfigurationLoader;
-import org.apache.pulsar.functions.worker.WorkerConfig;
+import org.apache.pulsar.websocket.service.WebSocketProxyConfiguration;
 import org.testng.annotations.Test;
 
 import java.io.File;
@@ -34,33 +31,9 @@ import java.io.InputStream;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
 
-public class TestWorkerConfig {
-    @Test
-    public void validateAuthenticationCompatibleWorkerConfig() {
-        WorkerConfig workerConfig = new WorkerConfig();
+import static org.testng.Assert.assertEquals;
 
-        workerConfig.setAuthenticationEnabled(false);
-        assertFalse(workerConfig.isAuthenticationEnabled());
-        workerConfig.setBrokerClientAuthenticationEnabled(null);
-        assertFalse(workerConfig.isBrokerClientAuthenticationEnabled());
-
-        workerConfig.setAuthenticationEnabled(true);
-        assertTrue(workerConfig.isAuthenticationEnabled());
-        workerConfig.setBrokerClientAuthenticationEnabled(null);
-        assertTrue(workerConfig.isBrokerClientAuthenticationEnabled());
-
-        workerConfig.setBrokerClientAuthenticationEnabled(true);
-        workerConfig.setAuthenticationEnabled(false);
-        assertTrue(workerConfig.isBrokerClientAuthenticationEnabled());
-        workerConfig.setAuthenticationEnabled(true);
-        assertTrue(workerConfig.isBrokerClientAuthenticationEnabled());
-
-        workerConfig.setBrokerClientAuthenticationEnabled(false);
-        workerConfig.setAuthenticationEnabled(false);
-        assertFalse(workerConfig.isBrokerClientAuthenticationEnabled());
-        workerConfig.setAuthenticationEnabled(true);
-        assertFalse(workerConfig.isBrokerClientAuthenticationEnabled());
-    }
+public class WebSocketProxyConfigurationTest {
 
     @Test
     public void testBackwardCompatibility() throws IOException {
@@ -70,14 +43,13 @@ public class TestWorkerConfig {
         }
         try (PrintWriter printWriter = new PrintWriter(new OutputStreamWriter(new FileOutputStream(testConfigFile)))) {
             printWriter.println("zooKeeperSessionTimeoutMillis=60");
-            printWriter.println("zooKeeperOperationTimeoutSeconds=600");
             printWriter.println("zooKeeperCacheExpirySeconds=500");
         }
         testConfigFile.deleteOnExit();
         InputStream stream = new FileInputStream(testConfigFile);
-        final WorkerConfig serviceConfig = PulsarConfigurationLoader.create(stream, WorkerConfig.class);
+        final WebSocketProxyConfiguration serviceConfig = PulsarConfigurationLoader.create(stream,
+                WebSocketProxyConfiguration.class);
         assertEquals(serviceConfig.getMetadataStoreSessionTimeoutMillis(), 60);
-        assertEquals(serviceConfig.getMetadataStoreOperationTimeoutSeconds(), 600);
         assertEquals(serviceConfig.getMetadataStoreCacheExpirySeconds(), 500);
     }
 }


### PR DESCRIPTION
### Motivation

To deprecate the zookeeper settings. PIP 45 introduced a unified metadata store API for Pulsar,
so we should make the metadata-related configuration start with `metadataStore`, not `zooKeeper`.

### Modification

change `zooKeeperSessionTimeoutMillis` to `metadataStoreSessionTimeoutMillis`
change `zooKeeperOperationTimeoutSeconds` to `metadataStoreOperationTimeoutSeconds`
change `zooKeeperCacheExpirySeconds` to `metadataStoreCacheExpirySeconds`

### Compatibility

Introduced set method for the deprecated configurations. If the broker read the configurations
from the old version config file, the configuration loader will use the set method to apply the
configured value to new configurations.

### Tests

Add new tests to make sure the change will not introduce a regression.


