### PR TITLE
[Proxy] Log warning when opening connection to broker fails

### DIFF
--- a/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/DirectProxyHandler.java
+++ b/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/DirectProxyHandler.java
@@ -143,6 +143,8 @@ public class DirectProxyHandler {
         f.addListener(future -> {
             if (!future.isSuccess()) {
                 // Close the connection if the connection attempt has failed.
+                log.warn("[{}] Establishing connection to {} ({}) failed. Closing inbound channel.", inboundChannel,
+                        targetBrokerAddress, targetBrokerUrl, future.cause());
                 inboundChannel.close();
                 return;
             }


### PR DESCRIPTION
### Motivation

The Pulsar proxy silently fails when establishing the broker connection fails. It's better to log a warning when opening of the connection to the broker fails.

I'm currently investigating an issue where connections between proxies and brokers fail with logs like this:
```
19:56:00.520 [pulsar-proxy-io-2-1] WARN  org.apache.pulsar.common.protocol.PulsarHandler - [[id: 0x00010ad9, L:/10.5.0.221:40136 - R:pulsar-broker.pulsar.svc.cluster.local/172.20.192.198:6650]] Pulsar Handshake was not completed within timeout, closing connection
19:56:00.520 [pulsar-proxy-io-2-1] WARN  org.apache.pulsar.client.impl.ConnectionPool - [[id: 0x00010ad9, L:/10.5.0.221:40136 ! R:pulsar-broker.pulsar.svc.cluster.local/172.20.192.198:6650]] Connection handshake failed: org.apache.pulsar.client.api.PulsarClientException: Connection already closed
```
The real reason is hidden, and this PR intends to improve logging.

The PR #14078 added connection timeout for proxy connections. The default is 10000 ms. It's possible that in environments with many connections, the default timeout is too short. Adding more logging will help detect the root cause.

### Modifications

Add logging at warn level.