### PR TITLE
Update .asf.yaml: keep stale reviews on PRs targeting master

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -73,7 +73,7 @@ github:
           - unit-tests
 
       required_pull_request_reviews:
-        dismiss_stale_reviews: true
+        dismiss_stale_reviews: false
         require_code_owner_reviews: true
         required_approving_review_count: 1
 


### PR DESCRIPTION
### Motivation

In https://github.com/apache/pulsar/pull/14226, I set this value to `true`. The previous setting was false.

Mailing list discussion: https://lists.apache.org/thread/0czyvl5csjnpcm0hvq4t8j2qxk2t2620

### Modifications

* Don't dismiss stale code reviews


