### PR TITLE
[Doc] ZooKeeper stats port correction since 2.8.0

### DIFF
--- a/site2/docs/deploy-monitoring.md
+++ b/site2/docs/deploy-monitoring.md
@@ -43,7 +43,7 @@ http://$LOCAL_ZK_SERVER:8000/metrics
 http://$GLOBAL_ZK_SERVER:8001/metrics
 ```
 
-The default port of local ZooKeeper is `8000` and the default port of configuration store is `8001`. You can change the default port of local ZooKeeper and configuration store by specifying system property `stats_server_port`.
+The default port of local ZooKeeper is `8000` and the default port of configuration store is `8001`. You can use a different stats port by configuring `metricsProvider.httpPort` in the `conf/zookeeper.conf` file.
 
 ### BookKeeper stats
 

--- a/site2/docs/deploy-monitoring.md
+++ b/site2/docs/deploy-monitoring.md
@@ -43,7 +43,7 @@ http://$LOCAL_ZK_SERVER:8000/metrics
 http://$GLOBAL_ZK_SERVER:8001/metrics
 ```
 
-The default port of local ZooKeeper is `8000` and the default port of configuration store is `8001`. You can use a different stats port by configuring `metricsProvider.httpPort` in the `conf/zookeeper.conf` file.
+The default port of local ZooKeeper is `8000` and the default port of the configuration store is `8001`. You can use a different stats port by configuring `metricsProvider.httpPort` in the `conf/zookeeper.conf` file.
 
 ### BookKeeper stats
 

--- a/site2/website/versioned_docs/version-2.8.0/deploy-monitoring.md
+++ b/site2/website/versioned_docs/version-2.8.0/deploy-monitoring.md
@@ -44,7 +44,7 @@ http://$LOCAL_ZK_SERVER:8000/metrics
 http://$GLOBAL_ZK_SERVER:8001/metrics
 ```
 
-The default port of local ZooKeeper is `8000` and the default port of configuration store is `8001`. You can change the default port of local ZooKeeper and configuration store by specifying system property `stats_server_port`.
+The default port of local ZooKeeper is `8000` and the default port of the configuration store is `8001`. You can use a different stats port by configuring `metricsProvider.httpPort` in the `conf/zookeeper.conf` file.
 
 ### BookKeeper stats
 

--- a/site2/website/versioned_docs/version-2.8.1/deploy-monitoring.md
+++ b/site2/website/versioned_docs/version-2.8.1/deploy-monitoring.md
@@ -44,7 +44,7 @@ http://$LOCAL_ZK_SERVER:8000/metrics
 http://$GLOBAL_ZK_SERVER:8001/metrics
 ```
 
-The default port of local ZooKeeper is `8000` and the default port of configuration store is `8001`. You can change the default port of local ZooKeeper and configuration store by specifying system property `stats_server_port`.
+The default port of local ZooKeeper is `8000` and the default port of the configuration store is `8001`. You can use a different stats port by configuring `metricsProvider.httpPort` in the `conf/zookeeper.conf` file.
 
 ### BookKeeper stats
 

--- a/site2/website/versioned_docs/version-2.8.2/deploy-monitoring.md
+++ b/site2/website/versioned_docs/version-2.8.2/deploy-monitoring.md
@@ -44,7 +44,7 @@ http://$LOCAL_ZK_SERVER:8000/metrics
 http://$GLOBAL_ZK_SERVER:8001/metrics
 ```
 
-The default port of local ZooKeeper is `8000` and the default port of configuration store is `8001`. You can change the default port of local ZooKeeper and configuration store by specifying system property `stats_server_port`.
+The default port of local ZooKeeper is `8000` and the default port of the configuration store is `8001`. You can use a different stats port by configuring `metricsProvider.httpPort` in the `conf/zookeeper.conf` file.
 
 ### BookKeeper stats
 

--- a/site2/website/versioned_docs/version-2.9.0/deploy-monitoring.md
+++ b/site2/website/versioned_docs/version-2.9.0/deploy-monitoring.md
@@ -44,7 +44,7 @@ http://$LOCAL_ZK_SERVER:8000/metrics
 http://$GLOBAL_ZK_SERVER:8001/metrics
 ```
 
-The default port of local ZooKeeper is `8000` and the default port of configuration store is `8001`. You can change the default port of local ZooKeeper and configuration store by specifying system property `stats_server_port`.
+The default port of local ZooKeeper is `8000` and the default port of the configuration store is `8001`. You can use a different stats port by configuring `metricsProvider.httpPort` in the `conf/zookeeper.conf` file.
 
 ### BookKeeper stats
 

--- a/site2/website/versioned_docs/version-2.9.1/deploy-monitoring.md
+++ b/site2/website/versioned_docs/version-2.9.1/deploy-monitoring.md
@@ -44,7 +44,7 @@ http://$LOCAL_ZK_SERVER:8000/metrics
 http://$GLOBAL_ZK_SERVER:8001/metrics
 ```
 
-The default port of local ZooKeeper is `8000` and the default port of configuration store is `8001`. You can change the default port of local ZooKeeper and configuration store by specifying system property `stats_server_port`.
+The default port of local ZooKeeper is `8000` and the default port of the configuration store is `8001`. You can use a different stats port by configuring `metricsProvider.httpPort` in the `conf/zookeeper.conf` file.
 
 ### BookKeeper stats
 


### PR DESCRIPTION
### Modifications

Fix #14423 

As per https://github.com/apache/pulsar/issues/11467, ZooKeeper starts to use an internal Prometheus metric provider since 3.6.0.

Modify the document (https://pulsar.apache.org/docs/en/2.8.0/deploy-monitoring/#zookeeper-stats) to replace the previous config `stats_server_port` with `metricsProvider.httpPort` in the `conf/zookeeper.conf` file for configuring a different stats port.

Note this change will be applied to more historical doc versions since 2.8.0.


### Documentation

- [x] `doc` 
  

