### PR TITLE
[pulsar-client-tools] Change IllegalArgumentException to ParameterException in CLI

### DIFF
--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdBookies.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdBookies.java
@@ -19,6 +19,7 @@
 package org.apache.pulsar.admin.cli;
 
 import com.beust.jcommander.Parameter;
+import com.beust.jcommander.ParameterException;
 import com.beust.jcommander.Parameters;
 import com.google.common.base.Strings;
 import java.util.function.Supplier;
@@ -111,7 +112,7 @@ public class CmdBookies extends CmdBase {
 
         private void checkArgument(boolean expression, @NonNull Object errorMessage) {
             if (!expression) {
-                throw new IllegalArgumentException(String.valueOf(errorMessage));
+                throw new ParameterException(String.valueOf(errorMessage));
             }
         }
     }

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/cli/CLITest.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/cli/CLITest.java
@@ -282,6 +282,18 @@ public class CLITest extends PulsarTestSuite {
                 "clear-properties",
                 namespace);
         assertTrue(result.getStdout().isEmpty());
+
+        try {
+            container.execCmd(
+                    PulsarCluster.ADMIN_SCRIPT,
+                    "bookies",
+                    "set-bookie-rack",
+                    "-b", "localhost:8082",
+                    "-r", "");
+            fail("Command should have exited with non-zero");
+        } catch (ContainerExecException e) {
+            assertEquals(e.getResult().getStderr(), "rack name is invalid, it should not be null, empty or '/'\n\n");
+        }
     }
 
     @Test


### PR DESCRIPTION
### Motivation

Change IllegalArgumentException to ParameterException in CLI

### Modifications

pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdBookies.java

### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API: (yes / **no**)
  - The schema: (yes / **no** / don't know)
  - The default values of configurations: (yes / **no**)
  - The wire protocol: (yes / **no**)
  - The rest endpoints: (yes / **no**)
  - The admin cli options: (yes / **no**)
  - Anything that affects deployment: (yes / **no** / don't know)

### Documentation

- [x] `no-need-doc` 
  