### PR TITLE
[Tests] Disable test retries for new or modified tests

### DIFF
--- a/.github/changes-filter.yaml
+++ b/.github/changes-filter.yaml
@@ -8,3 +8,5 @@ docs:
   - '.asf.yaml'
   - '*.md'
   - '**/*.md'
+tests:
+  - added|modified: '**/src/test/java/**/*.java'

--- a/.github/workflows/ci-build-macos.yaml
+++ b/.github/workflows/ci-build-macos.yaml
@@ -48,6 +48,7 @@ jobs:
         uses: apache/pulsar-test-infra/paths-filter@master
         with:
           filters: .github/changes-filter.yaml
+          list-files: csv
 
       - name: Check changed files
         id: check_changes

--- a/.github/workflows/ci-cpp-build-centos7.yaml
+++ b/.github/workflows/ci-cpp-build-centos7.yaml
@@ -50,6 +50,7 @@ jobs:
         uses: apache/pulsar-test-infra/paths-filter@master
         with:
           filters: .github/changes-filter.yaml
+          list-files: csv
 
       - name: Check changed files
         id: check_changes

--- a/.github/workflows/ci-cpp-build-windows.yaml
+++ b/.github/workflows/ci-cpp-build-windows.yaml
@@ -71,6 +71,7 @@ jobs:
         uses: apache/pulsar-test-infra/paths-filter@master
         with:
           filters: .github/changes-filter.yaml
+          list-files: csv
 
       - name: Check changed files
         id: check_changes

--- a/.github/workflows/ci-cpp.yaml
+++ b/.github/workflows/ci-cpp.yaml
@@ -48,6 +48,7 @@ jobs:
         uses: apache/pulsar-test-infra/paths-filter@master
         with:
           filters: .github/changes-filter.yaml
+          list-files: csv
 
       - name: Check changed files
         id: check_changes

--- a/.github/workflows/ci-go-functions-style.yaml
+++ b/.github/workflows/ci-go-functions-style.yaml
@@ -56,6 +56,7 @@ jobs:
         uses: apache/pulsar-test-infra/paths-filter@master
         with:
           filters: .github/changes-filter.yaml
+          list-files: csv
 
       - name: Check changed files
         id: check_changes

--- a/.github/workflows/ci-go-functions-test.yaml
+++ b/.github/workflows/ci-go-functions-test.yaml
@@ -58,6 +58,7 @@ jobs:
         uses: apache/pulsar-test-infra/paths-filter@master
         with:
           filters: .github/changes-filter.yaml
+          list-files: csv
 
       - name: Check changed files
         id: check_changes

--- a/.github/workflows/ci-integration-backwards-compatibility.yaml
+++ b/.github/workflows/ci-integration-backwards-compatibility.yaml
@@ -49,6 +49,7 @@ jobs:
         uses: apache/pulsar-test-infra/paths-filter@master
         with:
           filters: .github/changes-filter.yaml
+          list-files: csv
 
       - name: Check changed files
         id: check_changes
@@ -99,7 +100,7 @@ jobs:
 
       - name: run integration tests
         if: ${{ steps.check_changes.outputs.docs_only != 'true' }}
-        run: ./build/run_integration_group.sh BACKWARDS_COMPAT
+        run: CHANGED_TESTS="${{ steps.changes.outputs.tests_files }}" ./build/run_integration_group.sh BACKWARDS_COMPAT
 
       - name: Upload container logs
         uses: actions/upload-artifact@v2

--- a/.github/workflows/ci-integration-cli.yaml
+++ b/.github/workflows/ci-integration-cli.yaml
@@ -49,6 +49,7 @@ jobs:
         uses: apache/pulsar-test-infra/paths-filter@master
         with:
           filters: .github/changes-filter.yaml
+          list-files: csv
 
       - name: Check changed files
         id: check_changes
@@ -99,7 +100,7 @@ jobs:
 
       - name: run integration tests
         if: ${{ steps.check_changes.outputs.docs_only != 'true' }}
-        run: ./build/run_integration_group.sh CLI
+        run: CHANGED_TESTS="${{ steps.changes.outputs.tests_files }}" ./build/run_integration_group.sh CLI
 
       - name: Upload container logs
         uses: actions/upload-artifact@v2

