### PR TITLE
[Flaky-test] org.apache.pulsar.broker.service.RackAwareTest#testPlacement

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/RackAwareTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/RackAwareTest.java
@@ -141,6 +141,7 @@ public class RackAwareTest extends BkEnsemblesTestBase {
         for (int i = 0; i < 100; i++) {
             LedgerHandle lh = bkc.createLedger(2, 2, DigestType.DUMMY, new byte[0]);
             log.info("Ledger: {} -- Ensemble: {}", i, lh.getLedgerMetadata().getEnsembleAt(0));
+            assertTrue(bookies.get(0).isRunning(), "first bookie in rack 0 is not running any more");
             assertTrue(lh.getLedgerMetadata().getEnsembleAt(0).contains(firstBookie),
                     "first bookie in rack 0 not included in ensemble");
             lh.close();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/RackAwareTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/RackAwareTest.java
@@ -141,9 +141,10 @@ public class RackAwareTest extends BkEnsemblesTestBase {
         for (int i = 0; i < 100; i++) {
             LedgerHandle lh = bkc.createLedger(2, 2, DigestType.DUMMY, new byte[0]);
             log.info("Ledger: {} -- Ensemble: {}", i, lh.getLedgerMetadata().getEnsembleAt(0));
-            assertTrue(bookies.get(0).isRunning(), "first bookie in rack 0 is not running any more");
-            assertTrue(lh.getLedgerMetadata().getEnsembleAt(0).contains(firstBookie),
-                    "first bookie in rack 0 not included in ensemble");
+            if (bookies.get(0).isRunning()) {
+                assertTrue(lh.getLedgerMetadata().getEnsembleAt(0).contains(firstBookie),
+                        "first bookie in rack 0 not included in ensemble");
+            }
             lh.close();
         }
     }


### PR DESCRIPTION
Fixes #14106

### Motivation

Fixed flaky test testPlacement

### Modifications
Add a precondition assert `bookies.get(0).isRunning()`




### Documentation

Check the box below or label this PR directly (if you have committer privilege).

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)


