### PR TITLE
[PIP-74] Support auto scaled consumer receiver queue 

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/AutoScaledReceiverQueueSizeTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/AutoScaledReceiverQueueSizeTest.java
@@ -1,0 +1,258 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.pulsar.client.impl;
+
+
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.TimeUnit;
+import lombok.Cleanup;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.pulsar.broker.auth.MockedPulsarServiceBaseTest;
+import org.apache.pulsar.client.admin.PulsarAdminException;
+import org.apache.pulsar.client.api.BatchReceivePolicy;
+import org.apache.pulsar.client.api.Producer;
+import org.apache.pulsar.client.api.PulsarClientException;
+import org.awaitility.Awaitility;
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+@Slf4j
+public class AutoScaledReceiverQueueSizeTest extends MockedPulsarServiceBaseTest {
+    @BeforeClass(alwaysRun = true)
+    @Override
+    protected void setup() throws Exception {
+        super.internalSetup();
+        setupDefaultTenantAndNamespace();
+    }
+
+    @BeforeClass(alwaysRun = true)
+    @Override
+    protected void cleanup() throws Exception {
+        super.internalCleanup();
+    }
+
+    @Test
+    public void testConsumerImpl() throws PulsarClientException {
+        String topic = "persistent://public/default/testConsumerImpl" + System.currentTimeMillis();
+        @Cleanup
+        ConsumerImpl<byte[]> consumer = (ConsumerImpl<byte[]>) pulsarClient.newConsumer()
+                .topic(topic)
+                .subscriptionName("my-sub")
+                .receiverQueueSize(3)
+                .autoScaledReceiverQueueSizeEnabled(true)
+                .subscribe();
+        Assert.assertEquals(consumer.getCurrentReceiverQueueSize(), 1);
+
+        @Cleanup
+        Producer<byte[]> producer = pulsarClient.newProducer().topic(topic).enableBatching(false).create();
+        byte[] data = "data".getBytes(StandardCharsets.UTF_8);
+
+        producer.send(data);
+        Assert.assertNotNull(consumer.receive());
+        Awaitility.await().until(consumer.scaleReceiverQueueHint::get);
+        log.info("getCurrentReceiverQueueSize={}", consumer.getCurrentReceiverQueueSize());
+
+        //this will trigger receiver queue size expanding.
+        Assert.assertNull(consumer.receive(0, TimeUnit.MILLISECONDS));
+
+        log.info("getCurrentReceiverQueueSize={}", consumer.getCurrentReceiverQueueSize());
+        Assert.assertEquals(consumer.getCurrentReceiverQueueSize(), 2);
+        Assert.assertFalse(consumer.scaleReceiverQueueHint.get());
+
+        for (int i = 0; i < 5; i++) {
+            producer.send(data);
+            producer.send(data);
+            Assert.assertNotNull(consumer.receive());
+            Assert.assertNotNull(consumer.receive());
+            // queue maybe full, but no empty receive, so no expanding
+            Assert.assertEquals(consumer.getCurrentReceiverQueueSize(), 2);
+        }
+
+        producer.send(data);
+        producer.send(data);
+        Awaitility.await().until(consumer.scaleReceiverQueueHint::get);
+        Assert.assertNotNull(consumer.receive());
+        Assert.assertNotNull(consumer.receive());
+        Assert.assertNull(consumer.receive(0, TimeUnit.MILLISECONDS));
+        // queue is full, with empty receive, expanding to max size
+        Assert.assertEquals(consumer.getCurrentReceiverQueueSize(), 3);
+    }
+
+    @Test
+    public void testConsumerImplBatchReceive() throws PulsarClientException {
+        String topic = "persistent://public/default/testConsumerImplBatchReceive" + System.currentTimeMillis();
+        @Cleanup
+        ConsumerImpl<byte[]> consumer = (ConsumerImpl<byte[]>) pulsarClient.newConsumer()
+                .topic(topic)
+                .subscriptionName("my-sub")
+                .batchReceivePolicy(BatchReceivePolicy.builder().maxNumMessages(5).build())
+                .receiverQueueSize(20)
+                .autoScaledReceiverQueueSizeEnabled(true)
+                .subscribe();
+
+        int currentSize = 8;
+        Assert.assertEquals(consumer.getCurrentReceiverQueueSize(), currentSize);
+
+        @Cleanup
+        Producer<byte[]> producer = pulsarClient.newProducer().topic(topic).enableBatching(false).create();
+        byte[] data = "data".getBytes(StandardCharsets.UTF_8);
+
+        for (int i = 0; i < 10; i++) { // just run a few times.
+            for (int j = 0; j < 5; j++) {
+                producer.send(data);
+            }
+            Awaitility.await().until(() -> consumer.incomingMessages.size() == 5);
+            log.info("i={},expandReceiverQueueHint:{},local permits:{}",
+                    i, consumer.scaleReceiverQueueHint.get(), consumer.getAvailablePermits());
+            Assert.assertEquals(consumer.batchReceive().size(), 5);
+            Assert.assertEquals(consumer.getCurrentReceiverQueueSize(), currentSize);
+            log.info("getCurrentReceiverQueueSize={}", consumer.getCurrentReceiverQueueSize());
+        }
+
+        //clear local available permits.
+        int n = currentSize / 2 - consumer.getAvailablePermits();
+        for (int i = 0; i < n; i++) {
+            producer.send(data);
+            consumer.receive();
+        }
+        Assert.assertEquals(consumer.getAvailablePermits(), 0);
+
+        for (int i = 0; i < currentSize; i++) {
+            producer.send(data);
+        }
+
+        Awaitility.await().until(consumer.scaleReceiverQueueHint::get);
+        Assert.assertEquals(consumer.batchReceive().size(), 5);
+
+        //trigger expanding
+        consumer.batchReceiveAsync();
+        Awaitility.await().until(() -> consumer.getCurrentReceiverQueueSize() == currentSize * 2);
+        log.info("getCurrentReceiverQueueSize={}", consumer.getCurrentReceiverQueueSize());
+    }
+
+    @Test
+    public void testMultiConsumerImpl() throws Exception {
+        String topic = "persistent://public/default/testMultiConsumerImpl" + System.currentTimeMillis();
+        admin.topics().createPartitionedTopic(topic, 3);
+        @Cleanup
+        MultiTopicsConsumerImpl<byte[]> consumer = (MultiTopicsConsumerImpl<byte[]>) pulsarClient.newConsumer()
+                .topic(topic)
+                .subscriptionName("my-sub")
+                .receiverQueueSize(10)
+                .autoScaledReceiverQueueSizeEnabled(true)
+                .subscribe();
+
+        //queue size will be adjusted to partition number.
+        Awaitility.await().untilAsserted(() -> Assert.assertEquals(consumer.getCurrentReceiverQueueSize(), 3));
+
+        @Cleanup
+        Producer<byte[]> producer = pulsarClient.newProducer().topic(topic).enableBatching(false).create();
+        byte[] data = "data".getBytes(StandardCharsets.UTF_8);
+
+        for (int i = 0; i < 3; i++) {
+            producer.send(data);
+        }
+        Awaitility.await().until(consumer.scaleReceiverQueueHint::get);
+        for (int i = 0; i < 3; i++) {
+            Assert.assertNotNull(consumer.receive());
+        }
+        Assert.assertTrue(consumer.scaleReceiverQueueHint.get());
+        log.info("getCurrentReceiverQueueSize={}", consumer.getCurrentReceiverQueueSize());
+        Assert.assertEquals(consumer.getCurrentReceiverQueueSize(), 3); // queue size no change
+
+        //this will trigger receiver queue size expanding.
+        Assert.assertNull(consumer.receive(0, TimeUnit.MILLISECONDS));
+
+        log.info("getCurrentReceiverQueueSize={}", consumer.getCurrentReceiverQueueSize());
+        Assert.assertEquals(consumer.getCurrentReceiverQueueSize(), 6);
+        Assert.assertFalse(consumer.scaleReceiverQueueHint.get()); //expandReceiverQueueHint is reset.
+
+        for (int i = 0; i < 5; i++) {
+            for (int j = 0; j < 6; j++) {
+                producer.send(data);
+            }
+            for (int j = 0; j < 6; j++) {
+                Assert.assertNotNull(consumer.receive());
+            }
+            log.info("i={},currentReceiverQueueSize={},expandReceiverQueueHint={}", i,
+                    consumer.getCurrentReceiverQueueSize(), consumer.scaleReceiverQueueHint);
+            // queue maybe full, but no empty receive, so no expanding
+            Assert.assertEquals(consumer.getCurrentReceiverQueueSize(), 6);
+        }
+
+        for (int j = 0; j < 6; j++) {
+            producer.send(data);
+        }
+        Awaitility.await().until(() -> consumer.scaleReceiverQueueHint.get());
+        for (int j = 0; j < 6; j++) {
+            Assert.assertNotNull(consumer.receive());
+        }
+        Assert.assertNull(consumer.receive(0, TimeUnit.MILLISECONDS));
+        // queue is full, with empty receive, expanding to max size
+        log.info("getCurrentReceiverQueueSize={}", consumer.getCurrentReceiverQueueSize());
+        Assert.assertEquals(consumer.getCurrentReceiverQueueSize(), 10);
+    }
+
+    @Test
+    public void testMultiConsumerImplBatchReceive() throws PulsarClientException, PulsarAdminException {
+        String topic = "persistent://public/default/testMultiConsumerImplBatchReceive" + System.currentTimeMillis();
+        admin.topics().createPartitionedTopic(topic, 3);
+        @Cleanup
+        MultiTopicsConsumerImpl<byte[]> consumer = (MultiTopicsConsumerImpl<byte[]>) pulsarClient.newConsumer()
+                .topic(topic)
+                .subscriptionName("my-sub")
+                .batchReceivePolicy(BatchReceivePolicy.builder().maxNumMessages(5).build())
+                .receiverQueueSize(20)
+                .autoScaledReceiverQueueSizeEnabled(true)
+                .subscribe();
+
+        //receiver queue size init as 5.
+        int currentSize = 5;
+        Assert.assertEquals(consumer.getCurrentReceiverQueueSize(), currentSize);
+
+        @Cleanup
+        Producer<byte[]> producer = pulsarClient.newProducer().topic(topic).enableBatching(false).create();
+        byte[] data = "data".getBytes(StandardCharsets.UTF_8);
+
+        for (int i = 0; i < 10; i++) { // just run a few times.
+            for (int j = 0; j < 5; j++) {
+                producer.send(data);
+            }
+            log.info("i={},expandReceiverQueueHint:{},local permits:{}",
+                    i, consumer.scaleReceiverQueueHint.get(), consumer.getAvailablePermits());
+            Assert.assertEquals(consumer.batchReceive().size(), 5);
+            Assert.assertEquals(consumer.getCurrentReceiverQueueSize(), currentSize);
+            log.info("getCurrentReceiverQueueSize={}", consumer.getCurrentReceiverQueueSize());
+        }
+
+        for (int i = 0; i < currentSize; i++) {
+            producer.send(data);
+        }
+
+        Awaitility.await().until(consumer.scaleReceiverQueueHint::get);
+        Assert.assertEquals(consumer.batchReceive().size(), 5);
+
+        //trigger expanding
+        consumer.batchReceiveAsync();
+        Awaitility.await().until(() -> consumer.getCurrentReceiverQueueSize() == currentSize * 2);
+        log.info("getCurrentReceiverQueueSize={}", consumer.getCurrentReceiverQueueSize());
+    }
+}

