### PR TITLE
Bump netty version to 4.1.75

### DIFF
--- a/buildtools/pom.xml
+++ b/buildtools/pom.xml
@@ -134,7 +134,7 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-common</artifactId>
-      <version>4.1.74.Final</version>
+      <version>4.1.75.Final</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -352,26 +352,26 @@ The Apache Software License, Version 2.0
     - org.apache.commons-commons-compress-1.21.jar
     - org.apache.commons-commons-lang3-3.11.jar
  * Netty
-    - io.netty-netty-buffer-4.1.74.Final.jar
-    - io.netty-netty-codec-4.1.74.Final.jar
-    - io.netty-netty-codec-dns-4.1.74.Final.jar
-    - io.netty-netty-codec-http-4.1.74.Final.jar
-    - io.netty-netty-codec-http2-4.1.74.Final.jar
-    - io.netty-netty-codec-socks-4.1.74.Final.jar
-    - io.netty-netty-codec-haproxy-4.1.74.Final.jar
-    - io.netty-netty-common-4.1.74.Final.jar
-    - io.netty-netty-handler-4.1.74.Final.jar
-    - io.netty-netty-handler-proxy-4.1.74.Final.jar
-    - io.netty-netty-resolver-4.1.74.Final.jar
-    - io.netty-netty-resolver-dns-4.1.74.Final.jar
-    - io.netty-netty-transport-4.1.74.Final.jar
-    - io.netty-netty-transport-classes-epoll-4.1.74.Final.jar
-    - io.netty-netty-transport-native-epoll-4.1.74.Final-linux-x86_64.jar
-    - io.netty-netty-transport-native-epoll-4.1.74.Final.jar
-    - io.netty-netty-transport-native-unix-common-4.1.74.Final.jar
-    - io.netty-netty-transport-native-unix-common-4.1.74.Final-linux-x86_64.jar
-    - io.netty-netty-tcnative-boringssl-static-2.0.48.Final.jar
-    - io.netty-netty-tcnative-classes-2.0.48.Final.jar
+    - io.netty-netty-buffer-4.1.75.Final.jar
+    - io.netty-netty-codec-4.1.75.Final.jar
+    - io.netty-netty-codec-dns-4.1.75.Final.jar
+    - io.netty-netty-codec-http-4.1.75.Final.jar
+    - io.netty-netty-codec-http2-4.1.75.Final.jar
+    - io.netty-netty-codec-socks-4.1.75.Final.jar
+    - io.netty-netty-codec-haproxy-4.1.75.Final.jar
+    - io.netty-netty-common-4.1.75.Final.jar
+    - io.netty-netty-handler-4.1.75.Final.jar
+    - io.netty-netty-handler-proxy-4.1.75.Final.jar
+    - io.netty-netty-resolver-4.1.75.Final.jar
+    - io.netty-netty-resolver-dns-4.1.75.Final.jar
+    - io.netty-netty-transport-4.1.75.Final.jar
+    - io.netty-netty-transport-classes-epoll-4.1.75.Final.jar
+    - io.netty-netty-transport-native-epoll-4.1.75.Final-linux-x86_64.jar
+    - io.netty-netty-transport-native-epoll-4.1.75.Final.jar
+    - io.netty-netty-transport-native-unix-common-4.1.75.Final.jar
+    - io.netty-netty-transport-native-unix-common-4.1.75.Final-linux-x86_64.jar
+    - io.netty-netty-tcnative-boringssl-static-2.0.50.Final.jar
+    - io.netty-netty-tcnative-classes-2.0.50.Final.jar
  * Prometheus client
     - io.prometheus-simpleclient-0.5.0.jar
     - io.prometheus-simpleclient_common-0.5.0.jar

--- a/pom.xml
+++ b/pom.xml
@@ -111,7 +111,7 @@ flexible messaging model and an intuitive client API.</description>
     <dropwizardmetrics.version>3.2.5</dropwizardmetrics.version> <!-- ZooKeeper server -->
     <curator.version>5.1.0</curator.version>
     <netty.version>4.1.75.Final</netty.version>
-    <netty-tc-native.version>2.0.48.Final</netty-tc-native.version>
+    <netty-tc-native.version>2.0.50.Final</netty-tc-native.version>
     <jetty.version>9.4.44.v20210927</jetty.version>
     <conscrypt.version>2.5.2</conscrypt.version>
     <jersey.version>2.34</jersey.version>

