### PR TITLE
[pulsar-functions] Fix context.get_output_topic

### DIFF
--- a/pulsar-functions/instance/src/main/python/contextimpl.py
+++ b/pulsar-functions/instance/src/main/python/contextimpl.py
@@ -139,7 +139,7 @@ class ContextImpl(pulsar.Context):
     return list(self.instance_config.function_details.source.inputSpecs.keys())
 
   def get_output_topic(self):
-    return self.instance_config.function_details.output
+    return self.instance_config.function_details.sink.topic
 
   def get_output_serde_class_name(self):
     return self.instance_config.function_details.outputSerdeClassName


### PR DESCRIPTION
### Motivation
Even though output topic is set, when `context.get_output_topic()` is executed, `AttributeError: output` in function logs is outputted.

### Modifications

Fix that `context.get_output_topic()` returns function_details.sink.topic.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (yes)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no )

### Documentation  
- [x] `no-need-doc` 