### PR TITLE
[Management] Make ``BrokerBase#deleteDynamicConfiguration`` to pure async method.

### DIFF
--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/resources/DynamicConfigurationResources.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/resources/DynamicConfigurationResources.java
@@ -54,6 +54,11 @@ public class DynamicConfigurationResources extends BaseResources<Map<String, Str
         return super.setWithCreateAsync(BROKER_SERVICE_CONFIGURATION_PATH, createFunction);
     }
 
+    public CompletableFuture<Void> setDynamicConfigurationAsync(
+            Function<Map<String, String>, Map<String, String>> updateFunction){
+        return super.setAsync(BROKER_SERVICE_CONFIGURATION_PATH, updateFunction);
+    }
+
     public void setDynamicConfiguration(
             Function<Map<String, String>, Map<String, String>> updateFunction)
             throws MetadataStoreException {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/BrokersBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/BrokersBase.java
@@ -390,7 +390,7 @@ public class BrokersBase extends AdminResource {
                 });
     }
 
-    private synchronized CompletableFuture<Void> internalDeleteDynamicConfigurationOnMetadataAsync(String configName) {
+    private CompletableFuture<Void> internalDeleteDynamicConfigurationOnMetadataAsync(String configName) {
         if (!BrokerService.isDynamicConfiguration(configName)) {
             throw new RestException(Status.PRECONDITION_FAILED, " Can't update non-dynamic configuration");
         } else {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/BrokersBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/BrokersBase.java
@@ -184,8 +184,8 @@ public class BrokersBase extends AdminResource {
     @DELETE
     @Path("/configuration/{configName}")
     @ApiOperation(value =
-            "Delete dynamic ServiceConfiguration into metadata only." +
-                    " This operation requires Pulsar super-user privileges.")
+            "Delete dynamic ServiceConfiguration into metadata only."
+                    + " This operation requires Pulsar super-user privileges.")
     @ApiResponses(value = { @ApiResponse(code = 204, message = "Service configuration updated successfully"),
             @ApiResponse(code = 403, message = "You don't have admin permission to update service-configuration"),
             @ApiResponse(code = 412, message = "Invalid dynamic-config value"),

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/BrokersBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/BrokersBase.java
@@ -184,14 +184,24 @@ public class BrokersBase extends AdminResource {
     @DELETE
     @Path("/configuration/{configName}")
     @ApiOperation(value =
-            "Delete dynamic serviceconfiguration into zk only. This operation requires Pulsar super-user privileges.")
+            "Delete dynamic ServiceConfiguration into metadata only. This operation requires Pulsar super-user privileges.")
     @ApiResponses(value = { @ApiResponse(code = 204, message = "Service configuration updated successfully"),
             @ApiResponse(code = 403, message = "You don't have admin permission to update service-configuration"),
             @ApiResponse(code = 412, message = "Invalid dynamic-config value"),
             @ApiResponse(code = 500, message = "Internal server error") })
-    public void deleteDynamicConfiguration(@PathParam("configName") String configName) throws Exception {
-        validateSuperUserAccess();
-        deleteDynamicConfigurationOnZk(configName);
+    public void deleteDynamicConfiguration(
+            @Suspended AsyncResponse asyncResponse,
+            @PathParam("configName") String configName) {
+        validateSuperUserAccessAsync()
+                .thenCompose(__ -> internalDeleteDynamicConfigurationOnMetadataAsync(configName))
+                .thenAccept(__ -> {
+                    LOG.info("[{}] Successfully to delete dynamic configuration {}", clientAppId(), configName);
+                    asyncResponse.resume(Response.ok().build());
+                }).exceptionally(ex -> {
+                    LOG.error("[{}] Failed to delete dynamic configuration {}", clientAppId(), configName, ex);
+                    resumeAsyncResponseExceptionally(asyncResponse, ex);
+                    return null;
+                });
     }
 
     @GET
@@ -379,27 +389,16 @@ public class BrokersBase extends AdminResource {
                 });
     }
 
-    private synchronized void deleteDynamicConfigurationOnZk(String configName) {
-        try {
-            if (BrokerService.isDynamicConfiguration(configName)) {
-                dynamicConfigurationResources().setDynamicConfiguration(old -> {
-                    if (old != null) {
-                        old.remove(configName);
-                    }
-                    return old;
-                });
-                LOG.info("[{}] Deleted Service configuration {}", clientAppId(), configName);
-            } else {
-                if (LOG.isDebugEnabled()) {
-                    LOG.debug("[{}] Can't update non-dynamic configuration {}", clientAppId(), configName);
+    private synchronized CompletableFuture<Void> internalDeleteDynamicConfigurationOnMetadataAsync(String configName) {
+        if (!BrokerService.isDynamicConfiguration(configName)) {
+            throw new RestException(Status.PRECONDITION_FAILED, " Can't update non-dynamic configuration");
+        } else {
+            return dynamicConfigurationResources().setDynamicConfigurationAsync(old -> {
+                if (old != null) {
+                    old.remove(configName);
                 }
-                throw new RestException(Status.PRECONDITION_FAILED, " Can't update non-dynamic configuration");
-            }
-        } catch (RestException re) {
-            throw re;
-        } catch (Exception ie) {
-            LOG.error("[{}] Failed to update configuration {}, {}", clientAppId(), configName, ie.getMessage(), ie);
-            throw new RestException(ie);
+                return old;
+            });
         }
     }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/BrokersBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/BrokersBase.java
@@ -184,7 +184,8 @@ public class BrokersBase extends AdminResource {
     @DELETE
     @Path("/configuration/{configName}")
     @ApiOperation(value =
-            "Delete dynamic ServiceConfiguration into metadata only. This operation requires Pulsar super-user privileges.")
+            "Delete dynamic ServiceConfiguration into metadata only." +
+                    " This operation requires Pulsar super-user privileges.")
     @ApiResponses(value = { @ApiResponse(code = 204, message = "Service configuration updated successfully"),
             @ApiResponse(code = 403, message = "You don't have admin permission to update service-configuration"),
             @ApiResponse(code = 412, message = "Invalid dynamic-config value"),


### PR DESCRIPTION
### Motivation

Make ``BrokerBase#deleteDynamicConfiguration`` to a pure async method to avoid some problems caused by sync and async methods calling each other.

### Modifications

- Make ``BrokerBase#deleteDynamicConfiguration`` to pure async method.
- Use ``metadata``instead of ``zk`` in doc.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Documentation

- [x] `no-need-doc` 
  
