### PR TITLE
fix npe for getLength in class of  EntryImpl

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/EntryImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/EntryImpl.java
@@ -129,7 +129,7 @@ public final class EntryImpl extends AbstractCASReferenceCounted implements Entr
 
     @Override
     public int getLength() {
-        return data.readableBytes();
+        return data != null ? data.readableBytes() : 0;
     }
 
     @Override


### PR DESCRIPTION
### Motivation
**In pulsar broker logs, npe errors were found：**


00:46:15.817 [BookKeeperClientWorker-OrderedExecutor-45-0] ERROR org.apache.bookkeeper.common.util.SafeRunnable - Unexpected throwable caught
java.lang.NullPointerException: null
        at org.apache.bookkeeper.mledger.impl.EntryImpl.getLength(EntryImpl.java:133) ~[org.apache.pulsar-managed-ledger-2.8.1.2.jar:2.8.1.2]
        at org.apache.bookkeeper.mledger.util.RangeCache.put(RangeCache.java:78) ~[org.apache.pulsar-managed-ledger-2.8.1.2.jar:2.8.1.2]
        at org.apache.bookkeeper.mledger.impl.EntryCacheImpl.insert(EntryCacheImpl.java:114) ~[org.apache.pulsar-managed-ledger-2.8.1.2.jar:2.8.1.2]
        at org.apache.bookkeeper.mledger.impl.OpAddEntry.safeRun(OpAddEntry.java:198) ~[org.apache.pulsar-managed-ledger-2.8.1.2.jar:2.8.1.2]
        at org.apache.bookkeeper.common.util.SafeRunnable.run(SafeRunnable.java:36) [org.apache.bookkeeper-bookkeeper-common-4.14.2.1.jar:4.14.2.1]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149) [?:1.8.0_144]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624) [?:1.8.0_144]
        at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30) [io.netty-netty-common-4.1.66.Final.jar:4.1.66.Final]
        at java.lang.Thread.run(Thread.java:748) [?:1.8.0_144]


### Modifications
Make a non-null judgment on data in the method getLength


### Documentation

Check the box below or label this PR directly (if you have committer privilege).

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)


