### PR TITLE
[PIP-139] Support Broker send command to close producer/consumer.

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ClientCnx.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ClientCnx.java
@@ -731,7 +731,11 @@ public class ClientCnx extends PulsarHandler {
         final long producerId = closeProducer.getProducerId();
         ProducerImpl<?> producer = producers.get(producerId);
         if (producer != null) {
-            producer.connectionClosed(this);
+            if (closeProducer.isAllowReconnect()) {
+                producer.connectionClosed(this);
+            } else {
+                producer.closeAsync();
+            }
         } else {
             log.warn("Producer with id {} not found while closing producer ", producerId);
         }
@@ -743,7 +747,11 @@ public class ClientCnx extends PulsarHandler {
         final long consumerId = closeConsumer.getConsumerId();
         ConsumerImpl<?> consumer = consumers.get(consumerId);
         if (consumer != null) {
-            consumer.connectionClosed(this);
+            if (closeConsumer.isAllowReconnect()) {
+                consumer.connectionClosed(this);
+            } else {
+                consumer.closeAsync();
+            }
         } else {
             log.warn("Consumer with id {} not found while closing consumer ", consumerId);
         }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ClientCnx.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ClientCnx.java
@@ -731,7 +731,7 @@ public class ClientCnx extends PulsarHandler {
         final long producerId = closeProducer.getProducerId();
         ProducerImpl<?> producer = producers.get(producerId);
         if (producer != null) {
-            if (closeProducer.isAllowReconnect()) {
+            if (closeProducer.isReconnect()) {
                 producer.connectionClosed(this);
             } else {
                 producer.closeAsync();
@@ -747,7 +747,7 @@ public class ClientCnx extends PulsarHandler {
         final long consumerId = closeConsumer.getConsumerId();
         ConsumerImpl<?> consumer = consumers.get(consumerId);
         if (consumer != null) {
-            if (closeConsumer.isAllowReconnect()) {
+            if (closeConsumer.isReconnect()) {
                 consumer.connectionClosed(this);
             } else {
                 consumer.closeAsync();

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/ConsumerImplTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/ConsumerImplTest.java
@@ -227,7 +227,7 @@ public class ConsumerImplTest {
         CommandCloseConsumer commandCloseConsumer = new CommandCloseConsumer();
         commandCloseConsumer.setConsumerId(consumer.consumerId);
         commandCloseConsumer.setRequestId(1);
-        commandCloseConsumer.setAllowReconnect(false);
+        commandCloseConsumer.setReconnect(false);
         cnx.handleCloseConsumer(commandCloseConsumer);
         Awaitility.await().untilAsserted(() -> {
             HandlerState.State state = consumer.getState();

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/ProducerImplTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/ProducerImplTest.java
@@ -93,7 +93,7 @@ public class ProducerImplTest {
         CommandCloseProducer commandCloseProducer = new CommandCloseProducer();
         commandCloseProducer.setProducerId(producer.producerId);
         commandCloseProducer.setRequestId(1);
-        commandCloseProducer.setAllowReconnect(false);
+        commandCloseProducer.setReconnect(false);
         cnx.handleCloseProducer(commandCloseProducer);
         Awaitility.await().untilAsserted(() -> {
             HandlerState.State state = producer.getState();

--- a/pulsar-common/src/main/proto/PulsarApi.proto
+++ b/pulsar-common/src/main/proto/PulsarApi.proto
@@ -607,13 +607,13 @@ message CommandReachedEndOfTopic {
 message CommandCloseProducer {
     required uint64 producer_id = 1;
     required uint64 request_id = 2;
-    optional bool allow_reconnect = 3 [default = true];
+    optional bool reconnect = 3 [default = true];
 }
 
 message CommandCloseConsumer {
     required uint64 consumer_id = 1;
     required uint64 request_id = 2;
-    optional bool allow_reconnect = 3 [default = true];
+    optional bool reconnect = 3 [default = true];
 }
 
 message CommandRedeliverUnacknowledgedMessages {

--- a/pulsar-common/src/main/proto/PulsarApi.proto
+++ b/pulsar-common/src/main/proto/PulsarApi.proto
@@ -607,11 +607,13 @@ message CommandReachedEndOfTopic {
 message CommandCloseProducer {
     required uint64 producer_id = 1;
     required uint64 request_id = 2;
+    optional bool allow_reconnect = 3 [default = true];
 }
 
 message CommandCloseConsumer {
     required uint64 consumer_id = 1;
     required uint64 request_id = 2;
+    optional bool allow_reconnect = 3 [default = true];
 }
 
 message CommandRedeliverUnacknowledgedMessages {


### PR DESCRIPTION
### Motivation
  
 Original PIP  #13989

- When there are no user-created topics under a namespace, Namespace should be deleted. But currently, the system topic existed and the reader/producer could auto-create the system which may cause the namespace deletion to fail.
- When enabling geo-replication under a namespace, inactive topics could not be deleted by GC, and if the broker enables `auto-create` topic, the topic will be created(replicator) even deleted with `force=true`.

For the above reasons, we need to close the topics readers/producers first, then delete the relative topics.

Following this way, we need to close consumers/producers(not disconnect, which means do not allow them to reconnect). So we write this PIP to discuss to resolve this problem.

### Modifications

- Add ``optional bool reconnect = 3 [default = true];`` at ``CommandCloseConsumer``
- Add ``optional bool reconnect = 3 [default = true];`` at ``CommandCloseProducer``
- If broker send ``CommandCloseConsumer/CommandCloseProducer`` with ``isReconnect=false`` the Producer/Consumer will close immediately.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Does this pull request potentially affect one of the following parts:

  - The wire protocol: (yes)

### Documentation

Check the box below or label this PR directly (if you have committer privilege).

Need to update docs? 

- [x] `no-need-doc` 
  
