### PR TITLE
[Transaction] Move Exception from TransactionCoordinatorClientException to PulsarClientException

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/buffer/TransactionLowWaterMarkTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/buffer/TransactionLowWaterMarkTest.java
@@ -42,10 +42,10 @@ import org.apache.pulsar.broker.transaction.pendingack.impl.PendingAckHandleImpl
 import org.apache.pulsar.client.api.Consumer;
 import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.Producer;
+import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.api.SubscriptionInitialPosition;
 import org.apache.pulsar.client.api.SubscriptionType;
 import org.apache.pulsar.client.api.transaction.Transaction;
-import org.apache.pulsar.client.api.transaction.TransactionCoordinatorClientException;
 import org.apache.pulsar.client.api.transaction.TxnID;
 import org.apache.pulsar.client.impl.PulsarClientImpl;
 import org.apache.pulsar.client.impl.transaction.TransactionImpl;
@@ -139,7 +139,7 @@ public class TransactionLowWaterMarkTest extends TransactionTestBase {
             txn.commit().get();
             Assert.fail("The commit operation should be failed.");
         } catch (Exception e){
-            Assert.assertTrue(e.getCause() instanceof TransactionCoordinatorClientException.TransactionNotFoundException);
+            Assert.assertTrue(e.getCause() instanceof PulsarClientException.TransactionNotFoundException);
         }
 
         PartitionedTopicMetadata partitionedTopicMetadata =

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/TransactionClientConnectTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/TransactionClientConnectTest.java
@@ -27,6 +27,7 @@ import org.apache.bookkeeper.mledger.impl.ManagedLedgerImpl;
 import org.apache.pulsar.broker.TransactionMetadataStoreService;
 import org.apache.pulsar.broker.transaction.TransactionTestBase;
 import org.apache.pulsar.client.api.MessageId;
+import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.api.transaction.TransactionCoordinatorClientException;
 import org.apache.pulsar.client.api.transaction.TxnID;
 import org.apache.pulsar.client.impl.transaction.TransactionCoordinatorClientImpl;
@@ -87,7 +88,7 @@ public class TransactionClientConnectTest extends TransactionTestBase {
         try {
             callable1.call().get();
         } catch (ExecutionException e) {
-            assertFalse(e.getCause() instanceof TransactionCoordinatorClientException.CoordinatorNotFoundException);
+            assertFalse(e.getCause() instanceof PulsarClientException.CoordinatorNotFoundException);
             waitToReady();
             callable1.call().get();
         }
@@ -98,7 +99,7 @@ public class TransactionClientConnectTest extends TransactionTestBase {
         } catch (TimeoutException ignore) {
         } catch (ExecutionException e) {
             Assert.assertFalse(e.getCause()
-                    instanceof TransactionCoordinatorClientException.CoordinatorNotFoundException);
+                    instanceof PulsarClientException.CoordinatorNotFoundException);
         }
 
         unFence(getPulsarServiceList().get(0).getTransactionMetadataStoreService());

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/TransactionEndToEndTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/TransactionEndToEndTest.java
@@ -57,8 +57,6 @@ import org.apache.pulsar.client.api.SubscriptionInitialPosition;
 import org.apache.pulsar.client.api.SubscriptionType;
 import org.apache.pulsar.client.api.transaction.Transaction;
 import org.apache.pulsar.client.api.transaction.TransactionCoordinatorClient;
-import org.apache.pulsar.client.api.transaction.TransactionCoordinatorClientException;
-import org.apache.pulsar.client.api.transaction.TransactionCoordinatorClientException.TransactionNotFoundException;
 import org.apache.pulsar.client.api.transaction.TxnID;
 import org.apache.pulsar.client.impl.transaction.TransactionImpl;
 import org.apache.pulsar.client.internal.DefaultImplementation;
@@ -393,7 +391,8 @@ public class TransactionEndToEndTest extends TransactionTestBase {
                 // recommit one transaction should be failed
                 log.info("expected exception for recommit one transaction.");
                 Assert.assertNotNull(reCommitError);
-                Assert.assertTrue(reCommitError.getCause() instanceof TransactionNotFoundException);
+                Assert.assertTrue(reCommitError.getCause()
+                        instanceof PulsarClientException.TransactionNotFoundException);
             }
         }
     }
@@ -621,7 +620,8 @@ public class TransactionEndToEndTest extends TransactionTestBase {
                 // recommit one transaction should be failed
                 log.info("expected exception for recommit one transaction.");
                 Assert.assertNotNull(reCommitError);
-                Assert.assertTrue(reCommitError.getCause() instanceof TransactionNotFoundException);
+                Assert.assertTrue(reCommitError.getCause()
+                        instanceof PulsarClientException.TransactionNotFoundException);
             }
 
             message = consumer.receive(1, TimeUnit.SECONDS);
