### PR TITLE
[Branch-2.7] Fixed wrong behaviour caused by not cleaning up topic policy service state

### DIFF
--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/compaction/TestCompaction.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/compaction/TestCompaction.java
@@ -85,7 +85,7 @@ public class TestCompaction extends PulsarTestSuite {
                 assertEquals(m.getValue(), "content1");
             }
 
-            pulsarCluster.runPulsarBaseCommandOnAnyBroker("compact-topic", "-t", topic);
+            pulsarCluster.runAdminCommandOnAnyBroker("topics", "compact", topic);
 
             try (Consumer<String> consumer = client.newConsumer(Schema.STRING)
                 .topic(topic)


### PR DESCRIPTION
Cherry-pick https://github.com/apache/pulsar/pull/14503

### Motivation

The current exception handler does not clean all states, which will cause some wrong behaviour. 

**E.g:**

#### case 1:

https://github.com/apache/pulsar/blob/e20f34bd2a6b4bd7ce72390a593931a855f8e250/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/SystemTopicBasedTopicPoliciesService.java#L249-L264

When line 259 closes the reader with an exception, it doesn't remove namespace from ``policyCacheInitMap``, so next time this method is called, they will do nothing because ``policyCacheInitMap.putIfAbsent(namespace, false)`` is not empty.
This will cause `getTopicPolicies` throw TopicPoliciesCacheNotInitException.

https://github.com/apache/pulsar/blob/e20f34bd2a6b4bd7ce72390a593931a855f8e250/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/SystemTopicBasedTopicPoliciesService.java#L193-L205

#### case 2:

When line 384 gets ``AlreadyClosedException``, it doesn't remove namespace from ``policyCacheInitMap``, but the current namespace value in ``policyCacheInitMap`` is true. Therefore, the next time ``prepareInitPoliciesCache `` is called, a new reader is never created. This will cause `getTopicPolicies` get NULL value.

https://github.com/apache/pulsar/blob/e20f34bd2a6b4bd7ce72390a593931a855f8e250/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/SystemTopicBasedTopicPoliciesService.java#L376-L393

### Modifications

- Clean state when the reader gets an error.
- Don't clean ``ownedBundlesCountPerNamespace`` when reader get ``AlreadyClosedException``.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Documentation

- [x] `no-need-doc` 

