### PR TITLE
[Doc] Update the support of hostname verification in different clients

### DIFF
--- a/site2/docs/security-tls-transport.md
+++ b/site2/docs/security-tls-transport.md
@@ -178,7 +178,7 @@ Moreover, as the administrator has full control of the certificate authority, a 
 
 One scenario where you may want to enable hostname verification is where you have multiple proxy nodes behind a VIP, and the VIP has a DNS record, for example, pulsar.mycompany.com. In this case, you can generate a TLS cert with pulsar.mycompany.com as the "CommonName," and then enable hostname verification on the client.
 
-The examples below show that hostname verification are disabled for the CLI tools/Java/Python/C++/Node.js/C# clients by default. 
+The examples below show that hostname verification is disabled for the CLI tools/Java/Python/C++/Node.js/C# clients by default. 
 
 ### CLI tools
 

--- a/site2/docs/security-tls-transport.md
+++ b/site2/docs/security-tls-transport.md
@@ -178,7 +178,7 @@ Moreover, as the administrator has full control of the certificate authority, a 
 
 One scenario where you may want to enable hostname verification is where you have multiple proxy nodes behind a VIP, and the VIP has a DNS record, for example, pulsar.mycompany.com. In this case, you can generate a TLS cert with pulsar.mycompany.com as the "CommonName," and then enable hostname verification on the client.
 
-The examples below show hostname verification being disabled for the Java client, though you can omit this as the client disables the hostname verification by default. C++/python/Node.js clients do now allow configuring this at the moment.
+The examples below show that hostname verification are disabled for the CLI tools/Java/Python/C++/Node.js/C# clients by default. 
 
 ### CLI tools
 
@@ -215,7 +215,7 @@ PulsarClient client = PulsarClient.builder()
 from pulsar import Client
 
 client = Client("pulsar+ssl://broker.example.com:6651/",
-                tls_hostname_verification=True,
+                tls_hostname_verification=False,
                 tls_trust_certs_file_path="/path/to/ca.cert.pem",
                 tls_allow_insecure_connection=False) // defaults to false from v2.2.0 onwards
 ```
@@ -230,7 +230,7 @@ config.setUseTls(true);  // shouldn't be needed soon
 config.setTlsTrustCertsFilePath(caPath);
 config.setTlsAllowInsecureConnection(false);
 config.setAuth(pulsar::AuthTls::create(clientPublicKeyPath, clientPrivateKeyPath));
-config.setValidateHostName(true);
+config.setValidateHostName(false);
 ```
 
 #### Node.js client
@@ -242,6 +242,9 @@ const Pulsar = require('pulsar-client');
   const client = new Pulsar.Client({
     serviceUrl: 'pulsar+ssl://broker.example.com:6651/',
     tlsTrustCertsFilePath: '/path/to/ca.cert.pem',
+    useTls: true,
+    tlsValidateHostname: false,
+    tlsAllowInsecureConnection: false,
   });
 })();
 ```
@@ -256,3 +259,4 @@ var client = PulsarClient.Builder()
                          .VerifyCertificateName(false)     //Default is 'false'
                          .Build();
 ```
+> Note that `VerifyCertificateName` refers to the configuration of hostname verification in the C# client.

--- a/site2/website/versioned_docs/version-2.7.0/security-tls-transport.md
+++ b/site2/website/versioned_docs/version-2.7.0/security-tls-transport.md
@@ -177,7 +177,7 @@ Moreover, as the administrator has full control of the certificate authority, a 
 
 One scenario where you may want to enable hostname verification is where you have multiple proxy nodes behind a VIP, and the VIP has a DNS record, for example, pulsar.mycompany.com. In this case, you can generate a TLS cert with pulsar.mycompany.com as the "CommonName," and then enable hostname verification on the client.
 
-The examples below show hostname verification being disabled for the Java client, though you can omit this as the client disables the hostname verification by default. C++/python/Node.js clients do now allow configuring this at the moment.
+The examples below show that hostname verification is disabled for the CLI tools/Java/Python/C++/Node.js/C# clients by default. 
 
 ### CLI tools
 
