### PR TITLE
Set function channel to idle to prevent DNS resolution of deleted pod 

### DIFF
--- a/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/kubernetes/KubernetesRuntime.java
+++ b/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/kubernetes/KubernetesRuntime.java
@@ -646,7 +646,7 @@ public class KubernetesRuntime implements Runtime {
 
 
         Actions.Action waitForStatefulSetDeletion = Actions.Action.builder()
-                .actionName(String.format("Waiting for statefulset for function %s to complete deletion", fqfn))
+                .actionName(String.format("Waiting for StatefulSet deletion to complete deletion of function %s", fqfn))
                 // set retry period to be about 2x the graceshutdown time
                 .numRetries(KubernetesRuntimeFactory.numRetries * 2)
                 .sleepBetweenInvocationsMs(KubernetesRuntimeFactory.sleepBetweenRetriesMs * 2)
@@ -795,7 +795,7 @@ public class KubernetesRuntime implements Runtime {
                 .build();
 
         Actions.Action waitForServiceDeletion = Actions.Action.builder()
-                .actionName(String.format("Waiting for statefulset for function %s to complete deletion", fqfn))
+                .actionName(String.format("Waiting for service deletion to complete deletion of function %s", fqfn))
                 .numRetries(KubernetesRuntimeFactory.numRetries)
                 .sleepBetweenInvocationsMs(KubernetesRuntimeFactory.sleepBetweenRetriesMs)
                 .supplier(() -> {
@@ -805,7 +805,7 @@ public class KubernetesRuntime implements Runtime {
                                 null, null, null);
 
                     } catch (ApiException e) {
-                        // statefulset is gone
+                        // service is gone
                         if (e.getCode() == HTTP_NOT_FOUND) {
                             return Actions.ActionResult.builder().success(true).build();
                         }

--- a/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/kubernetes/KubernetesRuntime.java
+++ b/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/kubernetes/KubernetesRuntime.java
@@ -336,6 +336,15 @@ public class KubernetesRuntime implements Runtime {
 
     @Override
     public void stop() throws Exception {
+        // Because we're about to delete the function pods, we don't want the channel to attempt loading DNS, which
+        // will cease to exist if the deletion succeeds. However, we don't want to shut down the channel until
+        // the StatefulSet and Service are actually deleted.
+        if (channel != null) {
+            for (ManagedChannel cn : channel) {
+                cn.enterIdle();
+            }
+        }
+
         deleteStatefulSet();
         deleteService();
 

--- a/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/Actions.java
+++ b/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/Actions.java
@@ -111,7 +111,7 @@ public class Actions {
             ActionResult actionResult = action.getSupplier().get();
 
             if (actionResult.isSuccess()) {
-                log.info("Sucessfully completed action [ {} ]", action.getActionName());
+                log.info("Successfully completed action [ {} ]", action.getActionName());
                 if (action.getOnSuccess() != null) {
                     action.getOnSuccess().accept(actionResult);
                 }

--- a/pulsar-functions/utils/src/test/java/org/apache/pulsar/functions/utils/ActionsTest.java
+++ b/pulsar-functions/utils/src/test/java/org/apache/pulsar/functions/utils/ActionsTest.java
@@ -44,7 +44,7 @@ public class ActionsTest {
         when(supplier2.get()).thenReturn(Actions.ActionResult.builder().success(true).build());
 
         java.util.function.Consumer<Actions.ActionResult> onFail = mock(java.util.function.Consumer.class);
-        java.util.function.Consumer<Actions.ActionResult> onSucess = mock(java.util.function.Consumer.class);
+        java.util.function.Consumer<Actions.ActionResult> onSuccess = mock(java.util.function.Consumer.class);
 
         Actions.Action action1 = spy(
             Actions.Action.builder()
@@ -54,7 +54,7 @@ public class ActionsTest {
                 .supplier(supplier1)
                 .continueOn(true)
                 .onFail(onFail)
-                .onSuccess(onSucess)
+                .onSuccess(onSuccess)
                 .build());
 
         Actions.Action action2 = spy(
@@ -73,7 +73,7 @@ public class ActionsTest {
         assertEquals(actions.numActions(), 2);
         verify(supplier1, times(1)).get();
         verify(onFail, times(0)).accept(any());
-        verify(onSucess, times(1)).accept(any());
+        verify(onSuccess, times(1)).accept(any());
         verify(supplier2, times(1)).get();
     }
 
@@ -88,7 +88,7 @@ public class ActionsTest {
         when(supplier2.get()).thenReturn(Actions.ActionResult.builder().success(true).build());
 
         java.util.function.Consumer<Actions.ActionResult> onFail = mock(java.util.function.Consumer.class);
-        java.util.function.Consumer<Actions.ActionResult> onSucess = mock(java.util.function.Consumer.class);
+        java.util.function.Consumer<Actions.ActionResult> onSuccess = mock(java.util.function.Consumer.class);
 
         Actions.Action action1 = spy(
             Actions.Action.builder()
@@ -98,7 +98,7 @@ public class ActionsTest {
                 .supplier(supplier1)
                 .continueOn(false)
                 .onFail(onFail)
-                .onSuccess(onSucess)
+                .onSuccess(onSuccess)
                 .build());
         Actions.Action action2 = spy(
             Actions.Action.builder()
@@ -107,7 +107,7 @@ public class ActionsTest {
                 .sleepBetweenInvocationsMs(200)
                 .supplier(supplier2)
                 .onFail(onFail)
-                .onSuccess(onSucess)
+                .onSuccess(onSuccess)
                 .build());
 
         Actions actions = Actions.newBuilder()
@@ -118,7 +118,7 @@ public class ActionsTest {
         assertEquals(actions.numActions(), 2);
         verify(supplier1, times(1)).get();
         verify(onFail, times(0)).accept(any());
-        verify(onSucess, times(1)).accept(any());
+        verify(onSuccess, times(1)).accept(any());
         verify(supplier2, times(0)).get();
     }
 
@@ -134,7 +134,7 @@ public class ActionsTest {
         when(supplier2.get()).thenReturn(Actions.ActionResult.builder().success(true).build());
 
         java.util.function.Consumer<Actions.ActionResult> onFail = mock(java.util.function.Consumer.class);
-        java.util.function.Consumer<Actions.ActionResult> onSucess = mock(java.util.function.Consumer.class);
+        java.util.function.Consumer<Actions.ActionResult> onSuccess = mock(java.util.function.Consumer.class);
 
         Actions.Action action1 = spy(
             Actions.Action.builder()
@@ -144,7 +144,7 @@ public class ActionsTest {
                 .supplier(supplier1)
                 .continueOn(false)
                 .onFail(onFail)
-                .onSuccess(onSucess)
+                .onSuccess(onSuccess)
                 .build());
 
         Actions.Action action2 = spy(
@@ -163,7 +163,7 @@ public class ActionsTest {
         assertEquals(actions.numActions(), 2);
         verify(supplier1, times(11)).get();
         verify(onFail, times(1)).accept(any());
-        verify(onSucess, times(0)).accept(any());
+        verify(onSuccess, times(0)).accept(any());
         verify(supplier2, times(1)).get();
     }
 
@@ -177,7 +177,7 @@ public class ActionsTest {
       when(supplier2.get()).thenReturn(Actions.ActionResult.builder().success(true).build());
 
       java.util.function.Consumer<Actions.ActionResult> onFail = mock(java.util.function.Consumer.class);
-      java.util.function.Consumer<Actions.ActionResult> onSucess = mock(java.util.function.Consumer.class);
+      java.util.function.Consumer<Actions.ActionResult> onSuccess = mock(java.util.function.Consumer.class);
 
       Actions.Action action1 = spy(
           Actions.Action.builder()
@@ -186,7 +186,7 @@ public class ActionsTest {
               .sleepBetweenInvocationsMs(100)
               .supplier(supplier1)
               .onFail(onFail)
-              .onSuccess(onSucess)
+              .onSuccess(onSuccess)
               .build());
 
       Actions.Action action2 = spy(
@@ -205,7 +205,7 @@ public class ActionsTest {
       assertEquals(actions.numActions(), 2);
       verify(supplier1, times(1)).get();
       verify(onFail, times(0)).accept(any());
-      verify(onSucess, times(1)).accept(any());
+      verify(onSuccess, times(1)).accept(any());
       verify(supplier2, times(1)).get();
     }
 }


### PR DESCRIPTION
### Motivation

When running the Kubernetes runtime and deleting a function, it is possible to observe the following error log:

```
15:36:17.025 [worker-scheduler-0] INFO  org.apache.pulsar.functions.utils.Actions - Sucessfully completed action [ Deleting statefulset for function ds/default/gluon-revolut-ord-rsp-assembler ]
15:36:17.405 [grpc-default-executor-307] WARN  io.grpc.internal.ManagedChannelImpl - [Channel<99>: (pf-ds-default-gluon-revolut-ord-rsp-assembler-0.pf-ds-default-gluon-revolut-ord-rsp-assembler.pulsar.svc.cluster.local:9093)] Failed to resolve name. status=Status{code=UNAVAILABLE, description=Unable to resolve host pf-ds-default-gluon-revolut-ord-rsp-assembler-0.pf-ds-default-gluon-revolut-ord-rsp-assembler.pulsar.svc.cluster.local, cause=java.lang.RuntimeException: java.net.UnknownHostException: pf-ds-default-gluon-revolut-ord-rsp-assembler-0.pf-ds-default-gluon-revolut-ord-rsp-assembler.pulsar.svc.cluster.local: Name or service not known
	at io.grpc.internal.DnsNameResolver.resolveAll(DnsNameResolver.java:399)
	at io.grpc.internal.DnsNameResolver$Resolve.resolveInternal(DnsNameResolver.java:269)
	at io.grpc.internal.DnsNameResolver$Resolve.run(DnsNameResolver.java:225)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:834)
Caused by: java.net.UnknownHostException: pf-ds-default-gluon-revolut-ord-rsp-assembler-0.pf-ds-default-gluon-revolut-ord-rsp-assembler.pulsar.svc.cluster.local: Name or service not known
	at java.base/java.net.Inet4AddressImpl.lookupAllHostAddr(Native Method)
	at java.base/java.net.InetAddress$PlatformNameService.lookupAllHostAddr(InetAddress.java:929)
	at java.base/java.net.InetAddress.getAddressesFromNameService(InetAddress.java:1519)
	at java.base/java.net.InetAddress$NameServiceAddresses.get(InetAddress.java:848)
	at java.base/java.net.InetAddress.getAllByName0(InetAddress.java:1509)
	at java.base/java.net.InetAddress.getAllByName(InetAddress.java:1368)
	at java.base/java.net.InetAddress.getAllByName(InetAddress.java:1302)
	at io.grpc.internal.DnsNameResolver$JdkAddressResolver.resolveAddress(DnsNameResolver.java:624)
	at io.grpc.internal.DnsNameResolver.resolveAll(DnsNameResolver.java:367)
	... 5 more
}
```

This error happens because the `ManagedChannel` is created to target the StatefulSet pods, and the function worker deletes the pods before shutting down the `ManagedChannel`. Note that there is nothing about pod deletion that triggers the GRPC client to connect to the functions. The error happens due to the way that GRPC handles DNS and its frequent DNS resolution.

There are two solutions. First, we could shutdown the managed channel first, or we could set the channel to idle and prevent any new DNS resolution (as long as there are new connections). Given that the StatefulSet or the Service could fail to get deleted, it seems simpler to just set the channel to idle and then delete it after successfully deleting the function.

### Modifications

* Set all channels to idle before deleting the function pods in the K8s function runtime
* Fix some copy/pasted log lines that were a bit confusing
* Fix typos of `sucess`.

### Verifying this change

This is a trivial change that will not affect the logic of function deletion. It just ensures graceful shutdown and avoids benign errors that might otherwise confuse users.

### Does this pull request potentially affect one of the following parts:

This is a backwards compatible change.

### Documentation

- [x] `no-need-doc` 
  
This is an internal cleanup.