--- a/.github/workflows/ci-integration-function.yaml
+++ b/.github/workflows/ci-integration-function.yaml
@@ -49,6 +49,7 @@ jobs:
         uses: apache/pulsar-test-infra/paths-filter@master
         with:
           filters: .github/changes-filter.yaml
+          list-files: csv
 
       - name: Check changed files
         id: check_changes
@@ -99,7 +100,7 @@ jobs:
 
       - name: run integration tests
         if: ${{ steps.check_changes.outputs.docs_only != 'true' }}
-        run: ./build/run_integration_group.sh FUNCTION
+        run: CHANGED_TESTS="${{ steps.changes.outputs.tests_files }}" ./build/run_integration_group.sh FUNCTION
 
       - name: Upload container logs
         uses: actions/upload-artifact@v2

--- a/.github/workflows/ci-integration-messaging.yaml
+++ b/.github/workflows/ci-integration-messaging.yaml
@@ -49,6 +49,7 @@ jobs:
         uses: apache/pulsar-test-infra/paths-filter@master
         with:
           filters: .github/changes-filter.yaml
+          list-files: csv
 
       - name: Check changed files
         id: check_changes
@@ -99,7 +100,7 @@ jobs:
 
       - name: run integration tests
         if: ${{ steps.check_changes.outputs.docs_only != 'true' }}
-        run: ./build/run_integration_group.sh MESSAGING
+        run: CHANGED_TESTS="${{ steps.changes.outputs.tests_files }}" ./build/run_integration_group.sh MESSAGING
 
       - name: Upload container logs
         uses: actions/upload-artifact@v2

--- a/.github/workflows/ci-integration-process.yaml
+++ b/.github/workflows/ci-integration-process.yaml
@@ -48,6 +48,7 @@ jobs:
         uses: apache/pulsar-test-infra/paths-filter@master
         with:
           filters: .github/changes-filter.yaml
+          list-files: csv
 
       - name: Check changed files
         id: check_changes
@@ -98,7 +99,7 @@ jobs:
 
       - name: run integration tests
         if: ${{ steps.check_changes.outputs.docs_only != 'true' }}
-        run: ./build/run_integration_group.sh PULSAR_CONNECTORS_PROCESS
+        run: CHANGED_TESTS="${{ steps.changes.outputs.tests_files }}" ./build/run_integration_group.sh PULSAR_CONNECTORS_PROCESS
 
       - name: Log dmesg when failed
         if: ${{ failure() }}

--- a/.github/workflows/ci-integration-pulsar-io-ora.yaml
+++ b/.github/workflows/ci-integration-pulsar-io-ora.yaml
@@ -49,6 +49,7 @@ jobs:
         uses: apache/pulsar-test-infra/paths-filter@master
         with:
           filters: .github/changes-filter.yaml
+          list-files: csv
 
       - name: Check changed files
         id: check_changes
@@ -100,7 +101,7 @@ jobs:
 
       - name: run integration tests
         if: ${{ steps.check_changes.outputs.docs_only != 'true' }}
-        run: ./build/run_integration_group.sh PULSAR_IO_ORA
+        run: CHANGED_TESTS="${{ steps.changes.outputs.tests_files }}" ./build/run_integration_group.sh PULSAR_IO_ORA
 
       - name: Upload container logs
         uses: actions/upload-artifact@v2

--- a/.github/workflows/ci-integration-pulsar-io.yaml
+++ b/.github/workflows/ci-integration-pulsar-io.yaml
@@ -49,6 +49,7 @@ jobs:
         uses: apache/pulsar-test-infra/paths-filter@master
         with:
           filters: .github/changes-filter.yaml
+          list-files: csv
 
       - name: Check changed files
         id: check_changes
@@ -100,7 +101,7 @@ jobs:
 
       - name: run integration tests
         if: ${{ steps.check_changes.outputs.docs_only != 'true' }}
-        run: ./build/run_integration_group.sh PULSAR_IO
+        run: CHANGED_TESTS="${{ steps.changes.outputs.tests_files }}" ./build/run_integration_group.sh PULSAR_IO
 
       - name: Upload container logs
         uses: actions/upload-artifact@v2

--- a/.github/workflows/ci-integration-schema.yaml
+++ b/.github/workflows/ci-integration-schema.yaml
@@ -48,6 +48,7 @@ jobs:
         uses: apache/pulsar-test-infra/paths-filter@master
         with:
           filters: .github/changes-filter.yaml
