### PR TITLE
Update Kotlib Lib to 1.6.10, to address https://nvd.nist.gov/vuln/detail/CVE-2022-24329

### DIFF
--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -455,10 +455,10 @@ The Apache Software License, Version 2.0
  * Okio - com.squareup.okio-okio-2.8.0.jar
  * Javassist -- org.javassist-javassist-3.25.0-GA.jar
  * Kotlin Standard Lib
-     - org.jetbrains.kotlin-kotlin-stdlib-1.4.32.jar
-     - org.jetbrains.kotlin-kotlin-stdlib-common-1.4.32.jar
-     - org.jetbrains.kotlin-kotlin-stdlib-jdk7-1.4.32.jar
-     - org.jetbrains.kotlin-kotlin-stdlib-jdk8-1.4.32.jar
+     - org.jetbrains.kotlin-kotlin-stdlib-1.6.10.jar
+     - org.jetbrains.kotlin-kotlin-stdlib-common-1.6.10.jar
+     - org.jetbrains.kotlin-kotlin-stdlib-jdk7-1.6.10.jar
+     - org.jetbrains.kotlin-kotlin-stdlib-jdk8-1.6.10.jar
      - org.jetbrains-annotations-13.0.jar
  * gRPC
     - io.grpc-grpc-all-1.42.1.jar

--- a/pom.xml
+++ b/pom.xml
@@ -200,7 +200,7 @@ flexible messaging model and an intuitive client API.</description>
     <!-- use okio version that matches the okhttp3 version -->
     <okio.version>2.8.0</okio.version>
     <!-- override kotlin-stdlib used by okio in order to address CVE-2020-29582 -->
-    <kotlin-stdlib.version>1.4.32</kotlin-stdlib.version>
+    <kotlin-stdlib.version>1.6.10</kotlin-stdlib.version>
     <nsq-client.version>1.0</nsq-client.version>
     <cron-utils.version>9.1.6</cron-utils.version>
     <spring-context.version>5.3.15</spring-context.version>


### PR DESCRIPTION
### Motivation

OWASP checker reports this vulnerability
https://nvd.nist.gov/vuln/detail/CVE-2022-24329

### Modifications

Update Kotlib Lib to 1.6.10, to address https://nvd.nist.gov/vuln/detail/CVE-2022-24329

### Verifying this change
- [x] Make sure that the change passes the CI checks.
- This change is a trivial rework / code cleanup without any test coverage.



