### PR TITLE
Fix switchBackDelayNs failure problem in class of  AutoClusterFailover

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/AutoClusterFailover.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/AutoClusterFailover.java
@@ -105,8 +105,10 @@ public class AutoClusterFailover implements ServiceUrlProvider {
                 probeAndUpdateServiceUrl(primary, primaryAuthentication, primaryTlsTrustCertsFilePath,
                         primaryTlsTrustStorePath, primaryTlsTrustStorePassword);
                 // secondary cluster is up, check whether need to switch back to primary or not
-                probeAndCheckSwitchBack(primary, primaryAuthentication, primaryTlsTrustCertsFilePath,
-                        primaryTlsTrustStorePath, primaryTlsTrustStorePassword);
+                if (!currentPulsarServiceUrl.equals(primary)) {
+                    probeAndCheckSwitchBack(primary, primaryAuthentication, primaryTlsTrustCertsFilePath,
+                            primaryTlsTrustStorePath, primaryTlsTrustStorePassword);
+                }
             }
         }), intervalMs, intervalMs, TimeUnit.MILLISECONDS);
 

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/AutoClusterFailoverTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/AutoClusterFailoverTest.java
@@ -33,6 +33,7 @@ import org.mockito.Mockito;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 
 @Test(groups = "broker-impl")
