### PR TITLE
Fix bug: markdelete position not moving forward when skipping lost entries

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedCursor.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedCursor.java
@@ -54,6 +54,9 @@ public interface ManagedCursor {
         Include, Exclude
     }
 
+    default <T> void registerAutoSkipNonRecoverableDataListener(java.util.function.Consumer<T> listener) {
+        // do nothing
+    }
     /**
      * Get the unique cursor name.
      *
@@ -74,6 +77,17 @@ public interface ManagedCursor {
      */
     void updateLastActive();
 
+    default void addSkipPosition(Position skipPosition) {
+        // do nothing
+    }
+
+    default List<Position> getSkipPositions() {
+        return null;
+    }
+
+    default void clearSkipPositions(){
+        // do nothing
+    }
     /**
      * Return any properties that were associated with the last stored position.
      */

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
@@ -193,6 +193,8 @@ public class ManagedCursorImpl implements ManagedCursor {
     private int individualDeletedMessagesSerializedSize;
     private static final String COMPACTION_CURSOR_NAME = "__compaction";
 
+    private final List<Position> autoSkipEntryPosition;
+
     class MarkDeleteEntry {
         final PositionImpl newPosition;
         final MarkDeleteCallback callback;
@@ -247,6 +249,7 @@ public class ManagedCursorImpl implements ManagedCursor {
     }
 
     ManagedCursorImpl(BookKeeper bookkeeper, ManagedLedgerConfig config, ManagedLedgerImpl ledger, String cursorName) {
+        this.autoSkipEntryPosition = new ArrayList<>();
         this.bookkeeper = bookkeeper;
         this.config = config;
         this.ledger = ledger;
@@ -276,6 +279,21 @@ public class ManagedCursorImpl implements ManagedCursor {
             markDeleteLimiter = null;
         }
         this.mbean = new ManagedCursorMXBeanImpl(this);
+    }
+
+    @Override
+    public void addSkipPosition(Position skipPosition) {
+        autoSkipEntryPosition.add(skipPosition);
+    }
+
+    @Override
+    public List<Position> getSkipPositions() {
+        return autoSkipEntryPosition;
+    }
+
+    @Override
+    public void clearSkipPositions() {
+        autoSkipEntryPosition.clear();
     }
 
     @Override

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/OpReadEntry.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/OpReadEntry.java
@@ -100,8 +100,8 @@ class OpReadEntry implements ReadEntriesCallback {
         } else if (cursor.config.isAutoSkipNonRecoverableData() && exception instanceof NonRecoverableLedgerException) {
             log.warn("[{}][{}] read failed from ledger at position:{} : {}", cursor.ledger.getName(), cursor.getName(),
                     readPosition, exception.getMessage());
-            // try to find and move to next valid ledger
-            final Position nexReadPosition = cursor.getNextLedgerPosition(readPosition.getLedgerId());
+            // try to find and move to next valid entry position
+            PositionImpl nexReadPosition = cursor.getNextAvailablePosition(readPosition);
             // fail callback if it couldn't find next valid ledger
             if (nexReadPosition == null) {
                 callback.readEntriesFailed(exception, ctx);
@@ -109,6 +109,7 @@ class OpReadEntry implements ReadEntriesCallback {
                 recycle();
                 return;
             }
+            cursor.addSkipPosition(nexReadPosition);
             updateReadPosition(nexReadPosition);
             checkReadCompletion();
         } else {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Dispatcher.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Dispatcher.java
@@ -21,6 +21,7 @@ package org.apache.pulsar.broker.service;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
+import org.apache.bookkeeper.mledger.Position;
 import org.apache.bookkeeper.mledger.impl.PositionImpl;
 import org.apache.pulsar.broker.service.persistent.DispatchRateLimiter;
 import org.apache.pulsar.common.api.proto.CommandSubscribe.SubType;
@@ -44,6 +45,9 @@ public interface Dispatcher {
 
     boolean canUnsubscribe(Consumer consumer);
 
+    default void registerAutoSkipNonRecoverableDataListener(java.util.function.Consumer<List<Position>> listener) {
+        // do nothing
+    }
     /**
      * mark dispatcher closed to stop new incoming requests and disconnect all consumers.
      *

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentSubscription.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentSubscription.java
@@ -234,8 +234,9 @@ public class PersistentSubscription implements Subscription {
                                         ? new PersistentStreamingDispatcherMultipleConsumers(
                                                 topic, cursor, this)
                                         : new PersistentDispatcherMultipleConsumers(topic, cursor, this);
-                                dispatcher.registerAutoSkipNonRecoverableDataListener((List<Position> skipPositions) -> {
-                                    acknowledgeMessage(skipPositions, AckType.Individual, Collections.emptyMap());
+                                dispatcher.registerAutoSkipNonRecoverableDataListener((skipPositions) -> {
+                                    acknowledgeMessage((List<Position>) skipPositions, AckType.Individual,
+                                            Collections.emptyMap());
                                 });
                             }
                             break;
@@ -265,8 +266,9 @@ public class PersistentSubscription implements Subscription {
                                 previousDispatcher = dispatcher;
                                 dispatcher = new PersistentStickyKeyDispatcherMultipleConsumers(topic, cursor, this,
                                         topic.getBrokerService().getPulsar().getConfiguration(), ksm);
-                                dispatcher.registerAutoSkipNonRecoverableDataListener((List<Position> skipPositions) -> {
-                                    acknowledgeMessage(skipPositions, AckType.Individual, Collections.emptyMap());
+                                dispatcher.registerAutoSkipNonRecoverableDataListener((skipPositions) -> {
+                                    acknowledgeMessage((List<Position>) skipPositions, AckType.Individual,
+                                            Collections.emptyMap());
                                 });
                             }
                             break;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentSubscription.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentSubscription.java
@@ -234,6 +234,9 @@ public class PersistentSubscription implements Subscription {
                                         ? new PersistentStreamingDispatcherMultipleConsumers(
                                                 topic, cursor, this)
                                         : new PersistentDispatcherMultipleConsumers(topic, cursor, this);
+                                dispatcher.registerAutoSkipNonRecoverableDataListener((List<Position> skipPositions) -> {
+                                    acknowledgeMessage(skipPositions, AckType.Individual, Collections.emptyMap());
+                                });
                             }
                             break;
                         case Failover:
@@ -262,6 +265,9 @@ public class PersistentSubscription implements Subscription {
                                 previousDispatcher = dispatcher;
                                 dispatcher = new PersistentStickyKeyDispatcherMultipleConsumers(topic, cursor, this,
                                         topic.getBrokerService().getPulsar().getConfiguration(), ksm);
+                                dispatcher.registerAutoSkipNonRecoverableDataListener((List<Position> skipPositions) -> {
+                                    acknowledgeMessage(skipPositions, AckType.Individual, Collections.emptyMap());
+                                });
                             }
                             break;
                         default:

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentSubscription.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentSubscription.java
@@ -235,8 +235,7 @@ public class PersistentSubscription implements Subscription {
                                                 topic, cursor, this)
                                         : new PersistentDispatcherMultipleConsumers(topic, cursor, this);
                                 dispatcher.registerAutoSkipNonRecoverableDataListener((skipPositions) -> {
-                                    acknowledgeMessage((List<Position>) skipPositions, AckType.Individual,
-                                            Collections.emptyMap());
+                                    acknowledgeMessage(skipPositions, AckType.Individual, Collections.emptyMap());
                                 });
                             }
                             break;
@@ -267,8 +266,7 @@ public class PersistentSubscription implements Subscription {
                                 dispatcher = new PersistentStickyKeyDispatcherMultipleConsumers(topic, cursor, this,
                                         topic.getBrokerService().getPulsar().getConfiguration(), ksm);
                                 dispatcher.registerAutoSkipNonRecoverableDataListener((skipPositions) -> {
-                                    acknowledgeMessage((List<Position>) skipPositions, AckType.Individual,
-                                            Collections.emptyMap());
+                                    acknowledgeMessage(skipPositions, AckType.Individual, Collections.emptyMap());
                                 });
                             }
                             break;


### PR DESCRIPTION
### Motivation
discuss thread：https://lists.apache.org/thread/d3f8domf5dnj0h3ktc6sz3kr5tooy4cj

fix not ack for the skiped entry when autoSkipNonRecoverableData=true.

When it was found online that the broker no longer pushed data to the consumer due to loss entry, we tried to turn on the configuration autoSkipNonRecoverableData=true, but found that the message still would not be pushed.
The subscription type here is key share. After adding the log to confirm, it is found that the skipped entry has not been acked, so the mark delete position cannot be moved forward.

**error log:**

00:01:22.623 [BookKeeperClientWorker-OrderedExecutor-33-0] ERROR org.apache.pulsar.broker.service.persistent.PersistentDispatcherMultipleConsumers - [persistent://teg_onion_onion_common_data_gz/teg_onion_onion_common_data_gz/teg_onion_onion_common_data_gz-partition-275 / t_teg_onion_b_teg_onion_onion_common_data_gz_cg_onion_common_data_cos_svr_gz_001] Error reading entries at 15759573:15389 : No such entry, Read Type Normal - Retrying to read in 58.132 seconds

00:01:22.623 [BookKeeperClientWorker-OrderedExecutor-21-0] ERROR org.apache.bookkeeper.client.PendingReadOp - Read of ledger entry failed: L15759573 E15389-E15389, Sent to [****:3181, ***:3181], Heard from [] : bitset = {}, Error = 'No such entry'. First unread entry is (-1, rc = null)

**Through the bookkeeper command, I listed the corresponding entries in the ledger, I found that the smallest entryId is 20153, but the entryId that failed to read is 15389:**
![image](https://user-images.githubusercontent.com/19296967/158515930-03be36c5-4abd-47fc-b6ff-7a3ca1805104.png)



### Documentation

Check the box below or label this PR directly (if you have committer privilege).

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)


