### PR TITLE
[Broker] Increase default numHttpServerThreads value to 200 to prevent Admin API unavailability

### DIFF
--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -85,8 +85,9 @@ numIOThreads=
 # such as init zookeeper client, get namespace policies from zookeeper etc. It also used to split bundle. Default is 8
 numOrderedExecutorThreads=8
 
-# Number of threads to use for HTTP requests processing. Default is set to 2 * Runtime.getRuntime().availableProcessors()
-numHttpServerThreads=
+# Maximum number of threads to use for HTTP requests processing.
+# Default is set to 200. Initial number of threads is 8 when numHttpServerThreads >= 8.
+numHttpServerThreads=200
 
 # Number of thread pool size to use for pulsar broker service.
 # The executor in thread pool will do basic broker operation like load/unload bundle, update managedLedgerConfig,

--- a/conf/standalone.conf
+++ b/conf/standalone.conf
@@ -49,8 +49,9 @@ numIOThreads=
 # such as init zookeeper client, get namespace policies from zookeeper etc. It also used to split bundle. Default is 8
 numOrderedExecutorThreads=8
 
-# Number of threads to use for HTTP requests processing. Default is set to 2 * Runtime.getRuntime().availableProcessors()
-numHttpServerThreads=
+# Maximum number of threads to use for HTTP requests processing.
+# Default is set to 200. Initial number of threads is 8 when numHttpServerThreads >= 8.
+numHttpServerThreads=200
 
 # Number of thread pool size to use for pulsar broker service.
 # The executor in thread pool will do basic broker operation like load/unload bundle, update managedLedgerConfig,

--- a/deployment/terraform-ansible/templates/broker.conf
+++ b/deployment/terraform-ansible/templates/broker.conf
@@ -58,8 +58,9 @@ advertisedAddress={{ hostvars[inventory_hostname].private_ip }}
 # Number of threads to use for Netty IO. Default is set to 2 * Runtime.getRuntime().availableProcessors()
 numIOThreads=
 
-# Number of threads to use for HTTP requests processing. Default is set to 2 * Runtime.getRuntime().availableProcessors()
-numHttpServerThreads=
+# Maximum number of threads to use for HTTP requests processing.
+# Default is set to 200. Initial number of threads is 8 when numHttpServerThreads >= 8.
+numHttpServerThreads=200
 
 # Flag to control features that are meant to be used when running in standalone mode
 isRunningStandalone=

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -258,13 +258,10 @@ public class ServiceConfiguration implements PulsarConfiguration {
 
     @FieldContext(
             category = CATEGORY_SERVER,
-            doc = "Number of threads to use for HTTP requests processing"
-                + " Default is set to `2 * Runtime.getRuntime().availableProcessors()`"
-        )
-    // Use at least 8 threads to avoid having Jetty go into threads starving and
-    // having the possibility of getting into a deadlock where a Jetty thread is
-    // waiting for another HTTP call to complete in same thread.
-    private int numHttpServerThreads = Math.max(8, 2 * Runtime.getRuntime().availableProcessors());
+            doc = "Maximum number of threads to use for HTTP requests processing"
+                    + " Default is set to 200. Initial number of threads is 8 when numHttpServerThreads >= 8."
+    )
+    private int numHttpServerThreads = 200;
 
     @FieldContext(
         category = CATEGORY_SERVER,


### PR DESCRIPTION
### Motivation

Since Pulsar Admin API uses the blocking servlet API, it is possible that all Jetty threads are occupied and this causes unavailability on the Pulsar Admin API. The default value for the maximum number of threads for Jetty is too low in Pulsar. That is the root cause of many problems where Pulsar Admin API is unavailable when all threads are in use.

### Additional context

Mailing list thread about "make async" changes: https://lists.apache.org/thread/tn7rt59cd1k724l4ytfcmzx1w2sbtw7l
- Related issues/PRs #13666 #4756 #10619

### Modification 

- Jetty defaults to 200 maximum threads, to prevent thread pool starvation. Make Pulsar use the same default value by setting `numHttpServerThreads=200`.
- Update the documentation for `numHttpServerThreads`