### PR TITLE
Process maxRedeliverCount is 0 of DeadLeddterPolicy

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBuilderImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBuilderImpl.java
@@ -438,11 +438,7 @@ public class ConsumerBuilderImpl<T> implements ConsumerBuilder<T> {
                 conf.setAckTimeoutMillis(DEFAULT_ACK_TIMEOUT_MILLIS_FOR_DEAD_LETTER);
             }
 
-            // when MaxRedeliverCount <= 0 in DeadLetterPolicy, we reset MaxRedeliverCount
-            // to default value, Default: 16.
-            if (deadLetterPolicy.getMaxRedeliverCount() <= 0) {
-                deadLetterPolicy.setMaxRedeliverCount(RetryMessageUtil.MAX_RECONSUMETIMES);
-            }
+            checkArgument(deadLetterPolicy.getMaxRedeliverCount() > 0, "MaxRedeliverCount must not be > 0.");
             conf.setDeadLetterPolicy(deadLetterPolicy);
         }
         return this;

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBuilderImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBuilderImpl.java
@@ -161,7 +161,8 @@ public class ConsumerBuilderImpl<T> implements ConsumerBuilder<T> {
                                 // when MaxRedeliverCount <= 0 in DeadLetterPolicy, we reset MaxRedeliverCount
                                 // to default value, Default: 16.
                                 if (deadLetterPolicy.getMaxRedeliverCount() <= 0) {
-                                    conf.getDeadLetterPolicy().setMaxRedeliverCount(RetryMessageUtil.MAX_RECONSUMETIMES);
+                                    conf.getDeadLetterPolicy().setMaxRedeliverCount(
+                                            RetryMessageUtil.MAX_RECONSUMETIMES);
                                 }
                             }
                             conf.getTopicNames().add(conf.getDeadLetterPolicy().getRetryLetterTopic());

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBuilderImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBuilderImpl.java
@@ -158,6 +158,11 @@ public class ConsumerBuilderImpl<T> implements ConsumerBuilder<T> {
                                 if (StringUtils.isBlank(deadLetterPolicy.getDeadLetterTopic())) {
                                     conf.getDeadLetterPolicy().setDeadLetterTopic(deadLetterTopic);
                                 }
+                                // when MaxRedeliverCount <= 0 in DeadLetterPolicy, we reset MaxRedeliverCount
+                                // to default value, Default: 16.
+                                if (deadLetterPolicy.getMaxRedeliverCount() <= 0) {
+                                    conf.getDeadLetterPolicy().setMaxRedeliverCount(RetryMessageUtil.MAX_RECONSUMETIMES);
+                                }
                             }
                             conf.getTopicNames().add(conf.getDeadLetterPolicy().getRetryLetterTopic());
                         });

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBuilderImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBuilderImpl.java
@@ -158,12 +158,6 @@ public class ConsumerBuilderImpl<T> implements ConsumerBuilder<T> {
                                 if (StringUtils.isBlank(deadLetterPolicy.getDeadLetterTopic())) {
                                     conf.getDeadLetterPolicy().setDeadLetterTopic(deadLetterTopic);
                                 }
-                                // when MaxRedeliverCount <= 0 in DeadLetterPolicy, we reset MaxRedeliverCount
-                                // to default value, Default: 16.
-                                if (deadLetterPolicy.getMaxRedeliverCount() <= 0) {
-                                    conf.getDeadLetterPolicy().setMaxRedeliverCount(
-                                            RetryMessageUtil.MAX_RECONSUMETIMES);
-                                }
                             }
                             conf.getTopicNames().add(conf.getDeadLetterPolicy().getRetryLetterTopic());
                         });
@@ -442,6 +436,12 @@ public class ConsumerBuilderImpl<T> implements ConsumerBuilder<T> {
         if (deadLetterPolicy != null) {
             if (conf.getAckTimeoutMillis() == 0) {
                 conf.setAckTimeoutMillis(DEFAULT_ACK_TIMEOUT_MILLIS_FOR_DEAD_LETTER);
+            }
+
+            // when MaxRedeliverCount <= 0 in DeadLetterPolicy, we reset MaxRedeliverCount
+            // to default value, Default: 16.
+            if (deadLetterPolicy.getMaxRedeliverCount() <= 0) {
+                deadLetterPolicy.setMaxRedeliverCount(RetryMessageUtil.MAX_RECONSUMETIMES);
             }
             conf.setDeadLetterPolicy(deadLetterPolicy);
         }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBuilderImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBuilderImpl.java
@@ -438,7 +438,7 @@ public class ConsumerBuilderImpl<T> implements ConsumerBuilder<T> {
                 conf.setAckTimeoutMillis(DEFAULT_ACK_TIMEOUT_MILLIS_FOR_DEAD_LETTER);
             }
 
-            checkArgument(deadLetterPolicy.getMaxRedeliverCount() > 0, "MaxRedeliverCount must not be > 0.");
+            checkArgument(deadLetterPolicy.getMaxRedeliverCount() > 0, "MaxRedeliverCount must be > 0.");
             conf.setDeadLetterPolicy(deadLetterPolicy);
         }
         return this;

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/ConsumerBuilderImplTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/ConsumerBuilderImplTest.java
@@ -18,7 +18,12 @@
  */
 package org.apache.pulsar.client.impl;
 
