### PR TITLE
[client] Optimize pause when creating sub consumers in multi-topic consumer

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiTopicsConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiTopicsConsumerImpl.java
@@ -1028,6 +1028,7 @@ public class MultiTopicsConsumerImpl<T> extends ConsumerBase<T> {
                     partitionIndex -> {
                         String partitionName = TopicName.get(topicName).getPartition(partitionIndex).toString();
                         CompletableFuture<Consumer<T>> subFuture = new CompletableFuture<>();
+                        configurationData.setStartPaused(paused);
                         ConsumerImpl<T> newConsumer = ConsumerImpl.newConsumerImpl(client, partitionName,
                                     configurationData, client.externalExecutorProvider(),
                                     partitionIndex, true, subFuture,
@@ -1036,6 +1037,8 @@ public class MultiTopicsConsumerImpl<T> extends ConsumerBase<T> {
                         synchronized (pauseMutex) {
                             if (paused) {
                                 newConsumer.pause();
+                            } else {
+                                newConsumer.resume();
                             }
                             consumers.putIfAbsent(newConsumer.getTopic(), newConsumer);
                         }
@@ -1055,6 +1058,7 @@ public class MultiTopicsConsumerImpl<T> extends ConsumerBase<T> {
                     subscribeResult.completeExceptionally(new PulsarClientException(errorMessage));
                     return existingValue;
                 } else {
+                    internalConfig.setStartPaused(paused);
                     ConsumerImpl<T> newConsumer = ConsumerImpl.newConsumerImpl(client, topicName, internalConfig,
                             client.externalExecutorProvider(), -1,
                             true, subFuture, startMessageId, schema, interceptors,
@@ -1063,6 +1067,8 @@ public class MultiTopicsConsumerImpl<T> extends ConsumerBase<T> {
                     synchronized (pauseMutex) {
                         if (paused) {
                             newConsumer.pause();
+                        } else {
+                            newConsumer.resume();
                         }
                     }
                     return newConsumer;
@@ -1355,6 +1361,7 @@ public class MultiTopicsConsumerImpl<T> extends ConsumerBase<T> {
                         int partitionIndex = TopicName.getPartitionIndex(partitionName);
                         CompletableFuture<Consumer<T>> subFuture = new CompletableFuture<>();
                         ConsumerConfigurationData<T> configurationData = getInternalConsumerConfig();
+                        configurationData.setStartPaused(paused);
                         ConsumerImpl<T> newConsumer = ConsumerImpl.newConsumerImpl(
                                 client, partitionName, configurationData,
                                 client.externalExecutorProvider(),
@@ -1363,6 +1370,8 @@ public class MultiTopicsConsumerImpl<T> extends ConsumerBase<T> {
                         synchronized (pauseMutex) {
                             if (paused) {
                                 newConsumer.pause();
+                            } else {
+                                newConsumer.resume();
                             }
                             consumers.putIfAbsent(newConsumer.getTopic(), newConsumer);
                         }


### PR DESCRIPTION
### Motivation

Currently, if we subscribe new partitions/topics when multiTopicConsumer is paused, the sub consumers will start in non-pause mode and then changed to pause. 

### Modifications

Set `startPause` config when creating sub consumers.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change is already covered by existing tests, such as 
- org.apache.pulsar.client.api.PartitionedProducerConsumerTest#testPauseAndResume
- org.apache.pulsar.client.api.SimpleProducerConsumerTest#testPauseAndResume
- org.apache.pulsar.client.impl.ZeroQueueSizeTest#testPauseAndResume
### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

Check the box below and label this PR (if you have committer privilege).

Need to update docs? 
  
- [x] `no-need-doc` 

Internal optimization.