### PR TITLE
[Java Client] Optimize batch flush scheduling

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
@@ -2197,13 +2197,12 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
     }
 
     public int getPendingQueueSize() {
-        if (!isBatchMessagingEnabled()) {
-            return pendingMessages.messagesCount();
-        } else {
+        if (isBatchMessagingEnabled()) {
             synchronized (this) {
                 return pendingMessages.messagesCount() + batchMessageContainer.getNumMessagesInBatch();
             }
         }
+        return pendingMessages.messagesCount();
     }
 
     @Override

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
@@ -1890,7 +1890,7 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
                     // The diff is less than or equal to zero, meaning that the message has been timed out.
                     // Set the callback to timeout on every message, then clear the pending queue.
                     log.info("[{}] [{}] Message send timed out. Failing {} messages", topic, producerName,
-                            pendingMessages.messagesCount() + ((batchMessageContainer.isEmpty()) ? 0 : 1));
+                            pendingMessages.messagesCount() + batchMessageContainer.getNumMessagesInBatch());
                     String msg = format("The producer %s can not send message to the topic %s within given timeout",
                             producerName, topic);
                     if (firstMsg != null) {

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
@@ -638,8 +638,6 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
                         if (isBatchFull) {
                             batchMessageAndSend(false);
                         } else {
-                            // todo make it possible to skip the triggering!
-                            // user can call `flush` themselves
                             maybeScheduleBatchFlushTask();
                         }
                     }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
@@ -1991,12 +1991,10 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
             log.trace("[{}] [{}] Batching the messages from the batch container from flush thread",
                     topic, producerName);
         }
-        // No need to prematurely cut batches if we're not ready to send them.
-        if (getState() != State.Ready) {
-            this.batchFlushTask = null;
-        } else {
-            // Set to null here to prevent the unnecessary attempt to cancel this task.
-            this.batchFlushTask = null;
+        // Set to null here to prevent the unnecessary attempt to cancel this task.
+        this.batchFlushTask = null;
+        // Only cut batches if we're able to send them now.
+        if (getState() == State.Ready) {
             batchMessageAndSend();
         }
     }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
@@ -2001,7 +2001,7 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
     // must acquire semaphore before enqueuing
     private void batchMessageAndSend() {
         if (this.batchFlushTask != null) {
-            // Cancel batch timer task since we're sending the batch now. (Don't interrupt; it could be this future.)
+            // Cancel batch timer task since we're sending the batch now.
             this.batchFlushTask.cancel(false);
             this.batchFlushTask = null;
         }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
@@ -1869,7 +1869,7 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
             }
 
             OpSendMsg firstMsg = pendingMessages.peek();
-            if (firstMsg == null && batchMessageContainer.isEmpty()) {
+            if (firstMsg == null && (isBatchMessagingEnabled() && batchMessageContainer.isEmpty())) {
                 // If there are no pending messages, reset the timeout to the configured value.
                 timeToWaitMs = conf.getSendTimeoutMs();
             } else {
@@ -1890,7 +1890,7 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
                     // The diff is less than or equal to zero, meaning that the message has been timed out.
                     // Set the callback to timeout on every message, then clear the pending queue.
                     log.info("[{}] [{}] Message send timed out. Failing {} messages", topic, producerName,
-                            pendingMessages.messagesCount() + batchMessageContainer.getNumMessagesInBatch());
+                            getPendingQueueSize());
                     String msg = format("The producer %s can not send message to the topic %s within given timeout",
                             producerName, topic);
                     if (firstMsg != null) {
@@ -2164,7 +2164,7 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
         }
         // If any messages were enqueued while the producer was not Ready, we would have skipped
         // scheduling the batch flush task. Schedule it now, if there are messages in the batch container.
-        if (!batchMessageContainer.isEmpty()) {
+        if (isBatchMessagingEnabled() && !batchMessageContainer.isEmpty()) {
             maybeScheduleBatchFlushTask();
         }
         if (pendingRegisteringOp != null) {

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
@@ -1869,7 +1869,7 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
             }
 
             OpSendMsg firstMsg = pendingMessages.peek();
-            if (firstMsg == null && (isBatchMessagingEnabled() && batchMessageContainer.isEmpty())) {
+            if (firstMsg == null && (batchMessageContainer == null || batchMessageContainer.isEmpty())) {
                 // If there are no pending messages, reset the timeout to the configured value.
                 timeToWaitMs = conf.getSendTimeoutMs();
             } else {

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
@@ -635,7 +635,7 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
                         if (isBatchFull) {
                             batchMessageAndSend();
                         } else {
-                            maybeTriggerBatchTimerTask();
+                            maybeTriggerBatchFlushTask();
                         }
                     }
                     isLastSequenceIdPotentialDuplicated = false;


### PR DESCRIPTION
Master Issue: https://github.com/apache/pulsar/issues/11100

### Motivation

As observed in https://github.com/apache/pulsar/issues/11100, the Java client producer consumes cpu even when doing nothing. This is especially true when using many producers. Instead, we can make it so that the batch timer is only scheduled when it has messages to deliver or just fired and delivered messages.

If there are concerns about this optimization, I will need to take some time to complete benchmarks.

### Modifications

* Skip message batch delivery if the producer is not in `Ready` state. As a consequence, ensure that messages pending in the `batchMessageContainer` are still eligible to fail for `sendTimeout`.
* If there is no current batch flush task, schedule a single flush task when a message is added to a batch message container (assuming the message does not also trigger the delivery of the batch and the producer is in READY state).
* Schedule another batch flush task if and only if the batch flush task itself was responsible for sending messages.
* Keep track of `lastBatchSendNanoTime`, and only flush a batch message container if the `BatchingMaxPublishDelayMicros` time has passed since the last send time.
* Note that the timer task is only ever updated within `synchronized (this)` block, so we are guaranteed to have a consistent view free of race conditions. (There is one race condition, and that is that an existing batch timer might get canceled while it is starting. This is of little consequence since it'll result in either no delivery or a small batch.)

### Verifying this change

There are existing tests that cover batch message delivery. Specifically, the `BatchMessageTest` in the `pulsar-broker` module covers these changes.

### Does this pull request potentially affect one of the following parts:

This is a backwards compatible change.

### Documentation

- [x] `no-need-doc` 
