### PR TITLE
[Doc] add skip tests flag in minimal build cmd

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ $ mvn -pl module-name (e.g: pulsar-broker) install -DskipTests
 
 ## Minimal build (This skips most of external connectors and tiered storage handlers)
 ```
-mvn install -Pcore-modules,-main
+mvn install -Pcore-modules,-main -DskipTests
 ```
 
 Run Unit Tests:


### PR DESCRIPTION
Signed-off-by: Zixuan Liu <nodeces@gmail.com>

### Motivation

Running the tests is unnecessary when building this project.

### Modifications

- add skip tests flag in minimal build cmd

### Documentation

- [x] `doc` 


