### PR TITLE
[Broker] Check `allowAutoSubscriptionCreation` when creating init sub

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
@@ -1277,10 +1277,13 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
                                     String msg =
                                             "Could not create the initial subscription due to the auto subscription "
                                                     + "creation is not allowed.";
-                                    log.warn("[{}] {} initialSubscriptionName: {}, topic: {}",
-                                            remoteAddress, msg, initialSubscriptionName, topicName);
-                                    commandSender.sendErrorResponse(requestId,
-                                            ServerError.NotAllowedError, msg);
+                                    if (producerFuture.completeExceptionally(
+                                            new BrokerServiceException.NotAllowedException(msg))) {
+                                        log.warn("[{}] {} initialSubscriptionName: {}, topic: {}",
+                                                remoteAddress, msg, initialSubscriptionName, topicName);
+                                        commandSender.sendErrorResponse(requestId,
+                                                ServerError.NotAllowedError, msg);
+                                    }
                                     producers.remove(producerId, producerFuture);
                                     return;
                                 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
@@ -1273,6 +1273,17 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
                             if (!Strings.isNullOrEmpty(initialSubscriptionName)
                                     && topic.isPersistent()
                                     && !topic.getSubscriptions().containsKey(initialSubscriptionName)) {
+                                if (!this.getBrokerService().isAllowAutoSubscriptionCreation(topicName)) {
+                                    String msg =
+                                            "Could not create the initial subscription due to the auto subscription "
+                                                    + "creation is not allowed.";
+                                    log.warn("[{}] {} initialSubscriptionName: {}, topic: {}",
+                                            remoteAddress, msg, initialSubscriptionName, topicName);
+                                    commandSender.sendErrorResponse(requestId,
+                                            ServerError.NotAllowedError, msg);
+                                    producers.remove(producerId, producerFuture);
+                                    return;
+                                }
                                 createInitSubFuture =
                                         topic.createSubscription(initialSubscriptionName, InitialPosition.Earliest,
                                                 false);

--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/DeadLetterPolicy.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/DeadLetterPolicy.java
@@ -52,7 +52,7 @@ public class DeadLetterPolicy {
     /**
      * Name of the initial subscription name of the dead letter topic.
      * If this field is not set, the initial subscription for the dead letter topic will not be created.
-     * If this filed is set but the broker's `allowAutoSubscriptionCreation` is disabled, the DLQ producer will fail
+     * If this field is set but the broker's `allowAutoSubscriptionCreation` is disabled, the DLQ producer will fail
      * to be created.
      */
     private String initialSubscriptionName;

--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/DeadLetterPolicy.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/DeadLetterPolicy.java
@@ -51,8 +51,9 @@ public class DeadLetterPolicy {
 
     /**
      * Name of the initial subscription name of the dead letter topic.
-     * If this field is not set or the broker's `allowAutoSubscriptionCreation` is disabled, the initial subscription
-     * for the dead letter topic will not be created.
+     * If this field is not set, the initial subscription for the dead letter topic will not be created.
+     * If this filed is set but the broker's `allowAutoSubscriptionCreation` is disabled, the DLQ producer will fail
+     * to be created.
      */
     private String initialSubscriptionName;
 }

--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/DeadLetterPolicy.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/DeadLetterPolicy.java
@@ -51,7 +51,8 @@ public class DeadLetterPolicy {
 
     /**
      * Name of the initial subscription name of the dead letter topic.
-     * If this field is not set, the initial subscription for the dead letter topic will not be created.
+     * If this field is not set or the broker's `allowAutoSubscriptionCreation` is disabled, the initial subscription
+     * for the dead letter topic will not be created.
      */
     private String initialSubscriptionName;
 }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerBuilderImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerBuilderImpl.java
@@ -330,7 +330,7 @@ public class ProducerBuilderImpl<T> implements ProducerBuilder<T> {
      * If this field is not set, the initial subscription will not be created.
      * If this field is set but the broker's `allowAutoSubscriptionCreation` is disabled, the producer will fail to
      * be created.
-     * This method is limited to internal use.
+     * This method is limited to internal use. This method will only be used when the consumer creates the dlq producer.
      *
      * @param initialSubscriptionName Name of the initial subscription of the topic.
      * @return the producer builder implementation instance

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerBuilderImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerBuilderImpl.java
@@ -327,7 +327,8 @@ public class ProducerBuilderImpl<T> implements ProducerBuilder<T> {
 
     /**
      * Use this config to automatically create an initial subscription when creating the topic.
-     * If this field is not set, the initial subscription will not be created.
+     * If this field is not set or the broker's `allowAutoSubscriptionCreation` is disabled, the initial subscription
+     * will not be created.
      * This method is limited to internal use
      *
      * @param initialSubscriptionName Name of the initial subscription of the topic.

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerBuilderImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerBuilderImpl.java
@@ -328,7 +328,7 @@ public class ProducerBuilderImpl<T> implements ProducerBuilder<T> {
     /**
      * Use this config to automatically create an initial subscription when creating the topic.
      * If this field is not set, the initial subscription will not be created.
-     * If this filed is set but the broker's `allowAutoSubscriptionCreation` is disabled, the producer will fail to
+     * If this field is set but the broker's `allowAutoSubscriptionCreation` is disabled, the producer will fail to
      * be created.
      * This method is limited to internal use.
      *

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerBuilderImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerBuilderImpl.java
@@ -327,9 +327,10 @@ public class ProducerBuilderImpl<T> implements ProducerBuilder<T> {
 
     /**
      * Use this config to automatically create an initial subscription when creating the topic.
-     * If this field is not set or the broker's `allowAutoSubscriptionCreation` is disabled, the initial subscription
-     * will not be created.
-     * This method is limited to internal use
+     * If this field is not set, the initial subscription will not be created.
+     * If this filed is set but the broker's `allowAutoSubscriptionCreation` is disabled, the producer will fail to
+     * be created.
+     * This method is limited to internal use.
      *
      * @param initialSubscriptionName Name of the initial subscription of the topic.
      * @return the producer builder implementation instance

--- a/pulsar-common/src/main/proto/PulsarApi.proto
+++ b/pulsar-common/src/main/proto/PulsarApi.proto
@@ -496,7 +496,8 @@ message CommandProducer {
     optional bool txn_enabled = 12 [default = false];
 
     // Name of the initial subscription of the topic.
-    // If this field is not set, the initial subscription will not be created.
+    // If this field is not set or the broker's `allowAutoSubscriptionCreation`
+    // is disabled, the initial subscription will not be created.
     optional string initial_subscription_name = 13;
 }
 

--- a/pulsar-common/src/main/proto/PulsarApi.proto
+++ b/pulsar-common/src/main/proto/PulsarApi.proto
@@ -497,7 +497,7 @@ message CommandProducer {
 
     // Name of the initial subscription of the topic.
     // If this field is not set, the initial subscription will not be created.
-    // If this filed is set but the broker's `allowAutoSubscriptionCreation`
+    // If this field is set but the broker's `allowAutoSubscriptionCreation`
     // is disabled, the producer will fail to be created.
     optional string initial_subscription_name = 13;
 }

--- a/pulsar-common/src/main/proto/PulsarApi.proto
+++ b/pulsar-common/src/main/proto/PulsarApi.proto
@@ -496,8 +496,9 @@ message CommandProducer {
     optional bool txn_enabled = 12 [default = false];
 
     // Name of the initial subscription of the topic.
-    // If this field is not set or the broker's `allowAutoSubscriptionCreation`
-    // is disabled, the initial subscription will not be created.
+    // If this field is not set, the initial subscription will not be created.
+    // If this filed is set but the broker's `allowAutoSubscriptionCreation`
+    // is disabled, the producer will fail to be created.
     optional string initial_subscription_name = 13;
 }
 

--- a/site2/docs/concepts-messaging.md
+++ b/site2/docs/concepts-messaging.md
@@ -317,7 +317,7 @@ Consumer<byte[]> consumer = pulsarClient.newConsumer(Schema.BYTES)
                 
 ```
 
-By default, there is no subscription during a DLQ topic creation. Without a just-in-time subscription to the DLQ topic, you may lose messages. To automatically create an initial subscription for the DLQ, you can specify the `initialSubscriptionName` parameter.
+By default, there is no subscription during a DLQ topic creation. Without a just-in-time subscription to the DLQ topic, you may lose messages. To automatically create an initial subscription for the DLQ, you can specify the `initialSubscriptionName` parameter. If this parameter is set but the broker's `allowAutoSubscriptionCreation` is disabled, the DLQ producer will fail to be created.
 
 ```java
 Consumer<byte[]> consumer = pulsarClient.newConsumer(Schema.BYTES)


### PR DESCRIPTION
Master Issue: #13408 

### Motivation

In #13355, we added support for creating initial subscription when creating the producer. But the broker didn't check if the subscription can be created automatically. The initial subscription will be created even if the `allowAutoSubscriptionCreation` is disabled.

### Modifications

* Check `allowAutoSubscriptionCreation` when creating the initial subscription.

### Verifying this change

This change is already covered by existing tests, such as *testInitialSubscriptionCreationWithAutoCreationDisable*.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

- [x] `doc` 
  

