### PR TITLE
[C++] Fix wrong unit of Access Token Response's `expires_in` field

### DIFF
--- a/pulsar-client-cpp/lib/auth/AuthOauth2.h
+++ b/pulsar-client-cpp/lib/auth/AuthOauth2.h
@@ -20,6 +20,7 @@
 #pragma once
 
 #include <pulsar/Authentication.h>
+#include <chrono>
 #include <mutex>
 #include <string>
 
@@ -69,13 +70,15 @@ class ClientCredentialFlow : public Oauth2Flow {
 
 class Oauth2CachedToken : public CachedToken {
    public:
+    using Clock = std::chrono::high_resolution_clock;
+
     Oauth2CachedToken(Oauth2TokenResultPtr token);
     ~Oauth2CachedToken();
     bool isExpired();
     AuthenticationDataPtr getAuthData();
 
    private:
-    int64_t expiresAt_;
+    std::chrono::time_point<Clock> expiresAt_;
     Oauth2TokenResultPtr latest_;
     AuthenticationDataPtr authData_;
 };


### PR DESCRIPTION
### Motivation

The `expires_in` field of Access Token Response is in seconds. See
https://datatracker.ietf.org/doc/html/rfc6749#section-4.2.2. However,
C++ client treats it as milliseconds currently. It will leads to an
earlier expiration of the token.

### Modifications

Record the time point via the `std::time_point` class, which supports
add operations with a `std::duration` object. Then converts the
`expires_in` field via `std::chrono::second` function and calculate the
expired time point.

It also removes the usage of Boost time functions and makes code more clear.