### PR TITLE
[Broker] Fix errors will be ignored when ``checkGC``.

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/NonPersistentTopicE2ETest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/NonPersistentTopicE2ETest.java
@@ -37,11 +37,12 @@ import org.apache.pulsar.client.impl.schema.JSONSchema;
 import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.protocol.schema.SchemaData;
 import org.apache.pulsar.common.schema.SchemaType;
+import org.awaitility.Awaitility;
 import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
-
+import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 
@@ -235,10 +236,11 @@ public class NonPersistentTopicE2ETest extends BrokerTestBase {
         admin.topics().createPartitionedTopic(topicGc, partitions);
         Producer<byte[]> producer3 = pulsarClient.newProducer().topic(topicGc).create();
         producer3.close();
-        assertTrue(pulsar.getBrokerService().fetchPartitionedTopicMetadataAsync(
-                TopicName.get(topicGc)).join().partitions == partitions);
+        assertEquals(partitions, pulsar.getBrokerService().fetchPartitionedTopicMetadataAsync(
+                TopicName.get(topicGc)).join().partitions);
         runGC();
-        assertTrue(pulsar.getBrokerService().fetchPartitionedTopicMetadataAsync(
-                TopicName.get(topicGc)).join().partitions == 0);
+        Awaitility.await().untilAsserted(()->
+                assertEquals(pulsar.getBrokerService().
+                        fetchPartitionedTopicMetadataAsync(TopicName.get(topicGc)).join().partitions, 0));
     }
 }


### PR DESCRIPTION
### Motivation

``check GC`` ignores errors when executing ``tryToDeletePartitionedMetadata`` in the non-persistent topic, which can cause us to not find the corresponding problem when debugging.

### Modifications

- Fix errors will be ignored when ``check GC``.
- Make partition topic exist to pure async.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Documentation

- [x] `no-need-doc` 
  


