### PR TITLE
[WIP][security] Upgrade Jackson to 2.13.2

### DIFF
--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -312,14 +312,14 @@ The Apache Software License, Version 2.0
  * JCommander -- com.beust-jcommander-1.78.jar
  * High Performance Primitive Collections for Java -- com.carrotsearch-hppc-0.7.3.jar
  * Jackson
-     - com.fasterxml.jackson.core-jackson-annotations-2.12.6.jar
-     - com.fasterxml.jackson.core-jackson-core-2.12.6.jar
-     - com.fasterxml.jackson.core-jackson-databind-2.12.6.jar
-     - com.fasterxml.jackson.dataformat-jackson-dataformat-yaml-2.12.6.jar
-     - com.fasterxml.jackson.jaxrs-jackson-jaxrs-base-2.12.6.jar
-     - com.fasterxml.jackson.jaxrs-jackson-jaxrs-json-provider-2.12.6.jar
-     - com.fasterxml.jackson.module-jackson-module-jaxb-annotations-2.12.6.jar
-     - com.fasterxml.jackson.module-jackson-module-jsonSchema-2.12.6.jar
+     - com.fasterxml.jackson.core-jackson-annotations-2.13.2.jar
+     - com.fasterxml.jackson.core-jackson-core-2.13.2.jar
+     - com.fasterxml.jackson.core-jackson-databind-2.13.2.jar
+     - com.fasterxml.jackson.dataformat-jackson-dataformat-yaml-2.13.2.jar
+     - com.fasterxml.jackson.jaxrs-jackson-jaxrs-base-2.13.2.jar
+     - com.fasterxml.jackson.jaxrs-jackson-jaxrs-json-provider-2.13.2.jar
+     - com.fasterxml.jackson.module-jackson-module-jaxb-annotations-2.13.2.jar
+     - com.fasterxml.jackson.module-jackson-module-jsonSchema-2.13.2.jar
  * Caffeine -- com.github.ben-manes.caffeine-caffeine-2.9.1.jar
  * Conscrypt -- org.conscrypt-conscrypt-openjdk-uber-2.5.2.jar
  * Proto Google Common Protos -- com.google.api.grpc-proto-google-common-protos-2.0.1.jar

--- a/pom.xml
+++ b/pom.xml
@@ -124,8 +124,8 @@ flexible messaging model and an intuitive client API.</description>
     <log4j2.version>2.17.1</log4j2.version>
     <bouncycastle.version>1.69</bouncycastle.version>
     <bouncycastlefips.version>1.0.2</bouncycastlefips.version>
-    <jackson.version>2.12.6</jackson.version>
-    <jackson.databind.version>2.12.6</jackson.databind.version>
+    <jackson.version>2.13.2</jackson.version>
+    <jackson.databind.version>2.13.2</jackson.databind.version>
     <reflections.version>0.9.11</reflections.version>
     <swagger.version>1.6.2</swagger.version>
     <puppycrawl.checkstyle.version>8.37</puppycrawl.checkstyle.version>

--- a/pulsar-sql/presto-distribution/LICENSE
+++ b/pulsar-sql/presto-distribution/LICENSE
@@ -207,19 +207,19 @@ This projects includes binary packages with the following licenses:
 The Apache Software License, Version 2.0
 
   * Jackson
-    - jackson-annotations-2.12.6.jar
-    - jackson-core-2.12.6.jar
-    - jackson-databind-2.12.6.jar
-    - jackson-dataformat-smile-2.12.6.jar
-    - jackson-datatype-guava-2.12.6.jar
-    - jackson-datatype-jdk8-2.12.6.jar
-    - jackson-datatype-joda-2.12.6.jar
-    - jackson-datatype-jsr310-2.12.6.jar
-    - jackson-dataformat-yaml-2.12.6.jar
-    - jackson-jaxrs-base-2.12.6.jar
-    - jackson-jaxrs-json-provider-2.12.6.jar
-    - jackson-module-jaxb-annotations-2.12.6.jar
-    - jackson-module-jsonSchema-2.12.6.jar
+    - jackson-annotations-2.13.2.jar
+    - jackson-core-2.13.2.jar
+    - jackson-databind-2.13.2.jar
+    - jackson-dataformat-smile-2.13.2.jar
+    - jackson-datatype-guava-2.13.2.jar
+    - jackson-datatype-jdk8-2.13.2.jar
+    - jackson-datatype-joda-2.13.2.jar
+    - jackson-datatype-jsr310-2.13.2.jar
+    - jackson-dataformat-yaml-2.13.2.jar
+    - jackson-jaxrs-base-2.13.2.jar
+    - jackson-jaxrs-json-provider-2.13.2.jar
+    - jackson-module-jaxb-annotations-2.13.2.jar
+    - jackson-module-jsonSchema-2.13.2.jar
  * Guava
     - guava-31.0.1-jre.jar
     - listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.jar
@@ -454,7 +454,7 @@ The Apache Software License, Version 2.0
   * Snappy
     - snappy-java-1.1.7.jar
   * Jackson
-    - jackson-module-parameter-names-2.12.6.jar
+    - jackson-module-parameter-names-2.13.2.jar
   * Java Assist
     - javassist-3.25.0-GA.jar
   * Java Native Access

--- a/pulsar-sql/presto-distribution/pom.xml
+++ b/pulsar-sql/presto-distribution/pom.xml
@@ -38,10 +38,10 @@
     <airlift.version>0.170</airlift.version>
     <objenesis.version>2.6</objenesis.version>
     <objectsize.version>0.0.12</objectsize.version>
-    <jackson.version>2.12.6</jackson.version>
+    <jackson.version>2.13.2</jackson.version>
     <!--fix Security Vulnerabilities-->
     <!--https://www.cvedetails.com/vulnerability-list/vendor_id-15866/product_id-42991/Fasterxml-Jackson-databind.html-->
-    <jackson.databind.version>2.12.6</jackson.databind.version>
+    <jackson.databind.version>2.13.2</jackson.databind.version>
     <maven.version>3.0.5</maven.version>
     <guava.version>31.0.1-jre</guava.version>
     <asynchttpclient.version>2.12.1</asynchttpclient.version>


### PR DESCRIPTION
### Motivation

It seems that jackson-databind before 2.13.0 has a security vulnerability, so upgraded it to the latest version, 2.13.2.
https://nvd.nist.gov/vuln/detail/CVE-2020-36518

### Modifications

Upgrade Jackson from 2.12.6 to 2.13.2.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

### Documentation

- [x] `no-need-doc`