### PR TITLE
[Build] Fix jacoco-maven-plugin integration with the build

### DIFF
--- a/buildtools/pom.xml
+++ b/buildtools/pom.xml
@@ -170,7 +170,7 @@
               <value>org.apache.pulsar.tests.PulsarTestListener,org.apache.pulsar.tests.AnnotationListener,org.apache.pulsar.tests.FailFastNotifier</value>
             </property>
           </properties>
-          <argLine>@{argLine}
+          <argLine>@{testJacocoAgentArgument}
             ${test.additional.args}
           </argLine>
         </configuration>

--- a/buildtools/pom.xml
+++ b/buildtools/pom.xml
@@ -170,7 +170,7 @@
               <value>org.apache.pulsar.tests.PulsarTestListener,org.apache.pulsar.tests.AnnotationListener,org.apache.pulsar.tests.FailFastNotifier</value>
             </property>
           </properties>
-          <argLine>@{testJacocoAgentArgument}
+          <argLine>
             ${test.additional.args}
           </argLine>
         </configuration>

--- a/buildtools/pom.xml
+++ b/buildtools/pom.xml
@@ -170,7 +170,7 @@
               <value>org.apache.pulsar.tests.PulsarTestListener,org.apache.pulsar.tests.AnnotationListener,org.apache.pulsar.tests.FailFastNotifier</value>
             </property>
           </properties>
-          <argLine>
+          <argLine>@{argLine}
             ${test.additional.args}
           </argLine>
         </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -94,6 +94,7 @@ flexible messaging model and an intuitive client API.</description>
     <testForkCount>4</testForkCount>
     <testRealAWS>false</testRealAWS>
     <testRetryCount>1</testRetryCount>
+    <testJacocoAgentArgument></testJacocoAgentArgument>
     <docker.organization>apachepulsar</docker.organization>
     <skipSourceReleaseAssembly>false</skipSourceReleaseAssembly>
     <skipBuildDistribution>false</skipBuildDistribution>
@@ -1405,7 +1406,7 @@ flexible messaging model and an intuitive client API.</description>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
-          <argLine>@{argLine} -Xmx1G -XX:+UseG1GC
+          <argLine>@{testJacocoAgentArgument} -Xmx1G -XX:+UseG1GC
             -Dpulsar.allocator.pooled=true
             -Dpulsar.allocator.leak_detection=Advanced
             -Dpulsar.allocator.exit_on_oom=false
@@ -1914,6 +1915,9 @@ flexible messaging model and an intuitive client API.</description>
             <groupId>org.jacoco</groupId>
             <artifactId>jacoco-maven-plugin</artifactId>
             <version>${jacoco-maven-plugin.version}</version>
+            <configuration>
+              <propertyName>testJacocoAgentArgument</propertyName>
+            </configuration>
             <executions>
               <execution>
                 <id>pre-unit-test</id>

--- a/pom.xml
+++ b/pom.xml
@@ -249,7 +249,7 @@ flexible messaging model and an intuitive client API.</description>
     <git-commit-id-plugin.version>4.0.2</git-commit-id-plugin.version>
     <wagon-ssh-external.version>3.4.3</wagon-ssh-external.version>
     <os-maven-plugin.version>1.4.1.Final</os-maven-plugin.version>
-    <jacoco-maven-plugin.version>0.8.6</jacoco-maven-plugin.version>
+    <jacoco-maven-plugin.version>0.8.7</jacoco-maven-plugin.version>
     <spotbugs-maven-plugin.version>4.2.2</spotbugs-maven-plugin.version>
     <spotbugs.version>4.2.2</spotbugs.version>
     <errorprone.version>2.5.1</errorprone.version>

--- a/pom.xml
+++ b/pom.xml
@@ -1405,7 +1405,7 @@ flexible messaging model and an intuitive client API.</description>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
-          <argLine> -Xmx1G -XX:+UseG1GC
+          <argLine>@{argLine} -Xmx1G -XX:+UseG1GC
             -Dpulsar.allocator.pooled=true
             -Dpulsar.allocator.leak_detection=Advanced
             -Dpulsar.allocator.exit_on_oom=false

