### PR TITLE
add rack metrics

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
@@ -105,6 +105,7 @@ import org.apache.pulsar.broker.service.TopicPoliciesService;
 import org.apache.pulsar.broker.service.TransactionBufferSnapshotService;
 import org.apache.pulsar.broker.service.schema.SchemaRegistryService;
 import org.apache.pulsar.broker.stats.MetricsGenerator;
+import org.apache.pulsar.broker.stats.prometheus.BookkeeperIsolationGroupsStats;
 import org.apache.pulsar.broker.stats.prometheus.PrometheusMetricsServlet;
 import org.apache.pulsar.broker.stats.prometheus.PrometheusRawMetricsProvider;
 import org.apache.pulsar.broker.storage.ManagedLedgerStorage;
@@ -810,6 +811,9 @@ public class PulsarService implements AutoCloseable, ShutdownService {
                     config.getClusterName(), config);
 
             state = State.Started;
+
+            new BookkeeperIsolationGroupsStats(pulsarResources, getBookKeeperClient(), config,
+                    managedLedgerClientFactory.getStatsProvider());
         } catch (Exception e) {
             LOG.error("Failed to start Pulsar service: {}", e.getMessage(), e);
             throw new PulsarServerException(e);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/BookkeeperIsolationGroupsStats.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/BookkeeperIsolationGroupsStats.java
@@ -1,0 +1,172 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.stats.prometheus;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
+import org.apache.bookkeeper.client.BookKeeper;
+import org.apache.bookkeeper.discover.RegistrationClient;
+import org.apache.bookkeeper.meta.MetadataClientDriver;
+import org.apache.bookkeeper.net.BookieId;
+import org.apache.bookkeeper.stats.Gauge;
+import org.apache.bookkeeper.stats.NullStatsProvider;
+import org.apache.bookkeeper.stats.StatsLogger;
+import org.apache.bookkeeper.stats.StatsProvider;
+import org.apache.bookkeeper.stats.annotations.StatsDoc;
+import org.apache.pulsar.broker.ServiceConfiguration;
+import org.apache.pulsar.broker.resources.PulsarResources;
+import org.apache.pulsar.common.policies.data.BookiesClusterInfo;
+import org.apache.pulsar.common.policies.data.BookiesRackConfiguration;
+import org.apache.pulsar.common.policies.data.RawBookieInfo;
+
+public class BookkeeperIsolationGroupsStats {
+    private static final String CURRENT_RACKS_COUNT = "current-racks-count";
+    private static final String RACKS_COUNT = "racks-count";
+
+    @StatsDoc(
+            name = CURRENT_RACKS_COUNT,
+            help = "Number of current racks"
+    )
+    private Gauge<Integer> currRackCountGauge;
+
+    @StatsDoc(
+            name = RACKS_COUNT,
+            help = "Number of all racks"
+    )
+    private Gauge<Integer> allRackCountGauge;
+
+    private StatsProvider statsProvider = new NullStatsProvider();
+    private static final long UPDATE_INTERVAL_MILLIS = 60 * 1000;
+    private long lastUpdateTime = -1;
+    Map<String /*rackGroup*/, Integer /*rackCount*/> racksCount = Maps.newConcurrentMap();
+
+    public BookkeeperIsolationGroupsStats(PulsarResources pulsarResources, BookKeeper bkClient, ServiceConfiguration conf,
+                                          StatsProvider statsProvider) {
+        if (!conf.isBookkeeperClientExposeStatsToPrometheus()) {
+            return;
+        }
+        StatsLogger statsLogger = statsProvider.getStatsLogger("pulsar_managedRack_client");
+        // current rack group's rack metrics
+        Supplier<Integer> currRackCountSupplier = () -> {
+            try {
+                Integer currentGroupRackCount = getWritableBookieRackCount(pulsarResources, bkClient).
+                        get(conf.getBookkeeperClientIsolationGroups());
+                if (currentGroupRackCount == null) {
+                    return -1;
+                }
+                return currentGroupRackCount.intValue();
+            } catch (Exception e) {
+                return -1;
+            }
+        };
+        currRackCountGauge = new Gauge<Integer>() {
+            @Override
+            public Integer getDefaultValue() {
+                return 0;
+            }
+
+            @Override
+            public Integer getSample() {
+                return currRackCountSupplier.get();
+            }
+        };
+        statsLogger.registerGauge(CURRENT_RACKS_COUNT, currRackCountGauge);
+
+        // all rack group's writable rack metrics
+        Supplier<Map<String, Integer>> allRackCountSupplier = () -> {
+            try {
+                return getWritableBookieRackCount(pulsarResources, bkClient);
+            } catch (Exception e) {
+                return Maps.newConcurrentMap();
+            }
+        };
+        allRackCountSupplier.get().forEach((group, rackCount) -> {
+            allRackCountGauge = new Gauge<Integer>() {
+                @Override
+                public Integer getDefaultValue() {
+                    return 0;
+                }
+
+                @Override
+                public Integer getSample() {
+                    return allRackCountSupplier.get().get(group);
+                }
+            };
+            statsLogger.registerGauge(group + "-" + RACKS_COUNT, allRackCountGauge);
+        });
+    }
+
+    public synchronized Map<String /*rackGroup*/, Integer /*rackCount*/> getWritableBookieRackCount(
+            PulsarResources pulsarResources, BookKeeper bkClient) throws Exception {
+        if (System.currentTimeMillis() - lastUpdateTime < UPDATE_INTERVAL_MILLIS) {
+            return this.racksCount;
+        }
+
+        BookiesRackConfiguration rackInfos = getBookiesRackInfo(pulsarResources);
+        BookiesClusterInfo writableBookies = getWritableBookies(bkClient);
+        if (rackInfos == null || writableBookies == null) {
+            return this.racksCount;
+        }
+        Map<String /*rackGroup*/, Set<String> /*rackSet*/> racksSet = Maps.newConcurrentMap();
+        rackInfos.forEach((group, bookieInfoMap) -> {
+            bookieInfoMap.forEach((address, bookieInfo) -> {
+                if (writableBookies.getBookies().contains(new RawBookieInfo(address))) {
+                    Set<String> rackSet = racksSet.computeIfAbsent(group, k -> Sets.newConcurrentHashSet());
+                    rackSet.add(bookieInfo.getRack());
+                }
+            });
+        });
+
+        Map<String /*rackGroup*/, Integer /*rackCount*/> racksCountNew = Maps.newConcurrentMap();
+        racksSet.forEach((group, rackSet) -> racksCountNew.put(group, rackSet.size()));
+
+        lastUpdateTime = System.currentTimeMillis();
+        this.racksCount = racksCountNew;
+        return this.racksCount;
+    }
+
+    public BookiesRackConfiguration getBookiesRackInfo(PulsarResources pulsarResources) throws Exception {
+        AtomicReference<BookiesRackConfiguration> bookiesRackCof =
+                new AtomicReference<>(new BookiesRackConfiguration());
+        pulsarResources.getBookieResources().get()
+                .thenAccept(b -> {
+                    bookiesRackCof.set(b.get());
+                });
+        return bookiesRackCof.get();
+    }
+
+    public BookiesClusterInfo getWritableBookies(BookKeeper bkClient) throws Exception {
+        MetadataClientDriver metadataClientDriver = bkClient.getMetadataClientDriver();
+        RegistrationClient registrationClient = metadataClientDriver.getRegistrationClient();
+
+        Set<BookieId> writableBookies = registrationClient.getWritableBookies().get().getValue();
+        List<RawBookieInfo> result = Lists.newArrayListWithExpectedSize(writableBookies.size());
+        for (BookieId bookieId : writableBookies) {
+            RawBookieInfo bookieInfo = new RawBookieInfo(bookieId.toString());
+            result.add(bookieInfo);
+        }
+        return BookiesClusterInfo.builder().bookies(result).build();
+    }
+}

--- a/pulsar-client-admin-api/src/main/java/org/apache/pulsar/common/policies/data/BookiesRackConfiguration.java
+++ b/pulsar-client-admin-api/src/main/java/org/apache/pulsar/common/policies/data/BookiesRackConfiguration.java
@@ -26,7 +26,7 @@ import java.util.TreeMap;
 /**
  * The rack configuration map for bookies.
  */
-public class BookiesRackConfiguration extends TreeMap<String, Map<String, BookieInfo>> {
+public class BookiesRackConfiguration extends TreeMap<String/*rackGroup*/, Map<String/*address*/, BookieInfo>> {
 
     private static final long serialVersionUID = 0L;
 

--- a/pulsar-client-admin-api/src/main/java/org/apache/pulsar/common/policies/data/RawBookieInfo.java
+++ b/pulsar-client-admin-api/src/main/java/org/apache/pulsar/common/policies/data/RawBookieInfo.java
@@ -23,6 +23,8 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
 
+import java.util.Objects;
+
 /**
  * Bookie information.
  */
@@ -32,4 +34,19 @@ import lombok.ToString;
 @ToString
 public class RawBookieInfo {
     private String bookieId;
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        final RawBookieInfo other = (RawBookieInfo) obj;
+        return Objects.equals(this.bookieId, other.bookieId);
+    }
 }

--- a/pulsar-client-admin-api/src/main/java/org/apache/pulsar/common/policies/data/RawBookieInfo.java
+++ b/pulsar-client-admin-api/src/main/java/org/apache/pulsar/common/policies/data/RawBookieInfo.java
@@ -18,12 +18,11 @@
  */
 package org.apache.pulsar.common.policies.data;
 
+import java.util.Objects;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
-
-import java.util.Objects;
 
 /**
  * Bookie information.


### PR DESCRIPTION
Master Issue: no-issue

### Motivation

- pulsar lacks the bookie rack's metric in use


### Modifications

- Add main class BookkeeperIsolationGroupsStats,two categories of metrics:

1. current rack group's rack metrics
2. all rack group's writable rack metrics

- metric main class is inited  in class PulsarService
- add equals method in class RawBookieInfo
- add comments in class BookiesRackConfiguration

### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API: (no)
  - The schema: ( no )
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation
  
- [x] `no-need-doc` 
  
