### PR TITLE
[pulsar-admin] Change Exception to ParameterException in schemas cmd

### DIFF
--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdSchemas.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdSchemas.java
@@ -144,7 +144,7 @@ public class CmdSchemas extends CmdBase {
                 input.setType("JSON");
                 input.setSchema(SchemaExtractor.getJsonSchemaInfo(schemaDefinition));
             } else {
-                throw new Exception("Unknown schema type specified as type");
+                throw new ParameterException("Invalid schema type " + type + ". Valid options are: avro, json");
             }
             input.setProperties(schemaDefinition.getProperties());
             if (dryRun) {

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/cli/CLITest.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/cli/CLITest.java
@@ -336,6 +336,20 @@ public class CLITest extends PulsarTestSuite {
         } catch (ContainerExecException e) {
             assertTrue(e.getResult().getStderr().contains("Schema not found"));
         }
+
+        try {
+            container.execCmd(
+                    PulsarCluster.ADMIN_SCRIPT,
+                    "schemas",
+                    "extract",
+                    "--jar", "/pulsar/examples/api-examples.jar",
+                    "--type", "xml",
+                    "--classname", "org.apache.pulsar.functions.api.examples.pojo.Tick",
+                    topicName);
+            fail("Command should have exited with non-zero");
+        } catch (ContainerExecException e) {
+            assertEquals(e.getResult().getStderr(), "Invalid schema type xml. Valid options are: avro, json\n\n");
+        }
     }
 
     @Test


### PR DESCRIPTION
### Motivation
Change `Exception` to `ParameterException` in schemas cmd, which will only show error message to the user instead of stack information.

The similar PRs include #14388 and #14385.

### Documentation
- [x] `no-need-doc` 


