### PR TITLE
Protect branch-2.10 from force pushes

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -101,3 +101,4 @@ github:
     branch-2.7: {}
     branch-2.8: {}
     branch-2.9: {}
+    branch-2.10: {}


### PR DESCRIPTION
This addition ensures that `branch-2.10` is protected from force pushes. See #14226 for more information.