### PR TITLE
[CI]Increase Stale label operations per run number to 700

### DIFF
--- a/.github/workflows/ci-stale-issue-pr.yaml
+++ b/.github/workflows/ci-stale-issue-pr.yaml
@@ -14,3 +14,4 @@ jobs:
           stale-pr-message: 'The pr had no activity for 30 days, mark with Stale label.'
           days-before-stale: 30
           days-before-close: -1
+          operations-per-run: 700


### PR DESCRIPTION

### Motivation

It seems that the stale issues and prs number reach about 2000, so `30` operations per run to tag historical issues and prs will need too much time, so change the default value `30` to `700` and it will spend one week.

### Modifications

- Change 30 to 700 operations per run

### Verifying this change

- [x] Make sure that the change passes the CI checks.


### Documentation
  
- [x] `no-need-doc` 