### PR TITLE
Revert "[PIP 97] Update Authentication Interfaces to Include Async Au…

### DIFF
--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authentication/AuthenticationDataSource.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authentication/AuthenticationDataSource.java
@@ -102,10 +102,7 @@ public interface AuthenticationDataSource {
     /**
      * Evaluate and challenge the data that passed in, and return processed data back.
      * It is used for mutual authentication like SASL.
-     * NOTE: this method is not called by the Pulsar authentication framework.
-     * @deprecated use {@link AuthenticationProvider} or {@link AuthenticationState}.
      */
-    @Deprecated
     default AuthData authenticate(AuthData data) throws AuthenticationException {
         throw new AuthenticationException("Not supported");
     }

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authentication/AuthenticationProvider.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authentication/AuthenticationProvider.java
@@ -21,15 +21,12 @@ package org.apache.pulsar.broker.authentication;
 import java.io.Closeable;
 import java.io.IOException;
 import java.net.SocketAddress;
-import java.util.concurrent.CompletableFuture;
 import javax.naming.AuthenticationException;
 import javax.net.ssl.SSLSession;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import org.apache.pulsar.broker.ServiceConfiguration;
 import org.apache.pulsar.common.api.AuthData;
-import org.apache.pulsar.common.classification.InterfaceStability;
-import org.apache.pulsar.common.util.FutureUtil;
 
 /**
  * Provider of authentication mechanism.
@@ -53,29 +50,6 @@ public interface AuthenticationProvider extends Closeable {
 
     /**
      * Validate the authentication for the given credentials with the specified authentication data.
-     * This method is useful in one stage authentication, if you're not doing one stage or if you're providing
-     * your own state implementation for one stage authentication, it should return a failed future.
-     *
-     * <p>Warning: the calling thread is an IO thread. Any implementation that relies on blocking behavior
-     * must ensure that the execution is completed using a separate thread pool to ensure IO threads
-     * are never blocked.</p>
-     *
-     * @param authData authentication data generated while initiating a connection. There are several types,
-     *                 including, but not strictly limited to, {@link AuthenticationDataHttp},
-     *                 {@link AuthenticationDataHttps}, and {@link AuthenticationDataCommand}.
-     * @return A completed future with the "role" string for the authenticated connection, if authentication is
-     * successful, or a failed future if the authData is not valid.
-     */
-    default CompletableFuture<String> authenticateAsync(AuthenticationDataSource authData) {
-        try {
-            return CompletableFuture.completedFuture(this.authenticate(authData));
-        } catch (AuthenticationException e) {
-            return FutureUtil.failedFuture(e);
-        }
-    }
-
-    /**
-     * Validate the authentication for the given credentials with the specified authentication data.
      * This method is useful in one stage authn, if you're not doing one stage or if you're providing
      * your own state implementation for one stage authn, it should throw an exception.
      *
@@ -84,9 +58,7 @@ public interface AuthenticationProvider extends Closeable {
      * @return the "role" string for the authenticated connection, if the authentication was successful
      * @throws AuthenticationException
      *             if the credentials are not valid
-     * @deprecated use and implement {@link AuthenticationProvider#authenticateAsync(AuthenticationDataSource)} instead.
      */
-    @Deprecated
     default String authenticate(AuthenticationDataSource authData) throws AuthenticationException {
         throw new AuthenticationException("Not supported");
     }
@@ -102,37 +74,9 @@ public interface AuthenticationProvider extends Closeable {
     }
 
     /**
-     * Validate the authentication for the given credentials with the specified authentication data.
-     *
-     * <p>Warning: the calling thread is an IO thread. Any implementations that rely on blocking behavior
-     * must ensure that the execution is completed on using a separate thread pool to ensure IO threads
-     * are never blocked.</p>
-     *
-     * <p>Note: this method is marked as unstable because the Pulsar code base only calls it for the
-     * Pulsar Broker Auth SASL plugin. All non SASL HTTP requests are authenticated using the
-     * {@link AuthenticationProvider#authenticateAsync(AuthenticationDataSource)} method. As such,
-     * this method might be removed in favor of the SASL provider implementing the
-     * {@link AuthenticationProvider#authenticateAsync(AuthenticationDataSource)} method.</p>
-     *
-     * @return Set response, according to passed in request.
-     * and return whether we should do following chain.doFilter or not.
-     */
-    @InterfaceStability.Unstable
-    default CompletableFuture<Boolean> authenticateHttpRequestAsync(HttpServletRequest request,
-                                                                    HttpServletResponse response) {
-        try {
-            return CompletableFuture.completedFuture(this.authenticateHttpRequest(request, response));
-        } catch (Exception e) {
-            return FutureUtil.failedFuture(e);
-        }
-    }
-
-    /**
      * Set response, according to passed in request.
      * and return whether we should do following chain.doFilter or not.
-     * @deprecated use and implement {@link AuthenticationProvider#authenticateHttpRequestAsync} instead.
      */
-    @Deprecated
     default boolean authenticateHttpRequest(HttpServletRequest request, HttpServletResponse response) throws Exception {
         throw new AuthenticationException("Not supported");
     }

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authentication/AuthenticationState.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authentication/AuthenticationState.java
@@ -19,10 +19,8 @@
 
 package org.apache.pulsar.broker.authentication;
 
-import java.util.concurrent.CompletableFuture;
 import javax.naming.AuthenticationException;
 import org.apache.pulsar.common.api.AuthData;
-import org.apache.pulsar.common.util.FutureUtil;
 
 /**
  * Interface for authentication state.
@@ -40,36 +38,8 @@ public interface AuthenticationState {
 
     /**
      * Challenge passed in auth data and get response data.
-     * @deprecated use and implement {@link AuthenticationState#authenticateAsync(AuthData)} instead.
      */
-    @Deprecated
     AuthData authenticate(AuthData authData) throws AuthenticationException;
-
-    /**
-     * Challenge passed in auth data. If authentication is complete after the execution of this method, return null.
-     * Otherwise, return response data to be sent to the client.
-     *
-     * <p>Note: the implementation of {@link AuthenticationState#authenticate(AuthData)} converted a null result into a
-     * zero length byte array when {@link AuthenticationState#isComplete()} returned false after authentication. In
-     * order to simplify this interface, the determination of whether to send a challenge back to the client is only
-     * based on the result of this method. In order to maintain backwards compatibility, the default implementation of
-     * this method calls {@link AuthenticationState#isComplete()} and returns a result compliant with the new
-     * paradigm.</p>
-     */
-    default CompletableFuture<AuthData> authenticateAsync(AuthData authData) {
-        try {
-            AuthData result = this.authenticate(authData);
-            if (isComplete()) {
-                return CompletableFuture.completedFuture(null);
-            } else {
-                return result != null
-                        ? CompletableFuture.completedFuture(result)
-                        : CompletableFuture.completedFuture(AuthData.of(new byte[0]));
-            }
-        } catch (Exception e) {
-            return FutureUtil.failedFuture(e);
-        }
-    }
 
     /**
      * Return AuthenticationDataSource.
@@ -78,12 +48,7 @@ public interface AuthenticationState {
 
     /**
      * Whether the authentication is completed or not.
-     * @deprecated this method's logic is captured by the result of
-     * {@link AuthenticationState#authenticateAsync(AuthData)}. When the result is a {@link CompletableFuture} with a
-     * null result, authentication is complete. When the result is a {@link CompletableFuture} with a nonnull result,
-     * authentication is incomplete and requires an auth challenge.
      */
-    @Deprecated
     boolean isComplete();
 
     /**


### PR DESCRIPTION
…thentication Methods (#12104)"

This reverts commit 58680252b9c9d1be67474148130f0746d0feda6b.

Master Issue: https://github.com/apache/pulsar/issues/12105

### Motivation

Because the PIP is not completely implemented, we should not publish the interface changes in 2.10.

### Modifications

* Revert the core PR for PIP 97.

### Verifying this change

This change is trivial, because the original change was completely backwards compatible.

### Documentation

- [x] `no-need-doc` 
