### PR TITLE
[Broker] Fix NPE of internalExpireMessagesByTimestamp

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
@@ -3483,11 +3483,19 @@ public class PersistentTopicsBase extends AdminResource {
                             String remoteCluster = PersistentReplicator.getRemoteCluster(subName);
                             PersistentReplicator repl = (PersistentReplicator) topic
                                     .getPersistentReplicator(remoteCluster);
-                            checkNotNull(repl);
+                            if (repl == null) {
+                                resultFuture.completeExceptionally(
+                                        new RestException(Status.NOT_FOUND, "Replicator not found"));
+                                return;
+                            }
                             issued = repl.expireMessages(expireTimeInSeconds);
                         } else {
                             PersistentSubscription sub = topic.getSubscription(subName);
-                            checkNotNull(sub);
+                            if (sub == null) {
+                                resultFuture.completeExceptionally(
+                                        new RestException(Status.NOT_FOUND, "Subscription not found"));
+                                return;
+                            }
                             issued = sub.expireMessages(expireTimeInSeconds);
                         }
                         if (issued) {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiSubscriptionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiSubscriptionTest.java
@@ -1,0 +1,72 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.admin;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.expectThrows;
+import javax.ws.rs.core.Response;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.pulsar.broker.auth.MockedPulsarServiceBaseTest;
+import org.apache.pulsar.client.admin.PulsarAdminException;
+import org.apache.pulsar.client.api.MessageId;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+@Slf4j
+@Test(groups = "broker-admin")
+public class AdminApiSubscriptionTest  extends MockedPulsarServiceBaseTest {
+    @BeforeMethod
+    @Override
+    public void setup() throws Exception {
+        super.internalSetup();
+        super.setupDefaultTenantAndNamespace();
+    }
+
+    @AfterMethod(alwaysRun = true)
+    @Override
+    public void cleanup() throws Exception {
+        super.internalCleanup();
+    }
+
+    @Test
+    public void testExpireNonExistTopic() throws Exception {
+        String topic = "test-expire-messages-topic";
+        String subscriptionName = "test-expire-messages-sub";
+        admin.topics().createSubscription(topic, subscriptionName, MessageId.latest);
+        assertEquals(expectThrows(PulsarAdminException.class,
+                        () -> admin.topics().expireMessages(topic, subscriptionName, 1)).getStatusCode(),
+                Response.Status.CONFLICT.getStatusCode());
+        assertEquals(expectThrows(PulsarAdminException.class,
+                        () -> admin.topics().expireMessagesForAllSubscriptions(topic, 1)).getStatusCode(),
+                Response.Status.CONFLICT.getStatusCode());
+    }
+
+    @Test
+    public void TestExpireNonExistTopicAndNonExistSub() {
+        String topic = "test-expire-messages-topic";
+        String subscriptionName = "test-expire-messages-sub";
+        assertEquals(expectThrows(PulsarAdminException.class,
+                        () -> admin.topics().expireMessages(topic, subscriptionName, 1)).getStatusCode(),
+                Response.Status.NOT_FOUND.getStatusCode());
+        assertEquals(expectThrows(PulsarAdminException.class,
+                        () -> admin.topics().expireMessagesForAllSubscriptions(topic, 1)).getStatusCode(),
+                Response.Status.NOT_FOUND.getStatusCode());
+    }
+}

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/MockedPulsarServiceBaseTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/MockedPulsarServiceBaseTest.java
@@ -58,6 +58,7 @@ import org.apache.pulsar.client.api.ClientBuilder;
 import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.common.policies.data.ClusterData;
+import org.apache.pulsar.common.policies.data.TenantInfo;
 import org.apache.pulsar.common.policies.data.TenantInfoImpl;
 import org.apache.pulsar.metadata.api.MetadataStoreException;
 import org.apache.pulsar.metadata.api.extended.MetadataStoreExtended;
@@ -477,6 +478,25 @@ public abstract class MockedPulsarServiceBaseTest extends TestRetrySupport {
         configuration.setBrokerMaxConnections(0);
         configuration.setBrokerMaxConnectionsPerIp(0);
         return configuration;
+    }
+
+    protected void setupDefaultTenantAndNamespace() throws Exception {
+        final String tenant = "public";
+        final String namespace = tenant + "/default";
+
+        if (!admin.clusters().getClusters().contains(configClusterName)) {
+            admin.clusters().createCluster(configClusterName,
+                    ClusterData.builder().serviceUrl(pulsar.getWebServiceAddress()).build());
+        }
+
+        if (!admin.tenants().getTenants().contains(tenant)) {
+            admin.tenants().createTenant(tenant, TenantInfo.builder().allowedClusters(
+                    Sets.newHashSet(configClusterName)).build());
+        }
+
+        if (!admin.namespaces().getNamespaces(tenant).contains(namespace)) {
+            admin.namespaces().createNamespace(namespace);
+        }
     }
 
     private static final Logger log = LoggerFactory.getLogger(MockedPulsarServiceBaseTest.class);


### PR DESCRIPTION
### Motivation

This issue was triggered by #13880, it doesn't handle the NPE in [here](https://github.com/apache/pulsar/pull/13880/files#diff-66aeb65a64cbe7c541f013ae807c5bcbeab567bef77706c7ff2e0cbfe0d77eb1R3502), we can check the [diff code](https://github.com/apache/pulsar/pull/13880/files#diff-66aeb65a64cbe7c541f013ae807c5bcbeab567bef77706c7ff2e0cbfe0d77eb1L3489) in #13880.

/cc @liudezhi2098 

### Modifications

- Use `if` instead of `checkNotNull`

### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Documentation
  
- [x] `no-need-doc` - Fix the code 




