### PR TITLE
[Build] Cache vcpkg install to accelerate the CI

### DIFF
--- a/.github/workflows/ci-cpp-build-windows.yaml
+++ b/.github/workflows/ci-cpp-build-windows.yaml
@@ -41,6 +41,8 @@ jobs:
 
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
+    env:
+      VCPKG_ROOT: '${{ github.workspace }}/vcpkg'
     strategy:
       fail-fast: false
       matrix:
@@ -74,10 +76,33 @@ jobs:
         id: check_changes
         run: echo "::set-output name=docs_only::${{ fromJSON(steps.changes.outputs.all_count) == fromJSON(steps.changes.outputs.docs_count) && fromJSON(steps.changes.outputs.docs_count) > 0 }}"
 
-      - name: Restore artifacts
-        uses: lukka/run-vcpkg@v10.1
+      - name: Restore vcpkg and its artifacts.
+        uses: actions/cache@v2
+        id: vcpkg-cache
         with:
-          vcpkgJsonGlob: 'pulsar-client-cpp/vcpkg.json'
+          path: |
+            ${{ env.VCPKG_ROOT }}
+            pulsar-client-cpp/build/vcpkg_installed
+            !${{ env.VCPKG_ROOT }}/.git
+            !${{ env.VCPKG_ROOT }}/buildtrees
+            !${{ env.VCPKG_ROOT }}/packages
+            !${{ env.VCPKG_ROOT }}/downloads
+          key: |
+            ${{ hashFiles( 'pulsar-client-cpp/vcpkg.json' ) }}-${{ runner.os }}-${{ matrix.triplet}}
+
+      - name: Get vcpkg(windows)
+        if: ${{ runner.os == 'Windows' && steps.vcpkg-cache.outputs.cache-hit != 'true' }}
+        run: |
+          cd ${{ github.workspace }}
+          mkdir build -force
+          git clone https://github.com/Microsoft/vcpkg.git
+          cd vcpkg
+          .\bootstrap-vcpkg.bat
+
+      - name: remove system vcpkg(windows)
+        if: runner.os == 'Windows'
+        run: rm -rf "$VCPKG_INSTALLATION_ROOT"
+        shell: bash
 
       - name: Install vcpkg packages
         if: ${{ steps.check_changes.outputs.docs_only != 'true' }}

--- a/.github/workflows/ci-cpp-build-windows.yaml
+++ b/.github/workflows/ci-cpp-build-windows.yaml
@@ -41,8 +41,6 @@ jobs:
 
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
-    env:
-      VCPKG_ROOT: '${{ github.workspace }}/vcpkg'
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci-cpp-build-windows.yaml
+++ b/.github/workflows/ci-cpp-build-windows.yaml
@@ -76,19 +76,10 @@ jobs:
         id: check_changes
         run: echo "::set-output name=docs_only::${{ fromJSON(steps.changes.outputs.all_count) == fromJSON(steps.changes.outputs.docs_count) && fromJSON(steps.changes.outputs.docs_count) > 0 }}"
 
-      - name: Cache vcpkg install
-        uses: actions/cache@v2
-        id: vcpkg-cache
+      - name: Restore artifacts
+        uses: lukka/run-vcpkg@v10.1
         with:
-          path: |
-            ${{ env.VCPKG_ROOT }}
-            pulsar-client-cpp/build/vcpkg_installed
-            !${{ env.VCPKG_ROOT }}/.git
-            !${{ env.VCPKG_ROOT }}/buildtrees
-            !${{ env.VCPKG_ROOT }}/packages
-            !${{ env.VCPKG_ROOT }}/downloads
-          key: |
-            ${{ matrix.os }}-${{ matrix.triplet}}-${{ hashFiles( 'pulsar-client-cpp/vcpkg.json' ) }}-cache
+          vcpkgJsonGlob: 'pulsar-client-cpp/vcpkg.json'
 
       - name: Install vcpkg packages
         if: ${{ steps.check_changes.outputs.docs_only != 'true' }}

--- a/.github/workflows/ci-cpp-build-windows.yaml
+++ b/.github/workflows/ci-cpp-build-windows.yaml
@@ -82,13 +82,13 @@ jobs:
         with:
           path: |
             ${{ env.VCPKG_ROOT }}
-            pulsar-client-cpp/build/vcpkg_installed
+            pulsar-client-cpp/vcpkg_installed
             !${{ env.VCPKG_ROOT }}/.git
             !${{ env.VCPKG_ROOT }}/buildtrees
             !${{ env.VCPKG_ROOT }}/packages
             !${{ env.VCPKG_ROOT }}/downloads
           key: |
-            ${{ hashFiles( 'pulsar-client-cpp/vcpkg.json' ) }}-${{ runner.os }}-${{ matrix.triplet}}-cache
+            ${{ runner.os }}-${{ matrix.triplet}}-${{ hashFiles( 'pulsar-client-cpp/vcpkg.json' ) }}
 
       - name: Get vcpkg(windows)
         if: ${{ runner.os == 'Windows' && steps.vcpkg-cache.outputs.cache-hit != 'true' }}

