### PR TITLE
[Transaction] Move MetaStoreHandlerNotReadyException and add MetaStoreHandlerHasClosedException

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/TransactionClientConnectTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/TransactionClientConnectTest.java
@@ -27,6 +27,7 @@ import org.apache.bookkeeper.mledger.impl.ManagedLedgerImpl;
 import org.apache.pulsar.broker.TransactionMetadataStoreService;
 import org.apache.pulsar.broker.transaction.TransactionTestBase;
 import org.apache.pulsar.client.api.MessageId;
+import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.api.transaction.TransactionCoordinatorClientException;
 import org.apache.pulsar.client.api.transaction.TxnID;
 import org.apache.pulsar.client.impl.transaction.TransactionCoordinatorClientImpl;
@@ -156,8 +157,7 @@ public class TransactionClientConnectTest extends TransactionTestBase {
             try {
                 handler.newTransactionAsync(10, TimeUnit.SECONDS).get();
             } catch (ExecutionException | InterruptedException e) {
-                assertTrue(e.getCause()
-                        instanceof TransactionCoordinatorClientException.MetaStoreHandlerNotReadyException);
+                assertTrue(e.getCause() instanceof PulsarClientException.MetaStoreHandlerHasClosedException);
             }
         }
     }

--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/PulsarClientException.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/PulsarClientException.java
@@ -910,6 +910,32 @@ public class PulsarClientException extends IOException {
         }
     }
 
+    /**
+     * Thrown when send request to transaction meta store but the transaction meta store handler not ready.
+     */
+    public static class MetaStoreHandlerNotReadyException extends PulsarClientException {
+        public MetaStoreHandlerNotReadyException(long tcId) {
+            super("Transaction meta store handler for transaction meta store [" + tcId + "] not ready now.");
+        }
+
+        public MetaStoreHandlerNotReadyException(String message) {
+            super(message);
+        }
+    }
+
+    /**
+     * Thrown when send request to transaction meta store but the transaction meta store handler has closed.
+     */
+    public static class MetaStoreHandlerHasClosedException extends PulsarClientException {
+        public MetaStoreHandlerHasClosedException(long tcId) {
+            super("Transaction meta store handler for transaction meta store [" + tcId + "] has closed.");
+        }
+
+        public MetaStoreHandlerHasClosedException(String message) {
+            super(message);
+        }
+    }
+
     // wrap an exception to enriching more info messages.
     public static Throwable wrap(Throwable t, String msg) {
         msg += "\n" + t.getMessage();
@@ -972,6 +998,10 @@ public class PulsarClientException extends IOException {
             return new MessageAcknowledgeException(msg);
         } else if (t instanceof TransactionConflictException) {
             return new TransactionConflictException(msg);
+        } else if (t instanceof MetaStoreHandlerNotReadyException) {
+            return new MetaStoreHandlerNotReadyException(msg);
+        } else if (t instanceof MetaStoreHandlerHasClosedException) {
+            return new MetaStoreHandlerHasClosedException(msg);
         } else if (t instanceof PulsarClientException) {
             return new PulsarClientException(msg);
         } else if (t instanceof CompletionException) {
@@ -1062,6 +1092,10 @@ public class PulsarClientException extends IOException {
             newException = new MessageAcknowledgeException(msg);
         } else if (cause instanceof TransactionConflictException) {
             newException = new TransactionConflictException(msg);
+        } else if (cause instanceof MetaStoreHandlerNotReadyException) {
+            newException = new MetaStoreHandlerNotReadyException(msg);
+        } else if (cause instanceof MetaStoreHandlerHasClosedException) {
+            newException = new MetaStoreHandlerHasClosedException(msg);
         } else if (cause instanceof TopicDoesNotExistException) {
             newException = new TopicDoesNotExistException(msg);
         } else if (cause instanceof ProducerFencedException) {

--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/transaction/TransactionCoordinatorClientException.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/transaction/TransactionCoordinatorClientException.java
@@ -98,19 +98,6 @@ public class TransactionCoordinatorClientException extends IOException {
         }
     }
 
-    /**
-     * Thrown when send request to transaction meta store but the transaction meta store handler not ready.
-     */
-    public static class MetaStoreHandlerNotReadyException extends TransactionCoordinatorClientException {
-        public MetaStoreHandlerNotReadyException(long tcId) {
-            super("Transaction meta store handler for transaction meta store {} not ready now.");
-        }
-
-        public MetaStoreHandlerNotReadyException(String message) {
-            super(message);
-        }
-    }
-
     public static TransactionCoordinatorClientException unwrap(Throwable t) {
         if (t instanceof TransactionCoordinatorClientException) {
             return (TransactionCoordinatorClientException) t;

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/TransactionMetaStoreHandler.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/TransactionMetaStoreHandler.java
@@ -668,25 +668,18 @@ public class TransactionMetaStoreHandler extends HandlerState
             case Closing:
             case Closed:
                 op.callback.completeExceptionally(
-                        new TransactionCoordinatorClientException.MetaStoreHandlerNotReadyException(
-                                "Transaction meta store handler for tcId "
-                                        + transactionCoordinatorId
-                                        + " is closing or closed."));
+                        new PulsarClientException.MetaStoreHandlerHasClosedException(transactionCoordinatorId));
                 onResponse(op);
                 return false;
             case Failed:
             case Uninitialized:
                 op.callback.completeExceptionally(
-                        new TransactionCoordinatorClientException.MetaStoreHandlerNotReadyException(
-                                "Transaction meta store handler for tcId "
-                                        + transactionCoordinatorId
-                                        + " not connected."));
+                        new PulsarClientException.MetaStoreHandlerNotReadyException(transactionCoordinatorId));
                 onResponse(op);
                 return false;
             default:
                 op.callback.completeExceptionally(
-                        new TransactionCoordinatorClientException.MetaStoreHandlerNotReadyException(
-                                transactionCoordinatorId));
+                        new PulsarClientException.MetaStoreHandlerNotReadyException(transactionCoordinatorId));
                 onResponse(op);
                 return false;
         }


### PR DESCRIPTION
Master https://github.com/apache/pulsar/issues/13918

### Motivation & Modification
Makes exceptions on the Transaction client side clearer.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API: (yes / no)
  - The schema: (yes / no / don't know)
  - The default values of configurations: (yes / no)
  - The wire protocol: (yes / no)
  - The rest endpoints: (yes / no)
  - The admin cli options: (yes / no)
  - Anything that affects deployment: (yes / no / don't know)

### Documentation

Check the box below or label this PR directly (if you have committer privilege).

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)


