### PR TITLE
[offloader-jcloud] Remove duplicated bundled dependency - jaxb-api

### DIFF
--- a/tiered-storage/jcloud/pom.xml
+++ b/tiered-storage/jcloud/pom.xml
@@ -80,6 +80,12 @@
       <artifactId>jclouds-allblobstore</artifactId>
       <version>${jclouds.version}</version>
       <scope>provided</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>javax.xml.bind</groupId>
+          <artifactId>jaxb-api</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.amazonaws</groupId>
@@ -102,6 +108,12 @@
       <artifactId>jclouds-blobstore</artifactId>
       <version>${jclouds.version}</version>
       <scope>provided</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>javax.xml.bind</groupId>
+          <artifactId>jaxb-api</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>

--- a/tiered-storage/jcloud/pom.xml
+++ b/tiered-storage/jcloud/pom.xml
@@ -68,6 +68,10 @@
           <groupId>org.apache.jclouds.provider</groupId>
           <artifactId>*</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>javax.xml.bind</groupId>
+          <artifactId>jaxb-api</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
 


### PR DESCRIPTION
### Motivation
Jcloud submodule includes duplicate jar of jaxb-api which leads to Jacoco failing in this way.

```
Error:  Failed to execute goal org.jacoco:jacoco-maven-plugin:0.8.7:report (post-test) on project tiered-storage-jcloud: An error has occurred in JaCoCo report generation. Error while creating report: Error while analyzing /home/runner/work/pulsar/pulsar/tiered-storage/jcloud/target/classes/META-INF/bundled-dependencies/jaxb-api-2.3.1.jar@META-INF/versions/9/javax/xml/bind/ModuleUtil.class. Can't add different class with same name: javax/xml/bind/ModuleUtil -> [Help 1]
``` 
### Modifications

Removed the jar imported from the `jclouds-shaded` dependency.


- [x] `no-need-doc` 
