### PR TITLE
Bump netty version to 4.1.74.Final

### DIFF
--- a/buildtools/pom.xml
+++ b/buildtools/pom.xml
@@ -134,7 +134,7 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-common</artifactId>
-      <version>4.1.73.Final</version>
+      <version>4.1.74.Final</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -352,26 +352,26 @@ The Apache Software License, Version 2.0
     - org.apache.commons-commons-compress-1.21.jar
     - org.apache.commons-commons-lang3-3.11.jar
  * Netty
-    - io.netty-netty-buffer-4.1.73.Final.jar
-    - io.netty-netty-codec-4.1.73.Final.jar
-    - io.netty-netty-codec-dns-4.1.73.Final.jar
-    - io.netty-netty-codec-http-4.1.73.Final.jar
-    - io.netty-netty-codec-http2-4.1.73.Final.jar
-    - io.netty-netty-codec-socks-4.1.73.Final.jar
-    - io.netty-netty-codec-haproxy-4.1.73.Final.jar
-    - io.netty-netty-common-4.1.73.Final.jar
-    - io.netty-netty-handler-4.1.73.Final.jar
-    - io.netty-netty-handler-proxy-4.1.73.Final.jar
-    - io.netty-netty-resolver-4.1.73.Final.jar
-    - io.netty-netty-resolver-dns-4.1.73.Final.jar
-    - io.netty-netty-transport-4.1.73.Final.jar
-    - io.netty-netty-transport-classes-epoll-4.1.73.Final.jar
-    - io.netty-netty-transport-native-epoll-4.1.73.Final-linux-x86_64.jar
-    - io.netty-netty-transport-native-epoll-4.1.73.Final.jar
-    - io.netty-netty-transport-native-unix-common-4.1.73.Final.jar
-    - io.netty-netty-transport-native-unix-common-4.1.73.Final-linux-x86_64.jar
-    - io.netty-netty-tcnative-boringssl-static-2.0.46.Final.jar
-    - io.netty-netty-tcnative-classes-2.0.46.Final.jar
+    - io.netty-netty-buffer-4.1.74.Final.jar
+    - io.netty-netty-codec-4.1.74.Final.jar
+    - io.netty-netty-codec-dns-4.1.74.Final.jar
+    - io.netty-netty-codec-http-4.1.74.Final.jar
+    - io.netty-netty-codec-http2-4.1.74.Final.jar
+    - io.netty-netty-codec-socks-4.1.74.Final.jar
+    - io.netty-netty-codec-haproxy-4.1.74.Final.jar
+    - io.netty-netty-common-4.1.74.Final.jar
+    - io.netty-netty-handler-4.1.74.Final.jar
+    - io.netty-netty-handler-proxy-4.1.74.Final.jar
+    - io.netty-netty-resolver-4.1.74.Final.jar
+    - io.netty-netty-resolver-dns-4.1.74.Final.jar
+    - io.netty-netty-transport-4.1.74.Final.jar
+    - io.netty-netty-transport-classes-epoll-4.1.74.Final.jar
+    - io.netty-netty-transport-native-epoll-4.1.74.Final-linux-x86_64.jar
+    - io.netty-netty-transport-native-epoll-4.1.74.Final.jar
+    - io.netty-netty-transport-native-unix-common-4.1.74.Final.jar
+    - io.netty-netty-transport-native-unix-common-4.1.74.Final-linux-x86_64.jar
+    - io.netty-netty-tcnative-boringssl-static-2.0.48.Final.jar
+    - io.netty-netty-tcnative-classes-2.0.48.Final.jar
  * Prometheus client
     - io.prometheus-simpleclient-0.5.0.jar
     - io.prometheus-simpleclient_common-0.5.0.jar

