### PR TITLE
Add document for enabling get the last message in sql

### DIFF
--- a/site2/website/versioned_docs/version-2.9.1/sql-deployment-configurations.md
+++ b/site2/website/versioned_docs/version-2.9.1/sql-deployment-configurations.md
@@ -34,6 +34,13 @@ pulsar.web-service-url=http://localhost:8080,localhost:8081,localhost:8082
 pulsar.zookeeper-uri=localhost1,localhost2:2181
 ```
 
+> Note
+> By default, pulsar sql won't get the last message in the topic. If you want to 
+> get the last message, you need to configure the following configurations.
+> For the broker config, you need to set `bookkeeperExplicitLacIntervalInMills`.
+> For the Presto config, you need to set `pulsar.bookkeeper-use-v2-protocol=false` and `pulsar.bookkeeper-explicit-interval`.
+> Then you should get the last message from sql.
+
 ## Query data from existing Presto clusters
 
 If you already have a Presto cluster, you can copy the Presto Pulsar connector plugin to your existing cluster. Download the archived plugin package with the following command.


### PR DESCRIPTION

### Motivation

By default, the pulsar sql can not fetch the last message from the
topic. Add a document to introduce how to configure the pulsar sql
to fetch the last message from the topic.

### Modifications

- Add a note in the SQL deployment page.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API: (yes / no)
  - The schema: (yes / no / don't know)
  - The default values of configurations: (yes / no)
  - The wire protocol: (yes / no)
  - The rest endpoints: (yes / no)
  - The admin cli options: (yes / no)
  - Anything that affects deployment: (yes / no / don't know)

### Documentation

Check the box below or label this PR directly (if you have committer privilege).

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [ ] `no-need-doc` 
  
  (Please explain why)
  
- [x] `doc` 
  
  (If this PR contains doc changes)


