### PR TITLE
Support delete schema forcefully

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/SchemasResourceBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/SchemasResourceBase.java
@@ -113,11 +113,11 @@ public class SchemasResourceBase extends AdminResource {
         });
     }
 
-    public void deleteSchema(boolean authoritative, AsyncResponse response) {
+    public void deleteSchema(boolean authoritative, AsyncResponse response, boolean force) {
         validateDestinationAndAdminOperation(authoritative);
 
         String schemaId = getSchemaId();
-        pulsar().getSchemaRegistryService().deleteSchema(schemaId, defaultIfEmpty(clientAppId(), ""))
+        pulsar().getSchemaRegistryService().deleteSchema(schemaId, defaultIfEmpty(clientAppId(), ""), force)
                 .handle((version, error) -> {
                     if (isNull(error)) {
                         response.resume(Response.ok()

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v1/SchemasResource.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v1/SchemasResource.java
@@ -153,10 +153,11 @@ public class SchemasResource extends SchemasResourceBase {
         @PathParam("namespace") String namespace,
         @PathParam("topic") String topic,
         @QueryParam("authoritative") @DefaultValue("false") boolean authoritative,
+        @QueryParam("force") @DefaultValue("false") boolean force,
         @Suspended final AsyncResponse response
     ) {
         validateTopicName(tenant, cluster, namespace, topic);
-        deleteSchema(authoritative, response);
+        deleteSchema(authoritative, response, force);
     }
 
     @POST

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/SchemasResource.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/SchemasResource.java
@@ -151,10 +151,11 @@ public class SchemasResource extends SchemasResourceBase {
         @PathParam("namespace") String namespace,
         @PathParam("topic") String topic,
         @QueryParam("authoritative") @DefaultValue("false") boolean authoritative,
+        @QueryParam("force") @DefaultValue("false") boolean force,
         @Suspended final AsyncResponse response
     ) {
         validateTopicName(tenant, namespace, topic);
-        deleteSchema(authoritative, response);
+        deleteSchema(authoritative, response, force);
     }
 
     @POST

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/DefaultSchemaRegistryService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/DefaultSchemaRegistryService.java
@@ -71,7 +71,7 @@ public class DefaultSchemaRegistryService implements SchemaRegistryService {
     }
 
     @Override
-    public CompletableFuture<SchemaVersion> deleteSchema(String schemaId, String user) {
+    public CompletableFuture<SchemaVersion> deleteSchema(String schemaId, String user, boolean force) {
         return completedFuture(null);
     }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/SchemaRegistry.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/SchemaRegistry.java
@@ -37,7 +37,7 @@ public interface SchemaRegistry extends AutoCloseable {
     CompletableFuture<SchemaVersion> putSchemaIfAbsent(String schemaId, SchemaData schema,
                                                        SchemaCompatibilityStrategy strategy);
 
-    CompletableFuture<SchemaVersion> deleteSchema(String schemaId, String user);
+    CompletableFuture<SchemaVersion> deleteSchema(String schemaId, String user, boolean force);
 
     CompletableFuture<SchemaVersion> deleteSchemaStorage(String schemaId);
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/SchemaRegistryServiceImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/SchemaRegistryServiceImpl.java
@@ -172,8 +172,10 @@ public class SchemaRegistryServiceImpl implements SchemaRegistryService {
     }
 
     @Override
-    @NotNull
-    public CompletableFuture<SchemaVersion> deleteSchema(String schemaId, String user) {
+    public CompletableFuture<SchemaVersion> deleteSchema(String schemaId, String user, boolean force) {
+        if (force) {
+            return deleteSchemaStorage(schemaId, true);
+        }
         byte[] deletedEntry = deleted(schemaId, user).toByteArray();
         return schemaStorage.put(schemaId, deletedEntry, new byte[]{});
     }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/validator/SchemaRegistryServiceWithSchemaDataValidator.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/validator/SchemaRegistryServiceWithSchemaDataValidator.java
@@ -97,8 +97,8 @@ public class SchemaRegistryServiceWithSchemaDataValidator implements SchemaRegis
     }
 
     @Override
-    public CompletableFuture<SchemaVersion> deleteSchema(String schemaId, String user) {
-        return service.deleteSchema(schemaId, user);
+    public CompletableFuture<SchemaVersion> deleteSchema(String schemaId, String user, boolean force) {
+        return service.deleteSchema(schemaId, user, force);
     }
 
     @Override

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/schema/SchemaServiceTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/schema/SchemaServiceTest.java
@@ -308,7 +308,7 @@ public class SchemaServiceTest extends MockedPulsarServiceBaseTest {
     }
 
     private void deleteSchema(String schemaId, SchemaVersion expectedVersion) throws Exception {
-        SchemaVersion version = schemaRegistryService.deleteSchema(schemaId, userId).get();
+        SchemaVersion version = schemaRegistryService.deleteSchema(schemaId, userId, false).get();
         assertEquals(expectedVersion, version);
     }
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/schema/validator/SchemaRegistryServiceWithSchemaDataValidatorTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/schema/validator/SchemaRegistryServiceWithSchemaDataValidatorTest.java
@@ -80,11 +80,10 @@ public class SchemaRegistryServiceWithSchemaDataValidatorTest {
         String schemaId = "test-schema-id";
         String user = "test-user";
         CompletableFuture<SchemaVersion> deleteFuture = new CompletableFuture<>();
-        when(underlyingService.deleteSchema(eq(schemaId), eq(user)))
-            .thenReturn(deleteFuture);
-        assertSame(deleteFuture, service.deleteSchema(schemaId, user));
-        verify(underlyingService, times(1))
-            .deleteSchema(eq(schemaId), eq(user));
+        when(underlyingService.deleteSchema(eq(schemaId), eq(user), eq(false)))
+                .thenReturn(deleteFuture);
+        assertSame(deleteFuture, service.deleteSchema(schemaId, user, false));
+        verify(underlyingService, times(1)).deleteSchema(eq(schemaId), eq(user), eq(false));
     }
 
     @Test

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/SchemaDeleteTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/SchemaDeleteTest.java
@@ -26,10 +26,14 @@ import org.apache.pulsar.client.api.Producer;
 import org.apache.pulsar.client.api.Reader;
 import org.apache.pulsar.client.api.Schema;
 
+import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.policies.data.ClusterData;
 import org.apache.pulsar.common.policies.data.SchemaAutoUpdateCompatibilityStrategy;
 import org.apache.pulsar.common.policies.data.TenantInfoImpl;
 
+import org.apache.pulsar.common.schema.SchemaInfo;
+import org.apache.pulsar.common.schema.SchemaType;
+import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -88,6 +92,27 @@ public class SchemaDeleteTest extends MockedPulsarServiceBaseTest {
         try (Reader<DummyPojo> reader = pulsarClient.newReader(Schema.AVRO(DummyPojo.class))
                 .topic(topic).startMessageId(MessageId.latest).create()) {
         }
+    }
+
+    @Test
+    public void schemaForceDeleteTest() throws Exception {
+        String namespace = "my-property/my-ns";
+        String topic = namespace + "/topic1";
+        String foobar = "foo";
+
+        try (Producer<String> producer =
+                     pulsarClient.newProducer(Schema.STRING).topic(topic).create()) {
+            producer.send(foobar);
+        }
+        SchemaInfo schemaInfo = admin.schemas().getSchemaInfo(topic);
+        Assert.assertSame(schemaInfo.getType(), SchemaType.STRING);
+
+        String schemaPath = "/schemas/" + TopicName.get(topic).getSchemaName();
+
+        admin.schemas().deleteSchema(topic, false);
+        Assert.assertTrue(pulsar.getLocalMetadataStore().get(schemaPath).get().isPresent());
+        admin.schemas().deleteSchema(topic, true);
+        Assert.assertFalse(pulsar.getLocalMetadataStore().get(schemaPath).get().isPresent());
     }
 
     public static class DummyPojo {

--- a/pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/admin/Schemas.java
+++ b/pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/admin/Schemas.java
@@ -99,6 +99,22 @@ public interface Schemas {
     CompletableFuture<Void> deleteSchemaAsync(String topic);
 
     /**
+     * Delete the schema associated with a given <tt>topic</tt>.
+     *
+     * @param topic topic name, in fully qualified format
+     * @param force force to delete schema
+     * @throws PulsarAdminException
+     */
+    void deleteSchema(String topic, boolean force) throws PulsarAdminException;
+
+    /**
+     * Delete the schema associated with a given <tt>topic</tt> asynchronously.
+     *
+     * @param topic topic name, in fully qualified format
+     */
+    CompletableFuture<Void> deleteSchemaAsync(String topic, boolean force);
+
+    /**
      * Create a schema for a given <tt>topic</tt> with the provided schema info.
      *
      * @param topic topic name, in fully qualified fomrat

--- a/pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/admin/Schemas.java
+++ b/pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/admin/Schemas.java
@@ -102,7 +102,9 @@ public interface Schemas {
      * Delete the schema associated with a given <tt>topic</tt>.
      *
      * @param topic topic name, in fully qualified format
-     * @param force force to delete schema
+     * @param force whether to delete schema completely.
+     *              If true, delete all resources (including metastore and ledger),
+     *              otherwise only do a mark deletion and not remove any resources indeed
      * @throws PulsarAdminException
      */
     void deleteSchema(String topic, boolean force) throws PulsarAdminException;

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/SchemasImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/SchemasImpl.java
@@ -127,15 +127,25 @@ public class SchemasImpl extends BaseResource implements Schemas {
 
     @Override
     public void deleteSchema(String topic) throws PulsarAdminException {
-        sync(() ->deleteSchemaAsync(topic));
+        deleteSchema(topic, false);
     }
 
     @Override
     public CompletableFuture<Void> deleteSchemaAsync(String topic) {
-        TopicName tn = TopicName.get(topic);
+        return deleteSchemaAsync(topic, false);
+    }
+
+    @Override
+    public void deleteSchema(String topic, boolean force) throws PulsarAdminException {
+        sync(() ->deleteSchemaAsync(topic, force));
+    }
+
+    @Override
+    public CompletableFuture<Void> deleteSchemaAsync(String topic, boolean force) {
+        WebTarget path = schemaPath(TopicName.get(topic)).queryParam("force", Boolean.toString(force));
         final CompletableFuture<Void> future = new CompletableFuture<>();
         try {
-            request(schemaPath(tn)).async().delete(new InvocationCallback<DeleteSchemaResponse>() {
+            request(path).async().delete(new InvocationCallback<DeleteSchemaResponse>() {
                 @Override
                 public void completed(DeleteSchemaResponse deleteSchemaResponse) {
                     future.complete(null);

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/SchemasImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/SchemasImpl.java
@@ -137,7 +137,7 @@ public class SchemasImpl extends BaseResource implements Schemas {
 
     @Override
     public void deleteSchema(String topic, boolean force) throws PulsarAdminException {
-        sync(() ->deleteSchemaAsync(topic, force));
+        sync(() -> deleteSchemaAsync(topic, force));
     }
 
     @Override

--- a/pulsar-client-tools-test/src/test/java/org/apache/pulsar/admin/cli/PulsarAdminToolTest.java
+++ b/pulsar-client-tools-test/src/test/java/org/apache/pulsar/admin/cli/PulsarAdminToolTest.java
@@ -2074,7 +2074,11 @@ public class PulsarAdminToolTest {
 
         cmdSchemas = new CmdSchemas(() -> admin);
         cmdSchemas.run(split("delete persistent://tn1/ns1/tp1"));
-        verify(schemas).deleteSchema("persistent://tn1/ns1/tp1");
+        verify(schemas).deleteSchema("persistent://tn1/ns1/tp1", false);
+
+        cmdSchemas = new CmdSchemas(() -> admin);
+        cmdSchemas.run(split("delete persistent://tn1/ns1/tp1 -f"));
+        verify(schemas).deleteSchema("persistent://tn1/ns1/tp1", true);
 
         cmdSchemas = new CmdSchemas(() -> admin);
         String schemaFile = PulsarAdminToolTest.class.getClassLoader()

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdSchemas.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdSchemas.java
@@ -78,10 +78,14 @@ public class CmdSchemas extends CmdBase {
         @Parameter(description = "persistent://tenant/namespace/topic", required = true)
         private java.util.List<String> params;
 
+        @Parameter(names = { "-f",
+                "--force" }, description = "Delete schema forcefully")
+        private boolean force = false;
+
         @Override
         void run() throws Exception {
             String topic = validateTopicName(params);
-            getAdmin().schemas().deleteSchema(topic);
+            getAdmin().schemas().deleteSchema(topic, force);
         }
     }
 

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdSchemas.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdSchemas.java
@@ -79,7 +79,9 @@ public class CmdSchemas extends CmdBase {
         private java.util.List<String> params;
 
         @Parameter(names = { "-f",
-                "--force" }, description = "Delete schema forcefully")
+                "--force" }, description = "whether to delete schema completely. If true, delete "
+                + "all resources (including metastore and ledger), otherwise only do a mark deletion"
+                + " and not remove any resources indeed")
         private boolean force = false;
 
         @Override


### PR DESCRIPTION

Fixes #14654 

### Motivation
Currently, pulsar admin command for schemas can't delete a schema completely, it only appends a deleted  `schemaInfo` to mark this schema as deleted.
This may lead to some problems as described in #14654 
This pull request aims to delete schema forcefully which will remove the schema from the metastore and bookkeeper completely.


### Modifications
1. Add a new option for `DeleteSchema` to indicate delete schema forcefully or not, default is false
2. If delete schema forcefully, remove it from metastore and bookkeeper
3. Add test for force delete schema in `SchemaDeleteTest.schemaForceDeleteTest`

### Verifying this change


### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API: (yes / no)
  - The schema: (yes / no / don't know)
  - The default values of configurations: (yes / no)
  - The wire protocol: (yes / no)
  - The rest endpoints: (yes / no)
  - The admin cli options: (yes / no)
  - Anything that affects deployment: (yes / no / don't know)

### Documentation

Check the box below or label this PR directly (if you have committer privilege).

  
- [x] `no-need-doc` 
  



