### PR TITLE
[Transaction] delete CoordinatorClientStateException

### DIFF
--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/transaction/TransactionCoordinatorClientException.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/transaction/TransactionCoordinatorClientException.java
@@ -39,20 +39,6 @@ public class TransactionCoordinatorClientException extends IOException {
     }
 
     /**
-     * Thrown when transaction coordinator with unexpected state.
-     */
-    public static class CoordinatorClientStateException extends TransactionCoordinatorClientException {
-
-        public CoordinatorClientStateException() {
-            super("Unexpected state for transaction metadata client.");
-        }
-
-        public CoordinatorClientStateException(String message) {
-            super(message);
-        }
-    }
-
-    /**
      * Thrown when transaction coordinator not found in broker side.
      */
     public static class CoordinatorNotFoundException extends TransactionCoordinatorClientException {


### PR DESCRIPTION
Master https://github.com/apache/pulsar/issues/13918
### Motivation & Modification
The state transition in the first line of the `TransactionCoordinatorClientImpl::startAsync` method does not fail. The exception here is redundant.
So delete it.
### Verifying this change

- [x] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API: (yes / no)
  - The schema: (yes / no / don't know)
  - The default values of configurations: (yes / no)
  - The wire protocol: (yes / no)
  - The rest endpoints: (yes / no)
  - The admin cli options: (yes / no)
  - Anything that affects deployment: (yes / no / don't know)

### Documentation

Check the box below or label this PR directly (if you have committer privilege).

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)


