### PR TITLE
[test] do not rely on InetSocketAddress#toString() in tests

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/PulsarMultiListenersWithInternalListenerNameTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/PulsarMultiListenersWithInternalListenerNameTest.java
@@ -198,9 +198,4 @@ public class PulsarMultiListenersWithInternalListenerNameTest extends MockedPuls
         }
         super.internalCleanup();
     }
-
-    private static String unresolvedSocketAddressToString(InetSocketAddress address) {
-        return address.getHostString() + ":" + address.getPort();
-    }
-
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/PulsarMultiListenersWithInternalListenerNameTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/PulsarMultiListenersWithInternalListenerNameTest.java
@@ -58,8 +58,8 @@ import static org.mockito.Mockito.doReturn;
 public class PulsarMultiListenersWithInternalListenerNameTest extends MockedPulsarServiceBaseTest {
     private final boolean withInternalListener;
     private ExecutorService executorService;
-    private String hostAndBrokerPort;
-    private String hostAndBrokerPortSsl;
+    private InetSocketAddress brokerAddress;
+    private InetSocketAddress brokerSslAddress;
     private EventLoopGroup eventExecutors;
 
     public PulsarMultiListenersWithInternalListenerNameTest() {
@@ -80,9 +80,9 @@ public class PulsarMultiListenersWithInternalListenerNameTest extends MockedPuls
         this.isTcpLookup = true;
         String host = InetAddress.getLocalHost().getHostAddress();
         int brokerPort = getFreePort();
-        hostAndBrokerPort = host + ":" + brokerPort;
+        brokerAddress = InetSocketAddress.createUnresolved(host, brokerPort);
         int brokerPortSsl = getFreePort();
-        hostAndBrokerPortSsl = host + ":" + brokerPortSsl;
+        brokerSslAddress = InetSocketAddress.createUnresolved(host, brokerPortSsl);
         super.internalSetup();
     }
 
@@ -97,8 +97,9 @@ public class PulsarMultiListenersWithInternalListenerNameTest extends MockedPuls
     protected void doInitConf() throws Exception {
         super.doInitConf();
         this.conf.setClusterName("localhost");
-        this.conf.setAdvertisedListeners(String.format("internal:pulsar://%s,internal:pulsar+ssl://%s",
-                hostAndBrokerPort, hostAndBrokerPortSsl));
+        this.conf.setAdvertisedListeners(String.format("internal:pulsar://%s:%s,internal:pulsar+ssl://%s:%s",
+                brokerAddress.getHostString(), brokerAddress.getPort(),
+                brokerSslAddress.getHostString(), brokerSslAddress.getPort()));
         if (withInternalListener) {
             this.conf.setInternalListenerName("internal");
         }
@@ -136,16 +137,16 @@ public class PulsarMultiListenersWithInternalListenerNameTest extends MockedPuls
             CompletableFuture<Pair<InetSocketAddress, InetSocketAddress>> future =
                     lookupService.getBroker(TopicName.get("persistent://public/default/test"));
             Pair<InetSocketAddress, InetSocketAddress> result = future.get(10, TimeUnit.SECONDS);
-            Assert.assertEquals(result.getKey().toString(), hostAndBrokerPort);
-            Assert.assertEquals(result.getValue().toString(), hostAndBrokerPort);
+            Assert.assertEquals(result.getKey(), brokerAddress);
+            Assert.assertEquals(result.getValue(), brokerAddress);
         }
         // test request 2
         {
             CompletableFuture<Pair<InetSocketAddress, InetSocketAddress>> future =
                     lookupService.getBroker(TopicName.get("persistent://public/default/test"));
             Pair<InetSocketAddress, InetSocketAddress> result = future.get(10, TimeUnit.SECONDS);
-            Assert.assertEquals(result.getKey().toString(), hostAndBrokerPort);
-            Assert.assertEquals(result.getValue().toString(), hostAndBrokerPort);
+            Assert.assertEquals(result.getKey(), brokerAddress);
+            Assert.assertEquals(result.getValue(), brokerAddress);
         }
     }
 
@@ -169,10 +170,10 @@ public class PulsarMultiListenersWithInternalListenerNameTest extends MockedPuls
         LookupResult lookupResult = new LookupResult(pulsar.getWebServiceAddress(), null,
                 pulsar.getBrokerServiceUrl(), null, true);
         Optional<LookupResult> optional = Optional.of(lookupResult);
