### PR TITLE
[OWASP] Update mariadb-jdbc dependency and add suppression rule

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -152,7 +152,7 @@ flexible messaging model and an intuitive client API.</description>
     <mysql-jdbc.version>8.0.11</mysql-jdbc.version>
     <postgresql-jdbc.version>42.2.25</postgresql-jdbc.version>
     <clickhouse-jdbc.version>0.3.2</clickhouse-jdbc.version>
-    <mariadb-jdbc.version>2.6.0</mariadb-jdbc.version>
+    <mariadb-jdbc.version>2.7.5</mariadb-jdbc.version>
     <hdfs-offload-version3>3.3.1</hdfs-offload-version3>
     <json-smart.version>2.4.7</json-smart.version>
     <opensearch.version>1.2.4</opensearch.version>

--- a/src/owasp-dependency-check-suppressions.xml
+++ b/src/owasp-dependency-check-suppressions.xml
@@ -444,5 +444,15 @@
         <cve>CVE-2019-10174</cve>
         <cve>CVE-2020-25711</cve>
     </suppress>
+    <suppress>
+        <notes><![CDATA[
+       file name: mariadb-java-client-2.7.5.jar
+       ]]></notes>
+        <sha1>9dd29797ecabe7d2e7fa892ec6713a5552cfcc59</sha1>
+        <cve>CVE-2020-28912</cve>
+        <cve>CVE-2021-46669</cve>
+        <cve>CVE-2021-46666</cve>
+        <cve>CVE-2021-46667</cve>
+    </suppress>
 
 </suppressions>


### PR DESCRIPTION
Signed-off-by: Zixuan Liu <nodeces@gmail.com>

### Motivation

Fix `OWASP Dependency Check / owasp-dep-check` CI:
```
Error:  Failed to execute goal org.owasp:dependency-check-maven:6.1.6:aggregate (default) on project pulsar: 
Error:  
Error:  One or more dependencies were identified with vulnerabilities that have a CVSS score greater than or equal to '7.0': 
Error:  
Error:  mariadb-java-client-2.6.0.jar: CVE-2020-28912, CVE-2021-46669, CVE-2021-46666, CVE-2021-46667
Error:  
Error:  See the dependency-check report for more details.
Error:  -> [Help 1]
Error:  
Error:  To see the full stack trace of the errors, re-run Maven with the -e switch.
Error:  Re-run Maven using the -X switch to enable full debug logging.
Error:  
Error:  For more information about the errors and possible solutions, please read the following articles:
Error:  [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoFailureException
Error:  
Error:  After correcting the problems, you can resume the build with the command
Error:    mvn <args> -rf :pulsar
Error: Process completed with exit code 1.
```


### Modifications

- Upgrade mariadb-jdbc from 2.6.0 to 2.7.5
- Add mariadb-jdbc to `owasp-dependency-check-suppressions.xml`

### Documentation

  
- [x] `no-need-doc` 
Update dependencies

