### PR TITLE
Fix TableViewImpl not retrying partition update on exceptions

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/TableViewTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/TableViewTest.java
@@ -90,7 +90,7 @@ public class TableViewTest extends MockedPulsarServiceBaseTest {
         try (Producer<byte[]> producer = builder.create()) {
             CompletableFuture<?> lastFuture = null;
             for (int i = 0; i < count; i++) {
-                String key = "key" + i;
+                String key = "key"+ i;
                 byte[] data = ("my-message-" + i).getBytes();
                 lastFuture = producer.newMessage().key(key).value(data).sendAsync();
                 keys.add(key);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/TableViewTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/TableViewTest.java
@@ -30,12 +30,16 @@ import org.apache.pulsar.broker.auth.MockedPulsarServiceBaseTest;
 import org.apache.pulsar.client.api.MessageRoutingMode;
 import org.apache.pulsar.client.api.Producer;
 import org.apache.pulsar.client.api.ProducerBuilder;
+import org.apache.pulsar.client.api.PulsarClient;
+import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.client.api.TableView;
 import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.policies.data.ClusterData;
 import org.apache.pulsar.common.policies.data.TenantInfoImpl;
+import org.apache.pulsar.common.util.FutureUtil;
 import org.awaitility.Awaitility;
+import org.mockito.Mockito;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
@@ -86,7 +90,7 @@ public class TableViewTest extends MockedPulsarServiceBaseTest {
         try (Producer<byte[]> producer = builder.create()) {
             CompletableFuture<?> lastFuture = null;
             for (int i = 0; i < count; i++) {
-                String key = "key"+ i;
+                String key = "key" + i;
                 byte[] data = ("my-message-" + i).getBytes();
                 lastFuture = producer.newMessage().key(key).value(data).sendAsync();
                 keys.add(key);
@@ -152,6 +156,59 @@ public class TableViewTest extends MockedPulsarServiceBaseTest {
         // Send more data to partition 3, which is not in the current TableView, need update partitions
         Set<String> keys2 =
                 this.publishMessages(topicName.getPartition(3).toString(), count * 2, false);
+        Awaitility.await().atMost(Duration.ofSeconds(10)).untilAsserted(() -> {
+            log.info("Current tv size: {}", tv.size());
+            Assert.assertEquals(tv.size(), count * 2);
+        });
+        Assert.assertEquals(tv.keySet(), keys2);
+    }
+
+
+    @Test(timeOut = 30 * 1000)
+    // Regression test for making sure partition changes are always periodically checked even after a check returned
+    // exceptionally.
+    public void testTableViewUpdatePartitionsTriggeredDespiteExceptions() throws Exception {
+        String topic = "persistent://public/default/tableview-test-update-partitions";
+        admin.topics().createPartitionedTopic(topic, 3);
+        int count = 20;
+        Set<String> keys = this.publishMessages(topic, count, false);
+        PulsarClient spyPulsarClient = Mockito.spy(pulsarClient);
+        @Cleanup
+        TableView<byte[]> tv = spyPulsarClient.newTableViewBuilder(Schema.BYTES)
+                .topic(topic)
+                .autoUpdatePartitionsInterval(5, TimeUnit.SECONDS)
+                .create();
+        log.info("start tv size: {}", tv.size());
+        tv.forEachAndListen((k, v) -> log.info("{} -> {}", k, new String(v)));
+        Awaitility.await().untilAsserted(() -> {
+            log.info("Current tv size: {}", tv.size());
+            Assert.assertEquals(tv.size(), count);
+        });
+        Assert.assertEquals(tv.keySet(), keys);
+        tv.forEachAndListen((k, v) -> log.info("checkpoint {} -> {}", k, new String(v)));
+
+        // Let update partition check throw an exception
+        Mockito.doReturn(FutureUtil.failedFuture(new PulsarClientException("")))
+                .when(spyPulsarClient)
+                .getPartitionsForTopic(Mockito.any());
+
+        admin.topics().updatePartitionedTopic(topic, 4);
+        TopicName topicName = TopicName.get(topic);
+
+        // Make sure the get partitions callback is called; it should throw an exception
+        Mockito.verify(spyPulsarClient).getPartitionsForTopic(Mockito.any());
+
+        // Send more data to partition 3, which is not in the current TableView, need update partitions
+        Set<String> keys2 =
+                this.publishMessages(topicName.getPartition(3).toString(), count * 2, false);
+
+        // Wait for 10 seconds; verify that the messages haven't arrived, which would have happened if the partitions
+        // has been updated
+        TimeUnit.SECONDS.sleep(10);
+        Assert.assertEquals(tv.size(), count);
+
+        // Let update partition check succeed, and check the messages eventually arrives
+        Mockito.doCallRealMethod().when(spyPulsarClient).getPartitionsForTopic(Mockito.any());
         Awaitility.await().atMost(Duration.ofSeconds(10)).untilAsserted(() -> {
             log.info("Current tv size: {}", tv.size());
             Assert.assertEquals(tv.size(), count * 2);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/TableViewTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/TableViewTest.java
@@ -168,7 +168,7 @@ public class TableViewTest extends MockedPulsarServiceBaseTest {
     // Regression test for making sure partition changes are always periodically checked even after a check returned
     // exceptionally.
     public void testTableViewUpdatePartitionsTriggeredDespiteExceptions() throws Exception {
-        String topic = "persistent://public/default/tableview-test-update-partitions";
+        String topic = "persistent://public/default/tableview-test-update-partitions-triggered-despite-exceptions";
         admin.topics().createPartitionedTopic(topic, 3);
         int count = 20;
         Set<String> keys = this.publishMessages(topic, count, false);

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/TableViewImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/TableViewImpl.java
@@ -104,10 +104,10 @@ public class TableViewImpl<T> implements TableView<T> {
         }
 
         start().whenComplete((tw, ex) -> {
-            if (ex != null) {
-                log.warn("Failed to check for changes in number of partitions");
-                schedulePartitionsCheck();
-            }
+           if (ex != null) {
+               log.warn("Failed to check for changes in number of partitions: {}", ex);
+               schedulePartitionsCheck();
+           }
         });
     }
 
@@ -128,12 +128,12 @@ public class TableViewImpl<T> implements TableView<T> {
 
     @Override
     public T get(String key) {
-        return data.get(key);
+       return data.get(key);
     }
 
     @Override
     public Set<Map.Entry<String, T>> entrySet() {
-        return data.entrySet();
+       return data.entrySet();
     }
 
     @Override
@@ -237,27 +237,27 @@ public class TableViewImpl<T> implements TableView<T> {
                                          AtomicLong messagesRead) {
         reader.hasMessageAvailableAsync()
                 .thenAccept(hasMessage -> {
-                    if (hasMessage) {
-                        reader.readNextAsync()
-                                .thenAccept(msg -> {
-                                    messagesRead.incrementAndGet();
-                                    handleMessage(msg);
-                                    readAllExistingMessages(reader, future, startTime, messagesRead);
-                                }).exceptionally(ex -> {
-                                    future.completeExceptionally(ex);
-                                    return null;
-                                });
-                    } else {
-                        // Reached the end
-                        long endTime = System.nanoTime();
-                        long durationMillis = TimeUnit.NANOSECONDS.toMillis(endTime - startTime);
-                        log.info("Started table view for topic {} - replayed {} messages in {} seconds",
-                                reader.getTopic(),
-                                messagesRead,
-                                durationMillis / 1000.0);
-                        future.complete(reader);
-                        readTailMessages(reader);
-                    }
+                   if (hasMessage) {
+                       reader.readNextAsync()
+                               .thenAccept(msg -> {
+                                  messagesRead.incrementAndGet();
+                                  handleMessage(msg);
+                                  readAllExistingMessages(reader, future, startTime, messagesRead);
+                               }).exceptionally(ex -> {
+                                   future.completeExceptionally(ex);
+                                   return null;
+                               });
+                   } else {
+                       // Reached the end
+                       long endTime = System.nanoTime();
+                       long durationMillis = TimeUnit.NANOSECONDS.toMillis(endTime - startTime);
+                       log.info("Started table view for topic {} - Replayed {} messages in {} seconds",
+                               reader.getTopic(),
+                               messagesRead,
+                               durationMillis / 1000.0);
+                       future.complete(reader);
+                       readTailMessages(reader);
+                   }
                 });
     }
 

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/TableViewImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/TableViewImpl.java
@@ -104,9 +104,10 @@ public class TableViewImpl<T> implements TableView<T> {
         }
 
         start().whenComplete((tw, ex) -> {
-           if (ex != null) {
-               log.warn("Failed to check for changes in number of partitions");
-           }
+            if (ex != null) {
+                log.warn("Failed to check for changes in number of partitions");
+                schedulePartitionsCheck();
+            }
         });
     }
 
@@ -127,12 +128,12 @@ public class TableViewImpl<T> implements TableView<T> {
 
     @Override
     public T get(String key) {
-       return data.get(key);
+        return data.get(key);
     }
 
     @Override
     public Set<Map.Entry<String, T>> entrySet() {
-       return data.entrySet();
+        return data.entrySet();
     }
 
     @Override
@@ -236,27 +237,27 @@ public class TableViewImpl<T> implements TableView<T> {
                                          AtomicLong messagesRead) {
         reader.hasMessageAvailableAsync()
                 .thenAccept(hasMessage -> {
-                   if (hasMessage) {
-                       reader.readNextAsync()
-                               .thenAccept(msg -> {
-                                  messagesRead.incrementAndGet();
-                                  handleMessage(msg);
-                                  readAllExistingMessages(reader, future, startTime, messagesRead);
-                               }).exceptionally(ex -> {
-                                   future.completeExceptionally(ex);
-                                   return null;
-                               });
-                   } else {
-                       // Reached the end
-                       long endTime = System.nanoTime();
-                       long durationMillis = TimeUnit.NANOSECONDS.toMillis(endTime - startTime);
-                       log.info("Started table view for topic {} - Replayed {} messages in {} seconds",
-                               reader.getTopic(),
-                               messagesRead,
-                               durationMillis / 1000.0);
-                       future.complete(reader);
-                       readTailMessages(reader);
-                   }
+                    if (hasMessage) {
+                        reader.readNextAsync()
+                                .thenAccept(msg -> {
+                                    messagesRead.incrementAndGet();
+                                    handleMessage(msg);
+                                    readAllExistingMessages(reader, future, startTime, messagesRead);
+                                }).exceptionally(ex -> {
+                                    future.completeExceptionally(ex);
+                                    return null;
+                                });
+                    } else {
+                        // Reached the end
+                        long endTime = System.nanoTime();
+                        long durationMillis = TimeUnit.NANOSECONDS.toMillis(endTime - startTime);
+                        log.info("Started table view for topic {} - replayed {} messages in {} seconds",
+                                reader.getTopic(),
+                                messagesRead,
+                                durationMillis / 1000.0);
+                        future.complete(reader);
+                        readTailMessages(reader);
+                    }
                 });
     }
 


### PR DESCRIPTION
### Motivation

TableViewImpl doesn't keep scheduling partition update checks if one check fails exceptionally, so if a call to `start()` fails, it will stop keeping track of future partition updates. This fixes that by manually scheduling a check on exception.

### Modifications

* Added logic to schedule a partition update check on exceptions
* Added a regression test

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change added tests and can be verified as follows:

`mvn clean -pl pulsar-client install -Dmaven.test.skip && mvn clean -pl pulsar-broker test -Dtest=TableViewTest#testTableViewUpdatePartitionsKeepTryingOnExceptions`


### Documentation

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  Small fix
  
- [ ] `doc` 
  
  (If this PR contains doc changes)
