### PR TITLE
[ci] set single-test retries to reduce waste of resources caused by flaky tests

### DIFF
--- a/build/run_unit_group.sh
+++ b/build/run_unit_group.sh
@@ -31,7 +31,7 @@ echo_and_restore_trace() {
 alias echo='{ [[ $- =~ .*x.* ]] && trace_enabled=1 || trace_enabled=0; set +x; } 2> /dev/null; echo_and_restore_trace'
 
 MVN_COMMAND='mvn -B -ntp'
-MVN_COMMAND_WITH_RETRY="build/retry.sh ${MVN_COMMAND}"
+MVN_COMMAND_WITH_RETRY="build/retry.sh ${MVN_COMMAND} -DtestRetryCount=6"
 MVN_TEST_COMMAND="${MVN_COMMAND_WITH_RETRY} test"
 
 echo -n "Test Group : $TEST_GROUP"

--- a/build/run_unit_group.sh
+++ b/build/run_unit_group.sh
@@ -31,7 +31,7 @@ echo_and_restore_trace() {
 alias echo='{ [[ $- =~ .*x.* ]] && trace_enabled=1 || trace_enabled=0; set +x; } 2> /dev/null; echo_and_restore_trace'
 
 MVN_COMMAND='mvn -B -ntp'
-MVN_COMMAND_WITH_RETRY="build/retry.sh ${MVN_COMMAND} -DtestRetryCount=6"
+MVN_COMMAND_WITH_RETRY="${MVN_COMMAND} -DtestRetryCount=3"
 MVN_TEST_COMMAND="${MVN_COMMAND_WITH_RETRY} test"
 
 echo -n "Test Group : $TEST_GROUP"


### PR DESCRIPTION
### Motivation

In the unit tests github checks if a single test fails, then the whole job is rerun for at most 3 times. (using the [retry](https://github.com/apache/pulsar/blob/master/build/retry.sh) script).

Additionally, if a single test fails, there's [one attempt to rerun the test](https://github.com/apache/pulsar/blob/52b7059bdac7120f319a3c6f8085f25a2b9de7c8/buildtools/src/main/java/org/apache/pulsar/tests/RetryAnalyzer.java#L27). This parameter is configurable. The default (and actual value) is 1.


We can retry to run the single failing test instead of re-running the whole suite.
The benefits are multiple:
* Fast PR validations
* More stable PR validations (less need to re-trigger the CI)
* Less waste of resources in case the test passes on the second or third shot 

### Modifications
- Set `testRetryCount` to 3 on the unit test suites and remove retry.sh usage
  
### Documentation

- [x] `no-need-doc` 
