### PR TITLE
[Docs] Replace adoptopenjdk.net with adoptium.net

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ components in the Pulsar ecosystem, including connectors, adapters, and other la
 ## Build Pulsar
 
 Requirements:
- * Java [JDK 11](https://adoptopenjdk.net/?variant=openjdk11) or [JDK 8](https://adoptopenjdk.net/?variant=openjdk8)
+ * Java [JDK 11](https://adoptium.net/?variant=openjdk11) or [JDK 8](https://adoptium.net/?variant=openjdk8)
  * Maven 3.6.1+
  * zip
 
@@ -178,7 +178,7 @@ required plugins.
     
     From the JDK version drop-down list, select **Download JDK...** or choose an existing recent Java 11 JDK version.
 
-3. In the download dialog, select version **11**. You can pick a version from many vendors. Unless you have a specific preference, choose **AdoptOpenJDK (Hotspot)**.
+3. In the download dialog, select version **11**. You can pick a version from many vendors. Unless you have a specific preference, choose **Eclipse Temurin (AdoptOpenJDK (Hotspot))**.
  
 
 #### Configure Java version for Maven in IntelliJ

--- a/site2/docs/deploy-bare-metal.md
+++ b/site2/docs/deploy-bare-metal.md
@@ -40,7 +40,7 @@ To run Pulsar on bare metal, the following configuration is recommended:
 > * Broker is only supported on 64-bit JVM.
 > * If you do not have enough machines, or you want to test Pulsar in cluster mode (and expand the cluster later), You can fully deploy Pulsar on a node on which ZooKeeper, bookie and broker run.
 > * If you do not have a DNS server, you can use the multi-host format in the service URL instead.
-Each machine in your cluster needs to have [Java 8](https://adoptopenjdk.net/?variant=openjdk8) or [Java 11](https://adoptopenjdk.net/?variant=openjdk11) installed.
+Each machine in your cluster needs to have [Java 8](https://adoptium.net/?variant=openjdk8) or [Java 11](https://adoptium.net/?variant=openjdk11) installed.
 
 The following is a diagram showing the basic setup:
 

--- a/site2/website-next/docs/deploy-bare-metal.md
+++ b/site2/website-next/docs/deploy-bare-metal.md
@@ -46,7 +46,7 @@ To run Pulsar on bare metal, the following configuration is recommended:
 
 :::
 
-Each machine in your cluster needs to have [Java 8](https://adoptopenjdk.net/?variant=openjdk8) or [Java 11](https://adoptopenjdk.net/?variant=openjdk11) installed.
+Each machine in your cluster needs to have [Java 8](https://adoptium.net/?variant=openjdk8) or [Java 11](https://adoptium.net/?variant=openjdk11) installed.
 
 The following is a diagram showing the basic setup:
 

--- a/site2/website-next/versioned_docs/version-2.7.2/deploy-bare-metal.md
+++ b/site2/website-next/versioned_docs/version-2.7.2/deploy-bare-metal.md
@@ -53,7 +53,7 @@ Broker is only supported on 64-bit JVM.
 
 > If you do not have a DNS server, you can use the multi-host format in the service URL instead.
 
-Each machine in your cluster needs to have [Java 8](https://adoptopenjdk.net/?variant=openjdk8) or [Java 11](https://adoptopenjdk.net/?variant=openjdk11) installed.
+Each machine in your cluster needs to have [Java 8](https://adoptium.net/?variant=openjdk8) or [Java 11](https://adoptium.net/?variant=openjdk11) installed.
 
 The following is a diagram showing the basic setup:
 

--- a/site2/website-next/versioned_docs/version-2.8.0/deploy-bare-metal.md
+++ b/site2/website-next/versioned_docs/version-2.8.0/deploy-bare-metal.md
@@ -53,7 +53,7 @@ Broker is only supported on 64-bit JVM.
 
 > If you do not have a DNS server, you can use the multi-host format in the service URL instead.
 
-Each machine in your cluster needs to have [Java 8](https://adoptopenjdk.net/?variant=openjdk8) or [Java 11](https://adoptopenjdk.net/?variant=openjdk11) installed.
+Each machine in your cluster needs to have [Java 8](https://adoptium.net/?variant=openjdk8) or [Java 11](https://adoptium.net/?variant=openjdk11) installed.
 
 The following is a diagram showing the basic setup:
 

--- a/site2/website-next/versioned_docs/version-2.8.1/deploy-bare-metal.md
+++ b/site2/website-next/versioned_docs/version-2.8.1/deploy-bare-metal.md
@@ -53,7 +53,7 @@ Broker is only supported on 64-bit JVM.
 
 > If you do not have a DNS server, you can use the multi-host format in the service URL instead.
 
-Each machine in your cluster needs to have [Java 8](https://adoptopenjdk.net/?variant=openjdk8) or [Java 11](https://adoptopenjdk.net/?variant=openjdk11) installed.
+Each machine in your cluster needs to have [Java 8](https://adoptium.net/?variant=openjdk8) or [Java 11](https://adoptium.net/?variant=openjdk11) installed.
 
 The following is a diagram showing the basic setup:
 

--- a/site2/website-next/versioned_docs/version-2.8.2/deploy-bare-metal.md
+++ b/site2/website-next/versioned_docs/version-2.8.2/deploy-bare-metal.md
@@ -53,7 +53,7 @@ Broker is only supported on 64-bit JVM.
 
 > If you do not have a DNS server, you can use the multi-host format in the service URL instead.
 
-Each machine in your cluster needs to have [Java 8](https://adoptopenjdk.net/?variant=openjdk8) or [Java 11](https://adoptopenjdk.net/?variant=openjdk11) installed.
+Each machine in your cluster needs to have [Java 8](https://adoptium.net/?variant=openjdk8) or [Java 11](https://adoptium.net/?variant=openjdk11) installed.
 
 The following is a diagram showing the basic setup:
 

--- a/site2/website-next/versioned_docs/version-2.9.0/deploy-bare-metal.md
+++ b/site2/website-next/versioned_docs/version-2.9.0/deploy-bare-metal.md
@@ -47,7 +47,7 @@ To run Pulsar on bare metal, the following configuration is recommended:
 
 :::
 
-Each machine in your cluster needs to have [Java 8](https://adoptopenjdk.net/?variant=openjdk8) or [Java 11](https://adoptopenjdk.net/?variant=openjdk11) installed.
+Each machine in your cluster needs to have [Java 8](https://adoptium.net/?variant=openjdk8) or [Java 11](https://adoptium.net/?variant=openjdk11) installed.
 
 The following is a diagram showing the basic setup:
 

--- a/site2/website-next/versioned_docs/version-2.9.1/deploy-bare-metal.md
+++ b/site2/website-next/versioned_docs/version-2.9.1/deploy-bare-metal.md
@@ -47,7 +47,7 @@ To run Pulsar on bare metal, the following configuration is recommended:
 
 :::
 
-Each machine in your cluster needs to have [Java 8](https://adoptopenjdk.net/?variant=openjdk8) or [Java 11](https://adoptopenjdk.net/?variant=openjdk11) installed.
+Each machine in your cluster needs to have [Java 8](https://adoptium.net/?variant=openjdk8) or [Java 11](https://adoptium.net/?variant=openjdk11) installed.
 
 The following is a diagram showing the basic setup:
 

--- a/site2/website/versioned_docs/version-2.7.2/deploy-bare-metal.md
+++ b/site2/website/versioned_docs/version-2.7.2/deploy-bare-metal.md
@@ -52,7 +52,7 @@ To run Pulsar on bare metal, the following configuration is recommended:
 
 > If you do not have a DNS server, you can use the multi-host format in the service URL instead.
 
-Each machine in your cluster needs to have [Java 8](https://adoptopenjdk.net/?variant=openjdk8) or [Java 11](https://adoptopenjdk.net/?variant=openjdk11) installed.
+Each machine in your cluster needs to have [Java 8](https://adoptium.net/?variant=openjdk8) or [Java 11](https://adoptium.net/?variant=openjdk11) installed.
 
 The following is a diagram showing the basic setup:
 

--- a/site2/website/versioned_docs/version-2.8.0/deploy-bare-metal.md
+++ b/site2/website/versioned_docs/version-2.8.0/deploy-bare-metal.md
@@ -52,7 +52,7 @@ To run Pulsar on bare metal, the following configuration is recommended:
 
 > If you do not have a DNS server, you can use the multi-host format in the service URL instead.
 
-Each machine in your cluster needs to have [Java 8](https://adoptopenjdk.net/?variant=openjdk8) or [Java 11](https://adoptopenjdk.net/?variant=openjdk11) installed.
+Each machine in your cluster needs to have [Java 8](https://adoptium.net/?variant=openjdk8) or [Java 11](https://adoptium.net/?variant=openjdk11) installed.
 
 The following is a diagram showing the basic setup:
 

--- a/site2/website/versioned_docs/version-2.8.1/deploy-bare-metal.md
+++ b/site2/website/versioned_docs/version-2.8.1/deploy-bare-metal.md
@@ -52,7 +52,7 @@ To run Pulsar on bare metal, the following configuration is recommended:
 
 > If you do not have a DNS server, you can use the multi-host format in the service URL instead.
 
-Each machine in your cluster needs to have [Java 8](https://adoptopenjdk.net/?variant=openjdk8) or [Java 11](https://adoptopenjdk.net/?variant=openjdk11) installed.
+Each machine in your cluster needs to have [Java 8](https://adoptium.net/?variant=openjdk8) or [Java 11](https://adoptium.net/?variant=openjdk11) installed.
 
 The following is a diagram showing the basic setup:
 

--- a/site2/website/versioned_docs/version-2.8.2/deploy-bare-metal.md
+++ b/site2/website/versioned_docs/version-2.8.2/deploy-bare-metal.md
@@ -52,7 +52,7 @@ To run Pulsar on bare metal, the following configuration is recommended:
 
 > If you do not have a DNS server, you can use the multi-host format in the service URL instead.
 
-Each machine in your cluster needs to have [Java 8](https://adoptopenjdk.net/?variant=openjdk8) or [Java 11](https://adoptopenjdk.net/?variant=openjdk11) installed.
+Each machine in your cluster needs to have [Java 8](https://adoptium.net/?variant=openjdk8) or [Java 11](https://adoptium.net/?variant=openjdk11) installed.
 
 The following is a diagram showing the basic setup:
 

--- a/site2/website/versioned_docs/version-2.9.0/deploy-bare-metal.md
+++ b/site2/website/versioned_docs/version-2.9.0/deploy-bare-metal.md
@@ -41,7 +41,7 @@ To run Pulsar on bare metal, the following configuration is recommended:
 > * Broker is only supported on 64-bit JVM.
 > * If you do not have enough machines, or you want to test Pulsar in cluster mode (and expand the cluster later), You can fully deploy Pulsar on a node on which ZooKeeper, bookie and broker run.
 > * If you do not have a DNS server, you can use the multi-host format in the service URL instead.
-Each machine in your cluster needs to have [Java 8](https://adoptopenjdk.net/?variant=openjdk8) or [Java 11](https://adoptopenjdk.net/?variant=openjdk11) installed.
+Each machine in your cluster needs to have [Java 8](https://adoptium.net/?variant=openjdk8) or [Java 11](https://adoptium.net/?variant=openjdk11) installed.
 
 The following is a diagram showing the basic setup:
 

--- a/site2/website/versioned_docs/version-2.9.1/deploy-bare-metal.md
+++ b/site2/website/versioned_docs/version-2.9.1/deploy-bare-metal.md
@@ -41,7 +41,7 @@ To run Pulsar on bare metal, the following configuration is recommended:
 > * Broker is only supported on 64-bit JVM.
 > * If you do not have enough machines, or you want to test Pulsar in cluster mode (and expand the cluster later), You can fully deploy Pulsar on a node on which ZooKeeper, bookie and broker run.
 > * If you do not have a DNS server, you can use the multi-host format in the service URL instead.
-Each machine in your cluster needs to have [Java 8](https://adoptopenjdk.net/?variant=openjdk8) or [Java 11](https://adoptopenjdk.net/?variant=openjdk11) installed.
+Each machine in your cluster needs to have [Java 8](https://adoptium.net/?variant=openjdk8) or [Java 11](https://adoptium.net/?variant=openjdk11) installed.
 
 The following is a diagram showing the basic setup:
 


### PR DESCRIPTION
### Motivation

- AdoptOpenJDK has been replaced with Eclipse Adoptium / Temurin
  https://blog.adoptopenjdk.net/2021/03/transition-to-eclipse-an-update/

### Modifications

- replace adoptopenjdk.net with adoptium.net

- [x] `doc`