### PR TITLE
[Tests] Fix thread leak in MLTransactionMetadataStore

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
@@ -443,7 +443,7 @@ public class PulsarService implements AutoCloseable, ShutdownService {
             if (this.brokerService != null) {
                 CompletableFuture<Void> brokerCloseFuture = this.brokerService.closeAsync();
                 if (this.transactionMetadataStoreService != null) {
-                    asyncCloseFutures.add(brokerCloseFuture.thenAccept(__ -> {
+                    asyncCloseFutures.add(brokerCloseFuture.whenComplete((__, ___) -> {
                         // close transactionMetadataStoreService after the broker has been closed
                         this.transactionMetadataStoreService.close();
                         this.transactionMetadataStoreService = null;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
@@ -423,11 +423,6 @@ public class PulsarService implements AutoCloseable, ShutdownService {
                 brokerAdditionalServlets = null;
             }
 
-            if (this.transactionMetadataStoreService != null) {
-                this.transactionMetadataStoreService.close();
-                this.transactionMetadataStoreService = null;
-            }
-
             GracefulExecutorServicesShutdown executorServicesShutdown =
                     GracefulExecutorServicesShutdown
                             .initiate()
@@ -446,7 +441,16 @@ public class PulsarService implements AutoCloseable, ShutdownService {
 
             List<CompletableFuture<Void>> asyncCloseFutures = new ArrayList<>();
             if (this.brokerService != null) {
-                asyncCloseFutures.add(this.brokerService.closeAsync());
+                CompletableFuture<Void> brokerCloseFuture = this.brokerService.closeAsync();
+                if (this.transactionMetadataStoreService != null) {
+                    asyncCloseFutures.add(brokerCloseFuture.thenAccept(__ -> {
+                        // close transactionMetadataStoreService after the broker has been closed
+                        this.transactionMetadataStoreService.close();
+                        this.transactionMetadataStoreService = null;
+                    }));
+                } else {
+                    asyncCloseFutures.add(brokerCloseFuture);
+                }
                 this.brokerService = null;
             }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/TransactionMetadataStoreService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/TransactionMetadataStoreService.java
@@ -555,7 +555,17 @@ public class TransactionMetadataStoreService {
         return Collections.unmodifiableMap(stores);
     }
 
-    public void close () {
+    public synchronized void close () {
         this.internalPinnedExecutor.shutdown();
+        stores.forEach((tcId, metadataStore) -> {
+            metadataStore.closeAsync().whenComplete((v, ex) -> {
+                if (ex != null) {
+                    LOG.error("Close transaction metadata store with id " + tcId, ex);
+                } else {
+                    LOG.info("Removed and closed transaction meta store {}", tcId);
+                }
+            });
+        });
+        stores.clear();
     }
 }

--- a/pulsar-transaction/coordinator/src/main/java/org/apache/pulsar/transaction/coordinator/TransactionMetadataStoreState.java
+++ b/pulsar-transaction/coordinator/src/main/java/org/apache/pulsar/transaction/coordinator/TransactionMetadataStoreState.java
@@ -33,6 +33,7 @@ public abstract class TransactionMetadataStoreState {
         None,
         Initializing,
         Ready,
+        Closing,
         Close
     }
 
@@ -55,10 +56,14 @@ public abstract class TransactionMetadataStoreState {
         return STATE_UPDATER.compareAndSet(this, State.None, State.Initializing);
     }
 
+    protected boolean changeToClosingState() {
+        return (STATE_UPDATER.compareAndSet(this, State.Ready, State.Closing)
+                || STATE_UPDATER.compareAndSet(this, State.None, State.Closing)
+                || STATE_UPDATER.compareAndSet(this, State.Initializing, State.Closing));
+    }
+
     protected boolean changeToCloseState() {
-        return (STATE_UPDATER.compareAndSet(this, State.Ready, State.Close)
-                || STATE_UPDATER.compareAndSet(this, State.None, State.Close)
-                || STATE_UPDATER.compareAndSet(this, State.Initializing, State.Close));
+        return STATE_UPDATER.compareAndSet(this, State.Closing, State.Close);
     }
 
     protected boolean checkIfReady() {


### PR DESCRIPTION
### Motivation

- MLTransactionMetadataStore.internalPinnedExecutor wasn't closed
  when MLTransactionMetadataStore.closeAsync was called
  - problem was introduced by #14238 changes

- this issue causes tests to fail with OOME. This might also impact
  production code in some way.

- [example OOME in tests](https://github.com/apache/pulsar/runs/5377109499?check_suite_focus=true#step:9:838)  
  - [Thread dump](https://jstack.review/?https://gist.github.com/lhotari/43695769fda4dc8e1cce880e685c83e2#tda_1_dump)

### Modifications

- shutdown the ExecutorService when MLTransactionMetadataStore.closeAsync is called
  - Use Guava's `MoreExecutors.shutdownAndAwaitTermination` to handle ExecutorService shutdown since it handles shutdown in a proper way gracefully although in this case it seems that it would be fine to terminate forcefully by calling shutdownNow