### PR TITLE
Move reporting a vulnerability documentation to contact page

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,6 +297,10 @@ Pulsar slack channel at https://apache-pulsar.slack.com/
 
 You can self-register at https://apache-pulsar.herokuapp.com/
 
+##### Report a security vulnerability
+
+To report a vulnerability for Pulsar, contact the [Apache Security Team](https://www.apache.org/security/). When reporting a vulnerability to [security@apache.org](mailto:security@apache.org), you can copy your email to [private@pulsar.apache.org](mailto:private@pulsar.apache.org) to send your report to the Apache Pulsar Project Management Committee. This is a private mailing list.
+
 ## License
 
 Licensed under the Apache License, Version 2.0: http://www.apache.org/licenses/LICENSE-2.0

--- a/site2/docs/security-versioning-policy.md
+++ b/site2/docs/security-versioning-policy.md
@@ -4,12 +4,6 @@ title: Security Policy and Supported Versions
 sidebar_label: Security Policy and Supported Versions
 ---
 
-## Reporting a Vulnerability
-
-The current process for reporting vulnerabilities is outlined here: https://www.apache.org/security/. When reporting a
-vulnerability to security@apache.org, you can copy your email to [private@pulsar.apache.org](mailto:private@pulsar.apache.org)
-to send your report to the Apache Pulsar Project Management Committee. This is a private mailing list.
-
 ## Using Pulsar's Security Features
 
 You can find documentation on Pulsar's available security features and how to use them here:

--- a/site2/website/pages/en/contact.js
+++ b/site2/website/pages/en/contact.js
@@ -50,9 +50,9 @@ class Contact extends React.Component {
             There are many ways to get help from the Apache Pulsar community.
             The mailing lists are the primary place where all Pulsar committers are present.
             Bugs and feature requests can either be discussed on the dev mailing list or
-            by opening an issue on
-            <a href="https://github.com/apache/pulsar/" target="_blank">GitHub</a>.
-            </translate></p>
+            by opening an issue on</translate>
+            <a href="https://github.com/apache/pulsar/" target="_blank"> GitHub</a>.
+            </p>
 
             <h2><translate>Mailing Lists</translate></h2>
             <table className="versions">
@@ -79,6 +79,16 @@ class Contact extends React.Component {
                 )}
               </tbody>
             </table>
+            <h2><translate>Reporting Security Vulnerabilities</translate></h2>
+              <p><translate>
+              The current process for reporting vulnerabilities is outlined here: </translate>
+              <a href="https://www.apache.org/security/" target="_blank"> Apache Security</a>
+              <translate>. When reporting a vulnerability to</translate>
+              <a href="mailto:security@apache.org" target="_blank"> security@apache.org</a>
+              <translate>, you can copy your email to </translate>
+              <a href="mailto:private@pulsar.apache.org" target="_blank"> private@pulsar.apache.org </a>
+              <translate> to send your report to the Apache Pulsar Project Management Committee. This is a private mailing list.</translate>
+              </p>
 
             <h2><translate>Stack Overflow</translate></h2>
               <p><translate>


### PR DESCRIPTION
### Motivation

The context for this PR is on the mailing list here: https://lists.apache.org/thread/l2hp7tq5fr0r1v4pg0lvkbxtqtwo81pq

### Modifications

* Move the reporting a vulnerability information to the "contact" pages.

### Verifying this change

I was able to verify the changes for the old website, but not the new website (site2/website-next).

### Does this pull request potentially affect one of the following parts:

This is only a documentation update.

### Documentation

- [x] `doc` 
  
This is an update to the docs.


