### PR TITLE
[owasp] Suppress ZooKeeper 3.8.0 vulnerabilities

### DIFF
--- a/src/owasp-dependency-check-false-positives.xml
+++ b/src/owasp-dependency-check-false-positives.xml
@@ -60,6 +60,8 @@
     <cpe>cpe:/a:netty:netty</cpe>
   </suppress>
   <suppress>
+<!--    Zookkeeper false positive about Jetty and commons-io-->
+<!--    https://github.com/apache/zookeeper/pull/1824-->
     <notes><![CDATA[
    file name: zookeeper-3.8.0.jar
    ]]></notes>

--- a/src/owasp-dependency-check-false-positives.xml
+++ b/src/owasp-dependency-check-false-positives.xml
@@ -59,4 +59,68 @@
     <packageUrl regex="true">^pkg:maven/io\.netty/netty\-tcnative\-classes@.*$</packageUrl>
     <cpe>cpe:/a:netty:netty</cpe>
   </suppress>
+  <suppress>
+    <notes><![CDATA[
+   file name: zookeeper-3.8.0.jar
+   ]]></notes>
+    <sha1>e395c1d8a71557b7569cc6a83487b2e30e2e58fe</sha1>
+    <cve>CVE-2021-28164</cve>
+  </suppress>
+  <suppress>
+    <notes><![CDATA[
+   file name: zookeeper-3.8.0.jar
+   ]]></notes>
+    <sha1>e395c1d8a71557b7569cc6a83487b2e30e2e58fe</sha1>
+    <cve>CVE-2021-29425</cve>
+  </suppress>
+  <suppress>
+    <notes><![CDATA[
+   file name: zookeeper-3.8.0.jar
+   ]]></notes>
+    <sha1>e395c1d8a71557b7569cc6a83487b2e30e2e58fe</sha1>
+    <cve>CVE-2021-34429</cve>
+  </suppress>
+  <suppress>
+    <notes><![CDATA[
+   file name: zookeeper-prometheus-metrics-3.8.0.jar
+   ]]></notes>
+    <sha1>849e8ece2845cb0185d721233906d487a7f1e4cf</sha1>
+    <cve>CVE-2021-28164</cve>
+  </suppress>
+  <suppress>
+    <notes><![CDATA[
+   file name: zookeeper-prometheus-metrics-3.8.0.jar
+   ]]></notes>
+    <sha1>849e8ece2845cb0185d721233906d487a7f1e4cf</sha1>
+    <cve>CVE-2021-29425</cve>
+  </suppress>
+  <suppress>
+    <notes><![CDATA[
+   file name: zookeeper-prometheus-metrics-3.8.0.jar
+   ]]></notes>
+    <sha1>849e8ece2845cb0185d721233906d487a7f1e4cf</sha1>
+    <cve>CVE-2021-34429</cve>
+  </suppress>
+  <suppress>
+    <notes><![CDATA[
+   file name: zookeeper-jute-3.8.0.jar
+   ]]></notes>
+    <sha1>6560f966bcf1aa78d27bcfa75fb6c4463a72c6c5</sha1>
+    <cve>CVE-2021-28164</cve>
+  </suppress>
+  <suppress>
+    <notes><![CDATA[
+   file name: zookeeper-jute-3.8.0.jar
+   ]]></notes>
+    <sha1>6560f966bcf1aa78d27bcfa75fb6c4463a72c6c5</sha1>
+    <cve>CVE-2021-29425</cve>
+  </suppress>
+  <suppress>
+    <notes><![CDATA[
+   file name: zookeeper-jute-3.8.0.jar
+   ]]></notes>
+    <sha1>6560f966bcf1aa78d27bcfa75fb6c4463a72c6c5</sha1>
+    <cve>CVE-2021-34429</cve>
+  </suppress>
+
 </suppressions>

--- a/src/owasp-dependency-check-suppressions.xml
+++ b/src/owasp-dependency-check-suppressions.xml
@@ -36,11 +36,6 @@
         <gav>org.apache.thrift:libthrift:0.12.0</gav>
         <vulnerabilityName regex="true">.*</vulnerabilityName>
     </suppress>
-    <suppress>
-        <notes>Suppress Zookeeper 3.8.0 vulnerabilities</notes>
-        <gav regex="true">org\.apache\.zookeeper:.*:3\.8\.0</gav>
-        <vulnerabilityName regex="true">.*</vulnerabilityName>
-    </suppress>
 
     <!-- see https://github.com/alibaba/canal/issues/4010 -->
     <suppress>

--- a/src/owasp-dependency-check-suppressions.xml
+++ b/src/owasp-dependency-check-suppressions.xml
@@ -37,8 +37,8 @@
         <vulnerabilityName regex="true">.*</vulnerabilityName>
     </suppress>
     <suppress>
-        <notes>Suppress Zookeeper 3.6.2 vulnerabilities</notes>
-        <gav regex="true">org\.apache\.zookeeper:.*:3\.6\.2</gav>
+        <notes>Suppress Zookeeper 3.8.0 vulnerabilities</notes>
+        <gav regex="true">org\.apache\.zookeeper:.*:3\.8\.0</gav>
         <vulnerabilityName regex="true">.*</vulnerabilityName>
     </suppress>
 


### PR DESCRIPTION
### Motivation

After the ZK upgrade the OWASP check fails because ZK has known vulnerability. The owasp suppression aims ZK 3.6.2.

### Modifications

* Edited the ZK suppression to 3.8.0

- [x] `no-need-doc` 
