### PR TITLE
Change "Could not split namespace bundle" logging level to info

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/BundleSplitterTask.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/BundleSplitterTask.java
@@ -94,7 +94,7 @@ public class BundleSplitterTask implements BundleSplitStrategy {
                         if (bundleCount < maxBundleCount) {
                             bundleCache.add(bundle);
                         } else {
-                            log.warn(
+                            log.info(
                                     "Could not split namespace bundle {} because namespace {} has too many bundles: {}",
                                     bundle, namespace, bundleCount);
                         }


### PR DESCRIPTION
### Motivation

There are so many WARN log about `Could not split namespace bundle {} because namespace {} has too many bundles: {}`, it may disturb WARN log alarm.

### Modifications

Change to `INFO` level.

### Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

Check the box below or label this PR directly (if you have committer privilege).

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
- [ ] `doc` 
  
  (If this PR contains doc changes)


