### PR TITLE
[pulsar-broker] Fix: return non-null persistence policy for namespace

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/AdminResource.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/AdminResource.java
@@ -305,6 +305,14 @@ public abstract class AdminResource extends PulsarWebResource {
 
     }
 
+    protected PersistencePolicies getOrDefaultPersistencePolicy(PersistencePolicies policies) {
+        return policies != null ? policies
+                : new PersistencePolicies(pulsar().getConfiguration().getManagedLedgerDefaultEnsembleSize(),
+                        pulsar().getConfiguration().getManagedLedgerDefaultWriteQuorum(),
+                        pulsar().getConfiguration().getManagedLedgerDefaultAckQuorum(),
+                        pulsar().getConfiguration().getManagedLedgerDefaultMarkDeleteRateLimit());
+    }
+
     protected CompletableFuture<Policies> getNamespacePoliciesAsync(NamespaceName namespaceName) {
         return namespaceResources().getPoliciesAsync(namespaceName).thenCompose(policies -> {
             if (policies.isPresent()) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/NamespacesBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/NamespacesBase.java
@@ -1519,7 +1519,7 @@ public abstract class NamespacesBase extends AdminResource {
         validateNamespacePolicyOperation(namespaceName, PolicyName.PERSISTENCE, PolicyOperation.READ);
 
         Policies policies = getNamespacePolicies(namespaceName);
-        return policies.persistence;
+        return getOrDefaultPersistencePolicy(policies.persistence);
     }
 
     protected void internalClearNamespaceBacklog(AsyncResponse asyncResponse, boolean authoritative) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
@@ -3094,13 +3094,7 @@ public class PersistentTopicsBase extends AdminResource {
                     if (applied) {
                         PersistencePolicies namespacePolicy = getNamespacePolicies(namespaceName)
                                 .persistence;
-                        return namespacePolicy == null
-                                ? new PersistencePolicies(
-                                pulsar().getConfiguration().getManagedLedgerDefaultEnsembleSize(),
-                                pulsar().getConfiguration().getManagedLedgerDefaultWriteQuorum(),
-                                pulsar().getConfiguration().getManagedLedgerDefaultAckQuorum(),
-                                pulsar().getConfiguration().getManagedLedgerDefaultMarkDeleteRateLimit())
-                                : namespacePolicy;
+                        return getOrDefaultPersistencePolicy(namespacePolicy);
                     }
                     return null;
                 }));

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApi2Test.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApi2Test.java
@@ -390,7 +390,7 @@ public class AdminApi2Test extends MockedPulsarServiceBaseTest {
         final String namespace = "prop-xyz/ns2";
         admin.namespaces().createNamespace(namespace, Sets.newHashSet("test"));
 
-        assertNull(admin.namespaces().getPersistence(namespace));
+        assertNotNull(admin.namespaces().getPersistence(namespace));
         admin.namespaces().setPersistence(namespace, new PersistencePolicies(3, 3, 3, 10.0));
         assertEquals(admin.namespaces().getPersistence(namespace), new PersistencePolicies(3, 3, 3, 10.0));
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiTest.java
@@ -749,7 +749,7 @@ public class AdminApiTest extends MockedPulsarServiceBaseTest {
         policies.auth_policies.getNamespaceAuthentication().remove("my-role");
         assertEquals(admin.namespaces().getPolicies("prop-xyz/ns1"), policies);
 
-        assertEquals(admin.namespaces().getPersistence("prop-xyz/ns1"), null);
+        assertEquals(admin.namespaces().getPersistence("prop-xyz/ns1"), new PersistencePolicies(2, 2, 2, 1.0));
         admin.namespaces().setPersistence("prop-xyz/ns1", new PersistencePolicies(3, 2, 1, 10.0));
         assertEquals(admin.namespaces().getPersistence("prop-xyz/ns1"), new PersistencePolicies(3, 2, 1, 10.0));
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiTest.java
@@ -24,6 +24,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNull;
@@ -3119,4 +3120,16 @@ public class AdminApiTest extends MockedPulsarServiceBaseTest {
             assertEquals(peekedMessages.get(i).getData(), receivedMessages.get(i).getData());
         }
     }
+
+    @Test
+    public void testGetPersistenceAPI() throws Exception {
+        String namespace = "prop-xyz/test/persistence";
+        admin.namespaces().createNamespace(namespace);
+        PersistencePolicies persistencePolicies = admin.namespaces().getPersistence(namespace);
+        assertNotNull(persistencePolicies);
+        assertEquals(persistencePolicies.getBookkeeperEnsemble(), conf.getManagedLedgerDefaultEnsembleSize());
+        assertEquals(persistencePolicies.getBookkeeperWriteQuorum(), conf.getManagedLedgerDefaultWriteQuorum());
+        assertEquals(persistencePolicies.getBookkeeperAckQuorum(), conf.getManagedLedgerDefaultAckQuorum());
+    }
+
 }


### PR DESCRIPTION
### Motivation
Right now, if namespace is not configured with persistence policy then broker considers default persistence-policy while serving the topic but it returns null value in get-persistence admin API
```
./pulsar-admin namespaces get-persistence pulsar/standalone/ns2
null

```

### Modification
Return default persistence policy if namespace persistence policy is not configured.