### PR TITLE
[test] Fix await condition error in testMultiTopicsConsumerImplPauseForPartionNumberChange

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SimpleProducerConsumerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SimpleProducerConsumerTest.java
@@ -3223,7 +3223,7 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
         admin.topics().updatePartitionedTopic(topicName, 3);
 
         // 4. wait for client to update partitions
-        Awaitility.await().until(() -> ((MultiTopicsConsumerImpl) consumer).getConsumers().size() <= 1);
+        Awaitility.await().until(() -> ((MultiTopicsConsumerImpl) consumer).getConsumers().size() == 3);
 
         // 5. produce 5 more messages
         for (int i = 5; i < 10; i++) {


### PR DESCRIPTION
### Motivation

Await condition error introduced by #11281.

This line previously is 
```
        while(((MultiTopicsConsumerImpl)consumer).getConsumers().size() <= 1) {
            Thread.sleep(1);
        }
```

### Modifications

The consumer number should be equals to new partition number.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.



This change is a trivial rework / code cleanup without any test coverage.


### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

Check the box below and label this PR (if you have committer privilege).

Need to update docs? 
  
- [x] `no-need-doc` 
bug fix