### PR TITLE
[flaky-tests] AdminApiSchemaTest#testSchemaInfoApi

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/schema/SchemaTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/schema/SchemaTest.java
@@ -67,6 +67,7 @@ import org.apache.pulsar.client.impl.schema.KeyValueSchemaImpl;
 import org.apache.pulsar.client.impl.schema.SchemaInfoImpl;
 import org.apache.pulsar.client.impl.schema.generic.GenericJsonRecord;
 import org.apache.pulsar.client.impl.schema.writer.AvroWriter;
+import org.apache.pulsar.client.internal.DefaultImplementation;
 import org.apache.pulsar.common.naming.TopicDomain;
 import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.policies.data.ClusterData;
@@ -708,7 +709,7 @@ public class SchemaTest extends MockedPulsarServiceBaseTest {
         map.put(null, "value"); // null key is not allowed for JSON, it's only for test here
 
         // leave INT32 instance unchanged
-        final Schema<Integer> integerSchema = Schema.INT32.clone();
+        final Schema<Integer> integerSchema = DefaultImplementation.getDefaultImplementation().newIntSchema();
         ((SchemaInfoImpl) integerSchema.getSchemaInfo()).setProperties(map);
 
         final Consumer<Integer> consumer = pulsarClient.newConsumer(integerSchema).topic(topic)

--- a/pulsar-broker/src/test/java/org/apache/pulsar/schema/SchemaTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/schema/SchemaTest.java
@@ -707,7 +707,6 @@ public class SchemaTest extends MockedPulsarServiceBaseTest {
         map.put("key", null);
         map.put(null, "value"); // null key is not allowed for JSON, it's only for test here
 
-        // leave INT32 instance unchanged
         final Schema<Integer> integerSchema = Schema.JSON(Integer.class);
         ((SchemaInfoImpl) integerSchema.getSchemaInfo()).setProperties(map);
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/schema/SchemaTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/schema/SchemaTest.java
@@ -67,7 +67,6 @@ import org.apache.pulsar.client.impl.schema.KeyValueSchemaImpl;
 import org.apache.pulsar.client.impl.schema.SchemaInfoImpl;
 import org.apache.pulsar.client.impl.schema.generic.GenericJsonRecord;
 import org.apache.pulsar.client.impl.schema.writer.AvroWriter;
-import org.apache.pulsar.client.internal.DefaultImplementation;
 import org.apache.pulsar.common.naming.TopicDomain;
 import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.policies.data.ClusterData;
@@ -709,7 +708,7 @@ public class SchemaTest extends MockedPulsarServiceBaseTest {
         map.put(null, "value"); // null key is not allowed for JSON, it's only for test here
 
         // leave INT32 instance unchanged
-        final Schema<Integer> integerSchema = DefaultImplementation.getDefaultImplementation().newIntSchema();
+        final Schema<Integer> integerSchema = Schema.JSON(Integer.class);
         ((SchemaInfoImpl) integerSchema.getSchemaInfo()).setProperties(map);
 
         final Consumer<Integer> consumer = pulsarClient.newConsumer(integerSchema).topic(topic)


### PR DESCRIPTION
### Motivation
This is the same fix applied here #12461. The problem with the other pull is that the `AbstractSchema#clone()` method does return the same instance, so the fix is not useful at all.

I see this test also failing in 2.8 and 2.9 branch, I recommend to cherry-pick it.

### Modifications
* Create a new INT schema for the test purpose


- [x] `no-need-doc` 
  