### PR TITLE
ZKMetadataStore Use ZK_SCHEME_IDENTIFIER instead

### DIFF
--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/ZKMetadataStore.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/ZKMetadataStore.java
@@ -81,8 +81,8 @@ public class ZKMetadataStore extends AbstractBatchedMetadataStore
         super(metadataStoreConfig);
 
         try {
-            if (metadataURL.startsWith("zk:")) {
-                this.zkConnectString = metadataURL.substring(3);
+            if (metadataURL.startsWith(ZK_SCHEME_IDENTIFIER)) {
+                this.zkConnectString = metadataURL.substring(ZK_SCHEME_IDENTIFIER.length());
             } else {
                 this.zkConnectString = metadataURL;
             }


### PR DESCRIPTION
### Motivation

Use ZKMetadataStore#ZK_SCHEME_IDENTIFIER  instead

### Modifications

Use ZKMetadataStore#ZK_SCHEME_IDENTIFIER  instead



### Documentation

Check the box below or label this PR directly (if you have committer privilege).

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)


