### PR TITLE
Make copies of thread local MessageMetadata when it might be shared

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractBaseDispatcher.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractBaseDispatcher.java
@@ -145,9 +145,10 @@ public abstract class AbstractBaseDispatcher implements Dispatcher {
             MessageMetadata msgMetadata = entryWrapper.isPresent() && entryWrapper.get()[entryWrapperIndex] != null
                     ? entryWrapper.get()[entryWrapperIndex].getMetadata()
                     : null;
-            msgMetadata = msgMetadata == null
-                    ? Commands.peekMessageMetadata(metadataAndPayload, subscription.toString(), -1)
-                    : msgMetadata;
+            if (msgMetadata == null) {
+                msgMetadata = new MessageMetadata();
+                msgMetadata.copyFrom(Commands.peekMessageMetadata(metadataAndPayload, subscription.toString(), -1));
+            }
             if (CollectionUtils.isNotEmpty(entryFilters)) {
                 fillContext(filterContext, msgMetadata, subscription);
                 if (EntryFilter.FilterResult.REJECT == getFilterResult(filterContext, entry, entryFilters)) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/EntryWrapper.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/EntryWrapper.java
@@ -34,7 +34,6 @@ public class EntryWrapper {
             entryWrapper.hasMetadata = true;
             entryWrapper.metadata.copyFrom(metadata);
         }
-        entryWrapper.metadata.copyFrom(metadata);
         return entryWrapper;
     }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/EntryWrapper.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/EntryWrapper.java
@@ -24,7 +24,7 @@ import org.apache.pulsar.common.api.proto.MessageMetadata;
 
 public class EntryWrapper {
     private Entry entry = null;
-    private MessageMetadata metadata = new MessageMetadata();
+    private final MessageMetadata metadata = new MessageMetadata();
     private boolean hasMetadata = false;
 
     public static EntryWrapper get(Entry entry, MessageMetadata metadata) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/plugin/FilterContext.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/plugin/FilterContext.java
@@ -42,6 +42,6 @@ public class FilterContext {
     }
 
     public void setMsgMetadata(MessageMetadata msgMetadata) {
-        this.msgMetadata.copyFrom(msgMetadata);
+        this.msgMetadata.clear().copyFrom(msgMetadata);
     }
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/plugin/FilterContext.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/plugin/FilterContext.java
@@ -25,12 +25,23 @@ import org.apache.pulsar.common.api.proto.MessageMetadata;
 @Data
 public class FilterContext {
     private Subscription subscription;
-    private MessageMetadata msgMetadata;
+    private final MessageMetadata msgMetadata = new MessageMetadata();
+
+    public FilterContext() {
+    }
 
     public void reset() {
         subscription = null;
-        msgMetadata = null;
+        msgMetadata.clear();
     }
 
     public static final FilterContext FILTER_CONTEXT_DISABLED = new FilterContext();
+
+    public MessageMetadata getMsgMetadata() {
+        return this.msgMetadata;
+    }
+
+    public void setMsgMetadata(MessageMetadata msgMetadata) {
+        this.msgMetadata.copyFrom(msgMetadata);
+    }
 }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MessagePayloadContextImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MessagePayloadContextImpl.java
@@ -45,7 +45,7 @@ public class MessagePayloadContextImpl implements MessagePayloadContext {
 
     private final Recycler.Handle<MessagePayloadContextImpl> recyclerHandle;
     private BrokerEntryMetadata brokerEntryMetadata;
-    private MessageMetadata messageMetadata;
+    private final MessageMetadata messageMetadata = new MessageMetadata();
     private SingleMessageMetadata singleMessageMetadata;
     private MessageIdImpl messageId;
     private ConsumerImpl<?> consumer;
@@ -68,7 +68,7 @@ public class MessagePayloadContextImpl implements MessagePayloadContext {
         final MessagePayloadContextImpl context = RECYCLER.get();
         context.consumerEpoch = consumerEpoch;
         context.brokerEntryMetadata = brokerEntryMetadata;
-        context.messageMetadata = messageMetadata;
+        context.messageMetadata.copyFrom(messageMetadata);
         context.singleMessageMetadata = new SingleMessageMetadata();
         context.messageId = messageId;
         context.consumer = consumer;
@@ -82,7 +82,7 @@ public class MessagePayloadContextImpl implements MessagePayloadContext {
 
     public void recycle() {
         brokerEntryMetadata = null;
-        messageMetadata = null;
+        messageMetadata.clear();
         singleMessageMetadata = null;
         messageId = null;
         consumer = null;


### PR DESCRIPTION
### Motivation

- sharing the thread local MessageMetadata instance to other threads will cause issues
  - Thread local variable is org.apache.pulsar.common.protocol.Commands#LOCAL_MESSAGE_METADATA

### Additional context

- I was trying to find a fix for #14436 . My assumption was that the problem could occur as a result of sharing the thread local MessageMetadata instance to other threads. However, I'm not sure if this PR fixes that or not.

### Modifications

- make a copy when the thread local instance might be shared later