### PR TITLE
[feature][doc]Add doc for how to use MultiRolesTokenAuthorizationProvider

### DIFF
--- a/site2/docs/security-authorization.md
+++ b/site2/docs/security-authorization.md
@@ -103,7 +103,8 @@ PulsarAdmin admin = PulsarAdmin.builder()
 
 When a client is identified with multiple roles in a token (the type of role claim in the token is an array) during the authentication process, Pulsar supports to check the permissions of all the roles and further authorize the client as long as one of its roles has the required permissions.
 
-> Note: This authorization method is only compatible with [JWT authentication](security-jwt.md).
+> **Note**<br />
+> This authorization method is only compatible with [JWT authentication](security-jwt.md).
 
 To enable the support, configure the authorization provider as `MultiRolesTokenAuthorizationProvider` in the `conf/broker.conf` file.
 

--- a/site2/docs/security-authorization.md
+++ b/site2/docs/security-authorization.md
@@ -106,8 +106,9 @@ When a client is identified with multiple roles in a token (the type of role cla
 > **Note**<br />
 > This authorization method is only compatible with [JWT authentication](security-jwt.md).
 
-To enable the support, configure the authorization provider as `MultiRolesTokenAuthorizationProvider` in the `conf/broker.conf` file.
+To enable this authorization method, configure the authorization provider as `MultiRolesTokenAuthorizationProvider` in the `conf/broker.conf` file.
 
  ```properties
  # Authorization provider fully qualified class-name
  authorizationProvider=org.apache.pulsar.broker.authorization.MultiRolesTokenAuthorizationProvider
+```

--- a/site2/docs/security-authorization.md
+++ b/site2/docs/security-authorization.md
@@ -98,3 +98,15 @@ PulsarAdmin admin = PulsarAdmin.builder()
                     .tlsTrustCertsFilePath("/path/to/trust/cert")
                     .build();
 ```
+
+## Authorize an authenticated client with multiple roles
+
+When a client is identified with multiple roles in a token (the type of role claim in the token is an array) during the authentication process, Pulsar supports to check the permissions of all the roles and further authorize the client as long as one of its roles has the required permissions.
+
+> Note: This authorization method is only compatible with [JWT authentication](security-jwt.md).
+
+To enable the support, configure the authorization provider as `MultiRolesTokenAuthorizationProvider` in the `conf/broker.conf` file.
+
+ ```properties
+ # Authorization provider fully qualified class-name
+ authorizationProvider=org.apache.pulsar.broker.authorization.MultiRolesTokenAuthorizationProvider

--- a/site2/website/versioned_docs/version-2.8.1/security-authorization.md
+++ b/site2/website/versioned_docs/version-2.8.1/security-authorization.md
@@ -99,3 +99,17 @@ PulsarAdmin admin = PulsarAdmin.builder()
                     .tlsTrustCertsFilePath("/path/to/trust/cert")
                     .build();
 ```
+
+## Authorize an authenticated client with multiple roles
+
+When a client is identified with multiple roles in a token (the type of role claim in the token is an array) during the authentication process, Pulsar supports to check the permissions of all the roles and further authorize the client as long as one of its roles has the required permissions.
+
+> **Note**<br />
+> This authorization method is only compatible with [JWT authentication](security-jwt.md).
+
+To enable this authorization method, configure the authorization provider as `MultiRolesTokenAuthorizationProvider` in the `conf/broker.conf` file.
+
+ ```properties
+ # Authorization provider fully qualified class-name
+ authorizationProvider=org.apache.pulsar.broker.authorization.MultiRolesTokenAuthorizationProvider
+```

--- a/site2/website/versioned_docs/version-2.8.2/security-authorization.md
+++ b/site2/website/versioned_docs/version-2.8.2/security-authorization.md
@@ -99,3 +99,17 @@ PulsarAdmin admin = PulsarAdmin.builder()
                     .tlsTrustCertsFilePath("/path/to/trust/cert")
                     .build();
 ```
+
+## Authorize an authenticated client with multiple roles
+
+When a client is identified with multiple roles in a token (the type of role claim in the token is an array) during the authentication process, Pulsar supports to check the permissions of all the roles and further authorize the client as long as one of its roles has the required permissions.
+
+> **Note**<br />
+> This authorization method is only compatible with [JWT authentication](security-jwt.md).
+
+To enable this authorization method, configure the authorization provider as `MultiRolesTokenAuthorizationProvider` in the `conf/broker.conf` file.
+
+ ```properties
+ # Authorization provider fully qualified class-name
+ authorizationProvider=org.apache.pulsar.broker.authorization.MultiRolesTokenAuthorizationProvider
+```

--- a/site2/website/versioned_docs/version-2.9.0/security-authorization.md
+++ b/site2/website/versioned_docs/version-2.9.0/security-authorization.md
@@ -99,3 +99,17 @@ PulsarAdmin admin = PulsarAdmin.builder()
                     .tlsTrustCertsFilePath("/path/to/trust/cert")
                     .build();
 ```
+
+## Authorize an authenticated client with multiple roles
+
+When a client is identified with multiple roles in a token (the type of role claim in the token is an array) during the authentication process, Pulsar supports to check the permissions of all the roles and further authorize the client as long as one of its roles has the required permissions.
+
+> **Note**<br />
+> This authorization method is only compatible with [JWT authentication](security-jwt.md).
+
+To enable this authorization method, configure the authorization provider as `MultiRolesTokenAuthorizationProvider` in the `conf/broker.conf` file.
+
+ ```properties
+ # Authorization provider fully qualified class-name
+ authorizationProvider=org.apache.pulsar.broker.authorization.MultiRolesTokenAuthorizationProvider
+```

--- a/site2/website/versioned_docs/version-2.9.1/security-authorization.md
+++ b/site2/website/versioned_docs/version-2.9.1/security-authorization.md
@@ -99,3 +99,17 @@ PulsarAdmin admin = PulsarAdmin.builder()
                     .tlsTrustCertsFilePath("/path/to/trust/cert")
                     .build();
 ```
+
+## Authorize an authenticated client with multiple roles
+
+When a client is identified with multiple roles in a token (the type of role claim in the token is an array) during the authentication process, Pulsar supports to check the permissions of all the roles and further authorize the client as long as one of its roles has the required permissions.
+
+> **Note**<br />
+> This authorization method is only compatible with [JWT authentication](security-jwt.md).
+
+To enable this authorization method, configure the authorization provider as `MultiRolesTokenAuthorizationProvider` in the `conf/broker.conf` file.
+
+ ```properties
+ # Authorization provider fully qualified class-name
+ authorizationProvider=org.apache.pulsar.broker.authorization.MultiRolesTokenAuthorizationProvider
+```


### PR DESCRIPTION
### Motivation

Fix #14741 

### Modifications
Add doc for how to use MultiRolesTokenAuthorizationProvider.

Preview looks good.
<img width="1139" alt="image" src="https://user-images.githubusercontent.com/60642177/159444309-379a9493-97a3-4af8-b7b8-5c0047f40a4f.png">


### Documentation
  
- [x] `doc` 


