### PR TITLE
[Pulsar SQL] Fix PulsarRecordCursor deserialize issue.

### DIFF
--- a/pulsar-sql/presto-pulsar/src/main/java/org/apache/pulsar/sql/presto/PulsarRecordCursor.java
+++ b/pulsar-sql/presto-pulsar/src/main/java/org/apache/pulsar/sql/presto/PulsarRecordCursor.java
@@ -44,6 +44,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicLong;
 import org.apache.bookkeeper.mledger.AsyncCallbacks;
@@ -109,6 +110,7 @@ public class PulsarRecordCursor implements RecordCursor {
     private final long splitSize;
     private long entriesProcessed = 0;
     private int partition = -1;
+    private volatile Throwable deserializingError;
 
 
     private PulsarSqlSchemaInfoProvider schemaInfoProvider;
@@ -235,113 +237,117 @@ public class PulsarRecordCursor implements RecordCursor {
     }
 
     @VisibleForTesting
-    class DeserializeEntries implements Runnable {
+    class DeserializeEntries extends Thread {
 
         protected boolean isRunning = false;
 
-        private final Thread thread;
+        private final CompletableFuture<Void> closeHandle;
 
         public DeserializeEntries() {
-            this.thread = new Thread(this, "derserialize-thread-split-" + pulsarSplit.getSplitId());
+            super("deserialize-thread-split-" + pulsarSplit.getSplitId());
+            this.closeHandle = new CompletableFuture<>();
         }
 
-        public void interrupt() {
+        public CompletableFuture<Void> close() {
             isRunning = false;
-            thread.interrupt();
-        }
-
-        public void start() {
-            this.thread.start();
+            super.interrupt();
+            return closeHandle;
         }
 
         @Override
         public void run() {
             isRunning = true;
-            while (isRunning) {
-
-                 int read = entryQueue.drain(new MessagePassingQueue.Consumer<Entry>() {
-                    @Override
-                    public void accept(Entry entry) {
-
-                        try {
-                            entryQueueCacheSizeAllocator.release(entry.getLength());
-
-                            long bytes = entry.getDataBuffer().readableBytes();
-                            completedBytes += bytes;
-                            // register stats for bytes read
-                            metricsTracker.register_BYTES_READ(bytes);
-
-                            // check if we have processed all entries in this split
-                            // and no incomplete chunked messages exist
-                            if (entryExceedSplitEndPosition(entry) && chunkedMessagesMap.isEmpty()) {
-                                return;
-                            }
-
-                            // set start time for time deserializing entries for stats
-                            metricsTracker.start_ENTRY_DESERIALIZE_TIME();
+            try {
+                while (isRunning) {
+                    int read = entryQueue.drain(new MessagePassingQueue.Consumer<Entry>() {
+                        @Override
+                        public void accept(Entry entry) {
 
                             try {
-                                MessageParser.parseMessage(topicName, entry.getLedgerId(), entry.getEntryId(),
-                                        entry.getDataBuffer(), (message) -> {
-                                            try {
-                                                // start time for message queue read
-                                                metricsTracker.start_MESSAGE_QUEUE_ENQUEUE_WAIT_TIME();
+                                entryQueueCacheSizeAllocator.release(entry.getLength());
 
-                                                if (message.getNumChunksFromMsg() > 1)  {
-                                                    message = processChunkedMessages(message);
-                                                } else if (entryExceedSplitEndPosition(entry)) {
-                                                    // skip no chunk or no multi chunk message
-                                                    // that exceed split end position
-                                                    message.release();
-                                                    message = null;
-                                                }
-                                                if (message != null) {
-                                                    while (true) {
-                                                        if (!haveAvailableCacheSize(
-                                                                messageQueueCacheSizeAllocator, messageQueue)
-                                                                || !messageQueue.offer(message)) {
-                                                            Thread.sleep(1);
-                                                        } else {
-                                                            messageQueueCacheSizeAllocator.allocate(
-                                                                    message.getData().readableBytes());
-                                                            break;
+                                long bytes = entry.getDataBuffer().readableBytes();
+                                completedBytes += bytes;
+                                // register stats for bytes read
+                                metricsTracker.register_BYTES_READ(bytes);
+
+                                // check if we have processed all entries in this split
+                                // and no incomplete chunked messages exist
+                                if (entryExceedSplitEndPosition(entry) && chunkedMessagesMap.isEmpty()) {
+                                    return;
+                                }
+
+                                // set start time for time deserializing entries for stats
+                                metricsTracker.start_ENTRY_DESERIALIZE_TIME();
+
+                                try {
+                                    MessageParser.parseMessage(topicName, entry.getLedgerId(), entry.getEntryId(),
+                                            entry.getDataBuffer(), (message) -> {
+                                                try {
+                                                    // start time for message queue read
+                                                    metricsTracker.start_MESSAGE_QUEUE_ENQUEUE_WAIT_TIME();
+
+                                                    if (message.getNumChunksFromMsg() > 1)  {
+                                                        message = processChunkedMessages(message);
+                                                    } else if (entryExceedSplitEndPosition(entry)) {
+                                                        // skip no chunk or no multi chunk message
+                                                        // that exceed split end position
+                                                        message.release();
+                                                        message = null;
+                                                    }
+                                                    if (message != null) {
+                                                        while (true) {
+                                                            if (!haveAvailableCacheSize(
+                                                                    messageQueueCacheSizeAllocator, messageQueue)
+                                                                    || !messageQueue.offer(message)) {
+                                                                Thread.sleep(1);
+                                                            } else {
+                                                                messageQueueCacheSizeAllocator.allocate(
+                                                                        message.getData().readableBytes());
+                                                                break;
+                                                            }
                                                         }
                                                     }
+
+                                                    // stats for how long a read from message queue took
+                                                    metricsTracker.end_MESSAGE_QUEUE_ENQUEUE_WAIT_TIME();
+                                                    // stats for number of messages read
+                                                    metricsTracker.incr_NUM_MESSAGES_DESERIALIZED_PER_ENTRY();
+
+                                                } catch (InterruptedException e) {
+                                                    //no-op
                                                 }
+                                            }, pulsarConnectorConfig.getMaxMessageSize());
+                                } catch (IOException e) {
+                                    log.error(e, "Failed to parse message from pulsar topic %s", topicName.toString());
+                                    throw new RuntimeException(e);
+                                }
+                                // stats for time spend deserializing entries
+                                metricsTracker.end_ENTRY_DESERIALIZE_TIME();
 
-                                                // stats for how long a read from message queue took
-                                                metricsTracker.end_MESSAGE_QUEUE_ENQUEUE_WAIT_TIME();
-                                                // stats for number of messages read
-                                                metricsTracker.incr_NUM_MESSAGES_DESERIALIZED_PER_ENTRY();
+                                // stats for num messages per entry
+                                metricsTracker.end_NUM_MESSAGES_DESERIALIZED_PER_ENTRY();
 
-                                            } catch (InterruptedException e) {
-                                                //no-op
-                                            }
-                                        }, pulsarConnectorConfig.getMaxMessageSize());
-                            } catch (IOException e) {
-                                log.error(e, "Failed to parse message from pulsar topic %s", topicName.toString());
-                                throw new RuntimeException(e);
+                            } finally {
+                                entriesProcessed++;
+                                entry.release();
                             }
-                            // stats for time spend deserializing entries
-                            metricsTracker.end_ENTRY_DESERIALIZE_TIME();
+                        }
+                    });
 
-                            // stats for num messages per entry
-                            metricsTracker.end_NUM_MESSAGES_DESERIALIZED_PER_ENTRY();
-
-                        } finally {
-                            entriesProcessed++;
-                            entry.release();
+                    if (read <= 0) {
+                        try {
+                            Thread.sleep(1);
+                        } catch (InterruptedException e) {
+                            return;
                         }
                     }
-                });
-
-                if (read <= 0) {
-                    try {
-                        Thread.sleep(1);
-                    } catch (InterruptedException e) {
-                        return;
-                    }
                 }
+                closeHandle.complete(null);
+            } catch (Throwable ex) {
+                log.error(ex, "Stop running DeserializeEntries");
+                closeHandle.completeExceptionally(ex);
+                throw ex;
             }
         }
     }
@@ -467,6 +473,9 @@ public class PulsarRecordCursor implements RecordCursor {
         if (readEntries == null) {
             // start deserialize thread
             deserializeEntries = new DeserializeEntries();
+            deserializeEntries.setUncaughtExceptionHandler((t, ex) -> {
+                deserializingError = ex;
+            });
             deserializeEntries.start();
 
             readEntries = new ReadEntries();
@@ -491,6 +500,8 @@ public class PulsarRecordCursor implements RecordCursor {
             if (currentMessage != null) {
                 messageQueueCacheSizeAllocator.release(currentMessage.getData().readableBytes());
                 break;
+            } else if (deserializingError != null) {
+                throw new RuntimeException(deserializingError);
             } else {
                 try {
                     Thread.sleep(1);
@@ -502,7 +513,7 @@ public class PulsarRecordCursor implements RecordCursor {
             }
         }
 
-        //start time for deseralizing record
+        //start time for deserializing record
         metricsTracker.start_RECORD_DESERIALIZE_TIME();
 
         SchemaInfo schemaInfo = getSchemaInfo(pulsarSplit);
@@ -713,12 +724,12 @@ public class PulsarRecordCursor implements RecordCursor {
             messageQueue.drain(RawMessage::release);
         }
 
-        if (entryQueue != null) {
-            entryQueue.drain(Entry::release);
-        }
-
         if (deserializeEntries != null) {
-            deserializeEntries.interrupt();
+            deserializeEntries.close().whenComplete((r, t) -> {
+                if (entryQueue != null) {
+                    entryQueue.drain(Entry::release);
+                }
+            });
         }
 
         if (this.cursor != null) {


### PR DESCRIPTION
### Motivation

1. Sometimes when close PulsarRecordCursor, there may occur below exception:
```
2021-12-15T11:40:58.328803210-05:00 2021-12-15T16:40:58.328Z	INFO	SplitRunner-6-8221	org.apache.pulsar.sql.presto.PulsarRecordCursor	Closing cursor record
2021-12-15T11:40:58.330468168-05:00 2021-12-15T16:40:58.330Z	INFO	derserialize-thread-split-7	stderr	Exception in thread "derserialize-thread-split-7" 
2021-12-15T11:40:58.330560520-05:00 2021-12-15T16:40:58.330Z	INFO	derserialize-thread-split-7	stderr	io.netty.util.IllegalReferenceCountException: refCnt: 0, decrement: 1
2021-12-15T11:40:58.330567283-05:00 2021-12-15T16:40:58.330Z	INFO	derserialize-thread-split-7	stderr		at org.apache.bookkeeper.mledger.util.AbstractCASReferenceCounted.release0(AbstractCASReferenceCounted.java:99)
2021-12-15T11:40:58.330572615-05:00 2021-12-15T16:40:58.330Z	INFO	derserialize-thread-split-7	stderr		at org.apache.bookkeeper.mledger.util.AbstractCASReferenceCounted.release(AbstractCASReferenceCounted.java:87)
2021-12-15T11:40:58.330639859-05:00 2021-12-15T16:40:58.330Z	INFO	derserialize-thread-split-7	stderr		at org.apache.pulsar.sql.presto.PulsarRecordCursor$DeserializeEntries$1.accept(PulsarRecordCursor.java:314)
2021-12-15T11:40:58.330650078-05:00 2021-12-15T16:40:58.330Z	INFO	derserialize-thread-split-7	stderr		at org.apache.pulsar.sql.presto.PulsarRecordCursor$DeserializeEntries$1.accept(PulsarRecordCursor.java:254)
2021-12-15T11:40:58.330654136-05:00 2021-12-15T16:40:58.330Z	INFO	derserialize-thread-split-7	stderr		at org.jctools.queues.SpscArrayQueue.drain(SpscArrayQueue.java:266)
2021-12-15T11:40:58.330658199-05:00 2021-12-15T16:40:58.330Z	INFO	derserialize-thread-split-7	stderr		at org.jctools.queues.SpscArrayQueue.drain(SpscArrayQueue.java:239)
2021-12-15T11:40:58.330701030-05:00 2021-12-15T16:40:58.330Z	INFO	derserialize-thread-split-7	stderr		at org.apache.pulsar.sql.presto.PulsarRecordCursor$DeserializeEntries.run(PulsarRecordCursor.java:254)
2021-12-15T11:40:58.330706984-05:00 2021-12-15T16:40:58.330Z	INFO	derserialize-thread-split-7	stderr		at java.base/java.lang.Thread.run(Thread.java:829)
```
Because DeserializeEntries read entries from `entryQueue` and will release relative entries after processing.
But when PulsarRecordCursor closes, it will also release entries in the `entryQueue`, so different threads have released the same entry to cause the above issue.

2. If DeserializeEntries occurs any uncaught exception, PulsarRecordCursor#advanceNextPosition could not retrieve any data from `messageQueue` and make the current thread sleep indefinitely.
https://github.com/apache/pulsar/blob/0facd24e8eec2df56f6f241ce2cf87eb98590a7e/pulsar-sql/presto-pulsar/src/main/java/org/apache/pulsar/sql/presto/PulsarRecordCursor.java#L481-L503

So when no message from `messageQueue`, we should check if there is any uncaught exception.

### Modifications

1. Add `closeHandle` in DeserializeEntries and release entries in the `entryQueue` after DeserializeEntries close.
2. Add try/catch block in DeserializeEntries#run.


### Documentation
  
- [x] `no-need-doc` 
  
  (Please explain why)
  


