### PR TITLE
[Flaky-test] Fix metadata cache flaky tests

### DIFF
--- a/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/MetadataCacheTest.java
+++ b/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/MetadataCacheTest.java
@@ -36,6 +36,7 @@ import java.util.TreeMap;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Predicate;
 import java.util.function.Supplier;
 import lombok.AllArgsConstructor;
 import lombok.Cleanup;
@@ -233,7 +234,7 @@ public class MetadataCacheTest extends BaseMetadataStoreTest {
         v.put("b", "2");
         objCache.create(key1, v).join();
 
-        assertEquals(objCache.getIfCached(key1), Optional.of(v));
+        assertEqualsAndRetry(() -> objCache.getIfCached(key1), Optional.of(v), Optional.empty());
         assertEquals(objCache.get(key1).join(), Optional.of(v));
 
         objCache.delete(key1).join();
@@ -264,12 +265,12 @@ public class MetadataCacheTest extends BaseMetadataStoreTest {
             assertEquals(e.getCause().getClass(), AlreadyExistsException.class);
         }
 
-        assertEquals(objCache.getIfCached(key1), Optional.of(value1));
+        assertEqualsAndRetry(() -> objCache.getIfCached(key1), Optional.of(value1), Optional.empty());
         assertEquals(objCache.get(key1).join(), Optional.of(value1));
 
         assertEquals(objCache.readModifyUpdateOrCreate(key1, __ -> value2).join(), value2);
         assertEquals(objCache.get(key1).join(), Optional.of(value2));
-        assertEquals(objCache.getIfCached(key1), Optional.of(value2));
+        assertEqualsAndRetry(() -> objCache.getIfCached(key1), Optional.of(value2), Optional.empty());
 
         objCache.delete(key1).join();
 
@@ -320,7 +321,7 @@ public class MetadataCacheTest extends BaseMetadataStoreTest {
         store.put(key1, ObjectMapperFactory.getThreadLocal().writeValueAsBytes(value1), Optional.of(-1L)).join();
 
         assertEquals(objCache.get(key1).join(), Optional.of(value1));
-        assertEquals(objCache.getIfCached(key1), Optional.of(value1));
+        assertEqualsAndRetry(() -> objCache.getIfCached(key1), Optional.of(value1), Optional.empty());
     }
 
     @Test(dataProvider = "impl")
@@ -585,5 +586,36 @@ public class MetadataCacheTest extends BaseMetadataStoreTest {
         assertEquals(res.getValue().a, 1);
         assertEquals(res.getValue().b, 2);
         assertEquals(res.getValue().path, key1);
+    }
+
+    public static void assertEqualsAndRetry(Supplier<Object> actual,
+                                            Object expected,
+                                            Object expectedAndRetry) throws Exception {
+        assertEqualsAndRetry(actual, expected, expectedAndRetry, 5, 100);
+    }
+
+    public static void assertEqualsAndRetry(Supplier<Object> actual,
+                                            Object expected,
+                                            Object expectedAndRetry,
+                                            int retryCount,
+                                            long intSleepTimeInMillis) throws Exception {
+        assertTrue(retryStrategically((__) -> {
+            if (actual.get().equals(expectedAndRetry)) {
+                return false;
+            }
+            assertEquals(actual.get(), expected);
+            return true;
+        }, retryCount, intSleepTimeInMillis));
+    }
+
+    public static boolean retryStrategically(Predicate<Void> predicate, int retryCount, long intSleepTimeInMillis)
+            throws Exception {
+        for (int i = 0; i < retryCount; i++) {
+            if (predicate.test(null) || i == (retryCount - 1)) {
+                return true;
+            }
+            Thread.sleep(intSleepTimeInMillis + (intSleepTimeInMillis * i));
+        }
+        return false;
     }
 }


### PR DESCRIPTION
### Motivation

The `MetadataCache#getIfCached` method will return `Optional.empty()` if the required path is not cached yet or the cached future is not finished yet, this is normal behavior.

https://github.com/apache/pulsar/blob/773f9197cfb83092fb6ee2bf1b9ec38143f3c8b0/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/cache/impl/MetadataCacheImpl.java#L130-L137

We should add a retry mechanism when asserting getIfCached.

### Modifications

Add a retry mechanism to assert getIfCached.

### Documentation

Check the box below or label this PR directly (if you have committer privilege).

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)


