### PR TITLE
[pulsar-broker] support client configurable message chunk size

### DIFF
--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/ProducerBuilder.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/ProducerBuilder.java
@@ -344,6 +344,16 @@ public interface ProducerBuilder<T> extends Cloneable {
     ProducerBuilder<T> enableChunking(boolean enableChunking);
 
     /**
+     * Max chunk message size in bytes. Producer chunks the message if chunking is enabled and message size is larger
+     * than max chunk-message size. By default chunkMaxMessageSize value is -1 and in that case, producer chunks based
+     * on max-message size configured at broker.
+     *
+     * @param chunkMaxMessageSize
+     * @return
+     */
+    ProducerBuilder<T> chunkMaxMessageSize(int chunkMaxMessageSize);
+
+    /**
      * Sets a {@link CryptoKeyReader}.
      *
      * <p>Configure the key reader to be used to encrypt the message payloads.

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerBuilderImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerBuilderImpl.java
@@ -198,6 +198,12 @@ public class ProducerBuilderImpl<T> implements ProducerBuilder<T> {
     }
 
     @Override
+    public ProducerBuilder<T> chunkMaxMessageSize(int chunkMaxMessageSize) {
+        conf.setChunkMaxMessageSize(chunkMaxMessageSize);
+        return this;
+    }
+
+    @Override
     public ProducerBuilder<T> cryptoKeyReader(@NonNull CryptoKeyReader cryptoKeyReader) {
         conf.setCryptoKeyReader(cryptoKeyReader);
         return this;

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ProducerConfigurationData.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ProducerConfigurationData.java
@@ -74,6 +74,7 @@ public class ProducerConfigurationData implements Serializable, Cloneable {
     @JsonIgnore
     private BatcherBuilder batcherBuilder = BatcherBuilder.DEFAULT;
     private boolean chunkingEnabled = false;
+    private int chunkMaxMessageSize = -1;
 
     @JsonIgnore
     private CryptoKeyReader cryptoKeyReader;

--- a/site2/docs/client-libraries-java.md
+++ b/site2/docs/client-libraries-java.md
@@ -559,6 +559,8 @@ Producer<byte[]> producer = client.newProducer()
         .enableBatching(false)
         .create();
 ```
+
+By default, producer chunks the large message based on max message size (`maxMessageSize`) configured at broker (eg: 5MB). However, client can also configure max chunked size using producer configuration `chunkMaxMessageSize`.
 > **Note:** To enable chunking, you need to disable batching (`enableBatching`=`false`) concurrently.
 
 ## Consumer


### PR DESCRIPTION
### Modification
Right now, producer-client supports chunking to publish large messages. Producer chunks the message based on broker's `maxMessageSize` configuration which is by default 5MB. However, 5MB is still large block size for topic with higher throughput which can directly impact overall bookie's performance. In that case, client wants to publish smaller chunk (eg: 100KB) without changing broker's maxMessageSize because other low throughput tenant can still utilize 5MB message limit. So, user needs a feature where user can control max-chunk size by considering msg-throughput and without impacting broker's performance.

### Modification
Add `chunkMaxMessageSize` config for producer to control max-chunk size by a user.

### Result
User can publish custom sized chunk messages based on user requirements.