### PR TITLE
[cleanup][broker]: avoid using hard code strings in `NamespaceEventsSystemTopicFactory`

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/systopic/NamespaceEventsSystemTopicFactory.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/systopic/NamespaceEventsSystemTopicFactory.java
@@ -23,6 +23,7 @@ import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.common.events.EventType;
 import org.apache.pulsar.common.events.EventsTopicNames;
 import org.apache.pulsar.common.naming.NamespaceName;
+import org.apache.pulsar.common.naming.TopicDomain;
 import org.apache.pulsar.common.naming.TopicName;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -36,7 +37,7 @@ public class NamespaceEventsSystemTopicFactory {
     }
 
     public TopicPoliciesSystemTopicClient createTopicPoliciesSystemTopicClient(NamespaceName namespaceName) {
-        TopicName topicName = TopicName.get("persistent", namespaceName,
+        TopicName topicName = TopicName.get(TopicDomain.persistent.value(), namespaceName,
                 EventsTopicNames.NAMESPACE_EVENTS_LOCAL_NAME);
         log.info("Create topic policies system topic client {}", topicName.toString());
         return new TopicPoliciesSystemTopicClient(client, topicName);
@@ -44,7 +45,7 @@ public class NamespaceEventsSystemTopicFactory {
 
     public TransactionBufferSystemTopicClient createTransactionBufferSystemTopicClient(NamespaceName namespaceName,
                                                    TransactionBufferSnapshotService transactionBufferSnapshotService) {
-        TopicName topicName = TopicName.get("persistent", namespaceName,
+        TopicName topicName = TopicName.get(TopicDomain.persistent.value(), namespaceName,
                 EventsTopicNames.TRANSACTION_BUFFER_SNAPSHOT);
         log.info("Create transaction buffer snapshot client, topicName : {}", topicName.toString());
         return new TransactionBufferSystemTopicClient(client, topicName, transactionBufferSnapshotService);
@@ -53,10 +54,11 @@ public class NamespaceEventsSystemTopicFactory {
     public static TopicName getSystemTopicName(NamespaceName namespaceName, EventType eventType) {
         switch (eventType) {
             case TOPIC_POLICY:
-                return TopicName.get("persistent", namespaceName,
+                return TopicName.get(TopicDomain.persistent.value(), namespaceName,
                         EventsTopicNames.NAMESPACE_EVENTS_LOCAL_NAME);
             case TRANSACTION_BUFFER_SNAPSHOT:
-                return TopicName.get("persistent", namespaceName, EventsTopicNames.TRANSACTION_BUFFER_SNAPSHOT);
+                return TopicName.get(TopicDomain.persistent.value(), namespaceName,
+                        EventsTopicNames.TRANSACTION_BUFFER_SNAPSHOT);
             default:
                 return null;
         }


### PR DESCRIPTION
### Motivation

We should avoid using hard code strings in `NamespaceEventsSystemTopicFactory`.

### Modifications

Change the topic domain hard code.

### Documentation

Need to update docs? 

- [x] `no-need-doc` 


