### PR TITLE
Mark CGo client as deprecated in the documentation

### DIFF
--- a/site2/docs/client-libraries-cgo.md
+++ b/site2/docs/client-libraries-cgo.md
@@ -4,6 +4,8 @@ title: Pulsar CGo client
 sidebar_label: CGo(deprecated)
 ---
 
+> The CGo client has been deprecated since version 2.7.0. If possible, please use the [Go client](client-libraries-go.md) instead.
+
 You can use Pulsar Go client to create Pulsar [producers](#producers), [consumers](#consumers), and [readers](#readers) in Go (aka Golang).
 
 All the methods in [producers](#producers), [consumers](#consumers), and [readers](#readers) of a Go client are thread-safe.

--- a/site2/docs/client-libraries-cgo.md
+++ b/site2/docs/client-libraries-cgo.md
@@ -4,7 +4,7 @@ title: Pulsar CGo client
 sidebar_label: CGo(deprecated)
 ---
 
-> The CGo client has been deprecated since version 2.7.0. If possible, please use the [Go client](client-libraries-go.md) instead.
+> The CGo client has been deprecated since version 2.7.0. If possible, use the [Go client](client-libraries-go.md) instead.
 
 You can use Pulsar Go client to create Pulsar [producers](#producers), [consumers](#consumers), and [readers](#readers) in Go (aka Golang).
 

--- a/site2/docs/client-libraries-go.md
+++ b/site2/docs/client-libraries-go.md
@@ -4,7 +4,7 @@ title: Pulsar Go client
 sidebar_label: Go
 ---
 
-> Tips: Currently, the CGo client will be deprecated, if you want to know more about the CGo client, please refer to [CGo client docs](client-libraries-cgo.md)
+> Tips: The CGo client has been deprecated since version 2.7.0.
 
 You can use Pulsar [Go client](https://github.com/apache/pulsar-client-go) to create Pulsar [producers](#producers), [consumers](#consumers), and [readers](#readers) in Go (aka Golang).
 

--- a/site2/docs/schema-get-started.md
+++ b/site2/docs/schema-get-started.md
@@ -16,7 +16,7 @@ Applications typically adopt one of the following approaches to guarantee type s
 
 #### Note
 >
-> Currently, the Pulsar schema registry is only available for the [Java client](client-libraries-java.md), [CGo client](client-libraries-cgo.md), [Python client](client-libraries-python.md), and [C++ client](client-libraries-cpp.md).
+> Currently, the Pulsar schema registry is only available for the [Java client](client-libraries-java.md), [Go client](client-libraries-go.md), [Python client](client-libraries-python.md), and [C++ client](client-libraries-cpp.md).
 
 ### Client-side approach
 


### PR DESCRIPTION
Fixes #14609

### Motivation

The CGo client has been deprecated since version 2.7.0, but documentation for it is still there.

### Modifications

Stop referring to the documentation for the CGo client internally and state that it has been deprecated.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.

### Documentation
  
- [x] `doc` 


