### PR TITLE
[Doc] Fix the config document for elasticSearchUrl in io-elasticsearc…

### DIFF
--- a/site2/docs/io-elasticsearch-sink.md
+++ b/site2/docs/io-elasticsearch-sink.md
@@ -49,8 +49,8 @@ The configuration of the Elasticsearch sink connector has the following properti
 
 | Name | Type|Required | Default | Description 
 |------|----------|----------|---------|-------------|
-| `elasticSearchUrl` | String| true |" " (empty string)| The index name to which the connector writes messages. The default value is the topic name. It accepts date formats in the name to support event time based index with the pattern `%{+<date-format>}`. For example, suppose the event time of the record is 1645182000000L, the indexName is `logs-%{+yyyy-MM-dd}`, then the formatted index name would be `logs-2022-02-18`. |
-| `indexName` | String| false |" " (empty string)| The index name to which the connector writes messages. |
+| `elasticSearchUrl` | String| true |" " (empty string)| The URL of elastic search cluster to which the connector connects. |
+| `indexName` | String| false |" " (empty string)| The index name to which the connector writes messages. The default value is the topic name. It accepts date formats in the name to support event time based index with the pattern `%{+<date-format>}`. For example, suppose the event time of the record is 1645182000000L, the indexName is `logs-%{+yyyy-MM-dd}`, then the formatted index name would be `logs-2022-02-18`. |
 | `schemaEnable` | Boolean | false | false | Turn on the Schema Aware mode. |
 | `createIndexIfNeeded` | Boolean | false | false | Manage index if missing. |
 | `maxRetries` | Integer | false | 1 | The maximum number of retries for elasticsearch requests. Use -1 to disable it.  |


### PR DESCRIPTION
### Motivation

Fix bug in doc io-elasticsearch-sink

### Modifications

Last PR change the description of config elasticSearchUrl and indexName in `io-elasticsearch-sink`, but modified wrong row. This PR will fix it.

### Documentation
  
- [x] `doc` 