@@ -775,14 +775,14 @@ public class TransactionEndToEndTest extends TransactionTestBase {
             producer.newMessage(produceTxn).value(("Hello Pulsar!").getBytes()).sendAsync().get();
             fail();
         } catch (Exception e) {
-            assertTrue(e.getCause() instanceof TransactionCoordinatorClientException.InvalidTxnStatusException);
+            assertTrue(e.getCause() instanceof PulsarClientException.InvalidTxnStatusException);
         }
 
         try {
             produceTxn.commit().get();
             fail();
         } catch (Exception e) {
-            assertTrue(e.getCause() instanceof TransactionCoordinatorClientException.InvalidTxnStatusException);
+            assertTrue(e.getCause() instanceof PulsarClientException.InvalidTxnStatusException);
         }
 
 
@@ -793,14 +793,14 @@ public class TransactionEndToEndTest extends TransactionTestBase {
             consumer.acknowledgeAsync(message.getMessageId(), consumeTxn).get();
             fail();
         } catch (Exception e) {
-            assertTrue(e.getCause() instanceof TransactionCoordinatorClientException.InvalidTxnStatusException);
+            assertTrue(e.getCause() instanceof PulsarClientException.InvalidTxnStatusException);
         }
 
         try {
             consumeTxn.commit().get();
             fail();
         } catch (Exception e) {
-            assertTrue(e.getCause() instanceof TransactionCoordinatorClientException.InvalidTxnStatusException);
+            assertTrue(e.getCause() instanceof PulsarClientException.InvalidTxnStatusException);
         }
 
         Transaction timeoutTxn = pulsarClient
@@ -838,7 +838,7 @@ public class TransactionEndToEndTest extends TransactionTestBase {
             timeoutTxnSkipClientTimeout.commit().get();
             fail();
         } catch (Exception e) {
-            assertTrue(e.getCause() instanceof TransactionNotFoundException);
+            assertTrue(e.getCause() instanceof PulsarClientException.TransactionNotFoundException);
         }
         Field field = TransactionImpl.class.getDeclaredField("state");
         field.setAccessible(true);
@@ -1048,16 +1048,14 @@ public class TransactionEndToEndTest extends TransactionTestBase {
             producer.newMessage(transaction).send();
             Assert.fail();
         } catch (Exception e) {
-            Assert.assertTrue(e.getCause().getCause() instanceof TransactionCoordinatorClientException
-                    .InvalidTxnStatusException);
+            Assert.assertTrue(e.getCause().getCause() instanceof PulsarClientException.InvalidTxnStatusException);
         }
         try {
             Message<String> message = consumer.receive();
             consumer.acknowledgeAsync(message.getMessageId(), transaction).get();
             Assert.fail();
         } catch (Exception e) {
-            Assert.assertTrue(e.getCause() instanceof TransactionCoordinatorClientException
-                    .InvalidTxnStatusException);
+            Assert.assertTrue(e.getCause() instanceof PulsarClientException.InvalidTxnStatusException);
         }
     }
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/TransactionEndToEndTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/TransactionEndToEndTest.java
@@ -1048,7 +1048,7 @@ public class TransactionEndToEndTest extends TransactionTestBase {
             producer.newMessage(transaction).send();
             Assert.fail();
         } catch (Exception e) {
-            Assert.assertTrue(e.getCause().getCause() instanceof PulsarClientException.InvalidTxnStatusException);
+            Assert.assertTrue(e instanceof PulsarClientException.InvalidTxnStatusException);
         }
         try {
             Message<String> message = consumer.receive();

--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/PulsarClientException.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/PulsarClientException.java
@@ -910,6 +910,39 @@ public class PulsarClientException extends IOException {
         }
     }
 
