### PR TITLE
[Flaky-Test] BacklogQuotaManagerTest#testProducerExceptionAndThenUnblockSizeQuota

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BacklogQuotaManagerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BacklogQuotaManagerTest.java
@@ -1114,6 +1114,7 @@ public class BacklogQuotaManagerTest {
         // now remove backlog and ensure that producer is unblocked;
 
         TopicStats stats = admin.topics().getStats(topic1);
+        rolloverStats();
         int backlog = (int) stats.getSubscriptions().get(subName1).getMsgBacklog();
 
         for (int i = 0; i < backlog; i++) {


### PR DESCRIPTION
Fixes #14203

### Motivation

Fix flaky test

### Modifications

rolloverStats before `getMsgBacklog`



### Documentation

Check the box below or label this PR directly (if you have committer privilege).

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)