@@ -214,7 +214,7 @@ PulsarClient client = PulsarClient.builder()
 from pulsar import Client
 
 client = Client("pulsar+ssl://broker.example.com:6651/",
-                tls_hostname_verification=True,
+                tls_hostname_verification=False,
                 tls_trust_certs_file_path="/path/to/ca.cert.pem",
                 tls_allow_insecure_connection=False) // defaults to false from v2.2.0 onwards
 ```
@@ -229,7 +229,7 @@ config.setUseTls(true);  // shouldn't be needed soon
 config.setTlsTrustCertsFilePath(caPath);
 config.setTlsAllowInsecureConnection(false);
 config.setAuth(pulsar::AuthTls::create(clientPublicKeyPath, clientPrivateKeyPath));
-config.setValidateHostName(true);
+config.setValidateHostName(false);
 ```
 
 #### Node.js client
@@ -241,6 +241,9 @@ const Pulsar = require('pulsar-client');
   const client = new Pulsar.Client({
     serviceUrl: 'pulsar+ssl://broker.example.com:6651/',
     tlsTrustCertsFilePath: '/path/to/ca.cert.pem',
+    useTls: true,
+    tlsValidateHostname: false,
+    tlsAllowInsecureConnection: false,
   });
 })();
 ```
@@ -255,3 +258,4 @@ var client = PulsarClient.Builder()
                          .VerifyCertificateName(false)     //Default is 'false'
                          .Build();
 ```
+> Note that `VerifyCertificateName` refers to the configuration of hostname verification in the C# client.

--- a/site2/website/versioned_docs/version-2.7.1/security-tls-transport.md
+++ b/site2/website/versioned_docs/version-2.7.1/security-tls-transport.md
@@ -177,7 +177,7 @@ Moreover, as the administrator has full control of the certificate authority, a 
 
 One scenario where you may want to enable hostname verification is where you have multiple proxy nodes behind a VIP, and the VIP has a DNS record, for example, pulsar.mycompany.com. In this case, you can generate a TLS cert with pulsar.mycompany.com as the "CommonName," and then enable hostname verification on the client.
 
-The examples below show hostname verification being disabled for the Java client, though you can omit this as the client disables the hostname verification by default. C++/python/Node.js clients do now allow configuring this at the moment.
+The examples below show that hostname verification is disabled for the CLI tools/Java/Python/C++/Node.js/C# clients by default. 
 
 ### CLI tools
 
@@ -214,7 +214,7 @@ PulsarClient client = PulsarClient.builder()
 from pulsar import Client
 
 client = Client("pulsar+ssl://broker.example.com:6651/",
-                tls_hostname_verification=True,
+                tls_hostname_verification=False,
                 tls_trust_certs_file_path="/path/to/ca.cert.pem",
                 tls_allow_insecure_connection=False) // defaults to false from v2.2.0 onwards
 ```
@@ -229,7 +229,7 @@ config.setUseTls(true);  // shouldn't be needed soon
 config.setTlsTrustCertsFilePath(caPath);
 config.setTlsAllowInsecureConnection(false);
 config.setAuth(pulsar::AuthTls::create(clientPublicKeyPath, clientPrivateKeyPath));
-config.setValidateHostName(true);
+config.setValidateHostName(false);
 ```
 
 #### Node.js client
@@ -241,6 +241,9 @@ const Pulsar = require('pulsar-client');
   const client = new Pulsar.Client({
     serviceUrl: 'pulsar+ssl://broker.example.com:6651/',
     tlsTrustCertsFilePath: '/path/to/ca.cert.pem',
+    useTls: true,
+    tlsValidateHostname: false,
+    tlsAllowInsecureConnection: false,
   });
 })();
 ```
@@ -255,3 +258,4 @@ var client = PulsarClient.Builder()
                          .VerifyCertificateName(false)     //Default is 'false'
                          .Build();
 ```
