### PR TITLE
Fix MLTransactionMetadataStore.update async fail

### DIFF
--- a/pulsar-transaction/coordinator/src/main/java/org/apache/pulsar/transaction/coordinator/impl/MLTransactionMetadataStore.java
+++ b/pulsar-transaction/coordinator/src/main/java/org/apache/pulsar/transaction/coordinator/impl/MLTransactionMetadataStore.java
@@ -391,6 +391,7 @@ public class MLTransactionMetadataStore
                                 txnMetaMap.remove(txnID.getLeastSigBits());
                                 completableFuture.complete(null);
                             });
+                            return;
                         }
                         completableFuture.complete(null);
                     } catch (InvalidTxnStatusException e) {


### PR DESCRIPTION
### Motivation

#14525 

When update states is `TxnStatus.COMMITTED`,  Not correctly `completableFuture.complete`.

### Modifications
- When update states is `TxnStatus.COMMITTED`, Add return to ending. Avoid direct calls `completableFuture.complete` from other logic.

### Documentation
- [x ] `no-need-doc` 



