### PR TITLE
[metadata] Make BaseMetadataStoreTest#etcdCluster lazy init.

### DIFF
--- a/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/BaseMetadataStoreTest.java
+++ b/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/BaseMetadataStoreTest.java
@@ -22,6 +22,7 @@ import static org.testng.Assert.assertTrue;
 import io.etcd.jetcd.launcher.EtcdCluster;
 import io.etcd.jetcd.launcher.EtcdClusterFactory;
 import java.io.File;
+import java.net.URI;
 import java.util.UUID;
 import java.util.concurrent.CompletionException;
 import java.util.function.Supplier;
@@ -41,9 +42,6 @@ public abstract class BaseMetadataStoreTest extends TestRetrySupport {
     public final void setup() throws Exception {
         incrementSetupNumber();
         zks = new TestZKServer();
-
-        etcdCluster = EtcdClusterFactory.buildCluster("test", 1, false);
-        etcdCluster.start();
     }
 
     @AfterClass(alwaysRun = true)
@@ -57,6 +55,7 @@ public abstract class BaseMetadataStoreTest extends TestRetrySupport {
 
         if (etcdCluster != null) {
             etcdCluster.close();
+            etcdCluster = null;
         }
     }
 
@@ -74,12 +73,19 @@ public abstract class BaseMetadataStoreTest extends TestRetrySupport {
         // The new connection string won't be available to the test method unless a
         // Supplier<String> lambda is used for providing the value.
         return new Object[][]{
-                { "ZooKeeper", stringSupplier(() -> zks.getConnectionString()) },
-                { "Memory", stringSupplier(() -> "memory:" + UUID.randomUUID()) },
-                { "RocksDB", stringSupplier(() -> "rocksdb:" + createTempFolder()) },
-                {"Etcd", stringSupplier(() -> "etcd:" + etcdCluster.getClientEndpoints().stream().map(x -> x.toString())
-                        .collect(Collectors.joining(",")))},
+                {"ZooKeeper", stringSupplier(() -> zks.getConnectionString())},
+                {"Memory", stringSupplier(() -> "memory:" + UUID.randomUUID())},
+                {"RocksDB", stringSupplier(() -> "rocksdb:" + createTempFolder())},
+                {"Etcd", stringSupplier(() -> "etcd:" + getEtcdClusterConnectString())},
         };
+    }
+
+    private synchronized String getEtcdClusterConnectString() {
+        if (etcdCluster == null) {
+            etcdCluster = EtcdClusterFactory.buildCluster("test", 1, false);
+            etcdCluster.start();
+        }
+        return etcdCluster.getClientEndpoints().stream().map(URI::toString).collect(Collectors.joining(","));
     }
 
     public static Supplier<String> stringSupplier(Supplier<String> supplier) {


### PR DESCRIPTION
### Motivation

`etcdCluster` is initialized in `setup`, and we have to setup local docker environments properly to run most unit tests in pulsar-metadata

Mostly, we just need zk implementation to debug some metadata issue. 

### Modifications

Make `etcdCluster` lazy initialized 

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change is already covered by existing tests, such as MetadataStoreTest, etc.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

Check the box below and label this PR (if you have committer privilege).

Need to update docs? 
  
- [x] `no-need-doc` 
