### PR TITLE
[enh][security]: trim tokenSecretKey file path.

### DIFF
--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authentication/utils/AuthTokenUtils.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authentication/utils/AuthTokenUtils.java
@@ -102,6 +102,9 @@ public class AuthTokenUtils {
     public static byte[] readKeyFromUrl(String keyConfUrl) throws IOException {
         if (keyConfUrl.startsWith("data:") || keyConfUrl.startsWith("file:")) {
             try {
+                if (keyConfUrl.startsWith("file:")) {
+                    keyConfUrl = keyConfUrl.trim();
+                }
                 return IOUtils.toByteArray(URL.createURL(keyConfUrl));
             } catch (IOException e) {
                 throw e;

--- a/pulsar-broker-common/src/test/java/org/apache/pulsar/broker/authentication/AuthenticationProviderTokenTest.java
+++ b/pulsar-broker-common/src/test/java/org/apache/pulsar/broker/authentication/AuthenticationProviderTokenTest.java
@@ -231,6 +231,26 @@ public class AuthenticationProviderTokenTest {
     }
 
     @Test
+    public void testTrimAuthSecretKeyFilePath() throws Exception {
+        String space = " ";
+        SecretKey secretKey = AuthTokenUtils.createSecretKey(SignatureAlgorithm.HS256);
+
+        File secretKeyFile = File.createTempFile("pulsar-test-secret-key-", ".key");
+        secretKeyFile.deleteOnExit();
+        Files.write(Paths.get(secretKeyFile.toString()), secretKey.getEncoded());
+
+        AuthenticationProviderToken provider = new AuthenticationProviderToken();
+
+        Properties properties = new Properties();
+        String secretKeyFileUri = secretKeyFile.toURI().toString() + space;
+        properties.setProperty(AuthenticationProviderToken.CONF_TOKEN_SECRET_KEY, secretKeyFileUri);
+
+        ServiceConfiguration conf = new ServiceConfiguration();
+        conf.setProperties(properties);
+        provider.initialize(conf);
+    }
+
+    @Test
     public void testAuthSecretKeyFromFile() throws Exception {
         SecretKey secretKey = AuthTokenUtils.createSecretKey(SignatureAlgorithm.HS256);
 


### PR DESCRIPTION
### Motivation
trim tokenSecretKey file path.

When configuring tokenSecretKey=file:///data/tdbank/pulsar/conf/secret.key   , a few spaces were added at the end, resulting in an error:
<img width="1483" alt="wecom-temp-986fe3d1d754c04642dcc586d2f77b48" src="https://user-images.githubusercontent.com/19296967/158935521-3823e19c-67bf-45f0-8af4-949183e5b3cd.png">



### Documentation

Check the box below or label this PR directly (if you have committer privilege).

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)


