### PR TITLE
[Broker] Adjust topic exists check logic in http lookup process

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/lookup/TopicLookupBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/lookup/TopicLookupBase.java
@@ -80,10 +80,10 @@ public class TopicLookupBase extends PulsarWebResource {
             return;
         }
 
-        // Currently, it's hard to check the non-persistent-non-partitioned topic, because it only exists in broker,
-        // it doesn't have metadata. If the topic is non persistent and non partitioned, we'll return true flag first.
-        CompletableFuture<Boolean> existFuture = topicName.isPersistent() || topicName.isPartitioned() ?
-                pulsar().getNamespaceService().checkTopicExists(topicName) : CompletableFuture.completedFuture(true);
+        // Currently, it's hard to check the non-persistent-non-partitioned topic, because it only exists in the broker,
+        // it doesn't have metadata. If the topic is non-persistent and non-partitioned, we'll return the true flag.
+        CompletableFuture<Boolean> existFuture = topicName.isPersistent() || topicName.isPartitioned()
+                ? pulsar().getNamespaceService().checkTopicExists(topicName) : CompletableFuture.completedFuture(true);
         existFuture.thenAccept(exist -> {
             if (!exist && !pulsar().getBrokerService().isAllowAutoTopicCreation(topicName)) {
                 completeLookupResponseExceptionally(asyncResponse, new RestException(Response.Status.NOT_FOUND,

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/lookup/TopicLookupBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/lookup/TopicLookupBase.java
@@ -82,10 +82,11 @@ public class TopicLookupBase extends PulsarWebResource {
 
         // Currently, it's hard to check the non-persistent-non-partitioned topic, because it only exists in the broker,
         // it doesn't have metadata. If the topic is non-persistent and non-partitioned, we'll return the true flag.
-        CompletableFuture<Boolean> existFuture = topicName.isPersistent() || topicName.isPartitioned()
-                ? pulsar().getNamespaceService().checkTopicExists(topicName) : CompletableFuture.completedFuture(true);
+        CompletableFuture<Boolean> existFuture = pulsar().getBrokerService().isAllowAutoTopicCreation(topicName)
+                || (!topicName.isPersistent() && !topicName.isPartitioned())
+                ? CompletableFuture.completedFuture(true) : pulsar().getNamespaceService().checkTopicExists(topicName);
         existFuture.thenAccept(exist -> {
-            if (!exist && !pulsar().getBrokerService().isAllowAutoTopicCreation(topicName)) {
+            if (!exist) {
                 completeLookupResponseExceptionally(asyncResponse, new RestException(Response.Status.NOT_FOUND,
                         "Topic not found."));
                 return;

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiMultiBrokersTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiMultiBrokersTest.java
@@ -21,15 +21,23 @@ package org.apache.pulsar.broker.admin;
 import static org.testng.AssertJUnit.assertEquals;
 import static org.testng.AssertJUnit.assertTrue;
 
+import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.pulsar.broker.MultiBrokerBaseTest;
 import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.broker.loadbalance.LeaderBroker;
 import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.admin.PulsarAdminException;
+import org.apache.pulsar.common.naming.TopicDomain;
+import org.apache.pulsar.common.naming.TopicName;
+import org.apache.pulsar.common.policies.data.AutoTopicCreationOverride;
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 /**
@@ -66,6 +74,52 @@ public class AdminApiMultiBrokersTest extends MultiBrokerBaseTest {
             log.info("Pulsar admin get leader broker is {}", serviceUrl);
             assertEquals(leaderBroker.get().getServiceUrl(), serviceUrl);
         }
+    }
+
+    /**
+     * The data provider provide these data [TopicDomain, IsPartition].
+     */
+    @DataProvider
+    public Object[][] topicTypes(){
+        return new Object[][] {
+                {TopicDomain.persistent, false},
+                {TopicDomain.persistent, true},
+                {TopicDomain.non_persistent, false},
+                {TopicDomain.non_persistent, true},
+        };
+    }
+
+    @Test(timeOut = 30 * 1000, dataProvider = "topicTypes")
+    public void testTopicLookup(TopicDomain topicDomain, boolean isPartition) throws Exception {
+        PulsarAdmin admin0 = getAllAdmins().get(0);
+
+        String namespace = RandomStringUtils.randomAlphabetic(5);
+        admin0.namespaces().createNamespace( "public/" + namespace, 3);
+        admin0.namespaces().setAutoTopicCreation("public/" + namespace,
+                AutoTopicCreationOverride.builder().allowAutoTopicCreation(false).build());
+
+        TopicName topic = TopicName.get(topicDomain.value(), "public", namespace, "t1");
+        if (isPartition) {
+            admin0.topics().createPartitionedTopic(topic.getPartitionedTopicName(), 3);
+        } else {
+            admin0.topics().createNonPartitionedTopic(topic.getPartitionedTopicName());
+        }
+
+        // To ensure all admin could get a right lookup result.
+        Set<String> lookupResultSet = new HashSet<>();
+        for (PulsarAdmin pulsarAdmin : getAllAdmins()) {
+            try {
+                if (isPartition) {
+                    lookupResultSet.add(pulsarAdmin.lookups().lookupTopic(topic.getPartition(0).toString()));
+                } else {
+                    lookupResultSet.add(pulsarAdmin.lookups().lookupTopic(topic.getPartitionedTopicName()));
+                }
+            } catch (Exception e) {
+                log.error(pulsarAdmin.getServiceUrl() + " - Failed to execute lookup for topic {} .", topic, e);
+                Assert.fail("Failed to execute lookup by PulsarAdmin(" + pulsarAdmin.getServiceUrl() + ").");
+            }
+        }
+        Assert.assertEquals(lookupResultSet.size(), 1);
     }
 
 }


### PR DESCRIPTION
### Motivation

Currently, it's hard to check the non-persistent-non-partitioned topic exists or not, because it only exists in the broker cache, it doesn't have metadata.

If there is a non-persistent and non-partitioned topic exists in broker0 and the configuration `AllowAutoTopicCreation` is false, we perform an HTTP lookup request to broker1, it will return a TopicNotFound exception.

### Modifications

If the topic is non-persistent and non-partitioned, we'll return the true flag to ensure the http lookup can return a result.

### Verifying this change

Add a test to verify the HTTP lookup request to each broker could return a right lookup result.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

Check the box below or label this PR directly (if you have committer privilege).

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)


