### PR TITLE
[PIP-87][website] Remove .asf.yaml as website content is moving to repos/pulsar-site

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -1,2 +1,0 @@
-publish:
-  whoami: asf-site


### PR DESCRIPTION
Master Issue: #12637

### Motivation

We are ready to switch over website publishing to the pulsar-site repository.

### Modifications

Remove the .asf.yaml file which stops publishing of the website from the `asf-site` branch.

### Verifying this change

This change is a trivial rework / code cleanup without any test coverage.


### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

Need to update docs? 

- [X] `no-need-doc` 