+> Note that `VerifyCertificateName` refers to the configuration of hostname verification in the C# client.

--- a/site2/website/versioned_docs/version-2.7.2/security-tls-transport.md
+++ b/site2/website/versioned_docs/version-2.7.2/security-tls-transport.md
@@ -177,7 +177,7 @@ Moreover, as the administrator has full control of the certificate authority, a 
 
 One scenario where you may want to enable hostname verification is where you have multiple proxy nodes behind a VIP, and the VIP has a DNS record, for example, pulsar.mycompany.com. In this case, you can generate a TLS cert with pulsar.mycompany.com as the "CommonName," and then enable hostname verification on the client.
 
-The examples below show hostname verification being disabled for the Java client, though you can omit this as the client disables the hostname verification by default. C++/python/Node.js clients do now allow configuring this at the moment.
+The examples below show that hostname verification is disabled for the CLI tools/Java/Python/C++/Node.js/C# clients by default. 
 
 ### CLI tools
 
@@ -214,7 +214,7 @@ PulsarClient client = PulsarClient.builder()
 from pulsar import Client
 
 client = Client("pulsar+ssl://broker.example.com:6651/",
-                tls_hostname_verification=True,
+                tls_hostname_verification=False,
                 tls_trust_certs_file_path="/path/to/ca.cert.pem",
                 tls_allow_insecure_connection=False) // defaults to false from v2.2.0 onwards
 ```
@@ -229,7 +229,7 @@ config.setUseTls(true);  // shouldn't be needed soon
 config.setTlsTrustCertsFilePath(caPath);
 config.setTlsAllowInsecureConnection(false);
 config.setAuth(pulsar::AuthTls::create(clientPublicKeyPath, clientPrivateKeyPath));
-config.setValidateHostName(true);
+config.setValidateHostName(false);
 ```
 
 #### Node.js client
@@ -241,6 +241,9 @@ const Pulsar = require('pulsar-client');
   const client = new Pulsar.Client({
     serviceUrl: 'pulsar+ssl://broker.example.com:6651/',
     tlsTrustCertsFilePath: '/path/to/ca.cert.pem',
+    useTls: true,
+    tlsValidateHostname: false,
+    tlsAllowInsecureConnection: false,
   });
 })();
 ```
@@ -255,3 +258,4 @@ var client = PulsarClient.Builder()
                          .VerifyCertificateName(false)     //Default is 'false'
                          .Build();
 ```
+> Note that `VerifyCertificateName` refers to the configuration of hostname verification in the C# client.

--- a/site2/website/versioned_docs/version-2.7.3/security-tls-transport.md
+++ b/site2/website/versioned_docs/version-2.7.3/security-tls-transport.md
@@ -177,7 +177,7 @@ Moreover, as the administrator has full control of the certificate authority, a 
 
 One scenario where you may want to enable hostname verification is where you have multiple proxy nodes behind a VIP, and the VIP has a DNS record, for example, pulsar.mycompany.com. In this case, you can generate a TLS cert with pulsar.mycompany.com as the "CommonName," and then enable hostname verification on the client.
 
-The examples below show hostname verification being disabled for the Java client, though you can omit this as the client disables the hostname verification by default. C++/python/Node.js clients do now allow configuring this at the moment.
+The examples below show that hostname verification is disabled for the CLI tools/Java/Python/C++/Node.js/C# clients by default.
 
 ### CLI tools
 
@@ -214,7 +214,7 @@ PulsarClient client = PulsarClient.builder()
 from pulsar import Client
 
 client = Client("pulsar+ssl://broker.example.com:6651/",
-                tls_hostname_verification=True,
+                tls_hostname_verification=False,
                 tls_trust_certs_file_path="/path/to/ca.cert.pem",
                 tls_allow_insecure_connection=False) // defaults to false from v2.2.0 onwards
 ```
@@ -229,7 +229,7 @@ config.setUseTls(true);  // shouldn't be needed soon
 config.setTlsTrustCertsFilePath(caPath);
 config.setTlsAllowInsecureConnection(false);
 config.setAuth(pulsar::AuthTls::create(clientPublicKeyPath, clientPrivateKeyPath));
-config.setValidateHostName(true);
+config.setValidateHostName(false);
 ```
 
 #### Node.js client
