### PR TITLE
[fix][test] Fix wrong retry behavior in MetadataCacheTest

### DIFF
--- a/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/MetadataCacheTest.java
+++ b/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/MetadataCacheTest.java
@@ -611,7 +611,7 @@ public class MetadataCacheTest extends BaseMetadataStoreTest {
     public static boolean retryStrategically(Predicate<Void> predicate, int retryCount, long intSleepTimeInMillis)
             throws Exception {
         for (int i = 0; i < retryCount; i++) {
-            if (predicate.test(null) || i == (retryCount - 1)) {
+            if (predicate.test(null)) {
                 return true;
             }
             Thread.sleep(intSleepTimeInMillis + (intSleepTimeInMillis * i));


### PR DESCRIPTION
### Motivation

Currently, when the retry count reaches to end, the  `assertEqualsAndRetry` method is always successful, we should remove this check.

### Modifications

Fix wrong retry behavior in MetadataCacheTest

### Documentation

- [x] `no-need-doc` 
