### PR TITLE
[Doc] Add two parameters for transaction authentication

### DIFF
--- a/site2/docs/reference-cli-tools.md
+++ b/site2/docs/reference-cli-tools.md
@@ -168,7 +168,7 @@ Options
 |`-c` , `--cluster`|Cluster name||
 |`-cms` , `--configuration-metadata-store`|The configuration metadata store quorum connection string||
 |`--existing-bk-metadata-service-uri`|The metadata service URI of the existing BookKeeper cluster that you want to use||
-|`-h` , `--help`|Cluster name|false|
+|`-h` , `--help`|Help message|false|
 |`--initial-num-stream-storage-containers`|The number of storage containers of BookKeeper stream storage|16|
 |`--initial-num-transaction-coordinators`|The number of transaction coordinators assigned in a cluster|16|
 |`-uw` , `--web-service-url`|The web service URL for the new cluster||

--- a/site2/docs/reference-cli-tools.md
+++ b/site2/docs/reference-cli-tools.md
@@ -721,6 +721,8 @@ $ pulsar-perf transaction options
 
 |Flag|Description|Default|
 |---|---|---|
+`--auth-params`|Authentication parameters, whose format is determined by the implementation of method `configure` in authentication plugin class. For example, `key1:val1,key2:val2` or `{"key1":"val1","key2":"val2"}`.|N/A
+`--auth-plugin`|Authentication plugin class name.|N/A
 `-au`, `--admin-url`|Pulsar admin URL.|N/A
 `-cf`, `--conf-file`|Configuration file.|N/A
 `-h`, `--help`|Help messages.|N/A


### PR DESCRIPTION
### Modifications

1. To align with #14271, add the following two parameters to the transaction section of pulsar-perf.
    - `--auth-params`
    - `--auth-plugin`
2. A handy bug fix.

### Preview
![image](https://user-images.githubusercontent.com/60642177/154212107-1ea4e181-c290-4888-a914-59fe8af56832.png)

### Documentation
- [x] `doc` 