+          list-files: csv
 
       - name: Check changed files
         id: check_changes
@@ -95,7 +96,7 @@ jobs:
 
       - name: run integration tests
         if: ${{ steps.check_changes.outputs.docs_only != 'true' }}
-        run: ./build/run_integration_group.sh SCHEMA
+        run: CHANGED_TESTS="${{ steps.changes.outputs.tests_files }}" ./build/run_integration_group.sh SCHEMA
 
       - name: Upload container logs
         uses: actions/upload-artifact@v2

--- a/.github/workflows/ci-integration-sql.yaml
+++ b/.github/workflows/ci-integration-sql.yaml
@@ -49,6 +49,7 @@ jobs:
         uses: apache/pulsar-test-infra/paths-filter@master
         with:
           filters: .github/changes-filter.yaml
+          list-files: csv
 
       - name: Check changed files
         id: check_changes
@@ -99,7 +100,7 @@ jobs:
 
       - name: run integration tests
         if: ${{ steps.check_changes.outputs.docs_only != 'true' }}
-        run: ./build/run_integration_group.sh SQL
+        run: CHANGED_TESTS="${{ steps.changes.outputs.tests_files }}" ./build/run_integration_group.sh SQL
 
       - name: Log dmesg when failed
         if: ${{ failure() }}

--- a/.github/workflows/ci-integration-standalone.yaml
+++ b/.github/workflows/ci-integration-standalone.yaml
@@ -48,6 +48,7 @@ jobs:
         uses: apache/pulsar-test-infra/paths-filter@master
         with:
           filters: .github/changes-filter.yaml
+          list-files: csv
 
       - name: Check changed files
         id: check_changes
@@ -98,7 +99,7 @@ jobs:
 
       - name: run integration tests
         if: ${{ steps.check_changes.outputs.docs_only != 'true' }}
-        run: ./build/run_integration_group.sh STANDALONE
+        run: CHANGED_TESTS="${{ steps.changes.outputs.tests_files }}" ./build/run_integration_group.sh STANDALONE
 
       - name: Upload container logs
         uses: actions/upload-artifact@v2

--- a/.github/workflows/ci-integration-thread.yaml
+++ b/.github/workflows/ci-integration-thread.yaml
@@ -48,6 +48,7 @@ jobs:
         uses: apache/pulsar-test-infra/paths-filter@master
         with:
           filters: .github/changes-filter.yaml
+          list-files: csv
 
       - name: Check changed files
         id: check_changes
@@ -98,7 +99,7 @@ jobs:
 
       - name: run integration function
         if: ${{ steps.check_changes.outputs.docs_only != 'true' }}
-        run: ./build/run_integration_group.sh PULSAR_CONNECTORS_THREAD
+        run: CHANGED_TESTS="${{ steps.changes.outputs.tests_files }}" ./build/run_integration_group.sh PULSAR_CONNECTORS_THREAD
 
       - name: Upload container logs
         uses: actions/upload-artifact@v2

--- a/.github/workflows/ci-integration-tiered-filesystem.yaml
+++ b/.github/workflows/ci-integration-tiered-filesystem.yaml
@@ -48,6 +48,7 @@ jobs:
         uses: apache/pulsar-test-infra/paths-filter@master
         with:
           filters: .github/changes-filter.yaml
+          list-files: csv
 
       - name: Check changed files
         id: check_changes
@@ -98,7 +99,7 @@ jobs:
 
       - name: run integration tests
         if: ${{ steps.check_changes.outputs.docs_only != 'true' }}
-        run: ./build/run_integration_group.sh TIERED_FILESYSTEM
+        run: CHANGED_TESTS="${{ steps.changes.outputs.tests_files }}" ./build/run_integration_group.sh TIERED_FILESYSTEM
 
       - name: Upload container logs
         uses: actions/upload-artifact@v2

--- a/.github/workflows/ci-integration-tiered-jcloud.yaml
+++ b/.github/workflows/ci-integration-tiered-jcloud.yaml
@@ -48,6 +48,7 @@ jobs:
         uses: apache/pulsar-test-infra/paths-filter@master
         with:
           filters: .github/changes-filter.yaml
+          list-files: csv
 
       - name: Check changed files
         id: check_changes
@@ -98,7 +99,7 @@ jobs:
 
       - name: run integration tests
         if: ${{ steps.check_changes.outputs.docs_only != 'true' }}
