### PR TITLE
fix: NamespacesTest execution order

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/NamespacesTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/NamespacesTest.java
@@ -844,11 +844,11 @@ public class NamespacesTest extends MockedPulsarServiceBaseTest {
             assertEquals(re.getResponse().getStatus(), Status.PRECONDITION_FAILED.getStatusCode());
         }
         response = mock(AsyncResponse.class);
-        namespaces.deleteNamespace(response, testTenant, testLocalCluster, bundledNsLocal, false, false);
         doReturn(Optional.of(localWebServiceUrl)).when(nsSvc).getWebServiceUrl(any(NamespaceBundle.class), any(LookupOptions.class));
         for (NamespaceBundle bundle : nsBundles.getBundles()) {
             doReturn(true).when(nsSvc).isServiceUnitOwned(bundle);
         }
+        namespaces.deleteNamespace(response, testTenant, testLocalCluster, bundledNsLocal, false, false);
         ArgumentCaptor<Response> captor2 = ArgumentCaptor.forClass(Response.class);
         verify(response, timeout(5000).times(1)).resume(captor2.capture());
         assertEquals(captor2.getValue().getStatus(), Status.NO_CONTENT.getStatusCode());


### PR DESCRIPTION
### Motivation

Fixes: #14516 


Before delete a namespace, We should mock all done. 847 lines of code should be executed after 851 lines of code.

https://github.com/apache/pulsar/blob/4f1e39b6921ea401b8c27f17a041d06d85f8abf8/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/NamespacesTest.java#L847-L851

Otherwise, a null pointer may happen during verification `isServiceUnitOwned`

https://github.com/apache/pulsar/blob/4f1e39b6921ea401b8c27f17a041d06d85f8abf8/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/PulsarWebResource.java#L584

Final throw RestException

https://github.com/apache/pulsar/blob/4f1e39b6921ea401b8c27f17a041d06d85f8abf8/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/PulsarWebResource.java#L608-L610

### Modifications
- Fix NamespacesTest execution order


### Documentation

- [x] `no-need-doc` 

