### PR TITLE
Make sure policies.is_allow_auto_update_schema not null

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/AdminResource.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/AdminResource.java
@@ -293,6 +293,9 @@ public abstract class AdminResource extends PulsarWebResource {
             BundlesData bundleData = pulsar().getNamespaceService().getNamespaceBundleFactory()
                     .getBundles(namespaceName).getBundlesData();
             policies.bundles = bundleData != null ? bundleData : policies.bundles;
+            if (policies.is_allow_auto_update_schema == null) {
+                policies.is_allow_auto_update_schema = pulsar().getConfig().isAllowAutoUpdateSchemaEnabled();
+            }
 
             return policies;
         } catch (RestException re) {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/schema/compatibility/SchemaCompatibilityCheckTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/schema/compatibility/SchemaCompatibilityCheckTest.java
@@ -39,6 +39,7 @@ import org.apache.pulsar.common.naming.NamespaceName;
 import org.apache.pulsar.common.naming.TopicDomain;
 import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.policies.data.ClusterData;
+import org.apache.pulsar.common.policies.data.Policies;
 import org.apache.pulsar.common.policies.data.SchemaCompatibilityStrategy;
 import org.apache.pulsar.common.policies.data.TenantInfo;
 import org.apache.pulsar.common.schema.SchemaInfo;
@@ -247,6 +248,9 @@ public class SchemaCompatibilityCheckTest extends MockedPulsarServiceBaseTest {
 
 
         pulsar.getConfig().setAllowAutoUpdateSchemaEnabled(false);
+        Policies policies = admin.namespaces().getPolicies(namespaceName.toString());
+        Assert.assertFalse(policies.is_allow_auto_update_schema);
+
         ProducerBuilder<Schemas.PersonTwo> producerThreeBuilder = pulsarClient
                 .newProducer(Schema.AVRO(SchemaDefinition.<Schemas.PersonTwo>builder().withAlwaysAllowNull
                                 (false).withSupportSchemaVersioning(true).
@@ -259,6 +263,9 @@ public class SchemaCompatibilityCheckTest extends MockedPulsarServiceBaseTest {
         }
 
         pulsar.getConfig().setAllowAutoUpdateSchemaEnabled(true);
+        policies = admin.namespaces().getPolicies(namespaceName.toString());
+        Assert.assertTrue(policies.is_allow_auto_update_schema);
+
         ConsumerBuilder<Schemas.PersonTwo> comsumerBuilder = pulsarClient.newConsumer(Schema.AVRO(
                         SchemaDefinition.<Schemas.PersonTwo>builder().withAlwaysAllowNull
                                         (false).withSupportSchemaVersioning(true).


### PR DESCRIPTION
### Motivation

Follow code works fine on 2.8.x but get NPE on 2.9.x
```
Policies policies = pulsarAdmin.namespaces().getPolicies("namespacePath");
boolean allowedAutoupdateSchema = policies.is_allow_auto_update_schema;
```
Becasue `Policies.is_allow_auto_update_schema` changed from `boolean` to `Boolean` by #12786 and default value is null.
This may cause user's service fail when upgrade pulsar from 2.8.x to 2.9.x

### Modifications
Make sure `Policies.is_allow_auto_update_schema` not null when call `getPolicies`

### Documentation
  
- [x] `no-need-doc` 
  
  Just keep behaviour same between 2.8.x and 2.9.x

