### PR TITLE
[tests] PulsarByteBufAllocator constructor mock can make parallel tests fail

### DIFF
--- a/pulsar-common/src/test/java/org/apache/pulsar/common/allocator/PulsarByteBufAllocatorDefaultTest.java
+++ b/pulsar-common/src/test/java/org/apache/pulsar/common/allocator/PulsarByteBufAllocatorDefaultTest.java
@@ -26,6 +26,7 @@ import org.apache.bookkeeper.common.allocator.PoolingPolicy;
 import org.apache.bookkeeper.common.allocator.impl.ByteBufAllocatorImpl;
 import org.mockito.MockedConstruction;
 import org.mockito.Mockito;
+import org.powermock.reflect.Whitebox;
 import org.testng.annotations.Test;
 
 import java.util.List;
@@ -60,6 +61,9 @@ public class PulsarByteBufAllocatorDefaultTest {
                 PulsarByteBufAllocator.createByteBufAllocator();
             }
             assertTrue(called.get());
+        } finally {
+            Whitebox.setInternalState(PulsarByteBufAllocator.class, "DEFAULT",
+                    PulsarByteBufAllocator.createByteBufAllocator());
         }
     }
 

--- a/pulsar-common/src/test/java/org/apache/pulsar/common/allocator/PulsarByteBufAllocatorOomThrowExceptionTest.java
+++ b/pulsar-common/src/test/java/org/apache/pulsar/common/allocator/PulsarByteBufAllocatorOomThrowExceptionTest.java
@@ -26,6 +26,7 @@ import org.apache.bookkeeper.common.allocator.PoolingPolicy;
 import org.apache.bookkeeper.common.allocator.impl.ByteBufAllocatorImpl;
 import org.mockito.MockedConstruction;
 import org.mockito.Mockito;
+import org.powermock.reflect.Whitebox;
 import org.testng.annotations.Test;
 
 import java.util.List;
@@ -62,9 +63,9 @@ public class PulsarByteBufAllocatorOomThrowExceptionTest {
             assertTrue(called.get());
         } finally {
             System.clearProperty("pulsar.allocator.out_of_memory_policy");
+            Whitebox.setInternalState(PulsarByteBufAllocator.class, "DEFAULT",
+                    PulsarByteBufAllocator.createByteBufAllocator());
         }
-
-
     }
 
 }


### PR DESCRIPTION
### Motivation
In the CI we have the option `reuseFork` = true. This means the process are reused across tests. 
There are two tests that mock PulsarByteBufAllocator#DEFAULT field and this can lead the following tests with unexpected behaviours.

The tests are `PulsarByteBufAllocatorDefaultTest` and `PulsarByteBufAllocatorOomThrowExceptionTest`

Example of failure: https://github.com/apache/pulsar/runs/5200174968?check_suite_focus=true

### Modifications

* Clean the mocked instance of PulsarByteBufAllocator after the tests

  
- [x] `no-need-doc` 
