### PR TITLE
[functions] Add executor for CmdFunctions

### DIFF
--- a/pulsar-client-admin-api/src/main/java/org/apache/pulsar/common/functions/FunctionConfig.java
+++ b/pulsar-client-admin-api/src/main/java/org/apache/pulsar/common/functions/FunctionConfig.java
@@ -111,6 +111,7 @@ public class FunctionConfig {
     private String fqfn;
     private WindowConfig windowConfig;
     private Long timeoutMs;
+    private String executor;
     private String jar;
     private String py;
     private String go;

--- a/pulsar-client-tools-test/src/test/java/org/apache/pulsar/admin/cli/CmdFunctionsTest.java
+++ b/pulsar-client-tools-test/src/test/java/org/apache/pulsar/admin/cli/CmdFunctionsTest.java
@@ -321,6 +321,21 @@ public class CmdFunctionsTest {
     }
 
     @Test
+    public void testCreatePyFunctionWithExecutor() throws Exception {
+        cmd.run(new String[] {
+                "create",
+                "--executor", "python",
+                "--name", "test-py-function",
+                "--inputs", INPUT_TOPIC_NAME,
+                "--output", OUTPUT_TOPIC_NAME,
+                "--py", URL_WITH_PY,
+                "--tenant", "sample",
+                "--namespace", "ns1",
+                "--className", "process_python_function",
+        });
+    }
+
+    @Test
     public void testCreatePyFunctionWithFileUrl() throws Exception {
         cmd.run(new String[] {
                 "create",
@@ -639,6 +654,21 @@ public class CmdFunctionsTest {
         assertEquals(NAMESPACE, stateGetter.getNamespace());
         assertEquals(FN_NAME, stateGetter.getFunctionName());
         verify(functions, times(0)).getFunctionState(any(), any(), any(), any());
+    }
+
+    @Test
+    public void testCreateFunctionWithExecutor() throws Exception {
+        cmd.run(new String[] {
+                "create",
+                "--executor", "java",
+                "--name", FN_NAME,
+                "--inputs", INPUT_TOPIC_NAME,
+                "--output", OUTPUT_TOPIC_NAME,
+                "--jar", URL,
+                "--tenant", "sample",
+                "--namespace", "ns1",
+                "--className", DummyFunction.class.getName(),
+        });
     }
 
     @Test

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdFunctions.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdFunctions.java
@@ -198,6 +198,10 @@ public class CmdFunctions extends CmdBase {
         protected String deprecatedClassName;
         @Parameter(names = "--classname", description = "The class name of a Pulsar Function")
         protected String className;
+        @Parameter(names = "--executor", description = "Path to the executor for the function, "
+                + "if the function is written in Java, the default value is `java`,and if the function is "
+                + "written in Python, the default value is `python`")
+        protected String executor;
         @Parameter(names = "--jar", description = "Path to the JAR file for the function "
                 + "(if the function is written in Java). It also supports URL path [http/https/file "
                 + "(file protocol assumes that file already exists on worker host)/function "
@@ -617,6 +621,10 @@ public class CmdFunctions extends CmdBase {
                 functionConfig.setDeadLetterTopic(deadLetterTopic);
             }
 
+            if (null != executor) {
+                functionConfig.setExecutor(executor);
+            }
+
             if (null != jarFile) {
                 functionConfig.setJar(jarFile);
             }
@@ -657,6 +665,10 @@ public class CmdFunctions extends CmdBase {
             }
             if (StringUtils.isEmpty(functionConfig.getNamespace())) {
                 org.apache.pulsar.common.functions.Utils.inferMissingNamespace(functionConfig);
+            }
+
+            if (StringUtils.isEmpty(functionConfig.getExecutor())) {
+                org.apache.pulsar.common.functions.Utils.inferMissingExecutor(functionConfig);
             }
 
             if (isNotBlank(functionConfig.getJar()) && isNotBlank(functionConfig.getPy())

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/functions/Utils.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/functions/Utils.java
@@ -62,6 +62,14 @@ public class Utils {
         functionConfig.setNamespace(DEFAULT_NAMESPACE);
     }
 
+    public static void inferMissingExecutor(FunctionConfig functionConfig) {
+        if (functionConfig.getRuntime() == FunctionConfig.Runtime.JAVA) {
+            functionConfig.setExecutor("java");
+        } else if (functionConfig.getRuntime() == FunctionConfig.Runtime.PYTHON) {
+            functionConfig.setExecutor("python");
+        }
+    }
+
     public static void inferMissingArguments(SourceConfig sourceConfig) {
         if (sourceConfig.getTenant() == null) {
             sourceConfig.setTenant(PUBLIC_TENANT);

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/functions/Utils.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/functions/Utils.java
@@ -65,7 +65,8 @@ public class Utils {
     public static void inferMissingExecutor(FunctionConfig functionConfig) {
         if (functionConfig.getRuntime() == FunctionConfig.Runtime.JAVA) {
             functionConfig.setExecutor("java");
-        } else if (functionConfig.getRuntime() == FunctionConfig.Runtime.PYTHON) {
+        }
+        if (functionConfig.getRuntime() == FunctionConfig.Runtime.PYTHON) {
             functionConfig.setExecutor("python");
         }
     }

--- a/pulsar-functions/proto/src/main/proto/Function.proto
+++ b/pulsar-functions/proto/src/main/proto/Function.proto
@@ -88,6 +88,7 @@ message FunctionDetails {
     bool retainOrdering = 21;
     bool retainKeyOrdering = 22;
     SubscriptionPosition subscriptionPosition = 23;
+    string executor = 24;
 }
 
 message ConsumerSpec {

--- a/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/RuntimeUtils.java
+++ b/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/RuntimeUtils.java
@@ -284,8 +284,14 @@ public class RuntimeUtils {
             return getGoInstanceCmd(instanceConfig, originalCodeFileName, pulsarServiceUrl, k8sRuntime);
         }
 
+        String executor = instanceConfig.getFunctionDetails().getExecutor();
+
         if (instanceConfig.getFunctionDetails().getRuntime() == Function.FunctionDetails.Runtime.JAVA) {
-            args.add("java");
+            if (StringUtils.isNotEmpty(executor)) {
+                args.add(executor);
+            } else {
+                args.add("java");
+            }
             args.add("-cp");
 
             String classpath = instanceFile;
@@ -340,7 +346,11 @@ public class RuntimeUtils {
             args.add("--jar");
             args.add(originalCodeFileName);
         } else if (instanceConfig.getFunctionDetails().getRuntime() == Function.FunctionDetails.Runtime.PYTHON) {
-            args.add("python");
+            if (StringUtils.isNotEmpty(executor)) {
+                args.add(executor);
+            } else {
+                args.add("python");
+            }
             if (!isEmpty(instanceConfig.getFunctionDetails().getRuntimeFlags())) {
                 for (String runtimeFlagArg : splitRuntimeArgs(instanceConfig.getFunctionDetails().getRuntimeFlags())) {
                     args.add(runtimeFlagArg);
@@ -414,7 +424,7 @@ public class RuntimeUtils {
         }
         args.add("--max_buffered_tuples");
         args.add(String.valueOf(instanceConfig.getMaxBufferedTuples()));
-        
+
         args.add("--port");
         args.add(String.valueOf(grpcPort));
 
@@ -426,7 +436,7 @@ public class RuntimeUtils {
             args.add("--pending_async_requests");
             args.add(String.valueOf(instanceConfig.getMaxPendingAsyncRequests()));
         }
-        
+
         // state storage configs
         if (null != stateStorageServiceUrl) {
             args.add("--state_storage_serviceurl");

--- a/pulsar-functions/runtime/src/test/java/org/apache/pulsar/functions/runtime/process/ProcessRuntimeTest.java
+++ b/pulsar-functions/runtime/src/test/java/org/apache/pulsar/functions/runtime/process/ProcessRuntimeTest.java
@@ -180,6 +180,12 @@ public class ProcessRuntimeTest {
     FunctionDetails createFunctionDetails(FunctionDetails.Runtime runtime) {
         FunctionDetails.Builder functionDetailsBuilder = FunctionDetails.newBuilder();
         functionDetailsBuilder.setRuntime(runtime);
+        if (runtime == FunctionDetails.Runtime.JAVA) {
+            functionDetailsBuilder.setExecutor("java");
+        }
+        if (runtime == FunctionDetails.Runtime.PYTHON) {
+            functionDetailsBuilder.setExecutor("python");
+        }
         functionDetailsBuilder.setTenant(TEST_TENANT);
         functionDetailsBuilder.setNamespace(TEST_NAMESPACE);
         functionDetailsBuilder.setName(TEST_NAME);

--- a/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/FunctionConfigUtils.java
+++ b/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/FunctionConfigUtils.java
@@ -311,6 +311,11 @@ public class FunctionConfigUtils {
         } else {
             functionDetailsBuilder.setParallelism(1);
         }
+        if (functionConfig.getExecutor() != null) {
+            functionDetailsBuilder.setExecutor(functionConfig.getExecutor());
+        } else {
+            functionDetailsBuilder.setExecutor("");
+        }
 
         // use default resources if resources not set
         Resources resources = Resources.mergeWithDefault(functionConfig.getResources());
@@ -375,6 +380,7 @@ public class FunctionConfigUtils {
 
         functionConfig.setCleanupSubscription(functionDetails.getSource().getCleanupSubscription());
         functionConfig.setAutoAck(functionDetails.getAutoAck());
+        functionConfig.setExecutor(functionDetails.getExecutor());
 
         // Set subscription position
         functionConfig.setSubscriptionPosition(

--- a/pulsar-functions/utils/src/test/java/org/apache/pulsar/functions/utils/FunctionConfigUtilsTest.java
+++ b/pulsar-functions/utils/src/test/java/org/apache/pulsar/functions/utils/FunctionConfigUtilsTest.java
@@ -76,6 +76,7 @@ public class FunctionConfigUtilsTest {
         functionConfig.setForwardSourceMessageProperty(true);
         functionConfig.setUserConfig(new HashMap<>());
         functionConfig.setAutoAck(true);
+        functionConfig.setExecutor("java");
         functionConfig.setTimeoutMs(2000l);
         functionConfig.setRuntimeFlags("-DKerberos");
         ProducerConfig producerConfig = new ProducerConfig();
@@ -510,6 +511,7 @@ public class FunctionConfigUtilsTest {
         String namespace = "ns1";
         String tenant = "tenant1";
         String classname = getClass().getName();
+        String executor = "java";
         int parallelism = 3;
         Map<String, String> userConfig = new HashMap<>();
         userConfig.put("key1", "val1");
@@ -538,6 +540,7 @@ public class FunctionConfigUtilsTest {
                 .setTenant(tenant)
                 .setName(name)
                 .setClassName(classname)
+                .setExecutor(executor)
                 .setParallelism(parallelism)
                 .setUserConfig(new Gson().toJson(userConfig))
                 .setProcessingGuarantees(processingGuarantees)
@@ -557,6 +560,7 @@ public class FunctionConfigUtilsTest {
         assertEquals(functionConfig.getTenant(), tenant);
         assertEquals(functionConfig.getNamespace(), namespace);
         assertEquals(functionConfig.getName(), name);
+        assertEquals(functionConfig.getExecutor(), executor);
         assertEquals(functionConfig.getClassName(), classname);
         assertEquals(functionConfig.getLogTopic(), logTopic);
         assertEquals((Object) functionConfig.getResources().getCpu(), resources.getCpu());

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/functions/java/PulsarFunctionsJavaTest.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/functions/java/PulsarFunctionsJavaTest.java
@@ -43,7 +43,12 @@ public class PulsarFunctionsJavaTest extends PulsarFunctionsTest {
         testFunctionLocalRun(Runtime.JAVA);
     }
 
-   @Test(groups = {"java_function", "function"})
+    @Test(groups = {"java_function", "function"})
+    public void testJavaFunctionLocalRunWithExecutor() throws Exception {
+        testFunctionLocalRunWithExecutor(Runtime.JAVA, "java");
+    }
+
+    @Test(groups = {"java_function", "function"})
    public void testJavaFunctionNegAck() throws Exception {
        testFunctionNegAck(Runtime.JAVA);
    }

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/functions/python/PulsarFunctionsPythonTest.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/functions/python/PulsarFunctionsPythonTest.java
@@ -35,6 +35,11 @@ public class PulsarFunctionsPythonTest extends PulsarFunctionsTest {
     }
 
     @Test(groups = {"python_function", "function"})
+    public void testPythonFunctionLocalRunWithExecutor() throws Exception {
+        testFunctionLocalRunWithExecutor(Runtime.PYTHON, "python");
+    }
+
+    @Test(groups = {"python_function", "function"})
     public void testPythonFunctionNegAck() throws Exception {
         testFunctionNegAck(Runtime.PYTHON);
     }

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/functions/utils/CommandGenerator.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/functions/utils/CommandGenerator.java
@@ -217,6 +217,9 @@ public class CommandGenerator {
         if (subscriptionInitialPosition != null) {
             commandBuilder.append(" --subs-position " + subscriptionInitialPosition.name());
         }
+        if (executor != null) {
+            commandBuilder.append(" --executor " + executor);
+        }
 
         switch (runtime){
             case JAVA:

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/functions/utils/CommandGenerator.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/functions/utils/CommandGenerator.java
@@ -51,6 +51,7 @@ public class CommandGenerator {
     private String logTopic;
     private String outputSerDe;
     private String processingGuarantees;
+    private String executor;
     private Runtime runtime;
     private Integer parallelism;
     private String adminUrl;
@@ -99,8 +100,11 @@ public class CommandGenerator {
         if (functionName != null) {
             commandBuilder.append(" --name " + functionName);
         }
-        if(runtime != Runtime.GO){
+        if (runtime != Runtime.GO) {
             commandBuilder.append(" --className " + functionClassName);
+        }
+        if (executor != null) {
+            commandBuilder.append(" --executor " + executor);
         }
         if (StringUtils.isNotEmpty(sourceTopic)) {
             commandBuilder.append(" --inputs " + sourceTopic);


### PR DESCRIPTION
Fixes #14386 

### Motivation

In pulsar function, when the runtime is `Python` or `Java` , commands will start with `python` or `java`  
<img width="795" alt="image" src="https://user-images.githubusercontent.com/10069311/155286587-37d97742-b28a-4590-bb58-591166d11334.png">
This would be right in general, but sometimes  is not such as `/home/pulsar/jdk17/bin/java`, `python3` and `conda` `pyenv` python virutal env. We need to add a executor to let user to choose.

### Modifications

- Add `--executor` parameter to `CmdFunctions`.
- Add `executor` to `functions.proto`
- Replace `java` and `python` with executor

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change added tests and can be verified as follows:

  - *Extend unit tests for args which contains executor to be parsed*
  - *Added integration tests for function run with executor*

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API: (yes / **no**)
  - The schema: (yes / **no** / don't know)
  - The default values of configurations: (yes / **no**)
  - The wire protocol: (yes / **no**)
  - The rest endpoints: (yes / **no**)
  - **The admin cli options**: (**yes** / no)
  - Anything that affects deployment: (yes / **no** / don't know)

### Documentation

Need to update docs? 
  
- [x] `doc` 
  

