### PR TITLE
[LoadBalance] Optimize find nics process.

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/LinuxBrokerHostUsageImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/LinuxBrokerHostUsageImpl.java
@@ -233,18 +233,8 @@ public class LinuxBrokerHostUsageImpl implements BrokerHostUsage {
         try {
             // Check the type to make sure it's ethernet (type "1")
             String type = new String(Files.readAllBytes(path.resolve("type")), StandardCharsets.UTF_8).trim();
-            if (Integer.parseInt(type) == 1) {
-                try {
-                    Files.readAllBytes(path.resolve("speed"));
-                } catch (IOException ioe) {
-                    // In some cases, VMs in EC2 won't have the speed reported on the NIC and will
-                    // give a read-error.
-                }
-                return true;
-            } else {
-                // wireless NICs don't report speed, ignore them.
-                return false;
-            }
+            // wireless NICs don't report speed, ignore them.
+            return Integer.parseInt(type) == 1;
         } catch (Exception e) {
             // Read type got error.
             return false;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/LinuxBrokerHostUsageImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/LinuxBrokerHostUsageImpl.java
@@ -264,8 +264,8 @@ public class LinuxBrokerHostUsageImpl implements BrokerHostUsage {
                     try {
                         return Double.parseDouble(new String(Files.readAllBytes(getNicSpeedPath(nicPath))));
                     } catch (IOException e) {
-                        log.error(String.format("Failed to read speed for nic %s, maybe you can set broker" +
-                                " config [loadBalancerOverrideBrokerNicSpeedGbps] to override it.", nicPath), e);
+                        log.error(String.format("Failed to read speed for nic %s, maybe you can set broker"
+                                + " config [loadBalancerOverrideBrokerNicSpeedGbps] to override it.", nicPath), e);
                         return 0d;
                     }
                 }).sum() * 1024);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/LinuxBrokerHostUsageImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/LinuxBrokerHostUsageImpl.java
@@ -229,21 +229,27 @@ public class LinuxBrokerHostUsageImpl implements BrokerHostUsage {
     private boolean isPhysicalNic(Path path) {
         if (!path.toString().contains("/virtual/")) {
             try {
-                Files.readAllBytes(path.resolve("speed"));
-                return true;
-            } catch (Exception e) {
-                // In some cases, VMs in EC2 won't have the speed reported on the NIC and will give a read-error.
                 // Check the type to make sure it's ethernet (type "1")
-                try {
-                    String type = new String(Files.readAllBytes(path.resolve("type")), StandardCharsets.UTF_8).trim();
-                    return Integer.parseInt(type) == 1;
-                } catch (IOException ioe) {
-                    // wireless nics don't report speed, ignore them.
+                String type = new String(Files.readAllBytes(path.resolve("type")), StandardCharsets.UTF_8).trim();
+                if (Integer.parseInt(type) == 1) {
+                    try {
+                        Files.readAllBytes(path.resolve("speed"));
+                    } catch (IOException ioe) {
+                        // In some cases, VMs in EC2 won't have the speed reported on the NIC and will
+                        // give a read-error.
+                    }
+                    return true;
+                } else {
+                    // wireless NICs don't report speed, ignore them.
                     return false;
                 }
+            } catch (Exception e) {
+                // Read type got error.
+                return false;
             }
+        } else {
+            return false;
         }
-        return false;
     }
 
     private Path getNicSpeedPath(String nic) {
@@ -254,12 +260,13 @@ public class LinuxBrokerHostUsageImpl implements BrokerHostUsage {
         // Use the override value as configured. Return the total max speed across all available NICs, converted
         // from Gbps into Kbps
         return overrideBrokerNicSpeedGbps.map(aDouble -> aDouble * nics.size() * 1024 * 1024)
-                .orElseGet(() -> nics.stream().mapToDouble(s -> {
+                .orElseGet(() -> nics.stream().mapToDouble(nicPath -> {
                     // Nic speed is in Mbits/s, return kbits/s
                     try {
-                        return Double.parseDouble(new String(Files.readAllBytes(getNicSpeedPath(s))));
+                        return Double.parseDouble(new String(Files.readAllBytes(getNicSpeedPath(nicPath))));
                     } catch (IOException e) {
-                        log.error("Failed to read speed for nic " + s, e);
+                        log.error(String.format("Failed to read speed for nic %s, maybe you can set broker" +
+                                " config [loadBalancerOverrideBrokerNicSpeedGbps] to override it.", nicPath), e);
                         return 0d;
                     }
                 }).sum() * 1024);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/LinuxBrokerHostUsageImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/LinuxBrokerHostUsageImpl.java
@@ -227,27 +227,26 @@ public class LinuxBrokerHostUsageImpl implements BrokerHostUsage {
     }
 
     private boolean isPhysicalNic(Path path) {
-        if (!path.toString().contains("/virtual/")) {
-            try {
-                // Check the type to make sure it's ethernet (type "1")
-                String type = new String(Files.readAllBytes(path.resolve("type")), StandardCharsets.UTF_8).trim();
-                if (Integer.parseInt(type) == 1) {
-                    try {
-                        Files.readAllBytes(path.resolve("speed"));
-                    } catch (IOException ioe) {
-                        // In some cases, VMs in EC2 won't have the speed reported on the NIC and will
-                        // give a read-error.
-                    }
-                    return true;
-                } else {
-                    // wireless NICs don't report speed, ignore them.
-                    return false;
+        if (path.toString().contains("/virtual/")) {
+            return false;
+        }
+        try {
+            // Check the type to make sure it's ethernet (type "1")
+            String type = new String(Files.readAllBytes(path.resolve("type")), StandardCharsets.UTF_8).trim();
+            if (Integer.parseInt(type) == 1) {
+                try {
+                    Files.readAllBytes(path.resolve("speed"));
+                } catch (IOException ioe) {
+                    // In some cases, VMs in EC2 won't have the speed reported on the NIC and will
+                    // give a read-error.
                 }
-            } catch (Exception e) {
-                // Read type got error.
+                return true;
+            } else {
+                // wireless NICs don't report speed, ignore them.
                 return false;
             }
-        } else {
+        } catch (Exception e) {
+            // Read type got error.
             return false;
         }
     }


### PR DESCRIPTION
### Motivation

According to this PR #14252, 

We can know In some cases, VMs in EC2 won't have the speed reported on the NIC and will give a read error.

In a normal case, only eth0 has `speed` value. other devices have no `speed` value.

![image](https://user-images.githubusercontent.com/74767115/154424957-c2e3233e-a119-45d7-b311-c985247f8bb1.png)

So when we check `isPhysicalNic `, line 232 would get a read error many times.
https://github.com/apache/pulsar/blob/d3848e29775fed16c666822b07da63f99d531361/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/LinuxBrokerHostUsageImpl.java#L229-L247

Then I think we can change the process to check type first and then to check speed.

### Modifications

- Change find NICs process.
- Add log to remind the user to set config ``loadBalancerOverrideBrokerNicSpeedGbps `` when we can't read speed that is ethernet.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Documentation

- [x] `no-need-doc` 
  

