### PR TITLE
[Transaction] Call getCause() after exception wrapped by completeFuture

### DIFF
--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/transaction/TransactionCoordinatorClientException.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/transaction/TransactionCoordinatorClientException.java
@@ -19,6 +19,7 @@
 package org.apache.pulsar.client.api.transaction;
 
 import java.io.IOException;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutionException;
 import org.apache.pulsar.common.classification.InterfaceAudience;
 import org.apache.pulsar.common.classification.InterfaceStability;
@@ -123,7 +124,7 @@ public class TransactionCoordinatorClientException extends IOException {
             return (CoordinatorNotFoundException) t;
         } else if (t instanceof InvalidTxnStatusException) {
             return (InvalidTxnStatusException) t;
-        } else if (t instanceof ExecutionException) {
+        } else if (t instanceof ExecutionException | t instanceof CompletionException) {
             // Generic exception
             return unwrap(t.getCause());
         } else {

--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/transaction/TransactionCoordinatorClientException.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/transaction/TransactionCoordinatorClientException.java
@@ -120,7 +120,7 @@ public class TransactionCoordinatorClientException extends IOException {
         } else if (t instanceof InterruptedException) {
             Thread.currentThread().interrupt();
             return new TransactionCoordinatorClientException(t);
-        }  else if (t instanceof CoordinatorNotFoundException) {
+        } else if (t instanceof CoordinatorNotFoundException) {
             return (CoordinatorNotFoundException) t;
         } else if (t instanceof InvalidTxnStatusException) {
             return (InvalidTxnStatusException) t;

--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/transaction/TransactionCoordinatorClientException.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/transaction/TransactionCoordinatorClientException.java
@@ -119,18 +119,13 @@ public class TransactionCoordinatorClientException extends IOException {
         } else if (t instanceof InterruptedException) {
             Thread.currentThread().interrupt();
             return new TransactionCoordinatorClientException(t);
-        }  else if (!(t instanceof ExecutionException)) {
+        }  else if (t instanceof CoordinatorNotFoundException) {
+            return (CoordinatorNotFoundException) t;
+        } else if (t instanceof InvalidTxnStatusException) {
+            return (InvalidTxnStatusException) t;
+        } else if (t instanceof ExecutionException) {
             // Generic exception
-            return new TransactionCoordinatorClientException(t);
-        }
-
-        Throwable cause = t.getCause();
-        String msg = cause.getMessage();
-
-        if (cause instanceof CoordinatorNotFoundException) {
-            return new CoordinatorNotFoundException(msg);
-        } else if (cause instanceof InvalidTxnStatusException) {
-            return new InvalidTxnStatusException(msg);
+            return unwrap(t.getCause());
         } else {
             return new TransactionCoordinatorClientException(t);
         }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/transaction/TransactionCoordinatorClientImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/transaction/TransactionCoordinatorClientImpl.java
@@ -168,7 +168,7 @@ public class TransactionCoordinatorClientImpl implements TransactionCoordinatorC
         try {
             return newTransactionAsync(timeout, unit).get();
         } catch (Exception e) {
-            throw TransactionCoordinatorClientException.unwrap(e.getCause());
+            throw TransactionCoordinatorClientException.unwrap(e);
         }
     }
 
@@ -183,7 +183,7 @@ public class TransactionCoordinatorClientImpl implements TransactionCoordinatorC
         try {
             addPublishPartitionToTxnAsync(txnID, partitions).get();
         } catch (Exception e) {
-            throw TransactionCoordinatorClientException.unwrap(e.getCause());
+            throw TransactionCoordinatorClientException.unwrap(e);
         }
     }
 
@@ -204,7 +204,7 @@ public class TransactionCoordinatorClientImpl implements TransactionCoordinatorC
         try {
             addSubscriptionToTxnAsync(txnID, topic, subscription).get();
         } catch (Exception e) {
-            throw TransactionCoordinatorClientException.unwrap(e.getCause());
+            throw TransactionCoordinatorClientException.unwrap(e);
         }
     }
 
@@ -227,7 +227,7 @@ public class TransactionCoordinatorClientImpl implements TransactionCoordinatorC
         try {
             commitAsync(txnID).get();
         } catch (Exception e) {
-            throw TransactionCoordinatorClientException.unwrap(e.getCause());
+            throw TransactionCoordinatorClientException.unwrap(e);
         }
     }
 

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/transaction/TransactionCoordinatorClientImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/transaction/TransactionCoordinatorClientImpl.java
@@ -168,7 +168,7 @@ public class TransactionCoordinatorClientImpl implements TransactionCoordinatorC
         try {
             return newTransactionAsync(timeout, unit).get();
         } catch (Exception e) {
-            throw TransactionCoordinatorClientException.unwrap(e);
+            throw TransactionCoordinatorClientException.unwrap(e.getCause());
         }
     }
 
@@ -183,7 +183,7 @@ public class TransactionCoordinatorClientImpl implements TransactionCoordinatorC
         try {
             addPublishPartitionToTxnAsync(txnID, partitions).get();
         } catch (Exception e) {
-            throw TransactionCoordinatorClientException.unwrap(e);
+            throw TransactionCoordinatorClientException.unwrap(e.getCause());
         }
     }
 
@@ -204,7 +204,7 @@ public class TransactionCoordinatorClientImpl implements TransactionCoordinatorC
         try {
             addSubscriptionToTxnAsync(txnID, topic, subscription).get();
         } catch (Exception e) {
-            throw TransactionCoordinatorClientException.unwrap(e);
+            throw TransactionCoordinatorClientException.unwrap(e.getCause());
         }
     }
 
@@ -227,7 +227,7 @@ public class TransactionCoordinatorClientImpl implements TransactionCoordinatorC
         try {
             commitAsync(txnID).get();
         } catch (Exception e) {
-            throw TransactionCoordinatorClientException.unwrap(e);
+            throw TransactionCoordinatorClientException.unwrap(e.getCause());
         }
     }
 


### PR DESCRIPTION
Master Issue https://github.com/apache/pulsar/issues/13918
### Motivation & Modification
Call getCause() after exception wrapped by completeFuture
*Describe the modifications you've done.*

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API: (yes / no)
  - The schema: (yes / no / don't know)
  - The default values of configurations: (yes / no)
  - The wire protocol: (yes / no)
  - The rest endpoints: (yes / no)
  - The admin cli options: (yes / no)
  - Anything that affects deployment: (yes / no / don't know)

### Documentation

Check the box below or label this PR directly (if you have committer privilege).

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)


