### PR TITLE
Fixed 404 error msg not being returned correctly using http lookup.

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/RestException.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/RestException.java
@@ -49,7 +49,7 @@ public class RestException extends WebApplicationException {
     }
 
     public RestException(int code, String message) {
-        super(message, Response.status(code).entity(new ErrorData(message)).type(MediaType.APPLICATION_JSON).build());
+        super(message, Response.status(code, message).entity(new ErrorData(message)).type(MediaType.APPLICATION_JSON).build());
     }
 
     public RestException(Throwable t) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/RestException.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/RestException.java
@@ -49,7 +49,11 @@ public class RestException extends WebApplicationException {
     }
 
     public RestException(int code, String message) {
-        super(message, Response.status(code, message).entity(new ErrorData(message)).type(MediaType.APPLICATION_JSON).build());
+        super(message, Response
+                .status(code, message)
+                .entity(new ErrorData(message))
+                .type(MediaType.APPLICATION_JSON)
+                .build());
     }
 
     public RestException(Throwable t) {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentTopicE2ETest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentTopicE2ETest.java
@@ -1880,4 +1880,17 @@ public class PersistentTopicE2ETest extends BrokerTestBase {
 
         assertEquals(admin.topics().getStats(topicName).getPublishers().size(), 1);
     }
+
+    @Test
+    public void testHttpLookupWithNotFoundError() throws Exception {
+        stopBroker();
+        isTcpLookup = false;
+        setup();
+        try {
+            pulsarClient.newProducer().topic("unknownTenant/unknownNamespace/testNamespaceNotFound").create();
+        } catch (Exception ex) {
+            assertTrue(ex instanceof PulsarClientException.NotFoundException);
+            assertTrue(ex.getMessage().contains("Namespace not found"));
+        }
+    }
 }


### PR DESCRIPTION
### Motivation
When returning a 404 error using http-lookup, it doesn't prompt the correct message to user.  below is a demo:
```
@Test
public void testHttpLookupWithNotFoundError() throws Exception {
     # Try to create a topic before namespace is created
     pulsarClient.newProducer().topic("unknownTenant/unknownNamespace/testNamespaceNotFound").create();
}
```
It will throw :
```
org.apache.pulsar.client.api.PulsarClientException$NotFoundException: Not found: Not Found
```
In this case, we should return `Not found: Namespace not found`.

The root cause is : when HTTP lookup with 404, we get the message from StatusText.

https://github.com/apache/pulsar/blob/d02bd7378acd1f202d8bcf50aa6999749e61b20b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/HttpClient.java#L206-L216

But we only set status,no statusText in RestException:
https://github.com/apache/pulsar/blob/d02bd7378acd1f202d8bcf50aa6999749e61b20b/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/RestException.java#L51-L53

### Documentation
  
- [x] `no-need-doc` 



