### PR TITLE
[cleanup][broker]: Refactor PulsarAuthorizationProvider.

### DIFF
--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authorization/PulsarAuthorizationProvider.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authorization/PulsarAuthorizationProvider.java
@@ -112,7 +112,7 @@ public class PulsarAuthorizationProvider implements AuthorizationProvider {
                         }
                     } else {
                         if (isNotBlank(subscription)) {
-                            // validate if role is authorize to access subscription. (skip validatation if authorization
+                            // validate if role is authorized to access subscription. (skip validation if authorization
                             // list is empty)
                             Set<String> roles = policies.get().auth_policies
                                     .getSubscriptionAuthentication().get(subscription);
@@ -122,18 +122,20 @@ public class PulsarAuthorizationProvider implements AuthorizationProvider {
                             }
 
                             // validate if subscription-auth mode is configured
-                            switch (policies.get().subscription_auth_mode) {
-                                case Prefix:
-                                    if (!subscription.startsWith(role)) {
-                                        PulsarServerException ex = new PulsarServerException(String.format(
-                                                "Failed to create consumer - The subscription name needs to be"
-                                                + " prefixed by the authentication role, like %s-xxxx for topic: %s",
-                                                role, topicName));
-                                        return FutureUtil.failedFuture(ex);
-                                    }
-                                    break;
-                                default:
-                                    break;
+                            if (policies.get().subscription_auth_mode != null) {
+                                switch (policies.get().subscription_auth_mode) {
+                                    case Prefix:
+                                        if (!subscription.startsWith(role)) {
+                                            PulsarServerException ex = new PulsarServerException(String.format(
+                                                 "Failed to create consumer - The subscription name needs to be"
+                                                 + " prefixed by the authentication role, like %s-xxxx for topic: %s",
+                                                 role, topicName));
+                                            return FutureUtil.failedFuture(ex);
+                                        }
+                                        break;
+                                    default:
+                                        break;
+                                }
                             }
                         }
                     }

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authorization/PulsarAuthorizationProvider.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authorization/PulsarAuthorizationProvider.java
@@ -172,7 +172,7 @@ public class PulsarAuthorizationProvider implements AuthorizationProvider {
                                 + " permissions. {}", topicName.toString(), role, ex.getMessage());
 
                     }
-                    return null;
+                    throw FutureUtil.wrapToCompletionException(ex);
                 });
     }
 

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authorization/PulsarAuthorizationProvider.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authorization/PulsarAuthorizationProvider.java
@@ -20,7 +20,7 @@ package org.apache.pulsar.broker.authorization;
 
 import static java.util.Objects.requireNonNull;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
-import com.google.common.base.Joiner;
+import com.google.common.collect.Sets;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.HashMap;
@@ -39,7 +39,6 @@ import org.apache.pulsar.common.policies.data.AuthAction;
 import org.apache.pulsar.common.policies.data.NamespaceOperation;
 import org.apache.pulsar.common.policies.data.PolicyName;
 import org.apache.pulsar.common.policies.data.PolicyOperation;
-import org.apache.pulsar.common.policies.data.TenantInfo;
 import org.apache.pulsar.common.policies.data.TenantOperation;
 import org.apache.pulsar.common.policies.data.TopicOperation;
 import org.apache.pulsar.common.util.FutureUtil;
