### PR TITLE
[CI]Upgrade Windows runner os to windows-2022 and generator

### DIFF
--- a/.github/workflows/ci-cpp-build-windows.yaml
+++ b/.github/workflows/ci-cpp-build-windows.yaml
@@ -46,18 +46,18 @@ jobs:
       matrix:
         include:
           - name: 'Windows x64'
-            os: windows-latest
+            os: windows-2022
             triplet: x64-windows
             vcpkg_dir: 'C:\vcpkg'
             suffix: 'windows-win64'
-            generator: 'Visual Studio 16 2019'
+            generator: 'Visual Studio 17 2022'
             arch: '-A x64'
           - name: 'Windows x86'
-            os: windows-latest
+            os: windows-2022
             triplet: x86-windows
             vcpkg_dir: 'C:\vcpkg'
             suffix: 'windows-win32'
-            generator: 'Visual Studio 16 2019'
+            generator: 'Visual Studio 17 2022'
             arch: '-A Win32'
 
     steps:
@@ -65,7 +65,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Detect changed files
-        id:   changes
+        id: changes
         uses: apache/pulsar-test-infra/paths-filter@master
         with:
           filters: .github/changes-filter.yaml


### PR DESCRIPTION
### Motivation

As github windows runner latest upgrade to [2022](https://github.com/actions/virtual-environments/issues/4856), the `ci-cpp-build-windows.yaml` workflow should be changed otherwise the action would be failed such as [this one](https://github.com/apache/pulsar/actions/runs/1860147632)

### Modifications

- Upgrade os version to 2022 
- Change generator to `Visual Studio 17 2022`

### Verifying this change

- [x] Make sure that the change passes the CI checks.


### Documentation

  
- [x] `no-need-doc` 
