### PR TITLE
[PulsarAdmin] add get active brokers api without cluster name

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/BrokersBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/BrokersBase.java
@@ -106,6 +106,30 @@ public class BrokersBase extends AdminResource {
     }
 
     @GET
+    @Path("/")
+    @ApiOperation(
+            value = "Get the list of active brokers (web service addresses) in the local cluster."
+                    + "If authorization is not enabled",
+            response = String.class,
+            responseContainer = "Set")
+    @ApiResponses(
+            value = {
+                    @ApiResponse(code = 401, message = "Authentication required"),
+                    @ApiResponse(code = 403, message = "This operation requires super-user access") })
+    public void getActiveBrokers(@Suspended final AsyncResponse asyncResponse) throws Exception {
+        validateSuperUserAccessAsync()
+                .thenCompose(__ -> pulsar().getLoadManager().get().getAvailableBrokersAsync())
+                .thenAccept(activeBrokers -> {
+                    LOG.info("[{}] Successfully to get active brokers", clientAppId());
+                    asyncResponse.resume(activeBrokers);
+                }).exceptionally(ex -> {
+                    LOG.error("[{}] Fail to get active brokers", clientAppId(), ex);
+                    resumeAsyncResponseExceptionally(asyncResponse, ex);
+                    return null;
+                });
+    }
+
+    @GET
     @Path("/leaderBroker")
     @ApiOperation(
             value = "Get the information of the leader broker.",

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/BrokersBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/BrokersBase.java
@@ -90,8 +90,7 @@ public class BrokersBase extends AdminResource {
     public void getActiveBrokers(@Suspended final AsyncResponse asyncResponse,
                                  @PathParam("cluster") String cluster) {
         validateSuperUserAccessAsync()
-                .thenCompose(__ -> cluster == null ? CompletableFuture.completedFuture(null)
-                        : validateClusterOwnershipAsync(cluster))
+                .thenCompose(__ -> validateClusterOwnershipAsync(cluster))
                 .thenCompose(__ -> pulsar().getLoadManager().get().getAvailableBrokersAsync())
                 .thenAccept(activeBrokers -> {
                     LOG.info("[{}] Successfully to get active brokers, cluster={}", clientAppId(), cluster);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/BrokersBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/BrokersBase.java
@@ -106,7 +106,6 @@ public class BrokersBase extends AdminResource {
     }
 
     @GET
-    @Path("/")
     @ApiOperation(
             value = "Get the list of active brokers (web service addresses) in the local cluster."
                     + "If authorization is not enabled",

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiTest.java
@@ -468,6 +468,10 @@ public class AdminApiTest extends MockedPulsarServiceBaseTest {
         Assert.assertNotNull(list);
         Assert.assertEquals(list.size(), 1);
 
+        List<String> list1 = admin.brokers().getActiveBrokers();
+        Assert.assertNotNull(list1);
+        Assert.assertEquals(list1.size(), 1);
+
         List<String> list2 = otheradmin.brokers().getActiveBrokers("test");
         Assert.assertNotNull(list2);
         Assert.assertEquals(list2.size(), 1);

--- a/pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/admin/Brokers.java
+++ b/pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/admin/Brokers.java
@@ -33,6 +33,41 @@ import org.apache.pulsar.common.policies.data.NamespaceOwnershipStatus;
  */
 public interface Brokers {
     /**
+     * Get the list of active brokers in the local cluster.
+     * <p/>
+     * Get the list of active brokers (web service addresses) in the local cluster.
+     * <p/>
+     * Response Example:
+     *
+     * <pre>
+     * <code>["prod1-broker1.messaging.use.example.com:8080", "prod1-broker2.messaging.use.example.com:8080"
+     * * * "prod1-broker3.messaging.use.example.com:8080"]</code>
+     * </pre>
+     *
+     * @return a list of (host:port)
+     * @throws NotAuthorizedException
+     *             You don't have admin permission to get the list of active brokers in the cluster
+     * @throws PulsarAdminException
+     *             Unexpected error
+     */
+    List<String> getActiveBrokers() throws PulsarAdminException;
+
+    /**
+     * Get the list of active brokers in the local cluster asynchronously.
+     * <p/>
+     * Get the list of active brokers (web service addresses) in the local cluster.
+     * <p/>
+     * Response Example:
+     *
+     * <pre>
+     * <code>["prod1-broker1.messaging.use.example.com:8080", "prod1-broker2.messaging.use.example.com:8080",
+     * "prod1-broker3.messaging.use.example.com:8080"]</code>
+     * </pre>
+     *
+     * @return a list of (host:port)
+     */
+    CompletableFuture<List<String>> getActiveBrokersAsync();
+    /**
      * Get the list of active brokers in the cluster.
      * <p/>
      * Get the list of active brokers (web service addresses) in the cluster.

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/BrokersImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/BrokersImpl.java
@@ -43,13 +43,23 @@ public class BrokersImpl extends BaseResource implements Brokers {
     }
 
     @Override
+    public List<String> getActiveBrokers() throws PulsarAdminException {
+        return sync(() -> getActiveBrokersAsync(null));
+    }
+
+    @Override
+    public CompletableFuture<List<String>> getActiveBrokersAsync() {
+        return getActiveBrokersAsync(null);
+    }
+
+    @Override
     public List<String> getActiveBrokers(String cluster) throws PulsarAdminException {
         return sync(() -> getActiveBrokersAsync(cluster));
     }
 
     @Override
     public CompletableFuture<List<String>> getActiveBrokersAsync(String cluster) {
-        WebTarget path = adminBrokers.path(cluster);
+        WebTarget path = cluster == null ? adminBrokers : adminBrokers.path(cluster);
         final CompletableFuture<List<String>> future = new CompletableFuture<>();
         asyncGetRequest(path,
                 new InvocationCallback<List<String>>() {

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdBrokers.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdBrokers.java
@@ -29,12 +29,12 @@ public class CmdBrokers extends CmdBase {
 
     @Parameters(commandDescription = "List active brokers of the cluster")
     private class List extends CliCommand {
-        @Parameter(description = "cluster-name", required = true)
+        @Parameter(description = "cluster-name")
         private java.util.List<String> params;
 
         @Override
         void run() throws Exception {
-            String cluster = getOneArgument(params);
+            String cluster = params == null ? null : getOneArgument(params);
             print(getAdmin().brokers().getActiveBrokers(cluster));
         }
     }

--- a/site2/docs/admin-api-brokers.md
+++ b/site2/docs/admin-api-brokers.md
@@ -33,7 +33,32 @@ In addition to being configurable when you start them up, brokers can also be [d
 
 ### List active brokers
 
-Fetch all available active brokers that are serving traffic.
+Fetch all available active brokers that are serving traffic for local cluster .
+
+<!--DOCUSAURUS_CODE_TABS-->
+<!--pulsar-admin-->
+
+```shell
+$ pulsar-admin brokers list
+```
+
+```
+broker1.use.org.com:8080
+```
+
+<!--REST API-->
+
+{@inject: endpoint|GET|/admin/v2/brokers|operation/getActiveBrokers?version=[[pulsar:version_number]]}
+
+<!--JAVA-->
+
+```java
+admin.brokers().getActiveBrokers()
+```
+
+<!--END_DOCUSAURUS_CODE_TABS-->
+
+Fetch all available active brokers that are serving traffic with cluster name.
 
 <!--DOCUSAURUS_CODE_TABS-->
 <!--pulsar-admin-->

--- a/site2/docs/reference-pulsar-admin.md
+++ b/site2/docs/reference-pulsar-admin.md
@@ -142,6 +142,13 @@ Usage
 $ pulsar-admin brokers list cluster-name
 ```
 
+List active brokers of the local cluster
+
+Usage
+```bash
+$ pulsar-admin brokers list
+```
+
 ### `leader-broker`
 Get the information of the leader broker
 

--- a/site2/docs/reference-pulsar-admin.md
+++ b/site2/docs/reference-pulsar-admin.md
@@ -142,13 +142,6 @@ Usage
 $ pulsar-admin brokers list cluster-name
 ```
 
-List active brokers of the local cluster
-
-Usage
-```bash
-$ pulsar-admin brokers list
-```
-
 ### `leader-broker`
 Get the information of the leader broker
 


### PR DESCRIPTION
### Motivation
In order to list brokers in cluster, we need pass cluster name to admin api, although we only have one local cluster.
In case of get the broker list for local cluster, we could ignore the cluster name just like other admin api.

### Modifications
Add admin api to get broker list for local cluster without cluster name.

### Verifying this change
This change added tests and can be verified as follows:
AdminApiTest

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*
  - The public API: (yes)
  - The admin cli options: (yes)

### Documentation

Check the box below or label this PR directly (if you have committer privilege).

Need to update docs? 
- [x] `doc` 
