### PR TITLE
[C++ Client] Add braces around initialization of subobject

### DIFF
--- a/pulsar-client-cpp/lib/stats/ProducerStatsImpl.cc
+++ b/pulsar-client-cpp/lib/stats/ProducerStatsImpl.cc
@@ -26,7 +26,7 @@
 namespace pulsar {
 DECLARE_LOG_OBJECT();
 
-static const std::array<double, 4> probs = {0.5, 0.9, 0.99, 0.999};
+static const std::array<double, 4> probs = {{0.5, 0.9, 0.99, 0.999}};
 
 std::string ProducerStatsImpl::latencyToString(const LatencyAccumulator& obj) {
     boost::accumulators::detail::extractor_result<


### PR DESCRIPTION
Master Issue: https://github.com/apache/pulsar/issues/13429

### Motivation

While preparing the 2.8.3 python client release, I encountered the following error:

```
    default: /Users/vagrant/pulsar/pulsar-client-cpp/lib/stats/ProducerStatsImpl.cc:29:45: error: suggest braces around initialization of subobject [-Werror,-Wmissing-braces]
    default: static const std::array<double, 4> probs = {0.5, 0.9, 0.99, 0.999};
    default:                                             ^~~~~~~~~~~~~~~~~~~~~
    default:                                             {                    }
    default: 1 error generated.
    default: make[3]: *** [lib/CMakeFiles/PULSAR_OBJECT_LIB.dir/stats/ProducerStatsImpl.cc.o] Error 1
    default: make[3]: *** Waiting for unfinished jobs....
    default: make[2]: *** [lib/CMakeFiles/PULSAR_OBJECT_LIB.dir/all] Error 2
    default: make[1]: *** [python/CMakeFiles/_pulsar.dir/rule] Error 2
    default: make: *** [_pulsar] Error 2
```

### Modifications

* Add the suggested braces.

### Verifying this change

- I need help verifying this change, since I am not familiar with C++.

### Does this pull request potentially affect one of the following parts:

This is a minor change.

### Documentation

- [x] `no-need-doc` 

This is just code cleanup.

