### PR TITLE
[Broker] tidy up code about dispatchRate

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/DispatchRateLimiter.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/DispatchRateLimiter.java
@@ -169,40 +169,31 @@ public class DispatchRateLimiter {
      * broker-level
      */
     public void updateDispatchRate() {
+        DispatchRate dispatchRate;
         switch (type) {
             case TOPIC:
-                updateDispatchRate(topic.getDispatchRate());
-                return;
+                dispatchRate = topic.getDispatchRate();
+                break;
             case SUBSCRIPTION:
-                updateDispatchRate(topic.getSubscriptionDispatchRate());
-                return;
+                dispatchRate = topic.getSubscriptionDispatchRate();
+                break;
             case REPLICATOR:
-                updateDispatchRate(topic.getReplicatorDispatchRate());
+                dispatchRate = topic.getReplicatorDispatchRate();
+                break;
+            case BROKER:
+                dispatchRate = createDispatchRate();
+                break;
+            default:
+                log.warn("ignore configured dispatch rate for type {}", type);
                 return;
         }
-
-        Optional<DispatchRate> dispatchRate = getTopicPolicyDispatchRate(brokerService, topicName, type);
-        if (!dispatchRate.isPresent()) {
-            getPoliciesDispatchRateAsync(brokerService).thenAccept(dispatchRateOp -> {
-                if (!dispatchRateOp.isPresent()) {
-                    dispatchRateOp = Optional.of(createDispatchRate());
-                }
-                updateDispatchRate(dispatchRateOp.get());
-                if (type == Type.BROKER) {
-                  log.info("configured broker message-dispatch rate {}", dispatchRateOp.get());
-                } else {
-                  log.info("[{}] configured {} message-dispatch rate at broker {}",
-                          this.topicName, type, dispatchRateOp.get());
-                }
-            }).exceptionally(ex -> {
-                log.error("[{}] failed to get the dispatch rate policy from the namespace resource for type {}",
-                        topicName, type, ex);
-                return null;
-            });
+        if (type == Type.BROKER) {
+            log.info("configured broker message-dispatch rate {}", dispatchRate);
         } else {
-            updateDispatchRate(dispatchRate.get());
-            log.info("[{}] configured {} message-dispatch rate at broker {}", this.topicName, type, dispatchRate.get());
+            log.info("[{}] configured {} message-dispatch rate at broker {}",
+                this.topicName, type, dispatchRate);
         }
+        updateDispatchRate(dispatchRate);
     }
 
     public static boolean isDispatchRateNeeded(BrokerService brokerService, Optional<Policies> policies,
@@ -341,21 +332,6 @@ public class DispatchRateLimiter {
             }
             return isDispatchRateEnabled(dispatchRate) ? dispatchRate : null;
         }).orElse(null);
-    }
-
-
-    /**
-     * Gets configured dispatch-rate from namespace policies. Returns null if dispatch-rate is not configured
-     *
-     * @return
-     */
-    public CompletableFuture<Optional<DispatchRate>> getPoliciesDispatchRateAsync(BrokerService brokerService) {
-        if (topicName == null) {
-            return CompletableFuture.completedFuture(Optional.empty());
-        }
-        final String cluster = brokerService.pulsar().getConfiguration().getClusterName();
-        return getPoliciesAsync(brokerService, topicName).thenApply(policiesOp ->
-                Optional.ofNullable(getPoliciesDispatchRate(cluster, policiesOp, type)));
     }
 
     public static CompletableFuture<Optional<Policies>> getPoliciesAsync(BrokerService brokerService,

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerDispatchRateLimiterTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerDispatchRateLimiterTest.java
@@ -1,0 +1,59 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.service;
+
+import static org.testng.Assert.assertEquals;
+import org.apache.pulsar.client.admin.PulsarAdminException;
+import org.awaitility.Awaitility;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+@Test(groups = "broker")
+public class BrokerDispatchRateLimiterTest extends BrokerTestBase {
+    @BeforeClass
+    @Override
+    protected void setup() throws Exception {
+        super.baseSetup();
+    }
+
+    @AfterClass(alwaysRun = true)
+    @Override
+    protected void cleanup() throws Exception {
+        super.internalCleanup();
+    }
+
+    @Test
+    public void testUpdateBrokerDispatchRateLimiter() throws PulsarAdminException {
+        BrokerService service = pulsar.getBrokerService();
+        assertEquals(service.getBrokerDispatchRateLimiter().getAvailableDispatchRateLimitOnByte(), -1L);
+        assertEquals(service.getBrokerDispatchRateLimiter().getAvailableDispatchRateLimitOnMsg(), -1L);
+
+        admin.brokers().updateDynamicConfiguration("dispatchThrottlingRateInByte", "100");
+        Awaitility.await().untilAsserted(() ->
+            assertEquals(service.getBrokerDispatchRateLimiter().getAvailableDispatchRateLimitOnByte(), 100L));
+        assertEquals(service.getBrokerDispatchRateLimiter().getAvailableDispatchRateLimitOnMsg(), -1L);
+
+        admin.brokers().updateDynamicConfiguration("dispatchThrottlingRateInMsg", "100");
+        Awaitility.await().untilAsserted(() ->
+            assertEquals(service.getBrokerDispatchRateLimiter().getAvailableDispatchRateLimitOnMsg(), 100L));
+        assertEquals(service.getBrokerDispatchRateLimiter().getAvailableDispatchRateLimitOnMsg(), 100L);
+    }
+
+}


### PR DESCRIPTION
### Motivation

* Tidy up code about dispatchRate.
*  No need `getTopicPolicyDispatchRate` or `getPoliciesDispatchRateAsync` when update broker type  dispatch rate

### Modifications

*Describe the modifications you've done.*

### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation
  
- [x] `no-need-doc` 
  


