### PR TITLE
[Broker] Remove dead brokers timeaverage data

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/ModularLoadManagerImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/ModularLoadManagerImpl.java
@@ -491,17 +491,7 @@ public class ModularLoadManagerImpl implements ModularLoadManager {
         knownBrokers.removeAll(deadBrokers);
         if (pulsar.getLeaderElectionService() != null
                 && pulsar.getLeaderElectionService().isLeader()) {
-            for (String broker: deadBrokers) {
-                final String timeAverageZPath = TIME_AVERAGE_BROKER_ZPATH + "/" + broker;
-                try {
-                    timeAverageBrokerDataCache.delete(timeAverageZPath).join();
-                } catch (Exception e) {
-                    if (!(e.getCause() instanceof NotFoundException)) {
-                        log.warn("Failed to delete dead broker {} time "
-                                + "average data from metadata store", broker, e);
-                    }
-                }
-            }
+            deadBrokers.forEach(this::deleteTimeAverageDataFromMetadataStore);
         }
 
         final Map<String, BrokerData> brokerDataMap = loadData.getBrokerData();
@@ -1097,6 +1087,18 @@ public class ModularLoadManagerImpl implements ModularLoadManager {
         } catch (Exception e) {
             if (!(e.getCause() instanceof NotFoundException)) {
                 log.warn("Failed to delete bundle-data {} from metadata store", bundle, e);
+            }
+        }
+    }
+
+    private void deleteTimeAverageDataFromMetadataStore(String broker) {
+        final String timeAverageZPath = TIME_AVERAGE_BROKER_ZPATH + "/" + broker;
+        try {
+            timeAverageBrokerDataCache.delete(timeAverageZPath).join();
+        } catch (Exception e) {
+            if (!(e.getCause() instanceof NotFoundException)) {
+                log.warn("Failed to delete dead broker {} time "
+                        + "average data from metadata store", broker, e);
             }
         }
     }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/ModularLoadManagerImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/ModularLoadManagerImpl.java
@@ -475,15 +475,14 @@ public class ModularLoadManagerImpl implements ModularLoadManager {
         if (log.isDebugEnabled()) {
             log.debug("Updating broker and bundle data for loadreport");
         }
+        cleanupDeadBrokersData();
         updateAllBrokerData();
         updateBundleData();
         // broker has latest load-report: check if any bundle requires split
         checkNamespaceBundleSplit();
     }
 
-    // As the leader broker, update the broker data map in loadData by querying metadata store for the broker data put
-    // there by each broker via updateLocalBrokerData.
-    private void updateAllBrokerData() {
+    private void cleanupDeadBrokersData() {
         final Set<String> activeBrokers = getAvailableBrokers();
         Collection<String> newBrokers = CollectionUtils.subtract(activeBrokers, knownBrokers);
         knownBrokers.addAll(newBrokers);
@@ -493,7 +492,12 @@ public class ModularLoadManagerImpl implements ModularLoadManager {
                 && pulsar.getLeaderElectionService().isLeader()) {
             deadBrokers.forEach(this::deleteTimeAverageDataFromMetadataStoreAsync);
         }
+    }
 
+    // As the leader broker, update the broker data map in loadData by querying metadata store for the broker data put
+    // there by each broker via updateLocalBrokerData.
+    private void updateAllBrokerData() {
+        final Set<String> activeBrokers = getAvailableBrokers();
         final Map<String, BrokerData> brokerDataMap = loadData.getBrokerData();
         for (String broker : activeBrokers) {
             try {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/ModularLoadManagerImplTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/ModularLoadManagerImplTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pulsar.broker.loadbalance;
 
+import static org.apache.pulsar.broker.loadbalance.impl.ModularLoadManagerImpl.TIME_AVERAGE_BROKER_ZPATH;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
@@ -35,6 +36,7 @@ import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.net.URL;
 import java.util.EnumSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -51,6 +53,7 @@ import org.apache.pulsar.broker.BundleData;
 import org.apache.pulsar.broker.PulsarServerException;
 import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.broker.ServiceConfiguration;
+import org.apache.pulsar.broker.TimeAverageBrokerData;
 import org.apache.pulsar.broker.TimeAverageMessageData;
 import org.apache.pulsar.broker.loadbalance.impl.LoadManagerShared;
 import org.apache.pulsar.broker.loadbalance.impl.LoadManagerShared.BrokerTopicLoadingPredicate;
@@ -601,5 +604,32 @@ public class ModularLoadManagerImplTest {
         }
 
         pulsar.close();
+    }
+
+    @Test
+    public void testRemoveDeadBrokerTimeAverageData() throws Exception {
+        ModularLoadManagerWrapper loadManagerWrapper = (ModularLoadManagerWrapper) pulsar1.getLoadManager().get();
+        ModularLoadManagerImpl lm = Whitebox.getInternalState(loadManagerWrapper, "loadManager");
+        assertEquals(lm.getAvailableBrokers().size(), 2);
+
+        pulsar2.close();
+
+        Awaitility.await().untilAsserted(() -> {
+            assertEquals(lm.getAvailableBrokers().size(), 1);
+        });
+        lm.updateAll();
+
+        List<String> data =  pulsar1.getLocalMetadataStore()
+                .getMetadataCache(TimeAverageBrokerData.class).getChildren(TIME_AVERAGE_BROKER_ZPATH).join();
+
+        Awaitility.await().untilAsserted(() -> {
+            assertTrue(pulsar1.getLeaderElectionService().isLeader());
+        });
+
+        assertEquals(data.size(), 1);
+
+
+
+
     }
 }


### PR DESCRIPTION

### Motivation
After one broker is dead, the metadata under `/loadbalance/broker-time-average` is remained.


### Modifications

Delete dead broker's broker-time-average metadata

### Verifying this change
testRemoveDeadBrokerTimeAverageData



### Documentation

Check the box below or label this PR directly (if you have committer privilege).

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)


