### PR TITLE
[CI] Remove owasp-dep-check from required checks

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -56,7 +56,6 @@ github:
           - cpp-tests
           - function-state
           - messaging
-          - owasp-dep-check
           - process
           - pulsar-ci-test (group1)
           - pulsar-ci-test (group2)


### PR DESCRIPTION
### Motivation

- OWASP dependency check shouldn't be a required check
  - when a new vulnerability occurs, it blocks all PRs that change pom.xml
    files if his check is a required check.

### Modifications

- remove owasp-dep-check from required checks