### PR TITLE
[refactor][broker] Deprecate `AddEntryMetadataException`

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerServiceException.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerServiceException.java
@@ -77,6 +77,7 @@ public class BrokerServiceException extends Exception {
         }
     }
 
+    @Deprecated
     public static class AddEntryMetadataException extends BrokerServiceException {
         public AddEntryMetadataException(Throwable t) {
             super(t);


### PR DESCRIPTION
### Motivation

The `AddEntryMetadataException` is no longer used in pulsar internal but may be publicly accessible to clients/protocol handlers. It's better to deprecate it.

### Modifications

* Deprecate `AddEntryMetadataException`.

### Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

### Documentation

- [x] `no-need-doc` 
  