### PR TITLE
Pulsar Admin: grab contextual stacktrace for sync methods

### DIFF
--- a/pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/admin/PulsarAdminException.java
+++ b/pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/admin/PulsarAdminException.java
@@ -88,7 +88,7 @@ public class PulsarAdminException extends Exception {
 
         @Override
         protected PulsarAdminException clone() {
-            return new NotAllowedException(getCause(), getHttpError(), getStatusCode());
+            return new NotAuthorizedException(getCause(), getHttpError(), getStatusCode());
         }
     }
 

--- a/pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/admin/PulsarAdminException.java
+++ b/pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/admin/PulsarAdminException.java
@@ -70,11 +70,25 @@ public class PulsarAdminException extends Exception {
     }
 
     /**
+     * This method is meant to be overriden by all subclasses.
+     * We cannot make it 'abstract' because it would be a breaking change in the public API.
+     * @return a new PulsarAdminException
+     */
+    protected PulsarAdminException clone() {
+        return new PulsarAdminException(getMessage(), getCause(), httpError, statusCode);
+    }
+
+    /**
      * Not Authorized Exception.
      */
     public static class NotAuthorizedException extends PulsarAdminException {
         public NotAuthorizedException(Throwable t, String httpError, int statusCode) {
             super(httpError, t, httpError, statusCode);
+        }
+
+        @Override
+        protected PulsarAdminException clone() {
+            return new NotAllowedException(getCause(), getHttpError(), getStatusCode());
         }
     }
 
@@ -85,6 +99,11 @@ public class PulsarAdminException extends Exception {
         public NotFoundException(Throwable t, String httpError, int statusCode) {
             super(httpError, t, httpError, statusCode);
         }
+
+        @Override
+        protected PulsarAdminException clone() {
+            return new NotFoundException(getCause(), getHttpError(), getStatusCode());
+        }
     }
 
     /**
@@ -93,6 +112,11 @@ public class PulsarAdminException extends Exception {
     public static class NotAllowedException extends PulsarAdminException {
         public NotAllowedException(Throwable t, String httpError, int statusCode) {
             super(httpError, t, httpError, statusCode);
+        }
+
+        @Override
+        protected PulsarAdminException clone() {
+            return new NotAllowedException(getCause(), getHttpError(), getStatusCode());
         }
     }
 
@@ -103,6 +127,11 @@ public class PulsarAdminException extends Exception {
         public ConflictException(Throwable t, String httpError, int statusCode) {
             super(httpError, t, httpError, statusCode);
         }
+
+        @Override
+        protected PulsarAdminException clone() {
+            return new ConflictException(getCause(), getHttpError(), getStatusCode());
+        }
     }
 
     /**
@@ -112,6 +141,11 @@ public class PulsarAdminException extends Exception {
         public PreconditionFailedException(Throwable t, String httpError, int statusCode) {
             super(httpError, t, httpError, statusCode);
         }
+
+        @Override
+        protected PulsarAdminException clone() {
+            return new PreconditionFailedException(getCause(), getHttpError(), getStatusCode());
+        }
     }
 
     /**
@@ -120,6 +154,11 @@ public class PulsarAdminException extends Exception {
     public static class TimeoutException extends PulsarAdminException {
         public TimeoutException(Throwable t) {
             super(t);
+        }
+
+        @Override
+        protected PulsarAdminException clone() {
+            return new TimeoutException(getCause());
         }
     }
 
@@ -131,8 +170,14 @@ public class PulsarAdminException extends Exception {
             super(message, t, httpError, statusCode);
         }
 
+        @Deprecated
         public ServerSideErrorException(Throwable t) {
             super("Some error occourred on the server", t);
+        }
+
+        @Override
+        protected PulsarAdminException clone() {
+            return new ServerSideErrorException(getCause(), getMessage(), getHttpError(), getStatusCode());
         }
     }
 
@@ -147,6 +192,11 @@ public class PulsarAdminException extends Exception {
         public HttpErrorException(Throwable t) {
             super(t);
         }
+
+        @Override
+        protected PulsarAdminException clone() {
+            return new HttpErrorException(getCause());
+        }
     }
 
     /**
@@ -160,6 +210,11 @@ public class PulsarAdminException extends Exception {
         public ConnectException(String message, Throwable t) {
             super(message, t);
         }
+
+        @Override
+        protected PulsarAdminException clone() {
+            return new ConnectException(getMessage(), getCause());
+        }
     }
 
     /**
@@ -170,8 +225,30 @@ public class PulsarAdminException extends Exception {
             super(t);
         }
 
+        @Deprecated
         public GettingAuthenticationDataException(String msg) {
             super(msg);
         }
+
+        @Override
+        protected PulsarAdminException clone() {
+            return new GettingAuthenticationDataException(getCause());
+        }
+    }
+
+    /**
+     * Clone the exception and grab the current stacktrace.
+     * @param e a PulsarAdminException
+     * @return a new PulsarAdminException, of the same class.
+     */
+    public static PulsarAdminException wrap(PulsarAdminException e) {
+        PulsarAdminException cloned =  e.clone();
+        if (e.getClass() != cloned.getClass()) {
+            throw new IllegalStateException("Cloning a " + e.getClass() + " generated a "
+                    + cloned.getClass() + ", this is a bug, original error is " + e, e);
+        }
+        // adding a reference to the original exception.
+        cloned.addSuppressed(e);
+        return (PulsarAdminException) cloned.fillInStackTrace();
     }
 }

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/TopicPoliciesImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/TopicPoliciesImpl.java
@@ -21,9 +21,6 @@ package org.apache.pulsar.client.admin.internal;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.client.InvocationCallback;
 import javax.ws.rs.client.WebTarget;
