### PR TITLE
Cancel offload tasks when managed ledger closed.

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
@@ -2317,7 +2317,7 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
 
     private void maybeOffload(CompletableFuture<PositionImpl> finalPromise) {
         if (!offloadMutex.tryLock()) {
-            scheduledExecutor.schedule(safeRun(() -> maybeOffload(finalPromise)),
+            scheduledExecutor.schedule(safeRun(() -> maybeOffloadInBackground(finalPromise)),
                                        100, TimeUnit.MILLISECONDS);
         } else {
             CompletableFuture<PositionImpl> unlockingPromise = new CompletableFuture<>();

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
@@ -4094,7 +4094,6 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
         if (this.checkLedgerRollTask != null) {
             this.checkLedgerRollTask.cancel(false);
         }
-
     }
 
     @Override

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
@@ -2368,6 +2368,7 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
                     // offloadLoop will complete immediately with an empty list to offload
                     log.debug("[{}] Nothing to offload, total size = {}, already offloaded = {}, threshold = {}",
                             name, sizeSummed, alreadyOffloadedSize, threshold);
+                    unlockingPromise.complete(PositionImpl.LATEST);
                 }
             }
         }
@@ -2932,6 +2933,8 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
     private void offloadLoop(CompletableFuture<PositionImpl> promise, Queue<LedgerInfo> ledgersToOffload,
             PositionImpl firstUnoffloaded, Optional<Throwable> firstError) {
         if (getState() == State.Closed) {
+            promise.completeExceptionally(new ManagedLedgerAlreadyClosedException(
+                    String.format("managed ledger [%s] has already closed", name)));
             return;
         }
         LedgerInfo info = ledgersToOffload.poll();

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
@@ -30,7 +30,6 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Queues;
 import com.google.common.collect.Range;
-import com.google.common.util.concurrent.ListenableFuture;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.util.Recycler;
@@ -53,7 +52,6 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedDeque;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ConcurrentSkipListMap;
@@ -294,12 +292,6 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
      */
     @VisibleForTesting
     Map<String, byte[]> createdLedgerCustomMetadata;
-
-    final ConcurrentHashMap<Long, ListenableFuture<?>> executorOffloadTasks = new ConcurrentHashMap<>();
-    final ConcurrentHashMap<Long, ScheduledFuture<?>> schedulerOffloadTasks = new ConcurrentHashMap<>();
-    static final AtomicLongFieldUpdater<ManagedLedgerImpl> OFFLOAD_ID_UPDATER = AtomicLongFieldUpdater
-            .newUpdater(ManagedLedgerImpl.class, "offloadId");
-    private volatile long offloadId = 0;
 
     public ManagedLedgerImpl(ManagedLedgerFactoryImpl factory, BookKeeper bookKeeper, MetaStore store,
             ManagedLedgerConfig config, OrderedScheduler scheduledExecutor,
@@ -2319,24 +2311,18 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
                 && config.getLedgerOffloader().getOffloadPolicies() != null
                 && config.getLedgerOffloader().getOffloadPolicies().getManagedLedgerOffloadThresholdInBytes() != null
                 && config.getLedgerOffloader().getOffloadPolicies().getManagedLedgerOffloadThresholdInBytes() >= 0) {
-            long id = OFFLOAD_ID_UPDATER.incrementAndGet(this);
-            executorOffloadTasks.put(id, executor.submitOrdered(name.hashCode(), () -> {
-                maybeOffload(id, promise);
-                return promise;
-            }));
+            executor.executeOrdered(name, safeRun(() -> maybeOffload(promise)));
         }
     }
 