--- a/.github/workflows/ci-cpp-build-windows.yaml
+++ b/.github/workflows/ci-cpp-build-windows.yaml
@@ -88,7 +88,7 @@ jobs:
             !${{ env.VCPKG_ROOT }}/packages
             !${{ env.VCPKG_ROOT }}/downloads
           key: |
-            ${{ hashFiles( 'pulsar-client-cpp/vcpkg.json' ) }}-${{ runner.os }}-${{ matrix.triplet}}-cache
+            ${{ matrix.os }}-${{ matrix.triplet}}-${{ hashFiles( 'pulsar-client-cpp/vcpkg.json' ) }}-cache
 
       - name: Install vcpkg packages
         if: ${{ steps.check_changes.outputs.docs_only != 'true' }}

--- a/.github/workflows/ci-cpp-build-windows.yaml
+++ b/.github/workflows/ci-cpp-build-windows.yaml
@@ -104,11 +104,11 @@ jobs:
         run: rm -rf "$VCPKG_INSTALLATION_ROOT"
         shell: bash
 
-      - name: Install vcpkg packages
-        if: ${{ steps.check_changes.outputs.docs_only != 'true' }}
-        shell: bash
-        run: |
-          cd pulsar-client-cpp && vcpkg install --triplet ${{ matrix.triplet }}
+#      - name: Install vcpkg packages
+#        if: ${{ steps.check_changes.outputs.docs_only != 'true' }}
+#        shell: bash
+#        run: |
+#          cd pulsar-client-cpp && vcpkg install --triplet ${{ matrix.triplet }}
 
       - name: Configure (default)
         if: ${{ steps.check_changes.outputs.docs_only != 'true' }}
@@ -117,9 +117,10 @@ jobs:
           if [ "$RUNNER_OS" == "Windows" ]; then
             cd pulsar-client-cpp && \
             cmake \
-              -B ./build \
+              -B ./build-0 \
               -G "${{ matrix.generator }}" ${{ matrix.arch }} \
               -DBUILD_PYTHON_WRAPPER=OFF -DBUILD_TESTS=OFF \
+              -DCMAKE_TOOLCHAIN_FILE=${{ github.workspace }}/vcpkg/scripts/buildsystems/vcpkg.cmake \
               -DVCPKG_TRIPLET=${{ matrix.triplet }} \
               -DCMAKE_BUILD_TYPE=Release \
               -S .
@@ -131,7 +132,7 @@ jobs:
         run: |
           if [ "$RUNNER_OS" == "Windows" ]; then
             cd pulsar-client-cpp && \
-            cmake --build ./build --config Release
+            cmake --build ./build-0 --parallel --config Release
           fi
 
       - name: Configure (dynamic library only)
@@ -145,6 +146,7 @@ jobs:
               -G "${{ matrix.generator }}" ${{ matrix.arch }} \
               -DBUILD_PYTHON_WRAPPER=OFF -DBUILD_TESTS=OFF \
               -DVCPKG_TRIPLET=${{ matrix.triplet }} \
+              -DCMAKE_TOOLCHAIN_FILE=${{ github.workspace }}/vcpkg/scripts/buildsystems/vcpkg.cmake \
               -DCMAKE_BUILD_TYPE=Release \
               -DBUILD_STATIC_LIB=OFF \
               -S .
@@ -156,5 +158,5 @@ jobs:
         run: |
           if [ "$RUNNER_OS" == "Windows" ]; then
             cd pulsar-client-cpp && \
-            cmake --build ./build-1 --config Release
+            cmake --build ./build-1 --parallel --config Release
           fi

--- a/.github/workflows/ci-cpp-build-windows.yaml
+++ b/.github/workflows/ci-cpp-build-windows.yaml
@@ -108,7 +108,7 @@ jobs:
         if: ${{ steps.check_changes.outputs.docs_only != 'true' }}
         shell: bash
         run: |
-          cd pulsar-client-cpp && ${{ env.VCPKG_ROOT }}/vcpkg install --triplet ${{ matrix.triplet }}
+          cd pulsar-client-cpp && ${{ env.VCPKG_ROOT }}/vcpkg.exe install --triplet ${{ matrix.triplet }}
 
       - name: Configure (default)
         if: ${{ steps.check_changes.outputs.docs_only != 'true' }}

--- a/.github/workflows/ci-cpp-build-windows.yaml
+++ b/.github/workflows/ci-cpp-build-windows.yaml
@@ -88,7 +88,7 @@ jobs:
             !${{ env.VCPKG_ROOT }}/packages
             !${{ env.VCPKG_ROOT }}/downloads
           key: |
