### PR TITLE
[IO] Upgrade mariadb jdbc driver version to address vulnerabilities

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -152,7 +152,7 @@ flexible messaging model and an intuitive client API.</description>
     <mysql-jdbc.version>8.0.11</mysql-jdbc.version>
     <postgresql-jdbc.version>42.2.25</postgresql-jdbc.version>
     <clickhouse-jdbc.version>0.3.2</clickhouse-jdbc.version>
-    <mariadb-jdbc.version>2.6.0</mariadb-jdbc.version>
+    <mariadb-jdbc.version>3.0.3</mariadb-jdbc.version>
     <hdfs-offload-version3>3.3.1</hdfs-offload-version3>
     <json-smart.version>2.4.7</json-smart.version>
     <opensearch.version>1.2.4</opensearch.version>


### PR DESCRIPTION
### Motivation

OWASP dependency check fails with this error:

```
Error:  mariadb-java-client-2.6.0.jar: CVE-2020-28912, CVE-2021-46668, CVE-2021-46669, CVE-2021-46666, CVE-2021-46667, CVE-2021-46664, CVE-2021-46665, CVE-2021-46662, CVE-2021-46663, CVE-2021-46661
```

### Modifications

- upgrade mariadb jdbc driver version to 3.0.3