### PR TITLE
[C++] Fix GCC compilation failure caused by warning macro

### DIFF
--- a/pulsar-client-cpp/CMakeLists.txt
+++ b/pulsar-client-cpp/CMakeLists.txt
@@ -102,7 +102,7 @@ else() # GCC or Clang are mostly compatible:
     # Options unique to Clang or GCC:
     if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
         add_compile_options(-Qunused-arguments) 
-    elseif (CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND NOT (CMAKE_CXX_COMPILER_VERSION VERSION_LESS 4.9))
+    elseif (CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND NOT (CMAKE_CXX_COMPILER_VERSION VERSION_LESS 8.1))
         add_compile_options(-Wno-stringop-truncation)
     endif()
 endif()


### PR DESCRIPTION
### Motivation

When I tried to build the C++ client with GCC 7.3 and when warnings are
printed (because `BOOST_ARCH_X86_64` is not defined), the compilation
failed with:

```
#warning “BOOST_ARCH_X86_64 is not defined, CRC32C SSE4.2 will be disabled”
  ^~~~~~~
cc1plus: error: unrecognized command line option '-Wno-stringop-truncation' [-Werror]
cc1plus: all warnings being treated as errors
```

It seems to be a bug before GCC 8.1. I added
`-DCMAKE_VERBOSE_MAKEFILE=ON` to CMake command and see the full compile
command:

```
-Wno-error -Wall -Wformat-security -Wvla -Werror -Wno-sign-compare -Wno-deprecated-declarations -Wno-error=cpp -Wno-stringop-truncation
```

See
https://github.com/apache/pulsar/blob/b829a4ce121268f55748bbdd6f19ac36129e7dab/pulsar-client-cpp/CMakeLists.txt#L105-L106

For GCC > 4.9, `-Wno-stringop-truncation` option was added. However,
when a message was printed by `#warning` macro, it would fail with the
strange error message.

The simplest way to reproduce the bug is compiling following code:

```c++
#warnings "hello"

int main() {}
```

You can paste the code above to https://godbolt.org/, select any GCC
compiler whose version is lower than 8.0, then add the following
options:

```
-Werror -Wno-error=cpp -Wno-stringop-truncation
```

The compilation failed for x86-64 gcc 7.5 while it succeeded for 8.1.

### Modifications

Only add the `-Wno-stringop-truncation` option for GCC >= 8.1.