### PR TITLE
Fix error setMetadataServiceUri

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/PulsarClusterMetadataSetup.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/PulsarClusterMetadataSetup.java
@@ -244,8 +244,8 @@ public class PulsarClusterMetadataSetup {
         // Format BookKeeper ledger storage metadata
         if (arguments.existingBkMetadataServiceUri == null && arguments.bookieMetadataServiceUri == null) {
             ServerConfiguration bkConf = new ServerConfiguration();
-            bkConf.setMetadataServiceUri("metadata-store:"
-                    + arguments.metadataStoreUrl.replace(",", ";"));
+            bkConf.setDelimiterParsingDisabled(true);
+            bkConf.setMetadataServiceUri("metadata-store:" + arguments.metadataStoreUrl);
             bkConf.setZkTimeout(arguments.zkSessionTimeoutMillis);
             // only format if /ledgers doesn't exist
             if (!localStore.exists(BookKeeperConstants.DEFAULT_ZK_LEDGERS_ROOT_PATH).get()

--- a/pulsar-broker/src/main/java/org/apache/pulsar/PulsarClusterMetadataSetup.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/PulsarClusterMetadataSetup.java
@@ -244,7 +244,8 @@ public class PulsarClusterMetadataSetup {
         // Format BookKeeper ledger storage metadata
         if (arguments.existingBkMetadataServiceUri == null && arguments.bookieMetadataServiceUri == null) {
             ServerConfiguration bkConf = new ServerConfiguration();
-            bkConf.setMetadataServiceUri("metadata-store:" + metadataStoreUrlNoIdentifer);
+            bkConf.setMetadataServiceUri("metadata-store:"
+                    + arguments.metadataStoreUrl.replace(",", ";"));
             bkConf.setZkTimeout(arguments.zkSessionTimeoutMillis);
             // only format if /ledgers doesn't exist
             if (!localStore.exists(BookKeeperConstants.DEFAULT_ZK_LEDGERS_ROOT_PATH).get()

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/bookkeeper/AbstractMetadataDriver.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/bookkeeper/AbstractMetadataDriver.java
@@ -98,7 +98,9 @@ public abstract class AbstractMetadataDriver implements Closeable {
 
             String url;
             try {
-                url = conf.getMetadataServiceUri().replaceFirst(METADATA_STORE_SCHEME + ":", "");
+                url = conf.getMetadataServiceUri()
+                        .replaceFirst(METADATA_STORE_SCHEME + ":", "")
+                        .replace(";", ",");
             } catch (Exception e) {
                 throw new MetadataException(Code.METADATA_SERVICE_ERROR, e);
             }


### PR DESCRIPTION
### Motivation
1、BK `setMetadataServiceUri ` will set a ArrayList, If a string with comma delimiter. eg `zk1:2181,zk2:2181/test` will get result `["zk1:2181", "zk2:2181/test"]`

getMetadataServiceUri only return the first part in list `zk1:2181`.

2、If you set `metadataServiceUri` in bk conf with  semicolon, like  `zk1:2181;zk2:2181/test`, without replace  semicolon with comma.  metadataStore will be failed created.

### Modifications
Replace   comma  with semicolon in ZK connection string when set `setMetadataServiceUri`.
Then replace semicolon with comma  when metadata store created.

### Documentation

Check the box below or label this PR directly (if you have committer privilege).

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)


