### PR TITLE
[Docs] Add instructions for configuring CA on macOS

### DIFF
--- a/site2/docs/security-tls-transport.md
+++ b/site2/docs/security-tls-transport.md
@@ -68,7 +68,7 @@ chmod 444 certs/ca.cert.pem
 
 > **Tips**
 >
-> The default `openssl` on macOS doesn't work for commands above. You must upgrade the `openssl` via Homebrew:
+> The default `openssl` on macOS doesn't work for the commands above. You must upgrade the `openssl` via Homebrew:
 >
 > ```bash
 > brew install openssl

--- a/site2/docs/security-tls-transport.md
+++ b/site2/docs/security-tls-transport.md
@@ -57,12 +57,25 @@ chmod 700 private/
 touch index.txt
 echo 1000 > serial
 openssl genrsa -aes256 -out private/ca.key.pem 4096
+# You need enter a password in the command above
 chmod 400 private/ca.key.pem
 openssl req -config openssl.cnf -key private/ca.key.pem \
     -new -x509 -days 7300 -sha256 -extensions v3_ca \
     -out certs/ca.cert.pem
+# You must enter the same password in the previous openssl command
 chmod 444 certs/ca.cert.pem
 ```
+
+> **Tips**
+>
+> The default `openssl` on macOS doesn't work for commands above. You must upgrade the `openssl` via  Homebrew:
+>
+> ```bash
+> brew install openssl
+> export PATH="/usr/local/Cellar/openssl@3/3.0.1/bin:$PATH"
+> ```
+>
+> The version `3.0.1` might change in future, please use the actual path from the output of `brew install` command.
 
 4. After you answer the question prompts, CA-related files are stored in the `./my-ca` directory. Within that directory:
 

--- a/site2/docs/security-tls-transport.md
+++ b/site2/docs/security-tls-transport.md
@@ -68,7 +68,7 @@ chmod 444 certs/ca.cert.pem
 
 > **Tips**
 >
-> The default `openssl` on macOS doesn't work for commands above. You must upgrade the `openssl` via  Homebrew:
+> The default `openssl` on macOS doesn't work for commands above. You must upgrade the `openssl` via Homebrew:
 >
 > ```bash
 > brew install openssl

--- a/site2/docs/security-tls-transport.md
+++ b/site2/docs/security-tls-transport.md
@@ -75,7 +75,7 @@ chmod 444 certs/ca.cert.pem
 > export PATH="/usr/local/Cellar/openssl@3/3.0.1/bin:$PATH"
 > ```
 >
-> The version `3.0.1` might change in future, please use the actual path from the output of `brew install` command.
+> The version `3.0.1` might change in the future. Use the actual path from the output of `brew install` command.
 
 4. After you answer the question prompts, CA-related files are stored in the `./my-ca` directory. Within that directory:
 


### PR DESCRIPTION
### Motivation

The default `openssl` in macOS is LibreSSL 2.8.3, which doesn't work for the commands to generate CA (Certificate authority). There is an error when running `openssl req`:

> configuration file routines:CRYPTO_internal:variable has no value

We should use the `openssl` installed from Homebrew.

### Modifications

Add instructions for configuring CA on macOS. In addition, there are some interactions when executing `openssl` commands. This PR adds the notes for the input password.

### Documentation

Check the box below or label this PR directly (if you have committer privilege).

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [ ] `no-need-doc` 
  
  (Please explain why)
  
- [x] `doc` 
  
  (If this PR contains doc changes)