@@ -241,6 +241,9 @@ const Pulsar = require('pulsar-client');
   const client = new Pulsar.Client({
     serviceUrl: 'pulsar+ssl://broker.example.com:6651/',
     tlsTrustCertsFilePath: '/path/to/ca.cert.pem',
+    useTls: true,
+    tlsValidateHostname: false,
+    tlsAllowInsecureConnection: false,
   });
 })();
 ```
@@ -255,3 +258,4 @@ var client = PulsarClient.Builder()
                          .VerifyCertificateName(false)     //Default is 'false'
                          .Build();
 ```
+> Note that `VerifyCertificateName` refers to the configuration of hostname verification in the C# client.

--- a/site2/website/versioned_docs/version-2.7.4/security-tls-transport.md
+++ b/site2/website/versioned_docs/version-2.7.4/security-tls-transport.md
@@ -177,7 +177,7 @@ Moreover, as the administrator has full control of the certificate authority, a 
 
 One scenario where you may want to enable hostname verification is where you have multiple proxy nodes behind a VIP, and the VIP has a DNS record, for example, pulsar.mycompany.com. In this case, you can generate a TLS cert with pulsar.mycompany.com as the "CommonName," and then enable hostname verification on the client.
 
-The examples below show hostname verification being disabled for the Java client, though you can omit this as the client disables the hostname verification by default. C++/python/Node.js clients do now allow configuring this at the moment.
+The examples below show that hostname verification is disabled for the CLI tools/Java/Python/C++/Node.js/C# clients by default.
 
 ### CLI tools
 
@@ -214,7 +214,7 @@ PulsarClient client = PulsarClient.builder()
 from pulsar import Client
 
 client = Client("pulsar+ssl://broker.example.com:6651/",
-                tls_hostname_verification=True,
+                tls_hostname_verification=False,
                 tls_trust_certs_file_path="/path/to/ca.cert.pem",
                 tls_allow_insecure_connection=False) // defaults to false from v2.2.0 onwards
 ```
@@ -229,7 +229,7 @@ config.setUseTls(true);  // shouldn't be needed soon
 config.setTlsTrustCertsFilePath(caPath);
 config.setTlsAllowInsecureConnection(false);
 config.setAuth(pulsar::AuthTls::create(clientPublicKeyPath, clientPrivateKeyPath));
-config.setValidateHostName(true);
+config.setValidateHostName(false);
 ```
 
 #### Node.js client
@@ -241,6 +241,9 @@ const Pulsar = require('pulsar-client');
   const client = new Pulsar.Client({
     serviceUrl: 'pulsar+ssl://broker.example.com:6651/',
     tlsTrustCertsFilePath: '/path/to/ca.cert.pem',
+    useTls: true,
+    tlsValidateHostname: false,
+    tlsAllowInsecureConnection: false,
   });
 })();
 ```
@@ -255,3 +258,4 @@ var client = PulsarClient.Builder()
                          .VerifyCertificateName(false)     //Default is 'false'
                          .Build();
 ```
+> Note that `VerifyCertificateName` refers to the configuration of hostname verification in the C# client.

--- a/site2/website/versioned_docs/version-2.8.0/security-tls-transport.md
+++ b/site2/website/versioned_docs/version-2.8.0/security-tls-transport.md
@@ -178,7 +178,7 @@ Moreover, as the administrator has full control of the certificate authority, a 
 
 One scenario where you may want to enable hostname verification is where you have multiple proxy nodes behind a VIP, and the VIP has a DNS record, for example, pulsar.mycompany.com. In this case, you can generate a TLS cert with pulsar.mycompany.com as the "CommonName," and then enable hostname verification on the client.
 
