### PR TITLE
Fix npe caused by enabling packagemanagement service in standalone se…

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/PulsarStandaloneStarter.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/PulsarStandaloneStarter.java
@@ -107,6 +107,8 @@ public class PulsarStandaloneStarter extends PulsarStandalone {
         config.setConfigurationMetadataStoreUrl(metadataStoreUrl);
 
         config.setRunningStandalone(true);
+        config.getProperties().setProperty("metadataStoreUrl", metadataStoreUrl);
+        config.getProperties().setProperty("configurationMetadataStoreUrl", metadataStoreUrl);
 
         Runtime.getRuntime().addShutdownHook(new Thread() {
             public void run() {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/StandaloneTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/StandaloneTest.java
@@ -23,6 +23,7 @@ import org.apache.pulsar.broker.auth.MockedPulsarServiceBaseTest;
 import org.testng.annotations.Test;
 
 import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.AssertJUnit.assertNotNull;
 import static org.testng.AssertJUnit.assertNull;
 
 @Test(groups = "broker")
@@ -36,6 +37,15 @@ public class StandaloneTest extends MockedPulsarServiceBaseTest {
     @Override
     protected void cleanup() throws Exception {
 
+    }
+
+    @Test
+    public void testWithoutMetadataStoreUrlInConfFile() throws Exception {
+        String args[] = new String[]{"--config",
+                "../conf/standalone.conf"};
+        PulsarStandaloneStarter standalone = new PulsarStandaloneStarter(args);
+        assertNotNull(standalone.getConfig().getProperties().getProperty("metadataStoreUrl"));
+        assertNotNull(standalone.getConfig().getProperties().getProperty("configurationMetadataStoreUrl"));
     }
 
     @Test


### PR DESCRIPTION


### Motivation
NPE when enable packagemanagement service in standaloneService.
```
2022-02-25T16:23:41,253+0800 [main] ERROR org.apache.pulsar.broker.PulsarService - Failed to start Pulsar service: null
java.lang.NullPointerException: null
        at org.apache.distributedlog.impl.BKNamespaceDriver.getZKServersFromDLUri(BKNamespaceDriver.java:98) ~[org.apache.distributedlog-distributedlog-core-4.14.4.jar:4.14.4]
        at org.apache.distributedlog.ZooKeeperClientBuilder.uri(ZooKeeperClientBuilder.java:143) ~[org.apache.distributedlog-distributedlog-core-4.14.4.jar:4.14.4]
        at org.apache.distributedlog.metadata.DLMetadata.create(DLMetadata.java:146) ~[org.apache.distributedlog-distributedlog-core-4.14.4.jar:4.14.4]
        at org.apache.pulsar.packages.management.storage.bookkeeper.BookKeeperPackagesStorage.initializeDlogNamespace(BookKeeperPackagesStorage.java:105) ~[org.apache.pulsar-pulsar-package-bookkeeper-storage-2.10.0-SNAPSHOT.jar:2.10.0-SNAPSHOT]
        at org.apache.pulsar.packages.management.storage.bookkeeper.BookKeeperPackagesStorage.initialize(BookKeeperPackagesStorage.java:79) ~[org.apache.pulsar-pulsar-package-bookkeeper-storage-2.10.0-SNAPSHOT.jar:2.10.0-SNAPSHOT]
        at org.apache.pulsar.broker.PulsarService.startPackagesManagementService(PulsarService.java:1571) ~[org.apache.pulsar-pulsar-broker-2.10.0-SNAPSHOT.jar:2.10.0-SNAPSHOT]
        at org.apache.pulsar.broker.PulsarService.start(PulsarService.java:782) [org.apache.pulsar-pulsar-broker-2.10.0-SNAPSHOT.jar:2.10.0-SNAPSHOT]
        at org.apache.pulsar.PulsarStandalone.start(PulsarStandalone.java:301) [org.apache.pulsar-pulsar-broker-2.10.0-SNAPSHOT.jar:2.10.0-SNAPSHOT]
        at org.apache.pulsar.PulsarStandaloneStarter.main(PulsarStandaloneStarter.java:142) [org.apache.pulsar-pulsar-broker-2.10.0-SNAPSHOT.jar:2.10.0-SNAPSHOT]
```


### Modifications

Fix npe



### Documentation

Check the box below or label this PR directly (if you have committer privilege).

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)