@@ -1237,17 +1234,7 @@ public class TopicPoliciesImpl extends BaseResource implements TopicPolicies {
 
     @Override
     public void removeSubscriptionTypesEnabled(String topic) throws PulsarAdminException {
-        try {
-            removeSubscriptionTypesEnabledAsync(topic)
-                    .get(this.readTimeoutMs, TimeUnit.MILLISECONDS);
-        } catch (ExecutionException e) {
-            throw (PulsarAdminException) e.getCause();
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new PulsarAdminException(e);
-        } catch (TimeoutException e) {
-            throw new PulsarAdminException.TimeoutException(e);
-        }
+        sync(() -> removeSubscriptionTypesEnabledAsync(topic));
     }
 
     @Override


### PR DESCRIPTION
### Motivation
When you run Pulsar Admin API functions the stacktrace of the error is not user friendly as it does not report the stacktrace of the caller method, but usually it is the stacktrace of another thread (because requests are handled in the REST Client thread pool).

### Modifications

With this change all the PulsarAdminExceptions will be cloned, grabbing the current thread stacktrace, and then thrown.
The "cause" is preserved, and we are adding as "suppressed exception" the original exception.

I wanted to preserve the original "cause" because it is possible that some code relies (erroneously) on the cause to have fine grained details about the problem.



### Verifying this change

This change is already covered by existing tests

### Results:

This is an example of a application that calls "tenants.delete()" in a main() method in a class AdminTest, at line 52:

Before:
```
org.apache.pulsar.client.admin.PulsarAdminException$NotFoundException: Tenant doesn't exist
	at org.apache.pulsar.client.admin.internal.BaseResource.getApiException(BaseResource.java:230)
	at org.apache.pulsar.client.admin.internal.BaseResource$3.failed(BaseResource.java:184)
	at org.glassfish.jersey.client.JerseyInvocation$1.failed(JerseyInvocation.java:882)
	at org.glassfish.jersey.client.JerseyInvocation$1.completed(JerseyInvocation.java:863)
	at org.glassfish.jersey.client.ClientRuntime.processResponse(ClientRuntime.java:229)
	at org.glassfish.jersey.client.ClientRuntime.access$200(ClientRuntime.java:62)
	at org.glassfish.jersey.client.ClientRuntime$2.lambda$response$0(ClientRuntime.java:173)
	at org.glassfish.jersey.internal.Errors$1.call(Errors.java:248)
	at org.glassfish.jersey.internal.Errors$1.call(Errors.java:244)
	at org.glassfish.jersey.internal.Errors.process(Errors.java:292)
	at org.glassfish.jersey.internal.Errors.process(Errors.java:274)
	at org.glassfish.jersey.internal.Errors.process(Errors.java:244)
	at org.glassfish.jersey.process.internal.RequestScope.runInScope(RequestScope.java:288)
	at org.glassfish.jersey.client.ClientRuntime$2.response(ClientRuntime.java:173)
	at org.apache.pulsar.client.admin.internal.http.AsyncHttpConnector.lambda$apply$1(AsyncHttpConnector.java:228)
	at java.base/java.util.concurrent.CompletableFuture.uniWhenComplete(CompletableFuture.java:859)
	at java.base/java.util.concurrent.CompletableFuture$UniWhenComplete.tryFire(CompletableFuture.java:837)
	at java.base/java.util.concurrent.CompletableFuture.postComplete(CompletableFuture.java:506)
	at java.base/java.util.concurrent.CompletableFuture.complete(CompletableFuture.java:2073)
	at org.apache.pulsar.client.admin.internal.http.AsyncHttpConnector.lambda$retryOperation$4(AsyncHttpConnector.java:270)
	at java.base/java.util.concurrent.CompletableFuture.uniWhenComplete(CompletableFuture.java:859)
	at java.base/java.util.concurrent.CompletableFuture$UniWhenComplete.tryFire(CompletableFuture.java:837)
	at java.base/java.util.concurrent.CompletableFuture.postComplete(CompletableFuture.java:506)
	at java.base/java.util.concurrent.CompletableFuture.complete(CompletableFuture.java:2073)
	at org.asynchttpclient.netty.NettyResponseFuture.loadContent(NettyResponseFuture.java:222)
	at org.asynchttpclient.netty.NettyResponseFuture.done(NettyResponseFuture.java:257)
	at org.asynchttpclient.netty.handler.AsyncHttpClientHandler.finishUpdate(AsyncHttpClientHandler.java:241)
	at org.asynchttpclient.netty.handler.HttpHandler.handleChunk(HttpHandler.java:114)
	at org.asynchttpclient.netty.handler.HttpHandler.handleRead(HttpHandler.java:143)
	at org.asynchttpclient.netty.handler.AsyncHttpClientHandler.channelRead(AsyncHttpClientHandler.java:78)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357)
	at io.netty.handler.codec.MessageToMessageDecoder.channelRead(MessageToMessageDecoder.java:103)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357)
	at io.netty.channel.CombinedChannelDuplexHandler$DelegatingChannelHandlerContext.fireChannelRead(CombinedChannelDuplexHandler.java:436)
	at io.netty.handler.codec.ByteToMessageDecoder.fireChannelRead(ByteToMessageDecoder.java:324)
	at io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:296)
	at io.netty.channel.CombinedChannelDuplexHandler.channelRead(CombinedChannelDuplexHandler.java:251)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357)
	at io.netty.channel.DefaultChannelPipeline$HeadContext.channelRead(DefaultChannelPipeline.java:1410)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365)
	at io.netty.channel.DefaultChannelPipeline.fireChannelRead(DefaultChannelPipeline.java:919)
	at io.netty.channel.nio.AbstractNioByteChannel$NioByteUnsafe.read(AbstractNioByteChannel.java:166)
	at io.netty.channel.nio.NioEventLoop.processSelectedKey(NioEventLoop.java:719)
	at io.netty.channel.nio.NioEventLoop.processSelectedKeysOptimized(NioEventLoop.java:655)
	at io.netty.channel.nio.NioEventLoop.processSelectedKeys(NioEventLoop.java:581)
	at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:493)
	at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:986)
	at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
	at java.base/java.lang.Thread.run(Thread.java:829)
Caused by: javax.ws.rs.NotFoundException: HTTP 404 Not Found
	at org.glassfish.jersey.client.JerseyInvocation.convertToException(JerseyInvocation.java:948)
	at org.glassfish.jersey.client.JerseyInvocation.access$700(JerseyInvocation.java:82)
	... 54 more
```

After (you can see the original code AdminTest.main(AdminTest.java:52))
```
org.apache.pulsar.client.admin.PulsarAdminException$NotFoundException: Tenant doesn't exist
	at org.apache.pulsar.client.admin.PulsarAdminException.wrap(PulsarAdminException.java:252)
	at org.apache.pulsar.client.admin.internal.BaseResource.sync(BaseResource.java:302)
	at org.apache.pulsar.client.admin.internal.TenantsImpl.deleteTenant(TenantsImpl.java:114)
	at AdminTest.main(AdminTest.java:52)
	Suppressed: org.apache.pulsar.client.admin.PulsarAdminException$NotFoundException: Tenant doesn't exist
		at org.apache.pulsar.client.admin.internal.BaseResource.getApiException(BaseResource.java:234)
		at org.apache.pulsar.client.admin.internal.BaseResource$3.failed(BaseResource.java:188)
		at org.glassfish.jersey.client.JerseyInvocation$1.failed(JerseyInvocation.java:882)
		at org.glassfish.jersey.client.JerseyInvocation$1.completed(JerseyInvocation.java:863)
		at org.glassfish.jersey.client.ClientRuntime.processResponse(ClientRuntime.java:229)
		at org.glassfish.jersey.client.ClientRuntime.access$200(ClientRuntime.java:62)
		at org.glassfish.jersey.client.ClientRuntime$2.lambda$response$0(ClientRuntime.java:173)
		at org.glassfish.jersey.internal.Errors$1.call(Errors.java:248)
		at org.glassfish.jersey.internal.Errors$1.call(Errors.java:244)
		at org.glassfish.jersey.internal.Errors.process(Errors.java:292)
		at org.glassfish.jersey.internal.Errors.process(Errors.java:274)
		at org.glassfish.jersey.internal.Errors.process(Errors.java:244)
		at org.glassfish.jersey.process.internal.RequestScope.runInScope(RequestScope.java:288)
		at org.glassfish.jersey.client.ClientRuntime$2.response(ClientRuntime.java:173)
		at org.apache.pulsar.client.admin.internal.http.AsyncHttpConnector.lambda$apply$1(AsyncHttpConnector.java:228)
		at java.base/java.util.concurrent.CompletableFuture.uniWhenComplete(CompletableFuture.java:859)
		at java.base/java.util.concurrent.CompletableFuture$UniWhenComplete.tryFire(CompletableFuture.java:837)
		at java.base/java.util.concurrent.CompletableFuture.postComplete(CompletableFuture.java:506)
		at java.base/java.util.concurrent.CompletableFuture.complete(CompletableFuture.java:2073)
		at org.apache.pulsar.client.admin.internal.http.AsyncHttpConnector.lambda$retryOperation$4(AsyncHttpConnector.java:270)
		at java.base/java.util.concurrent.CompletableFuture.uniWhenComplete(CompletableFuture.java:859)
		at java.base/java.util.concurrent.CompletableFuture$UniWhenComplete.tryFire(CompletableFuture.java:837)
		at java.base/java.util.concurrent.CompletableFuture.postComplete(CompletableFuture.java:506)
		at java.base/java.util.concurrent.CompletableFuture.complete(CompletableFuture.java:2073)
		at org.asynchttpclient.netty.NettyResponseFuture.loadContent(NettyResponseFuture.java:222)
		at org.asynchttpclient.netty.NettyResponseFuture.done(NettyResponseFuture.java:257)
		at org.asynchttpclient.netty.handler.AsyncHttpClientHandler.finishUpdate(AsyncHttpClientHandler.java:241)
		at org.asynchttpclient.netty.handler.HttpHandler.handleChunk(HttpHandler.java:114)
		at org.asynchttpclient.netty.handler.HttpHandler.handleRead(HttpHandler.java:143)
		at org.asynchttpclient.netty.handler.AsyncHttpClientHandler.channelRead(AsyncHttpClientHandler.java:78)
		at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379)
		at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365)
		at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357)
		at io.netty.handler.codec.MessageToMessageDecoder.channelRead(MessageToMessageDecoder.java:103)
		at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379)
		at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365)
		at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357)
		at io.netty.channel.CombinedChannelDuplexHandler$DelegatingChannelHandlerContext.fireChannelRead(CombinedChannelDuplexHandler.java:436)
		at io.netty.handler.codec.ByteToMessageDecoder.fireChannelRead(ByteToMessageDecoder.java:327)
		at io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:299)
		at io.netty.channel.CombinedChannelDuplexHandler.channelRead(CombinedChannelDuplexHandler.java:251)
		at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379)
		at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365)
		at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357)
		at io.netty.channel.DefaultChannelPipeline$HeadContext.channelRead(DefaultChannelPipeline.java:1410)
		at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379)
		at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365)
		at io.netty.channel.DefaultChannelPipeline.fireChannelRead(DefaultChannelPipeline.java:919)
		at io.netty.channel.nio.AbstractNioByteChannel$NioByteUnsafe.read(AbstractNioByteChannel.java:166)
		at io.netty.channel.nio.NioEventLoop.processSelectedKey(NioEventLoop.java:722)
		at io.netty.channel.nio.NioEventLoop.processSelectedKeysOptimized(NioEventLoop.java:658)
		at io.netty.channel.nio.NioEventLoop.processSelectedKeys(NioEventLoop.java:584)
		at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:496)
		at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:986)
		at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
		at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
		at java.base/java.lang.Thread.run(Thread.java:829)
	Caused by: javax.ws.rs.NotFoundException: HTTP 404 Not Found
		at org.glassfish.jersey.client.JerseyInvocation.convertToException(JerseyInvocation.java:948)
		at org.glassfish.jersey.client.JerseyInvocation.access$700(JerseyInvocation.java:82)
		... 54 more
Caused by: [CIRCULAR REFERENCE: javax.ws.rs.NotFoundException: HTTP 404 Not Found]

```
