### PR TITLE
[tests] Pulsar IO - Elasticsearch - reduce elastic container memory usage

### DIFF
--- a/pulsar-io/elastic-search/src/test/java/org/apache/pulsar/io/elasticsearch/ElasticSearchBWCTests.java
+++ b/pulsar-io/elastic-search/src/test/java/org/apache/pulsar/io/elasticsearch/ElasticSearchBWCTests.java
@@ -23,7 +23,7 @@ import org.apache.commons.lang3.tuple.Pair;
 import org.apache.pulsar.client.api.schema.GenericObject;
 import org.apache.pulsar.common.schema.SchemaType;
 import org.apache.pulsar.functions.api.Record;
-import org.junit.Test;
+import org.testng.annotations.Test;
 
 import java.nio.charset.StandardCharsets;
 

--- a/pulsar-io/elastic-search/src/test/java/org/apache/pulsar/io/elasticsearch/ElasticSearchClientSslTests.java
+++ b/pulsar-io/elastic-search/src/test/java/org/apache/pulsar/io/elasticsearch/ElasticSearchClientSslTests.java
@@ -25,16 +25,12 @@ import org.testng.annotations.Test;
 
 import java.io.IOException;
 import java.time.Duration;
-import java.util.Optional;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
 
 // see https://www.elastic.co/guide/en/elasticsearch/reference/current/security-settings.html#ssl-tls-settings
