### PR TITLE
[improve][broker] Failed to start broker when Linux load balancer can't get NIC speed

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
@@ -647,8 +647,8 @@ public class PulsarService implements AutoCloseable, ShutdownService {
 
             if (config.isLoadBalancerEnabled() && LinuxInfoUtils.isLinux()) {
                 if (!LinuxInfoUtils.checkHasNicSpeeds()) {
-                    throw new IllegalStateException("Unable to read VM NIC speed. You must set " +
-                            "[loadBalancerOverrideBrokerNicSpeedGbps] to override it when load balancer is enabled.");
+                    throw new IllegalStateException("Unable to read VM NIC speed. You must set "
+                            + "[loadBalancerOverrideBrokerNicSpeedGbps] to override it when load balancer is enabled.");
                 }
             }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
@@ -84,6 +84,7 @@ import org.apache.pulsar.broker.authorization.AuthorizationService;
 import org.apache.pulsar.broker.intercept.BrokerInterceptor;
 import org.apache.pulsar.broker.intercept.BrokerInterceptors;
 import org.apache.pulsar.broker.loadbalance.LeaderElectionService;
+import org.apache.pulsar.broker.loadbalance.LinuxInfoUtils;
 import org.apache.pulsar.broker.loadbalance.LoadManager;
 import org.apache.pulsar.broker.loadbalance.LoadReportUpdaterTask;
 import org.apache.pulsar.broker.loadbalance.LoadResourceQuotaUpdaterTask;
@@ -642,6 +643,13 @@ public class PulsarService implements AutoCloseable, ShutdownService {
             if (config.isAuthorizationEnabled() && !config.isAuthenticationEnabled()) {
                 throw new IllegalStateException("Invalid broker configuration. Authentication must be enabled with "
                         + "authenticationEnabled=true when authorization is enabled with authorizationEnabled=true.");
+            }
+
+            if (config.isLoadBalancerEnabled() && LinuxInfoUtils.isLinux()) {
+                if (!LinuxInfoUtils.checkHasNicSpeeds()) {
+                    throw new IllegalStateException("Unable to read VM NIC speed. You must set " +
+                            "[loadBalancerOverrideBrokerNicSpeedGbps] to override it when load balancer is enabled.");
+                }
             }
 
             localMetadataStore = createLocalMetadataStore();

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
@@ -645,11 +645,12 @@ public class PulsarService implements AutoCloseable, ShutdownService {
                         + "authenticationEnabled=true when authorization is enabled with authorizationEnabled=true.");
             }
 
-            if (config.isLoadBalancerEnabled() && LinuxInfoUtils.isLinux()) {
-                if (!LinuxInfoUtils.checkHasNicSpeeds()) {
-                    throw new IllegalStateException("Unable to read VM NIC speed. You must set "
-                            + "[loadBalancerOverrideBrokerNicSpeedGbps] to override it when load balancer is enabled.");
-                }
+            if (!config.getLoadBalancerOverrideBrokerNicSpeedGbps().isPresent()
+                    && config.isLoadBalancerEnabled()
+                    && LinuxInfoUtils.isLinux()
+                    && !LinuxInfoUtils.checkHasNicSpeeds()) {
+                throw new IllegalStateException("Unable to read VM NIC speed. You must set "
+                        + "[loadBalancerOverrideBrokerNicSpeedGbps] to override it when load balancer is enabled.");
             }
 
             localMetadataStore = createLocalMetadataStore();

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/LinuxInfoUtils.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/LinuxInfoUtils.java
@@ -147,10 +147,10 @@ public class LinuxInfoUtils {
      * @return whether The VM has physical nic.
      */
     private static boolean isPhysicalNic(Path nicPath) {
-        if (nicPath.toString().contains("/virtual/")) {
-            return false;
-        }
         try {
+            if (nicPath.toRealPath().toString().contains("/virtual/")) {
+                return false;
+            }
             // Check the type to make sure it's ethernet (type "1")
             String type = readTrimStringFromFile(nicPath.resolve("type"));
             // wireless NICs don't report speed, ignore them.

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/LinuxInfoUtils.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/LinuxInfoUtils.java
@@ -1,22 +1,22 @@
 package org.apache.pulsar.broker.loadbalance;
 
 import com.google.common.base.Charsets;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.collections4.CollectionUtils;
-import org.apache.commons.lang3.SystemUtils;
+import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.lang3.SystemUtils;
 
 @Slf4j
 public class LinuxInfoUtils {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/LinuxInfoUtils.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/LinuxInfoUtils.java
@@ -161,23 +161,6 @@ public class LinuxInfoUtils {
     }
 
     /**
-     * Get all physical nic limit.
-     * @param nics All nic path
-     * @param nicUnit Nic speed unit
-     * @return Total nic limit
-     * @throws IOException Read file exception
-     */
-    public static double getUncheckedTotalNicLimit(List<String> nics, NICUnit nicUnit)
-            throws IOException {
-        double sum = 0.0;
-        for (String nicPath : nics) {
-            double v = readDoubleFromFile(getReplacedNICPath(NIC_SPEED_TEMPLATE, nicPath));
-            sum += v;
-        }
-        return nicUnit.convertBy(sum);
-    }
-
-    /**
      * Get all physical nic usage.
      * @param nics All nic path
      * @param type Nic's usage type:  transport, receive
@@ -219,13 +202,8 @@ public class LinuxInfoUtils {
         if (CollectionUtils.isEmpty(physicalNICs)) {
             return false;
         }
-        try {
-            double totalNicLimit = getUncheckedTotalNicLimit(physicalNICs, NICUnit.Kbps);
-            return totalNicLimit > 0;
-        } catch (IOException e) {
-            log.error("[LinuxInfo] Failed to get total nic limit.", e);
-            return false;
-        }
+        double totalNicLimit = getTotalNicLimit(physicalNICs, NICUnit.Kbps);
+        return totalNicLimit > 0;
     }
 
     private static Path getReplacedNICPath(String template, String nic) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/LinuxInfoUtils.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/LinuxInfoUtils.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.pulsar.broker.loadbalance;
 
 import com.google.common.base.Charsets;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/LinuxInfoUtils.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/LinuxInfoUtils.java
@@ -1,0 +1,296 @@
+package org.apache.pulsar.broker.loadbalance;
+
+import com.google.common.base.Charsets;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.lang3.SystemUtils;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+@Slf4j
+public class LinuxInfoUtils {
+
+    // CGROUP
+    private static final String CGROUPS_CPU_USAGE_PATH = "/sys/fs/cgroup/cpu/cpuacct.usage";
+    private static final String CGROUPS_CPU_LIMIT_QUOTA_PATH = "/sys/fs/cgroup/cpu/cpu.cfs_quota_us";
+    private static final String CGROUPS_CPU_LIMIT_PERIOD_PATH = "/sys/fs/cgroup/cpu/cpu.cfs_period_us";
+    // proc states
+    private static final String PROC_STAT_PATH = "/proc/stat";
+    private static final String NIC_PATH = "/sys/class/net/";
+    // NIC type
+    private static final int ARPHRD_ETHER = 1;
+    private static final String NIC_SPEED_TEMPLATE = "/sys/class/net/%s/speed";
+
+
+    /**
+     * Determine whether the OS is the linux kernel.
+     * @return Whether the OS is the linux kernel
+     */
+    public static boolean isLinux() {
+        return SystemUtils.IS_OS_LINUX;
+    }
+
+    /**
+     * Determine whether the OS enable CG Group.
+     */
+    public static boolean isCGroupEnabled() {
+        try {
+            return Files.exists(Paths.get(CGROUPS_CPU_USAGE_PATH));
+        } catch (Exception e) {
+            log.warn("[LinuxInfo] Failed to check cgroup CPU usage file: {}", e.getMessage());
+            return false;
+        }
+    }
+
+    /**
+     * Get total cpu limit.
+     * @param isCGroupsEnabled Whether CGroup is enabled
+     * @return Total cpu limit
+     */
+    public static double getTotalCpuLimit(boolean isCGroupsEnabled) {
+        if (isCGroupsEnabled) {
+            try {
+                long quota = readLongFromFile(Paths.get(CGROUPS_CPU_LIMIT_QUOTA_PATH));
+                long period = readLongFromFile(Paths.get(CGROUPS_CPU_LIMIT_PERIOD_PATH));
+                if (quota > 0) {
+                    return 100.0 * quota / period;
+                }
+            } catch (IOException e) {
+                log.warn("[LinuxInfo] Failed to read CPU quotas from cgroups", e);
+                // Fallback to availableProcessors
+            }
+        }
+        // Fallback to JVM reported CPU quota
+        return 100 * Runtime.getRuntime().availableProcessors();
+    }
+
+    /**
+     * Get CGroup cpu usage.
+     * @return Cpu usage
+     */
+    public static double getCpuUsageForCGroup() {
+        try {
+            return readLongFromFile(Paths.get(CGROUPS_CPU_USAGE_PATH));
+        } catch (IOException e) {
+            log.error("[LinuxInfo] Failed to read CPU usage from {}", CGROUPS_CPU_USAGE_PATH, e);
+            return -1;
+        }
+    }
+
+
+    /**
+     * Reads first line of /proc/stat to get total cpu usage.
+     *
+     * <pre>
+     *     cpu  user   nice system idle    iowait irq softirq steal guest guest_nice
+     *     cpu  317808 128  58637  2503692 7634   0   13472   0     0     0
+     * </pre>
+     * <p>
+     * Line is split in "words", filtering the first. The sum of all numbers give the amount of cpu cycles used this
+     * far. Real CPU usage should equal the sum substracting the idle cycles, this would include iowait, irq and steal.
+     */
+    public static ResourceUsage getCpuUsageForEntireHost() {
+        try (Stream<String> stream = Files.lines(Paths.get(PROC_STAT_PATH))) {
+            Optional<String> first = stream.findFirst();
+            if (!first.isPresent()) {
+                log.error("[LinuxInfo] Failed to read CPU usage from /proc/stat, because of empty values.");
+                return ResourceUsage.empty();
+            }
+            String[] words = first.get().split("\\s+");
+            long total = Arrays.stream(words)
+                    .filter(s -> !s.contains("cpu"))
+                    .mapToLong(Long::parseLong)
+                    .sum();
+            long idle = Long.parseLong(words[4]);
+            return ResourceUsage.builder()
+                    .usage(total - idle)
+                    .idle(idle)
+                    .total(total).build();
+        } catch (IOException e) {
+            log.error("[LinuxInfo] Failed to read CPU usage from /proc/stat", e);
+            return ResourceUsage.empty();
+        }
+    }
+
+    /**
+     * Determine whether the VM has physical nic.
+     * @param nicPath Nic path
+     * @return whether The VM has physical nic.
+     */
+    private static boolean isPhysicalNic(Path nicPath) {
+        if (nicPath.toString().contains("/virtual/")) {
+            return false;
+        }
+        try {
+            // Check the type to make sure it's ethernet (type "1")
+            String type = readTrimStringFromFile(nicPath.resolve("type"));
+            // wireless NICs don't report speed, ignore them.
+            return Integer.parseInt(type) == ARPHRD_ETHER;
+        } catch (Exception e) {
+            // Read type got error.
+            return false;
+        }
+    }
+
+    /**
+     * Get all physical nic limit.
+     * @param nics All nic path
+     * @param nicUnit Nic speed unit
+     * @return Total nic limit
+     */
+    public static double getTotalNicLimit(List<String> nics, NICUnit nicUnit) {
+        return nicUnit.convertBy(nics.stream().mapToDouble(nicPath -> {
+            try {
+                return readDoubleFromFile(getReplacedNICPath(NIC_SPEED_TEMPLATE, nicPath));
+            } catch (IOException e) {
+                log.error("[LinuxInfo] Failed to get total nic limit.", e);
+                return 0d;
+            }
+        }).sum());
+    }
+
+    /**
+     * Get all physical nic limit.
+     * @param nics All nic path
+     * @param nicUnit Nic speed unit
+     * @return Total nic limit
+     * @throws IOException Read file exception
+     */
+    public static double getUncheckedTotalNicLimit(List<String> nics, NICUnit nicUnit)
+            throws IOException {
+        double sum = 0.0;
+        for (String nicPath : nics) {
+            double v = readDoubleFromFile(getReplacedNICPath(NIC_SPEED_TEMPLATE, nicPath));
+            sum += v;
+        }
+        return nicUnit.convertBy(sum);
+    }
+
+    /**
+     * Get all physical nic usage
+     * @param nics All nic path
+     * @param type Nic's usage type:  transport, receive
+     * @param unit Nic usage unit.
+     * @return Total nic usage
+     */
+    public static double getTotalNicUsage(List<String> nics, NICUsageType type, UsageUnit unit) {
+        return unit.convertBy(nics.stream().mapToDouble(nic -> {
+            try {
+                return readDoubleFromFile(getReplacedNICPath(type.template, nic));
+            } catch (IOException e) {
+                log.error("[LinuxInfo] Failed to read {} bytes for NIC {} ", type, nic, e);
+                return 0d;
+            }
+        }).sum());
+    }
+
+    /**
+     * Get all physical nic path.
+     * @return All physical nic path.
+     */
+    public static List<String> getPhysicalNICs() {
+        try (Stream<Path> stream = Files.list(Paths.get(NIC_PATH))) {
+            return stream.filter(LinuxInfoUtils::isPhysicalNic)
+                    .map(path -> path.getFileName().toString())
+                    .collect(Collectors.toList());
+        } catch (IOException e) {
+            log.error("[LinuxInfo] Failed to find NICs", e);
+            return Collections.emptyList();
+        }
+    }
+
+    /**
+     * Check this VM has nic speed.
+     * @return Whether the VM has nic speed.
+     */
+    public static boolean checkHasNicSpeeds() {
+        List<String> physicalNICs = getPhysicalNICs();
+        if (CollectionUtils.isEmpty(physicalNICs)) {
+            return false;
+        }
+        try {
+            double totalNicLimit = getUncheckedTotalNicLimit(physicalNICs, NICUnit.Kbps);
+            return totalNicLimit > 0;
+        } catch (IOException e) {
+            log.error("[LinuxInfo] Failed to get total nic limit.", e);
+            return false;
+        }
+    }
+
+    private static Path getReplacedNICPath(String template, String nic) {
+        return Paths.get(String.format(template, nic));
+    }
+
+    private static String readTrimStringFromFile(Path path) throws IOException {
+        return new String(Files.readAllBytes(path), Charsets.UTF_8).trim();
+    }
+
+    private static long readLongFromFile(Path path) throws IOException {
+        return Long.parseLong(readTrimStringFromFile(path));
+    }
+
+    private static double readDoubleFromFile(Path path) throws IOException {
+        return Double.parseDouble(readTrimStringFromFile(path));
+    }
+
+    @AllArgsConstructor
+    public enum NICUnit {
+        Kbps(1024);
+
+        private final int convertUnit;
+
+        public double convertBy(double usageBytes) {
+            return this.convertUnit * usageBytes;
+        }
+    }
+
+    @AllArgsConstructor
+    public enum UsageUnit {
+        Kbps(8 / 1024);
+
+        private final int convertUnit;
+
+        public double convertBy(double usageBytes) {
+            return this.convertUnit * usageBytes;
+        }
+    }
+
+    @AllArgsConstructor
+    public enum NICUsageType {
+        // transport
+        TX("/sys/class/net/%s/statistics/tx_bytes"),
+        // receive
+        RX("/sys/class/net/%s/statistics/rx_bytes");
+        private final String template;
+    }
+
+    @Data
+    @Builder
+    public static class ResourceUsage {
+        private final long total;
+        private final long idle;
+        private final long usage;
+
+        public static ResourceUsage empty() {
+            return ResourceUsage.builder()
+                    .total(-1)
+                    .idle(-1)
+                    .usage(-1).build();
+        }
+
+        public boolean isEmpty() {
+            return this.total == -1 && idle == -1 && usage == -1;
+        }
+    }
+}

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/LinuxInfoUtils.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/LinuxInfoUtils.java
@@ -7,10 +7,10 @@ import lombok.Data;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.SystemUtils;
-import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -178,10 +178,10 @@ public class LinuxInfoUtils {
     }
 
     /**
-     * Get all physical nic usage
+     * Get all physical nic usage.
      * @param nics All nic path
      * @param type Nic's usage type:  transport, receive
-     * @param unit Nic usage unit.
+     * @param unit Nic usage unit
      * @return Total nic usage
      */
     public static double getTotalNicUsage(List<String> nics, NICUsageType type, UsageUnit unit) {
@@ -197,7 +197,7 @@ public class LinuxInfoUtils {
 
     /**
      * Get all physical nic path.
-     * @return All physical nic path.
+     * @return All physical nic path
      */
     public static List<String> getPhysicalNICs() {
         try (Stream<Path> stream = Files.list(Paths.get(NIC_PATH))) {
@@ -212,7 +212,7 @@ public class LinuxInfoUtils {
 
     /**
      * Check this VM has nic speed.
-     * @return Whether the VM has nic speed.
+     * @return Whether the VM has nic speed
      */
     public static boolean checkHasNicSpeeds() {
         List<String> physicalNICs = getPhysicalNICs();

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/LinuxBrokerHostUsageImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/LinuxBrokerHostUsageImpl.java
@@ -160,8 +160,8 @@ public class LinuxBrokerHostUsageImpl implements BrokerHostUsage {
         if (cpuUsageForEntireHost.isEmpty()) {
             return -1;
         }
-        double currentUsage = (cpuUsageForEntireHost.getUsage() - lastCpuUsage) /
-                (cpuUsageForEntireHost.getTotal() - lastCpuTotalTime) * getTotalCpuLimit(isCGroupsEnabled);
+        double currentUsage = (cpuUsageForEntireHost.getUsage() - lastCpuUsage)
+                / (cpuUsageForEntireHost.getTotal() - lastCpuTotalTime) * getTotalCpuLimit(isCGroupsEnabled);
         lastCpuUsage = cpuUsageForEntireHost.getUsage();
         lastCpuTotalTime = cpuUsageForEntireHost.getTotal();
         return currentUsage;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/LinuxBrokerHostUsageImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/LinuxBrokerHostUsageImpl.java
@@ -18,26 +18,27 @@
  */
 package org.apache.pulsar.broker.loadbalance.impl;
 
+import static org.apache.pulsar.broker.loadbalance.LinuxInfoUtils.NICUnit;
+import static org.apache.pulsar.broker.loadbalance.LinuxInfoUtils.NICUsageType;
+import static org.apache.pulsar.broker.loadbalance.LinuxInfoUtils.UsageUnit;
+import static org.apache.pulsar.broker.loadbalance.LinuxInfoUtils.getCpuUsageForCGroup;
+import static org.apache.pulsar.broker.loadbalance.LinuxInfoUtils.getCpuUsageForEntireHost;
+import static org.apache.pulsar.broker.loadbalance.LinuxInfoUtils.getPhysicalNICs;
+import static org.apache.pulsar.broker.loadbalance.LinuxInfoUtils.getTotalCpuLimit;
+import static org.apache.pulsar.broker.loadbalance.LinuxInfoUtils.getTotalNicLimit;
+import static org.apache.pulsar.broker.loadbalance.LinuxInfoUtils.getTotalNicUsage;
+import static org.apache.pulsar.broker.loadbalance.LinuxInfoUtils.isCGroupEnabled;
 import static org.apache.pulsar.common.util.Runnables.catchingAndLoggingThrowables;
-import com.google.common.base.Charsets;
 import com.sun.management.OperatingSystemMXBean;
-import java.io.IOException;
 import java.lang.management.ManagementFactory;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.broker.loadbalance.BrokerHostUsage;
+import org.apache.pulsar.broker.loadbalance.LinuxInfoUtils;
 import org.apache.pulsar.policies.data.loadbalancer.ResourceUsage;
 import org.apache.pulsar.policies.data.loadbalancer.SystemResourceUsage;
 
@@ -54,13 +55,8 @@ public class LinuxBrokerHostUsageImpl implements BrokerHostUsage {
     private double lastCpuTotalTime;
     private OperatingSystemMXBean systemBean;
     private SystemResourceUsage usage;
-
     private final Optional<Double> overrideBrokerNicSpeedGbps;
     private final boolean isCGroupsEnabled;
-
-    private static final String CGROUPS_CPU_USAGE_PATH = "/sys/fs/cgroup/cpu/cpuacct.usage";
-    private static final String CGROUPS_CPU_LIMIT_QUOTA_PATH = "/sys/fs/cgroup/cpu/cpu.cfs_quota_us";
-    private static final String CGROUPS_CPU_LIMIT_PERIOD_PATH = "/sys/fs/cgroup/cpu/cpu.cfs_period_us";
 
     public LinuxBrokerHostUsageImpl(PulsarService pulsar) {
         this(
@@ -77,15 +73,7 @@ public class LinuxBrokerHostUsageImpl implements BrokerHostUsage {
         this.lastCollection = 0L;
         this.usage = new SystemResourceUsage();
         this.overrideBrokerNicSpeedGbps = overrideBrokerNicSpeedGbps;
-
-        boolean isCGroupsEnabled = false;
-        try {
-             isCGroupsEnabled = Files.exists(Paths.get(CGROUPS_CPU_USAGE_PATH));
-        } catch (Exception e) {
-            log.warn("Failed to check cgroup CPU usage file: {}", e.getMessage());
-        }
-        this.isCGroupsEnabled = isCGroupsEnabled;
-
+        this.isCGroupsEnabled = isCGroupEnabled();
         // Call now to initialize values before the constructor returns
         calculateBrokerHostUsage();
         executorService.scheduleWithFixedDelay(catchingAndLoggingThrowables(this::calculateBrokerHostUsage),
@@ -100,19 +88,17 @@ public class LinuxBrokerHostUsageImpl implements BrokerHostUsage {
 
     @Override
     public void calculateBrokerHostUsage() {
-        List<String> nics = getNics();
-        double totalNicLimit = getTotalNicLimitKbps(nics);
-        double totalNicUsageTx = getTotalNicUsageTxKb(nics);
-        double totalNicUsageRx = getTotalNicUsageRxKb(nics);
-        double totalCpuLimit = getTotalCpuLimit();
-
+        List<String> nics = getPhysicalNICs();
+        double totalNicLimit = getTotalNicLimitWithConfiguration(nics);
+        double totalNicUsageTx = getTotalNicUsage(nics, NICUsageType.TX, UsageUnit.Kbps);
+        double totalNicUsageRx = getTotalNicUsage(nics, NICUsageType.RX, UsageUnit.Kbps);
+        double totalCpuLimit = getTotalCpuLimit(isCGroupsEnabled);
         long now = System.currentTimeMillis();
         double elapsedSeconds = (now - lastCollection) / 1000d;
         if (elapsedSeconds <= 0) {
             log.warn("elapsedSeconds {} is not expected, skip this round of calculateBrokerHostUsage", elapsedSeconds);
             return;
         }
-
         SystemResourceUsage usage = new SystemResourceUsage();
         double cpuUsage = getTotalCpuUsage(elapsedSeconds);
 
@@ -136,22 +122,11 @@ public class LinuxBrokerHostUsageImpl implements BrokerHostUsage {
         usage.setCpu(new ResourceUsage(cpuUsage, totalCpuLimit));
     }
 
-    private double getTotalCpuLimit() {
-        if (isCGroupsEnabled) {
-            try {
-                long quota = readLongFromFile(CGROUPS_CPU_LIMIT_QUOTA_PATH);
-                long period = readLongFromFile(CGROUPS_CPU_LIMIT_PERIOD_PATH);
-                if (quota > 0) {
-                    return 100.0 * quota / period;
-                }
-            } catch (IOException e) {
-                log.warn("Failed to read CPU quotas from cgroups", e);
-                // Fallback to availableProcessors
-            }
-        }
-
-        // Fallback to JVM reported CPU quota
-        return 100 * Runtime.getRuntime().availableProcessors();
+    private double getTotalNicLimitWithConfiguration(List<String> nics) {
+        // Use the override value as configured. Return the total max speed across all available NICs, converted
+        // from Gbps into Kbps
+        return overrideBrokerNicSpeedGbps.map(aDouble -> aDouble * nics.size() * 1024 * 1024)
+                .orElseGet(() -> getTotalNicLimit(nics, NICUnit.Kbps));
     }
 
     private double getTotalCpuUsage(double elapsedTimeSeconds) {
@@ -160,6 +135,13 @@ public class LinuxBrokerHostUsageImpl implements BrokerHostUsage {
         } else {
             return getTotalCpuUsageForEntireHost();
         }
+    }
+
+    private double getTotalCpuUsageForCGroup(double elapsedTimeSeconds) {
+        double usage = getCpuUsageForCGroup();
+        double currentUsage = usage - lastCpuUsage;
+        lastCpuUsage = usage;
+        return 100 * currentUsage / elapsedTimeSeconds / TimeUnit.SECONDS.toNanos(1);
     }
 
     /**
@@ -174,36 +156,15 @@ public class LinuxBrokerHostUsageImpl implements BrokerHostUsage {
      * far. Real CPU usage should equal the sum substracting the idle cycles, this would include iowait, irq and steal.
      */
     private double getTotalCpuUsageForEntireHost() {
-        try (Stream<String> stream = Files.lines(Paths.get("/proc/stat"))) {
-            String[] words = stream.findFirst().get().split("\\s+");
-
-            long total = Arrays.stream(words).filter(s -> !s.contains("cpu")).mapToLong(Long::parseLong).sum();
-            long idle = Long.parseLong(words[4]);
-            long usage = total - idle;
-
-            double currentUsage = (usage - lastCpuUsage)  / (total - lastCpuTotalTime) * getTotalCpuLimit();
-
-            lastCpuUsage = usage;
-            lastCpuTotalTime = total;
-
-            return currentUsage;
-        } catch (IOException e) {
-            log.error("Failed to read CPU usage from /proc/stat", e);
+        LinuxInfoUtils.ResourceUsage cpuUsageForEntireHost = getCpuUsageForEntireHost();
+        if (cpuUsageForEntireHost.isEmpty()) {
             return -1;
         }
-    }
-
-    private double getTotalCpuUsageForCGroup(double elapsedTimeSeconds) {
-        try {
-            long usage = readLongFromFile(CGROUPS_CPU_USAGE_PATH);
-            double currentUsage = usage - lastCpuUsage;
-            lastCpuUsage = usage;
-
-            return 100 * currentUsage / elapsedTimeSeconds / TimeUnit.SECONDS.toNanos(1);
-        } catch (IOException e) {
-            log.error("Failed to read CPU usage from {}", CGROUPS_CPU_USAGE_PATH, e);
-            return -1;
-        }
+        double currentUsage = (cpuUsageForEntireHost.getUsage() - lastCpuUsage) /
+                (cpuUsageForEntireHost.getTotal() - lastCpuTotalTime) * getTotalCpuLimit(isCGroupsEnabled);
+        lastCpuUsage = cpuUsageForEntireHost.getUsage();
+        lastCpuTotalTime = cpuUsageForEntireHost.getTotal();
+        return currentUsage;
     }
 
     private ResourceUsage getMemUsage() {
@@ -212,86 +173,4 @@ public class LinuxBrokerHostUsageImpl implements BrokerHostUsage {
         return new ResourceUsage(total - free, total);
     }
 
-    private List<String> getNics() {
-        try (Stream<Path> stream = Files.list(Paths.get("/sys/class/net/"))) {
-            return stream.filter(this::isPhysicalNic).map(path -> path.getFileName().toString())
-                    .collect(Collectors.toList());
-        } catch (IOException e) {
-            log.error("Failed to find NICs", e);
-            return Collections.emptyList();
-        }
-    }
-
-    public int getNicCount() {
-        return getNics().size();
-    }
-
-    private boolean isPhysicalNic(Path path) {
-        try {
-            if (path.toRealPath().toString().contains("/virtual/")) {
-                return false;
-            }
-            // Check the type to make sure it's ethernet (type "1")
-            String type = new String(Files.readAllBytes(path.resolve("type")), StandardCharsets.UTF_8).trim();
-            // wireless NICs don't report speed, ignore them.
-            return Integer.parseInt(type) == 1;
-        } catch (Exception e) {
-            // Read type got error.
-            return false;
-        }
-    }
-
-    private Path getNicSpeedPath(String nic) {
-        return Paths.get(String.format("/sys/class/net/%s/speed", nic));
-    }
-
-    private double getTotalNicLimitKbps(List<String> nics) {
-        // Use the override value as configured. Return the total max speed across all available NICs, converted
-        // from Gbps into Kbps
-        return overrideBrokerNicSpeedGbps.map(aDouble -> aDouble * nics.size() * 1024 * 1024)
-                .orElseGet(() -> nics.stream().mapToDouble(nicPath -> {
-                    // Nic speed is in Mbits/s, return kbits/s
-                    try {
-                        return Double.parseDouble(new String(Files.readAllBytes(getNicSpeedPath(nicPath))));
-                    } catch (IOException e) {
-                        log.error(String.format("Failed to read speed for nic %s, maybe you can set broker"
-                                + " config [loadBalancerOverrideBrokerNicSpeedGbps] to override it.", nicPath), e);
-                        return 0d;
-                    }
-                }).sum() * 1024);
-    }
-
-    private Path getNicTxPath(String nic) {
-        return Paths.get(String.format("/sys/class/net/%s/statistics/tx_bytes", nic));
-    }
-
-    private Path getNicRxPath(String nic) {
-        return Paths.get(String.format("/sys/class/net/%s/statistics/rx_bytes", nic));
-    }
-
-    private double getTotalNicUsageRxKb(List<String> nics) {
-        return nics.stream().mapToDouble(s -> {
-            try {
-                return Double.parseDouble(new String(Files.readAllBytes(getNicRxPath(s))));
-            } catch (IOException e) {
-                log.error("Failed to read rx_bytes for NIC " + s, e);
-                return 0d;
-            }
-        }).sum() * 8 / 1024;
-    }
-
-    private double getTotalNicUsageTxKb(List<String> nics) {
-        return nics.stream().mapToDouble(s -> {
-            try {
-                return Double.parseDouble(new String(Files.readAllBytes(getNicTxPath(s))));
-            } catch (IOException e) {
-                log.error("Failed to read tx_bytes for NIC " + s, e);
-                return 0d;
-            }
-        }).sum() * 8 / 1024;
-    }
-
-    private static long readLongFromFile(String path) throws IOException {
-        return Long.parseLong(new String(Files.readAllBytes(Paths.get(path)), Charsets.UTF_8).trim());
-    }
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/LoadReportNetworkLimitTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/LoadReportNetworkLimitTest.java
@@ -22,7 +22,6 @@ import static org.testng.Assert.assertEquals;
 import java.util.Optional;
 import org.apache.commons.lang3.SystemUtils;
 import org.apache.pulsar.broker.auth.MockedPulsarServiceBaseTest;
-import org.apache.pulsar.broker.loadbalance.impl.LinuxBrokerHostUsageImpl;
 import org.apache.pulsar.policies.data.loadbalancer.LoadManagerReport;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
@@ -40,7 +39,7 @@ public class LoadReportNetworkLimitTest extends MockedPulsarServiceBaseTest {
         super.internalSetup();
 
         if (SystemUtils.IS_OS_LINUX) {
-            nicCount = new LinuxBrokerHostUsageImpl(pulsar).getNicCount();
+            nicCount = LinuxInfoUtils.getPhysicalNICs().size();
         }
     }
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/SimpleBrokerStartTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/SimpleBrokerStartTest.java
@@ -1,0 +1,97 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.loadbalance;
+
+import static org.mockito.Mockito.spy;
+import java.util.Optional;
+import lombok.Cleanup;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.pulsar.broker.PulsarServerException;
+import org.apache.pulsar.broker.PulsarService;
+import org.apache.pulsar.broker.ServiceConfiguration;
+import org.apache.pulsar.broker.loadbalance.impl.SimpleLoadManagerImpl;
+import org.apache.pulsar.zookeeper.LocalBookkeeperEnsemble;
+import org.junit.Assert;
+import org.testng.annotations.Test;
+
+@Slf4j
+@Test(groups = "broker")
+public class SimpleBrokerStartTest {
+
+    public void testHasNICSpeed() throws Exception {
+        if (!LinuxInfoUtils.isLinux()) {
+            return;
+        }
+        // Start local bookkeeper ensemble
+        @Cleanup("stop")
+        LocalBookkeeperEnsemble bkEnsemble = new LocalBookkeeperEnsemble(3, 0, () -> 0);
+        bkEnsemble.start();
+        // Start broker
+        ServiceConfiguration config = spy(ServiceConfiguration.class);
+        config.setClusterName("use");
+        config.setWebServicePort(Optional.of(0));
+        config.setMetadataStoreUrl("zk:127.0.0.1" + ":" + bkEnsemble.getZookeeperPort());
+        config.setBrokerShutdownTimeoutMs(0L);
+        config.setBrokerServicePort(Optional.of(0));
+        config.setLoadManagerClassName(SimpleLoadManagerImpl.class.getName());
+        config.setBrokerServicePortTls(Optional.of(0));
+        config.setWebServicePortTls(Optional.of(0));
+        config.setAdvertisedAddress("localhost");
+        boolean hasNicSpeeds = LinuxInfoUtils.checkHasNicSpeeds();
+        if (hasNicSpeeds) {
+            @Cleanup
+            PulsarService pulsarService = new PulsarService(config);
+            pulsarService.start();
+        }
+    }
+
+    public void testNoNICSpeed() throws Exception {
+        if (!LinuxInfoUtils.isLinux()) {
+            return;
+        }
+        // Start local bookkeeper ensemble
+        @Cleanup("stop")
+        LocalBookkeeperEnsemble bkEnsemble = new LocalBookkeeperEnsemble(3, 0, () -> 0);
+        bkEnsemble.start();
+        // Start broker
+        ServiceConfiguration config = spy(ServiceConfiguration.class);
+        config.setClusterName("use");
+        config.setWebServicePort(Optional.of(0));
+        config.setMetadataStoreUrl("zk:127.0.0.1" + ":" + bkEnsemble.getZookeeperPort());
+        config.setBrokerShutdownTimeoutMs(0L);
+        config.setBrokerServicePort(Optional.of(0));
+        config.setLoadManagerClassName(SimpleLoadManagerImpl.class.getName());
+        config.setBrokerServicePortTls(Optional.of(0));
+        config.setWebServicePortTls(Optional.of(0));
+        config.setAdvertisedAddress("localhost");
+        boolean hasNicSpeeds = LinuxInfoUtils.checkHasNicSpeeds();
+        if (!hasNicSpeeds) {
+            @Cleanup
+            PulsarService pulsarService = new PulsarService(config);
+            try {
+                pulsarService.start();
+                Assert.fail("unexpected behaviour");
+            } catch (PulsarServerException ex) {
+                Assert.assertTrue(ex.getCause() instanceof IllegalStateException);
+            }
+        }
+    }
+
+
+}

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/topologies/PulsarCluster.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/topologies/PulsarCluster.java
@@ -171,6 +171,7 @@ public class PulsarCluster {
                         .withEnv("configurationStoreServers", CSContainer.NAME + ":" + CS_PORT)
                         .withEnv("clusterName", clusterName)
                         .withEnv("brokerServiceCompactionMonitorIntervalInSeconds", "1")
+                        .withEnv("loadBalancerOverrideBrokerNicSpeedGbps", "1")
                         // used in s3 tests
                         .withEnv("AWS_ACCESS_KEY_ID", "accesskey")
                         .withEnv("AWS_SECRET_KEY", "secretkey")


### PR DESCRIPTION
### Motivation

The context here: #14537

The current design is frequently logging an error while ignoring the NIC. The only real course of action for an operator is to reconfigure the broker. It seems like a better course of action to fail on startup so that operators know immediately that they need to fix the configuration instead of finding out sometime later when observing the logs.

### Modifications

- Verify whether VM has NIC speed.
- Refactor ``LinuxBrokerHostUsageImpl`` and extract some Linux operate to another class.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Documentation

- [x] `no-need-doc` 
  



