### PR TITLE
[Issue 14372][C++] Fix segfault caused by erased iterators

### DIFF
--- a/pulsar-client-cpp/lib/MultiTopicsConsumerImpl.cc
+++ b/pulsar-client-cpp/lib/MultiTopicsConsumerImpl.cc
@@ -383,6 +383,7 @@ void MultiTopicsConsumerImpl::closeAsync(ResultCallback callback) {
                                           shared_from_this(), std::placeholders::_1, topicPartitionName,
                                           callback));
     }
+    consumers_.clear();
 
     // fail pending recieve
     failPendingReceiveCallback();
@@ -390,11 +391,6 @@ void MultiTopicsConsumerImpl::closeAsync(ResultCallback callback) {
 
 void MultiTopicsConsumerImpl::handleSingleConsumerClose(Result result, std::string& topicPartitionName,
                                                         CloseCallback callback) {
-    std::map<std::string, ConsumerImplPtr>::iterator iterator = consumers_.find(topicPartitionName);
-    if (consumers_.end() != iterator) {
-        consumers_.erase(iterator);
-    }
-
     LOG_DEBUG("Closing the consumer for partition - " << topicPartitionName << " numberTopicPartitions_ - "
                                                       << numberTopicPartitions_->load());
 


### PR DESCRIPTION
Fixes #14372


### Motivation

As described in #14372, `acknowledge_cumulative()` does not work with a consumer subscribed to multiple topics. Upon initial inspection, the segfault is caused by iterators being erased within a for loop.

### Modifications

I removed the code erasing every single consumer iterator in `MultiTopicsConsumerImpl::handleSingleConsumerClose()`. Instead, I cleared the map entirely after the for loop is done in `MultiTopicsConsumerImpl::closeAsync()`.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change added tests and can be verified as follows:
- testMultiTopicsConsumerAcknowledgeCumulative

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

Check the box below or label this PR directly (if you have committer privilege).

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  Bug fix only
  
- [ ] `doc` 
  
  (If this PR contains doc changes)


