### PR TITLE
Fix inconsistent prompt message when schema version is empty using AVRO.

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
@@ -2028,7 +2028,8 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
         SchemaVersion schemaVersion = SchemaVersion.Latest;
         if (commandGetSchema.hasSchemaVersion()) {
             if (commandGetSchema.getSchemaVersion().length == 0) {
-                commandSender.sendGetSchemaErrorResponse(requestId, ServerError.IncompatibleSchema, "Empty schema version");
+                commandSender.sendGetSchemaErrorResponse(requestId, ServerError.IncompatibleSchema,
+                        "Empty schema version");
                 return;
             }
             schemaVersion = schemaService.versionFromBytes(commandGetSchema.getSchemaVersion());

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
@@ -2027,6 +2027,10 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
         long requestId = commandGetSchema.getRequestId();
         SchemaVersion schemaVersion = SchemaVersion.Latest;
         if (commandGetSchema.hasSchemaVersion()) {
+            if (commandGetSchema.getSchemaVersion().length == 0) {
+                commandSender.sendGetSchemaErrorResponse(requestId, ServerError.IncompatibleSchema, "Empty schema version");
+                return;
+            }
             schemaVersion = schemaService.versionFromBytes(commandGetSchema.getSchemaVersion());
         }
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/schema/SchemaTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/schema/SchemaTest.java
@@ -1116,6 +1116,9 @@ public class SchemaTest extends MockedPulsarServiceBaseTest {
 
     @Test
     public void testAvroSchemaWithHttpLookup() throws Exception {
+        stopBroker();
+        isTcpLookup = false;
+        setup();
         final String namespace = "test-namespace-" + randomName(16);
         String ns = PUBLIC_TENANT + "/" + namespace;
         admin.namespaces().createNamespace(ns, Sets.newHashSet(CLUSTER_NAME));

--- a/pulsar-broker/src/test/java/org/apache/pulsar/schema/SchemaTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/schema/SchemaTest.java
@@ -1119,44 +1119,7 @@ public class SchemaTest extends MockedPulsarServiceBaseTest {
         stopBroker();
         isTcpLookup = false;
         setup();
-        final String namespace = "test-namespace-" + randomName(16);
-        String ns = PUBLIC_TENANT + "/" + namespace;
-        admin.namespaces().createNamespace(ns, Sets.newHashSet(CLUSTER_NAME));
-        final String autoProducerTopic = getTopicName(ns, "testAvroSchemaWithHttpLookup");
-
-        @Cleanup
-        Consumer<User> consumer = pulsarClient
-                .newConsumer(Schema.AVRO(User.class))
-                .topic(autoProducerTopic)
-                .subscriptionType(SubscriptionType.Shared)
-                .subscriptionName("sub-1")
-                .subscribe();
-
-        @Cleanup
-        Producer<User> userProducer = pulsarClient
-                .newProducer(Schema.AVRO(User.class))
-                .topic(autoProducerTopic)
-                .enableBatching(false)
-                .create();
-
-        @Cleanup
-        Producer<byte[]> producer = pulsarClient
-                .newProducer()
-                .topic(autoProducerTopic)
-                .enableBatching(false)
-                .create();
-        User test = new User("test");
-        userProducer.send(test);
-        producer.send("test".getBytes(StandardCharsets.UTF_8));
-        Message<User> message1 = consumer.receive();
-        Assert.assertEquals(test, message1.getValue());
-        try {
-            Message<User> message2 = consumer.receive();
-            message2.getValue();
-        } catch (Throwable ex) {
-            Assert.assertTrue(Throwables.getRootCause(ex) instanceof SchemaSerializationException);
-            Assert.assertEquals(Throwables.getRootCause(ex).getMessage(),"Empty schema version");
-        }
+        testEmptySchema();
     }
 
     @Test
@@ -1164,11 +1127,15 @@ public class SchemaTest extends MockedPulsarServiceBaseTest {
         stopBroker();
         isTcpLookup = true;
         setup();
+        testEmptySchema();
+    }
+
+    private void testEmptySchema() throws Exception {
         final String namespace = "test-namespace-" + randomName(16);
         String ns = PUBLIC_TENANT + "/" + namespace;
         admin.namespaces().createNamespace(ns, Sets.newHashSet(CLUSTER_NAME));
 
-        final String autoProducerTopic = getTopicName(ns, "testAvroSchemaWithTcpLookup");
+        final String autoProducerTopic = getTopicName(ns, "testEmptySchema");
 
         @Cleanup
         Consumer<User> consumer = pulsarClient

--- a/pulsar-broker/src/test/java/org/apache/pulsar/schema/SchemaTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/schema/SchemaTest.java
@@ -29,12 +29,13 @@ import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 import static org.testng.internal.junit.ArrayAsserts.assertArrayEquals;
 
+import com.google.common.base.Throwables;
+import lombok.EqualsAndHashCode;
 import org.apache.avro.Schema.Parser;
-
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.collect.Sets;
-
 import java.io.ByteArrayInputStream;
+import java.io.Serializable;
 import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.HashMap;
@@ -44,7 +45,6 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
-
 import lombok.Cleanup;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.bookkeeper.client.BKException;
@@ -59,7 +59,9 @@ import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.Producer;
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.api.Schema;
+import org.apache.pulsar.client.api.SchemaSerializationException;
 import org.apache.pulsar.client.api.SubscriptionInitialPosition;
+import org.apache.pulsar.client.api.SubscriptionType;
 import org.apache.pulsar.client.api.TypedMessageBuilder;
 import org.apache.pulsar.client.api.schema.GenericRecord;
 import org.apache.pulsar.client.api.schema.SchemaDefinition;
@@ -1109,6 +1111,104 @@ public class SchemaTest extends MockedPulsarServiceBaseTest {
                 break;
             default:
                 // nothing to do
+        }
+    }
+
+    @Test
+    public void testAvroSchemaWithHttpLookup() throws Exception {
+        final String namespace = "test-namespace-" + randomName(16);
+        String ns = PUBLIC_TENANT + "/" + namespace;
+        admin.namespaces().createNamespace(ns, Sets.newHashSet(CLUSTER_NAME));
+        final String autoProducerTopic = getTopicName(ns, "testAvroSchemaWithHttpLookup");
+
+        @Cleanup
+        Consumer<User> consumer = pulsarClient
+                .newConsumer(Schema.AVRO(User.class))
+                .topic(autoProducerTopic)
+                .subscriptionType(SubscriptionType.Shared)
+                .subscriptionName("sub-1")
+                .subscribe();
+
+        @Cleanup
+        Producer<User> userProducer = pulsarClient
+                .newProducer(Schema.AVRO(User.class))
+                .topic(autoProducerTopic)
+                .enableBatching(false)
+                .create();
+
+        @Cleanup
+        Producer<byte[]> producer = pulsarClient
+                .newProducer()
+                .topic(autoProducerTopic)
+                .enableBatching(false)
+                .create();
+        User test = new User("test");
+        userProducer.send(test);
+        producer.send("test".getBytes(StandardCharsets.UTF_8));
+        Message<User> message1 = consumer.receive();
+        Assert.assertEquals(test, message1.getValue());
+        try {
+            Message<User> message2 = consumer.receive();
+            message2.getValue();
+        } catch (Throwable ex) {
+            Assert.assertTrue(Throwables.getRootCause(ex) instanceof SchemaSerializationException);
+            Assert.assertEquals(Throwables.getRootCause(ex).getMessage(),"Empty schema version");
+        }
+    }
+
+    @Test
+    public void testAvroSchemaWithTcpLookup() throws Exception {
+        stopBroker();
+        isTcpLookup = true;
+        setup();
+        final String namespace = "test-namespace-" + randomName(16);
+        String ns = PUBLIC_TENANT + "/" + namespace;
+        admin.namespaces().createNamespace(ns, Sets.newHashSet(CLUSTER_NAME));
+
+        final String autoProducerTopic = getTopicName(ns, "testAvroSchemaWithTcpLookup");
+
+        @Cleanup
+        Consumer<User> consumer = pulsarClient
+                .newConsumer(Schema.AVRO(User.class))
+                .topic(autoProducerTopic)
+                .subscriptionType(SubscriptionType.Shared)
+                .subscriptionName("sub-1")
+                .subscribe();
+
+        @Cleanup
+        Producer<User> userProducer = pulsarClient
+                .newProducer(Schema.AVRO(User.class))
+                .topic(autoProducerTopic)
+                .enableBatching(false)
+                .create();
+
+        @Cleanup
+        Producer<byte[]> producer = pulsarClient
+                .newProducer()
+                .topic(autoProducerTopic)
+                .enableBatching(false)
+                .create();
+
+        User test = new User("test");
+        userProducer.send(test);
+        producer.send("test".getBytes(StandardCharsets.UTF_8));
+        Message<User> message1 = consumer.receive();
+        Assert.assertEquals(test, message1.getValue());
+        try {
+            Message<User> message2 = consumer.receive();
+            message2.getValue();
+        } catch (Throwable ex) {
+            Assert.assertTrue(Throwables.getRootCause(ex) instanceof SchemaSerializationException);
+            Assert.assertEquals(Throwables.getRootCause(ex).getMessage(),"Empty schema version");
+        }
+    }
+
+    @EqualsAndHashCode
+    static class User implements Serializable {
+        private String name;
+        public User() {}
+        public User(String name) {
+            this.name = name;
         }
     }
 

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/BinaryProtoLookupService.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/BinaryProtoLookupService.java
@@ -32,6 +32,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.pulsar.client.api.PulsarClientException;
+import org.apache.pulsar.client.api.SchemaSerializationException;
 import org.apache.pulsar.common.api.proto.CommandGetTopicsOfNamespace.Mode;
 import org.apache.pulsar.common.api.proto.CommandLookupTopicResponse;
 import org.apache.pulsar.common.api.proto.CommandLookupTopicResponse.LookupType;
@@ -222,9 +223,12 @@ public class BinaryProtoLookupService implements LookupService {
 
     @Override
     public CompletableFuture<Optional<SchemaInfo>> getSchema(TopicName topicName, byte[] version) {
-        InetSocketAddress socketAddress = serviceNameResolver.resolveHost();
         CompletableFuture<Optional<SchemaInfo>> schemaFuture = new CompletableFuture<>();
-
+        if (version != null && version.length == 0) {
+            schemaFuture.completeExceptionally(new SchemaSerializationException("Empty schema version"));
+            return schemaFuture;
+        }
+        InetSocketAddress socketAddress = serviceNameResolver.resolveHost();
         client.getCnxPool().getConnection(socketAddress).thenAccept(clientCnx -> {
             long requestId = client.newRequestId();
             ByteBuf request = Commands.newGetSchema(requestId, topicName.toString(),

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/HttpLookupService.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/HttpLookupService.java
@@ -34,6 +34,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.api.PulsarClientException.NotFoundException;
+import org.apache.pulsar.client.api.SchemaSerializationException;
 import org.apache.pulsar.client.impl.conf.ClientConfigurationData;
 import org.apache.pulsar.client.impl.schema.SchemaInfoUtil;
 import org.apache.pulsar.client.impl.schema.SchemaUtils;
@@ -159,6 +160,10 @@ public class HttpLookupService implements LookupService {
         String schemaName = topicName.getSchemaName();
         String path = String.format("admin/v2/schemas/%s/schema", schemaName);
         if (version != null) {
+            if (version.length == 0) {
+                future.completeExceptionally(new SchemaSerializationException("Empty schema version"));
+                return future;
+            }
             path = String.format("admin/v2/schemas/%s/schema/%s",
                     schemaName,
                     ByteBuffer.wrap(version).getLong());

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
@@ -1562,7 +1562,7 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
                         schemaInfo = schema.getSchemaInfo();
                     }
                 } else if (schema.getSchemaInfo().getType() == SchemaType.BYTES
-                    || schema.getSchemaInfo().getType() == SchemaType.NONE) {
+                        || schema.getSchemaInfo().getType() == SchemaType.NONE) {
                     // don't set schema info for Schema.BYTES
                     schemaInfo = null;
                 } else {

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
@@ -1562,7 +1562,7 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
                         schemaInfo = schema.getSchemaInfo();
                     }
                 } else if (schema.getSchemaInfo().getType() == SchemaType.BYTES
-                        || schema.getSchemaInfo().getType() == SchemaType.NONE) {
+                    || schema.getSchemaInfo().getType() == SchemaType.NONE) {
                     // don't set schema info for Schema.BYTES
                     schemaInfo = null;
                 } else {


### PR DESCRIPTION
### Motivation
 
When create a topic with schema - AVRO,  if a producer sends bytes data directly to the topic, a consumer with HTTP and TCP lookup has different prompt message. See below test:

```
# Consume
Consumer<User> consumer = pulsarClient
                .newConsumer(Schema.AVRO(User.class))
                .topic("persistent://public/default/test")
                .subscriptionName("sub-2")
                .subscriptionType(SubscriptionType.Shared)
                .subscribe();
while(true){
     Message<User> message = consumer.receive();
     System.out.println("received msg : " + message.getValue());
}

# Produce
bin/pulsar-client produce -n 5 -m "hello" test
```
If the consumer is using TCP lookup, it will get the below message :
```
Exception in thread "main" com.google.common.util.concurrent.UncheckedExecutionException: org.apache.commons.lang3.SerializationException: Failed at fetching schema info for EMPTY
	at com.google.common.cache.LocalCache$Segment.get(LocalCache.java:2051)
	at com.google.common.cache.LocalCache.get(LocalCache.java:3951)
	at com.google.common.cache.LocalCache.getOrLoad(LocalCache.java:3974)
	at com.google.common.cache.LocalCache$LocalLoadingCache.get(LocalCache.java:4935)
	at org.apache.pulsar.client.impl.schema.reader.AbstractMultiVersionReader.getSchemaReader(AbstractMultiVersionReader.java:83)
```
But with HTTP lookup, the error message change to ：
```
com.google.common.util.concurrent.UncheckedExecutionException: com.google.common.util.concurrent.UncheckedExecutionException: java.nio.BufferUnderflowException
	at com.google.common.cache.LocalCache$Segment.get(LocalCache.java:2055)
	at com.google.common.cache.LocalCache.get(LocalCache.java:3966)
	at com.google.common.cache.LocalCache.getOrLoad(LocalCache.java:3989)
	at com.google.common.cache.LocalCache$LocalLoadingCache.get(LocalCache.java:4950)
	at org.apache.pulsar.client.impl.schema.reader.AbstractMultiVersionReader.getSchemaReader(AbstractMultiVersionReader.java:82)
```
The root cause is that : if producer produce with bytes data, the schema version is empty. When in TCP lookup, the server will throw unchecked exception here(line-244) :
https://github.com/apache/pulsar/blob/7c1f17a6f0e2f1a5775277d61f51ac31636f39b4/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/BookkeeperSchemaStorage.java#L236-L245

When in HTTP lookup, the error will throw by the client here(line-164):
https://github.com/apache/pulsar/blob/7c1f17a6f0e2f1a5775277d61f51ac31636f39b4/pulsar-client/src/main/java/org/apache/pulsar/client/impl/HttpLookupService.java#L161-L165

So in order to keep the consistent prompt message, we will check the empty schema at the client-side and throw the same exception.

### Modifications
- Keep checking the empty version at the client-side.
- Using the same exception.
- Add server-side check at ServerCnx#handleGetSchema to help non-java client to print the same error.

### Documentation
  
- [x] `no-need-doc` 
  