@@ -106,63 +105,41 @@ public class PulsarAuthorizationProvider implements AuthorizationProvider {
     @Override
     public CompletableFuture<Boolean> canConsumeAsync(TopicName topicName, String role,
             AuthenticationDataSource authenticationData, String subscription) {
-        CompletableFuture<Boolean> permissionFuture = new CompletableFuture<>();
-        try {
-            pulsarResources.getNamespaceResources().getPoliciesAsync(topicName.getNamespaceObject())
-                    .thenAccept(policies -> {
-                if (!policies.isPresent()) {
-                    if (log.isDebugEnabled()) {
-                        log.debug("Policies node couldn't be found for topic : {}", topicName);
-                    }
-                } else {
-                    if (isNotBlank(subscription)) {
-                        // validate if role is authorize to access subscription. (skip validatation if authorization
-                        // list is empty)
-                        Set<String> roles = policies.get().auth_policies
-                                .getSubscriptionAuthentication().get(subscription);
-                        if (roles != null && !roles.isEmpty() && !roles.contains(role)) {
-                            log.warn("[{}] is not authorized to subscribe on {}-{}", role, topicName, subscription);
-                            permissionFuture.complete(false);
-                            return;
+        return pulsarResources.getNamespaceResources().getPoliciesAsync(topicName.getNamespaceObject())
+                .thenCompose(policies -> {
+                    if (!policies.isPresent()) {
+                        if (log.isDebugEnabled()) {
+                            log.debug("Policies node couldn't be found for topic : {}", topicName);
                         }
-
-                        // validate if subscription-auth mode is configured
-                        switch (policies.get().subscription_auth_mode) {
-                        case Prefix:
-                            if (!subscription.startsWith(role)) {
-                                PulsarServerException ex = new PulsarServerException(String.format(
-                                        "Failed to create consumer - The subscription name needs to be prefixed by the "
-                                                + "authentication role, like %s-xxxx for topic: %s", role, topicName));
-                                permissionFuture.completeExceptionally(ex);
-                                return;
+                    } else {
+                        if (isNotBlank(subscription)) {
+                            // validate if role is authorize to access subscription. (skip validatation if authorization
+                            // list is empty)
+                            Set<String> roles = policies.get().auth_policies
+                                    .getSubscriptionAuthentication().get(subscription);
+                            if (roles != null && !roles.isEmpty() && !roles.contains(role)) {
+                                log.warn("[{}] is not authorized to subscribe on {}-{}", role, topicName, subscription);
+                                return CompletableFuture.completedFuture(false);
                             }
-                            break;
-                        default:
-                            break;
+
+                            // validate if subscription-auth mode is configured
+                            switch (policies.get().subscription_auth_mode) {
+                                case Prefix:
+                                    if (!subscription.startsWith(role)) {
+                                        PulsarServerException ex = new PulsarServerException(String.format(
+                                                "Failed to create consumer - The subscription name needs to be"
+                                                + " prefixed by the authentication role, like %s-xxxx for topic: %s",
+                                                role, topicName));
+                                        return FutureUtil.failedFuture(ex);
+                                    }
+                                    break;
+                                default:
+                                    break;
+                            }
                         }
                     }
-                }
-                // check namespace and topic level consume-permissions
-                checkAuthorization(topicName, role, AuthAction.consume).thenAccept(isAuthorized -> {
-                    permissionFuture.complete(isAuthorized);
-                }).exceptionally(ex -> {
-                    log.warn("Client with Role - {} failed to get permissions for topic - {}. {}", role, topicName,
-                            ex.getMessage());
-                    permissionFuture.completeExceptionally(ex);
-                    return null;
+                    return checkAuthorization(topicName, role, AuthAction.consume);
                 });
-            }).exceptionally(ex -> {
-                log.warn("Client with Role - {} failed to get permissions for topic - {}. {}", role, topicName,
-                        ex.getMessage());
-                permissionFuture.completeExceptionally(ex);
-                return null;
-            });
-        } catch (Exception e) {
-            log.warn("Client  with Role - {} failed to get permissions for topic - {}. {}", role, topicName,
-                    e.getMessage());
-            permissionFuture.completeExceptionally(e);
-        }
-        return permissionFuture;
     }
 
     /**
@@ -178,36 +155,8 @@ public class PulsarAuthorizationProvider implements AuthorizationProvider {
     @Override
     public CompletableFuture<Boolean> canLookupAsync(TopicName topicName, String role,
             AuthenticationDataSource authenticationData) {
-        CompletableFuture<Boolean> finalResult = new CompletableFuture<Boolean>();
-        canProduceAsync(topicName, role, authenticationData).whenComplete((produceAuthorized, ex) -> {
-            if (ex == null) {
-                if (produceAuthorized) {
-                    finalResult.complete(produceAuthorized);
-                    return;
-                }
-            } else {
-                if (log.isDebugEnabled()) {
-                    log.debug(
-                            "Topic [{}] Role [{}] exception occurred while trying to check Produce permissions. {}",
-                            topicName.toString(), role, ex.getMessage());
-                }
-            }
-            canConsumeAsync(topicName, role, authenticationData, null).whenComplete((consumeAuthorized, e)
-                    -> {
-                if (e == null) {
-                    finalResult.complete(consumeAuthorized);
-                } else {
-                    if (log.isDebugEnabled()) {
-                        log.debug(
-                                "Topic [{}] Role [{}] exception occurred while trying to check Consume permissions. {}",
-                                topicName.toString(), role, e.getMessage());
-
-                    }
-                    finalResult.completeExceptionally(e);
-                }
-            });
-        });
-        return finalResult;
+        return canProduceAsync(topicName, role, authenticationData)
+                .thenCompose(__ -> canConsumeAsync(topicName, role, authenticationData, null));
     }
 
     @Override
@@ -231,185 +180,151 @@ public class PulsarAuthorizationProvider implements AuthorizationProvider {
     private CompletableFuture<Boolean> allowConsumeOrProduceOpsAsync(NamespaceName namespaceName,
                                                                      String role,
                                                                      AuthenticationDataSource authenticationData) {
-        CompletableFuture<Boolean> finalResult = new CompletableFuture<>();
-        allowTheSpecifiedActionOpsAsync(namespaceName, role, authenticationData, AuthAction.consume)
-                .whenComplete((consumeAuthorized, e) -> {
-                    if (e == null) {
-                        if (consumeAuthorized) {
-                            finalResult.complete(consumeAuthorized);
-                            return;
-                        }
-                    } else {
-                        if (log.isDebugEnabled()) {
-                            log.debug("Namespace [{}] Role [{}] exception occurred while trying to check Consume "
-                                    + "permission. {}", namespaceName, role, e.getCause());
-                        }
-                    }
-                    allowTheSpecifiedActionOpsAsync(namespaceName, role, authenticationData, AuthAction.produce)
-                            .whenComplete((produceAuthorized, ex) -> {
-                                if (ex == null) {
-                                    finalResult.complete(produceAuthorized);
-                                } else {
-                                    if (log.isDebugEnabled()) {
-                                        log.debug("Namespace [{}] Role [{}] exception occurred while trying to check "
-                                                + "Produce permission. {}", namespaceName, role, ex.getCause());
-                                    }
-                                    finalResult.completeExceptionally(ex.getCause());
-                                }
-                            });
-                });
+        return allowTheSpecifiedActionOpsAsync(namespaceName, role, authenticationData,
+                                                    Sets.newHashSet(AuthAction.consume, AuthAction.produce));
 
-        return finalResult;
     }
 
     private CompletableFuture<Boolean> allowTheSpecifiedActionOpsAsync(NamespaceName namespaceName, String role,
                                                                        AuthenticationDataSource authenticationData,
                                                                        AuthAction authAction) {
-        CompletableFuture<Boolean> permissionFuture = new CompletableFuture<>();
-        try {
-            pulsarResources.getNamespaceResources().getPoliciesAsync(namespaceName).thenAccept(policies -> {
-                if (!policies.isPresent()) {
-                    if (log.isDebugEnabled()) {
-                        log.debug("Policies node couldn't be found for namespace : {}", namespaceName);
-                    }
-                } else {
-                    Map<String, Set<AuthAction>> namespaceRoles = policies.get()
-                            .auth_policies.getNamespaceAuthentication();
-                    Set<AuthAction> namespaceActions = namespaceRoles.get(role);
-                    if (namespaceActions != null && namespaceActions.contains(authAction)) {
-                        // The role has namespace level permission
-                        permissionFuture.complete(true);
-                        return;
-                    }
+        return allowTheSpecifiedActionOpsAsync(namespaceName, role, authenticationData, Sets.newHashSet(authAction));
+    }
 
-                    // Using wildcard
-                    if (conf.isAuthorizationAllowWildcardsMatching()) {
-                        if (checkWildcardPermission(role, authAction, namespaceRoles)) {
-                            // The role has namespace level permission by wildcard match
-                            permissionFuture.complete(true);
-                            return;
-                        }
+    private CompletableFuture<Boolean> allowTheSpecifiedActionOpsAsync(NamespaceName namespaceName, String role,
+                                                                       AuthenticationDataSource authenticationData,
+                                                                       Set<AuthAction> authActions) {
+        return pulsarResources.getNamespaceResources().getPoliciesAsync(namespaceName).thenApply(policies -> {
+            if (!policies.isPresent()) {
+                if (log.isDebugEnabled()) {
+                    log.debug("Policies node couldn't be found for namespace : {}", namespaceName);
+                }
+            } else {
+                Map<String, Set<AuthAction>> namespaceRoles = policies.get()
+                        .auth_policies.getNamespaceAuthentication();
+                Set<AuthAction> namespaceActions = namespaceRoles.get(role);
+                if (namespaceActions != null && namespaceActions.containsAll(authActions)) {
+                    // The role has namespace level permission
+                    return true;
+                }
+
+                // Using wildcard
+                if (conf.isAuthorizationAllowWildcardsMatching()) {
+                    if (checkWildcardPermission(role, authActions, namespaceRoles)) {
+                        // The role has namespace level permission by wildcard match
+                        return true;
                     }
                 }
-                permissionFuture.complete(false);
-            }).exceptionally(ex -> {
-                log.warn("Client  with Role - {} failed to get permissions for namespace - {}. {}", role, namespaceName,
-                        ex.getMessage());
-                permissionFuture.completeExceptionally(ex);
-                return null;
-            });
-        } catch (Exception e) {
-            log.warn("Client  with Role - {} failed to get permissions for namespace - {}. {}", role, namespaceName,
-                    e.getMessage());
-            permissionFuture.completeExceptionally(e);
-        }
-        return permissionFuture;
+            }
+            return false;
+        });
     }
 
     @Override
     public CompletableFuture<Void> grantPermissionAsync(TopicName topicName, Set<AuthAction> actions,
-            String role, String authDataJson) {
-        try {
-            validatePoliciesReadOnlyAccess();
-        } catch (Exception e) {
-            return FutureUtil.failedFuture(e);
-        }
+                                                        String role, String authDataJson) {
 
-        String topicUri = topicName.toString();
-        return pulsarResources.getNamespaceResources()
-                .setPoliciesAsync(topicName.getNamespaceObject(), policies -> {
-                    policies.auth_policies.getTopicAuthentication()
-                            .computeIfAbsent(topicUri, __ -> new HashMap<>())
-                            .put(role, actions);
-                    return policies;
-                }).whenComplete((__, throwable) -> {
-                    if (throwable != null) {
-                        log.error("[{}] Failed to set permissions for role {} on topic {}", role, role, topicName,
-                                throwable);
-                    } else {
-                        log.info("[{}] Successfully granted access for role {}: {} - topic {}", role, role, actions,
-                                topicUri);
-                    }
-                });
+        return getPoliciesReadOnlyAsync().thenCompose(readonly -> {
+            if (readonly) {
+                if (log.isDebugEnabled()) {
+                    log.debug("Policies are read-only. Broker cannot do read-write operations");
+                }
+                throw new IllegalStateException("policies are in readonly mode");
+            }
+            String topicUri = topicName.toString();
+            return pulsarResources.getNamespaceResources()
+                    .setPoliciesAsync(topicName.getNamespaceObject(), policies -> {
+                        policies.auth_policies.getTopicAuthentication()
+                                .computeIfAbsent(topicUri, __ -> new HashMap<>())
+                                .put(role, actions);
+                        return policies;
+                    }).whenComplete((__, ex) -> {
+                        if (ex != null) {
+                            log.error("Failed to set permissions for role {} on topic {}", role, topicName, ex);
+                        } else {
+                            log.info("Successfully granted access for role {}: {} - topic {}", role, actions, topicUri);
+                        }
+                    });
+        });
     }
 
     @Override
     public CompletableFuture<Void> grantPermissionAsync(NamespaceName namespaceName, Set<AuthAction> actions,
-            String role, String authDataJson) {
-        try {
-            validatePoliciesReadOnlyAccess();
-        } catch (Exception e) {
-            return FutureUtil.failedFuture(e);
-        }
-
-        return pulsarResources.getNamespaceResources()
-                .setPoliciesAsync(namespaceName, policies -> {
-                    policies.auth_policies.getNamespaceAuthentication().put(role, actions);
-                    return policies;
-                }).whenComplete((__, throwable) -> {
-                    if (throwable != null) {
-                        log.error("[{}] Failed to set permissions for role {} namespace {}", role, role, namespaceName,
-                                throwable);
-                    } else {
-                        log.info("[{}] Successfully granted access for role {}: {} - namespace {}", role, role, actions,
-                                namespaceName);
-                    }
-                });
+                                                        String role, String authDataJson) {
+        return getPoliciesReadOnlyAsync().thenCompose(readonly -> {
+            if (readonly) {
+                if (log.isDebugEnabled()) {
+                    log.debug("Policies are read-only. Broker cannot do read-write operations");
+                }
+                throw new IllegalStateException("policies are in readonly mode");
+            }
+            return pulsarResources.getNamespaceResources()
+                    .setPoliciesAsync(namespaceName, policies -> {
+                        policies.auth_policies.getNamespaceAuthentication().put(role, actions);
+                        return policies;
+                    }).whenComplete((__, ex) -> {
+                        if (ex != null) {
+                            log.error("Failed to set permissions for role {} namespace {}", role, namespaceName, ex);
+                        } else {
+                            log.info("Successfully granted access for role {}: {} - namespace {}", role, actions,
+                                    namespaceName);
+                        }
+                    });
+        });
     }
 
     @Override
     public CompletableFuture<Void> grantSubscriptionPermissionAsync(NamespaceName namespace, String subscriptionName,
-            Set<String> roles, String authDataJson) {
+                                                                    Set<String> roles, String authDataJson) {
         return updateSubscriptionPermissionAsync(namespace, subscriptionName, roles, false);
     }
 
     @Override
     public CompletableFuture<Void> revokeSubscriptionPermissionAsync(NamespaceName namespace, String subscriptionName,
-            String role, String authDataJson) {
+                                                                     String role, String authDataJson) {
         return updateSubscriptionPermissionAsync(namespace, subscriptionName, Collections.singleton(role), true);
     }
 
     private CompletableFuture<Void> updateSubscriptionPermissionAsync(NamespaceName namespace, String subscriptionName,
-                                                                      Set<String> roles,
-                                                                      boolean remove) {
-        try {
-            validatePoliciesReadOnlyAccess();
-        } catch (Exception e) {
-            return FutureUtil.failedFuture(e);
-        }
-
-        return pulsarResources.getNamespaceResources()
-                .setPoliciesAsync(namespace, policies -> {
-                    if (remove) {
-                        Set<String> subscriptionAuth =
-                                policies.auth_policies.getSubscriptionAuthentication().get(subscriptionName);
-                        if (subscriptionAuth != null) {
-                            subscriptionAuth.removeAll(roles);
+                                                                      Set<String> roles, boolean remove) {
+        return getPoliciesReadOnlyAsync().thenCompose(readonly -> {
+            if (readonly) {
+                if (log.isDebugEnabled()) {
+                    log.debug("Policies are read-only. Broker cannot do read-write operations");
+                }
+                throw new IllegalStateException("policies are in readonly mode");
+            }
+            return pulsarResources.getNamespaceResources()
+                    .setPoliciesAsync(namespace, policies -> {
+                        if (remove) {
+                            Set<String> subscriptionAuth =
+                                    policies.auth_policies.getSubscriptionAuthentication().get(subscriptionName);
+                            if (subscriptionAuth != null) {
+                                subscriptionAuth.removeAll(roles);
+                            } else {
+                                log.info("[{}] Couldn't find role {} while revoking for sub = {}", namespace,
+                                        roles, subscriptionName);
+                                throw new IllegalArgumentException("couldn't find subscription");
+                            }
                         } else {
-                            log.info("[{}] Couldn't find role {} while revoking for sub = {}", namespace,
-                                    roles, subscriptionName);
-                            throw new IllegalArgumentException("couldn't find subscription");
+                            policies.auth_policies.getSubscriptionAuthentication().put(subscriptionName, roles);
                         }
-                    } else {
-                        policies.auth_policies.getSubscriptionAuthentication().put(subscriptionName, roles);
-                    }
-                    return policies;
-                }).whenComplete((__, throwable) -> {
-                    if (throwable != null) {
-                        log.error("[{}] Failed to set permissions for role {} on namespace {}", subscriptionName, roles,
-                                namespace, throwable);
-                    } else {
-                        log.info("[{}] Successfully granted access for role {} for sub = {}", namespace,
-                                roles, subscriptionName);
-                    }
-                });
+                        return policies;
+                    }).whenComplete((__, throwable) -> {
+                        if (throwable != null) {
+                            log.error("[{}] Failed to set permissions for role {} on namespace {}", subscriptionName,
+                                    roles, namespace, throwable);
+                        } else {
+                            log.info("[{}] Successfully granted access for role {} for sub = {}", namespace,
+                                    roles, subscriptionName);
+                        }
+                    });
+        });
     }
 
     private CompletableFuture<Boolean> checkAuthorization(TopicName topicName, String role, AuthAction action) {
-        return checkPermission(topicName, role, action).
-                thenApply(isPermission -> isPermission).
-                thenCompose(permission -> permission ? checkCluster(topicName) :
-                    CompletableFuture.completedFuture(false));
+        return checkPermission(topicName, role, action).thenCompose(permission ->
+                permission ? checkCluster(topicName) : CompletableFuture.completedFuture(false));
     }
 
     private CompletableFuture<Boolean> checkCluster(TopicName topicName) {
@@ -420,88 +335,68 @@ public class PulsarAuthorizationProvider implements AuthorizationProvider {
             log.debug("Topic [{}] does not belong to local cluster [{}]", topicName.toString(), conf.getClusterName());
         }
         return pulsarResources.getClusterResources().listAsync()
-                .thenApply(clusters -> {
-                    return clusters.contains(topicName.getCluster());
-                });
+                .thenApply(clusters -> clusters.contains(topicName.getCluster()));
     }
 
     public CompletableFuture<Boolean> checkPermission(TopicName topicName, String role, AuthAction action) {
-        CompletableFuture<Boolean> permissionFuture = new CompletableFuture<>();
-        try {
-            pulsarResources.getNamespaceResources().getPoliciesAsync(topicName.getNamespaceObject())
-                    .thenAccept(policies -> {
-                if (!policies.isPresent()) {
-                    if (log.isDebugEnabled()) {
-                        log.debug("Policies node couldn't be found for topic : {}", topicName);
-                    }
-                } else {
-                    Map<String, Set<AuthAction>> namespaceRoles = policies.get().auth_policies
-                            .getNamespaceAuthentication();
-                    Set<AuthAction> namespaceActions = namespaceRoles.get(role);
-                    if (namespaceActions != null && namespaceActions.contains(action)) {
-                        // The role has namespace level permission
-                        permissionFuture.complete(true);
-                        return;
-                    }
-
-                    Map<String, Set<AuthAction>> topicRoles = policies.get().auth_policies.getTopicAuthentication()
-                            .get(topicName.toString());
-                    if (topicRoles != null && role != null) {
-                        // Topic has custom policy
-                        Set<AuthAction> topicActions = topicRoles.get(role);
-                        if (topicActions != null && topicActions.contains(action)) {
-                            // The role has topic level permission
-                            permissionFuture.complete(true);
-                            return;
+        return pulsarResources.getNamespaceResources().getPoliciesAsync(topicName.getNamespaceObject())
+                .thenApply(policies -> {
+                    if (!policies.isPresent()) {
+                        if (log.isDebugEnabled()) {
+                            log.debug("Policies node couldn't be found for topic : {}", topicName);
                         }
-                    }
-
-                    // Using wildcard
-                    if (conf.isAuthorizationAllowWildcardsMatching()) {
-                        if (checkWildcardPermission(role, action, namespaceRoles)) {
-                            // The role has namespace level permission by wildcard match
-                            permissionFuture.complete(true);
-                            return;
+                    } else {
+                        Map<String, Set<AuthAction>> namespaceRoles = policies.get().auth_policies
+                                .getNamespaceAuthentication();
+                        Set<AuthAction> namespaceActions = namespaceRoles.get(role);
+                        if (namespaceActions != null && namespaceActions.contains(action)) {
+                            // The role has namespace level permission
+                            return true;
                         }
 
-                        if (topicRoles != null && checkWildcardPermission(role, action, topicRoles)) {
-                            // The role has topic level permission by wildcard match
-                            permissionFuture.complete(true);
-                            return;
-                        }
-                    }
-
-                    // If the partition number of the partitioned topic having topic level policy is updated,
-                    // the new sub partitions may not inherit the policy of the partition topic.
-                    // We can also check the permission of partitioned topic.
-                    // For https://github.com/apache/pulsar/issues/10300
-                    if (topicName.isPartitioned()) {
-                        topicRoles = policies.get().auth_policies
-                                .getTopicAuthentication().get(topicName.getPartitionedTopicName());
-                        if (topicRoles != null) {
+                        Map<String, Set<AuthAction>> topicRoles = policies.get().auth_policies.getTopicAuthentication()
+                                .get(topicName.toString());
+                        if (topicRoles != null && role != null) {
                             // Topic has custom policy
                             Set<AuthAction> topicActions = topicRoles.get(role);
                             if (topicActions != null && topicActions.contains(action)) {
                                 // The role has topic level permission
-                                permissionFuture.complete(true);
-                                return;
+                                return true;
+                            }
+                        }
+
+                        // Using wildcard
+                        if (conf.isAuthorizationAllowWildcardsMatching()) {
+                            if (checkWildcardPermission(role, action, namespaceRoles)) {
+                                // The role has namespace level permission by wildcard match
+                                return true;
+                            }
+
+                            if (topicRoles != null && checkWildcardPermission(role, action, topicRoles)) {
+                                // The role has topic level permission by wildcard match
+                                return true;
+                            }
+                        }
+
+                        // If the partition number of the partitioned topic having topic level policy is updated,
+                        // the new sub partitions may not inherit the policy of the partition topic.
+                        // We can also check the permission of partitioned topic.
+                        // For https://github.com/apache/pulsar/issues/10300
+                        if (topicName.isPartitioned()) {
+                            topicRoles = policies.get().auth_policies
+                                    .getTopicAuthentication().get(topicName.getPartitionedTopicName());
+                            if (topicRoles != null) {
+                                // Topic has custom policy
+                                Set<AuthAction> topicActions = topicRoles.get(role);
+                                if (topicActions != null && topicActions.contains(action)) {
+                                    // The role has topic level permission
+                                    return true;
+                                }
                             }
                         }
                     }
-                }
-                permissionFuture.complete(false);
-            }).exceptionally(ex -> {
-                log.warn("Client with Role - {} failed to get permissions for topic - {}. {}", role, topicName,
-                        ex.getMessage());
-                permissionFuture.completeExceptionally(ex);
-                return null;
-            });
-        } catch (Exception e) {
-            log.warn("Client with Role - {} failed to get permissions for topic - {}. {}", role, topicName,
-                    e.getMessage());
-            permissionFuture.completeExceptionally(e);
-        }
-        return permissionFuture;
+                    return false;
+                });
     }
 
     private boolean checkWildcardPermission(String checkedRole, AuthAction checkedAction,
@@ -528,28 +423,24 @@ public class PulsarAuthorizationProvider implements AuthorizationProvider {
         return false;
     }
 
+    private boolean checkWildcardPermission(String checkedRole, Set<AuthAction> checkedActions,
+                                            Map<String, Set<AuthAction>> permissionMap) {
+        for (AuthAction authAction : checkedActions) {
+            if (!checkWildcardPermission(checkedRole, authAction, permissionMap)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
 
     @Override
     public void close() throws IOException {
         // No-op
     }
 
-    private void validatePoliciesReadOnlyAccess() {
-        boolean arePoliciesReadOnly = true;
-
-        try {
-            arePoliciesReadOnly = pulsarResources.getNamespaceResources().getPoliciesReadOnly();
-        } catch (Exception e) {
-            log.warn("Unable to check if policies are read-only", e);
-            throw new IllegalStateException("Unable to fetch content from configuration metadata store");
-        }
-
-        if (arePoliciesReadOnly) {
-            if (log.isDebugEnabled()) {
-                log.debug("Policies are read-only. Broker cannot do read-write operations");
-            }
-            throw new IllegalStateException("policies are in readonly mode");
-        }
+    private CompletableFuture<Boolean> getPoliciesReadOnlyAsync() {
+        return pulsarResources.getNamespaceResources().getPoliciesReadOnlyAsync();
     }
 
     @Override
@@ -669,43 +560,37 @@ public class PulsarAuthorizationProvider implements AuthorizationProvider {
     }
 
     @Override
-    public CompletableFuture<Boolean> allowTopicPolicyOperationAsync(TopicName topicName,
-                                                                     String role,
+    public CompletableFuture<Boolean> allowTopicPolicyOperationAsync(TopicName topicName, String role,
                                                                      PolicyName policyName,
                                                                      PolicyOperation policyOperation,
                                                                      AuthenticationDataSource authData) {
         return validateTenantAdminAccess(topicName.getTenant(), role, authData);
     }
 
-    private static String path(String... parts) {
-        StringBuilder sb = new StringBuilder();
-        sb.append("/admin/");
-        Joiner.on('/').appendTo(sb, parts);
-        return sb.toString();
-    }
-
-    public CompletableFuture<Boolean> validateTenantAdminAccess(String tenantName,
-                                                                 String role,
-                                                                 AuthenticationDataSource authData) {
+    public CompletableFuture<Boolean> validateTenantAdminAccess(String tenantName, String role,
+                                                                AuthenticationDataSource authData) {
         return isSuperUser(role, authData, conf)
                 .thenCompose(isSuperUser -> {
                     if (isSuperUser) {
                         return CompletableFuture.completedFuture(true);
-                    } else {
-                        try {
-                            TenantInfo tenantInfo = pulsarResources.getTenantResources()
-                                    .getTenant(tenantName)
-                                    .orElseThrow(() -> new RestException(Response.Status.NOT_FOUND,
-                                            "Tenant does not exist"));
-                            return isTenantAdmin(tenantName, role, tenantInfo, authData);
-                        } catch (NotFoundException e) {
-                            log.warn("Failed to get tenant info data for non existing tenant {}", tenantName);
-                            throw new RestException(Response.Status.NOT_FOUND, "Tenant does not exist");
-                        } catch (Exception e) {
-                            log.error("Failed to get tenant {}", tenantName, e);
-                            throw new RestException(e);
-                        }
                     }
+                    return pulsarResources.getTenantResources()
+                            .getTenantAsync(tenantName)
+                            .thenCompose(op -> {
+                                if (op.isPresent()) {
+                                    return isTenantAdmin(tenantName, role, op.get(), authData);
+                                } else {
+                                    throw new RestException(Response.Status.NOT_FOUND, "Tenant does not exist");
+                                }
+                            }).exceptionally(ex -> {
+                                Throwable cause = ex.getCause();
+                                if (cause instanceof NotFoundException) {
+                                    log.warn("Failed to get tenant info data for non existing tenant {}", tenantName);
+                                    throw new RestException(Response.Status.NOT_FOUND, "Tenant does not exist");
+                                }
+                                log.error("Failed to get tenant {}", tenantName, cause);
+                                throw new RestException(cause);
+                            });
                 });
     }
 

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authorization/PulsarAuthorizationProvider.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authorization/PulsarAuthorizationProvider.java
@@ -140,6 +140,10 @@ public class PulsarAuthorizationProvider implements AuthorizationProvider {
                         }
                     }
                     return checkAuthorization(topicName, role, AuthAction.consume);
+                }).exceptionally(ex -> {
+                    log.warn("Client with Role - {} failed to get permissions for topic - {}. {}", role, topicName,
+                            ex.getMessage());
+                    return null;
                 });
     }
 
@@ -162,6 +166,13 @@ public class PulsarAuthorizationProvider implements AuthorizationProvider {
                         return CompletableFuture.completedFuture(true);
                     }
                     return canConsumeAsync(topicName, role, authenticationData, null);
+                }).exceptionally(ex -> {
+                    if (log.isDebugEnabled()) {
+                        log.debug("Topic [{}] Role [{}] exception occurred while trying to check produce/consume"
+                                + " permissions. {}", topicName.toString(), role, ex.getMessage());
+
+                    }
+                    return null;
                 });
     }
 


### PR DESCRIPTION
### Motivation

PulsarAuthorizationProvider has many duplicate codes and some logic is un-readable.

### Modifications
- `canConsumeAsync` : remove permissionFuture
- `allowConsumeOrProduceOpsAsync`: Using Set to avoid duplicate codes.
- `grantPermissionAsync`: make fully async.
- `checkPermission`: make fully async.
- `path` : remove this unsed method.
### Documentation
  
- [x] `no-need-doc` 