--- a/tests/bc_2_0_0/pom.xml
+++ b/tests/bc_2_0_0/pom.xml
@@ -91,7 +91,7 @@
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-surefire-plugin</artifactId>
                         <configuration>
-                            <argLine>@{argLine} -Xmx2G -XX:MaxDirectMemorySize=8G
+                            <argLine>@{testJacocoAgentArgument} -Xmx2G -XX:MaxDirectMemorySize=8G
                                 -Dio.netty.leakDetectionLevel=advanced
                                 ${test.additional.args}
                             </argLine>

--- a/tests/bc_2_0_0/pom.xml
+++ b/tests/bc_2_0_0/pom.xml
@@ -91,7 +91,7 @@
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-surefire-plugin</artifactId>
                         <configuration>
-                            <argLine>-Xmx2G -XX:MaxDirectMemorySize=8G
+                            <argLine>@{argLine} -Xmx2G -XX:MaxDirectMemorySize=8G
                                 -Dio.netty.leakDetectionLevel=advanced
                                 ${test.additional.args}
                             </argLine>

--- a/tests/bc_2_0_1/pom.xml
+++ b/tests/bc_2_0_1/pom.xml
@@ -91,7 +91,7 @@
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-surefire-plugin</artifactId>
                         <configuration>
-                            <argLine>@{argLine} -Xmx2G -XX:MaxDirectMemorySize=8G
+                            <argLine>@{testJacocoAgentArgument} -Xmx2G -XX:MaxDirectMemorySize=8G
                                 -Dio.netty.leakDetectionLevel=advanced
                                 ${test.additional.args}
                             </argLine>

--- a/tests/bc_2_0_1/pom.xml
+++ b/tests/bc_2_0_1/pom.xml
@@ -91,7 +91,7 @@
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-surefire-plugin</artifactId>
                         <configuration>
-                            <argLine>-Xmx2G -XX:MaxDirectMemorySize=8G
+                            <argLine>@{argLine} -Xmx2G -XX:MaxDirectMemorySize=8G
                                 -Dio.netty.leakDetectionLevel=advanced
                                 ${test.additional.args}
                             </argLine>

--- a/tests/bc_2_6_0/pom.xml
+++ b/tests/bc_2_6_0/pom.xml
@@ -98,7 +98,7 @@
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-surefire-plugin</artifactId>
                         <configuration>
-                            <argLine>-Xmx2G -XX:MaxDirectMemorySize=8G
+                            <argLine>@{argLine} -Xmx2G -XX:MaxDirectMemorySize=8G
                                 -Dio.netty.leakDetectionLevel=advanced
                                 ${test.additional.args}
                             </argLine>

--- a/tests/bc_2_6_0/pom.xml
+++ b/tests/bc_2_6_0/pom.xml
@@ -98,7 +98,7 @@
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-surefire-plugin</artifactId>
                         <configuration>
-                            <argLine>@{argLine} -Xmx2G -XX:MaxDirectMemorySize=8G
+                            <argLine>@{testJacocoAgentArgument} -Xmx2G -XX:MaxDirectMemorySize=8G
                                 -Dio.netty.leakDetectionLevel=advanced
                                 ${test.additional.args}
                             </argLine>

--- a/tests/integration/pom.xml
+++ b/tests/integration/pom.xml
@@ -233,7 +233,7 @@
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-surefire-plugin</artifactId>
             <configuration>
-              <argLine>-Xmx1G -XX:MaxDirectMemorySize=1G
+              <argLine>@{argLine} -Xmx1G -XX:MaxDirectMemorySize=1G
               -Dio.netty.leakDetectionLevel=advanced
               ${test.additional.args}
               </argLine>

--- a/tests/integration/pom.xml
+++ b/tests/integration/pom.xml
@@ -233,7 +233,7 @@
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-surefire-plugin</artifactId>
             <configuration>
