### PR TITLE
[fix][broker]: Fix splitNamespaceBundle api request param

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/Namespaces.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/Namespaces.java
@@ -571,7 +571,7 @@ public class Namespaces extends NamespacesBase {
             @QueryParam("authoritative") @DefaultValue("false") boolean authoritative,
             @QueryParam("unload") @DefaultValue("false") boolean unload,
             @QueryParam("splitAlgorithmName") String splitAlgorithmName,
-            @ApiParam("splitBoundaries") List<Long> splitBoundaries) {
+            @QueryParam("splitBoundaries") List<Long> splitBoundaries) {
         try {
             validateNamespaceName(tenant, namespace);
             internalSplitNamespaceBundle(asyncResponse,


### PR DESCRIPTION
Signed-off-by: Zixuan Liu <nodeces@gmail.com>

### Motivation

Use incorrect annotation to get the URL query string in `org.apache.pulsar.broker.admin.v2.Namespaces#splitNamespaceBundle`.
### Modifications

`@ApiParam` -> `@QueryParam`

### Documentation

- [x] `no-need-doc` 


