### PR TITLE
make `setMessageRoutingMode` method more readable and optimize unit test for `messageRoutingMode`

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerBuilderImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerBuilderImpl.java
@@ -352,11 +352,11 @@ public class ProducerBuilderImpl<T> implements ProducerBuilder<T> {
             return;
         }
         if (conf.getCustomMessageRouter() == null) {
-            checkMessageRoutingModeValid(conf.getMessageRoutingMode() != MessageRoutingMode.CustomPartition,
+            checkMessageRoutingArgument(conf.getMessageRoutingMode() != MessageRoutingMode.CustomPartition,
                     "When 'messageRouter' is null, 'messageRoutingMode' should not be set as "
                             + MessageRoutingMode.CustomPartition);
         } else {
-            checkMessageRoutingModeValid(conf.getMessageRoutingMode() == null
+            checkMessageRoutingArgument(conf.getMessageRoutingMode() == null
                             || conf.getMessageRoutingMode() == MessageRoutingMode.CustomPartition,
                     "When 'messageRouter' is set, 'messageRoutingMode' should be set as "
                             + MessageRoutingMode.CustomPartition);
@@ -364,7 +364,7 @@ public class ProducerBuilderImpl<T> implements ProducerBuilder<T> {
         }
     }
 
-    private void checkMessageRoutingModeValid(boolean expression, String errorMessage) throws PulsarClientException {
+    private void checkMessageRoutingArgument(boolean expression, String errorMessage) throws PulsarClientException {
         if (!expression) {
             throw new PulsarClientException(errorMessage);
         }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerBuilderImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerBuilderImpl.java
@@ -349,14 +349,22 @@ public class ProducerBuilderImpl<T> implements ProducerBuilder<T> {
     private void setMessageRoutingMode() throws PulsarClientException {
         if (conf.getMessageRoutingMode() == null && conf.getCustomMessageRouter() == null) {
             messageRoutingMode(MessageRoutingMode.RoundRobinPartition);
-        } else if (conf.getMessageRoutingMode() == null && conf.getCustomMessageRouter() != null) {
+            return;
+        }
+        if (conf.getCustomMessageRouter() == null) {
+            checkMessageRoutingModeValid(conf.getMessageRoutingMode() != MessageRoutingMode.CustomPartition,
+                    "When 'messageRouter' is null, 'messageRoutingMode' should not be set as " + MessageRoutingMode.CustomPartition);
+        } else {
+            checkMessageRoutingModeValid(conf.getMessageRoutingMode() == null
+                            || conf.getMessageRoutingMode() == MessageRoutingMode.CustomPartition,
+                    "When 'messageRouter' is set, 'messageRoutingMode' should be set as " + MessageRoutingMode.CustomPartition);
             messageRoutingMode(MessageRoutingMode.CustomPartition);
-        } else if ((conf.getMessageRoutingMode() == MessageRoutingMode.CustomPartition
-                && conf.getCustomMessageRouter() == null)
-                || (conf.getMessageRoutingMode() != MessageRoutingMode.CustomPartition
-                && conf.getCustomMessageRouter() != null)) {
-            throw new PulsarClientException("When 'messageRouter' is set, 'messageRoutingMode' "
-                    + "should be set as " + MessageRoutingMode.CustomPartition);
+        }
+    }
+
+    private void checkMessageRoutingModeValid(boolean expression, String errorMessage) throws PulsarClientException {
+        if (!expression) {
+            throw new PulsarClientException(errorMessage);
         }
     }
 

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerBuilderImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerBuilderImpl.java
@@ -353,11 +353,13 @@ public class ProducerBuilderImpl<T> implements ProducerBuilder<T> {
         }
         if (conf.getCustomMessageRouter() == null) {
             checkMessageRoutingModeValid(conf.getMessageRoutingMode() != MessageRoutingMode.CustomPartition,
-                    "When 'messageRouter' is null, 'messageRoutingMode' should not be set as " + MessageRoutingMode.CustomPartition);
+                    "When 'messageRouter' is null, 'messageRoutingMode' should not be set as "
+                            + MessageRoutingMode.CustomPartition);
         } else {
             checkMessageRoutingModeValid(conf.getMessageRoutingMode() == null
                             || conf.getMessageRoutingMode() == MessageRoutingMode.CustomPartition,
-                    "When 'messageRouter' is set, 'messageRoutingMode' should be set as " + MessageRoutingMode.CustomPartition);
+                    "When 'messageRouter' is set, 'messageRoutingMode' should be set as "
+                            + MessageRoutingMode.CustomPartition);
             messageRoutingMode(MessageRoutingMode.CustomPartition);
         }
     }

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/ProducerBuilderImplTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/ProducerBuilderImplTest.java
@@ -38,6 +38,7 @@ import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 
 /**
@@ -84,6 +85,7 @@ public class ProducerBuilderImplTest {
         Producer producer = producerBuilderImpl.topic(TOPIC_NAME)
                 .create();
         assertNotNull(producer);
+        assertEquals(producerBuilderImpl.getConf().getMessageRoutingMode(), MessageRoutingMode.RoundRobinPartition);
     }
 
     @Test
@@ -93,6 +95,7 @@ public class ProducerBuilderImplTest {
                 .messageRoutingMode(MessageRoutingMode.SinglePartition)
                 .create();
         assertNotNull(producer);
+        assertEquals(producerBuilderImpl.getConf().getMessageRoutingMode(), MessageRoutingMode.SinglePartition);
     }
 
     @Test
@@ -102,6 +105,7 @@ public class ProducerBuilderImplTest {
                 .messageRoutingMode(MessageRoutingMode.RoundRobinPartition)
                 .create();
         assertNotNull(producer);
+        assertEquals(producerBuilderImpl.getConf().getMessageRoutingMode(), MessageRoutingMode.RoundRobinPartition);
     }
 
     @Test
@@ -111,6 +115,7 @@ public class ProducerBuilderImplTest {
                 .messageRouter(new CustomMessageRouter())
                 .create();
         assertNotNull(producer);
+        assertEquals(producerBuilderImpl.getConf().getMessageRoutingMode(), MessageRoutingMode.CustomPartition);
     }
 
     @Test
@@ -121,6 +126,7 @@ public class ProducerBuilderImplTest {
                 .messageRouter(new CustomMessageRouter())
                 .create();
         assertNotNull(producer);
+        assertEquals(producerBuilderImpl.getConf().getMessageRoutingMode(), MessageRoutingMode.CustomPartition);
     }
 
     @Test(expectedExceptions = PulsarClientException.class)


### PR DESCRIPTION

### Motivation

when I first read `setMessageRoutingMode`,  I was confused, the logic is not very clear,  and the error hints is not completely right,   I try to make the logic  more readable and clear, and split into different error hints

hope to be adopted, thanks

### Modifications

split the check logic in `setMessageRoutingMode` method of  class `ProducerBuilderImpl` 



### Documentation

Check the box below or label this PR directly (if you have committer privilege).

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)


