### PR TITLE
Remove unused placeholder for warn log

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/TableViewImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/TableViewImpl.java
@@ -105,7 +105,7 @@ public class TableViewImpl<T> implements TableView<T> {
 
         start().whenComplete((tw, ex) -> {
            if (ex != null) {
-               log.warn("Failed to check for changes in number of partitions: {}", ex);
+               log.warn("Failed to check for changes in number of partitions:", ex);
                schedulePartitionsCheck();
            }
         });


### PR DESCRIPTION
### Motivation
We shouldn't add a placeholder for exception since the warn method's second parameter is Throwable type.

See `public void warn(String msg, Throwable t);`

### Documentation

Need to update docs? 

- [x] `no-need-doc` 


