### PR TITLE
[Broker]Move normalize to DispatchRateImpl

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractTopic.java
@@ -206,12 +206,14 @@ public abstract class AbstractTopic implements Topic, TopicPolicyListener<TopicP
         topicPolicies.getMessageTTLInSeconds().updateTopicValue(data.getMessageTTLInSeconds());
         topicPolicies.getPublishRate().updateTopicValue(PublishRate.normalize(data.getPublishRate()));
         topicPolicies.getDelayedDeliveryEnabled().updateTopicValue(data.getDelayedDeliveryEnabled());
-        topicPolicies.getReplicatorDispatchRate().updateTopicValue(normalize(data.getReplicatorDispatchRate()));
+        topicPolicies.getReplicatorDispatchRate().updateTopicValue(
+            DispatchRateImpl.normalize(data.getReplicatorDispatchRate()));
         topicPolicies.getDelayedDeliveryTickTimeMillis().updateTopicValue(data.getDelayedDeliveryTickTimeMillis());
         topicPolicies.getSubscribeRate().updateTopicValue(SubscribeRate.normalize(data.getSubscribeRate()));
-        topicPolicies.getSubscriptionDispatchRate().updateTopicValue(normalize(data.getSubscriptionDispatchRate()));
+        topicPolicies.getSubscriptionDispatchRate().updateTopicValue(
+            DispatchRateImpl.normalize(data.getSubscriptionDispatchRate()));
         topicPolicies.getCompactionThreshold().updateTopicValue(data.getCompactionThreshold());
-        topicPolicies.getDispatchRate().updateTopicValue(normalize(data.getDispatchRate()));
+        topicPolicies.getDispatchRate().updateTopicValue(DispatchRateImpl.normalize(data.getDispatchRate()));
     }
 
     protected void updateTopicPolicyByNamespacePolicy(Policies namespacePolicies) {
@@ -265,7 +267,7 @@ public abstract class AbstractTopic implements Topic, TopicPolicyListener<TopicP
         if (dispatchRate == null) {
             dispatchRate = namespacePolicies.clusterDispatchRate.get(cluster);
         }
-        topicPolicies.getDispatchRate().updateNamespaceValue(normalize(dispatchRate));
+        topicPolicies.getDispatchRate().updateNamespaceValue(DispatchRateImpl.normalize(dispatchRate));
     }
 
     private void updateNamespaceSubscribeRate(Policies namespacePolicies, String cluster) {
@@ -275,22 +277,12 @@ public abstract class AbstractTopic implements Topic, TopicPolicyListener<TopicP
 
     private void updateNamespaceSubscriptionDispatchRate(Policies namespacePolicies, String cluster) {
         topicPolicies.getSubscriptionDispatchRate()
-            .updateNamespaceValue(normalize(namespacePolicies.subscriptionDispatchRate.get(cluster)));
+            .updateNamespaceValue(DispatchRateImpl.normalize(namespacePolicies.subscriptionDispatchRate.get(cluster)));
     }
 
     private void updateNamespaceReplicatorDispatchRate(Policies namespacePolicies, String cluster) {
         topicPolicies.getReplicatorDispatchRate()
-            .updateNamespaceValue(normalize(namespacePolicies.replicatorDispatchRate.get(cluster)));
-    }
-
-    private DispatchRateImpl normalize(DispatchRateImpl dispatchRate) {
-        if (dispatchRate != null
-            && (dispatchRate.getDispatchThrottlingRateInMsg() > 0
-            || dispatchRate.getDispatchThrottlingRateInByte() > 0)) {
-            return dispatchRate;
-        } else {
-            return null;
-        }
+            .updateNamespaceValue(DispatchRateImpl.normalize(namespacePolicies.replicatorDispatchRate.get(cluster)));
     }
 
     private void updateSchemaCompatibilityStrategyNamespaceValue(Policies namespacePolicies){

--- a/pulsar-client-admin-api/src/main/java/org/apache/pulsar/common/policies/data/impl/DispatchRateImpl.java
+++ b/pulsar-client-admin-api/src/main/java/org/apache/pulsar/common/policies/data/impl/DispatchRateImpl.java
@@ -40,6 +40,16 @@ public final class DispatchRateImpl implements DispatchRate {
         return new DispatchRateImplBuilder();
     }
 
+    public static DispatchRateImpl normalize(DispatchRateImpl dispatchRate) {
+        if (dispatchRate != null
+            && (dispatchRate.getDispatchThrottlingRateInMsg() > 0
+            || dispatchRate.getDispatchThrottlingRateInByte() > 0)) {
+            return dispatchRate;
+        } else {
+            return null;
+        }
+    }
+
     public static class DispatchRateImplBuilder implements DispatchRate.Builder {
 
         private int dispatchThrottlingRateInMsg = -1;


### PR DESCRIPTION
### Motivation

Move `normalize` method to `DispatchRateImpl` as a static method  like `PublishRate` and `SubscribeRate`

### Modifications

Move `normalize` method to `DispatchRateImpl` as a static method

### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation
  
- [x] `no-need-doc` 


