### PR TITLE
[tests] reduce ManagedLedgerFactoryShutdownTest flakyness

### DIFF
--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerFactoryShutdownTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerFactoryShutdownTest.java
@@ -33,6 +33,8 @@ import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+
+import lombok.extern.slf4j.Slf4j;
 import org.apache.bookkeeper.client.AsyncCallback;
 import org.apache.bookkeeper.client.BookKeeper;
 import org.apache.bookkeeper.client.LedgerHandle;
@@ -46,22 +48,29 @@ import org.apache.bookkeeper.mledger.proto.MLDataFormats;
 import org.apache.pulsar.metadata.api.GetResult;
 import org.apache.pulsar.metadata.api.Stat;
 import org.apache.pulsar.metadata.api.extended.MetadataStoreExtended;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.testng.Assert;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
+@Slf4j
 public class ManagedLedgerFactoryShutdownTest {
-    private static final Logger log = LoggerFactory.getLogger(ManagedLedgerFactoryShutdownTest.class);
 
-    @Test(timeOut = 5000)
-    public void openEncounteredShutdown() throws Exception {
-        final String ledgerName = UUID.randomUUID().toString();
+    private final String ledgerName = UUID.randomUUID().toString();
+    private final CountDownLatch slowZk = new CountDownLatch(1);
+
+    private MetadataStoreExtended metadataStore;
+    private BookKeeper bookKeeper;
+
+    @BeforeMethod
+    private void setup() {
+
         final long version = 0;
         final long createTimeMillis = System.currentTimeMillis();
 
-        MetadataStoreExtended metadataStore = mock(MetadataStoreExtended.class);
-        CountDownLatch slowZk = new CountDownLatch(1);
+        metadataStore = mock(MetadataStoreExtended.class);
+        bookKeeper = mock(BookKeeper.class);
+
+
         given(metadataStore.get(any())).willAnswer(inv -> {
             String path = inv.getArgument(0, String.class);
             if (path == null) {
@@ -109,6 +118,7 @@ public class ManagedLedgerFactoryShutdownTest {
             }
         });
         given(metadataStore.put(anyString(), any(), any())).willAnswer(inv -> {
+            @SuppressWarnings("unchecked cast")
             Optional<Long> expectedVersion = inv.getArgument(2, Optional.class);
             return CompletableFuture.supplyAsync(() -> new Stat(inv.getArgument(0, String.class),
                     expectedVersion.orElse(0L) + 1, createTimeMillis,
@@ -117,7 +127,7 @@ public class ManagedLedgerFactoryShutdownTest {
         given(metadataStore.getChildren(anyString()))
                 .willAnswer(inv -> CompletableFuture.supplyAsync(() -> Collections.singletonList("cursor")));
 
-        BookKeeper bookKeeper = mock(BookKeeper.class);
+
         LedgerHandle ledgerHandle = mock(LedgerHandle.class);
         LedgerHandle newLedgerHandle = mock(LedgerHandle.class);
         OrderedExecutor executor = OrderedExecutor.newBuilder().name("Test").build();
@@ -133,6 +143,13 @@ public class ManagedLedgerFactoryShutdownTest {
             return null;
         }).when(bookKeeper)
                 .asyncCreateLedger(anyInt(), anyInt(), anyInt(), any(), any(), any()/*callback*/, any(), any());
+
+
+
+    }
+
+    @Test(timeOut = 5000)
+    public void openEncounteredShutdown() throws Exception {
 
         ManagedLedgerFactoryImpl factory = new ManagedLedgerFactoryImpl(metadataStore, bookKeeper);
         CountDownLatch callbackInvoked = new CountDownLatch(2);


### PR DESCRIPTION
### Motivation
ManagedLedgerFactoryShutdownTest#openEncounteredShutdown is flaky. I've seen failing that due to timeout.

```
[ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 8.941 s <<< FAILURE! - in org.apache.bookkeeper.mledger.impl.ManagedLedgerFactoryShutdownTest
[ERROR] openEncounteredShutdown(org.apache.bookkeeper.mledger.impl.ManagedLedgerFactoryShutdownTest)  Time elapsed: 5.033 s  <<< FAILURE!
org.testng.internal.thread.ThreadTimeoutException: Method org.apache.bookkeeper.mledger.impl.ManagedLedgerFactoryShutdownTest.openEncounteredShutdown() didn't finish within the time-out 5000
```
After investigating I found out that the first Mockito `mock` call takes more than 2-3 seconds.

Mockito setup should be done in the @BeforeMethod and leave the timeout to the managed ledger logic. 

### Modifications
* Moved the the mockito setup to the @BeforeMethod method

- [x] `no-need-doc` 