### PR TITLE
[WIP] Using the latest version in bookkeeper, the ConcurrentLongLongPairHas…

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Consumer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Consumer.java
@@ -186,7 +186,7 @@ public class Consumer {
         stats.metadata = this.metadata;
 
         if (Subscription.isIndividualAckMode(subType)) {
-            this.pendingAcks = new ConcurrentLongLongPairHashMap(256, 1);
+            this.pendingAcks = ConcurrentLongLongPairHashMap.newBuilder().autoShrink(true).build();
         } else {
             // We don't need to keep track of pending acks if the subscription is not shared
             this.pendingAcks = null;


### PR DESCRIPTION

### Motivation
issue: https://github.com/apache/pulsar/issues/14268
Using the latest version in bookkeeper, the ConcurrentLongLongPairHashMap of this version supports to shrink when removing, which can solve the problem of continuous memory increase and frequent FGC in pulsar broker.
See the PR corresponding to bookkeeper: https://github.com/apache/bookkeeper/pull/3061.

I need to wait for bookkeeper to release a new version, then I will change the version that bookkeeper depends on in pom.


### Documentation

Check the box below or label this PR directly (if you have committer privilege).

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)


