### PR TITLE
apply-config-from-env.py: Handle input files that don't end with a new line

### DIFF
--- a/docker/pulsar/scripts/apply-config-from-env.py
+++ b/docker/pulsar/scripts/apply-config-from-env.py
@@ -57,6 +57,10 @@ for conf_filename in conf_files:
             if PF_ENV_DEBUG:
                 print("[%s] skip Processing %s" % (conf_filename, line))
 
+    # add a newline to last line if the input file didn't end with a newline
+    if lines[-1][-1] != '\n':
+        lines[-1] += '\n'
+
     # Update values from Env
     for k in sorted(os.environ.keys()):
         v = os.environ[k].strip()


### PR DESCRIPTION
Fixes #14357

### Motivation

See #14357, it doesn't handle files that don't end with a new line

### Modifications

Add a new line to the last line that was read from the input file if it's not there already