### PR TITLE
[Flaky-test]: Flush produce before close it.

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/MultiTopicsConsumerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/MultiTopicsConsumerTest.java
@@ -178,6 +178,7 @@ public class MultiTopicsConsumerTest extends ProducerConsumerBase {
             sequenceNumber++;
         }
         for (Producer<Long> producer : producers) {
+            producer.flush();
             producer.close();
         }
 


### PR DESCRIPTION
### Motivation

#14558 

In the test, the producer sends it async. We should flush it before produce close it. Otherwise, the quantity pulled by consumers may not meet expectations.

### Modifications

- Flush produce before close it.

### Documentation

- [x] `no-need-doc` 
  
