### PR TITLE
[Build/Tests] Make the test JVM exit if OOME occurs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1409,7 +1409,7 @@ flexible messaging model and an intuitive client API.</description>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
-          <argLine>${testJacocoAgentArgument} -Xmx1G -XX:+UseG1GC
+          <argLine>${testJacocoAgentArgument} -XX:+ExitOnOutOfMemoryError -Xmx1G -XX:+UseG1GC
             -Dpulsar.allocator.pooled=true
             -Dpulsar.allocator.leak_detection=Advanced
             -Dpulsar.allocator.exit_on_oom=false

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/ClientDeduplicationFailureTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/ClientDeduplicationFailureTest.java
@@ -189,7 +189,8 @@ public class ClientDeduplicationFailureTest {
         }
     }
 
-    @Test(timeOut = 300000, groups = "quarantine")
+    // TODO: Test disabled since it results in a OOME
+    @Test(timeOut = 300000, groups = "quarantine", enabled = false)
     public void testClientDeduplicationCorrectnessWithFailure() throws Exception {
         final String namespacePortion = "dedup";
         final String replNamespace = tenant + "/" + namespacePortion;

--- a/tests/bc_2_0_0/pom.xml
+++ b/tests/bc_2_0_0/pom.xml
@@ -91,7 +91,7 @@
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-surefire-plugin</artifactId>
                         <configuration>
-                            <argLine>${testJacocoAgentArgument} -Xmx2G -XX:MaxDirectMemorySize=8G
+                            <argLine>${testJacocoAgentArgument} -XX:+ExitOnOutOfMemoryError -Xmx2G -XX:MaxDirectMemorySize=8G
                                 -Dio.netty.leakDetectionLevel=advanced
                                 ${test.additional.args}
                             </argLine>

--- a/tests/bc_2_0_1/pom.xml
+++ b/tests/bc_2_0_1/pom.xml
@@ -91,7 +91,7 @@
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-surefire-plugin</artifactId>
                         <configuration>
-                            <argLine>${testJacocoAgentArgument} -Xmx2G -XX:MaxDirectMemorySize=8G
+                            <argLine>${testJacocoAgentArgument} -XX:+ExitOnOutOfMemoryError -Xmx2G -XX:MaxDirectMemorySize=8G
                                 -Dio.netty.leakDetectionLevel=advanced
                                 ${test.additional.args}
                             </argLine>

--- a/tests/bc_2_6_0/pom.xml
+++ b/tests/bc_2_6_0/pom.xml
@@ -98,7 +98,7 @@
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-surefire-plugin</artifactId>
                         <configuration>
-                            <argLine>${testJacocoAgentArgument} -Xmx2G -XX:MaxDirectMemorySize=8G
+                            <argLine>${testJacocoAgentArgument} -XX:+ExitOnOutOfMemoryError -Xmx2G -XX:MaxDirectMemorySize=8G
                                 -Dio.netty.leakDetectionLevel=advanced
                                 ${test.additional.args}
                             </argLine>

--- a/tests/integration/pom.xml
+++ b/tests/integration/pom.xml
@@ -233,7 +233,7 @@
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-surefire-plugin</artifactId>
             <configuration>
-              <argLine>${testJacocoAgentArgument} -Xmx1G -XX:MaxDirectMemorySize=1G
+              <argLine>${testJacocoAgentArgument} -XX:+ExitOnOutOfMemoryError -Xmx1G -XX:MaxDirectMemorySize=1G
               -Dio.netty.leakDetectionLevel=advanced
               ${test.additional.args}
               </argLine>

--- a/tests/pulsar-client-admin-shade-test/pom.xml
+++ b/tests/pulsar-client-admin-shade-test/pom.xml
@@ -106,7 +106,7 @@
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-surefire-plugin</artifactId>
                         <configuration>
-                            <argLine>${testJacocoAgentArgument} -Xmx2G -XX:MaxDirectMemorySize=8G
+                            <argLine>${testJacocoAgentArgument} -XX:+ExitOnOutOfMemoryError -Xmx2G -XX:MaxDirectMemorySize=8G
                                 -Dio.netty.leakDetectionLevel=advanced
                                 ${test.additional.args}
                             </argLine>

--- a/tests/pulsar-client-all-shade-test/pom.xml
+++ b/tests/pulsar-client-all-shade-test/pom.xml
@@ -105,7 +105,7 @@
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-surefire-plugin</artifactId>
                         <configuration>
-                            <argLine>${testJacocoAgentArgument} -Xmx2G -XX:MaxDirectMemorySize=8G
+                            <argLine>${testJacocoAgentArgument} -XX:+ExitOnOutOfMemoryError -Xmx2G -XX:MaxDirectMemorySize=8G
                                 -Dio.netty.leakDetectionLevel=advanced
                                 ${test.additional.args}
                             </argLine>

--- a/tests/pulsar-client-shade-test/pom.xml
+++ b/tests/pulsar-client-shade-test/pom.xml
@@ -100,7 +100,7 @@
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-surefire-plugin</artifactId>
                         <configuration>
-                            <argLine>${testJacocoAgentArgument} -Xmx2G -XX:MaxDirectMemorySize=8G
+                            <argLine>${testJacocoAgentArgument} -XX:+ExitOnOutOfMemoryError -Xmx2G -XX:MaxDirectMemorySize=8G
                                 -Dio.netty.leakDetectionLevel=advanced
                                 ${test.additional.args}
                             </argLine>


### PR DESCRIPTION
### Motivation

- OOMEs can make the build to take very long to complete or to hang.
  It's better to fail fast in tests when OOMEs occur.

- example of a build failure where the build hangs: https://github.com/apache/pulsar/runs/5371747143?check_suite_focus=true
  - [thread dump](https://jstack.review/?https://gist.github.com/lhotari/63f57f4ce94cc23caaa7833587210971#tda_1_sync_0x00000000c3affce0) 
  - it looks like Zookeeper client has gotten into a bad state because of OOME, however I'm not sure about this.

### Modifications

- Add `XX:+ExitOnOutOfMemoryError` to test JVM arguments
- disable ClientDeduplicationFailureTest.testClientDeduplicationCorrectnessWithFailure completely since it leads to OOMEs in certain conditions.