### PR TITLE
PulsarStandaloneStarter's incorrect split metadataStoreUrl

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/PulsarStandaloneStarter.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/PulsarStandaloneStarter.java
@@ -87,7 +87,17 @@ public class PulsarStandaloneStarter extends PulsarStandalone {
         // Priority: args > conf > default
         if (!argsContains(args, "--zookeeper-port")) {
             if (StringUtils.isNotBlank(config.getMetadataStoreUrl())) {
-                this.setZkPort(Integer.parseInt(config.getMetadataStoreUrl().split(":")[1]));
+                String[] metadataStoreUrl = config.getMetadataStoreUrl().split(",")[0].split(":");
+                if (metadataStoreUrl.length == 2) {
+                    this.setZkPort(Integer.parseInt(metadataStoreUrl[1]));
+                } else if ((metadataStoreUrl.length == 3)){
+                    String zkPort = metadataStoreUrl[2];
+                    if (zkPort.contains("/")) {
+                        this.setZkPort(Integer.parseInt(zkPort.substring(0, zkPort.lastIndexOf("/"))));
+                    } else {
+                        this.setZkPort(Integer.parseInt(zkPort));
+                    }
+                }
             }
         }
         config.setZookeeperServers(zkServers + ":" + this.getZkPort());

--- a/pulsar-broker/src/test/resources/configurations/pulsar_broker_test_standalone.conf
+++ b/pulsar-broker/src/test/resources/configurations/pulsar_broker_test_standalone.conf
@@ -18,8 +18,8 @@
 #
 
 applicationName="pulsar_broker"
-zookeeperServers=
-configurationStoreServers="localhost"
+metadataStoreUrl="zk:localhost:2181/ledger"
+configurationMetadataStoreUrl="zk:localhost:2181"
 brokerServicePort=6650
 brokerServicePortTls=6651
 webServicePort=8080


### PR DESCRIPTION

### Motivation

In PulsarStandaloneStarter, it would split metadataStoreUrl to get ZK Port. But metadataStoreUrl is with zk prefix.

old split way would  cause number format exception.

### Modifications

Make it compatible with multiple kinds of metadataStore url

### Verifying this change
Can be verify by `org.apache.pulsar.broker.service.StandaloneTest#testAdvertised`

### Documentation

Check the box below or label this PR directly (if you have committer privilege).

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)


