### PR TITLE
Support  JAVA_HOME in env file when check java version

### DIFF
--- a/conf/bkenv.sh
+++ b/conf/bkenv.sh
@@ -40,7 +40,13 @@ BOOKIE_MEM=${BOOKIE_MEM:-${PULSAR_MEM:-"-Xms2g -Xmx2g -XX:MaxDirectMemorySize=2g
 # Garbage collection options
 BOOKIE_GC=${BOOKIE_GC:-${PULSAR_GC:-"-XX:+UseG1GC -XX:MaxGCPauseMillis=10 -XX:+ParallelRefProcEnabled -XX:+UnlockExperimentalVMOptions -XX:+DoEscapeAnalysis -XX:ParallelGCThreads=32 -XX:ConcGCThreads=32 -XX:G1NewSizePercent=50 -XX:+DisableExplicitGC"}}
 
-IS_JAVA_8=`java -version 2>&1 |grep version|grep '"1\.8'`
+if [ -z "$JAVA_HOME" ]
+then
+  IS_JAVA_8=`java -version 2>&1 |grep version|grep '"1\.8'`
+else
+  IS_JAVA_8=`$JAVA_HOME/bin/java -version 2>&1 |grep version|grep '"1\.8'`
+fi
+
 # java version has space, use [[ -n $PARAM ]] to judge if variable exists
 if [[ -n $IS_JAVA_8 ]]; then
   BOOKIE_GC_LOG=${BOOKIE_GC_LOG:-${PULSAR_GC_LOG:-"-Xloggc:logs/pulsar_bookie_gc_%p.log -XX:+PrintGCDetails -XX:+PrintGCDateStamps -XX:+UseGCLogFileRotation -XX:NumberOfGCLogFiles=10 -XX:GCLogFileSize=20M"}}

--- a/conf/pulsar_env.sh
+++ b/conf/pulsar_env.sh
@@ -48,7 +48,12 @@ PULSAR_MEM=${PULSAR_MEM:-"-Xms2g -Xmx2g -XX:MaxDirectMemorySize=4g"}
 PULSAR_GC=${PULSAR_GC:-"-XX:+UseG1GC -XX:MaxGCPauseMillis=10 -XX:+ParallelRefProcEnabled -XX:+UnlockExperimentalVMOptions -XX:+DoEscapeAnalysis -XX:ParallelGCThreads=32 -XX:ConcGCThreads=32 -XX:G1NewSizePercent=50 -XX:+DisableExplicitGC"}
 
 # Garbage collection log.
-IS_JAVA_8=`java -version 2>&1 |grep version|grep '"1\.8'`
+if [ -z "$JAVA_HOME" ]
+then
+  IS_JAVA_8=`java -version 2>&1 |grep version|grep '"1\.8'`
+else
+  IS_JAVA_8=`$JAVA_HOME/bin/java -version 2>&1 |grep version|grep '"1\.8'`
+fi
 # java version has space, use [[ -n $PARAM ]] to judge if variable exists
 if [[ -n $IS_JAVA_8 ]]; then
   PULSAR_GC_LOG=${PULSAR_GC_LOG:-"-Xloggc:logs/pulsar_gc_%p.log -XX:+PrintGCDetails -XX:+PrintGCDateStamps -XX:+UseGCLogFileRotation -XX:NumberOfGCLogFiles=10 -XX:GCLogFileSize=20M"}


### PR DESCRIPTION
### Motivation
1、Currently, If we set JAVA_HOME in env file, but `IS_JAVA_8 ` always use `java -version` to check java version.
It will get wrong version if we set JAVA_HOME, thus, wrong gc parameters are set.

### Modifications
Check if we have set JAVA_HOME or not. before check java version.




### Documentation

Check the box below or label this PR directly (if you have committer privilege).

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)


