### PR TITLE
AbstractMetadataStore: invalidate childrenCache correctly when node created

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/zookeeper/MultiBrokerMetadataConsistencyTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/zookeeper/MultiBrokerMetadataConsistencyTest.java
@@ -1,0 +1,97 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.zookeeper;
+
+import static org.testng.Assert.assertTrue;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.pulsar.broker.MultiBrokerBaseTest;
+import org.apache.pulsar.client.admin.PulsarAdmin;
+import org.apache.pulsar.client.admin.PulsarAdminException;
+import org.apache.pulsar.metadata.TestZKServer;
+import org.apache.pulsar.metadata.api.MetadataStoreConfig;
+import org.apache.pulsar.metadata.api.MetadataStoreException;
+import org.apache.pulsar.metadata.api.extended.MetadataStoreExtended;
+import org.apache.pulsar.zookeeper.ZooKeeperClientFactory;
+import org.apache.pulsar.zookeeper.ZookeeperClientFactoryImpl;
+import org.apache.zookeeper.ZooKeeper;
+import org.testng.annotations.Test;
+
+@Slf4j
+@Test(groups = "broker")
+public class MultiBrokerMetadataConsistencyTest extends MultiBrokerBaseTest {
+    @Override
+    protected int numberOfAdditionalBrokers() {
+        return 2;
+    }
+
+    TestZKServer testZKServer;
+
+    @Override
+    protected void doInitConf() throws Exception {
+        super.doInitConf();
+        testZKServer = new TestZKServer();
+    }
+
+    @Override
+    protected void onCleanup() {
+        super.onCleanup();
+        if (testZKServer != null) {
+            try {
+                testZKServer.close();
+            } catch (Exception e) {
+                log.error("Error in stopping ZK server", e);
+            }
+        }
+    }
+
+    @Override
+    protected ZooKeeperClientFactory createZooKeeperClientFactory() {
+        return new ZookeeperClientFactoryImpl() {
+            @Override
+            public CompletableFuture<ZooKeeper> create(String serverList, SessionType sessionType,
+                                                       int zkSessionTimeoutMillis) {
+                return super.create(testZKServer.getConnectionString(), sessionType, zkSessionTimeoutMillis);
+            }
+        };
+    }
+
+    @Override
+    protected MetadataStoreExtended createLocalMetadataStore() throws MetadataStoreException {
+        return MetadataStoreExtended.create(testZKServer.getConnectionString(), MetadataStoreConfig.builder().build());
+    }
+
+    @Override
+    protected MetadataStoreExtended createConfigurationMetadataStore() throws MetadataStoreException {
+        return MetadataStoreExtended.create(testZKServer.getConnectionString(), MetadataStoreConfig.builder().build());
+    }
+
+    @Test
+    public void newTopicShouldBeInTopicsList() throws PulsarAdminException {
+        List<PulsarAdmin> admins = getAllAdmins();
+        PulsarAdmin first = admins.get(0);
+        PulsarAdmin second = admins.get(1);
+        List<String> cacheMiss = second.topics().getList("public/default");
+        assertTrue(cacheMiss.isEmpty());
+        first.topics().createNonPartitionedTopic("persistent://public/default/my-topic");
+        List<String> topics = second.topics().getList("public/default");
+        assertTrue(topics.contains("persistent://public/default/my-topic"));
+    }
+}

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/AbstractMetadataStore.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/AbstractMetadataStore.java
@@ -166,6 +166,7 @@ public abstract class AbstractMetadataStore implements MetadataStoreExtended, Co
 
         if (type == NotificationType.Created || type == NotificationType.Deleted) {
             existsCache.synchronous().invalidate(path);
+            childrenCache.synchronous().invalidate(path);
             String parent = parent(path);
             if (parent != null) {
                 childrenCache.synchronous().invalidate(parent);


### PR DESCRIPTION
### Motivation

In Pulsar 2.8, there is currently a bug that can lead to an incorrectly cached value in the `childrenCache`. The resulting behavior is that the broker serves the stale cache value until it is evicted from the cache.

### Steps to Reproduce Issue

Start a 2.8 cluster with at least 2 brokers. It is helpful to run with debug logging to observe the ZK watch notifications. Run the following bash commands in order:

```
BROKER_1=192.168.6.228
BROKER_2=192.168.79.61
bin/pulsar-admin --admin-url http://$BROKER_1:8080 tenants create test
bin/pulsar-admin --admin-url http://$BROKER_1:8080 namespaces create test/a
bin/pulsar-admin --admin-url http://$BROKER_2:8080 topics list test/a
bin/pulsar-admin --admin-url http://$BROKER_1:8080 topics create persistent://test/a/a
bin/pulsar-admin --admin-url http://$BROKER_2:8080 topics list test/a
```

When broker 2 handles the command for `bin/pulsar-admin --admin-url http://$BROKER_2:8080 topics list test/a`, it caches a miss in the `childrenCache` in `AbstractMetadataStore` for path `/managed-ledgers/test/a/persistent`.

After caching the miss, broker 2 only logs two ZK events:

> 05:21:16.810 [main-EventThread] DEBUG org.apache.pulsar.metadata.impl.ZKMetadataStore - Received ZK watch : WatchedEvent state:SyncConnected type:NodeCreated path:/admin/local-policies/test/a

> 05:21:19.808 [main-EventThread] DEBUG org.apache.pulsar.metadata.impl.ZKMetadataStore - Received ZK watch : WatchedEvent state:SyncConnected type:NodeCreated path:/managed-ledgers/test/a/persistent

Note that the second even is of type `NodeCreated`. Because of its type, the `AbstractMetadataStore` does not invalidate the correct node in the `childrenCache`: 

https://github.com/apache/pulsar/blob/42422d84ab5c6d24b57138c39453b45d7dcfba35/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/AbstractMetadataStore.java#L163-L182

I was not able to reproduce this issue in 2.9. My theory is that we get around it because we have a persistent watch at `/`.

Note also that when creating a second topic in the namespace, we see the following notification:

> 07:14:42.181 [main-EventThread] DEBUG org.apache.pulsar.metadata.impl.ZKMetadataStore - Received ZK watch : WatchedEvent state:SyncConnected type:NodeChildrenChanged path:/managed-ledgers/test/a/persistent

In this case, we properly invalidate the child node in the cache.

Also note that in 2.7 we _always_ invalidate the child node for a notification. I don't believe this is strictly necessary because we'll get `NodeChildrenChanged` notifications when the event is not created/deleted.

https://github.com/apache/pulsar/blob/77f7965673119ff40c929b065ee837fe2256a221/pulsar-zookeeper-utils/src/main/java/org/apache/pulsar/zookeeper/ZooKeeperCache.java#L146

### Modifications

* Invalidate the `path` for `childrenCache` when the `path` is created or deleted.

### Verifying this change

I added a test that failed before this change and passes after the change.

### Does this pull request potentially affect one of the following parts:

This is an internal change.

### Documentation
- [x] `no-need-doc` 