@@ -96,6 +97,49 @@ public class AutoClusterFailoverTest {
         Assert.assertEquals(secondaryTlsTrustCertsFilePath,
                 autoClusterFailover1.getSecondaryTlsTrustCertsFilePaths().get(secondary));
         Assert.assertEquals(secondaryAuthentication, autoClusterFailover1.getSecondaryAuthentications().get(secondary));
+    }
+
+    @Test
+    public void testInitialize() {
+        String primary = "pulsar://localhost:6650";
+        String secondary = "pulsar://localhost:6651";
+        long failoverDelay = 10;
+        long switchBackDelay = 10;
+        long checkInterval = 1_000;
+
+        ClientConfigurationData configurationData = new ClientConfigurationData();
+
+        ServiceUrlProvider provider = AutoClusterFailover.builder()
+                .primary(primary)
+                .secondary(Collections.singletonList(secondary))
+                .failoverDelay(failoverDelay, TimeUnit.MILLISECONDS)
+                .switchBackDelay(switchBackDelay, TimeUnit.MILLISECONDS)
+                .checkInterval(checkInterval, TimeUnit.MILLISECONDS)
+                .build();
+
+        AutoClusterFailover autoClusterFailover = Mockito.spy((AutoClusterFailover) provider);
+        PulsarClientImpl pulsarClient = mock(PulsarClientImpl.class);
+        Mockito.doReturn(false).when(autoClusterFailover).probeAvailable(primary);
+        Mockito.doReturn(true).when(autoClusterFailover).probeAvailable(secondary);
+        Mockito.doReturn(configurationData).when(pulsarClient).getConfiguration();
+
+        autoClusterFailover.initialize(pulsarClient);
+
+
+        for (int i = 0; i < 1000; i++) {
+            Awaitility.await().untilAsserted(() ->
+                    Assert.assertEquals(secondary, autoClusterFailover.getServiceUrl()));
+
+            // primary cluster came back
+            Mockito.doReturn(true).when(autoClusterFailover).probeAvailable(primary);
+            Awaitility.await().untilAsserted(() ->
+                    Assert.assertEquals(primary, autoClusterFailover.getServiceUrl()));
+            if (autoClusterFailover.getCurrentPulsarServiceUrl().equals(primary)) {
+                assertTrue(autoClusterFailover.getRecoverTimestamp() == -1);
+            }
+
+            Mockito.doReturn(false).when(autoClusterFailover).probeAvailable(primary);
+        }
     }
 
     @Test

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/AutoClusterFailoverTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/AutoClusterFailoverTest.java
@@ -34,7 +34,6 @@ import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 
 @Test(groups = "broker-impl")

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/AutoClusterFailoverTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/AutoClusterFailoverTest.java
@@ -128,14 +128,14 @@ public class AutoClusterFailoverTest {
         for (int i = 0; i < 2; i++) {
             Awaitility.await().untilAsserted(() ->
                     Assert.assertEquals(secondary, autoClusterFailover.getServiceUrl()));
-            assertEquals(autoClusterFailover.getFailedTimestamp(), -1);
+            assertEquals(-1, autoClusterFailover.getFailedTimestamp());
 
             // primary cluster came back
             Mockito.doReturn(true).when(autoClusterFailover).probeAvailable(primary);
             Awaitility.await().untilAsserted(() ->
                     Assert.assertEquals(primary, autoClusterFailover.getServiceUrl()));
-            assertEquals(autoClusterFailover.getRecoverTimestamp(), -1);
-            assertEquals(autoClusterFailover.getFailedTimestamp(), -1);
+            assertEquals(-1, autoClusterFailover.getRecoverTimestamp());
+            assertEquals(-1, autoClusterFailover.getFailedTimestamp());
 
             Mockito.doReturn(false).when(autoClusterFailover).probeAvailable(primary);
         }

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/AutoClusterFailoverTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/AutoClusterFailoverTest.java
@@ -33,6 +33,7 @@ import org.mockito.Mockito;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 
@@ -128,13 +129,14 @@ public class AutoClusterFailoverTest {
         for (int i = 0; i < 2; i++) {
             Awaitility.await().untilAsserted(() ->
                     Assert.assertEquals(secondary, autoClusterFailover.getServiceUrl()));
+            assertEquals(autoClusterFailover.getFailedTimestamp(), -1);
 
             // primary cluster came back
             Mockito.doReturn(true).when(autoClusterFailover).probeAvailable(primary);
             Awaitility.await().untilAsserted(() ->
                     Assert.assertEquals(primary, autoClusterFailover.getServiceUrl()));
-            assertTrue(autoClusterFailover.getRecoverTimestamp() == -1);
-            assertTrue(autoClusterFailover.getFailedTimestamp() == -1);
+            assertEquals(autoClusterFailover.getRecoverTimestamp(), -1);
+            assertEquals(autoClusterFailover.getFailedTimestamp(), -1);
 
             Mockito.doReturn(false).when(autoClusterFailover).probeAvailable(primary);
         }

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/AutoClusterFailoverTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/AutoClusterFailoverTest.java
@@ -125,7 +125,6 @@ public class AutoClusterFailoverTest {
 
         autoClusterFailover.initialize(pulsarClient);
 
-
         for (int i = 0; i < 2; i++) {
             Awaitility.await().untilAsserted(() ->
                     Assert.assertEquals(secondary, autoClusterFailover.getServiceUrl()));
@@ -134,9 +133,8 @@ public class AutoClusterFailoverTest {
             Mockito.doReturn(true).when(autoClusterFailover).probeAvailable(primary);
             Awaitility.await().untilAsserted(() ->
                     Assert.assertEquals(primary, autoClusterFailover.getServiceUrl()));
-            if (autoClusterFailover.getCurrentPulsarServiceUrl().equals(primary)) {
-                assertTrue(autoClusterFailover.getRecoverTimestamp() == -1);
-            }
+            assertTrue(autoClusterFailover.getRecoverTimestamp() == -1);
+            assertTrue(autoClusterFailover.getFailedTimestamp() == -1);
 
             Mockito.doReturn(false).when(autoClusterFailover).probeAvailable(primary);
         }

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/AutoClusterFailoverTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/AutoClusterFailoverTest.java
@@ -126,7 +126,7 @@ public class AutoClusterFailoverTest {
         autoClusterFailover.initialize(pulsarClient);
 
 
-        for (int i = 0; i < 1000; i++) {
+        for (int i = 0; i < 2; i++) {
             Awaitility.await().untilAsserted(() ->
                     Assert.assertEquals(secondary, autoClusterFailover.getServiceUrl()));
 


### PR DESCRIPTION

### Motivation

Consider such a bad case:
1. When the following line of code is executed, switch secondary to primary:
https://github.com/apache/pulsar/blob/ced57866700aaeae163bcc6670d9a8eb1ffe8c50/pulsar-client/src/main/java/org/apache/pulsar/client/impl/AutoClusterFailover.java#L104-L106
2. The currentPulsarServiceUrl at this time is primary, and then the probeAndCheckSwitchBack method is executed immediately, in which the recoverTimestamp timestamp will be updated:
https://github.com/apache/pulsar/blob/ced57866700aaeae163bcc6670d9a8eb1ffe8c50/pulsar-client/src/main/java/org/apache/pulsar/client/impl/AutoClusterFailover.java#L248-L250
3. When the primary is switched to the secondary again and the probeAndCheckSwitchBack method is executed, the switchBackDelayNs parameter will be invalid, because the recoverTimestamp has been updated again and is no longer equal to -1;

So we need to judge currentPulsarServiceUrl.equals(primary) again before executing probeAndCheckSwitchBack();


### Documentation

Check the box below or label this PR directly (if you have committer privilege).

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)


