### PR TITLE
Fix Flaky-test: SubscriptionSeekTest.testShouldCloseAllConsumersForMultipleConsumerDispatcherWhenSeek

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/SubscriptionSeekTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/SubscriptionSeekTest.java
@@ -560,7 +560,7 @@ public class SubscriptionSeekTest extends BrokerTestBase {
                 .subscriptionName("my-subscription")
                 .subscribe();
 
-        pulsarClient.newConsumer()
+        org.apache.pulsar.client.api.Consumer<byte[]> consumer2 = pulsarClient.newConsumer()
                 .topic(topicName)
                 .subscriptionType(SubscriptionType.Shared)
                 .subscriptionName("my-subscription")
@@ -579,6 +579,7 @@ public class SubscriptionSeekTest extends BrokerTestBase {
         consumer1.seek(MessageId.earliest);
         // Wait for consumer to reconnect
         Awaitility.await().until(consumer1::isConnected);
+        Awaitility.await().until(consumer2::isConnected);
 
         consumers = topicRef.getSubscriptions().get("my-subscription").getConsumers();
         assertEquals(consumers.size(), 2);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/SubscriptionSeekTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/SubscriptionSeekTest.java
@@ -586,6 +586,8 @@ public class SubscriptionSeekTest extends BrokerTestBase {
         for (Consumer consumer : consumers) {
             assertFalse(connectedSinceSet.contains(consumer.getStats().getConnectedSince()));
         }
+        consumer1.close();
+        consumer2.close();
     }
 
     @Test


### PR DESCRIPTION
### Motivation

#11703

When `conumser1` call seek, need wait for `conumser2` also reconnect success, then assert.


### Modifications
- add wait for `conumser2` reconnect.

### Documentation
- [x] `no-need-doc` 
