### PR TITLE
[Dockerfile] Enable retries for apt-get when building Pulsar docker image

### DIFF
--- a/docker/pulsar/Dockerfile
+++ b/docker/pulsar/Dockerfile
@@ -51,6 +51,7 @@ ARG UBUNTU_MIRROR=mirror://mirrors.ubuntu.com/mirrors.txt
 
 # Install some utilities
 RUN sed -i "s|http://archive\.ubuntu\.com/ubuntu/|${UBUNTU_MIRROR:-mirror://mirrors.ubuntu.com/mirrors.txt}|g" /etc/apt/sources.list \
+     && echo 'Acquire::http::Timeout "30";\nAcquire::ftp::Timeout "30";\nAcquire::Retries "3";' > /etc/apt/apt.conf.d/99timeout_and_retries \
      && apt-get update \
      && apt-get -y dist-upgrade \
      && apt-get -y install --no-install-recommends openjdk-11-jdk-headless netcat dnsutils less procps iputils-ping \


### PR DESCRIPTION
### Motivation

- prevents issues where apt repository doesn't respond
- example failure: https://github.com/apache/pulsar/runs/5374589351?check_suite_focus=true#step:10:1458
```
[INFO] E: Failed to fetch http://azure.archive.ubuntu.com/ubuntu/pool/main/b/base-files/base-files_11ubuntu5.5_amd64.deb  Could not connect to azure.archive.ubuntu.com:80 (52.250.76.244), connection timed out
[INFO] E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
[INFO] 
Error:  The command '/bin/sh -c sed -i "s|http://archive\.ubuntu\.com/ubuntu/|${UBUNTU_MIRROR:-mirror://mirrors.ubuntu.com/mirrors.txt}|g" /etc/apt/sources.list      && apt-get update      && apt-get -y dist-upgrade      && apt-get -y install --no-install-recommends openjdk-11-jdk-headless netcat dnsutils less procps iputils-ping                  python3 python3-yaml python3-kazoo python3-pip                  curl ca-certificates      && apt-get -y --purge autoremove      && apt-get autoclean      && apt-get clean      && rm -rf /var/lib/apt/lists/*' returned a non-zero code: 100
```

### Modifications

- set retries to 3
- also reduce default timeout to 30 seconds