### PR TITLE
[Flaky Test] BrokerServiceLookupTest#testModularLoadManagerSplitBundle

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/BrokerServiceLookupTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/BrokerServiceLookupTest.java
@@ -731,7 +731,7 @@ public class BrokerServiceLookupTest extends ProducerConsumerBase {
             // broker-2 loadManager is a leader and let it refresh load-report from all the brokers
             pulsar.getLeaderElectionService().close();
 
-            Awaitility.await().atMost(5, TimeUnit.SECONDS)
+            Awaitility.await()
                     .untilAsserted(() -> pulsar2.getLeaderElectionService().isLeader());
 
             ModularLoadManagerImpl loadManager = (ModularLoadManagerImpl) ((ModularLoadManagerWrapper) pulsar2

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/BrokerServiceLookupTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/BrokerServiceLookupTest.java
@@ -731,6 +731,9 @@ public class BrokerServiceLookupTest extends ProducerConsumerBase {
             // broker-2 loadManager is a leader and let it refresh load-report from all the brokers
             pulsar.getLeaderElectionService().close();
 
+            Awaitility.await().atMost(5, TimeUnit.SECONDS)
+                    .untilAsserted(() -> pulsar2.getLeaderElectionService().isLeader());
+
             ModularLoadManagerImpl loadManager = (ModularLoadManagerImpl) ((ModularLoadManagerWrapper) pulsar2
                     .getLoadManager().get()).getLoadManager();
 


### PR DESCRIPTION
Fixes #13102

### Motivation

Flaky test

### Modifications
Wait until pulsar2 becomes leader. Or ` checkNamespaceBundleSplit` will return none.



### Documentation

Check the box below or label this PR directly (if you have committer privilege).

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)


