### PR TITLE
[fix][broker]Fix NPE cause by duplicated removeSubscription

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -1051,12 +1051,14 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
 
     void removeSubscription(String subscriptionName) {
         PersistentSubscription sub = subscriptions.remove(subscriptionName);
-        if (sub != null) {
-            // preserve accumulative stats form removed subscription
-            SubscriptionStatsImpl stats = sub.getStats(false, false, false);
-            bytesOutFromRemovedSubscriptions.add(stats.bytesOutCounter);
-            msgOutFromRemovedSubscriptions.add(stats.msgOutCounter);
+        if (sub == null) {
+            log.warn("[{}][{}] Subscription is not existed.", topic, subscriptionName);
+            return;
         }
+        // preserve accumulative stats form removed subscription
+        SubscriptionStatsImpl stats = sub.getStats(false, false, false);
+        bytesOutFromRemovedSubscriptions.add(stats.bytesOutCounter);
+        msgOutFromRemovedSubscriptions.add(stats.msgOutCounter);
     }
 
     /**

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -1051,10 +1051,12 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
 
     void removeSubscription(String subscriptionName) {
         PersistentSubscription sub = subscriptions.remove(subscriptionName);
-        // preserve accumulative stats form removed subscription
-        SubscriptionStatsImpl stats = sub.getStats(false, false, false);
-        bytesOutFromRemovedSubscriptions.add(stats.bytesOutCounter);
-        msgOutFromRemovedSubscriptions.add(stats.msgOutCounter);
+        if (sub != null) {
+            // preserve accumulative stats form removed subscription
+            SubscriptionStatsImpl stats = sub.getStats(false, false, false);
+            bytesOutFromRemovedSubscriptions.add(stats.bytesOutCounter);
+            msgOutFromRemovedSubscriptions.add(stats.msgOutCounter);
+        }
     }
 
     /**


### PR DESCRIPTION
### Motivation
NPE when trying removeSubscription. 
 #14362 had solved it, But i think, it's safer to add a null check, avoid there may be other calls this method.
```
2022-03-10T18:34:44,240+0800 [pulsar-web-36-35] INFO  org.apache.pulsar.broker.service.persistent.PersistentSubscription - [persistent://pulsar/test/kafka-perf-test001.ys.diditaxi.com:8020/healthcheck][reader-b9d1f1f82a] Successfully disconnected and closed subscription
2022-03-10T18:34:44,240+0800 [pulsar-io-4-19] INFO  org.apache.pulsar.client.impl.ConnectionHandler - [persistent://pulsar/test/kafka-perf-test001.ys.diditaxi.com:8020/healthcheck] [reader-b9d1f1f82a] Closed connection [id: 0x50ecb987, L:/10.89.254.31:48326 - R:kafka-perf-test001.ys.diditaxi.com/10.89.254.31:8022] -- Will try again in 0.1 s
2022-03-10T18:34:44,241+0800 [pulsar-2-16] ERROR org.apache.bookkeeper.mledger.impl.ManagedLedgerImpl - Deleting cursor
org.apache.bookkeeper.mledger.ManagedLedgerException$CursorNotFoundException: ManagedCursor not found: reader-b9d1f1f82a
2022-03-10T18:34:44,241+0800 [pulsar-2-16] WARN  org.apache.pulsar.broker.service.persistent.PersistentSubscription - [persistent://pulsar/test/kafka-perf-test001.ys.diditaxi.com:8020/healthcheck] [reader-b9d1f1f82a] Failed to remove non durable cursor
org.apache.bookkeeper.mledger.ManagedLedgerException$CursorNotFoundException: ManagedCursor not found: reader-b9d1f1f82a
2022-03-10T18:34:44,241+0800 [pulsar-web-36-35] ERROR org.apache.pulsar.broker.service.persistent.PersistentSubscription - [persistent://pulsar/test/kafka-perf-test001.ys.diditaxi.com:8020/healthcheck][reader-b9d1f1f82a] Error deleting subscription
java.util.concurrent.CompletionException: java.lang.NullPointerException
        at java.util.concurrent.CompletableFuture.encodeThrowable(CompletableFuture.java:314) ~[?:?]
        at java.util.concurrent.CompletableFuture.uniComposeStage(CompletableFuture.java:1113) ~[?:?]
        at java.util.concurrent.CompletableFuture.thenCompose(CompletableFuture.java:2235) ~[?:?]
        at org.apache.pulsar.broker.service.persistent.PersistentSubscription.delete(PersistentSubscription.java:852) ~[org.apache.pulsar-pulsar-broker-2.10.0.jar:2.10.0]
        at org.apache.pulsar.broker.service.persistent.PersistentSubscription.deleteForcefully(PersistentSubscription.java:815) ~[org.apache.pulsar-pulsar-broker-2.10.0.jar:2.10.0]
        at java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:195) ~[?:?]
        at java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1654) ~[?:?]
        at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:484) ~[?:?]
        at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:474) ~[?:?]
        at java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:913) ~[?:?]
        at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234) ~[?:?]
        at java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:578) ~[?:?]
        at org.apache.pulsar.broker.admin.impl.BrokersBase.lambda$internalRunHealthCheck$19(BrokersBase.java:356) ~[org.apache.pulsar-pulsar-broker-2.10.0.jar:2.10.0]
        at java.util.concurrent.CompletableFuture.uniComposeStage(CompletableFuture.java:1106) ~[?:?]
        at java.util.concurrent.CompletableFuture.thenCompose(CompletableFuture.java:2235) ~[?:?]
        at org.apache.pulsar.broker.admin.impl.BrokersBase.internalRunHealthCheck(BrokersBase.java:347) ~[org.apache.pulsar-pulsar-broker-2.10.0.jar:2.10.0]
        at org.apache.pulsar.broker.admin.impl.BrokersBase.lambda$healthCheck$15(BrokersBase.java:326) ~[org.apache.pulsar-pulsar-broker-2.10.0.jar:2.10.0]
        at java.util.concurrent.CompletableFuture.uniComposeStage(CompletableFuture.java:1106) ~[?:?]
        at java.util.concurrent.CompletableFuture.thenCompose(CompletableFuture.java:2235) ~[?:?]
        at org.apache.pulsar.broker.admin.impl.BrokersBase.healthCheck(BrokersBase.java:326) ~[org.apache.pulsar-pulsar-broker-2.10.0.jar:2.10.0]
        at jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[?:?]
        at jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62) ~[?:?]
        at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:?]
        at java.lang.reflect.Method.invoke(Method.java:566) ~[?:?]
        at org.glassfish.jersey.server.model.internal.ResourceMethodInvocationHandlerFactory.lambda$static$0(ResourceMethodInvocationHandlerFactory.java:52) ~[org.glassfish.jersey.core-jersey-server-2.34.jar:?]
        at org.glassfish.jersey.server.model.internal.AbstractJavaResourceMethodDispatcher$1.run(AbstractJavaResourceMethodDispatcher.java:124) ~[org.glassfish.jersey.core-jersey-server-2.34.jar:?]
        at org.glassfish.jersey.server.model.internal.AbstractJavaResourceMethodDispatcher.invoke(AbstractJavaResourceMethodDispatcher.java:167) ~[org.glassfish.jersey.core-jersey-server-2.34.jar:?]
Caused by: java.lang.NullPointerException
        at org.apache.pulsar.broker.service.persistent.PersistentTopic.removeSubscription(PersistentTopic.java:1054) ~[org.apache.pulsar-pulsar-broker-2.10.0.jar:2.10.0]
        at org.apache.pulsar.broker.service.persistent.PersistentTopic$5.deleteCursorComplete(PersistentTopic.java:1030) ~[org.apache.pulsar-pulsar-broker-2.10.0.jar:2.10.0]
        at org.apache.bookkeeper.mledger.impl.ManagedLedgerImpl.asyncDeleteCursor(ManagedLedgerImpl.java:970) ~[org.apache.pulsar-managed-ledger-2.10.0.jar:2.10.0]
        at org.apache.pulsar.broker.service.persistent.PersistentTopic.asyncDeleteCursor(PersistentTopic.java:1024) ~[org.apache.pulsar-pulsar-broker-2.10.0.jar:2.10.0]
        at org.apache.pulsar.broker.service.persistent.PersistentTopic.unsubscribe(PersistentTopic.java:1017) ~[org.apache.pulsar-pulsar-broker-2.10.0.jar:2.10.0]
        at org.apache.pulsar.broker.service.persistent.PersistentSubscription.lambda$delete$19(PersistentSubscription.java:852) ~[org.apache.pulsar-pulsar-broker-2.10.0.jar:2.10.0]
```
This cause by when trying `doUnsubscribe`,  if a cursor is nondurable, both `consumer.close()` and `delete()` will try to  invoke `removeSubscription`. this will cause NPE.
```
@Override
    public CompletableFuture<Void> doUnsubscribe(Consumer consumer) {
        CompletableFuture<Void> future = new CompletableFuture<>();
        try {
            if (dispatcher.canUnsubscribe(consumer)) {
                consumer.close();
                return delete();
            }
            future.completeExceptionally(
                    new ServerMetadataException("Unconnected or shared consumer attempting to unsubscribe"));
        } catch (BrokerServiceException e) {
            log.warn("Error removing consumer {}", consumer);
            future.completeExceptionally(e);
        }
        return future;
    }
```
### Modifications

remove  `removeSubscription`  in method `consumer.close()` if cursor is nondurable.



### Documentation

Check the box below or label this PR directly (if you have committer privilege).

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)


