### PR TITLE
bug fix: IllegalArgumentException: Invalid period 0.0 to calculate rate

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerFactoryImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerFactoryImpl.java
@@ -188,7 +188,7 @@ public class ManagedLedgerFactoryImpl implements ManagedLedgerFactory {
         this.config = config;
         this.mbean = new ManagedLedgerFactoryMBeanImpl(this);
         this.entryCacheManager = new EntryCacheManager(this);
-        this.statsTask = scheduledExecutor.scheduleAtFixedRate(catchingAndLoggingThrowables(this::refreshStats),
+        this.statsTask = scheduledExecutor.scheduleWithFixedDelay(catchingAndLoggingThrowables(this::refreshStats),
                 0, config.getStatsPeriodSeconds(), TimeUnit.SECONDS);
         this.flushCursorsTask = scheduledExecutor.scheduleAtFixedRate(catchingAndLoggingThrowables(this::flushCursors),
                 config.getCursorPositionFlushSeconds(), config.getCursorPositionFlushSeconds(), TimeUnit.SECONDS);


### PR DESCRIPTION
### Motivation
use scheduleWithFixedDelay replace scheduleAtFixedRate in the class  of ManagedLedgerFactoryImpl.
Because an exception was found in the broker log:

11:37:52.455 [bookkeeper-ml-scheduler-OrderedScheduler-24-0] ERROR org.apache.bookkeeper.common.util.SafeRunnable - Unexpected throwable caught 
java.lang.IllegalArgumentException: Invalid period 0.0 to calculate rate
        at com.google.common.base.Preconditions.checkArgument(Preconditions.java:217) ~[com.google.guava-guava-30.1-jre.jar:?]
        at org.apache.pulsar.common.stats.Rate.calculateRate(Rate.java:64) ~[org.apache.pulsar-pulsar-common-2.8.1.2.jar:2.8.1.2]
        at org.apache.bookkeeper.mledger.impl.ManagedLedgerMBeanImpl.refreshStats(ManagedLedgerMBeanImpl.java:66) ~[org.apache.pulsar-managed-ledger-2.8.1.2.jar:2.8.1.2]
        at org.apache.bookkeeper.mledger.impl.ManagedLedgerFactoryImpl.lambda$refreshStats$3(ManagedLedgerFactoryImpl.java:227) ~[org.apache.pulsar-managed-ledger-2.8.1.2.jar:2.8.1.2]
        at java.util.concurrent.ConcurrentHashMap$ValuesView.forEach(ConcurrentHashMap.java:4707) ~[?:1.8.0_144]
        at org.apache.bookkeeper.mledger.impl.ManagedLedgerFactoryImpl.refreshStats(ManagedLedgerFactoryImpl.java:223) ~[org.apache.pulsar-managed-ledger-2.8.1.2.jar:2.8.1.2]
        at org.apache.bookkeeper.common.util.SafeRunnable.run(SafeRunnable.java:36) [org.apache.bookkeeper-bookkeeper-common-4.14.2.jar:4.14.2]
        at org.apache.bookkeeper.common.util.OrderedExecutor$TimedRunnable.run(OrderedExecutor.java:203) [org.apache.bookkeeper-bookkeeper-common-4.14.2.jar:4.14.2]
        at org.apache.bookkeeper.common.util.OrderedExecutor$TimedRunnable.run(OrderedExecutor.java:203) [org.apache.bookkeeper-bookkeeper-common-4.14.2.jar:4.14.2]
        at com.google.common.util.concurrent.MoreExecutors$ScheduledListeningDecorator$NeverSuccessfulListenableFutureTask.run(MoreExecutors.java:705) [com.google.guava-guava-30.1-jre.jar:?]
        at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511) [?:1.8.0_144]
        at java.util.concurrent.FutureTask.runAndReset(FutureTask.java:308) [?:1.8.0_144]
        at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$301(ScheduledThreadPoolExecutor.java:180) [?:1.8.0_144]
        at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:294) [?:1.8.0_144]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149) [?:1.8.0_144]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624) [?:1.8.0_144]
        at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30) [io.netty-netty-common-4.1.66.Final.jar:4.1.66.Final]
        at java.lang.Thread.run(Thread.java:748) [?:1.8.0_144]


### Documentation

Check the box below or label this PR directly (if you have committer privilege).

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)