--- a/pom.xml
+++ b/pom.xml
@@ -109,8 +109,8 @@ flexible messaging model and an intuitive client API.</description>
     <snappy.version>1.1.7</snappy.version> <!-- ZooKeeper server -->
     <dropwizardmetrics.version>3.2.5</dropwizardmetrics.version> <!-- ZooKeeper server -->
     <curator.version>5.1.0</curator.version>
-    <netty.version>4.1.73.Final</netty.version>
-    <netty-tc-native.version>2.0.46.Final</netty-tc-native.version>
+    <netty.version>4.1.74.Final</netty.version>
+    <netty-tc-native.version>2.0.48.Final</netty-tc-native.version>
     <jetty.version>9.4.44.v20210927</jetty.version>
     <conscrypt.version>2.5.2</conscrypt.version>
     <jersey.version>2.34</jersey.version>

--- a/pulsar-sql/presto-distribution/LICENSE
+++ b/pulsar-sql/presto-distribution/LICENSE
@@ -233,26 +233,26 @@ The Apache Software License, Version 2.0
     - commons-lang3-3.11.jar
  * Netty
     - netty-3.10.6.Final.jar
-    - netty-buffer-4.1.73.Final.jar
-    - netty-codec-4.1.73.Final.jar
-    - netty-codec-dns-4.1.73.Final.jar
-    - netty-codec-http-4.1.73.Final.jar
-    - netty-codec-haproxy-4.1.73.Final.jar
-    - netty-codec-socks-4.1.73.Final.jar
-    - netty-handler-proxy-4.1.73.Final.jar
-    - netty-common-4.1.73.Final.jar
-    - netty-handler-4.1.73.Final.jar
+    - netty-buffer-4.1.74.Final.jar
+    - netty-codec-4.1.74.Final.jar
+    - netty-codec-dns-4.1.74.Final.jar
+    - netty-codec-http-4.1.74.Final.jar
+    - netty-codec-haproxy-4.1.74.Final.jar
+    - netty-codec-socks-4.1.74.Final.jar
+    - netty-handler-proxy-4.1.74.Final.jar
+    - netty-common-4.1.74.Final.jar
+    - netty-handler-4.1.74.Final.jar
     - netty-reactive-streams-2.0.4.jar
-    - netty-resolver-4.1.73.Final.jar
-    - netty-resolver-dns-4.1.73.Final.jar
-    - netty-tcnative-boringssl-static-2.0.46.Final.jar
-    - netty-tcnative-classes-2.0.46.Final.jar
-    - netty-transport-4.1.73.Final.jar
-    - netty-transport-classes-epoll-4.1.73.Final.jar
-    - netty-transport-native-epoll-4.1.73.Final-linux-x86_64.jar
-    - netty-transport-native-unix-common-4.1.73.Final.jar
-    - netty-transport-native-unix-common-4.1.73.Final-linux-x86_64.jar
-    - netty-codec-http2-4.1.73.Final.jar
+    - netty-resolver-4.1.74.Final.jar
+    - netty-resolver-dns-4.1.74.Final.jar
+    - netty-tcnative-boringssl-static-2.0.48.Final.jar
+    - netty-tcnative-classes-2.0.48.Final.jar
+    - netty-transport-4.1.74.Final.jar
+    - netty-transport-classes-epoll-4.1.74.Final.jar
+    - netty-transport-native-epoll-4.1.74.Final-linux-x86_64.jar
+    - netty-transport-native-unix-common-4.1.74.Final.jar
+    - netty-transport-native-unix-common-4.1.74.Final-linux-x86_64.jar
+    - netty-codec-http2-4.1.74.Final.jar
  * GRPC
     - grpc-api-1.42.1.jar
     - grpc-context-1.42.1.jar


### PR DESCRIPTION
### Motivation

Changelog: https://netty.io/news/2022/02/08/4-1-74-Final.html

Netty 4.1.74 had solved several dns resolver bug

### Modifications

* Upgrade Netty from 4.1.73.Final to 4.1.74.Final
* Netty 4.1.74.Final depends on netty-tc-native 2.0.48, also updates