### PR TITLE
[testclient] Add short name for parameter 

### DIFF
--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdNamespaces.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdNamespaces.java
@@ -254,11 +254,12 @@ public class CmdNamespaces extends CmdBase {
         @Parameter(description = "tenant/namespace", required = true)
         private java.util.List<String> params;
 
-        @Parameter(names = "--subscription",
+        @Parameter(names = {"-s", "--subscription"},
                 description = "Subscription name for which permission will be granted to roles", required = true)
         private String subscription;
 
-        @Parameter(names = "--roles", description = "Client roles to which grant permissions (comma separated roles)",
+        @Parameter(names = {"-rs", "--roles"},
+                description = "Client roles to which grant permissions (comma separated roles)",
                 required = true, splitter = CommaParameterSplitter.class)
         private List<String> roles;
 
@@ -274,11 +275,12 @@ public class CmdNamespaces extends CmdBase {
         @Parameter(description = "tenant/namespace", required = true)
         private java.util.List<String> params;
 
-        @Parameter(names = "--subscription", description = "Subscription name for which permission "
+        @Parameter(names = {"-s", "--subscription"}, description = "Subscription name for which permission "
                 + "will be revoked to roles", required = true)
         private String subscription;
 
-        @Parameter(names = "--role", description = "Client role to which revoke permissions", required = true)
+        @Parameter(names = {"-r", "--role"},
+                description = "Client role to which revoke permissions", required = true)
         private String role;
 
         @Override


### PR DESCRIPTION
## Motivation

- Add short name '-s' for parameter '--subscription'
- Add short name '-r' for parameter '--role'

## Modifications
- pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdNamespaces.java

## Verifying this change

 Make sure that the change passes the CI checks.
(Please pick either of the following options)

This change is already covered by existing tests.

## Does this pull request potentially affect one of the following parts:

If yes was chosen, please highlight the changes

Dependencies (does it add or upgrade a dependency): (yes / **no**)
The public API: (yes / **no**)
The schema: (yes / **no** / don't know)
The default values of configurations: (yes / **no**)
The wire protocol: (yes / **no**)
The rest endpoints: (yes / **no**)
The admin cli options: (yes / **no**)
Anything that affects deployment: (yes / **no** / don't know)

## Documentation

Check the box below or label this PR directly (if you have committer privilege).

## Need to update docs?

- [x] doc


