### PR TITLE
[Performance] Optimize PositionImpl toString, compareTo and hashCode methods

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/PositionImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/PositionImpl.java
@@ -18,9 +18,6 @@
  */
 package org.apache.bookkeeper.mledger.impl;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-import com.google.common.base.Objects;
-import com.google.common.collect.ComparisonChain;
 import org.apache.bookkeeper.mledger.Position;
 import org.apache.bookkeeper.mledger.proto.MLDataFormats.NestedPositionInfo;
 import org.apache.bookkeeper.mledger.proto.MLDataFormats.PositionInfo;
@@ -102,20 +99,27 @@ public class PositionImpl implements Position, Comparable<PositionImpl> {
      */
     @Override
     public String toString() {
-        return String.format("%d:%d", ledgerId, entryId);
+        return ledgerId + ":" + entryId;
     }
 
     @Override
-    public int compareTo(PositionImpl other) {
-        checkNotNull(other);
+    public int compareTo(PositionImpl that) {
+        if (this.ledgerId != that.ledgerId) {
+            return (this.ledgerId < that.ledgerId ? -1 : 1);
+        }
 
-        return ComparisonChain.start().compare(this.ledgerId, other.ledgerId).compare(this.entryId, other.entryId)
-                .result();
+        if (this.entryId != that.entryId) {
+            return (this.entryId < that.entryId ? -1 : 1);
+        }
+
+        return 0;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hashCode(ledgerId, entryId);
+        int result = (int) (ledgerId ^ (ledgerId >>> 32));
+        result = 31 * result + (int) (entryId ^ (entryId >>> 32));
+        return result;
     }
 
     @Override


### PR DESCRIPTION
### Motivation

PositionImpl's toString, compareTo and hashCode methods aren't consistent with the style of performance optimized code used in Pulsar in a lot of hotspots. 
- `String.format` should be avoided in any performance optimized code. 
- `compareTo` was using Guava's ComparisonChain which creates object instances. It's better to avoid it in this case.
- `Objects.hashCode` creates a new array instance on each call. that can be avoided.

### Modifications

- refactor `toString`, `compareTo` and `hashCode` methods to minimize object allocations