### PR TITLE
[tests] Enable BookKeeper NativeIO feature in order to make the tests pass on JDK17

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1889,6 +1889,7 @@ flexible messaging model and an intuitive client API.</description>
         <test.additional.args>
           --add-opens java.base/jdk.internal.loader=ALL-UNNAMED
           --add-opens java.base/java.lang=ALL-UNNAMED <!--Mockito-->
+          --add-opens java.base/java.io=ALL-UNNAMED <!--Bookkeeper NativeIO -->
         </test.additional.args>
       </properties>
       <build>


### PR DESCRIPTION
### Motivation

Running a test that require a bookie to be started fails with JDK17, due to the BookKeeper Native IO logic. For example you can run the `PulsarSourceE2ETest` test to see it crash.

https://github.com/apache/bookkeeper/blob/4debbbf84db09f80ffeb4154e8e6feed134be0c0/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/NativeIO.java#L59-L88  

BookKeeper expects to be able to access to `FileDescriptor` and it will throw an assertion error if it something goes wrong. To make this possible w/ JDK17 we need to pass the Java runtime option to open the `java.io` package to be accessed.  

Surefire add the `-ea` flag [by default](https://maven.apache.org/surefire/maven-surefire-plugin/test-mojo.html#enableAssertions) but the production process is not affected since we don't set the flag on Pulsar scripts.

An alternative could be to skip Java assertions error in the tests but I prefer to open the package as I see it as a more conservative choice.

### Modifications

* Added `--add-opens java.base/java.io=ALL-UNNAMED` to surefire options (only for build w/ jdk11+)

- [x] `no-need-doc` 
  