-        run: ./build/run_integration_group.sh TIERED_JCLOUD
+        run: CHANGED_TESTS="${{ steps.changes.outputs.tests_files }}" ./build/run_integration_group.sh TIERED_JCLOUD
 
       - name: Upload container logs
         uses: actions/upload-artifact@v2

--- a/.github/workflows/ci-integration-transaction.yaml
+++ b/.github/workflows/ci-integration-transaction.yaml
@@ -48,6 +48,7 @@ jobs:
         uses: apache/pulsar-test-infra/paths-filter@master
         with:
           filters: .github/changes-filter.yaml
+          list-files: csv
 
       - name: Check changed files
         id: check_changes
@@ -95,7 +96,7 @@ jobs:
 
       - name: run integration tests
         if: ${{ steps.check_changes.outputs.docs_only != 'true' }}
-        run: ./build/run_integration_group.sh TRANSACTION
+        run: CHANGED_TESTS="${{ steps.changes.outputs.tests_files }}" ./build/run_integration_group.sh TRANSACTION
 
       - name: Upload container logs
         uses: actions/upload-artifact@v2

--- a/.github/workflows/ci-license.yaml
+++ b/.github/workflows/ci-license.yaml
@@ -48,6 +48,7 @@ jobs:
         uses: apache/pulsar-test-infra/paths-filter@master
         with:
           filters: .github/changes-filter.yaml
+          list-files: csv
 
       - name: Check changed files
         id: check_changes

--- a/.github/workflows/ci-python-build-3.9-client.yaml
+++ b/.github/workflows/ci-python-build-3.9-client.yaml
@@ -50,6 +50,7 @@ jobs:
         uses: apache/pulsar-test-infra/paths-filter@master
         with:
           filters: .github/changes-filter.yaml
+          list-files: csv
 
       - name: Check changed files
         id: check_changes

--- a/.github/workflows/ci-shade-test.yaml
+++ b/.github/workflows/ci-shade-test.yaml
@@ -49,6 +49,7 @@ jobs:
         uses: apache/pulsar-test-infra/paths-filter@master
         with:
           filters: .github/changes-filter.yaml
+          list-files: csv
 
       - name: Check changed files
         id: check_changes
@@ -99,4 +100,4 @@ jobs:
 
       - name: run shade tests
         if: ${{ steps.check_changes.outputs.docs_only != 'true' }}
-        run: ./build/run_integration_group.sh SHADE
+        run: CHANGED_TESTS="${{ steps.changes.outputs.tests_files }}" ./build/run_integration_group.sh SHADE

--- a/.github/workflows/ci-unit-broker-broker-gp.yaml
+++ b/.github/workflows/ci-unit-broker-broker-gp.yaml
@@ -52,6 +52,7 @@ jobs:
         uses: apache/pulsar-test-infra/paths-filter@master
         with:
           filters: .github/changes-filter.yaml
+          list-files: csv
 
       - name: Check changed files
         id: check_changes
@@ -81,15 +82,15 @@ jobs:
 
       - name: run unit test 'BROKER_GROUP_1'
         if: ${{ steps.check_changes.outputs.docs_only != 'true' && matrix.group == 'group1' }}
-        run: ./build/run_unit_group.sh BROKER_GROUP_1
+        run: CHANGED_TESTS="${{ steps.changes.outputs.tests_files }}" ./build/run_unit_group.sh BROKER_GROUP_1
 
       - name: run unit test 'BROKER_GROUP_2'
         if: ${{ steps.check_changes.outputs.docs_only != 'true' && matrix.group == 'group2' }}
-        run: ./build/run_unit_group.sh BROKER_GROUP_2
+        run: CHANGED_TESTS="${{ steps.changes.outputs.tests_files }}" ./build/run_unit_group.sh BROKER_GROUP_2
 
       - name: run unit test 'BROKER_GROUP_3'
         if: ${{ steps.check_changes.outputs.docs_only != 'true' && matrix.group == 'group3' }}
-        run: ./build/run_unit_group.sh BROKER_GROUP_3
+        run: CHANGED_TESTS="${{ steps.changes.outputs.tests_files }}" ./build/run_unit_group.sh BROKER_GROUP_3
 
       - name: print JVM thread dumps when cancelled
         if: cancelled()

