### PR TITLE
[Broker] fix error log miss stack trace when create tenant fail

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/TenantsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/TenantsBase.java
@@ -162,12 +162,12 @@ public class TenantsBase extends PulsarWebResource {
                     log.info("[{}] Created tenant {}", clientAppId(), tenant);
                     asyncResponse.resume(Response.noContent().build());
                 }).exceptionally(ex -> {
-                    log.error("[{}] Failed to create tenant {}", clientAppId, tenant, e);
+                    log.error("[{}] Failed to create tenant {}", clientAppId, tenant, ex);
                     asyncResponse.resume(new RestException(ex));
                     return null;
                 });
             }).exceptionally(ex -> {
-                log.error("[{}] Failed to create tenant {}", clientAppId(), tenant, e);
+                log.error("[{}] Failed to create tenant {}", clientAppId(), tenant, ex);
                 asyncResponse.resume(new RestException(ex));
                 return null;
             });


### PR DESCRIPTION
### Motivation

When create tenant fail, the error log did not print out the stack trace.

### Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

### Documentation
- [x] `no-need-doc` 
only a fix for error log

