### PR TITLE
Check ``getTlsTrustStorePath`` NPE when user forget to set it.

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PulsarChannelInitializer.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PulsarChannelInitializer.java
@@ -73,8 +73,8 @@ public class PulsarChannelInitializer extends ChannelInitializer<SocketChannel> 
             if (tlsEnabledWithKeyStore) {
                 AuthenticationDataProvider authData1 = conf.getAuthentication().getAuthData();
                 if (conf.getTlsTrustStorePath() == null) {
-                    throw new RuntimeException("Failed to create TLS context, Due to empty " +
-                            "TlsTrustStorePath configuration.");
+                    throw new RuntimeException("Failed to create TLS context, Due to empty "
+                            + "TlsTrustStorePath configuration.");
                 }
                 nettySSLContextAutoRefreshBuilder = new NettySSLContextAutoRefreshBuilder(
                             conf.getSslProvider(),

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PulsarChannelInitializer.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PulsarChannelInitializer.java
@@ -72,7 +72,10 @@ public class PulsarChannelInitializer extends ChannelInitializer<SocketChannel> 
         if (tlsEnabled) {
             if (tlsEnabledWithKeyStore) {
                 AuthenticationDataProvider authData1 = conf.getAuthentication().getAuthData();
-
+                if (conf.getTlsTrustStorePath() == null) {
+                    throw new RuntimeException("Failed to create TLS context, Due to empty " +
+                            "TlsTrustStorePath configuration.");
+                }
                 nettySSLContextAutoRefreshBuilder = new NettySSLContextAutoRefreshBuilder(
                             conf.getSslProvider(),
                             conf.isTlsAllowInsecureConnection(),

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PulsarChannelInitializer.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PulsarChannelInitializer.java
@@ -75,8 +75,8 @@ public class PulsarChannelInitializer extends ChannelInitializer<SocketChannel> 
             if (tlsEnabledWithKeyStore) {
                 AuthenticationDataProvider authData1 = conf.getAuthentication().getAuthData();
                 if (StringUtils.isBlank(conf.getTlsTrustStorePath())) {
-                    throw new PulsarClientException("Failed to create TLS context, the tlsTrustStorePath" +
-                            " need to be configured if useKeyStoreTls enabled");
+                    throw new PulsarClientException("Failed to create TLS context, the tlsTrustStorePath"
+                            + " need to be configured if useKeyStoreTls enabled");
                 }
                 nettySSLContextAutoRefreshBuilder = new NettySSLContextAutoRefreshBuilder(
                             conf.getSslProvider(),

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PulsarChannelInitializer.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PulsarChannelInitializer.java
@@ -32,7 +32,9 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.pulsar.client.api.AuthenticationDataProvider;
+import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.impl.conf.ClientConfigurationData;
 import org.apache.pulsar.client.util.ObjectCache;
 import org.apache.pulsar.common.protocol.ByteBufPair;
@@ -72,9 +74,9 @@ public class PulsarChannelInitializer extends ChannelInitializer<SocketChannel> 
         if (tlsEnabled) {
             if (tlsEnabledWithKeyStore) {
                 AuthenticationDataProvider authData1 = conf.getAuthentication().getAuthData();
-                if (conf.getTlsTrustStorePath() == null) {
-                    throw new RuntimeException("Failed to create TLS context, Due to empty "
-                            + "TlsTrustStorePath configuration.");
+                if (StringUtils.isBlank(conf.getTlsTrustStorePath())) {
+                    throw new PulsarClientException("Failed to create TLS context, the tlsTrustStorePath" +
+                            " need to be configured if useKeyStoreTls enabled");
                 }
                 nettySSLContextAutoRefreshBuilder = new NettySSLContextAutoRefreshBuilder(
                             conf.getSslProvider(),


### PR DESCRIPTION
### Motivation

If a user sets ``useKeyStoreTls=true`` then forget to set ``getTlsTrustStorePath``, we’re having NPE which becomes hard to debug for users.

### Modifications

- Add NPE check and give use more clear error information.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

- [x] `no-need-doc` 
  