-public class ElasticSearchClientSslTests {
-
-    public static final String ELASTICSEARCH_IMAGE = Optional.ofNullable(System.getenv("ELASTICSEARCH_IMAGE"))
-            .orElse("docker.elastic.co/elasticsearch/elasticsearch:7.16.3-amd64");
+public class ElasticSearchClientSslTests extends ElasticSearchTestBase {
 
     final static String INDEX = "myindex";
 
@@ -43,7 +39,7 @@ public class ElasticSearchClientSslTests {
 
     @Test
     public void testSslBasic() throws IOException {
-        try(ElasticsearchContainer container = new ElasticsearchContainer(ELASTICSEARCH_IMAGE)
+        try (ElasticsearchContainer container = createElasticsearchContainer()
                 .withFileSystemBind(sslResourceDir, configDir + "/ssl")
                 .withPassword("elastic")
                 .withEnv("xpack.license.self_generated.type", "trial")
@@ -78,7 +74,7 @@ public class ElasticSearchClientSslTests {
 
     @Test
     public void testSslWithHostnameVerification() throws IOException {
-        try(ElasticsearchContainer container = new ElasticsearchContainer(ELASTICSEARCH_IMAGE)
+        try (ElasticsearchContainer container = createElasticsearchContainer()
                 .withFileSystemBind(sslResourceDir, configDir + "/ssl")
                 .withPassword("elastic")
                 .withEnv("xpack.license.self_generated.type", "trial")
@@ -116,7 +112,7 @@ public class ElasticSearchClientSslTests {
 
     @Test
     public void testSslWithClientAuth() throws IOException {
-        try(ElasticsearchContainer container = new ElasticsearchContainer(ELASTICSEARCH_IMAGE)
+        try(ElasticsearchContainer container = createElasticsearchContainer()
                 .withFileSystemBind(sslResourceDir, configDir + "/ssl")
                 .withPassword("elastic")
                 .withEnv("xpack.license.self_generated.type", "trial")

--- a/pulsar-io/elastic-search/src/test/java/org/apache/pulsar/io/elasticsearch/ElasticSearchClientTests.java
+++ b/pulsar-io/elastic-search/src/test/java/org/apache/pulsar/io/elasticsearch/ElasticSearchClientTests.java
@@ -25,12 +25,12 @@ import org.apache.pulsar.client.api.schema.GenericObject;
 import org.apache.pulsar.functions.api.Record;
 import org.apache.pulsar.io.elasticsearch.testcontainers.ElasticToxiproxiContainer;
 import org.awaitility.Awaitility;
-import org.junit.AfterClass;
 import org.mockito.Mockito;
 import org.opensearch.action.delete.DeleteRequest;
 import org.opensearch.action.index.IndexRequest;
 import org.testcontainers.containers.Network;
 import org.testcontainers.elasticsearch.ElasticsearchContainer;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -38,28 +38,29 @@ import java.io.IOException;
 import java.util.Optional;
 import java.util.UUID;
 
-import static org.junit.Assert.*;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.*;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertThrows;
+import static org.testng.Assert.assertTrue;
 
 @Slf4j
-public class ElasticSearchClientTests {
-    public static final String ELASTICSEARCH_IMAGE = Optional.ofNullable(System.getenv("ELASTICSEARCH_IMAGE"))
-            .orElse("docker.elastic.co/elasticsearch/elasticsearch:7.16.3-amd64");
+public class ElasticSearchClientTests extends ElasticSearchTestBase {
 
     static ElasticsearchContainer container;
     static Network network = Network.newNetwork();
 
     @BeforeClass
     public static final void initBeforeClass() throws IOException {
-        container = new ElasticsearchContainer(ELASTICSEARCH_IMAGE).withNetwork(network);
+        container = createElasticsearchContainer().withNetwork(network);
         container.start();
     }
 
-    @AfterClass
+    @AfterClass(alwaysRun = true)
     public static void closeAfterClass() {
         container.close();
         network.close();

--- a/pulsar-io/elastic-search/src/test/java/org/apache/pulsar/io/elasticsearch/ElasticSearchExtractTests.java
+++ b/pulsar-io/elastic-search/src/test/java/org/apache/pulsar/io/elasticsearch/ElasticSearchExtractTests.java
@@ -18,8 +18,10 @@
  */
 package org.apache.pulsar.io.elasticsearch;
 
-import com.google.common.collect.ImmutableList;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
 import com.google.common.collect.ImmutableMap;
+import java.util.Optional;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.client.api.schema.GenericObject;
@@ -31,33 +33,18 @@ import org.apache.pulsar.common.schema.KeyValue;
 import org.apache.pulsar.common.schema.KeyValueEncodingType;
 import org.apache.pulsar.common.schema.SchemaType;
 import org.apache.pulsar.functions.api.Record;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameters;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
 
-import java.util.Collection;
-import java.util.Optional;
-
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertNull;
-
-@RunWith(Parameterized.class)
 public class ElasticSearchExtractTests {
 
-    SchemaType schemaType;
-
-    @Parameters
-    public static Collection schemaTypes() {
-        return ImmutableList.of(SchemaType.JSON, SchemaType.AVRO);
+    @DataProvider(name = "schemaType")
+    public Object[] schemaType() {
+        return new Object[]{SchemaType.JSON, SchemaType.AVRO};
     }
 
-    public ElasticSearchExtractTests(SchemaType schemaType) {
-        this.schemaType = schemaType;
-    }
-
-    @Test
-    public void testGenericRecord() throws Exception {
+    @Test(dataProvider = "schemaType")
+    public void testGenericRecord(SchemaType schemaType) throws Exception {
         RecordSchemaBuilder valueSchemaBuilder = org.apache.pulsar.client.api.schema.SchemaBuilder.record("value");
         valueSchemaBuilder.field("c").type(SchemaType.STRING).optional().defaultValue(null);
         valueSchemaBuilder.field("d").type(SchemaType.INT32).optional().defaultValue(null);
@@ -154,8 +141,8 @@ public class ElasticSearchExtractTests {
         assertNull(pair4.getRight());
     }
 
-    @Test
-    public void testKeyValueGenericRecord() throws Exception {
+    @Test(dataProvider = "schemaType")
+    public void testKeyValueGenericRecord(SchemaType schemaType) throws Exception {
         RecordSchemaBuilder keySchemaBuilder = org.apache.pulsar.client.api.schema.SchemaBuilder.record("key");
         keySchemaBuilder.field("a").type(SchemaType.STRING).optional().defaultValue(null);
         keySchemaBuilder.field("b").type(SchemaType.INT32).optional().defaultValue(null);

--- a/pulsar-io/elastic-search/src/test/java/org/apache/pulsar/io/elasticsearch/ElasticSearchSinkRawDataTests.java
+++ b/pulsar-io/elastic-search/src/test/java/org/apache/pulsar/io/elasticsearch/ElasticSearchSinkRawDataTests.java
@@ -23,11 +23,11 @@ import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.client.api.schema.GenericObject;
 import org.apache.pulsar.functions.api.Record;
 import org.apache.pulsar.io.core.SinkContext;
-import org.junit.AfterClass;
 import org.mockito.Mock;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 import org.testcontainers.elasticsearch.ElasticsearchContainer;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeMethod;
@@ -43,10 +43,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-public class ElasticSearchSinkRawDataTests {
-
-    public static final String ELASTICSEARCH_IMAGE = Optional.ofNullable(System.getenv("ELASTICSEARCH_IMAGE"))
-            .orElse("docker.elastic.co/elasticsearch/elasticsearch:7.16.3-amd64");
+public class ElasticSearchSinkRawDataTests extends ElasticSearchTestBase {
 
     private static ElasticsearchContainer container;
 
@@ -65,11 +62,11 @@ public class ElasticSearchSinkRawDataTests {
 
     @BeforeClass
     public static final void initBeforeClass() {
-        container = new ElasticsearchContainer(ELASTICSEARCH_IMAGE);
+        container = createElasticsearchContainer();
         schema = Schema.BYTES;
     }
 
-    @AfterClass
+    @AfterClass(alwaysRun = true)
     public static void closeAfterClass() {
         container.close();
     }

--- a/pulsar-io/elastic-search/src/test/java/org/apache/pulsar/io/elasticsearch/ElasticSearchSinkTests.java
+++ b/pulsar-io/elastic-search/src/test/java/org/apache/pulsar/io/elasticsearch/ElasticSearchSinkTests.java
@@ -54,10 +54,7 @@ import org.testng.annotations.Test;
 import java.util.Locale;
 import static org.testng.Assert.assertNull;
 
-public class ElasticSearchSinkTests {
-
-    public static final String ELASTICSEARCH_IMAGE = Optional.ofNullable(System.getenv("ELASTICSEARCH_IMAGE"))
-            .orElse("docker.elastic.co/elasticsearch/elasticsearch:7.16.3-amd64");
+public class ElasticSearchSinkTests extends ElasticSearchTestBase {
 
     private static ElasticsearchContainer container;
 
@@ -76,7 +73,7 @@ public class ElasticSearchSinkTests {
 
     @BeforeClass
     public static final void initBeforeClass() {
-        container = new ElasticsearchContainer(ELASTICSEARCH_IMAGE);
+        container = createElasticsearchContainer();
 
         valueSchema = Schema.JSON(UserProfile.class);
         genericSchema = Schema.generic(valueSchema.getSchemaInfo());
@@ -89,7 +86,7 @@ public class ElasticSearchSinkTests {
 
     }
 
-    @AfterClass
+    @AfterClass(alwaysRun = true)
     public static void closeAfterClass() {
         container.close();
     }

--- a/pulsar-io/elastic-search/src/test/java/org/apache/pulsar/io/elasticsearch/ElasticSearchTestBase.java
+++ b/pulsar-io/elastic-search/src/test/java/org/apache/pulsar/io/elasticsearch/ElasticSearchTestBase.java
@@ -1,0 +1,36 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.io.elasticsearch;
+
+import org.testcontainers.elasticsearch.ElasticsearchContainer;
+
+import java.util.Optional;
+
+public class ElasticSearchTestBase {
+
+    private static final String ELASTICSEARCH_IMAGE = Optional.ofNullable(System.getenv("ELASTICSEARCH_IMAGE"))
+            .orElse("docker.elastic.co/elasticsearch/elasticsearch:7.16.3-amd64");
+
+    protected static ElasticsearchContainer createElasticsearchContainer() {
+        return new ElasticsearchContainer(ELASTICSEARCH_IMAGE)
+                .withEnv("ES_JAVA_OPTS", "-Xms128m -Xmx256m");
+
+    }
+
+}


### PR DESCRIPTION
### Motivation
Sometimes I see Elasticsearch tests failing because the ES container exits with 137 code. 
By default Elastic container allocates 2g. In Pulsar IO testing this is not needed at all and we can limit it by setting the related properties.
More doc here: https://discuss.elastic.co/t/elasticsearch-docker-container-keeps-crashing-with-exit-status-of-137/125410

### Modifications
* Refactored the Elastic container init in a common method that set `ES_JAVA_OPTS` to `-Xms128m -Xmx256m`. It seems enough memory to get Elastic container works.
* Removed the junit usage in favor of testNG. they were mixed in same classes and it leads to unpredictable behaviours, such as do not cleaning up resources and so on. (partially copied from https://github.com/apache/pulsar/pull/14065) 

- [x] `no-need-doc` 
  