-The examples below show hostname verification being disabled for the Java client, though you can omit this as the client disables the hostname verification by default. C++/python/Node.js clients do now allow configuring this at the moment.
+The examples below show that hostname verification is disabled for the CLI tools/Java/Python/C++/Node.js/C# clients by default. 
 
 ### CLI tools
 
@@ -215,7 +215,7 @@ PulsarClient client = PulsarClient.builder()
 from pulsar import Client
 
 client = Client("pulsar+ssl://broker.example.com:6651/",
-                tls_hostname_verification=True,
+                tls_hostname_verification=False,
                 tls_trust_certs_file_path="/path/to/ca.cert.pem",
                 tls_allow_insecure_connection=False) // defaults to false from v2.2.0 onwards
 ```
@@ -230,7 +230,7 @@ config.setUseTls(true);  // shouldn't be needed soon
 config.setTlsTrustCertsFilePath(caPath);
 config.setTlsAllowInsecureConnection(false);
 config.setAuth(pulsar::AuthTls::create(clientPublicKeyPath, clientPrivateKeyPath));
-config.setValidateHostName(true);
+config.setValidateHostName(false);
 ```
 
 #### Node.js client
@@ -242,6 +242,9 @@ const Pulsar = require('pulsar-client');
   const client = new Pulsar.Client({
     serviceUrl: 'pulsar+ssl://broker.example.com:6651/',
     tlsTrustCertsFilePath: '/path/to/ca.cert.pem',
+    useTls: true,
+    tlsValidateHostname: false,
+    tlsAllowInsecureConnection: false,
   });
 })();
 ```
@@ -256,3 +259,4 @@ var client = PulsarClient.Builder()
                          .VerifyCertificateName(false)     //Default is 'false'
                          .Build();
 ```
+> Note that `VerifyCertificateName` refers to the configuration of hostname verification in the C# client.

--- a/site2/website/versioned_docs/version-2.8.1/security-tls-transport.md
+++ b/site2/website/versioned_docs/version-2.8.1/security-tls-transport.md
@@ -178,7 +178,7 @@ Moreover, as the administrator has full control of the certificate authority, a 
 
 One scenario where you may want to enable hostname verification is where you have multiple proxy nodes behind a VIP, and the VIP has a DNS record, for example, pulsar.mycompany.com. In this case, you can generate a TLS cert with pulsar.mycompany.com as the "CommonName," and then enable hostname verification on the client.
 
-The examples below show hostname verification being disabled for the Java client, though you can omit this as the client disables the hostname verification by default. C++/python/Node.js clients do now allow configuring this at the moment.
+The examples below show that hostname verification is disabled for the CLI tools/Java/Python/C++/Node.js/C# clients by default. 
 
 ### CLI tools
 
@@ -215,7 +215,7 @@ PulsarClient client = PulsarClient.builder()
 from pulsar import Client
 
 client = Client("pulsar+ssl://broker.example.com:6651/",
-                tls_hostname_verification=True,
+                tls_hostname_verification=False,
                 tls_trust_certs_file_path="/path/to/ca.cert.pem",
                 tls_allow_insecure_connection=False) // defaults to false from v2.2.0 onwards
 ```
@@ -230,7 +230,7 @@ config.setUseTls(true);  // shouldn't be needed soon
 config.setTlsTrustCertsFilePath(caPath);
 config.setTlsAllowInsecureConnection(false);
 config.setAuth(pulsar::AuthTls::create(clientPublicKeyPath, clientPrivateKeyPath));
-config.setValidateHostName(true);
+config.setValidateHostName(false);
 ```
 
 #### Node.js client
@@ -242,6 +242,9 @@ const Pulsar = require('pulsar-client');
   const client = new Pulsar.Client({
     serviceUrl: 'pulsar+ssl://broker.example.com:6651/',
     tlsTrustCertsFilePath: '/path/to/ca.cert.pem',
+    useTls: true,
+    tlsValidateHostname: false,
+    tlsAllowInsecureConnection: false,
   });
 })();
 ```
@@ -256,3 +259,4 @@ var client = PulsarClient.Builder()
                          .VerifyCertificateName(false)     //Default is 'false'
                          .Build();
 ```
