### PR TITLE
[WIP]Support ManagedLedger EntryCache cache entires before the slowest cursor

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedLedgerFactoryConfig.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedLedgerFactoryConfig.java
@@ -53,6 +53,12 @@ public class ManagedLedgerFactoryConfig {
     private long cacheEvictionTimeThresholdMillis = 1000;
 
     /**
+     * Whether the cache eviction task should skip evict entries before the slowest cursor which means
+     * the cache eviction task only evict entries by {@link #cacheEvictionTimeThresholdMillis}.
+     */
+    private boolean cacheEvictionSkipSlowestCursor = false;
+
+    /**
      * Whether we should make a copy of the entry payloads when inserting in cache.
      */
     private boolean copyEntriesInCache = false;

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerFactoryImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerFactoryImpl.java
@@ -277,7 +277,7 @@ public class ManagedLedgerFactoryImpl implements ManagedLedgerFactory {
             if (mlfuture.isDone() && !mlfuture.isCompletedExceptionally()) {
                 ManagedLedgerImpl ml = mlfuture.getNow(null);
                 if (ml != null) {
-                    ml.doCacheEviction(maxTimestamp);
+                    ml.doCacheEviction(maxTimestamp, config.isCacheEvictionSkipSlowestCursor());
                 }
             }
         });

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
@@ -2160,16 +2160,17 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
         }
     }
 
-    void doCacheEviction(long maxTimestamp) {
+    void doCacheEviction(long maxTimestamp, boolean isOnlyEvictByTime) {
         if (entryCache.getSize() <= 0) {
             return;
         }
-        // Always remove all entries already read by active cursors
-        PositionImpl slowestReaderPos = getEarlierReadPositionForActiveCursors();
-        if (slowestReaderPos != null) {
-            entryCache.invalidateEntries(slowestReaderPos);
+        if (!isOnlyEvictByTime) {
+            // Always remove all entries already read by active cursors
+            PositionImpl slowestReaderPos = getEarlierReadPositionForActiveCursors();
+            if (slowestReaderPos != null) {
+                entryCache.invalidateEntries(slowestReaderPos);
+            }
         }
-
         // Remove entries older than the cutoff threshold
         entryCache.invalidateEntriesBeforeTimestamp(maxTimestamp);
     }

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -1690,6 +1690,10 @@ public class ServiceConfiguration implements PulsarConfiguration {
             doc = "All entries that have stayed in cache for more than the configured time, will be evicted")
     private long managedLedgerCacheEvictionTimeThresholdMillis = 1000;
     @FieldContext(category = CATEGORY_STORAGE_ML,
+            doc = "Whether the cache eviction task should skip evict entries before the slowest cursor which means "
+                    + "the cache eviction task only evict entries by managedLedgerCacheEvictionTimeThresholdMillis")
+    private boolean managedLedgerCacheEvictionSkipSlowestCursor = false;
+    @FieldContext(category = CATEGORY_STORAGE_ML,
             doc = "Configure the threshold (in number of entries) from where a cursor should be considered 'backlogged'"
                     + " and thus should be set as inactive.")
     private long managedLedgerCursorBackloggedThreshold = 1000;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/ManagedLedgerClientFactory.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/ManagedLedgerClientFactory.java
@@ -62,6 +62,8 @@ public class ManagedLedgerClientFactory implements ManagedLedgerStorage {
         managedLedgerFactoryConfig.setCacheEvictionFrequency(conf.getManagedLedgerCacheEvictionFrequency());
         managedLedgerFactoryConfig.setCacheEvictionTimeThresholdMillis(
                 conf.getManagedLedgerCacheEvictionTimeThresholdMillis());
+        managedLedgerFactoryConfig.setCacheEvictionSkipSlowestCursor(
+                conf.isManagedLedgerCacheEvictionSkipSlowestCursor());
         managedLedgerFactoryConfig.setCopyEntriesInCache(conf.isManagedLedgerCacheCopyEntries());
         managedLedgerFactoryConfig.setPrometheusStatsLatencyRolloverSeconds(
                 conf.getManagedLedgerPrometheusStatsLatencyRolloverSeconds());


### PR DESCRIPTION

Fixes #14495 

### Motivation

 Support ManagedLedger EntryCache cache entries before the slowest cursor 

### Modifications
1. Add a new configuration `managedLedgerCacheEvictionSkipSlowestCursor` to control whether the cacheEvictionTask will remove entries read by all active cursors.
2. add test  EntryCacheManagerTest#verifyEvictionSkipSlowestCursor

### Verifying this change

This change added tests and can be verified as follows:
`EntryCacheManagerTest#verifyEvictionSkipSlowestCursor`

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation
  
- [x] `no-need-doc` 

