### PR TITLE
[fix][deploy]: fix the pid occupied check when use pulsar-daemon start or stop process

### DIFF
--- a/bin/pulsar-daemon
+++ b/bin/pulsar-daemon
@@ -141,7 +141,7 @@ rotate_out_log ()
 start ()
 {
   if [ -f $pid ]; then
-      if kill -0 `cat $pid` > /dev/null 2>&1; then
+      if ps -p `cat $pid` > /dev/null 2>&1; then
         echo $command running as process `cat $pid`.  Stop it first.
         exit 1
       fi
@@ -164,7 +164,7 @@ stop ()
 {
   if [ -f $pid ]; then
       TARGET_PID=$(cat $pid)
-      if kill -0 $TARGET_PID > /dev/null 2>&1; then
+      if ps -p $TARGET_PID > /dev/null 2>&1; then
         echo "stopping $command"
         kill $TARGET_PID
 
@@ -185,7 +185,7 @@ stop ()
             echo "Shutdown completed."
         fi
 
-        if kill -0 $TARGET_PID > /dev/null 2>&1; then
+        if ps -p $TARGET_PID > /dev/null 2>&1; then
               fileName=$location/$command.out
               $JAVA_HOME/bin/jstack $TARGET_PID > $fileName
               echo "Thread dumps are taken for analysis at $fileName"


### PR DESCRIPTION
Master Issue: #14700

Fixes: #14700

### Motivation
Fix the failed pid occupied check. we'll fail when use pulsar-daemon start or stop process, after the last time we exit the process direct kill or the progress occurred non-normal exit, then the bin/pulsar-broker.pid are retained, and the pid in the file is occupied by the thread in other progress.

### Modifications
Change the pid occupied check from 'kill -0 $pid' to 'ps -p $pid'. The both will return true when the pid is occupied by one progress, but 'kill -0 $pid' will return true and the 'ps -p $pid' will return false  when the pid  is occupied by one progress's sub thread.


Need to update docs? 
  
- [X] `no-need-doc` 
  


