### PR TITLE
Prometheus metric support label

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/metrics/DataSketchesOpStatsLogger.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/metrics/DataSketchesOpStatsLogger.java
@@ -36,13 +36,13 @@ import org.apache.bookkeeper.stats.OpStatsLogger;
  */
 public class DataSketchesOpStatsLogger implements OpStatsLogger {
 
-    /*
+    /**
      * Use 2 rotating thread local accessor so that we can safely swap them.
      */
     private volatile ThreadLocalAccessor current;
     private volatile ThreadLocalAccessor replacement;
 
-    /*
+    /**
      * These are the sketches where all the aggregated results are published.
      */
     private volatile DoublesSketch successResult;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/metrics/DataSketchesOpStatsLogger.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/metrics/DataSketchesOpStatsLogger.java
@@ -36,13 +36,13 @@ import org.apache.bookkeeper.stats.OpStatsLogger;
  */
 public class DataSketchesOpStatsLogger implements OpStatsLogger {
 
-    /**
+    /*
      * Use 2 rotating thread local accessor so that we can safely swap them.
      */
     private volatile ThreadLocalAccessor current;
     private volatile ThreadLocalAccessor replacement;
 
-    /**
+    /*
      * These are the sketches where all the aggregated results are published.
      */
     private volatile DoublesSketch successResult;
@@ -54,9 +54,12 @@ public class DataSketchesOpStatsLogger implements OpStatsLogger {
     private final LongAdder successSumAdder = new LongAdder();
     private final LongAdder failSumAdder = new LongAdder();
 
-    public DataSketchesOpStatsLogger() {
+    private final Map<String, String> labels;
+
+    public DataSketchesOpStatsLogger(Map<String, String> labels) {
         this.current = new ThreadLocalAccessor();
         this.replacement = new ThreadLocalAccessor();
+        this.labels = labels;
     }
 
     @Override
@@ -170,6 +173,10 @@ public class DataSketchesOpStatsLogger implements OpStatsLogger {
     public double getQuantileValue(boolean success, double quantile) {
         DoublesSketch s = success ? successResult : failResult;
         return s != null ? s.getQuantile(quantile) : Double.NaN;
+    }
+
+    public Map<String, String> getLabels() {
+        return labels;
     }
 
     private static class LocalData {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/metrics/PrometheusMetricsProvider.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/metrics/PrometheusMetricsProvider.java
@@ -24,12 +24,13 @@ import io.netty.util.concurrent.DefaultThreadFactory;
 import io.prometheus.client.Collector;
 import java.io.IOException;
 import java.io.Writer;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
-import java.util.concurrent.ConcurrentSkipListMap;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
-import org.apache.bookkeeper.stats.CachingStatsProvider;
 import org.apache.bookkeeper.stats.StatsLogger;
 import org.apache.bookkeeper.stats.StatsProvider;
 import org.apache.commons.configuration.Configuration;
@@ -47,46 +48,12 @@ public class PrometheusMetricsProvider implements StatsProvider {
     public static final String DEFAULT_CLUSTER_NAME = "pulsar";
 
     private String cluster;
-    private final CachingStatsProvider cachingStatsProvider;
-
     /**
      * These acts a registry of the metrics defined in this provider.
      */
-    public final ConcurrentMap<String, LongAdderCounter> counters = new ConcurrentSkipListMap<>();
-    public final ConcurrentMap<String, SimpleGauge<? extends Number>> gauges = new ConcurrentSkipListMap<>();
-    public final ConcurrentMap<String, DataSketchesOpStatsLogger> opStats = new ConcurrentSkipListMap<>();
-
-    public PrometheusMetricsProvider() {
-        this.cachingStatsProvider = new CachingStatsProvider(new StatsProvider() {
-            @Override
-            public void start(Configuration conf) {
-                // nop
-            }
-
-            @Override
-            public void stop() {
-                // nop
-            }
-
-            @Override
-            public StatsLogger getStatsLogger(String scope) {
-                return new PrometheusStatsLogger(PrometheusMetricsProvider.this, scope);
-            }
-
-            @Override
-            public String getStatsName(String... statsComponents) {
-                String completeName;
-                if (statsComponents.length == 0) {
-                    return "";
-                } else if (statsComponents[0].isEmpty()) {
-                    completeName = StringUtils.join(statsComponents, '_', 1, statsComponents.length);
-                } else {
-                    completeName = StringUtils.join(statsComponents, '_');
-                }
-                return Collector.sanitizeMetricName(completeName);
-            }
-        });
-    }
+    public final ConcurrentMap<ScopeContext, LongAdderCounter> counters = new ConcurrentHashMap<>();
+    public final ConcurrentMap<ScopeContext, SimpleGauge<? extends Number>> gauges = new ConcurrentHashMap<>();
+    public final ConcurrentMap<ScopeContext, DataSketchesOpStatsLogger> opStats = new ConcurrentHashMap<>();
 
     @Override
     public void start(Configuration conf) {
@@ -107,20 +74,30 @@ public class PrometheusMetricsProvider implements StatsProvider {
 
     @Override
     public StatsLogger getStatsLogger(String scope) {
-        return this.cachingStatsProvider.getStatsLogger(scope);
+        Map<String, String> labels = new HashMap<>();
+        labels.put(CLUSTER_NAME, cluster);
+        return new PrometheusStatsLogger(PrometheusMetricsProvider.this, scope, labels);
     }
 
     @Override
     public void writeAllMetrics(Writer writer) throws IOException {
-        gauges.forEach((name, gauge) -> PrometheusTextFormatUtil.writeGauge(writer, name, cluster, gauge));
-        counters.forEach((name, counter) -> PrometheusTextFormatUtil.writeCounter(writer, name, cluster, counter));
-        opStats.forEach((name, opStatLogger) -> PrometheusTextFormatUtil.writeOpStat(writer, name, cluster,
-                opStatLogger));
+        gauges.forEach((sc, gauge) -> PrometheusTextFormatUtil.writeGauge(writer, sc.getScope(), gauge));
+        counters.forEach((sc, counter) -> PrometheusTextFormatUtil.writeCounter(writer, sc.getScope(), counter));
+        opStats.forEach((sc, opStatLogger) -> PrometheusTextFormatUtil.writeOpStat(writer, sc.getScope(),
+            opStatLogger));
     }
 
     @Override
     public String getStatsName(String... statsComponents) {
-        return cachingStatsProvider.getStatsName(statsComponents);
+        String completeName;
+        if (statsComponents.length == 0) {
+            return "";
+        } else if (statsComponents[0].isEmpty()) {
+            completeName = StringUtils.join(statsComponents, '_', 1, statsComponents.length);
+        } else {
+            completeName = StringUtils.join(statsComponents, '_');
+        }
+        return Collector.sanitizeMetricName(completeName);
     }
 
     @VisibleForTesting

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/metrics/ScopeContext.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/metrics/ScopeContext.java
@@ -19,50 +19,38 @@
 package org.apache.pulsar.broker.stats.prometheus.metrics;
 
 import java.util.Map;
-import java.util.concurrent.atomic.LongAdder;
-import org.apache.bookkeeper.stats.Counter;
+import java.util.Objects;
 
 /**
- * {@link Counter} implementation based on {@link LongAdder}.
- *
- * <p>LongAdder keeps a counter per-thread and then aggregates to get the result, in order to avoid contention between
- * multiple threads.
+ * Holder for a scope and a set of associated labels.
  */
-public class LongAdderCounter implements Counter {
-    private final LongAdder counter = new LongAdder();
-
+public class ScopeContext {
+    private final String scope;
     private final Map<String, String> labels;
 
-    public LongAdderCounter(Map<String, String> labels) {
+    public ScopeContext(String scope, Map<String, String> labels) {
+        this.scope = scope;
         this.labels = labels;
     }
 
-    @Override
-    public void clear() {
-        counter.reset();
+    public String getScope() {
+        return scope;
     }
 
     @Override
-    public void inc() {
-        counter.increment();
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ScopeContext that = (ScopeContext) o;
+        return Objects.equals(scope, that.scope) && Objects.equals(labels, that.labels);
     }
 
     @Override
-    public void dec() {
-        counter.decrement();
-    }
-
-    @Override
-    public void add(long delta) {
-        counter.add(delta);
-    }
-
-    @Override
-    public Long get() {
-        return counter.sum();
-    }
-
-    public Map<String, String> getLabels() {
-        return labels;
+    public int hashCode() {
+        return Objects.hash(scope, labels);
     }
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/metrics/SimpleGauge.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/metrics/SimpleGauge.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pulsar.broker.stats.prometheus.metrics;
 
+import java.util.Map;
 import org.apache.bookkeeper.stats.Gauge;
 
 /**
@@ -26,12 +27,18 @@ import org.apache.bookkeeper.stats.Gauge;
 public class SimpleGauge<T extends Number> {
 
     private final Gauge<T> gauge;
+    private final Map<String, String> labels;
 
-    public SimpleGauge(final Gauge<T> gauge) {
+    public SimpleGauge(final Gauge<T> gauge, Map<String, String> labels) {
         this.gauge = gauge;
+        this.labels = labels;
     }
 
     public Number getSample() {
         return gauge.getSample();
+    }
+
+    public Map<String, String> getLabels() {
+        return labels;
     }
 }


### PR DESCRIPTION
### Motivation
Current prometheus metric doesn't support configure scope label. If we configure multiple scope labels to a stats logger, it will append those labels into metric name, which leading metric name too long.

https://github.com/apache/bookkeeper/blob/74b00a101cb6ffd06dafccfe9d31c8c5be66efaf/bookkeeper-stats/src/main/java/org/apache/bookkeeper/stats/StatsLogger.java#L95-L104

### Modifications
1. Add label support for prometheus metrics

Current tests has been covered this change.
https://github.com/apache/pulsar/blob/4f1e39b6921ea401b8c27f17a041d06d85f8abf8/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/PrometheusMetricsTest.java#L969-L1008

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API: (yes / no)
  - The schema: (yes / no / don't know)
  - The default values of configurations: (yes / no)
  - The wire protocol: (yes / no)
  - The rest endpoints: (yes / no)
  - The admin cli options: (yes / no)
  - Anything that affects deployment: (yes / no / don't know)

### Documentation

Check the box below or label this PR directly (if you have committer privilege).

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)



- [x] `doc-not-needed`