-import org.apache.pulsar.client.api.*;
+import org.apache.pulsar.client.api.BatchReceivePolicy;
+import org.apache.pulsar.client.api.Consumer;
+import org.apache.pulsar.client.api.PulsarClientException;
+import org.apache.pulsar.client.api.Schema;
+import org.apache.pulsar.client.api.SubscriptionInitialPosition;
+import org.apache.pulsar.client.api.SubscriptionMode;
 import org.apache.pulsar.client.impl.conf.ConsumerConfigurationData;
 import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/ConsumerBuilderImplTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/ConsumerBuilderImplTest.java
@@ -20,6 +20,7 @@ package org.apache.pulsar.client.impl;
 
 import org.apache.pulsar.client.api.BatchReceivePolicy;
 import org.apache.pulsar.client.api.Consumer;
+import org.apache.pulsar.client.api.DeadLetterPolicy;
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.client.api.SubscriptionInitialPosition;

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/ConsumerBuilderImplTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/ConsumerBuilderImplTest.java
@@ -18,12 +18,7 @@
  */
 package org.apache.pulsar.client.impl;
 
-import org.apache.pulsar.client.api.BatchReceivePolicy;
-import org.apache.pulsar.client.api.Consumer;
-import org.apache.pulsar.client.api.PulsarClientException;
-import org.apache.pulsar.client.api.Schema;
-import org.apache.pulsar.client.api.SubscriptionInitialPosition;
-import org.apache.pulsar.client.api.SubscriptionMode;
+import org.apache.pulsar.client.api.*;
 import org.apache.pulsar.client.impl.conf.ConsumerConfigurationData;
 import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
@@ -286,6 +281,15 @@ public class ConsumerBuilderImplTest {
                 .maxNumMessages(0)
                 .maxNumBytes(0)
                 .timeout(0, TimeUnit.MILLISECONDS)
+                .build());
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testRedeliverCountOfDeadLetterPolicy() {
+        consumerBuilderImpl.deadLetterPolicy(DeadLetterPolicy.builder()
+                .maxRedeliverCount(0)
+                .deadLetterTopic("test-dead-letter-topic")
+                .retryLetterTopic("test-retry-letter-topic")
                 .build());
     }
 

--- a/pulsar-websocket/src/test/java/org/apache/pulsar/websocket/AbstractWebSocketHandlerTest.java
+++ b/pulsar-websocket/src/test/java/org/apache/pulsar/websocket/AbstractWebSocketHandlerTest.java
@@ -368,11 +368,12 @@ public class AbstractWebSocketHandlerTest {
         consumerHandler.clearQueryParams();
         consumerHandler.putQueryParam("receiverQueueSize", "1001");
         consumerHandler.putQueryParam("deadLetterTopic", "dead-letter-topic");
+        consumerHandler.putQueryParam("maxRedeliverCount", "3");
 
         conf = consumerHandler.getConf();
         // receive queue size is the minimum value of default value (1000) and user defined value(1001)
         assertEquals(conf.getReceiverQueueSize(), 1000);
         assertEquals(conf.getDeadLetterPolicy().getDeadLetterTopic(), "dead-letter-topic");
-        assertEquals(conf.getDeadLetterPolicy().getMaxRedeliverCount(), 0);
+        assertEquals(conf.getDeadLetterPolicy().getMaxRedeliverCount(), 3);
     }
 }


### PR DESCRIPTION
Signed-off-by: xiaolongran <xiaolongran@tencent.com>


Fixes #14704 



### Motivation

When the user uses the function of DeadLetterPolicy, it is better than misoperation. MaxRedeliverCount may be set to 0. When it is set to 0, according to the current processing logic of the Java Client, the message will be pushed to the DeadLetter Topic every time.


### Modifications

- When MaxRedeliverCount <= 0 in DeadLetterPolicy, we reset MaxRedeliverCount to default value

