### PR TITLE
[Function] The incrCounter method should wait it done

### DIFF
--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/state/PulsarMetadataStateStoreImpl.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/state/PulsarMetadataStateStoreImpl.java
@@ -114,7 +114,7 @@ public class PulsarMetadataStateStoreImpl implements DefaultStateStore {
 
     @Override
     public void incrCounter(String key, long amount) {
-        incrCounterAsync(key, amount);
+        incrCounterAsync(key, amount).join();
     }
 
     @Override


### PR DESCRIPTION
Fixes: #14219

### Motivation
The `incrCounter` method is a sync method, we should wait for it done.

### Modifications

Wait `incrCounterAsync` done in `incrCounter` method.

### Documentation

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
This is a bug fix, no need docs.
  
- [ ] `doc` 
  
  (If this PR contains doc changes)


