### PR TITLE
[fix][deploy]: Fix setting BOOKIE_LOG_DIR variable in bkenv.sh takes no effects

### DIFF
--- a/bin/pulsar-daemon
+++ b/bin/pulsar-daemon
@@ -51,11 +51,6 @@ then
     . "$PULSAR_HOME/conf/pulsar_env.sh"
 fi
 
-PULSAR_LOG_DIR=${PULSAR_LOG_DIR:-"$PULSAR_HOME/logs"}
-PULSAR_LOG_APPENDER=${PULSAR_LOG_APPENDER:-"RollingFile"}
-PULSAR_STOP_TIMEOUT=${PULSAR_STOP_TIMEOUT:-30}
-PULSAR_PID_DIR=${PULSAR_PID_DIR:-$PULSAR_HOME/bin}
-
 if [ $# = 0 ]; then
     usage
     exit 1
@@ -74,6 +69,16 @@ startStop=$1
 shift
 command=$1
 shift
+
+if [[ "$command" = "bookie" ]]
+then
+  PULSAR_LOG_DIR=${BOOKIE_LOG_DIR:-"$PULSAR_HOME/logs"}
+else
+  PULSAR_LOG_DIR=${PULSAR_LOG_DIR:-"$PULSAR_HOME/logs"}
+fi
+PULSAR_LOG_APPENDER=${PULSAR_LOG_APPENDER:-"RollingFile"}
+PULSAR_STOP_TIMEOUT=${PULSAR_STOP_TIMEOUT:-30}
+PULSAR_PID_DIR=${PULSAR_PID_DIR:-$PULSAR_HOME/bin}
 
 case $command in
     (broker)


### PR DESCRIPTION

### Motivation
Setting `BOOKIE_LOG_DIR` variable  in  `bkenv.sh` takes no effects


## Modifications
If a bookie started, use BOOKIE_LOG_DIR instead of PULSAR_LOG_DIR



### Documentation

Check the box below or label this PR directly (if you have committer privilege).

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)


