### PR TITLE
[Python Client] Fix ModuleNotFoundError is not defined in python2

### DIFF
--- a/pulsar-client-cpp/python/pulsar/schema/schema_avro.py
+++ b/pulsar-client-cpp/python/pulsar/schema/schema_avro.py
@@ -27,7 +27,7 @@ from .schema import Schema
 try:
     import fastavro
     HAS_AVRO = True
-except ModuleNotFoundError:
+except ImportError:
     HAS_AVRO = False
 
 if HAS_AVRO:


### PR DESCRIPTION
Fixes #14193 

### Motivation

`ModuleNotFoundError` is a builtin since python3.6. If we use python2 version pulsar, python will raise `NameError: name 'ModuleNotFoundError' is not defined` error.

### Modifications

Change `ModuleNotFoundError`  to `ImportError`

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API: (yes / **no**)
  - The schema: (yes / **no** / don't know)
  - The default values of configurations: (yes / **no**)
  - The wire protocol: (yes / **no**)
  - The rest endpoints: (yes / **no**)
  - The admin cli options: (yes / **no**)
  - Anything that affects deployment: (yes / **no** / don't know)

### Documentation
  
- [x] `no-need-doc` 