+    /**
+     * Thrown when transaction coordinator not found in broker side.
+     */
+    public static class CoordinatorNotFoundException extends PulsarClientException {
+        public CoordinatorNotFoundException(String message) {
+            super(message);
+        }
+    }
+
+    /**
+     * Thrown when transaction switch to a invalid status.
+     */
+    public static class InvalidTxnStatusException extends PulsarClientException {
+        public InvalidTxnStatusException(String message) {
+            super(message);
+        }
+
+        public InvalidTxnStatusException(String txnId, String actualState, String expectState) {
+            super("[" + txnId + "] with unexpected state : "
+                    + actualState + ", expect " + expectState + " state!");
+        }
+    }
+
+    /**
+     * Thrown when transaction not found in transaction coordinator.
+     */
+    public static class TransactionNotFoundException extends PulsarClientException {
+        public TransactionNotFoundException(String message) {
+            super(message);
+        }
+    }
+
+
     // wrap an exception to enriching more info messages.
     public static Throwable wrap(Throwable t, String msg) {
         msg += "\n" + t.getMessage();
@@ -972,6 +1005,12 @@ public class PulsarClientException extends IOException {
             return new MessageAcknowledgeException(msg);
         } else if (t instanceof TransactionConflictException) {
             return new TransactionConflictException(msg);
+        } else if (t instanceof CoordinatorNotFoundException) {
+            return new CoordinatorNotFoundException(msg);
+        } else if (t instanceof InvalidTxnStatusException) {
+            return new InvalidTxnStatusException(msg);
+        } else if (t instanceof TransactionNotFoundException) {
+            return new TransactionNotFoundException(msg);
         } else if (t instanceof PulsarClientException) {
             return new PulsarClientException(msg);
         } else if (t instanceof CompletionException) {
@@ -1062,6 +1101,12 @@ public class PulsarClientException extends IOException {
             newException = new MessageAcknowledgeException(msg);
         } else if (cause instanceof TransactionConflictException) {
             newException = new TransactionConflictException(msg);
+        } else if (cause instanceof CoordinatorNotFoundException) {
+            newException = new CoordinatorNotFoundException(msg);
+        } else if (cause instanceof InvalidTxnStatusException) {
+            newException = new InvalidTxnStatusException(msg);
+        } else if (cause instanceof TransactionNotFoundException) {
+            newException = new TransactionNotFoundException(msg);
         } else if (cause instanceof TopicDoesNotExistException) {
             newException = new TopicDoesNotExistException(msg);
         } else if (cause instanceof ProducerFencedException) {

--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/transaction/TransactionCoordinatorClientException.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/transaction/TransactionCoordinatorClientException.java
@@ -53,38 +53,6 @@ public class TransactionCoordinatorClientException extends IOException {
     }
 
     /**
-     * Thrown when transaction coordinator not found in broker side.
-     */
-    public static class CoordinatorNotFoundException extends TransactionCoordinatorClientException {
-        public CoordinatorNotFoundException(String message) {
-            super(message);
-        }
-    }
-
-    /**
-     * Thrown when transaction switch to a invalid status.
-     */
-    public static class InvalidTxnStatusException extends TransactionCoordinatorClientException {
-        public InvalidTxnStatusException(String message) {
-            super(message);
-        }
-
-        public InvalidTxnStatusException(String txnId, String actualState, String expectState) {
-            super("[" + txnId + "] with unexpected state : "
-                    + actualState + ", expect " + expectState + " state!");
-        }
-    }
-
-    /**
-     * Thrown when transaction not found in transaction coordinator.
-     */
-    public static class TransactionNotFoundException extends TransactionCoordinatorClientException {
-        public TransactionNotFoundException(String message) {
-            super(message);
-        }
-    }
-
-    /**
      * Thrown when transaction meta store handler not exists.
      */
     public static class MetaStoreHandlerNotExistsException extends TransactionCoordinatorClientException {
@@ -122,15 +90,6 @@ public class TransactionCoordinatorClientException extends IOException {
         }  else if (!(t instanceof ExecutionException)) {
             // Generic exception
             return new TransactionCoordinatorClientException(t);
-        }
-
-        Throwable cause = t.getCause();
-        String msg = cause.getMessage();
-
-        if (cause instanceof CoordinatorNotFoundException) {
-            return new CoordinatorNotFoundException(msg);
-        } else if (cause instanceof InvalidTxnStatusException) {
-            return new InvalidTxnStatusException(msg);
         } else {
             return new TransactionCoordinatorClientException(t);
         }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/TransactionMetaStoreHandler.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/TransactionMetaStoreHandler.java
@@ -522,8 +522,7 @@ public class TransactionMetaStoreHandler extends HandlerState
     private boolean checkIfNeedRetryByError(ServerError error, String message, OpBase<?> op) {
         if (error == ServerError.TransactionCoordinatorNotFound) {
             if (getState() != State.Connecting) {
-                connectionHandler.reconnectLater(new TransactionCoordinatorClientException
-                        .CoordinatorNotFoundException(message));
+                connectionHandler.reconnectLater(new PulsarClientException.CoordinatorNotFoundException(message));
             }
             return true;
         }
@@ -615,16 +614,16 @@ public class TransactionMetaStoreHandler extends HandlerState
         };
     }
 
-    public static TransactionCoordinatorClientException getExceptionByServerError(ServerError serverError, String msg) {
+    public static PulsarClientException getExceptionByServerError(ServerError serverError, String msg) {
         switch (serverError) {
             case TransactionCoordinatorNotFound:
-                return new TransactionCoordinatorClientException.CoordinatorNotFoundException(msg);
+                return new PulsarClientException.CoordinatorNotFoundException(msg);
             case InvalidTxnStatus:
-                return new TransactionCoordinatorClientException.InvalidTxnStatusException(msg);
+                return new PulsarClientException.InvalidTxnStatusException(msg);
             case TransactionNotFound:
-                return new TransactionCoordinatorClientException.TransactionNotFoundException(msg);
+                return new PulsarClientException.TransactionNotFoundException(msg);
             default:
-                return new TransactionCoordinatorClientException(msg);
+                return new PulsarClientException(msg);
         }
     }
 


### PR DESCRIPTION
Master Issue https://github.com/apache/pulsar/issues/13918
### Motivation & Modification
Make exceptions on the Transaction client side clearer.
### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API: (yes / no)
  - The schema: (yes / no / don't know)
  - The default values of configurations: (yes / no)
  - The wire protocol: (yes / no)
  - The rest endpoints: (yes / no)
  - The admin cli options: (yes / no)
  - Anything that affects deployment: (yes / no / don't know)

### Documentation

Check the box below or label this PR directly (if you have committer privilege).

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)


