### PR TITLE
[Performance] Optimize comparisons by replacing ComparisonChain in hotspots

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/EntryImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/EntryImpl.java
@@ -19,7 +19,6 @@
 package org.apache.bookkeeper.mledger.impl;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.ComparisonChain;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.util.Recycler;
@@ -149,7 +148,15 @@ public final class EntryImpl extends AbstractCASReferenceCounted implements Entr
 
     @Override
     public int compareTo(EntryImpl other) {
-        return ComparisonChain.start().compare(ledgerId, other.ledgerId).compare(entryId, other.entryId).result();
+        if (this.ledgerId != other.ledgerId) {
+            return this.ledgerId < other.ledgerId ? -1 : 1;
+        }
+
+        if (this.entryId != other.entryId) {
+            return this.entryId < other.entryId ? -1 : 1;
+        }
+
+        return 0;
     }
 
     @Override

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
@@ -30,7 +30,6 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Predicate;
 import com.google.common.collect.Collections2;
-import com.google.common.collect.ComparisonChain;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Range;
@@ -41,6 +40,7 @@ import java.time.Clock;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -102,7 +102,17 @@ import org.slf4j.LoggerFactory;
 
 @SuppressWarnings("checkstyle:javadoctype")
 public class ManagedCursorImpl implements ManagedCursor {
+    private static final Comparator<Entry> ENTRY_COMPARATOR = (e1, e2) -> {
+        if (e1.getLedgerId() != e2.getLedgerId()) {
+            return e1.getLedgerId() < e2.getLedgerId() ? -1 : 1;
+        }
 
+        if (e1.getEntryId() != e2.getEntryId()) {
+            return e1.getEntryId() < e2.getEntryId() ? -1 : 1;
+        }
+
+        return 0;
+    };
     protected final BookKeeper bookkeeper;
     protected final ManagedLedgerConfig config;
     protected final ManagedLedgerImpl ledger;
@@ -1275,9 +1285,7 @@ public class ManagedCursorImpl implements ManagedCursor {
                     entries.add(entry);
                     if (--pendingCallbacks == 0) {
                         if (sortEntries) {
-                            entries.sort((e1, e2) -> ComparisonChain.start()
-                                    .compare(e1.getLedgerId(), e2.getLedgerId())
-                                    .compare(e1.getEntryId(), e2.getEntryId()).result());
+                            entries.sort(ENTRY_COMPARATOR);
                         }
                         callback.readEntriesComplete(entries, ctx);
                     }

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/util/PositionAckSetUtil.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/util/PositionAckSetUtil.java
@@ -18,7 +18,6 @@
  */
 package org.apache.bookkeeper.mledger.util;
 
-import com.google.common.collect.ComparisonChain;
 import org.apache.bookkeeper.mledger.impl.PositionImpl;
 import org.apache.pulsar.common.util.collections.BitSetRecyclable;
 
@@ -62,9 +61,7 @@ public class PositionAckSetUtil {
             throw new IllegalArgumentException("Two positions can't be null! "
                     + "current position : [" + currentPosition + "] other position : [" + otherPosition + "]");
         }
-        int result = ComparisonChain.start().compare(currentPosition.getLedgerId(),
-                otherPosition.getLedgerId()).compare(currentPosition.getEntryId(), otherPosition.getEntryId())
-                .result();
+        int result = currentPosition.compareTo(otherPosition);
         if (result == 0) {
             BitSetRecyclable otherAckSet;
             BitSetRecyclable currentAckSet;

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/util/collections/LongPairRangeSet.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/util/collections/LongPairRangeSet.java
@@ -18,7 +18,6 @@
  */
 package org.apache.pulsar.common.util.collections;
 
-import com.google.common.collect.ComparisonChain;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Range;
 import com.google.common.collect.RangeSet;
@@ -176,13 +175,21 @@ public interface LongPairRangeSet<T extends Comparable<T>> {
         }
 
         @Override
-        public int compareTo(LongPair o) {
-            return ComparisonChain.start().compare(key, o.getKey()).compare(value, o.getValue()).result();
+        public int compareTo(LongPair that) {
+            if (this.key != that.key) {
+                return this.key < that.key ? -1 : 1;
+            }
+
+            if (this.value != that.value) {
+                return this.value < that.value ? -1 : 1;
+            }
+
+            return 0;
         }
 
         @Override
         public String toString() {
-            return String.format("%d:%d", key, value);
+            return key + ":" + value;
         }
     }
 


### PR DESCRIPTION
### Motivation

The use of Guava's ComparisonChain isn't consistent with the style of performance optimized code used in Pulsar in hotspots. There's usually a strict goal to minimize object allocations.

- remove ComparisonChain from some hotspots since ComparisonChain creates object instances when it is used

### Modifications

- replace ComparisonChain usage with plain Java code