### PR TITLE
[fix][test] Fix flaky test LeaderElectionTest

### DIFF
--- a/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/LeaderElectionTest.java
+++ b/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/LeaderElectionTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pulsar.metadata;
 
+import static org.apache.pulsar.metadata.MetadataCacheTest.assertEqualsAndRetry;
 import static org.testng.Assert.assertEquals;
 import java.util.EnumSet;
 import java.util.Optional;
@@ -111,21 +112,21 @@ public class LeaderElectionTest extends BaseMetadataStoreTest {
 
         LeaderElectionState les1 = le1.elect("test-1").join();
         assertEquals(les1, LeaderElectionState.Leading);
-        assertEquals(le1.getLeaderValueIfPresent(), Optional.of("test-1"));
+        assertEqualsAndRetry(() -> le1.getLeaderValueIfPresent(), Optional.of("test-1"), Optional.empty());
         assertEquals(le1.getLeaderValue().join(), Optional.of("test-1"));
         assertEquals(n1.poll(3, TimeUnit.SECONDS), LeaderElectionState.Leading);
 
         LeaderElectionState les2 = le2.elect("test-2").join();
         assertEquals(les2, LeaderElectionState.Following);
         assertEquals(le2.getLeaderValue().join(), Optional.of("test-1"));
-        assertEquals(le2.getLeaderValueIfPresent(), Optional.of("test-1"));
+        assertEqualsAndRetry(() -> le2.getLeaderValueIfPresent(), Optional.of("test-1"), Optional.empty());
         assertEquals(n2.poll(3, TimeUnit.SECONDS), LeaderElectionState.Following);
 
         le1.close();
 
         assertEquals(n2.poll(3, TimeUnit.SECONDS), LeaderElectionState.Leading);
         assertEquals(le2.getState(), LeaderElectionState.Leading);
-        assertEquals(le2.getLeaderValueIfPresent(), Optional.of("test-2"));
+        assertEqualsAndRetry(() -> le2.getLeaderValueIfPresent(), Optional.of("test-2"), Optional.empty());
         assertEquals(le2.getLeaderValue().join(), Optional.of("test-2"));
     }
 
@@ -209,7 +210,7 @@ public class LeaderElectionTest extends BaseMetadataStoreTest {
         LeaderElectionState les = le.elect("test-2").join();
         assertEquals(les, LeaderElectionState.Leading);
         assertEquals(le.getLeaderValue().join(), Optional.of("test-2"));
-        assertEquals(le.getLeaderValueIfPresent(), Optional.of("test-2"));
+        assertEqualsAndRetry(() -> le.getLeaderValueIfPresent(), Optional.of("test-2"), Optional.empty());
     }
 
     @Test(dataProvider = "impl")
@@ -244,7 +245,7 @@ public class LeaderElectionTest extends BaseMetadataStoreTest {
         LeaderElectionState les = le.elect("test-1").join();
         assertEquals(les, LeaderElectionState.Leading);
         assertEquals(le.getLeaderValue().join(), Optional.of("test-1"));
-        assertEquals(le.getLeaderValueIfPresent(), Optional.of("test-1"));
+        assertEqualsAndRetry(() -> le.getLeaderValueIfPresent(), Optional.of("test-1"), Optional.empty());
     }
 
 
@@ -280,6 +281,6 @@ public class LeaderElectionTest extends BaseMetadataStoreTest {
         LeaderElectionState les = le.elect("test-2").join();
         assertEquals(les, LeaderElectionState.Following);
         assertEquals(le.getLeaderValue().join(), Optional.of("test-1"));
-        assertEquals(le.getLeaderValueIfPresent(), Optional.of("test-1"));
+        assertEqualsAndRetry(() -> le.getLeaderValueIfPresent(), Optional.of("test-1"), Optional.empty());
     }
 }


### PR DESCRIPTION
Fixes #14771

### Motivation
flaky test LeaderElectionTest


### Modifications
`getLeaderValueIfPresent` invoke `getIfCached` method. It's the same problem with #14373.



### Documentation

Check the box below or label this PR directly (if you have committer privilege).

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)


