### PR TITLE
[Broker] Add deprecated to `subscriptionKeySharedEnable`

### DIFF
--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -599,6 +599,7 @@ public class ServiceConfiguration implements PulsarConfiguration {
     private Set<String> subscriptionTypesEnabled =
             Sets.newHashSet("Exclusive", "Shared", "Failover", "Key_Shared");
 
+    @Deprecated
     @FieldContext(
         category = CATEGORY_POLICIES,
         dynamic = true,


### PR DESCRIPTION
### Motivation

`subscriptionKeySharedEnable` is deprecated in #9401. Need to add the deprecated annotation to it in the `ServiceConfiguration`.

### Modifications

* Add deprecated to `subscriptionKeySharedEnable`

### Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

### Documentation
  
- [x] `no-need-doc` 
  