--- a/pom.xml
+++ b/pom.xml
@@ -110,7 +110,7 @@ flexible messaging model and an intuitive client API.</description>
     <snappy.version>1.1.7</snappy.version> <!-- ZooKeeper server -->
     <dropwizardmetrics.version>3.2.5</dropwizardmetrics.version> <!-- ZooKeeper server -->
     <curator.version>5.1.0</curator.version>
-    <netty.version>4.1.74.Final</netty.version>
+    <netty.version>4.1.75.Final</netty.version>
     <netty-tc-native.version>2.0.48.Final</netty-tc-native.version>
     <jetty.version>9.4.44.v20210927</jetty.version>
     <conscrypt.version>2.5.2</conscrypt.version>

--- a/pulsar-sql/presto-distribution/LICENSE
+++ b/pulsar-sql/presto-distribution/LICENSE
@@ -232,26 +232,26 @@ The Apache Software License, Version 2.0
     - commons-lang3-3.11.jar
  * Netty
     - netty-3.10.6.Final.jar
-    - netty-buffer-4.1.74.Final.jar
-    - netty-codec-4.1.74.Final.jar
-    - netty-codec-dns-4.1.74.Final.jar
-    - netty-codec-http-4.1.74.Final.jar
-    - netty-codec-haproxy-4.1.74.Final.jar
-    - netty-codec-socks-4.1.74.Final.jar
-    - netty-handler-proxy-4.1.74.Final.jar
-    - netty-common-4.1.74.Final.jar
-    - netty-handler-4.1.74.Final.jar
+    - netty-buffer-4.1.75.Final.jar
+    - netty-codec-4.1.75.Final.jar
+    - netty-codec-dns-4.1.75.Final.jar
+    - netty-codec-http-4.1.75.Final.jar
+    - netty-codec-haproxy-4.1.75.Final.jar
+    - netty-codec-socks-4.1.75.Final.jar
+    - netty-handler-proxy-4.1.75.Final.jar
+    - netty-common-4.1.75.Final.jar
+    - netty-handler-4.1.75.Final.jar
     - netty-reactive-streams-2.0.4.jar
-    - netty-resolver-4.1.74.Final.jar
-    - netty-resolver-dns-4.1.74.Final.jar
+    - netty-resolver-4.1.75.Final.jar
+    - netty-resolver-dns-4.1.75.Final.jar
     - netty-tcnative-boringssl-static-2.0.48.Final.jar
     - netty-tcnative-classes-2.0.48.Final.jar
-    - netty-transport-4.1.74.Final.jar
-    - netty-transport-classes-epoll-4.1.74.Final.jar
-    - netty-transport-native-epoll-4.1.74.Final-linux-x86_64.jar
-    - netty-transport-native-unix-common-4.1.74.Final.jar
-    - netty-transport-native-unix-common-4.1.74.Final-linux-x86_64.jar
-    - netty-codec-http2-4.1.74.Final.jar
+    - netty-transport-4.1.75.Final.jar
+    - netty-transport-classes-epoll-4.1.75.Final.jar
+    - netty-transport-native-epoll-4.1.75.Final-linux-x86_64.jar
+    - netty-transport-native-unix-common-4.1.75.Final.jar
+    - netty-transport-native-unix-common-4.1.75.Final-linux-x86_64.jar
+    - netty-codec-http2-4.1.75.Final.jar
  * GRPC
     - grpc-api-1.42.1.jar
     - grpc-context-1.42.1.jar

--- a/pulsar-sql/presto-distribution/LICENSE
+++ b/pulsar-sql/presto-distribution/LICENSE
@@ -244,8 +244,8 @@ The Apache Software License, Version 2.0
     - netty-reactive-streams-2.0.4.jar
     - netty-resolver-4.1.75.Final.jar
     - netty-resolver-dns-4.1.75.Final.jar
-    - netty-tcnative-boringssl-static-2.0.48.Final.jar
-    - netty-tcnative-classes-2.0.48.Final.jar
+    - netty-tcnative-boringssl-static-2.0.50.Final.jar
+    - netty-tcnative-classes-2.0.50.Final.jar
     - netty-transport-4.1.75.Final.jar
     - netty-transport-classes-epoll-4.1.75.Final.jar
     - netty-transport-native-epoll-4.1.75.Final-linux-x86_64.jar


### PR DESCRIPTION
### Motivation

Changelog: https://netty.io/news/2022/03/10/4-1-75-Final.html

### Modifications

* Upgrade Netty from 4.1.74.Final to 4.1.75.Final
* Netty 4.1.75.Final depends on netty-tc-native 2.0.50, also updates
