### PR TITLE
Fix NoClassDefFoundError: com/google/inject/AbstractModule in pulsar-io/batch-data-generator and Jcloud offloader

### DIFF
--- a/pulsar-io/data-generator/pom.xml
+++ b/pulsar-io/data-generator/pom.xml
@@ -53,13 +53,13 @@
             <groupId>com.google.inject</groupId>
             <artifactId>guice</artifactId>
             <version>${guice.version}</version>
-            <scope>provided</scope>
+            <scope>runtime</scope>
         </dependency>
         <dependency>
             <groupId>com.google.inject.extensions</groupId>
             <artifactId>guice-assistedinject</artifactId>
             <version>${guice.version}</version>
-            <scope>provided</scope>
+            <scope>runtime</scope>
         </dependency>
 
         <dependency>

--- a/tiered-storage/jcloud/pom.xml
+++ b/tiered-storage/jcloud/pom.xml
@@ -104,13 +104,13 @@
       <groupId>com.google.inject</groupId>
       <artifactId>guice</artifactId>
       <version>${guice.version}</version>
-      <scope>provided</scope>
+      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>com.google.inject.extensions</groupId>
       <artifactId>guice-assistedinject</artifactId>
       <version>${guice.version}</version>
-      <scope>provided</scope>
+      <scope>runtime</scope>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
### Motivation

After https://github.com/apache/pulsar/pull/13810, if you try to run the batch-data-generator in a functions worker runner, you'll see this error:
```
2022-02-07T01:06:42,232+0000 [public/default/data-generator-source-0] ERROR org.apache.pulsar.functions.instance.JavaInstanceRunnable - [public/default/data-generator-source:0] Uncaught exception in Java Instance
java.lang.NoClassDefFoundError: com/google/inject/AbstractModule
	at java.lang.ClassLoader.defineClass1(Native Method) ~[?:?]
	at java.lang.ClassLoader.defineClass(ClassLoader.java:1017) ~[?:?]
	at java.security.SecureClassLoader.defineClass(SecureClassLoader.java:174) ~[?:?]
	at java.net.URLClassLoader.defineClass(URLClassLoader.java:555) ~[?:?]
	at java.net.URLClassLoader$1.run(URLClassLoader.java:458) ~[?:?]
	at java.net.URLClassLoader$1.run(URLClassLoader.java:452) ~[?:?]
	at java.security.AccessController.doPrivileged(Native Method) ~[?:?]
	at java.net.URLClassLoader.findClass(URLClassLoader.java:451) ~[?:?]
	at java.lang.ClassLoader.loadClass(ClassLoader.java:589) ~[?:?]
	at java.lang.ClassLoader.loadClass(ClassLoader.java:522) ~[?:?]
	at io.codearte.jfairy.Fairy.create(Fairy.java:48) ~[?:?]
	at org.apache.pulsar.io.datagenerator.DataGeneratorSource.open(DataGeneratorSource.java:36) ~[?:?]
	at org.apache.pulsar.functions.instance.JavaInstanceRunnable.setupInput(JavaInstanceRunnable.java:752) ~[org.apache.pulsar-pulsar-functions-instance-2.10.0-SNAPSHOT.jar:2.10.0-SNAPSHOT]
	at org.apache.pulsar.functions.instance.JavaInstanceRunnable.setup(JavaInstanceRunnable.java:227) ~[org.apache.pulsar-pulsar-functions-instance-2.10.0-SNAPSHOT.jar:2.10.0-SNAPSHOT]
	at org.apache.pulsar.functions.instance.JavaInstanceRunnable.run(JavaInstanceRunnable.java:255) [org.apache.pulsar-pulsar-functions-instance-2.10.0-SNAPSHOT.jar:2.10.0-SNAPSHOT]
	at java.lang.Thread.run(Thread.java:829) [?:?]
Caused by: java.lang.ClassNotFoundException: com.google.inject.AbstractModule
	at java.net.URLClassLoader.findClass(URLClassLoader.java:476) ~[?:?]
	at java.lang.ClassLoader.loadClass(ClassLoader.java:589) ~[?:?]
	at java.lang.ClassLoader.loadClass(ClassLoader.java:522) ~[?:?]
	... 16 more
```

 
### Modifications
* Fixed the dependencies to be `runtime` instead of `provided`
### Documentation

- [x] `no-need-doc` 