-              <argLine>@{argLine} -Xmx1G -XX:MaxDirectMemorySize=1G
+              <argLine>@{testJacocoAgentArgument} -Xmx1G -XX:MaxDirectMemorySize=1G
               -Dio.netty.leakDetectionLevel=advanced
               ${test.additional.args}
               </argLine>

--- a/tests/pulsar-client-admin-shade-test/pom.xml
+++ b/tests/pulsar-client-admin-shade-test/pom.xml
@@ -106,7 +106,7 @@
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-surefire-plugin</artifactId>
                         <configuration>
-                            <argLine>-Xmx2G -XX:MaxDirectMemorySize=8G
+                            <argLine>@{argLine} -Xmx2G -XX:MaxDirectMemorySize=8G
                                 -Dio.netty.leakDetectionLevel=advanced
                                 ${test.additional.args}
                             </argLine>

--- a/tests/pulsar-client-admin-shade-test/pom.xml
+++ b/tests/pulsar-client-admin-shade-test/pom.xml
@@ -106,7 +106,7 @@
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-surefire-plugin</artifactId>
                         <configuration>
-                            <argLine>@{argLine} -Xmx2G -XX:MaxDirectMemorySize=8G
+                            <argLine>@{testJacocoAgentArgument} -Xmx2G -XX:MaxDirectMemorySize=8G
                                 -Dio.netty.leakDetectionLevel=advanced
                                 ${test.additional.args}
                             </argLine>

--- a/tests/pulsar-client-all-shade-test/pom.xml
+++ b/tests/pulsar-client-all-shade-test/pom.xml
@@ -105,7 +105,7 @@
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-surefire-plugin</artifactId>
                         <configuration>
-                            <argLine>-Xmx2G -XX:MaxDirectMemorySize=8G
+                            <argLine>@{argLine} -Xmx2G -XX:MaxDirectMemorySize=8G
                                 -Dio.netty.leakDetectionLevel=advanced
                                 ${test.additional.args}
                             </argLine>

--- a/tests/pulsar-client-all-shade-test/pom.xml
+++ b/tests/pulsar-client-all-shade-test/pom.xml
@@ -105,7 +105,7 @@
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-surefire-plugin</artifactId>
                         <configuration>
-                            <argLine>@{argLine} -Xmx2G -XX:MaxDirectMemorySize=8G
+                            <argLine>@{testJacocoAgentArgument} -Xmx2G -XX:MaxDirectMemorySize=8G
                                 -Dio.netty.leakDetectionLevel=advanced
                                 ${test.additional.args}
                             </argLine>

--- a/tests/pulsar-client-shade-test/pom.xml
+++ b/tests/pulsar-client-shade-test/pom.xml
@@ -100,7 +100,7 @@
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-surefire-plugin</artifactId>
                         <configuration>
-                            <argLine>@{argLine} -Xmx2G -XX:MaxDirectMemorySize=8G
+                            <argLine>@{testJacocoAgentArgument} -Xmx2G -XX:MaxDirectMemorySize=8G
                                 -Dio.netty.leakDetectionLevel=advanced
                                 ${test.additional.args}
                             </argLine>

--- a/tests/pulsar-client-shade-test/pom.xml
+++ b/tests/pulsar-client-shade-test/pom.xml
@@ -100,7 +100,7 @@
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-surefire-plugin</artifactId>
                         <configuration>
-                            <argLine>-Xmx2G -XX:MaxDirectMemorySize=8G
+                            <argLine>@{argLine} -Xmx2G -XX:MaxDirectMemorySize=8G
                                 -Dio.netty.leakDetectionLevel=advanced
                                 ${test.additional.args}
                             </argLine>


### PR DESCRIPTION
### Motivation

The jacoco-maven-plugin integration with the build is broken

### Modifications

- Configure jacoco-maven-plugin to set the JVM arguments in `testJacocoAgentArgument` property
- Fix the integration by replacing `<argLine>` with `<argLine>@{testJacocoAgentArgument} ` in `maven-surefire-plugin` configuration
- Upgrade jacoco-maven-plugin to latest version
 