### PR TITLE
[Build] Exclude more files from src package

### DIFF
--- a/src/assembly-source-package.xml
+++ b/src/assembly-source-package.xml
@@ -74,7 +74,9 @@
         
         <!-- misc -->
         <exclude>%regex[(?!((?!${project.build.directory}/)[^/]+/)*src/)(.*/)?cobertura\.ser]</exclude>
-        
+        <exclude>%regex[(?!((?!${project.build.directory}/)[^/]+/)*src/)(.*/)?pom\.xml\.versionsBackup]</exclude>
+        <exclude>%regex[(?!((?!${project.build.directory}/)[^/]+/)*src/)(.*/)?dependency-reduced-pom\.xml]</exclude>
+
         <!-- release-plugin temp files -->
         <exclude>%regex[(?!((?!${project.build.directory}/)[^/]+/)*src/)(.*/)?pom\.xml\.releaseBackup]</exclude>
         <exclude>%regex[(?!((?!${project.build.directory}/)[^/]+/)*src/)(.*/)?release\.properties]</exclude>


### PR DESCRIPTION
Source packages might include pom.xml.versionsBackup and
dependency-reduced-pom.xml files. 

This change adds exclude rules to avoid including them.