+> Note that `VerifyCertificateName` refers to the configuration of hostname verification in the C# client.

--- a/site2/website/versioned_docs/version-2.8.2/security-tls-transport.md
+++ b/site2/website/versioned_docs/version-2.8.2/security-tls-transport.md
@@ -178,7 +178,7 @@ Moreover, as the administrator has full control of the certificate authority, a 
 
 One scenario where you may want to enable hostname verification is where you have multiple proxy nodes behind a VIP, and the VIP has a DNS record, for example, pulsar.mycompany.com. In this case, you can generate a TLS cert with pulsar.mycompany.com as the "CommonName," and then enable hostname verification on the client.
 
-The examples below show hostname verification being disabled for the Java client, though you can omit this as the client disables the hostname verification by default. C++/python/Node.js clients do now allow configuring this at the moment.
+The examples below show that hostname verification is disabled for the CLI tools/Java/Python/C++/Node.js/C# clients by default. 
 
 ### CLI tools
 
@@ -215,7 +215,7 @@ PulsarClient client = PulsarClient.builder()
 from pulsar import Client
 
 client = Client("pulsar+ssl://broker.example.com:6651/",
-                tls_hostname_verification=True,
+                tls_hostname_verification=False,
                 tls_trust_certs_file_path="/path/to/ca.cert.pem",
                 tls_allow_insecure_connection=False) // defaults to false from v2.2.0 onwards
 ```
@@ -230,7 +230,7 @@ config.setUseTls(true);  // shouldn't be needed soon
 config.setTlsTrustCertsFilePath(caPath);
 config.setTlsAllowInsecureConnection(false);
 config.setAuth(pulsar::AuthTls::create(clientPublicKeyPath, clientPrivateKeyPath));
-config.setValidateHostName(true);
+config.setValidateHostName(false);
 ```
 
 #### Node.js client
@@ -242,6 +242,9 @@ const Pulsar = require('pulsar-client');
   const client = new Pulsar.Client({
     serviceUrl: 'pulsar+ssl://broker.example.com:6651/',
     tlsTrustCertsFilePath: '/path/to/ca.cert.pem',
+    useTls: true,
+    tlsValidateHostname: false,
+    tlsAllowInsecureConnection: false,
   });
 })();
 ```
@@ -256,3 +259,4 @@ var client = PulsarClient.Builder()
                          .VerifyCertificateName(false)     //Default is 'false'
                          .Build();
 ```
+> Note that `VerifyCertificateName` refers to the configuration of hostname verification in the C# client.

--- a/site2/website/versioned_docs/version-2.9.0/security-tls-transport.md
+++ b/site2/website/versioned_docs/version-2.9.0/security-tls-transport.md
@@ -178,7 +178,7 @@ Moreover, as the administrator has full control of the certificate authority, a 
 
 One scenario where you may want to enable hostname verification is where you have multiple proxy nodes behind a VIP, and the VIP has a DNS record, for example, pulsar.mycompany.com. In this case, you can generate a TLS cert with pulsar.mycompany.com as the "CommonName," and then enable hostname verification on the client.
 
-The examples below show hostname verification being disabled for the Java client, though you can omit this as the client disables the hostname verification by default. C++/python/Node.js clients do now allow configuring this at the moment.
+The examples below show that hostname verification is disabled for the CLI tools/Java/Python/C++/Node.js/C# clients by default. 
 
 ### CLI tools
 
