### PR TITLE
[C++ Client] Warn, don't fail, on unknown compiler options

### DIFF
--- a/pulsar-client-cpp/CMakeLists.txt
+++ b/pulsar-client-cpp/CMakeLists.txt
@@ -95,7 +95,7 @@ else() # GCC or Clang are mostly compatible:
     # Turn on warnings and enable warnings-as-errors:
     add_compile_options(-Wall -Wformat-security -Wvla -Werror) 
     # Turn off certain warnings that are too much pain for too little gain:
-    add_compile_options(-Wno-sign-compare -Wno-deprecated-declarations -Wno-error=cpp)
+    add_compile_options(-Wno-sign-compare -Wno-deprecated-declarations -Wno-error=cpp -Wno-error=unknown-warning-option)
     if (CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64")
         add_compile_options(-msse4.2 -mpclmul)
     endif()


### PR DESCRIPTION
Fix: https://github.com/apache/pulsar/issues/13429

### Motivation

As discussed in #13429, it's helpful to make warnings errors. As such, I (naively) propose that instead of turning off this option, we should just turn it off for unknown warning options.

An alternative option is to remove the `-Wno-error=cpp` option. However, based on the comment in the code just above it, it looks like that class of warnings is generally okay to ignore. Although, this change might be problematic in the event that certain warnings will break the build for one compiler and not for another, which will only become evident at release time.

### Modifications

* add `-Wno-error=unknown-warning-option` to c++ client options

### Verifying this change

I will rely on those more familiar with C++ to verify this change. I am proposing it simply to try to fix the current issues.

Note that after this change, building the Python Client has these warning logs (that used to be errors):

```
    default: [  5%] Building CXX object lib/CMakeFiles/PULSAR_OBJECT_LIB.dir/Authentication.cc.o
    default: warning: unknown warning option '-Werror=cpp' [-Wunknown-warning-option]
    default: warning: unknown warning option '-Werror=cpp' [-Wunknown-warning-option]
    default: warning: unknown warning option '-Werror=cpp' [-Wunknown-warning-option]
```

### Does this pull request potentially affect one of the following parts:

It just affects the build.


