### PR TITLE
[Issue 13756][Broker]Optimize topic policy with HierarchyTopicPolicies about subscribeRate

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractTopic.java
@@ -328,13 +328,13 @@ public abstract class AbstractTopic implements Topic, TopicPolicyListener<TopicP
         if (isSystemTopic()) {
             schemaCompatibilityStrategy = config.getSystemTopicSchemaCompatibilityStrategy();
         }
-        topicPolicies.getSubscribeRate().updateBrokerValue(subscribeRate(config));
+        topicPolicies.getSubscribeRate().updateBrokerValue(subscribeRateInBroker(config));
         topicPolicies.getSubscriptionDispatchRate().updateBrokerValue(subscriptionDispatchRateInBroker(config));
         topicPolicies.getSchemaCompatibilityStrategy()
                 .updateBrokerValue(formatSchemaCompatibilityStrategy(schemaCompatibilityStrategy));
     }
 
-    private SubscribeRate subscribeRate(ServiceConfiguration config) {
+    private SubscribeRate subscribeRateInBroker(ServiceConfiguration config) {
         return new SubscribeRate(
             config.getSubscribeThrottlingRatePerConsumer(),
             config.getSubscribeRatePeriodPerConsumerInSecond()

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/SubscribeRateLimiter.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/SubscribeRateLimiter.java
@@ -27,12 +27,9 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
-import org.apache.pulsar.broker.ServiceConfiguration;
 import org.apache.pulsar.broker.service.BrokerService;
-import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.policies.data.Policies;
 import org.apache.pulsar.common.policies.data.SubscribeRate;
-import org.apache.pulsar.common.policies.data.TopicPolicies;
 import org.apache.pulsar.common.util.RateLimiter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -52,22 +49,7 @@ public class SubscribeRateLimiter {
         subscribeRateLimiter = new ConcurrentHashMap<>();
         this.executorService = brokerService.pulsar().getExecutor();
         // get subscribeRate from topic level policies
-        this.subscribeRate = topic.getTopicPolicies()
-                .map(TopicPolicies::getSubscribeRate)
-                .orElse(null);
-
-        // subscribeRate of topic level policies not set, get from zookeeper
-        if (this.subscribeRate == null) {
-            this.subscribeRate = getPoliciesSubscribeRate();
-        }
-
-        // get subscribeRate from broker.conf
-        if (this.subscribeRate == null) {
-            this.subscribeRate = new SubscribeRate(brokerService.pulsar()
-                    .getConfiguration().getSubscribeThrottlingRatePerConsumer(),
-                    brokerService.pulsar().getConfiguration().getSubscribeRatePeriodPerConsumerInSecond());
-
-        }
+        this.subscribeRate = topic.getSubscribeRate();
         if (isSubscribeRateEnabled(this.subscribeRate)) {
             resetTask = createTask();
             log.info("[{}] configured subscribe-dispatch rate at broker {}", this.topicName, subscribeRate);
@@ -157,41 +139,7 @@ public class SubscribeRateLimiter {
         }
     }
 
-    public void onPoliciesUpdate(Policies data) {
-        // if subscribe rate is set on topic policy, skip subscribe rate update
-        SubscribeRate subscribeRate = brokerService.getTopicPolicies(TopicName.get(topicName))
-                .map(TopicPolicies::getSubscribeRate)
-                .orElse(null);
-        if (subscribeRate != null) {
-            return;
-        }
-
-        String cluster = brokerService.pulsar().getConfiguration().getClusterName();
-
-        subscribeRate = data.clusterSubscribeRate.get(cluster);
-
-        onSubscribeRateUpdate(subscribeRate);
-
-    }
-
     public void onSubscribeRateUpdate(SubscribeRate subscribeRate) {
-        final SubscribeRate namespacePolicySubscribeRate = getPoliciesSubscribeRate();
-        final SubscribeRate newSubscribeRate = new SubscribeRate(
-                brokerService.pulsar().getConfiguration().getSubscribeThrottlingRatePerConsumer(),
-                brokerService.pulsar().getConfiguration().getSubscribeRatePeriodPerConsumerInSecond()
-                );
-
-        // if policy-throttling rate is disabled and cluster-throttling is enabled then apply
-        // cluster-throttling rate
-        // if topic policy-throttling rate is disabled
-        if (!isSubscribeRateEnabled(subscribeRate) && isSubscribeRateEnabled(namespacePolicySubscribeRate)) {
-            subscribeRate = namespacePolicySubscribeRate;
-        }
-
-        if (!isSubscribeRateEnabled(subscribeRate) && !isSubscribeRateEnabled(namespacePolicySubscribeRate)
-                && isSubscribeRateEnabled(newSubscribeRate)) {
-            subscribeRate = newSubscribeRate;
-        }
         this.subscribeRate = subscribeRate;
         stopResetTask();
         for (ConsumerIdentifier consumerIdentifier : this.subscribeRateLimiter.keySet()) {
@@ -214,23 +162,6 @@ public class SubscribeRateLimiter {
      */
     public SubscribeRate getPoliciesSubscribeRate() {
         return getPoliciesSubscribeRate(brokerService, topicName);
-    }
-
-    public static boolean isDispatchRateNeeded(BrokerService brokerService, Optional<Policies> policies,
-            String topicName) {
-        ServiceConfiguration serviceConfig = brokerService.pulsar().getConfiguration();
-        policies = policies.isPresent() ? policies : DispatchRateLimiter.getPolicies(brokerService, topicName);
-        return isDispatchRateNeeded(serviceConfig, policies, topicName);
-    }
-
-    private static boolean isDispatchRateNeeded(final ServiceConfiguration serviceConfig,
-            final Optional<Policies> policies, final String topicName) {
-        SubscribeRate subscribeRate = getPoliciesSubscribeRate(serviceConfig.getClusterName(), policies, topicName);
-        if (subscribeRate == null) {
-            return serviceConfig.getSubscribeThrottlingRatePerConsumer() > 0
-                    && serviceConfig.getSubscribeRatePeriodPerConsumerInSecond() > 0;
-        }
-        return true;
     }
 
     public static SubscribeRate getPoliciesSubscribeRate(BrokerService brokerService, final String topicName) {
@@ -262,8 +193,8 @@ public class SubscribeRateLimiter {
                 != null ? subscribeRateLimiter.get(consumerIdentifier).getRate() : -1;
     }
 
-    private static boolean isSubscribeRateEnabled(SubscribeRate subscribeRate) {
-        return subscribeRate != null && (subscribeRate.subscribeThrottlingRatePerConsumer > 0);
+    public static boolean isSubscribeRateEnabled(SubscribeRate subscribeRate) {
+        return subscribeRate.subscribeThrottlingRatePerConsumer > 0 && subscribeRate.ratePeriodInSecond > 0;
     }
 
     public void close() {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ServerCnxTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ServerCnxTest.java
@@ -1382,6 +1382,7 @@ public class ServerCnxTest {
         Policies policies = mock(Policies.class);
         policies.encryption_required = true;
         policies.topicDispatchRate = Maps.newHashMap();
+        policies.clusterSubscribeRate = Maps.newHashMap();
         // add `clusterDispatchRate` otherwise there will be a NPE
         // `org.apache.pulsar.broker.service.persistent.DispatchRateLimiter.getPoliciesDispatchRate`
         policies.clusterDispatchRate = Maps.newHashMap();
@@ -1414,6 +1415,7 @@ public class ServerCnxTest {
         Policies policies = mock(Policies.class);
         policies.encryption_required = true;
         policies.topicDispatchRate = Maps.newHashMap();
+        policies.clusterSubscribeRate = Maps.newHashMap();
         // add `clusterDispatchRate` otherwise there will be a NPE
         // `org.apache.pulsar.broker.service.persistent.DispatchRateLimiter.getPoliciesDispatchRate`
         policies.clusterDispatchRate = Maps.newHashMap();
@@ -1451,6 +1453,7 @@ public class ServerCnxTest {
         // Namespace policy doesn't require encryption
         policies.encryption_required = false;
         policies.topicDispatchRate = Maps.newHashMap();
+        policies.clusterSubscribeRate = Maps.newHashMap();
         // add `clusterDispatchRate` otherwise there will be a NPE
         policies.clusterDispatchRate = Maps.newHashMap();
         // add `clusterDispatchRate` otherwise there will be a NPE
@@ -1484,6 +1487,7 @@ public class ServerCnxTest {
         Policies policies = mock(Policies.class);
         policies.encryption_required = true;
         policies.topicDispatchRate = Maps.newHashMap();
+        policies.clusterSubscribeRate = Maps.newHashMap();
         // add `clusterDispatchRate` otherwise there will be a NPE
         // `org.apache.pulsar.broker.service.persistent.DispatchRateLimiter.getPoliciesDispatchRate`
         policies.clusterDispatchRate = Maps.newHashMap();
@@ -1524,6 +1528,7 @@ public class ServerCnxTest {
         Policies policies = mock(Policies.class);
         policies.encryption_required = true;
         policies.topicDispatchRate = Maps.newHashMap();
+        policies.clusterSubscribeRate = Maps.newHashMap();
         // add `clusterDispatchRate` otherwise there will be a NPE
         // `org.apache.pulsar.broker.service.persistent.DispatchRateLimiter.getPoliciesDispatchRate`
         policies.clusterDispatchRate = Maps.newHashMap();

--- a/pulsar-client-admin-api/src/main/java/org/apache/pulsar/common/policies/data/SubscribeRate.java
+++ b/pulsar-client-admin-api/src/main/java/org/apache/pulsar/common/policies/data/SubscribeRate.java
@@ -38,6 +38,16 @@ public class SubscribeRate {
         this.ratePeriodInSecond = ratePeriodInSecond;
     }
 
+    public static SubscribeRate normalize(SubscribeRate subscribeRate) {
+        if (subscribeRate != null
+            && subscribeRate.subscribeThrottlingRatePerConsumer > 0
+            && subscribeRate.ratePeriodInSecond > 0) {
+            return subscribeRate;
+        } else {
+            return null;
+        }
+    }
+
     @Override
     public int hashCode() {
         return Objects.hash(subscribeThrottlingRatePerConsumer, ratePeriodInSecond);

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/HierarchyTopicPolicies.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/HierarchyTopicPolicies.java
@@ -52,6 +52,7 @@ public class HierarchyTopicPolicies {
     final PolicyHierarchyValue<Boolean> delayedDeliveryEnabled;
     final PolicyHierarchyValue<Long> delayedDeliveryTickTimeMillis;
     final PolicyHierarchyValue<Integer> maxConsumersPerSubscription;
+    final PolicyHierarchyValue<SubscribeRate> subscribeRate;
     final PolicyHierarchyValue<DispatchRateImpl> subscriptionDispatchRate;
     final PolicyHierarchyValue<SchemaCompatibilityStrategy> schemaCompatibilityStrategy;
 
@@ -78,6 +79,7 @@ public class HierarchyTopicPolicies {
         delayedDeliveryEnabled = new PolicyHierarchyValue<>();
         delayedDeliveryTickTimeMillis = new PolicyHierarchyValue<>();
         compactionThreshold = new PolicyHierarchyValue<>();
+        subscribeRate = new PolicyHierarchyValue<>();
         subscriptionDispatchRate = new PolicyHierarchyValue<>();
         schemaCompatibilityStrategy = new PolicyHierarchyValue<>();
     }


### PR DESCRIPTION
Master Issue: https://github.com/apache/pulsar/issues/13756

### Motivation

See issue: https://github.com/apache/pulsar/issues/13756

### Modifications

* Add field `subscribeRate`  in `org.apache.pulsar.common.policies.data.HierarchyTopicPolicies`
* Methods to update `subscribeRate`  in `org.apache.pulsar.broker.service.AbstractTopic`
* Other Modifications are concerning on `org.apache.pulsar.broker.service.persistent.SubscribeRateLimiter`  where  `subscribeRate` are used

### Verifying this change

- [x] Make sure that the change passes the CI checks.


### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation
  
- [x] `no-need-doc` 
 


