### PR TITLE
add instance filed into metrics output to make the metrics line continuous

### DIFF
--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -60,6 +60,9 @@ bindAddresses=
 # Hostname or IP address the service advertises to the outside world. If not set, the value of InetAddress.getLocalHost().getHostName() is used.
 advertisedAddress=
 
+# Hostname or IP address the metrics generator used, for monitor continuity.
+metricsHostname=
+
 # Used to specify multiple advertised listeners for the broker.
 # The value must format as <listener_name>:pulsar://<host>:<port>,
 # multiple listeners should separate with commas.

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -207,6 +207,12 @@ public class ServiceConfiguration implements PulsarConfiguration {
     )
     private String advertisedAddress;
 
+    @FieldContext(
+            category = CATEGORY_SERVER,
+            doc = "Hostname or IP address the metrics generator used, for monitor continuity."
+    )
+    private String metricsHostname;
+
     @FieldContext(category = CATEGORY_SERVER,
             doc = "Used to specify multiple advertised listeners for the broker."
                     + " The value must format as <listener_name>:pulsar://<host>:<port>,"

--- a/pulsar-broker/src/main/java/org/apache/pulsar/PulsarBrokerStarter.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/PulsarBrokerStarter.java
@@ -202,7 +202,6 @@ public class PulsarBrokerStarter {
             if (StringUtils.isEmpty(brokerConfig.getMetricsHostname())) {
                 brokerConfig.setMetricsHostname(InetAddress.getLocalHost().getHostName());
             }
-
             // init pulsar service
             pulsarService = new PulsarService(brokerConfig,
                                               workerConfig,

--- a/pulsar-broker/src/main/java/org/apache/pulsar/PulsarBrokerStarter.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/PulsarBrokerStarter.java
@@ -31,6 +31,7 @@ import com.google.common.annotations.VisibleForTesting;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.InputStream;
+import java.net.InetAddress;
 import java.net.MalformedURLException;
 import java.nio.file.Paths;
 import java.text.DateFormat;
@@ -45,6 +46,7 @@ import org.apache.bookkeeper.replication.AutoRecoveryMain;
 import org.apache.bookkeeper.stats.StatsProvider;
 import org.apache.bookkeeper.util.DirectMemoryUtils;
 import org.apache.commons.configuration.ConfigurationException;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.core.util.datetime.FixedDateFormat;
 import org.apache.pulsar.broker.PulsarServerException;
@@ -195,6 +197,10 @@ public class PulsarBrokerStarter {
             } else {
                 workerConfig = null;
                 functionsWorkerService = null;
+            }
+
+            if (StringUtils.isEmpty(brokerConfig.getMetricsHostname())) {
+                brokerConfig.setMetricsHostname(InetAddress.getLocalHost().getHostName());
             }
 
             // init pulsar service

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
@@ -36,6 +36,7 @@ import io.netty.util.concurrent.DefaultThreadFactory;
 import java.io.IOException;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
+import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.MalformedURLException;
 import java.time.Duration;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/TopicStats.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/TopicStats.java
@@ -108,264 +108,264 @@ class TopicStats {
 
     static void printTopicStats(SimpleTextOutputStream stream, String cluster, String namespace, String topic,
                                 TopicStats stats, Optional<CompactorMXBean> compactorMXBean,
-                                boolean splitTopicAndPartitionIndexLabel) {
+                                boolean splitTopicAndPartitionIndexLabel, String metricsHostname, long currentTime) {
         metric(stream, cluster, namespace, topic, "pulsar_subscriptions_count", stats.subscriptionsCount,
-                splitTopicAndPartitionIndexLabel);
+                splitTopicAndPartitionIndexLabel, metricsHostname, currentTime);
         metric(stream, cluster, namespace, topic, "pulsar_producers_count", stats.producersCount,
-                splitTopicAndPartitionIndexLabel);
+                splitTopicAndPartitionIndexLabel, metricsHostname, currentTime);
         metric(stream, cluster, namespace, topic, "pulsar_consumers_count", stats.consumersCount,
-                splitTopicAndPartitionIndexLabel);
+                splitTopicAndPartitionIndexLabel, metricsHostname, currentTime);
 
         metric(stream, cluster, namespace, topic, "pulsar_rate_in", stats.rateIn,
-                splitTopicAndPartitionIndexLabel);
+                splitTopicAndPartitionIndexLabel, metricsHostname, currentTime);
         metric(stream, cluster, namespace, topic, "pulsar_rate_out", stats.rateOut,
-                splitTopicAndPartitionIndexLabel);
+                splitTopicAndPartitionIndexLabel, metricsHostname, currentTime);
         metric(stream, cluster, namespace, topic, "pulsar_throughput_in", stats.throughputIn,
-                splitTopicAndPartitionIndexLabel);
+                splitTopicAndPartitionIndexLabel, metricsHostname, currentTime);
         metric(stream, cluster, namespace, topic, "pulsar_throughput_out", stats.throughputOut,
-                splitTopicAndPartitionIndexLabel);
+                splitTopicAndPartitionIndexLabel, metricsHostname, currentTime);
         metric(stream, cluster, namespace, topic, "pulsar_average_msg_size", stats.averageMsgSize,
-                splitTopicAndPartitionIndexLabel);
+                splitTopicAndPartitionIndexLabel, metricsHostname, currentTime);
 
         metric(stream, cluster, namespace, topic, "pulsar_storage_size", stats.managedLedgerStats.storageSize,
-                splitTopicAndPartitionIndexLabel);
+                splitTopicAndPartitionIndexLabel, metricsHostname, currentTime);
         metric(stream, cluster, namespace, topic, "pulsar_storage_logical_size",
-                stats.managedLedgerStats.storageLogicalSize, splitTopicAndPartitionIndexLabel);
+                stats.managedLedgerStats.storageLogicalSize, splitTopicAndPartitionIndexLabel, metricsHostname, currentTime);
         metric(stream, cluster, namespace, topic, "pulsar_msg_backlog", stats.msgBacklog,
-                splitTopicAndPartitionIndexLabel);
+                splitTopicAndPartitionIndexLabel, metricsHostname, currentTime);
         metric(stream, cluster, namespace, topic, "pulsar_storage_backlog_size",
-                stats.managedLedgerStats.backlogSize, splitTopicAndPartitionIndexLabel);
+                stats.managedLedgerStats.backlogSize, splitTopicAndPartitionIndexLabel, metricsHostname, currentTime);
         metric(stream, cluster, namespace, topic, "pulsar_publish_rate_limit_times", stats.publishRateLimitedTimes,
-                splitTopicAndPartitionIndexLabel);
+                splitTopicAndPartitionIndexLabel, metricsHostname, currentTime);
         metric(stream, cluster, namespace, topic, "pulsar_storage_offloaded_size", stats.managedLedgerStats
-                .offloadedStorageUsed, splitTopicAndPartitionIndexLabel);
+                .offloadedStorageUsed, splitTopicAndPartitionIndexLabel, metricsHostname, currentTime);
         metric(stream, cluster, namespace, topic, "pulsar_storage_backlog_quota_limit", stats.backlogQuotaLimit,
-                splitTopicAndPartitionIndexLabel);
+                splitTopicAndPartitionIndexLabel, metricsHostname, currentTime);
         metric(stream, cluster, namespace, topic, "pulsar_storage_backlog_quota_limit_time",
-                stats.backlogQuotaLimitTime, splitTopicAndPartitionIndexLabel);
+                stats.backlogQuotaLimitTime, splitTopicAndPartitionIndexLabel, metricsHostname, currentTime);
 
         long[] latencyBuckets = stats.managedLedgerStats.storageWriteLatencyBuckets.getBuckets();
         metric(stream, cluster, namespace, topic, "pulsar_storage_write_latency_le_0_5", latencyBuckets[0],
-                splitTopicAndPartitionIndexLabel);
+                splitTopicAndPartitionIndexLabel, metricsHostname, currentTime);
         metric(stream, cluster, namespace, topic, "pulsar_storage_write_latency_le_1", latencyBuckets[1],
-                splitTopicAndPartitionIndexLabel);
+                splitTopicAndPartitionIndexLabel, metricsHostname, currentTime);
         metric(stream, cluster, namespace, topic, "pulsar_storage_write_latency_le_5", latencyBuckets[2],
-                splitTopicAndPartitionIndexLabel);
+                splitTopicAndPartitionIndexLabel, metricsHostname, currentTime);
         metric(stream, cluster, namespace, topic, "pulsar_storage_write_latency_le_10", latencyBuckets[3],
-                splitTopicAndPartitionIndexLabel);
+                splitTopicAndPartitionIndexLabel, metricsHostname, currentTime);
         metric(stream, cluster, namespace, topic, "pulsar_storage_write_latency_le_20", latencyBuckets[4],
-                splitTopicAndPartitionIndexLabel);
+                splitTopicAndPartitionIndexLabel, metricsHostname, currentTime);
         metric(stream, cluster, namespace, topic, "pulsar_storage_write_latency_le_50", latencyBuckets[5],
-                splitTopicAndPartitionIndexLabel);
+                splitTopicAndPartitionIndexLabel, metricsHostname, currentTime);
         metric(stream, cluster, namespace, topic, "pulsar_storage_write_latency_le_100", latencyBuckets[6],
-                splitTopicAndPartitionIndexLabel);
+                splitTopicAndPartitionIndexLabel, metricsHostname, currentTime);
         metric(stream, cluster, namespace, topic, "pulsar_storage_write_latency_le_200", latencyBuckets[7],
-                splitTopicAndPartitionIndexLabel);
+                splitTopicAndPartitionIndexLabel, metricsHostname, currentTime);
         metric(stream, cluster, namespace, topic, "pulsar_storage_write_latency_le_1000", latencyBuckets[8],
-                splitTopicAndPartitionIndexLabel);
+                splitTopicAndPartitionIndexLabel, metricsHostname, currentTime);
         metric(stream, cluster, namespace, topic, "pulsar_storage_write_latency_overflow", latencyBuckets[9],
-                splitTopicAndPartitionIndexLabel);
+                splitTopicAndPartitionIndexLabel, metricsHostname, currentTime);
         metric(stream, cluster, namespace, topic, "pulsar_storage_write_latency_count",
-                stats.managedLedgerStats.storageWriteLatencyBuckets.getCount(), splitTopicAndPartitionIndexLabel);
+                stats.managedLedgerStats.storageWriteLatencyBuckets.getCount(), splitTopicAndPartitionIndexLabel, metricsHostname, currentTime);
         metric(stream, cluster, namespace, topic, "pulsar_storage_write_latency_sum",
-                stats.managedLedgerStats.storageWriteLatencyBuckets.getSum(), splitTopicAndPartitionIndexLabel);
+                stats.managedLedgerStats.storageWriteLatencyBuckets.getSum(), splitTopicAndPartitionIndexLabel, metricsHostname, currentTime);
 
         long[] ledgerWriteLatencyBuckets = stats.managedLedgerStats.storageLedgerWriteLatencyBuckets.getBuckets();
         metric(stream, cluster, namespace, topic, "pulsar_storage_ledger_write_latency_le_0_5",
-                ledgerWriteLatencyBuckets[0], splitTopicAndPartitionIndexLabel);
+                ledgerWriteLatencyBuckets[0], splitTopicAndPartitionIndexLabel, metricsHostname, currentTime);
         metric(stream, cluster, namespace, topic, "pulsar_storage_ledger_write_latency_le_1",
-                ledgerWriteLatencyBuckets[1], splitTopicAndPartitionIndexLabel);
+                ledgerWriteLatencyBuckets[1], splitTopicAndPartitionIndexLabel, metricsHostname, currentTime);
         metric(stream, cluster, namespace, topic, "pulsar_storage_ledger_write_latency_le_5",
-                ledgerWriteLatencyBuckets[2], splitTopicAndPartitionIndexLabel);
+                ledgerWriteLatencyBuckets[2], splitTopicAndPartitionIndexLabel, metricsHostname, currentTime);
         metric(stream, cluster, namespace, topic, "pulsar_storage_ledger_write_latency_le_10",
-                ledgerWriteLatencyBuckets[3], splitTopicAndPartitionIndexLabel);
+                ledgerWriteLatencyBuckets[3], splitTopicAndPartitionIndexLabel, metricsHostname, currentTime);
         metric(stream, cluster, namespace, topic, "pulsar_storage_ledger_write_latency_le_20",
-                ledgerWriteLatencyBuckets[4], splitTopicAndPartitionIndexLabel);
+                ledgerWriteLatencyBuckets[4], splitTopicAndPartitionIndexLabel, metricsHostname, currentTime);
         metric(stream, cluster, namespace, topic, "pulsar_storage_ledger_write_latency_le_50",
-                ledgerWriteLatencyBuckets[5], splitTopicAndPartitionIndexLabel);
+                ledgerWriteLatencyBuckets[5], splitTopicAndPartitionIndexLabel, metricsHostname, currentTime);
         metric(stream, cluster, namespace, topic, "pulsar_storage_ledger_write_latency_le_100",
-                ledgerWriteLatencyBuckets[6], splitTopicAndPartitionIndexLabel);
+                ledgerWriteLatencyBuckets[6], splitTopicAndPartitionIndexLabel, metricsHostname, currentTime);
         metric(stream, cluster, namespace, topic, "pulsar_storage_ledger_write_latency_le_200",
-                ledgerWriteLatencyBuckets[7], splitTopicAndPartitionIndexLabel);
+                ledgerWriteLatencyBuckets[7], splitTopicAndPartitionIndexLabel, metricsHostname, currentTime);
         metric(stream, cluster, namespace, topic, "pulsar_storage_ledger_write_latency_le_1000",
-                ledgerWriteLatencyBuckets[8], splitTopicAndPartitionIndexLabel);
+                ledgerWriteLatencyBuckets[8], splitTopicAndPartitionIndexLabel, metricsHostname, currentTime);
         metric(stream, cluster, namespace, topic, "pulsar_storage_ledger_write_latency_overflow",
-                ledgerWriteLatencyBuckets[9], splitTopicAndPartitionIndexLabel);
+                ledgerWriteLatencyBuckets[9], splitTopicAndPartitionIndexLabel, metricsHostname, currentTime);
         metric(stream, cluster, namespace, topic, "pulsar_storage_ledger_write_latency_count",
                 stats.managedLedgerStats.storageLedgerWriteLatencyBuckets.getCount(),
-                splitTopicAndPartitionIndexLabel);
+                splitTopicAndPartitionIndexLabel, metricsHostname, currentTime);
         metric(stream, cluster, namespace, topic, "pulsar_storage_ledger_write_latency_sum",
                 stats.managedLedgerStats.storageLedgerWriteLatencyBuckets.getSum(),
-                splitTopicAndPartitionIndexLabel);
+                splitTopicAndPartitionIndexLabel, metricsHostname, currentTime);
 
         long[] entrySizeBuckets = stats.managedLedgerStats.entrySizeBuckets.getBuckets();
         metric(stream, cluster, namespace, topic, "pulsar_entry_size_le_128", entrySizeBuckets[0],
-                splitTopicAndPartitionIndexLabel);
+                splitTopicAndPartitionIndexLabel, metricsHostname, currentTime);
         metric(stream, cluster, namespace, topic, "pulsar_entry_size_le_512", entrySizeBuckets[1],
-                splitTopicAndPartitionIndexLabel);
+                splitTopicAndPartitionIndexLabel, metricsHostname, currentTime);
         metric(stream, cluster, namespace, topic, "pulsar_entry_size_le_1_kb", entrySizeBuckets[2],
-                splitTopicAndPartitionIndexLabel);
+                splitTopicAndPartitionIndexLabel, metricsHostname, currentTime);
         metric(stream, cluster, namespace, topic, "pulsar_entry_size_le_2_kb", entrySizeBuckets[3],
-                splitTopicAndPartitionIndexLabel);
+                splitTopicAndPartitionIndexLabel, metricsHostname, currentTime);
         metric(stream, cluster, namespace, topic, "pulsar_entry_size_le_4_kb", entrySizeBuckets[4],
-                splitTopicAndPartitionIndexLabel);
+                splitTopicAndPartitionIndexLabel, metricsHostname, currentTime);
         metric(stream, cluster, namespace, topic, "pulsar_entry_size_le_16_kb", entrySizeBuckets[5],
-                splitTopicAndPartitionIndexLabel);
+                splitTopicAndPartitionIndexLabel, metricsHostname, currentTime);
         metric(stream, cluster, namespace, topic, "pulsar_entry_size_le_100_kb", entrySizeBuckets[6],
-                splitTopicAndPartitionIndexLabel);
+                splitTopicAndPartitionIndexLabel, metricsHostname, currentTime);
         metric(stream, cluster, namespace, topic, "pulsar_entry_size_le_1_mb", entrySizeBuckets[7],
-                splitTopicAndPartitionIndexLabel);
+                splitTopicAndPartitionIndexLabel, metricsHostname, currentTime);
         metric(stream, cluster, namespace, topic, "pulsar_entry_size_le_overflow", entrySizeBuckets[8],
-                splitTopicAndPartitionIndexLabel);
+                splitTopicAndPartitionIndexLabel, metricsHostname, currentTime);
         metric(stream, cluster, namespace, topic, "pulsar_entry_size_count",
-                stats.managedLedgerStats.entrySizeBuckets.getCount(), splitTopicAndPartitionIndexLabel);
+                stats.managedLedgerStats.entrySizeBuckets.getCount(), splitTopicAndPartitionIndexLabel, metricsHostname, currentTime);
         metric(stream, cluster, namespace, topic, "pulsar_entry_size_sum",
-                stats.managedLedgerStats.entrySizeBuckets.getSum(), splitTopicAndPartitionIndexLabel);
+                stats.managedLedgerStats.entrySizeBuckets.getSum(), splitTopicAndPartitionIndexLabel, metricsHostname, currentTime);
 
         stats.producerStats.forEach((p, producerStats) -> {
             metric(stream, cluster, namespace, topic, p, producerStats.producerId, "pulsar_producer_msg_rate_in",
-                    producerStats.msgRateIn, splitTopicAndPartitionIndexLabel);
+                    producerStats.msgRateIn, splitTopicAndPartitionIndexLabel, metricsHostname, currentTime);
             metric(stream, cluster, namespace, topic, p, producerStats.producerId, "pulsar_producer_msg_throughput_in",
-                    producerStats.msgThroughputIn, splitTopicAndPartitionIndexLabel);
+                    producerStats.msgThroughputIn, splitTopicAndPartitionIndexLabel, metricsHostname, currentTime);
             metric(stream, cluster, namespace, topic, p, producerStats.producerId, "pulsar_producer_msg_average_Size",
-                    producerStats.averageMsgSize, splitTopicAndPartitionIndexLabel);
+                    producerStats.averageMsgSize, splitTopicAndPartitionIndexLabel, metricsHostname, currentTime);
         });
 
         stats.subscriptionStats.forEach((n, subsStats) -> {
             metric(stream, cluster, namespace, topic, n, "pulsar_subscription_back_log",
-                    subsStats.msgBacklog, splitTopicAndPartitionIndexLabel);
+                    subsStats.msgBacklog, splitTopicAndPartitionIndexLabel, metricsHostname, currentTime);
             metric(stream, cluster, namespace, topic, n, "pulsar_subscription_back_log_no_delayed",
-                    subsStats.msgBacklogNoDelayed, splitTopicAndPartitionIndexLabel);
+                    subsStats.msgBacklogNoDelayed, splitTopicAndPartitionIndexLabel, metricsHostname, currentTime);
             metric(stream, cluster, namespace, topic, n, "pulsar_subscription_delayed",
-                    subsStats.msgDelayed, splitTopicAndPartitionIndexLabel);
+                    subsStats.msgDelayed, splitTopicAndPartitionIndexLabel, metricsHostname, currentTime);
             metric(stream, cluster, namespace, topic, n, "pulsar_subscription_msg_rate_redeliver",
-                    subsStats.msgRateRedeliver, splitTopicAndPartitionIndexLabel);
+                    subsStats.msgRateRedeliver, splitTopicAndPartitionIndexLabel, metricsHostname, currentTime);
             metric(stream, cluster, namespace, topic, n, "pulsar_subscription_unacked_messages",
-                    subsStats.unackedMessages, splitTopicAndPartitionIndexLabel);
+                    subsStats.unackedMessages, splitTopicAndPartitionIndexLabel, metricsHostname, currentTime);
             metric(stream, cluster, namespace, topic, n, "pulsar_subscription_blocked_on_unacked_messages",
-                    subsStats.blockedSubscriptionOnUnackedMsgs ? 1 : 0, splitTopicAndPartitionIndexLabel);
+                    subsStats.blockedSubscriptionOnUnackedMsgs ? 1 : 0, splitTopicAndPartitionIndexLabel, metricsHostname, currentTime);
             metric(stream, cluster, namespace, topic, n, "pulsar_subscription_msg_rate_out",
-                    subsStats.msgRateOut, splitTopicAndPartitionIndexLabel);
+                    subsStats.msgRateOut, splitTopicAndPartitionIndexLabel, metricsHostname, currentTime);
             metric(stream, cluster, namespace, topic, n, "pulsar_subscription_msg_throughput_out",
-                    subsStats.msgThroughputOut, splitTopicAndPartitionIndexLabel);
+                    subsStats.msgThroughputOut, splitTopicAndPartitionIndexLabel, metricsHostname, currentTime);
             metric(stream, cluster, namespace, topic, n, "pulsar_out_bytes_total",
-                    subsStats.bytesOutCounter, splitTopicAndPartitionIndexLabel);
+                    subsStats.bytesOutCounter, splitTopicAndPartitionIndexLabel, metricsHostname, currentTime);
             metric(stream, cluster, namespace, topic, n, "pulsar_out_messages_total",
-                    subsStats.msgOutCounter, splitTopicAndPartitionIndexLabel);
+                    subsStats.msgOutCounter, splitTopicAndPartitionIndexLabel, metricsHostname, currentTime);
             metric(stream, cluster, namespace, topic, n, "pulsar_subscription_last_expire_timestamp",
-                    subsStats.lastExpireTimestamp, splitTopicAndPartitionIndexLabel);
+                    subsStats.lastExpireTimestamp, splitTopicAndPartitionIndexLabel, metricsHostname, currentTime);
             metric(stream, cluster, namespace, topic, n, "pulsar_subscription_last_acked_timestamp",
-                subsStats.lastAckedTimestamp, splitTopicAndPartitionIndexLabel);
+                subsStats.lastAckedTimestamp, splitTopicAndPartitionIndexLabel, metricsHostname, currentTime);
             metric(stream, cluster, namespace, topic, n, "pulsar_subscription_last_consumed_flow_timestamp",
-                subsStats.lastConsumedFlowTimestamp, splitTopicAndPartitionIndexLabel);
+                subsStats.lastConsumedFlowTimestamp, splitTopicAndPartitionIndexLabel, metricsHostname, currentTime);
             metric(stream, cluster, namespace, topic, n, "pulsar_subscription_last_consumed_timestamp",
-                subsStats.lastConsumedTimestamp, splitTopicAndPartitionIndexLabel);
+                subsStats.lastConsumedTimestamp, splitTopicAndPartitionIndexLabel, metricsHostname, currentTime);
             metric(stream, cluster, namespace, topic, n, "pulsar_subscription_last_mark_delete_advanced_timestamp",
-                subsStats.lastMarkDeleteAdvancedTimestamp, splitTopicAndPartitionIndexLabel);
+                subsStats.lastMarkDeleteAdvancedTimestamp, splitTopicAndPartitionIndexLabel, metricsHostname, currentTime);
             metric(stream, cluster, namespace, topic, n, "pulsar_subscription_msg_rate_expired",
-                    subsStats.msgRateExpired, splitTopicAndPartitionIndexLabel);
+                    subsStats.msgRateExpired, splitTopicAndPartitionIndexLabel, metricsHostname, currentTime);
             metric(stream, cluster, namespace, topic, n, "pulsar_subscription_total_msg_expired",
-                    subsStats.totalMsgExpired, splitTopicAndPartitionIndexLabel);
+                    subsStats.totalMsgExpired, splitTopicAndPartitionIndexLabel, metricsHostname, currentTime);
             subsStats.consumerStat.forEach((c, consumerStats) -> {
                 metric(stream, cluster, namespace, topic, n, c.consumerName(), c.consumerId(),
                         "pulsar_consumer_msg_rate_redeliver", consumerStats.msgRateRedeliver,
-                        splitTopicAndPartitionIndexLabel);
+                        splitTopicAndPartitionIndexLabel, metricsHostname, currentTime);
                 metric(stream, cluster, namespace, topic, n, c.consumerName(), c.consumerId(),
                         "pulsar_consumer_unacked_messages", consumerStats.unackedMessages,
-                        splitTopicAndPartitionIndexLabel);
+                        splitTopicAndPartitionIndexLabel, metricsHostname, currentTime);
                 metric(stream, cluster, namespace, topic, n, c.consumerName(), c.consumerId(),
                         "pulsar_consumer_blocked_on_unacked_messages",
                         consumerStats.blockedSubscriptionOnUnackedMsgs ? 1 : 0,
-                        splitTopicAndPartitionIndexLabel);
+                        splitTopicAndPartitionIndexLabel, metricsHostname, currentTime);
                 metric(stream, cluster, namespace, topic, n, c.consumerName(), c.consumerId(),
                         "pulsar_consumer_msg_rate_out", consumerStats.msgRateOut,
-                        splitTopicAndPartitionIndexLabel);
+                        splitTopicAndPartitionIndexLabel, metricsHostname, currentTime);
                 metric(stream, cluster, namespace, topic, n, c.consumerName(), c.consumerId(),
                         "pulsar_consumer_msg_throughput_out", consumerStats.msgThroughputOut,
-                        splitTopicAndPartitionIndexLabel);
+                        splitTopicAndPartitionIndexLabel, metricsHostname, currentTime);
                 metric(stream, cluster, namespace, topic, n, c.consumerName(), c.consumerId(),
                         "pulsar_consumer_available_permits", consumerStats.availablePermits,
-                        splitTopicAndPartitionIndexLabel);
+                        splitTopicAndPartitionIndexLabel, metricsHostname, currentTime);
                 metric(stream, cluster, namespace, topic, n, c.consumerName(), c.consumerId(),
                         "pulsar_out_bytes_total", consumerStats.bytesOutCounter,
-                        splitTopicAndPartitionIndexLabel);
+                        splitTopicAndPartitionIndexLabel, metricsHostname, currentTime);
                 metric(stream, cluster, namespace, topic, n, c.consumerName(), c.consumerId(),
                         "pulsar_out_messages_total", consumerStats.msgOutCounter,
-                        splitTopicAndPartitionIndexLabel);
+                        splitTopicAndPartitionIndexLabel, metricsHostname, currentTime);
             });
         });
 
         if (!stats.replicationStats.isEmpty()) {
             stats.replicationStats.forEach((remoteCluster, replStats) -> {
                 metricWithRemoteCluster(stream, cluster, namespace, topic, "pulsar_replication_rate_in", remoteCluster,
-                        replStats.msgRateIn, splitTopicAndPartitionIndexLabel);
+                        replStats.msgRateIn, splitTopicAndPartitionIndexLabel, metricsHostname, currentTime);
                 metricWithRemoteCluster(stream, cluster, namespace, topic, "pulsar_replication_rate_out", remoteCluster,
-                        replStats.msgRateOut, splitTopicAndPartitionIndexLabel);
+                        replStats.msgRateOut, splitTopicAndPartitionIndexLabel, metricsHostname, currentTime);
                 metricWithRemoteCluster(stream, cluster, namespace, topic, "pulsar_replication_throughput_in",
-                        remoteCluster, replStats.msgThroughputIn, splitTopicAndPartitionIndexLabel);
+                        remoteCluster, replStats.msgThroughputIn, splitTopicAndPartitionIndexLabel, metricsHostname, currentTime);
                 metricWithRemoteCluster(stream, cluster, namespace, topic, "pulsar_replication_throughput_out",
-                        remoteCluster, replStats.msgThroughputOut, splitTopicAndPartitionIndexLabel);
+                        remoteCluster, replStats.msgThroughputOut, splitTopicAndPartitionIndexLabel, metricsHostname, currentTime);
                 metricWithRemoteCluster(stream, cluster, namespace, topic, "pulsar_replication_backlog", remoteCluster,
-                        replStats.replicationBacklog, splitTopicAndPartitionIndexLabel);
+                        replStats.replicationBacklog, splitTopicAndPartitionIndexLabel, metricsHostname, currentTime);
                 metricWithRemoteCluster(stream, cluster, namespace, topic, "pulsar_replication_connected_count",
-                        remoteCluster, replStats.connectedCount, splitTopicAndPartitionIndexLabel);
+                        remoteCluster, replStats.connectedCount, splitTopicAndPartitionIndexLabel, metricsHostname, currentTime);
                 metricWithRemoteCluster(stream, cluster, namespace, topic, "pulsar_replication_rate_expired",
-                        remoteCluster, replStats.msgRateExpired, splitTopicAndPartitionIndexLabel);
+                        remoteCluster, replStats.msgRateExpired, splitTopicAndPartitionIndexLabel, metricsHostname, currentTime);
                 metricWithRemoteCluster(stream, cluster, namespace, topic, "pulsar_replication_delay_in_seconds",
-                        remoteCluster, replStats.replicationDelayInSeconds, splitTopicAndPartitionIndexLabel);
+                        remoteCluster, replStats.replicationDelayInSeconds, splitTopicAndPartitionIndexLabel, metricsHostname, currentTime);
             });
         }
 
         metric(stream, cluster, namespace, topic, "pulsar_in_bytes_total", stats.bytesInCounter,
-                splitTopicAndPartitionIndexLabel);
+                splitTopicAndPartitionIndexLabel, metricsHostname, currentTime);
         metric(stream, cluster, namespace, topic, "pulsar_in_messages_total", stats.msgInCounter,
-                splitTopicAndPartitionIndexLabel);
+                splitTopicAndPartitionIndexLabel, metricsHostname, currentTime);
 
         // Compaction
         boolean hasCompaction = compactorMXBean.flatMap(mxBean -> mxBean.getCompactionRecordForTopic(topic))
                 .map(__ -> true).orElse(false);
         if (hasCompaction) {
             metric(stream, cluster, namespace, topic, "pulsar_compaction_removed_event_count",
-                    stats.compactionRemovedEventCount, splitTopicAndPartitionIndexLabel);
+                    stats.compactionRemovedEventCount, splitTopicAndPartitionIndexLabel, metricsHostname, currentTime);
             metric(stream, cluster, namespace, topic, "pulsar_compaction_succeed_count",
-                    stats.compactionSucceedCount, splitTopicAndPartitionIndexLabel);
+                    stats.compactionSucceedCount, splitTopicAndPartitionIndexLabel, metricsHostname, currentTime);
             metric(stream, cluster, namespace, topic, "pulsar_compaction_failed_count",
-                    stats.compactionFailedCount, splitTopicAndPartitionIndexLabel);
+                    stats.compactionFailedCount, splitTopicAndPartitionIndexLabel, metricsHostname, currentTime);
             metric(stream, cluster, namespace, topic, "pulsar_compaction_duration_time_in_mills",
-                    stats.compactionDurationTimeInMills, splitTopicAndPartitionIndexLabel);
+                    stats.compactionDurationTimeInMills, splitTopicAndPartitionIndexLabel, metricsHostname, currentTime);
             metric(stream, cluster, namespace, topic, "pulsar_compaction_read_throughput",
-                    stats.compactionReadThroughput, splitTopicAndPartitionIndexLabel);
+                    stats.compactionReadThroughput, splitTopicAndPartitionIndexLabel, metricsHostname, currentTime);
             metric(stream, cluster, namespace, topic, "pulsar_compaction_write_throughput",
-                    stats.compactionWriteThroughput, splitTopicAndPartitionIndexLabel);
+                    stats.compactionWriteThroughput, splitTopicAndPartitionIndexLabel, metricsHostname, currentTime);
             metric(stream, cluster, namespace, topic, "pulsar_compaction_compacted_entries_count",
-                    stats.compactionCompactedEntriesCount, splitTopicAndPartitionIndexLabel);
+                    stats.compactionCompactedEntriesCount, splitTopicAndPartitionIndexLabel, metricsHostname, currentTime);
             metric(stream, cluster, namespace, topic, "pulsar_compaction_compacted_entries_size",
-                    stats.compactionCompactedEntriesSize, splitTopicAndPartitionIndexLabel);
+                    stats.compactionCompactedEntriesSize, splitTopicAndPartitionIndexLabel, metricsHostname, currentTime);
             long[] compactionLatencyBuckets = stats.compactionLatencyBuckets.getBuckets();
             metric(stream, cluster, namespace, topic, "pulsar_compaction_latency_le_0_5",
-                    compactionLatencyBuckets[0], splitTopicAndPartitionIndexLabel);
+                    compactionLatencyBuckets[0], splitTopicAndPartitionIndexLabel, metricsHostname, currentTime);
             metric(stream, cluster, namespace, topic, "pulsar_compaction_latency_le_1",
-                    compactionLatencyBuckets[1], splitTopicAndPartitionIndexLabel);
+                    compactionLatencyBuckets[1], splitTopicAndPartitionIndexLabel, metricsHostname, currentTime);
             metric(stream, cluster, namespace, topic, "pulsar_compaction_latency_le_5",
-                    compactionLatencyBuckets[2], splitTopicAndPartitionIndexLabel);
+                    compactionLatencyBuckets[2], splitTopicAndPartitionIndexLabel, metricsHostname, currentTime);
             metric(stream, cluster, namespace, topic, "pulsar_compaction_latency_le_10",
-                    compactionLatencyBuckets[3], splitTopicAndPartitionIndexLabel);
+                    compactionLatencyBuckets[3], splitTopicAndPartitionIndexLabel, metricsHostname, currentTime);
             metric(stream, cluster, namespace, topic, "pulsar_compaction_latency_le_20",
-                    compactionLatencyBuckets[4], splitTopicAndPartitionIndexLabel);
+                    compactionLatencyBuckets[4], splitTopicAndPartitionIndexLabel, metricsHostname, currentTime);
             metric(stream, cluster, namespace, topic, "pulsar_compaction_latency_le_50",
-                    compactionLatencyBuckets[5], splitTopicAndPartitionIndexLabel);
+                    compactionLatencyBuckets[5], splitTopicAndPartitionIndexLabel, metricsHostname, currentTime);
             metric(stream, cluster, namespace, topic, "pulsar_compaction_latency_le_100",
-                    compactionLatencyBuckets[6], splitTopicAndPartitionIndexLabel);
+                    compactionLatencyBuckets[6], splitTopicAndPartitionIndexLabel, metricsHostname, currentTime);
             metric(stream, cluster, namespace, topic, "pulsar_compaction_latency_le_200",
-                    compactionLatencyBuckets[7], splitTopicAndPartitionIndexLabel);
+                    compactionLatencyBuckets[7], splitTopicAndPartitionIndexLabel, metricsHostname, currentTime);
             metric(stream, cluster, namespace, topic, "pulsar_compaction_latency_le_1000",
-                    compactionLatencyBuckets[8], splitTopicAndPartitionIndexLabel);
+                    compactionLatencyBuckets[8], splitTopicAndPartitionIndexLabel, metricsHostname, currentTime);
             metric(stream, cluster, namespace, topic, "pulsar_compaction_latency_overflow",
-                    compactionLatencyBuckets[9], splitTopicAndPartitionIndexLabel);
+                    compactionLatencyBuckets[9], splitTopicAndPartitionIndexLabel, metricsHostname, currentTime);
             metric(stream, cluster, namespace, topic, "pulsar_compaction_latency_sum",
-                    stats.compactionLatencyBuckets.getSum(), splitTopicAndPartitionIndexLabel);
+                    stats.compactionLatencyBuckets.getSum(), splitTopicAndPartitionIndexLabel, metricsHostname, currentTime);
             metric(stream, cluster, namespace, topic, "pulsar_compaction_latency_count",
-                    stats.compactionLatencyBuckets.getCount(), splitTopicAndPartitionIndexLabel);
+                    stats.compactionLatencyBuckets.getCount(), splitTopicAndPartitionIndexLabel, metricsHostname, currentTime);
         }
     }
 
