### PR TITLE
[fix][admin-cli]: Remove the trust certs check

### DIFF
--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdClusters.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdClusters.java
@@ -77,11 +77,6 @@ public class CmdClusters extends CmdBase {
                             "You must specify tls-trust-store-type, tls-trust-store and tls-trust-store-pwd"
                                     + " when enable tls-enable-keystore");
                 }
-            } else {
-                if (StringUtils.isBlank(clusterData.getBrokerClientTrustCertsFilePath())) {
-                    throw new RuntimeException("You must specify tls-trust-certs-filepath"
-                            + " when tls-enable-keystore is not enable");
-                }
             }
         }
     }


### PR DESCRIPTION
Signed-off-by: Zixuan Liu <nodeces@gmail.com>

### Motivation

I tried to use pulsar-admin clusters create to create a cluster with TLS. when I specify `--tls-enable`, it returns the following error.
`You must specify tls-trust-certs-filepath when tls-enable-keystore is not enable`

If we use the public trusted certs, we don't need to set the trust-certs-filepath.

### Modifications

- Remove the trust certs check

### Documentation

- [x] `no-need-doc` 


