### PR TITLE
fix rackaware placement policy does not take effect after delete rack configuration 

### DIFF
--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/bookie/rackawareness/BookieRackAffinityMapping.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/bookie/rackawareness/BookieRackAffinityMapping.java
@@ -85,7 +85,8 @@ public class BookieRackAffinityMapping extends AbstractDNSToSwitchMapping
                     bookieAddressListLastTime.add(BookieId.parse(address));
                 }
                 if (LOG.isDebugEnabled()) {
-                    LOG.debug("BookieRackAffinityMapping init, bookieAddressListLastTime {}", bookieAddressListLastTime);
+                    LOG.debug("BookieRackAffinityMapping init, bookieAddressListLastTime {}",
+                            bookieAddressListLastTime);
                 }
             }
         } catch (InterruptedException | ExecutionException e) {

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/bookie/rackawareness/BookieRackAffinityMapping.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/bookie/rackawareness/BookieRackAffinityMapping.java
@@ -22,12 +22,13 @@ import java.net.InetAddress;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
-import java.util.stream.Collectors;
 import org.apache.bookkeeper.client.ITopologyAwareEnsemblePlacementPolicy;
 import org.apache.bookkeeper.client.RackChangeNotifier;
 import org.apache.bookkeeper.net.AbstractDNSToSwitchMapping;
@@ -221,16 +222,10 @@ public class BookieRackAffinityMapping extends AbstractDNSToSwitchMapping
                             LOG.debug("Bookies with rack update from {} to {}", bookieAddressListLastTime,
                                     bookieAddressList);
                         }
-                        // find the bookies has been deleted rack
-                        List<BookieId> deletedBookies =
-                                bookieAddressListLastTime
-                                        .stream()
-                                        .filter(bookie -> !bookieAddressList.contains(bookie))
-                                        .collect(Collectors.toList());
+                        Set<BookieId> bookieIdSet = new HashSet<>(bookieAddressList);
+                        bookieIdSet.addAll(bookieAddressListLastTime);
                         bookieAddressListLastTime = bookieAddressList;
-                        // calculate final bookie list to notify RackAwarePolicy
-                        bookieAddressList.addAll(deletedBookies);
-                        rackawarePolicy.onBookieRackChange(bookieAddressList);
+                        rackawarePolicy.onBookieRackChange(new ArrayList<>(bookieIdSet));
                     });
         }
     }

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/bookie/rackawareness/BookieRackAffinityMapping.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/bookie/rackawareness/BookieRackAffinityMapping.java
@@ -90,7 +90,7 @@ public class BookieRackAffinityMapping extends AbstractDNSToSwitchMapping
                 }
             }
         } catch (InterruptedException | ExecutionException e) {
-            LOG.warn("Failed to init BookieId list", e);
+            throw new RuntimeException(METADATA_STORE_INSTANCE + " failed to init BookieId list");
         }
         store.registerListener(this::handleUpdates);
 


### PR DESCRIPTION
Fixes #14247 

### Motivation

fix rack aware placement policy does not take effect after deleting rack configuration 

### Modifications

1. when bookie's rack configuration is deleted, notify EnsemblePlacementPolicy the delete change
2. add test for rack update

### Verifying this change

This change added tests and can be verified as follows: `RackAwareTest.testRackUpdate()`


### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations:  (no)
  - The wire protocol:  (no)
  - The rest endpoints:  (no)
  - The admin cli options:  (no)
  - Anything that affects deployment: (no)

### Documentation

  
- [x] `no-need-doc` 
  
  (Please explain why)
  


