### PR TITLE
Fix consumer block problem: skip no entry

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumers.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumers.java
@@ -636,7 +636,7 @@ public class PersistentDispatcherMultipleConsumers extends AbstractDispatcherMul
         } else if (!(exception instanceof TooManyRequestsException)) {
             log.error("[{}] Error reading entries at {} : {}, Read Type {} - Retrying to read in {} seconds", name,
                     cursor.getReadPosition(), exception.getMessage(), readType, waitTimeMillis / 1000.0);
-        } else if(exception instanceof ManagedLedgerException.NonRecoverableLedgerException){
+        } else if (exception instanceof ManagedLedgerException.NonRecoverableLedgerException) {
             log.error("[{}] Error reading entries at {} : {}, Read Type {} - No such entry, skip to next entry!", name,
                     cursor.getReadPosition(), exception.getMessage(), readType);
             Position nextPosition = cursor.getMarkDeletedPosition().getNext();

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumers.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumers.java
@@ -636,6 +636,11 @@ public class PersistentDispatcherMultipleConsumers extends AbstractDispatcherMul
         } else if (!(exception instanceof TooManyRequestsException)) {
             log.error("[{}] Error reading entries at {} : {}, Read Type {} - Retrying to read in {} seconds", name,
                     cursor.getReadPosition(), exception.getMessage(), readType, waitTimeMillis / 1000.0);
+        } else if(exception instanceof ManagedLedgerException.NonRecoverableLedgerException){
+            log.error("[{}] Error reading entries at {} : {}, Read Type {} - No such entry, skip to next entry!", name,
+                    cursor.getReadPosition(), exception.getMessage(), readType);
+            Position nextPosition = cursor.getMarkDeletedPosition().getNext();
+            cursor.seek(nextPosition);
         } else {
             if (log.isDebugEnabled()) {
                 log.debug("[{}] Error reading entries at {} : {}, Read Type {} - Retrying to read in {} seconds", name,


### PR DESCRIPTION
### Motivation
We encountered such a problem: the broker never pushes messages because it reads a non-existing entry, and will keep trying to read the non-existing entry.

**Through the stats command, we found that some partitions have not pushed messages to consumers:**
![image](https://user-images.githubusercontent.com/19296967/156531846-fd9e75e6-f321-4a3a-8030-474b8061c109.png)



**The error log is as follows:**
00:00:10.094 [pulsar-io-4-122] INFO  org.apache.pulsar.broker.service.persistent.PersistentDispatcherMultipleConsumers - [persistent://teg_onion_onion_common_data_gz/teg_onion_onion_common_data_gz/teg_onion_onion_common_data_gz-partition-159 / t_teg_onion_b_teg_onion_onion_common_data_gz_cg_onion_common_data_cos_svr_gz_001] Retrying read operation
00:00:28.320 [BookKeeperClientWorker-OrderedExecutor-21-0] ERROR org.apache.bookkeeper.client.PendingReadOp - Read of ledger entry failed: L15759573 E15389-E15389, Sent to [11.135.219.182:3181, 11.135.217.80:3181], Heard from [] : bitset = {}, Error = 'No such entry'. First unread entry is (-1, rc = null)
00:00:28.320 [BookKeeperClientWorker-OrderedExecutor-33-0] WARN  org.apache.bookkeeper.mledger.impl.OpReadEntry - [teg_onion_onion_common_data_gz/teg_onion_onion_common_data_gz/persistent/teg_onion_onion_common_data_gz-partition-275][t_teg_onion_b_teg_onion_onion_common_data_gz_cg_onion_common_data_cos_svr_gz_001] read failed from ledger at position:15759573:15389
org.apache.bookkeeper.mledger.ManagedLedgerException$NonRecoverableLedgerException: No such entry
00:00:28.320 [BookKeeperClientWorker-OrderedExecutor-33-0] ERROR org.apache.pulsar.broker.service.persistent.PersistentDispatcherMultipleConsumers - [persistent://teg_onion_onion_common_data_gz/teg_onion_onion_common_data_gz/teg_onion_onion_common_data_gz-partition-275 / t_teg_onion_b_teg_onion_onion_common_data_gz_cg_onion_common_data_cos_svr_gz_001] Error reading entries at 15759573:15389 : No such entry, Read Type Normal - Retrying to read in 54.299 seconds

**And I found through the bookkeeper command: sh bin/bookkeeper shell ledger 15759573 that entryId=15389 does not exist, and the smallest entryid=15558:**
![image](https://user-images.githubusercontent.com/19296967/156530705-1bf1df88-fb2e-497b-a17f-7bd65b819c8b.png)


**Through monitoring, we found that the consumption delay of some partiotns continued to rise：**
![image](https://user-images.githubusercontent.com/19296967/156531328-da03b92f-c73f-4207-9d21-9098847f616b.png)




### Modifications
When we encounter this situation, skip the entry


### Documentation

Check the box below or label this PR directly (if you have committer privilege).

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)


