### PR TITLE
use scheduleWithFixedDelay instead of scheduleAtFixedRate in AutoClusterFailover and ControllerClusterFailover 

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/AutoClusterFailover.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/AutoClusterFailover.java
@@ -95,7 +95,7 @@ public class AutoClusterFailover implements ServiceUrlProvider {
         }
 
         // start to probe primary cluster active or not
-        this.executor.scheduleAtFixedRate(catchingAndLoggingThrowables(() -> {
+        this.executor.scheduleWithFixedDelay(catchingAndLoggingThrowables(() -> {
             if (currentPulsarServiceUrl.equals(primary)) {
                 // current service url is primary, probe whether it is down
                 probeAndUpdateServiceUrl(secondary, secondaryAuthentications, secondaryTlsTrustCertsFilePaths,

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ControlledClusterFailover.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ControlledClusterFailover.java
@@ -110,7 +110,7 @@ public class ControlledClusterFailover implements ServiceUrlProvider {
         this.pulsarClient = (PulsarClientImpl) client;
 
         // start to check service url every 30 seconds
-        this.executor.scheduleAtFixedRate(catchingAndLoggingThrowables(() -> {
+        this.executor.scheduleWithFixedDelay(catchingAndLoggingThrowables(() -> {
             ControlledConfiguration controlledConfiguration = null;
             try {
                 controlledConfiguration = fetchControlledConfiguration();


### PR DESCRIPTION
### Motivation
use scheduleWithFixedDelay instead of scheduleAtFixedRate in AutoClusterFailover and ControllerClusterFailover.

### Documentation

Check the box below or label this PR directly (if you have committer privilege).

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)


