### PR TITLE
[pulsar-functions] fix some IOExceptions when create functions from package URL

### DIFF
--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/PackagesImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/PackagesImpl.java
@@ -25,6 +25,7 @@ import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import javax.ws.rs.client.Entity;
@@ -144,7 +145,7 @@ public class PackagesImpl extends ComponentResource implements Packages {
                         if (destinyPath.getParent() != null) {
                             Files.createDirectories(destinyPath.getParent());
                         }
-                        Files.copy(inputStream, destinyPath);
+                        Files.copy(inputStream, destinyPath, StandardCopyOption.REPLACE_EXISTING);
                         future.complete(null);
                     } catch (IOException e) {
                         future.completeExceptionally(e);

--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/api/FunctionsImpl.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/api/FunctionsImpl.java
@@ -815,6 +815,7 @@ public class FunctionsImpl extends ComponentImpl implements Functions<PulsarWork
             // use the Nar extraction directory as a temporary directory for downloaded files
             tempDirectory = Paths.get(worker.getWorkerConfig().getNarExtractionDirectory());
         }
+        Files.createDirectories(tempDirectory);
         File file = Files.createTempFile(tempDirectory, "function", ".tmp").toFile();
         worker.getBrokerAdmin().packages().download(packageName, file.toString());
         return file;


### PR DESCRIPTION
### Motivation

fix #14536

When create functions from package URL (from package management service), some of IOExceptions may thrown due to directory not exists.

### Modifications

- add `StandardCopyOption.REPLACE_EXISTING` to package download, to prevent `FileAlreadyExistsException`
- make sure the directory exists before `Files.createTempFile`

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API: (yes / no)
  - The schema: (yes / no / don't know)
  - The default values of configurations: (yes / no)
  - The wire protocol: (yes / no)
  - The rest endpoints: (yes / no)
  - The admin cli options: (yes / no)
  - Anything that affects deployment: (yes / no / don't know)

### Documentation

Check the box below or label this PR directly (if you have committer privilege).

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)