@@ -379,77 +379,79 @@ class TopicStats {
     }
 
     private static void metric(SimpleTextOutputStream stream, String cluster, String namespace, String topic,
-            String name, double value, boolean splitTopicAndPartitionIndexLabel) {
+            String name, double value, boolean splitTopicAndPartitionIndexLabel, String metricsHostname, long currentTime) {
         metricType(stream, name);
-        appendRequiredLabels(stream, cluster, namespace, topic, name, splitTopicAndPartitionIndexLabel).write("\"} ");
+        appendRequiredLabels(stream, cluster, namespace, topic, name, splitTopicAndPartitionIndexLabel, metricsHostname).write("\"} ");
         stream.write(value);
-        appendEndings(stream);
+        appendEndings(stream, currentTime);
     }
 
     private static void metric(SimpleTextOutputStream stream, String cluster, String namespace, String topic,
-           String subscription, String name, long value, boolean splitTopicAndPartitionIndexLabel) {
+           String subscription, String name, long value, boolean splitTopicAndPartitionIndexLabel, String metricsHostname, long currentTime) {
         metricType(stream, name);
-        appendRequiredLabels(stream, cluster, namespace, topic, name, splitTopicAndPartitionIndexLabel)
+        appendRequiredLabels(stream, cluster, namespace, topic, name, splitTopicAndPartitionIndexLabel, metricsHostname)
                 .write("\",subscription=\"").write(subscription).write("\"} ");
         stream.write(value);
-        appendEndings(stream);
+        appendEndings(stream, currentTime);
     }
 
     private static void metric(SimpleTextOutputStream stream, String cluster, String namespace, String topic,
-            String producerName, long produceId, String name, double value, boolean splitTopicAndPartitionIndexLabel) {
+                               String producerName, long produceId, String name, double value, boolean splitTopicAndPartitionIndexLabel,
+                               String metricsHostname, long currentTime) {
         metricType(stream, name);
-        appendRequiredLabels(stream, cluster, namespace, topic, name, splitTopicAndPartitionIndexLabel)
+        appendRequiredLabels(stream, cluster, namespace, topic, name, splitTopicAndPartitionIndexLabel, metricsHostname)
                 .write("\",producer_name=\"").write(producerName)
                 .write("\",producer_id=\"").write(produceId).write("\"} ");
         stream.write(value);
-        appendEndings(stream);
+        appendEndings(stream, currentTime);
     }
 
     private static void metric(SimpleTextOutputStream stream, String cluster, String namespace, String topic,
-            String subscription, String name, double value, boolean splitTopicAndPartitionIndexLabel) {
+            String subscription, String name, double value, boolean splitTopicAndPartitionIndexLabel, String metricsHostname, long currentTime) {
         metricType(stream, name);
-        appendRequiredLabels(stream, cluster, namespace, topic, name, splitTopicAndPartitionIndexLabel)
+        appendRequiredLabels(stream, cluster, namespace, topic, name, splitTopicAndPartitionIndexLabel, metricsHostname)
                 .write("\",subscription=\"").write(subscription).write("\"} ");
         stream.write(value);
-        appendEndings(stream);
+        appendEndings(stream, currentTime);
     }
 
     private static void metric(SimpleTextOutputStream stream, String cluster, String namespace, String topic,
             String subscription, String consumerName, long consumerId, String name, long value,
-            boolean splitTopicAndPartitionIndexLabel) {
+            boolean splitTopicAndPartitionIndexLabel, String metricsHostname, long currentTime) {
         metricType(stream, name);
-        appendRequiredLabels(stream, cluster, namespace, topic, name, splitTopicAndPartitionIndexLabel)
+        appendRequiredLabels(stream, cluster, namespace, topic, name, splitTopicAndPartitionIndexLabel, metricsHostname)
                 .write("\",subscription=\"").write(subscription)
                 .write("\",consumer_name=\"").write(consumerName).write("\",consumer_id=\"").write(consumerId)
                 .write("\"} ");
         stream.write(value);
-        appendEndings(stream);
+        appendEndings(stream, currentTime);
     }
 
     private static void metric(SimpleTextOutputStream stream, String cluster, String namespace, String topic,
             String subscription, String consumerName, long consumerId, String name, double value,
-            boolean splitTopicAndPartitionIndexLabel) {
+            boolean splitTopicAndPartitionIndexLabel, String metricsHostname, long currentTime) {
         metricType(stream, name);
-        appendRequiredLabels(stream, cluster, namespace, topic, name, splitTopicAndPartitionIndexLabel)
+        appendRequiredLabels(stream, cluster, namespace, topic, name, splitTopicAndPartitionIndexLabel, metricsHostname)
                 .write("\",subscription=\"").write(subscription)
                 .write("\",consumer_name=\"").write(consumerName).write("\",consumer_id=\"")
                 .write(consumerId).write("\"} ");
         stream.write(value);
-        appendEndings(stream);
+        appendEndings(stream, currentTime);
     }
 
     private static void metricWithRemoteCluster(SimpleTextOutputStream stream, String cluster, String namespace,
-            String topic, String name, String remoteCluster, double value, boolean splitTopicAndPartitionIndexLabel) {
+                                                String topic, String name, String remoteCluster, double value,
+                                                boolean splitTopicAndPartitionIndexLabel, String metricsHostname, long currentTime) {
         metricType(stream, name);
-        appendRequiredLabels(stream, cluster, namespace, topic, name, splitTopicAndPartitionIndexLabel)
+        appendRequiredLabels(stream, cluster, namespace, topic, name, splitTopicAndPartitionIndexLabel, metricsHostname)
                 .write("\",remote_cluster=\"").write(remoteCluster).write("\"} ");
         stream.write(value);
-        appendEndings(stream);
+        appendEndings(stream, currentTime);
     }
 
     private static SimpleTextOutputStream appendRequiredLabels(SimpleTextOutputStream stream, String cluster,
-            String namespace, String topic, String name, boolean splitTopicAndPartitionIndexLabel) {
-        stream.write(name).write("{cluster=\"").write(cluster).write("\",namespace=\"").write(namespace);
+            String namespace, String topic, String name, boolean splitTopicAndPartitionIndexLabel, String metricsHostname) {
+        stream.write(name).write("{cluster=\"").write(cluster).write("\",instance=\"").write(metricsHostname).write("\",namespace=\"").write(namespace);
         if (splitTopicAndPartitionIndexLabel) {
             int index = topic.indexOf(PARTITIONED_TOPIC_SUFFIX);
             if (index > 0) {
@@ -464,7 +466,7 @@ class TopicStats {
         return stream;
     }
 
-    private static void appendEndings(SimpleTextOutputStream stream) {
-        stream.write(' ').write(System.currentTimeMillis()).write('\n');
+    private static void appendEndings(SimpleTextOutputStream stream, long currentTime) {
+        stream.write(' ').write(currentTime).write('\n');
     }
 }


### PR DESCRIPTION
If we deploy pulsar in k8s without pulsar proxy, we use prometheus to collect metrics, the IP in pulsar cluster is reachable,
but if the pulsar pod restart for some reason, the metrics line is not continuous. we can add pod name into metrics output, thus the metrics line can be continuous. 
When pulsar generate metrics output, for each metrics line, we frequently call System.currentTimeMills(), this function should not call frequently, this has performance issue, the document explain the reason, [why System.currentTimeMills() is slow](http://pzemtsov.github.io/2017/07/23/the-slow-currenttimemillis.html), we should try our best to use the same current time for each metrics collector. 

