### PR TITLE
[Tests] Remove retryStrategically from MetadataCacheTest

### DIFF
--- a/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/MetadataCacheTest.java
+++ b/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/MetadataCacheTest.java
@@ -36,7 +36,6 @@ import java.util.TreeMap;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.atomic.AtomicReference;
-import java.util.function.Predicate;
 import java.util.function.Supplier;
 import lombok.AllArgsConstructor;
 import lombok.Cleanup;
@@ -234,7 +233,6 @@ public class MetadataCacheTest extends BaseMetadataStoreTest {
         v.put("b", "2");
         objCache.create(key1, v).join();
 
-        assertEqualsAndRetry(() -> objCache.getIfCached(key1), Optional.of(v), Optional.empty());
         assertEquals(objCache.get(key1).join(), Optional.of(v));
 
         objCache.delete(key1).join();
@@ -265,12 +263,11 @@ public class MetadataCacheTest extends BaseMetadataStoreTest {
             assertEquals(e.getCause().getClass(), AlreadyExistsException.class);
         }
 
-        assertEqualsAndRetry(() -> objCache.getIfCached(key1), Optional.of(value1), Optional.empty());
         assertEquals(objCache.get(key1).join(), Optional.of(value1));
 
         assertEquals(objCache.readModifyUpdateOrCreate(key1, __ -> value2).join(), value2);
         assertEquals(objCache.get(key1).join(), Optional.of(value2));
-        assertEqualsAndRetry(() -> objCache.getIfCached(key1), Optional.of(value2), Optional.empty());
+        Awaitility.await().untilAsserted(() -> assertEquals(objCache.getIfCached(key1), Optional.of(value2)));
 
         objCache.delete(key1).join();
 
@@ -321,7 +318,7 @@ public class MetadataCacheTest extends BaseMetadataStoreTest {
         store.put(key1, ObjectMapperFactory.getThreadLocal().writeValueAsBytes(value1), Optional.of(-1L)).join();
 
         assertEquals(objCache.get(key1).join(), Optional.of(value1));
-        assertEqualsAndRetry(() -> objCache.getIfCached(key1), Optional.of(value1), Optional.empty());
+        Awaitility.await().untilAsserted(() -> assertEquals(objCache.getIfCached(key1), Optional.of(value1)));
     }
 
     @Test(dataProvider = "impl")
@@ -586,36 +583,5 @@ public class MetadataCacheTest extends BaseMetadataStoreTest {
         assertEquals(res.getValue().a, 1);
         assertEquals(res.getValue().b, 2);
         assertEquals(res.getValue().path, key1);
-    }
-
-    public static void assertEqualsAndRetry(Supplier<Object> actual,
-                                            Object expected,
-                                            Object expectedAndRetry) throws Exception {
-        assertEqualsAndRetry(actual, expected, expectedAndRetry, 5, 100);
-    }
-
-    public static void assertEqualsAndRetry(Supplier<Object> actual,
-                                            Object expected,
-                                            Object expectedAndRetry,
-                                            int retryCount,
-                                            long intSleepTimeInMillis) throws Exception {
-        assertTrue(retryStrategically((__) -> {
-            if (actual.get().equals(expectedAndRetry)) {
-                return false;
-            }
-            assertEquals(actual.get(), expected);
-            return true;
-        }, retryCount, intSleepTimeInMillis));
-    }
-
-    public static boolean retryStrategically(Predicate<Void> predicate, int retryCount, long intSleepTimeInMillis)
-            throws Exception {
-        for (int i = 0; i < retryCount; i++) {
-            if (predicate.test(null) || i == (retryCount - 1)) {
-                return true;
-            }
-            Thread.sleep(intSleepTimeInMillis + (intSleepTimeInMillis * i));
-        }
-        return false;
     }
 }


### PR DESCRIPTION
### Motivation

- [see comments in #14373](https://github.com/apache/pulsar/pull/14373#issuecomment-1055500489)

- the retryStrategically method will always pass on the last retry unless
  previous retries fail with an exception. This is very confusing.
- Awaitility should be used instead of retryStrategically

### Modifications

- remove the retryStrategically solution from MetadataCacheTest