### PR TITLE
[pulsar-common] Fix wrong calculation of consumerStats.avgMessagesPerEntry

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherSingleActiveConsumer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherSingleActiveConsumer.java
@@ -400,7 +400,7 @@ public class PersistentDispatcherSingleActiveConsumer extends AbstractDispatcher
         long bytesToRead = serviceConfig.getDispatcherMaxReadSizeBytes();
         // if turn of precise dispatcher flow control, adjust the records to read
         if (consumer.isPreciseDispatcherFlowControl()) {
-            int avgMessagesPerEntry = consumer.getAvgMessagesPerEntry();
+            float avgMessagesPerEntry = consumer.getAvgMessagesPerEntry();
             messagesToRead = Math.min((int) Math.ceil(availablePermits * 1.0 / avgMessagesPerEntry), readBatchSize);
         }
 

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/stats/ConsumerStatsImpl.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/stats/ConsumerStatsImpl.java
@@ -58,7 +58,7 @@ public class ConsumerStatsImpl implements ConsumerStats {
     public int unackedMessages;
 
     /** Number of average messages per entry for the consumer consumed. */
-    public int avgMessagesPerEntry;
+    public float avgMessagesPerEntry;
 
     /** Flag to verify if consumer is blocked due to reaching threshold of unacked messages. */
     public boolean blockedConsumerOnUnackedMsgs;
@@ -160,5 +160,10 @@ public class ConsumerStatsImpl implements ConsumerStats {
 
     public String getReadPositionWhenJoining() {
         return readPositionWhenJoining;
+    }
+
+    // return integer for compatibility
+    public int getAvgMessagesPerEntry() {
+        return (int) avgMessagesPerEntry;
     }
 }


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - Name the pull request in the form "[Issue XYZ][component] Title of the pull request", where *XYZ* should be replaced by the actual issue number.
    Skip *Issue XYZ* if there is no associated github issue for this pull request.
    Skip *component* if you are unsure about which is the best component. E.g. `[docs] Fix typo in produce method`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.

**(The sections below can be removed for hotfixes of typos)**
-->
### Motivation

Currently the `consumerStats.avgMessagesPerEntry` is calculated as `Math.round(oldValue * 0.9 + 0.1 * newValue)`, when producer turn off batching mode which `avgMessagesPerEntry` is 1, but actual is 6.
```json
{
  "msgRateOut": 14.283385519824838,
  "msgThroughputOut": 32989.9038668956,
  "bytesOutCounter": 45166825378,
  "msgOutCounter": 19027280,
  "msgRateRedeliver": 0,
  "chunkedMessageRate": 0,
  "consumerName": "d1191",
  "availablePermits": 720,
  "unackedMessages": 0,
  "avgMessagesPerEntry": 6,
  "blockedConsumerOnUnackedMsgs": false,
  "lastAckedTimestamp": 1645964907480,
  "lastConsumedTimestamp": 1645964907480,
  "metadata": {},
  "address": "/10.172.xxx.xxx:50156",
  "connectedSince": "2022-02-18T22:57:41.311+08:00",
  "clientVersion": "2.8.1"
}
```
```java
// assume current oldValue is 6
// oldValue * 0.9 + 0.1 * newValue = 6 * 0.9 + 0.1 * 1 = 5.5;
Math.round(oldValue * 0.9 + 0.1 * newValue) = Math.round(5.5) = 6;
```
So `avgMessagesPerEntry` will be 6 forever even if producer turn off batching mode.

### Modifications

Use `float` instead of int for internal, keep use `int` in public api.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

Check the box below or label this PR directly (if you have committer privilege).

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
bugfix only
  
- [ ] `doc` 
  
  (If this PR contains doc changes)


