### PR TITLE
[perf]: replace `ConcurrentSkipListMap.size()` with `isEmpty()`

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
@@ -356,7 +356,7 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
                 }
 
                 // Last ledger stat may be zeroed, we must update it
-                if (ledgers.size() > 0) {
+                if (!ledgers.isEmpty()) {
                     final long id = ledgers.lastKey();
                     OpenCallback opencb = (rc, lh, ctx1) -> {
                         executor.executeOrdered(name, safeRun(() -> {

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerOfflineBacklog.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerOfflineBacklog.java
@@ -152,7 +152,7 @@ public class ManagedLedgerOfflineBacklog {
                         }
 
                         // find no of entries in last ledger
-                        if (ledgers.size() > 0) {
+                        if (!ledgers.isEmpty()) {
                             final long id = ledgers.lastKey();
                             AsyncCallback.OpenCallback opencb = (rc, lh, ctx1) -> {
                                 if (log.isDebugEnabled()) {
@@ -212,7 +212,7 @@ public class ManagedLedgerOfflineBacklog {
             final NavigableMap<Long, MLDataFormats.ManagedLedgerInfo.LedgerInfo> ledgers,
             final PersistentOfflineTopicStats offlineTopicStats) throws Exception {
 
-        if (ledgers.size() == 0) {
+        if (ledgers.isEmpty()) {
             return;
         }
         String managedLedgerName = topicName.getPersistenceNamingEncoding();

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/HashRangeAutoSplitStickyKeyConsumerSelector.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/HashRangeAutoSplitStickyKeyConsumerSelector.java
@@ -78,7 +78,7 @@ public class HashRangeAutoSplitStickyKeyConsumerSelector implements StickyKeyCon
 
     @Override
     public synchronized void addConsumer(Consumer consumer) throws ConsumerAssignException {
-        if (rangeMap.size() == 0) {
+        if (rangeMap.isEmpty()) {
             rangeMap.put(rangeSize, consumer);
             consumerRange.put(consumer, rangeSize);
         } else {
@@ -103,7 +103,7 @@ public class HashRangeAutoSplitStickyKeyConsumerSelector implements StickyKeyCon
 
     @Override
     public Consumer select(int hash) {
-        if (rangeMap.size() > 0) {
+        if (!rangeMap.isEmpty()) {
             int slot = hash % rangeSize;
             return rangeMap.ceilingEntry(slot).getValue();
         } else {

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/util/collections/ConcurrentOpenLongPairRangeSet.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/util/collections/ConcurrentOpenLongPairRangeSet.java
@@ -169,7 +169,7 @@ public class ConcurrentOpenLongPairRangeSet<T extends Comparable<T>> implements 
 
     @Override
     public Range<T> span() {
-        if (rangeBitSetMap.size() == 0) {
+        if (rangeBitSetMap.isEmpty()) {
             return null;
         }
         Entry<Long, BitSet> firstSet = rangeBitSetMap.firstEntry();


### PR DESCRIPTION


### Motivation

[java_doc](https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/ConcurrentSkipListMap.html#:~:text=Beware%20that%2C%20unlike%20in%20most%20collections%2C%20the%20size%20method%20is%20not%20a%20constant%2Dtime%20operation.)
`ConcurrentSkipListMap.size()` is not a constant-time operation, it is unnessary to calculate the size when we just want to check if collection is empty.

generally, we should always use `isEmpty` instead of `size` in `checkEmpty` case as it is more clear.



### Modifications

replace `ConcurrentSkipListMap.size()` with `isEmpty()` when check if collection is empty.


### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*



### Documentation

Check the box below or label this PR directly (if you have committer privilege).

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
it is an internal improvement, no action is changed.
  
- [ ] `doc` 
  
  (If this PR contains doc changes)


