### PR TITLE
[pulsar-broker] Fix avg-messagePerEntry metrics for consumer

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Consumer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Consumer.java
@@ -282,7 +282,7 @@ public class Consumer {
 
         // calculate avg message per entry
         int tmpAvgMessagesPerEntry = AVG_MESSAGES_PER_ENTRY.get(this);
-        tmpAvgMessagesPerEntry = (int) Math.round(tmpAvgMessagesPerEntry * avgPercent
+        tmpAvgMessagesPerEntry = (int) Math.floor(tmpAvgMessagesPerEntry * avgPercent
                 + (1 - avgPercent) * totalMessages / entries.size());
         AVG_MESSAGES_PER_ENTRY.set(this, tmpAvgMessagesPerEntry);
 


### PR DESCRIPTION
### Motivation

Right now, consumer-metrics always shows `"avgMessagesPerEntry" : 6` in `topics stats` metrics even though entry has only 1 message in it. It's because of avg-message size formula uses `Math.round` which always converts `5.5 => 6` and it never decreases avg messages per entry.
```
 "consumers" : [ {
        "msgRateOut" : 852.8218898769269,
        :
        "avgMessagesPerEntry" : 6,
```

After the fix it shows below correct result
```
"consumers" : [ {
        "msgRateOut" : 943.489431427803,
        :
        "avgMessagesPerEntry" : 1,
```