### PR TITLE
allow user override subproperties for update properties

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentSubscription.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentSubscription.java
@@ -19,6 +19,7 @@
 package org.apache.pulsar.broker.service.persistent;
 
 import static org.apache.pulsar.common.events.EventsTopicNames.checkTopicIsEventsNames;
+
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.MoreObjects;
 import java.util.Collections;
@@ -1167,9 +1168,11 @@ public class PersistentSubscription implements Subscription {
         return subscriptionProperties;
     }
 
-    public void setSubscriptionProperties(Map<String, String> newSubscriptionProperties){
-        this.subscriptionProperties = newSubscriptionProperties == null
-                ? new HashMap<>() : Collections.unmodifiableMap(newSubscriptionProperties);
+    public void setSubscriptionProperties(Map<String, String> newSubscriptionProperties) {
+        if (MapUtils.isEmpty(newSubscriptionProperties)) {
+            return;
+        }
+        this.subscriptionProperties = Collections.unmodifiableMap(newSubscriptionProperties);
     }
 
     /**

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentSubscription.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentSubscription.java
@@ -1167,6 +1167,11 @@ public class PersistentSubscription implements Subscription {
         return subscriptionProperties;
     }
 
+    public void setSubscriptionProperties(Map<String, String> newSubscriptionProperties){
+        this.subscriptionProperties = newSubscriptionProperties == null
+                ? new HashMap<>() : Collections.unmodifiableMap(newSubscriptionProperties);
+    }
+
     /**
      * Return a merged map that contains the cursor properties specified by used
      * (eg. when using compaction subscription) and the subscription properties.

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentSubscription.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentSubscription.java
@@ -1168,7 +1168,7 @@ public class PersistentSubscription implements Subscription {
     }
 
     public void setSubscriptionProperties(Map<String, String> newSubscriptionProperties) {
-        if (MapUtils.isEmpty(newSubscriptionProperties)) {
+        if (newSubscriptionProperties == null) {
             return;
         }
         this.subscriptionProperties = Collections.unmodifiableMap(newSubscriptionProperties);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentSubscription.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentSubscription.java
@@ -19,7 +19,6 @@
 package org.apache.pulsar.broker.service.persistent;
 
 import static org.apache.pulsar.common.events.EventsTopicNames.checkTopicIsEventsNames;
-
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.MoreObjects;
 import java.util.Collections;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -849,6 +849,10 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
                                   name -> createPersistentSubscription(subscriptionName, cursor,
                                           replicated, subscriptionProperties));
                 } else {
+
+                    //update subscription subscriptionProperties
+                    subscription.setSubscriptionProperties(subscriptionProperties);
+
                     // if subscription exists, check if it's a non-durable subscription
                     if (subscription.getCursor() != null && !subscription.getCursor().isDurable()) {
                         subscriptionFuture.completeExceptionally(

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/CreateSubscriptionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/CreateSubscriptionTest.java
@@ -276,7 +276,10 @@ public class CreateSubscriptionTest extends ProducerConsumerBase {
         subscription4 = (PersistentSubscription) pulsar.getBrokerService()
                 .getTopicReference(topic).get().getSubscription(subName);
         properties4 = subscription4.getSubscriptionProperties();
-        assertTrue(properties4.isEmpty());
+        assertTrue(properties4.containsKey("3"));
+        assertTrue(properties4.containsKey("4"));
+        assertEquals(properties4.get("3"), "3");
+        assertEquals(properties4.get("4"), "4");
         consumer4.close();
 
         //restart broker, it won't get any properties

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/CreateSubscriptionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/CreateSubscriptionTest.java
@@ -276,10 +276,7 @@ public class CreateSubscriptionTest extends ProducerConsumerBase {
         subscription4 = (PersistentSubscription) pulsar.getBrokerService()
                 .getTopicReference(topic).get().getSubscription(subName);
         properties4 = subscription4.getSubscriptionProperties();
-        assertTrue(properties4.containsKey("3"));
-        assertTrue(properties4.containsKey("4"));
-        assertEquals(properties4.get("3"), "3");
-        assertEquals(properties4.get("4"), "4");
+        assertTrue(properties4.isEmpty());
         consumer4.close();
 
         //restart broker, it won't get any properties


### PR DESCRIPTION
now entry filter uses the first consumer properties to PersistentSubscription , but when users modified their code, and change the properties, it will not take effect.

### Motivation

users use entry filter to implement tag filter, 

time 1 : they use tag1 
time 2 : users upgrade their code, and use tag2,

We will not take effect, only restart all brokers or users restart their apps. it is impossible.

*Explain here the context, and why you're making that change. What is the problem you're trying to solve.*

### Modifications


override the properties every time. then when users upgrade their app, this will take effect.

### Verifying this change

add test case

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): no
  - The public API: no
  - The schema: no
  - The default values of configurations: no
  - The wire protocol: no
  - The rest endpoints: no
  - The admin cli options: no
  - Anything that affects deployment: no

### Documentation

Check the box below or label this PR directly (if you have committer privilege).

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)


