### PR TITLE
[pulsar-broker] fix ack-hole and backlog for persistent-replicator

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
@@ -224,7 +224,7 @@ public class ManagedCursorImpl implements ManagedCursor {
     // The last active time (Unix time, milliseconds) of the cursor
     private long lastActive;
 
-    enum State {
+    public enum State {
         Uninitialized, // Cursor is being initialized
         NoLedger, // There is no metadata ledger open for writing
         Open, // Metadata ledger is ready
@@ -3078,6 +3078,11 @@ public class ManagedCursorImpl implements ManagedCursor {
 
     private boolean isCompactionCursor() {
         return COMPACTION_CURSOR_NAME.equals(name);
+    }
+
+    @VisibleForTesting
+    public void setState(State state) {
+        this.state = state;
     }
 
     private static final Logger log = LoggerFactory.getLogger(ManagedCursorImpl.class);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractReplicator.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractReplicator.java
@@ -259,4 +259,8 @@ public abstract class AbstractReplicator {
     }
 
     private static final Logger log = LoggerFactory.getLogger(AbstractReplicator.class);
+
+    public State getState() {
+        return state;
+    }
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatorTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatorTest.java
@@ -51,11 +51,15 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import lombok.Cleanup;
+
 import org.apache.bookkeeper.mledger.AsyncCallbacks.DeleteCursorCallback;
 import org.apache.bookkeeper.mledger.Entry;
 import org.apache.bookkeeper.mledger.ManagedCursor;
 import org.apache.bookkeeper.mledger.ManagedLedgerException;
 import org.apache.bookkeeper.mledger.ManagedLedgerException.CursorAlreadyClosedException;
+import org.apache.bookkeeper.mledger.Position;
+import org.apache.bookkeeper.mledger.impl.ManagedCursorImpl;
+import org.apache.bookkeeper.mledger.impl.ManagedCursorImpl.State;
 import org.apache.bookkeeper.mledger.impl.ManagedLedgerFactoryImpl;
 import org.apache.bookkeeper.mledger.impl.ManagedLedgerImpl;
 import org.apache.pulsar.broker.BrokerTestUtil;
@@ -1364,6 +1368,61 @@ public class ReplicatorTest extends ReplicatorTestBase {
         for (String expectTopic : expectedTopicList) {
             Assert.assertTrue(list.contains(expectTopic));
         }
+    }
+
+    @Test
+    public void testReplicatorWithFailedAck() throws Exception {
+
+        log.info("--- Starting ReplicatorTest::testReplication ---");
+
+        String namespace = "pulsar/global/ns2";
+        admin1.namespaces().createNamespace(namespace);
+        admin1.namespaces().setNamespaceReplicationClusters(namespace, Sets.newHashSet("r1", "r2"));
+        final TopicName dest = TopicName
+                .get(BrokerTestUtil.newUniqueName("persistent://" + namespace + "/ackFailedTopic"));
+
+        @Cleanup
+        MessageProducer producer1 = new MessageProducer(url1, dest);
+        log.info("--- Starting producer --- " + url1);
+
+        // Produce from cluster1 and consume from the rest
+        producer1.produce(2);
+
+        PersistentTopic topic = (PersistentTopic) pulsar1.getBrokerService().getTopic(dest.toString(), false)
+                .getNow(null).get();
+        ConcurrentOpenHashMap<String, Replicator> replicators = topic.getReplicators();
+        PersistentReplicator replicator = (PersistentReplicator) replicators.get("r2");
+
+        Awaitility.await().timeout(50, TimeUnit.SECONDS)
+                .untilAsserted(() -> assertEquals(org.apache.pulsar.broker.service.AbstractReplicator.State.Started,
+                        replicator.getState()));
+
+        assertEquals(replicator.getState(), org.apache.pulsar.broker.service.AbstractReplicator.State.Started);
+        ManagedCursorImpl cursor = (ManagedCursorImpl) replicator.getCursor();
+        cursor.setState(State.Closed);
+
+        Field field = ManagedCursorImpl.class.getDeclaredField("state");
+        field.setAccessible(true);
+        field.set(cursor, State.Closed);
+
+        producer1.produce(10);
+
+        Position deletedPos = cursor.getMarkDeletedPosition();
+        Position readPos = cursor.getReadPosition();
+
+        Awaitility.await().timeout(30, TimeUnit.SECONDS).until(
+                () -> cursor.getMarkDeletedPosition().getEntryId() != (cursor.getReadPosition().getEntryId() - 1));
+
+        assertNotEquals((readPos.getEntryId() - 1), deletedPos.getEntryId());
+
+        field.set(cursor, State.Open);
+
+        Awaitility.await().timeout(30, TimeUnit.SECONDS).until(
+                () -> cursor.getMarkDeletedPosition().getEntryId() == (cursor.getReadPosition().getEntryId() - 1));
+
+        deletedPos = cursor.getMarkDeletedPosition();
+        readPos = cursor.getReadPosition();
+        assertEquals((readPos.getEntryId() - 1), deletedPos.getEntryId());
     }
 
     private static final Logger log = LoggerFactory.getLogger(ReplicatorTest.class);


### PR DESCRIPTION
### Motivation

Pulsar replicator fails to delete messages sometimes which creates ack-hole for replicator and causes huge backlog if it's not taken care soon. Therefore, broker should handle such failure of acknowledged message and avoid creating any ack-hole of the replicator's cursor.
```
./pulsar-admin persistent stats-internal persistent://prop/global/ns/t1
{
  :
    "lastConfirmedEntry" : "621807735:29501",
  "state" : "LedgerOpened",
  "ledgers" : [ {
    "ledgerId" : 615666239,
    "entries" : 50000,
    "size" : 20897862,
    "offloaded" : false
  }, {
    "ledgerId" : 615672180,
    "entries" : 50000,
    "size" : 20846027,
    "offloaded" : false
  }:
  :
  :
   ],  "cursors" : {
    "us-west1" : {
      "markDeletePosition" : "615666239:14710",
      "readPosition" : "621807735:29502",
      "individuallyDeletedMessages" : "[(615666239:15073..621807735:29501]]",
      "state" : "Open",
      "numberOfEntriesSinceFirstNotAckedMessage" : 104117591,
      "totalNonContiguousDeletedMessagesRange" : 1,
      "properties" : { }
    },
    "us-east1" : {
      "markDeletePosition" : "616189378:46815",
      "readPosition" : "621807735:29502",
      "individuallyDeletedMessages" : "[(616189378:48037..621807735:29501]]",
      "state" : "Open",
      "numberOfEntriesSinceFirstNotAckedMessage" : 96735486,
      "totalNonContiguousDeletedMessagesRange" : 1,
      "properties" : { }
    }
```

### Modification
Retry failure in replicator-acking to avoid backlog.