--- a/.github/workflows/ci-unit-broker-client-api.yaml
+++ b/.github/workflows/ci-unit-broker-client-api.yaml
@@ -48,6 +48,7 @@ jobs:
         uses: apache/pulsar-test-infra/paths-filter@master
         with:
           filters: .github/changes-filter.yaml
+          list-files: csv
 
       - name: Check changed files
         id: check_changes
@@ -77,7 +78,7 @@ jobs:
 
       - name: run unit test 'BROKER_CLIENT_API'
         if: ${{ steps.check_changes.outputs.docs_only != 'true' }}
-        run: ./build/run_unit_group.sh BROKER_CLIENT_API
+        run: CHANGED_TESTS="${{ steps.changes.outputs.tests_files }}" ./build/run_unit_group.sh BROKER_CLIENT_API
 
       - name: print JVM thread dumps when cancelled
         if: cancelled()

--- a/.github/workflows/ci-unit-broker-client-impl.yaml
+++ b/.github/workflows/ci-unit-broker-client-impl.yaml
@@ -48,6 +48,7 @@ jobs:
         uses: apache/pulsar-test-infra/paths-filter@master
         with:
           filters: .github/changes-filter.yaml
+          list-files: csv
 
       - name: Check changed files
         id: check_changes
@@ -77,7 +78,7 @@ jobs:
 
       - name: run unit test 'BROKER_CLIENT_IMPL'
         if: ${{ steps.check_changes.outputs.docs_only != 'true' }}
-        run: ./build/run_unit_group.sh BROKER_CLIENT_IMPL
+        run: CHANGED_TESTS="${{ steps.changes.outputs.tests_files }}" ./build/run_unit_group.sh BROKER_CLIENT_IMPL
 
       - name: print JVM thread dumps when cancelled
         if: cancelled()

--- a/.github/workflows/ci-unit-broker-jdk8.yaml
+++ b/.github/workflows/ci-unit-broker-jdk8.yaml
@@ -48,6 +48,7 @@ jobs:
         uses: apache/pulsar-test-infra/paths-filter@master
         with:
           filters: .github/changes-filter.yaml
+          list-files: csv
 
       - name: Check changed files
         id: check_changes
@@ -77,7 +78,7 @@ jobs:
 
       - name: run unit test 'BROKER_GROUP_1'
         if: ${{ steps.check_changes.outputs.docs_only != 'true' }}
-        run: ./build/run_unit_group.sh BROKER_JDK8
+        run: CHANGED_TESTS="${{ steps.changes.outputs.tests_files }}" ./build/run_unit_group.sh BROKER_JDK8
 
       - name: print JVM thread dumps when cancelled
         if: cancelled()

--- a/.github/workflows/ci-unit-broker-other.yaml
+++ b/.github/workflows/ci-unit-broker-other.yaml
@@ -48,6 +48,7 @@ jobs:
         uses: apache/pulsar-test-infra/paths-filter@master
         with:
           filters: .github/changes-filter.yaml
+          list-files: csv
 
       - name: Check changed files
         id: check_changes
@@ -77,7 +78,7 @@ jobs:
 
       - name: run unit test 'BROKER_FLAKY'
         if: ${{ steps.check_changes.outputs.docs_only != 'true' }}
-        run: ./build/run_unit_group.sh BROKER_FLAKY
+        run: CHANGED_TESTS="${{ steps.changes.outputs.tests_files }}" ./build/run_unit_group.sh BROKER_FLAKY
 
       - name: print JVM thread dumps when cancelled
         if: cancelled()

--- a/.github/workflows/ci-unit-proxy.yaml
+++ b/.github/workflows/ci-unit-proxy.yaml
@@ -48,6 +48,7 @@ jobs:
         uses: apache/pulsar-test-infra/paths-filter@master
         with:
           filters: .github/changes-filter.yaml
+          list-files: csv
 
       - name: Check changed files
         id: check_changes
@@ -77,7 +78,7 @@ jobs:
 
       - name: run unit test 'PROXY'
         if: ${{ steps.check_changes.outputs.docs_only != 'true' }}
-        run: ./build/run_unit_group.sh PROXY
+        run: CHANGED_TESTS="${{ steps.changes.outputs.tests_files }}" ./build/run_unit_group.sh PROXY
 
       - name: print JVM thread dumps when cancelled
         if: cancelled()