-    private void maybeOffload(long id, CompletableFuture<PositionImpl> finalPromise) {
+    private void maybeOffload(CompletableFuture<PositionImpl> finalPromise) {
         if (!offloadMutex.tryLock()) {
-            schedulerOffloadTasks.put(id, scheduledExecutor.schedule(safeRun(() -> maybeOffload(id, finalPromise)),
-                                       100, TimeUnit.MILLISECONDS));
+            scheduledExecutor.schedule(safeRun(() -> maybeOffload(finalPromise)),
+                                       100, TimeUnit.MILLISECONDS);
         } else {
             CompletableFuture<PositionImpl> unlockingPromise = new CompletableFuture<>();
             unlockingPromise.whenComplete((res, ex) -> {
                     offloadMutex.unlock();
-                    schedulerOffloadTasks.remove(id);
-                    executorOffloadTasks.remove(id);
                     if (ex != null) {
                         finalPromise.completeExceptionally(ex);
                     } else {
@@ -2945,6 +2931,9 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
 
     private void offloadLoop(CompletableFuture<PositionImpl> promise, Queue<LedgerInfo> ledgersToOffload,
             PositionImpl firstUnoffloaded, Optional<Throwable> firstError) {
+        if (getState() == State.Closed) {
+            return;
+        }
         LedgerInfo info = ledgersToOffload.poll();
         if (info == null) {
             if (firstError.isPresent()) {
@@ -4105,10 +4094,7 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
         if (this.checkLedgerRollTask != null) {
             this.checkLedgerRollTask.cancel(false);
         }
-        this.executorOffloadTasks.values().forEach(v -> v.cancel(true));
-        this.schedulerOffloadTasks.values().forEach(v -> v.cancel(true));
-        this.executorOffloadTasks.clear();
-        this.schedulerOffloadTasks.clear();
+
     }
 
     @Override


### PR DESCRIPTION
### Motivation
When the user config the offloader, as the ledger close, it will trigger the ledger to offload. If there are many ledgers that need to offload, but the topic has been unloaded, the offloader will continue to offload. Because the offloader uses the shared executor pool in ManagedLedgerFactoryImpl and when the managed ledger closes, it doesn't cancel the tasks.

```
15:29:59.180 [pulsar-web-41-3] INFO  org.apache.pulsar.broker.admin.impl.PersistentTopicsBase - [null] Unloading topic persistent://public/default/UpdateNodeCharts
15:29:59.201 [pulsar-web-41-3] INFO  org.apache.bookkeeper.mledger.impl.ManagedLedgerImpl - [public/default/persistent/UpdateNodeCharts] Closing managed ledger
15:29:59.216 [main-EventThread] INFO  org.apache.bookkeeper.mledger.impl.MetaStoreImpl - [public/default/persistent/UpdateNodeCharts] [cloud-nodes-service] Updating cursor info ledgerId=-1 mark-delete=789182:82011
15:29:59.219 [bookkeeper-ml-scheduler-OrderedScheduler-4-0] INFO  org.apache.bookkeeper.mledger.impl.ManagedCursorImpl - [public/default/persistent/UpdateNodeCharts][cloud-nodes-service] Closed cursor at md-position=789182:82011
15:29:59.221 [bookkeeper-ml-scheduler-OrderedScheduler-4-0] INFO  org.apache.pulsar.broker.service.persistent.PersistentTopic - [persistent://public/default/UpdateNodeCharts] Topic closed
15:29:59.221 [bookkeeper-ml-scheduler-OrderedScheduler-4-0] INFO  org.apache.pulsar.broker.admin.impl.PersistentTopicsBase - [null] Successfully unloaded topic persistent://public/default/UpdateNodeCharts
15:31:05.432 [offloader-OrderedScheduler-1-0] INFO  org.apache.bookkeeper.mledger.impl.ManagedLedgerImpl - [public/default/persistent/UpdateNodeCharts] Preparing metadata to offload ledger 422142 with uuid 030267e2-a2f9-40a3-848b-482f9b007c00
15:31:05.432 [offloader-OrderedScheduler-1-0] INFO  org.apache.bookkeeper.mledger.impl.ManagedLedgerImpl - [public/default/persistent/UpdateNodeCharts] Found previous offload attempt for ledger 422142, uuid 030267e2-a2f9-40a3-848b-482f9b007c00, cleaning up
15:31:05.432 [offloader-OrderedScheduler-1-0] INFO  org.apache.bookkeeper.mledger.impl.ManagedLedgerImpl - [public/default/persistent/UpdateNodeCharts] Cleanup offload for ledgerId 422142 uuid 3725b3c1-1dbc-481f-a1dd-8aaffb75e603 because of the reason Previous failed offload.
```

### Modifications

- When do `offloadLoop`, check state first. if `Close`, nothing to do. 

### Documentation
  
- [x] `no-need-doc` 


