### PR TITLE
Change "Could not split namespace bundle" logging level to debug

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/BundleSplitterTask.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/BundleSplitterTask.java
@@ -94,9 +94,11 @@ public class BundleSplitterTask implements BundleSplitStrategy {
                         if (bundleCount < maxBundleCount) {
                             bundleCache.add(bundle);
                         } else {
-                            log.info(
-                                    "Could not split namespace bundle {} because namespace {} has too many bundles: {}",
-                                    bundle, namespace, bundleCount);
+                            if (log.isDebugEnabled()) {
+                                log.debug(
+                                        "Could not split namespace bundle {} because namespace {} has too many bundles:"
+                                                + "{}", bundle, namespace, bundleCount);
+                            }
                         }
                     } catch (Exception e) {
                         log.warn("Error while getting bundle count for namespace {}", namespace, e);


### PR DESCRIPTION
### Motivation

See #14635. In that PR, you can see that this log line was written of 150k times in a 15 minute period. While the log line might be informative, I think it is too expensive to log this frequently. I propose changing it to debug.

### Modifications

* Change to `DEBUG` log level.

### Verifying this change

Trivial change.

