### PR TITLE
[branch-2.8] Remove awaitility duplicated declaration warning

### DIFF
--- a/pulsar-metadata/pom.xml
+++ b/pulsar-metadata/pom.xml
@@ -72,12 +72,6 @@
       <groupId>com.github.ben-manes.caffeine</groupId>
       <artifactId>caffeine</artifactId>
     </dependency>
-
-    <dependency>
-      <groupId>org.awaitility</groupId>
-      <artifactId>awaitility</artifactId>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
 
   <build>


### PR DESCRIPTION
### Motivation
`pulsar-metadata` has duplicated declaration of awaitility.

```
[INFO] Scanning for projects...
Warning:  
Warning:  Some problems were encountered while building the effective model for org.apache.pulsar:pulsar-metadata:jar:2.8.3
Warning:  'dependencies.dependency.(groupId:artifactId:type:classifier)' must be unique: org.awaitility:awaitility:jar -> duplicate declaration of version (?) @ line 76, column [17](https://github.com/apache/pulsar/runs/5375392184?check_suite_focus=true#step:8:17)
Warning:  
Warning:  It is highly recommended to fix these problems because they threaten the stability of your build.
Warning:  
Warning:  For this reason, future Maven versions might no longer support building such malformed projects.
Warning:
```


### Modifications

* Kept only one declaration


- [x] `no-need-doc` 
  