### PR TITLE
Fix ConsumerBuilderImpl#subscribeAsync blocks calling thread.

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBuilderImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBuilderImpl.java
@@ -126,13 +126,13 @@ public class ConsumerBuilderImpl<T> implements ConsumerBuilder<T> {
                     + RetryMessageUtil.RETRY_GROUP_TOPIC_SUFFIX;
             String oldDeadLetterTopic = topicFirst.getNamespace() + "/" + conf.getSubscriptionName()
                     + RetryMessageUtil.DLQ_GROUP_TOPIC_SUFFIX;
-            CompletableFuture<PartitionedTopicMetadata> retryLetterTopicMetadata =
-                    client.getPartitionedTopicMetadata(oldRetryLetterTopic);
-            CompletableFuture<PartitionedTopicMetadata> deadLetterTopicMetadata =
-                    client.getPartitionedTopicMetadata(oldDeadLetterTopic);
             DeadLetterPolicy deadLetterPolicy = conf.getDeadLetterPolicy();
             if (deadLetterPolicy == null || StringUtils.isBlank(deadLetterPolicy.getRetryLetterTopic())
                     || StringUtils.isBlank(deadLetterPolicy.getDeadLetterTopic())) {
+                CompletableFuture<PartitionedTopicMetadata> retryLetterTopicMetadata =
+                        client.getPartitionedTopicMetadata(oldRetryLetterTopic);
+                CompletableFuture<PartitionedTopicMetadata> deadLetterTopicMetadata =
+                        client.getPartitionedTopicMetadata(oldDeadLetterTopic);
                 applyDLQConfig = CompletableFuture.allOf(retryLetterTopicMetadata, deadLetterTopicMetadata)
                         .thenAccept(__ -> {
                             String retryLetterTopic = topicFirst + "-" + conf.getSubscriptionName()

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBuilderImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBuilderImpl.java
@@ -144,7 +144,6 @@ public class ConsumerBuilderImpl<T> implements ConsumerBuilder<T> {
                         if (metadata.partitions > 0) {
                             deadLetterTopic.set(oldDeadLetterTopic);
                         }
-                    }).thenAccept(__ -> {
                         if (conf.getDeadLetterPolicy() == null) {
                             conf.setDeadLetterPolicy(DeadLetterPolicy.builder()
                                     .maxRedeliverCount(RetryMessageUtil.MAX_RECONSUMETIMES)

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBuilderImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBuilderImpl.java
@@ -161,8 +161,8 @@ public class ConsumerBuilderImpl<T> implements ConsumerBuilder<T> {
                             }
                             conf.getTopicNames().add(conf.getDeadLetterPolicy().getRetryLetterTopic());
                         });
-
             } else {
+                conf.getTopicNames().add(conf.getDeadLetterPolicy().getRetryLetterTopic());
                 applyDLQConfig = CompletableFuture.completedFuture(null);
             }
         } else {

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBuilderImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBuilderImpl.java
@@ -25,9 +25,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import lombok.AccessLevel;
@@ -119,52 +118,59 @@ public class ConsumerBuilderImpl<T> implements ConsumerBuilder<T> {
             return FutureUtil.failedFuture(
                     new InvalidConfigurationException("KeySharedPolicy must set with KeyShared subscription"));
         }
+        CompletableFuture<Void> applyDLQConfig;
         if (conf.isRetryEnable() && conf.getTopicNames().size() > 0) {
             TopicName topicFirst = TopicName.get(conf.getTopicNames().iterator().next());
-            String retryLetterTopic =
-                    topicFirst + "-" + conf.getSubscriptionName() + RetryMessageUtil.RETRY_GROUP_TOPIC_SUFFIX;
-            String deadLetterTopic =
-                    topicFirst + "-" + conf.getSubscriptionName() + RetryMessageUtil.DLQ_GROUP_TOPIC_SUFFIX;
+            AtomicReference<String> retryLetterTopic =
+                    new AtomicReference<>(topicFirst + "-" + conf.getSubscriptionName()
+                            + RetryMessageUtil.RETRY_GROUP_TOPIC_SUFFIX);
+            AtomicReference<String> deadLetterTopic =
+                    new AtomicReference<>(topicFirst + "-" + conf.getSubscriptionName()
+                            + RetryMessageUtil.DLQ_GROUP_TOPIC_SUFFIX);
 
             //Issue 9327: do compatibility check in case of the default retry and dead letter topic name changed
             String oldRetryLetterTopic = topicFirst.getNamespace() + "/" + conf.getSubscriptionName()
                     + RetryMessageUtil.RETRY_GROUP_TOPIC_SUFFIX;
             String oldDeadLetterTopic = topicFirst.getNamespace() + "/" + conf.getSubscriptionName()
                     + RetryMessageUtil.DLQ_GROUP_TOPIC_SUFFIX;
-            try {
-                if (client.getPartitionedTopicMetadata(oldRetryLetterTopic)
-                        .get(client.conf.getOperationTimeoutMs(), TimeUnit.MILLISECONDS).partitions > 0) {
-                    retryLetterTopic = oldRetryLetterTopic;
-                }
-                if (client.getPartitionedTopicMetadata(oldDeadLetterTopic)
-                        .get(client.conf.getOperationTimeoutMs(), TimeUnit.MILLISECONDS).partitions > 0) {
-                    deadLetterTopic = oldDeadLetterTopic;
-                }
-            } catch (InterruptedException | TimeoutException e) {
-                return FutureUtil.failedFuture(e);
-            } catch (ExecutionException e) {
-                return FutureUtil.failedFuture(e.getCause());
-            }
-
-            if (conf.getDeadLetterPolicy() == null) {
-                conf.setDeadLetterPolicy(DeadLetterPolicy.builder()
-                                        .maxRedeliverCount(RetryMessageUtil.MAX_RECONSUMETIMES)
-                                        .retryLetterTopic(retryLetterTopic)
-                                        .deadLetterTopic(deadLetterTopic)
-                                        .build());
-            } else {
-                if (StringUtils.isBlank(conf.getDeadLetterPolicy().getRetryLetterTopic())) {
-                    conf.getDeadLetterPolicy().setRetryLetterTopic(retryLetterTopic);
-                }
-                if (StringUtils.isBlank(conf.getDeadLetterPolicy().getDeadLetterTopic())) {
-                    conf.getDeadLetterPolicy().setDeadLetterTopic(deadLetterTopic);
-                }
-            }
-            conf.getTopicNames().add(conf.getDeadLetterPolicy().getRetryLetterTopic());
+            applyDLQConfig = client.getPartitionedTopicMetadata(oldRetryLetterTopic)
+                    .thenAccept(metadata -> {
+                        if (metadata.partitions > 0) {
+                            retryLetterTopic.set(oldRetryLetterTopic);
+                        }
+                    })
+                    .thenCompose(__ -> client.getPartitionedTopicMetadata(oldDeadLetterTopic))
+                    .thenAccept(metadata -> {
+                        if (metadata.partitions > 0) {
+                            deadLetterTopic.set(oldDeadLetterTopic);
+                        }
+                    }).thenAccept(__ -> {
+                        if (conf.getDeadLetterPolicy() == null) {
+                            conf.setDeadLetterPolicy(DeadLetterPolicy.builder()
+                                    .maxRedeliverCount(RetryMessageUtil.MAX_RECONSUMETIMES)
+                                    .retryLetterTopic(retryLetterTopic.get())
+                                    .deadLetterTopic(deadLetterTopic.get())
+                                    .build());
+                        } else {
+                            if (StringUtils.isBlank(conf.getDeadLetterPolicy().getRetryLetterTopic())) {
+                                conf.getDeadLetterPolicy().setRetryLetterTopic(retryLetterTopic.get());
+                            }
+                            if (StringUtils.isBlank(conf.getDeadLetterPolicy().getDeadLetterTopic())) {
+                                conf.getDeadLetterPolicy().setDeadLetterTopic(deadLetterTopic.get());
+                            }
+                        }
+                        conf.getTopicNames().add(conf.getDeadLetterPolicy().getRetryLetterTopic());
+                    });
+        } else {
+            applyDLQConfig = CompletableFuture.completedFuture(null);
         }
-        return interceptorList == null || interceptorList.size() == 0
-                ? client.subscribeAsync(conf, schema, null)
-                : client.subscribeAsync(conf, schema, new ConsumerInterceptors<>(interceptorList));
+        return applyDLQConfig.thenCompose(__ -> {
+            if (interceptorList == null || interceptorList.size() == 0) {
+                return client.subscribeAsync(conf, schema, null);
+            } else {
+                return client.subscribeAsync(conf, schema, new ConsumerInterceptors<>(interceptorList));
+            }
+        });
     }
 
     @Override


### PR DESCRIPTION
Fixes #14413

### Motivation

When Retry topics are enabled, ConsumerBuilderImpl performs a backwards-compatibility check to look for DLQ or Retry topics that were created on previous version of Pulsar using a different naming scheme.

It does this by calling `getPartitionedTopicMetadata` and then using `.get()` to block while waiting for the results

```java
if (client.getPartitionedTopicMetadata(oldRetryLetterTopic)
        .get(client.conf.getOperationTimeoutMs(), TimeUnit.MILLISECONDS).partitions > 0) {
    retryLetterTopic = oldRetryLetterTopic;
}
if (client.getPartitionedTopicMetadata(oldDeadLetterTopic)
        .get(client.conf.getOperationTimeoutMs(), TimeUnit.MILLISECONDS).partitions > 0) {
    deadLetterTopic = oldDeadLetterTopic;
}
```

This was implemented in https://github.com/apache/pulsar/pull/10129
A partial fix to add a Timeout was implemented in https://github.com/apache/pulsar/pull/11597

However this fix does still block the calling thread during the lookup.

This can be an issue for code that attempt to call `subscribeAsync` on a non-blocking Pool (such as when using Netty). The signature of `subscribeAsync` implies that it's non-blocking. (And it seems somewhat pointless to have `subscribeAsync` if it blocks anyway)

Note that this is an undocumented *breaking* change in behavior. Up until 2.9, it was safe to call this from a non-blocking pool.

In our case, we were running a custom SLF4J log exporter on the same thread pool, which resulted in a *deadlock* when the number of concurrent `subscribeAsync` calls exceeded the pool size. (This is probably an extreme example and a poor decision on our part, but perhaps a good example of why unexpected blocking can be dangerous)

Note that blocking call is still made even if the retry and DLQ names are explicitly specified in DeadLetterPolicy. In that scenario the check should not be needed. Aside from blocking the calling Thread, this also results in unneeded lookup requests.

### Modifications

- Make retry and DLQ metadata async.

### Documentation

- [x] `no-need-doc` 