-            ${{ hashFiles( 'pulsar-client-cpp/vcpkg.json' ) }}-${{ runner.os }}-${{ matrix.triplet}}
+            ${{ hashFiles( 'pulsar-client-cpp/vcpkg.json' ) }}-${{ runner.os }}-${{ matrix.triplet}}-cache
 
       - name: Get vcpkg(windows)
         if: ${{ runner.os == 'Windows' && steps.vcpkg-cache.outputs.cache-hit != 'true' }}
@@ -106,9 +106,8 @@ jobs:
 
       - name: Install vcpkg packages
         if: ${{ steps.check_changes.outputs.docs_only != 'true' }}
-        shell: bash
         run: |
-          cd pulsar-client-cpp && ${{ env.VCPKG_ROOT }}/vcpkg.exe install --triplet ${{ matrix.triplet }}
+          cd pulsar-client-cpp && ${{ env.VCPKG_ROOT }}\vcpkg.exe install --triplet ${{ matrix.triplet }}
 
       - name: Configure (default)
         if: ${{ steps.check_changes.outputs.docs_only != 'true' }}

--- a/.github/workflows/ci-cpp-build-windows.yaml
+++ b/.github/workflows/ci-cpp-build-windows.yaml
@@ -41,6 +41,8 @@ jobs:
 
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
+    env:
+      VCPKG_ROOT: '${{ github.workspace }}/vcpkg'
     strategy:
       fail-fast: false
       matrix:
@@ -73,6 +75,20 @@ jobs:
       - name: Check changed files
         id: check_changes
         run: echo "::set-output name=docs_only::${{ fromJSON(steps.changes.outputs.all_count) == fromJSON(steps.changes.outputs.docs_count) && fromJSON(steps.changes.outputs.docs_count) > 0 }}"
+
+      - name: Cache vcpkg install
+        uses: actions/cache@v2
+        id: vcpkg-cache
+        with:
+          path: |
+            ${{ env.VCPKG_ROOT }}
+            pulsar-client-cpp/build/vcpkg_installed
+            !${{ env.VCPKG_ROOT }}/.git
+            !${{ env.VCPKG_ROOT }}/buildtrees
+            !${{ env.VCPKG_ROOT }}/packages
+            !${{ env.VCPKG_ROOT }}/downloads
+          key: |
+            ${{ hashFiles( 'pulsar-client-cpp/vcpkg.json' ) }}-${{ runner.os }}-${{ matrix.triplet}}-cache
 
       - name: Install vcpkg packages
         if: ${{ steps.check_changes.outputs.docs_only != 'true' }}

--- a/.github/workflows/ci-cpp-build-windows.yaml
+++ b/.github/workflows/ci-cpp-build-windows.yaml
@@ -104,11 +104,11 @@ jobs:
         run: rm -rf "$VCPKG_INSTALLATION_ROOT"
         shell: bash
 
-#      - name: Install vcpkg packages
-#        if: ${{ steps.check_changes.outputs.docs_only != 'true' }}
-#        shell: bash
-#        run: |
-#          cd pulsar-client-cpp && vcpkg install --triplet ${{ matrix.triplet }}
+      - name: Install vcpkg packages
+        if: ${{ steps.check_changes.outputs.docs_only != 'true' }}
+        shell: bash
+        run: |
+          cd pulsar-client-cpp && ${{ env.VCPKG_ROOT }}/vcpkg install --triplet ${{ matrix.triplet }}
 
       - name: Configure (default)
         if: ${{ steps.check_changes.outputs.docs_only != 'true' }}
@@ -120,7 +120,6 @@ jobs:
               -B ./build-0 \
               -G "${{ matrix.generator }}" ${{ matrix.arch }} \
               -DBUILD_PYTHON_WRAPPER=OFF -DBUILD_TESTS=OFF \
-              -DCMAKE_TOOLCHAIN_FILE=${{ github.workspace }}/vcpkg/scripts/buildsystems/vcpkg.cmake \
               -DVCPKG_TRIPLET=${{ matrix.triplet }} \
               -DCMAKE_BUILD_TYPE=Release \
               -S .
@@ -146,7 +145,6 @@ jobs:
               -G "${{ matrix.generator }}" ${{ matrix.arch }} \
               -DBUILD_PYTHON_WRAPPER=OFF -DBUILD_TESTS=OFF \
               -DVCPKG_TRIPLET=${{ matrix.triplet }} \
-              -DCMAKE_TOOLCHAIN_FILE=${{ github.workspace }}/vcpkg/scripts/buildsystems/vcpkg.cmake \
               -DCMAKE_BUILD_TYPE=Release \
               -DBUILD_STATIC_LIB=OFF \
               -S .


### PR DESCRIPTION
Master Issue: #14401 

### Motivation

As mentioned in the issue above, `Install vcpkg packages` cost much time, so this pr aims to reduce it.

### Modifications

- Add vcpkg install cache

### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Documentation
  
- [x] `no-need-doc` 