-        String address = "192.168.0.1:8080";
-        String httpAddress = "192.168.0.1:8081";
-        NamespaceEphemeralData namespaceEphemeralData = new NamespaceEphemeralData("pulsar://" + address,
-                null, "http://" + httpAddress, null, false);
+        InetSocketAddress address = InetSocketAddress.createUnresolved("192.168.0.1", 8080);
+        NamespaceEphemeralData namespaceEphemeralData =
+                new NamespaceEphemeralData("pulsar://" + address.getHostName() + ":" + address.getPort(),
+                null, "http://192.168.0.1:8081", null, false);
         LookupResult lookupResult2 = new LookupResult(namespaceEphemeralData);
         Optional<LookupResult> optional2 = Optional.of(lookupResult2);
         doReturn(CompletableFuture.completedFuture(optional), CompletableFuture.completedFuture(optional2))
@@ -182,8 +183,8 @@ public class PulsarMultiListenersWithInternalListenerNameTest extends MockedPuls
                 lookupService.getBroker(TopicName.get("persistent://public/default/test"));
 
         Pair<InetSocketAddress, InetSocketAddress> result = future.get(10, TimeUnit.SECONDS);
-        Assert.assertEquals(result.getKey().toString(), address);
-        Assert.assertEquals(result.getValue().toString(), address);
+        Assert.assertEquals(result.getKey(), address);
+        Assert.assertEquals(result.getValue(), address);
     }
 
     @AfterMethod(alwaysRun = true)
@@ -196,6 +197,10 @@ public class PulsarMultiListenersWithInternalListenerNameTest extends MockedPuls
             eventExecutors.shutdownGracefully();
         }
         super.internalCleanup();
+    }
+
+    private static String unresolvedSocketAddressToString(InetSocketAddress address) {
+        return address.getHostString() + ":" + address.getPort();
     }
 
 }

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/BinaryProtoLookupServiceTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/BinaryProtoLookupServiceTest.java
@@ -81,8 +81,10 @@ public class BinaryProtoLookupServiceTest {
     @Test(invocationTimeOut = 3000)
     public void maxLookupRedirectsTest1() throws Exception {
         Pair<InetSocketAddress, InetSocketAddress> addressPair = lookup.getBroker(topicName).get();
-        assertEquals(addressPair.getLeft().toString(), "broker2.pulsar.apache.org:6650");
-        assertEquals(addressPair.getRight().toString(), "broker2.pulsar.apache.org:6650");
+        assertEquals(addressPair.getLeft(), InetSocketAddress
+                .createUnresolved("broker2.pulsar.apache.org" ,6650));
+        assertEquals(addressPair.getRight(), InetSocketAddress
+                .createUnresolved("broker2.pulsar.apache.org" ,6650));
     }
 
     @Test(invocationTimeOut = 3000)
@@ -92,8 +94,10 @@ public class BinaryProtoLookupServiceTest {
         field.set(lookup, 2);
 
         Pair<InetSocketAddress, InetSocketAddress> addressPair = lookup.getBroker(topicName).get();
-        assertEquals(addressPair.getLeft().toString(), "broker2.pulsar.apache.org:6650");
-        assertEquals(addressPair.getRight().toString(), "broker2.pulsar.apache.org:6650");
+        assertEquals(addressPair.getLeft(), InetSocketAddress
+                .createUnresolved("broker2.pulsar.apache.org" ,6650));
+        assertEquals(addressPair.getRight(), InetSocketAddress
+                .createUnresolved("broker2.pulsar.apache.org" ,6650));
     }
 
     @Test(invocationTimeOut = 3000)


### PR DESCRIPTION
### Motivation
There are some tests that assert the equality of two `InetSocketAddress` instances by using the `toString()` method.
Since JDK14, the `toString()` has changed for unresolved ´InetSocketAddress´ instances. See https://bugs.java.com/bugdatabase/view_bug.do?bug_id=JDK-8225499

### Modifications

* Assert equality based on `equals` method.

Note: I manually checked the usage of toString in the `src` codebase and I haven't found implementations that rely on the `toString()` method

### Documentation
 
- [x] `no-need-doc` 