--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/ConsumerBuilder.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/ConsumerBuilder.java
@@ -798,4 +798,18 @@ public interface ConsumerBuilder<T> extends Cloneable {
      * @default false
      */
     ConsumerBuilder<T> startPaused(boolean paused);
+
+    /**
+     * If this is enabled, consumer receiver queue size is init as a very small value, 1 by default,
+     * and it will double itself unit it reaches the value set by {@link #receiverQueueSize(int)}, if and only if
+     * 1) User calls receive() and there is no messages in receiver queue.
+     * 2) The last message we put in the receiver queue took the last space available in receiver queue.
+     *
+     * This is disabled by default and currentReceiverQueueSize is init as maxReceiverQueueSize.
+     *
+     * The feature should be able to reduce client memory usage.
+     *
+     * @param enabled whether to enable AutoScaledReceiverQueueSize.
+     */
+    ConsumerBuilder<T> autoScaledReceiverQueueSizeEnabled(boolean enabled);
 }

--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/ConsumerBuilder.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/ConsumerBuilder.java
@@ -801,7 +801,7 @@ public interface ConsumerBuilder<T> extends Cloneable {
 
     /**
      * If this is enabled, consumer receiver queue size is init as a very small value, 1 by default,
-     * and it will double itself unit it reaches the value set by {@link #receiverQueueSize(int)}, if and only if
+     * and it will double itself until it reaches the value set by {@link #receiverQueueSize(int)}, if and only if
      * 1) User calls receive() and there is no messages in receiver queue.
      * 2) The last message we put in the receiver queue took the last space available in receiver queue.
      *

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBase.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBase.java
@@ -1053,13 +1053,11 @@ public abstract class ConsumerBase<T> extends HandlerState implements Consumer<T
     }
 
     protected void resetIncomingMessageSize() {
-        long size = INCOMING_MESSAGES_SIZE_UPDATER.getAndSet(this, 0);
-        client.getMemoryLimitController().releaseMemory(size);
+        INCOMING_MESSAGES_SIZE_UPDATER.getAndSet(this, 0);
     }
 
     protected void decreaseIncomingMessageSize(final Message<?> message) {
         INCOMING_MESSAGES_SIZE_UPDATER.addAndGet(this, -message.size());
-        client.getMemoryLimitController().releaseMemory(message.size());
     }
 
     public long getIncomingMessageSize() {

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBuilderImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBuilderImpl.java
@@ -530,4 +530,10 @@ public class ConsumerBuilderImpl<T> implements ConsumerBuilder<T> {
         conf.setStartPaused(paused);
         return this;
     }
+
+    @Override
+    public ConsumerBuilder<T> autoScaledReceiverQueueSizeEnabled(boolean enabled) {
+        conf.setAutoScaledReceiverQueueSizeEnabled(enabled);
+        return this;
+    }
 }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiTopicsConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiTopicsConsumerImpl.java
@@ -1513,7 +1513,7 @@ public class MultiTopicsConsumerImpl<T> extends ConsumerBase<T> {
         checkArgument(newSize > 0, "receiver queue size should larger than 0");
         if (log.isDebugEnabled()) {
             log.debug("[{}][{}] setMaxReceiverQueueSize={}, previous={}", topic, subscription,
-                    getCurrentReceiverQueueSize(), newSize);
+                    newSize, getCurrentReceiverQueueSize());
         }
         CURRENT_RECEIVER_QUEUE_SIZE_UPDATER.set(this, newSize);
         resumeReceivingFromPausedConsumersIfNeeded();

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ZeroQueueConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ZeroQueueConsumerImpl.java
@@ -57,6 +57,16 @@ public class ZeroQueueConsumerImpl<T> extends ConsumerImpl<T> {
     }
 
     @Override
+    public void initReceiverQueueSize() {
+        if (conf.isAutoScaledReceiverQueueSizeEnabled()) {
+            throw new NotImplementedException("AutoScaledReceiverQueueSize is not supported in ZeroQueueConsumerImpl");
+        } else {
+            CURRENT_RECEIVER_QUEUE_SIZE_UPDATER.set(this, 0);
+        }
+
+    }
+
+    @Override
     protected Message<T> internalReceive() throws PulsarClientException {
         zeroQueueLock.lock();
         try {

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ConsumerConfigurationData.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ConsumerConfigurationData.java
@@ -162,6 +162,8 @@ public class ConsumerConfigurationData<T> implements Serializable, Cloneable {
 
     private boolean startPaused = false;
 
+    private boolean autoScaledReceiverQueueSizeEnabled = false;
+
     public void setAutoUpdatePartitionsIntervalSeconds(int interval, TimeUnit timeUnit) {
         checkArgument(interval > 0, "interval needs to be > 0");
         this.autoUpdatePartitionsIntervalSeconds = timeUnit.toSeconds(interval);


### PR DESCRIPTION
### Motivation
1. Pick a proper receiver queue size is not an easy thing. If the value is too small, it impact the throughput, and if the value is too large, it consumes too many memory. With default set up, the queue size is 1000, and the max message size is 5MB, this means maximum of 5GB memory occupation.

3. This is part of the work for [PIP 74](https://github.com/apache/pulsar/wiki/PIP-74%3A-Pulsar-client-memory-limits). We need auto scale `currentReceiverQueue` to control client memory. 

### Modifications

Add optional autoScaledReceiverQueueSizeEnabled for consumer client.

Previous `receiverQueueSize` is the max value of this auto scaled queue size.

Every time the client will try to double the size of `currentReceiverQueue` if it limits message throughput. Currently, it's determined by the following two conditions in exact order:
A) Current receiver queue (`ConsumerBase#incomingMessages`) is full after we put a message into it. (it's marked by `scaleReceiverQueueHint` as true).
B) Application wants process more messages but the receiver queue is empty. (`expectMoreIncomingMessages` is called in this PR).

The queue size won't grow if we got new messages during A and B. So if assume current receiver queue size is 10, and the timeline would be like
1. Consumer send flow command to client, and client receive 10 messages, so `scaleReceiverQueueHint` is marked as true. 
2. Application calls `receive()` repeatedly and processed all 10 messages. And in the meanwhile no new message is sent to client[1].
3. Receiver queue size will be doubled to 20.
4. ...

NOTE: 
`Condition A` here is slightly different from original design in PIP-74 described as "there are messages pending to be sent for this consumer" (let's refer it as Condition X). This is proposed with these consideration: 
a) We can assume that when receiver queue is full, the chance of broker have no more messages is insignificant in practice.
b) If we accept a), then `Condition A` implies `Condition X`, as new messages are pending because local queue size is full.  But it's NOT vice versa.
c) Once fact we should accept is that we don't need expand queue size every time it limits the throughput as some slight and occasional delay is acceptable and won't affect overall throughput. And by replacing `Condition A` with `Condition X`, we can reduce the sensitivity of the expansion. 

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change added tests and can be verified as follows:

*(example:)*
  - org.apache.pulsar.client.impl.AutoScaledReceiverQueueSizeTest
  
### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - **The public API: (yes, add a config for consumer builder)**
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

Check the box below and label this PR (if you have committer privilege).

Need to update docs? 
  
- [x] `no-need-doc` 
