### PR TITLE
[Transaction] Optimize changeToCloseState

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/TopicTransactionBufferState.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/TopicTransactionBufferState.java
@@ -62,11 +62,8 @@ public abstract class TopicTransactionBufferState {
         return STATE_UPDATER.compareAndSet(this, State.NoSnapshot, State.Ready);
     }
 
-    protected boolean changeToCloseState() {
-        return (STATE_UPDATER.compareAndSet(this, State.Ready, State.Close)
-                || STATE_UPDATER.compareAndSet(this, State.None, State.Close)
-                || STATE_UPDATER.compareAndSet(this, State.Initializing, State.Close)
-                || STATE_UPDATER.compareAndSet(this, State.NoSnapshot, State.Close));
+    protected void changeToCloseState() {
+        STATE_UPDATER.set(this, State.Close);
     }
 
     public boolean checkIfReady() {


### PR DESCRIPTION
### Motivation
The four judgments are not atomic. If there is a state transition in the judgment, errors may occur. For example, in ` state_ UPDATER. When compareandset (this, state. None, state. Close) ` is selected, the state of TB changes from nosnapshot to ready, then this changeToClosed will fail.
### Modification
change to `STATE_UPDATER.set(this, State.Close);`

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API: (yes / no)
  - The schema: (yes / no / don't know)
  - The default values of configurations: (yes / no)
  - The wire protocol: (yes / no)
  - The rest endpoints: (yes / no)
  - The admin cli options: (yes / no)
  - Anything that affects deployment: (yes / no / don't know)

### Documentation

Check the box below or label this PR directly (if you have committer privilege).

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)


