### PR TITLE
Add a note for configuring `tlsTrustStorePath` along with `useKeyStoreTls`.

### DIFF
--- a/site2/docs/security-tls-keystore.md
+++ b/site2/docs/security-tls-keystore.md
@@ -158,10 +158,10 @@ Optional settings that may worth consider:
     By default, it is not set.
 ### Configuring Clients
 
-This is similar to [TLS encryption configuing for client with PEM type](security-tls-transport.md#Client configuration).
-For a a minimal configuration, user need to provide the TrustStore information.
+This is similar to [TLS encryption configuing for client with PEM type](security-tls-transport.md#client-configuration).
+For a minimal configuration, you need to provide the TrustStore information.
 
-e.g. 
+For example:
 1. for [Command-line tools](reference-cli-tools.md) like [`pulsar-admin`](reference-cli-tools#pulsar-admin), [`pulsar-perf`](reference-cli-tools#pulsar-perf), and [`pulsar-client`](reference-cli-tools#pulsar-client) use the `conf/client.conf` config file in a Pulsar installation.
 
     ```properties
@@ -188,14 +188,16 @@ e.g.
     ```
 
 1. for java admin client
-```java
-    PulsarAdmin amdin = PulsarAdmin.builder().serviceHttpUrl("https://broker.example.com:8443")
-                .useKeyStoreTls(true)
-                .tlsTrustStorePath("/var/private/tls/client.truststore.jks")
-                .tlsTrustStorePassword("clientpw")
-                .allowTlsInsecureConnection(false)
-                .build();
-```
+    ```java
+        PulsarAdmin amdin = PulsarAdmin.builder().serviceHttpUrl("https://broker.example.com:8443")
+            .useKeyStoreTls(true)
+            .tlsTrustStorePath("/var/private/tls/client.truststore.jks")
+            .tlsTrustStorePassword("clientpw")
+            .allowTlsInsecureConnection(false)
+            .build();
+    ```
+
+> **Note:** Please configure `tlsTrustStorePath` when you set `useKeyStoreTls` to `true`.
 
 ## TLS authentication with KeyStore configure
 
@@ -244,7 +246,7 @@ webSocketServiceEnabled=false
 
 Besides the TLS encryption configuring. The main work is configuring the KeyStore, which contains a valid CN as client role, for client.
 
-e.g. 
+For example:
 1. for [Command-line tools](reference-cli-tools.md) like [`pulsar-admin`](reference-cli-tools#pulsar-admin), [`pulsar-perf`](reference-cli-tools#pulsar-perf), and [`pulsar-client`](reference-cli-tools#pulsar-client) use the `conf/client.conf` config file in a Pulsar installation.
 
     ```properties
@@ -287,6 +289,8 @@ e.g.
                    "keyStoreType:JKS,keyStorePath:/var/private/tls/client.keystore.jks,keyStorePassword:clientpw")
             .build();
     ```
+
+> **Note:** Please configure `tlsTrustStorePath` when you set `useKeyStoreTls` to `true`.
 
 ## Enabling TLS Logging
 


### PR DESCRIPTION
### Modifications
1. Add a note to clarify the mandatory configuration `tlsTrustStorePath` when `useKeyStoreTls` is set to `true`.
Relevant code PR: #14253 
2. Minor fix for doc bugs.

### Preview
![image](https://user-images.githubusercontent.com/60642177/153817769-c7164321-47a9-42f2-ba58-6435269111f4.png)


### Documentation

- [x] `doc` 
  