--- a/.github/workflows/ci-unit.yaml
+++ b/.github/workflows/ci-unit.yaml
@@ -48,6 +48,7 @@ jobs:
         uses: apache/pulsar-test-infra/paths-filter@master
         with:
           filters: .github/changes-filter.yaml
+          list-files: csv
 
       - name: Check changed files
         id: check_changes
@@ -73,7 +74,7 @@ jobs:
 
       - name: run unit test 'OTHER'
         if: ${{ steps.check_changes.outputs.docs_only != 'true' }}
-        run: ./build/run_unit_group.sh OTHER
+        run: CHANGED_TESTS="${{ steps.changes.outputs.tests_files }}" ./build/run_unit_group.sh OTHER
 
       - name: print JVM thread dumps when cancelled
         if: cancelled()

--- a/build/retry.sh
+++ b/build/retry.sh
@@ -18,6 +18,8 @@
 # under the License.
 #
 
+shopt -s nullglob
+
 function fail {
   echo $1 >&2
   exit 1
@@ -30,6 +32,11 @@ function retry {
   while true; do
     "$@" && break || {
       if [[ $n -lt $max ]]; then
+        if [[ -n "$CHANGED_TESTS" ]]; then
+          if grep -q -F -f <(printf "$CHANGED_TESTS" | sed 's/,/\n/g' | sed -E 's|.*src/test/java/(.*)\.java$|\1|' | sed 's|/|.|g') */*/*/target/surefire-reports/testng-failed.xml */*/target/surefire-reports/testng-failed.xml */target/surefire-reports/testng-failed.xml; then
+            fail "Not retrying since one of the changed tests failed."
+          fi
+        fi
         ((n++))
         echo "Command failed. Attempt $n/$max:"
         sleep $delay;

--- a/buildtools/src/main/java/org/apache/pulsar/tests/RetryAnalyzer.java
+++ b/buildtools/src/main/java/org/apache/pulsar/tests/RetryAnalyzer.java
@@ -18,6 +18,15 @@
  */
 package org.apache.pulsar.tests;
 
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import org.apache.commons.lang3.StringUtils;
 import org.testng.ITestResult;
 import org.testng.SkipException;
 import org.testng.util.RetryAnalyzerCount;
@@ -26,8 +35,34 @@ public class RetryAnalyzer extends RetryAnalyzerCount {
     // Only try again once
     static final int MAX_RETRIES = Integer.parseInt(System.getProperty("testRetryCount", "1"));
 
+    // Don't retry test classes that are changed in the current changeset in CI
+    private static final Pattern TEST_FILE_PATTERN = Pattern.compile("^.*src/test/java/(.*)\\.java$");
+    private static final Set<String> CHANGED_TEST_CLASSES = Optional.ofNullable(System.getenv("CHANGED_TESTS"))
+            .map(changedTestsCsv ->
+                    Collections.unmodifiableSet(Arrays.stream(StringUtils.split(changedTestsCsv))
+                            .map(path -> {
+                                Matcher matcher = TEST_FILE_PATTERN.matcher(path);
+                                if (matcher.matches()) {
+                                    return matcher.group(1)
+                                            .replace('/', '.');
+                                } else {
+                                    return null;
+                                }
+                            })
+                            .filter(Objects::nonNull)
+                            .collect(Collectors.toSet())))
+            .orElse(Collections.emptySet());
+
     public RetryAnalyzer() {
         setCount(MAX_RETRIES);
+    }
+
+    @Override
+    public boolean retry(ITestResult result) {
+        if (CHANGED_TEST_CLASSES.contains((result.getTestClass().getName()))) {
+            return false;
+        }
+        return super.retry(result);
     }
 
     @Override


### PR DESCRIPTION
### Motivation

There's a [discussion on the mailing about improving unit test stability](https://lists.apache.org/thread/d4tq105wmsmm3s84lwy19d0b6hbxn7vz). 
One of the methods is to disable test retries for new or modified test classes. This will reduce the likelihood of introducing more flaky tests into the code base.

### Modifications

- Use the paths-filter in GitHub Actions to list test class changes. Use GitHub Actions to place the CSV list to a environment variable called `CHANGED_TESTS`.
- parse `CHANGED_TESTS` in RetryAnalyzer which determines whether a failed test method should be retried or not. Disable test retries for new or modified tests.
- parse `CHANGED_TESTS` in `build/retry.sh` script. Skip retries if there's a test failure in one of the changed tests.