### PR TITLE
[Java client] Add timeout to closeAsync so that closing a client doesn't block forever

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PulsarClientImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PulsarClientImpl.java
@@ -29,6 +29,7 @@ import io.netty.util.Timer;
 import io.netty.util.concurrent.DefaultThreadFactory;
 import java.io.IOException;
 import java.time.Clock;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -38,6 +39,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.ThreadLocalRandom;
@@ -90,6 +92,7 @@ import org.slf4j.LoggerFactory;
 public class PulsarClientImpl implements PulsarClient {
 
     private static final Logger log = LoggerFactory.getLogger(PulsarClientImpl.class);
+    private static final int CLOSE_TIMEOUT_SECONDS = 60;
 
     protected final ClientConfigurationData conf;
     private final boolean createdExecutorProviders;
@@ -723,7 +726,17 @@ public class PulsarClientImpl implements PulsarClient {
         // If there are consumers or producers that need to be shutdown we cannot use the same thread
         // to shutdown the EventLoopGroup as well as that would be trying to shutdown itself thus a deadlock
         // would happen
-        FutureUtil.waitForAll(futures).thenRun(() -> new Thread(() -> {
+        CompletableFuture<Void> combinedFuture = FutureUtil.waitForAll(futures);
+        ScheduledExecutorService shutdownExecutor = Executors.newSingleThreadScheduledExecutor(
+                new DefaultThreadFactory("pulsar-client-shutdown-timeout-scheduler"));
+        FutureUtil.addTimeoutHandling(combinedFuture, Duration.ofSeconds(CLOSE_TIMEOUT_SECONDS),
+                shutdownExecutor, () -> FutureUtil.createTimeoutException("Closing producers and consumers timed out.",
+                        PulsarClientImpl.class, "closeAsync"));
+        combinedFuture.whenComplete((__, t) -> new Thread(() -> {
+            if (t != null) {
+                log.error("Closing producers and consumers failed. Continuing with shutdown.", t);
+            }
+            shutdownExecutor.shutdownNow();
             // All producers & consumers are now closed, we can stop the client safely
             try {
                 shutdown();
@@ -824,7 +837,7 @@ public class PulsarClientImpl implements PulsarClient {
     private void shutdownEventLoopGroup(EventLoopGroup eventLoopGroup) throws PulsarClientException {
         if (createdEventLoopGroup && eventLoopGroup != null && !eventLoopGroup.isShutdown()) {
             try {
-                eventLoopGroup.shutdownGracefully().get();
+                eventLoopGroup.shutdownGracefully().get(CLOSE_TIMEOUT_SECONDS, TimeUnit.SECONDS);
             } catch (Throwable t) {
                 throw PulsarClientException.unwrap(t);
             }


### PR DESCRIPTION
Fixes #13964

### Motivation

Closing a Pulsar client gets blocked or leaves unclosed resources behind in CI. 
This causes builds to timeout. Similar problems could happen in production code that closing the client blocks or leaves resources behind if the closing of a producer or a consumer completes with an exception.

see #13964 for issue report about closing getting blocked.

Examples:

PulsarClientImpl.shutdownEventLoopGroup stuck:

[thread dump from stalled build job](https://github.com/apache/pulsar/runs/5389016985?check_suite_focus=true#step:12:1341)
```
"main" #1 prio=5 os_prio=0 cpu=49933.58ms elapsed=347.19s tid=0x00007f86b4028000 nid=0x1f5ee in Object.wait()  [0x00007f86bbfb2000]
   java.lang.Thread.State: WAITING (on object monitor)
        at java.lang.Object.wait(java.base@11.0.14.1/Native Method)
        - waiting on <no object reference available>
        at java.lang.Object.wait(java.base@11.0.14.1/Object.java:328)
        at io.netty.util.concurrent.DefaultPromise.await(DefaultPromise.java:253)
        - waiting to re-lock in wait() <0x00000000d4c60d18> (a io.netty.util.concurrent.DefaultPromise)
        at io.netty.util.concurrent.DefaultPromise.get(DefaultPromise.java:337)
        at org.apache.pulsar.client.impl.PulsarClientImpl.shutdownEventLoopGroup(PulsarClientImpl.java:821)
        at org.apache.pulsar.client.impl.PulsarClientImpl.shutdown(PulsarClientImpl.java:767)
        at org.apache.pulsar.broker.auth.MockedPulsarServiceBaseTest.internalCleanup(MockedPulsarServiceBaseTest.java:203)
        at org.apache.pulsar.broker.intercept.BrokerInterceptorTest.teardown(BrokerInterceptorTest.java:99)
```


### Modifications

- don't terminate the closing sequence when exceptions occur in closing producers and consumers 
  - log exceptions when closing producers and consumers
- add timeout handling for waiting for the closing of producers and consumers to complete
- add timeout for shutting down eventLoopGroup