### PR TITLE
Fix the wrong parameter in the log.

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/SystemTopicBasedTopicPoliciesService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/SystemTopicBasedTopicPoliciesService.java
@@ -340,7 +340,7 @@ public class SystemTopicBasedTopicPoliciesService implements TopicPoliciesServic
                 reader.readNextAsync().whenComplete((msg, e) -> {
                     if (e != null) {
                         log.error("[{}] Failed to read event from the system topic.",
-                                reader.getSystemTopic().getTopicName(), ex);
+                                reader.getSystemTopic().getTopicName(), e);
                         future.completeExceptionally(e);
                         readerCaches.remove(reader.getSystemTopic().getTopicName().getNamespaceObject());
                         policyCacheInitMap.remove(reader.getSystemTopic().getTopicName().getNamespaceObject());


### PR DESCRIPTION
### Motivation

Bad parameters in the log will always print "null", which can confuse users.

### Modifications

- Correct exception parameter.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Documentation

- [x] `no-need-doc` 
  
  (Please explain why)
  