@@ -215,7 +215,7 @@ PulsarClient client = PulsarClient.builder()
 from pulsar import Client
 
 client = Client("pulsar+ssl://broker.example.com:6651/",
-                tls_hostname_verification=True,
+                tls_hostname_verification=False,
                 tls_trust_certs_file_path="/path/to/ca.cert.pem",
                 tls_allow_insecure_connection=False) // defaults to false from v2.2.0 onwards
 ```
@@ -230,7 +230,7 @@ config.setUseTls(true);  // shouldn't be needed soon
 config.setTlsTrustCertsFilePath(caPath);
 config.setTlsAllowInsecureConnection(false);
 config.setAuth(pulsar::AuthTls::create(clientPublicKeyPath, clientPrivateKeyPath));
-config.setValidateHostName(true);
+config.setValidateHostName(false);
 ```
 
 #### Node.js client
@@ -242,6 +242,9 @@ const Pulsar = require('pulsar-client');
   const client = new Pulsar.Client({
     serviceUrl: 'pulsar+ssl://broker.example.com:6651/',
     tlsTrustCertsFilePath: '/path/to/ca.cert.pem',
+    useTls: true,
+    tlsValidateHostname: false,
+    tlsAllowInsecureConnection: false,
   });
 })();
 ```
@@ -256,3 +259,4 @@ var client = PulsarClient.Builder()
                          .VerifyCertificateName(false)     //Default is 'false'
                          .Build();
 ```
+> Note that `VerifyCertificateName` refers to the configuration of hostname verification in the C# client.

--- a/site2/website/versioned_docs/version-2.9.1/security-tls-transport.md
+++ b/site2/website/versioned_docs/version-2.9.1/security-tls-transport.md
@@ -178,7 +178,7 @@ Moreover, as the administrator has full control of the certificate authority, a 
 
 One scenario where you may want to enable hostname verification is where you have multiple proxy nodes behind a VIP, and the VIP has a DNS record, for example, pulsar.mycompany.com. In this case, you can generate a TLS cert with pulsar.mycompany.com as the "CommonName," and then enable hostname verification on the client.
 
-The examples below show hostname verification being disabled for the Java client, though you can omit this as the client disables the hostname verification by default. C++/python/Node.js clients do now allow configuring this at the moment.
+The examples below show that hostname verification is disabled for the CLI tools/Java/Python/C++/Node.js/C# clients by default. 
 
 ### CLI tools
 
@@ -215,7 +215,7 @@ PulsarClient client = PulsarClient.builder()
 from pulsar import Client
 
 client = Client("pulsar+ssl://broker.example.com:6651/",
-                tls_hostname_verification=True,
+                tls_hostname_verification=False,
                 tls_trust_certs_file_path="/path/to/ca.cert.pem",
                 tls_allow_insecure_connection=False) // defaults to false from v2.2.0 onwards
 ```
@@ -230,7 +230,7 @@ config.setUseTls(true);  // shouldn't be needed soon
 config.setTlsTrustCertsFilePath(caPath);
 config.setTlsAllowInsecureConnection(false);
 config.setAuth(pulsar::AuthTls::create(clientPublicKeyPath, clientPrivateKeyPath));
-config.setValidateHostName(true);
+config.setValidateHostName(false);
 ```
 
 #### Node.js client
@@ -242,6 +242,9 @@ const Pulsar = require('pulsar-client');
   const client = new Pulsar.Client({
     serviceUrl: 'pulsar+ssl://broker.example.com:6651/',
     tlsTrustCertsFilePath: '/path/to/ca.cert.pem',
+    useTls: true,
+    tlsValidateHostname: false,
+    tlsAllowInsecureConnection: false,
   });
 })();
 ```
@@ -256,3 +259,4 @@ var client = PulsarClient.Builder()
                          .VerifyCertificateName(false)     //Default is 'false'
                          .Build();
 ```
+> Note that `VerifyCertificateName` refers to the configuration of hostname verification in the C# client.


### PR DESCRIPTION
### Modifications
Fix #14432.

1. Streamline the default value of configuration to false.
2. Update the code sample for the Node.js client.
3. Add a note for the C# client.

Note that the changes will be applied to more historical doc versions since 2.7.0. 

### Documentation
- [x] `doc` 


