### PR TITLE
[Broker] Move schema compatibility strategy cmd from topics to topicPolicies

### DIFF
--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdTopics.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdTopics.java
@@ -72,7 +72,6 @@ import org.apache.pulsar.common.policies.data.PersistencePolicies;
 import org.apache.pulsar.common.policies.data.PersistentTopicInternalStats;
 import org.apache.pulsar.common.policies.data.PublishRate;
 import org.apache.pulsar.common.policies.data.RetentionPolicies;
-import org.apache.pulsar.common.policies.data.SchemaCompatibilityStrategy;
 import org.apache.pulsar.common.policies.data.SubscribeRate;
 import org.apache.pulsar.common.util.DateFormatter;
 import org.apache.pulsar.common.util.RelativeTimeUtil;
@@ -244,10 +243,6 @@ public class CmdTopics extends CmdBase {
         jcommander.addCommand("get-replication-clusters", new GetReplicationClusters());
         jcommander.addCommand("set-replication-clusters", new SetReplicationClusters());
         jcommander.addCommand("remove-replication-clusters", new RemoveReplicationClusters());
-
-        jcommander.addCommand("remove-schema-compatibility-strategy", new RemoveSchemaCompatibilityStrategy());
-        jcommander.addCommand("set-schema-compatibility-strategy", new SetSchemaCompatibilityStrategy());
-        jcommander.addCommand("get-schema-compatibility-strategy", new GetSchemaCompatibilityStrategy());
 
         initDeprecatedCommands();
     }
@@ -2814,50 +2809,6 @@ public class CmdTopics extends CmdBase {
             }
             print(getTopics().getBacklogSizeByMessageId(persistentTopic, messageId));
 
-        }
-    }
-
-    @Parameters(commandDescription = "Remove schema compatibility strategy on a topic")
-    private class RemoveSchemaCompatibilityStrategy extends CliCommand {
-        @Parameter(description = "persistent://tenant/namespace/topic", required = true)
-        private java.util.List<String> params;
-
-        @Override
-        void run() throws PulsarAdminException {
-            String persistentTopic = validatePersistentTopic(params);
-            getAdmin().topicPolicies().removeSchemaCompatibilityStrategy(persistentTopic);
-        }
-    }
-
-    @Parameters(commandDescription = "Set schema compatibility strategy on a topic")
-    private class SetSchemaCompatibilityStrategy extends CliCommand {
-        @Parameter(description = "persistent://tenant/namespace/topic", required = true)
-        private java.util.List<String> params;
-
-        @Parameter(names = {"--strategy", "-s"}, description = "Schema compatibility strategy: [UNDEFINED, "
-                + "ALWAYS_INCOMPATIBLE, ALWAYS_COMPATIBLE, BACKWARD, FORWARD, FULL, BACKWARD_TRANSITIVE, "
-                + "FORWARD_TRANSITIVE, FULL_TRANSITIVE]", required = true)
-        private SchemaCompatibilityStrategy strategy;
-
-        @Override
-        void run() throws PulsarAdminException {
-            String persistentTopic = validatePersistentTopic(params);
-            getAdmin().topicPolicies().setSchemaCompatibilityStrategy(persistentTopic, strategy);
-        }
-    }
-
-    @Parameters(commandDescription = "Get schema compatibility strategy on a topic")
-    private class GetSchemaCompatibilityStrategy extends CliCommand {
-        @Parameter(description = "persistent://tenant/namespace/topic", required = true)
-        private java.util.List<String> params;
-
-        @Parameter(names = {"-ap", "--applied"}, description = "Get the applied policy of the topic")
-        private boolean applied = false;
-
-        @Override
-        void run() throws PulsarAdminException {
-            String persistentTopic = validatePersistentTopic(params);
-            print(getAdmin().topicPolicies().getSchemaCompatibilityStrategy(persistentTopic, applied));
         }
     }
 }

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/suites/PulsarCliTestSuite.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/suites/PulsarCliTestSuite.java
@@ -1,0 +1,40 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.tests.integration.suites;
+
+import org.apache.pulsar.tests.integration.topologies.PulsarClusterTestBase;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+
+public abstract class PulsarCliTestSuite extends PulsarClusterTestBase {
+    @BeforeClass(alwaysRun = true)
+    public void before() throws Exception {
+        setup();
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void after() throws Exception {
+        cleanup();
+    }
+
+    protected final void enableTopicPolicies() {
+        this.brokerEnvs.put("systemTopicEnabled", "true");
+        this.brokerEnvs.put("topicLevelPoliciesEnabled", "true");
+    }
+}

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/topologies/PulsarClusterTestBase.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/topologies/PulsarClusterTestBase.java
@@ -18,6 +18,8 @@
  */
 package org.apache.pulsar.tests.integration.topologies;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.function.Supplier;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.client.admin.PulsarAdmin;
@@ -29,6 +31,8 @@ import static java.util.stream.Collectors.joining;
 
 @Slf4j
 public abstract class PulsarClusterTestBase extends PulsarTestBase {
+    protected final Map<String, String> brokerEnvs = new HashMap<>();
+
     @Override
     protected final void setup() throws Exception {
         setupCluster();
@@ -98,7 +102,8 @@ public abstract class PulsarClusterTestBase extends PulsarTestBase {
                 .collect(joining("-"));
 
         PulsarClusterSpec.PulsarClusterSpecBuilder specBuilder = PulsarClusterSpec.builder()
-                .clusterName(clusterName);
+                .clusterName(clusterName)
+                .brokerEnvs(brokerEnvs);
 
         setupCluster(beforeSetupCluster(clusterName, specBuilder).build());
     }

--- a/tests/integration/src/test/resources/pulsar-cli.xml
+++ b/tests/integration/src/test/resources/pulsar-cli.xml
@@ -30,6 +30,7 @@
             <class name="org.apache.pulsar.tests.integration.cli.FunctionsCLITest"/>
             <class name="org.apache.pulsar.tests.integration.cli.PackagesCliTest"/>
             <class name="org.apache.pulsar.tests.integration.cli.PulsarVersionTest"/>
+            <class name="org.apache.pulsar.tests.integration.cli.topicpolicies.SchemaCompatibilityStrategyTest"/>
         </classes>
     </test>
 </suite>


### PR DESCRIPTION
### Motivation

The `schema-compatibility-strategy` cmd should be in the `topicPolicies` subcommand, it is topic policies.

### Modifications

- Move the schema compatibility strategy cmd from topics to topicPolicies
- Fix the schema compatibility strategy test

### Documentation

Need to update docs? 

- [x] `doc-required` - #14232 
Need to update the `pulsar-admin topics *-schema-compatibility-strategy` -> `pulsar-admin topicPolicies *-schema-compatibility-strategy`
  

