### PR TITLE
fix npe in ManagedLedgerImpl

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
@@ -3252,8 +3252,8 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
                     totalEntriesInCurrentLedger = 0;
                 }
             } else {
-                totalEntriesInCurrentLedger = ledgers.get(currentLedgerId) != null ?
-                        ledgers.get(currentLedgerId).getEntries() : 0;
+                totalEntriesInCurrentLedger = ledgers.get(currentLedgerId) != null
+                        ? ledgers.get(currentLedgerId).getEntries() : 0;
             }
 
 

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
@@ -3252,12 +3252,10 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
                     totalEntriesInCurrentLedger = 0;
                 }
             } else {
-                totalEntriesInCurrentLedger = ledgers.get(currentLedgerId).getEntries();
+                totalEntriesInCurrentLedger = ledgers.get(currentLedgerId) != null ?
+                        ledgers.get(currentLedgerId).getEntries() : 0;
             }
 
-            if (null == ledgers.get(currentLedgerId)) {
-                break;
-            }
 
             long unreadEntriesInCurrentLedger = totalEntriesInCurrentLedger - currentEntryId;
 

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
@@ -3252,8 +3252,8 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
                     totalEntriesInCurrentLedger = 0;
                 }
             } else {
-                totalEntriesInCurrentLedger = ledgers.get(currentLedgerId) != null
-                        ? ledgers.get(currentLedgerId).getEntries() : 0;
+                LedgerInfo ledgerInfo = ledgers.get(currentLedgerId);
+                totalEntriesInCurrentLedger = ledgerInfo != null ? ledgerInfo.getEntries() : 0;
             }
 
 

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
@@ -3255,6 +3255,10 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
                 totalEntriesInCurrentLedger = ledgers.get(currentLedgerId).getEntries();
             }
 
+            if (null == ledgers.get(currentLedgerId)) {
+                break;
+            }
+
             long unreadEntriesInCurrentLedger = totalEntriesInCurrentLedger - currentEntryId;
 
             if (unreadEntriesInCurrentLedger >= entriesToSkip) {


### PR DESCRIPTION
### Motivation
The following errors were found in the broker log:
00:01:35.380 [pulsar-msg-expiry-monitor-27-1] WARN  org.apache.pulsar.broker.service.persistent.PersistentTopic - [persistent://tenant_g_cdg_cft_g_input_output_stat_base__cft/b_cdg_cft_dz_licaitong/tdbank_lct_t_region_tengan_hh-partition-2] Error while getting the oldest message
java.lang.NullPointerException: null
at org.apache.bookkeeper.mledger.impl.ManagedLedgerImpl.getPositionAfterN(ManagedLedgerImpl.java:3174) ~[org.apache.pulsar-managed-ledger-2.8.1.2.jar:2.8.1.2]
at org.apache.bookkeeper.mledger.impl.ManagedCursorImpl.asyncGetNthEntry(ManagedCursorImpl.java:685) ~[org.apache.pulsar-managed-ledger-2.8.1.2.jar:2.8.1.2]
at org.apache.bookkeeper.mledger.impl.ManagedCursorImpl.getNthEntry(ManagedCursorImpl.java:642) ~[org.apache.pulsar-managed-ledger-2.8.1.2.jar:2.8.1.2]
at org.apache.pulsar.broker.service.persistent.PersistentTopic.isOldestMessageExpired(PersistentTopic.java:2608) ~[org.apache.pulsar-pulsar-broker-2.8.1.2.jar:2.8.1.2]
at org.apache.pulsar.broker.service.persistent.PersistentSubscription.expireMessages(PersistentSubscription.java:983) ~[org.apache.pulsar-pulsar-broker-2.8.1.2.jar:2.8.1.2]
at org.apache.pulsar.broker.service.persistent.PersistentTopic.lambda$checkMessageExpiry$43(PersistentTopic.java:1386) ~[org.apache.pulsar-pulsar-broker-2.8.1.2.jar:2.8.1.2]
at org.apache.pulsar.common.util.collections.ConcurrentOpenHashMap$Section.forEach(ConcurrentOpenHashMap.java:387) ~[org.apache.pulsar-pulsar-common-2.8.1.2.jar:2.8.1.2]
at org.apache.pulsar.common.util.collections.ConcurrentOpenHashMap.forEach(ConcurrentOpenHashMap.java:159) ~[org.apache.pulsar-pulsar-common-2.8.1.2.jar:2.8.1.2]
at org.apache.pulsar.broker.service.persistent.PersistentTopic.checkMessageExpiry(PersistentTopic.java:1386) ~[org.apache.pulsar-pulsar-broker-2.8.1.2.jar:2.8.1.2]
at java.util.Optional.ifPresent(Optional.java:159) ~[?:1.8.0_144]
at org.apache.pulsar.broker.service.BrokerService.lambda$forEachTopic$65(BrokerService.java:1616) ~[org.apache.pulsar-pulsar-broker-2.8.1.2.jar:2.8.1.2]
at org.apache.pulsar.common.util.collections.ConcurrentOpenHashMap$Section.forEach(ConcurrentOpenHashMap.java:387) ~[org.apache.pulsar-pulsar-common-2.8.1.2.jar:2.8.1.2]
at org.apache.pulsar.common.util.collections.ConcurrentOpenHashMap.forEach(ConcurrentOpenHashMap.java:159) ~[org.apache.pulsar-pulsar-common-2.8.1.2.jar:2.8.1.2]




### Documentation

Check the box below or label this PR directly (if you have committer privilege).

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)


