### PR TITLE
[tests] Add Kinesis Sink integration tests

### DIFF
--- a/pulsar-io/aws/pom.xml
+++ b/pulsar-io/aws/pom.xml
@@ -53,6 +53,7 @@
       <artifactId>sts</artifactId>
       <version>2.10.56</version>
     </dependency>
+
 	<!-- /aws dependencies -->
 
   </dependencies>

--- a/pulsar-io/aws/pom.xml
+++ b/pulsar-io/aws/pom.xml
@@ -53,7 +53,6 @@
       <artifactId>sts</artifactId>
       <version>2.10.56</version>
     </dependency>
-
 	<!-- /aws dependencies -->
 
   </dependencies>

--- a/pulsar-io/kinesis/pom.xml
+++ b/pulsar-io/kinesis/pom.xml
@@ -114,6 +114,18 @@
       <version>2.3.0</version>
     </dependency>
 
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>localstack</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 
   <build>

--- a/pulsar-io/kinesis/src/main/java/org/apache/pulsar/io/kinesis/BaseKinesisConfig.java
+++ b/pulsar-io/kinesis/src/main/java/org/apache/pulsar/io/kinesis/BaseKinesisConfig.java
@@ -36,11 +36,26 @@ public abstract class BaseKinesisConfig implements Serializable {
     private String awsEndpoint = "";
 
     @FieldDoc(
+            required = false,
+            defaultValue = "",
+            help = "Kinesis end-point port. It can be found at https://docs.aws.amazon.com/general/latest/gr/rande.html"
+    )
+    private Integer awsEndpointPort;
+
+    @FieldDoc(
         required = false,
         defaultValue = "",
         help = "Appropriate aws region. E.g. us-west-1, us-west-2"
     )
     private String awsRegion = "";
+
+
+    @FieldDoc(
+            required = false,
+            defaultValue = "false",
+            help = "Tell to Kinesis Client to skip certificate validation. This is useful while performing local tests, it's recommended to always validate certificate in production environment."
+    )
+    private Boolean skipCertificateValidation = false;
 
     @FieldDoc(
         required = true,

--- a/pulsar-io/kinesis/src/main/java/org/apache/pulsar/io/kinesis/BaseKinesisConfig.java
+++ b/pulsar-io/kinesis/src/main/java/org/apache/pulsar/io/kinesis/BaseKinesisConfig.java
@@ -35,12 +35,6 @@ public abstract class BaseKinesisConfig implements Serializable {
     )
     private String awsEndpoint = "";
 
-    @FieldDoc(
-            required = false,
-            defaultValue = "",
-            help = "Kinesis end-point port. It can be found at https://docs.aws.amazon.com/general/latest/gr/rande.html"
-    )
-    private Integer awsEndpointPort;
 
     @FieldDoc(
         required = false,
@@ -48,14 +42,6 @@ public abstract class BaseKinesisConfig implements Serializable {
         help = "Appropriate aws region. E.g. us-west-1, us-west-2"
     )
     private String awsRegion = "";
-
-
-    @FieldDoc(
-            required = false,
-            defaultValue = "false",
-            help = "Tell to Kinesis Client to skip certificate validation. This is useful while performing local tests, it's recommended to always validate certificate in production environment."
-    )
-    private Boolean skipCertificateValidation = false;
 
     @FieldDoc(
         required = true,
@@ -74,7 +60,7 @@ public abstract class BaseKinesisConfig implements Serializable {
     private String awsCredentialPluginName = "";
 
     @FieldDoc(
-        required = false,
+        required = true,
         defaultValue = "",
         sensitive = true,
         help = "json-parameters to initialize `AwsCredentialsProviderPlugin`")

--- a/pulsar-io/kinesis/src/main/java/org/apache/pulsar/io/kinesis/KinesisSink.java
+++ b/pulsar-io/kinesis/src/main/java/org/apache/pulsar/io/kinesis/KinesisSink.java
@@ -161,10 +161,17 @@ public class KinesisSink extends AbstractAwsConnector implements Sink<byte[]> {
 
         KinesisProducerConfiguration kinesisConfig = new KinesisProducerConfiguration();
         kinesisConfig.setKinesisEndpoint(kinesisSinkConfig.getAwsEndpoint());
+        if (kinesisSinkConfig.getAwsEndpointPort() != null) {
+            kinesisConfig.setKinesisPort(kinesisSinkConfig.getAwsEndpointPort());
+        }
         kinesisConfig.setRegion(kinesisSinkConfig.getAwsRegion());
         kinesisConfig.setThreadingModel(ThreadingModel.POOLED);
         kinesisConfig.setThreadPoolSize(4);
         kinesisConfig.setCollectionMaxCount(1);
+        if (kinesisSinkConfig.getSkipCertificateValidation() != null &&
+                kinesisSinkConfig.getSkipCertificateValidation()) {
+            kinesisConfig.setVerifyCertificate(false);
+        }
         AWSCredentialsProvider credentialsProvider = createCredentialProvider(
                 kinesisSinkConfig.getAwsCredentialPluginName(),
                 kinesisSinkConfig.getAwsCredentialPluginParam())

--- a/pulsar-io/kinesis/src/main/java/org/apache/pulsar/io/kinesis/KinesisSink.java
+++ b/pulsar-io/kinesis/src/main/java/org/apache/pulsar/io/kinesis/KinesisSink.java
@@ -168,8 +168,8 @@ public class KinesisSink extends AbstractAwsConnector implements Sink<byte[]> {
         kinesisConfig.setThreadingModel(ThreadingModel.POOLED);
         kinesisConfig.setThreadPoolSize(4);
         kinesisConfig.setCollectionMaxCount(1);
-        if (kinesisSinkConfig.getSkipCertificateValidation() != null &&
-                kinesisSinkConfig.getSkipCertificateValidation()) {
+        if (kinesisSinkConfig.getSkipCertificateValidation() != null
+                && kinesisSinkConfig.getSkipCertificateValidation()) {
             kinesisConfig.setVerifyCertificate(false);
         }
         AWSCredentialsProvider credentialsProvider = createCredentialProvider(

--- a/pulsar-io/kinesis/src/main/java/org/apache/pulsar/io/kinesis/KinesisSinkConfig.java
+++ b/pulsar-io/kinesis/src/main/java/org/apache/pulsar/io/kinesis/KinesisSinkConfig.java
@@ -35,6 +35,20 @@ public class KinesisSinkConfig extends BaseKinesisConfig implements Serializable
     private static final long serialVersionUID = 1L;
 
     @FieldDoc(
+            required = false,
+            defaultValue = "",
+            help = "Kinesis end-point port. It can be found at https://docs.aws.amazon.com/general/latest/gr/rande.html"
+    )
+    private Integer awsEndpointPort;
+
+    @FieldDoc(
+            required = false,
+            defaultValue = "false",
+            help = "Tell to Kinesis Client to skip certificate validation. This is useful while performing local tests, it's recommended to always validate certificates in production environments."
+    )
+    private Boolean skipCertificateValidation = false;
+
+    @FieldDoc(
         required = true,
         defaultValue = "ONLY_RAW_PAYLOAD",
         help = "Message format in which kinesis sink converts pulsar messages and publishes to kinesis streams.\n"

--- a/pulsar-io/kinesis/src/test/java/org/apache/pulsar/io/kinesis/KinesisSinkAuthTest.java
+++ b/pulsar-io/kinesis/src/test/java/org/apache/pulsar/io/kinesis/KinesisSinkAuthTest.java
@@ -1,0 +1,151 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.io.kinesis;
+
+import java.io.IOException;
+import java.util.Map;
+
+import org.apache.pulsar.io.aws.AwsCredentialProviderPlugin;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+import org.testng.collections.Maps;
+
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.auth.BasicSessionCredentials;
+import com.google.gson.Gson;
+
+public class KinesisSinkAuthTest {
+
+    @Test
+    public void testDefaultCredentialProvider() throws Exception {
+        KinesisSink sink = new KinesisSink();
+        Map<String, String> credentialParam = Maps.newHashMap();
+        String awsCredentialPluginParam = new Gson().toJson(credentialParam);
+        try {
+            sink.defaultCredentialProvider(awsCredentialPluginParam);
+            Assert.fail("accessKey and SecretKey validation not applied");
+        } catch (IllegalArgumentException ie) {
+            // Ok..
+        }
+
+        final String accesKey = "ak";
+        final String secretKey = "sk";
+        credentialParam.put(KinesisSink.ACCESS_KEY_NAME, accesKey);
+        credentialParam.put(KinesisSink.SECRET_KEY_NAME, secretKey);
+        awsCredentialPluginParam = new Gson().toJson(credentialParam);
+        AWSCredentialsProvider credentialProvider = sink.defaultCredentialProvider(awsCredentialPluginParam)
+                .getCredentialProvider();
+        Assert.assertNotNull(credentialProvider);
+        Assert.assertEquals(credentialProvider.getCredentials().getAWSAccessKeyId(), accesKey);
+        Assert.assertEquals(credentialProvider.getCredentials().getAWSSecretKey(), secretKey);
+
+        sink.close();
+    }
+
+    @Test
+    public void testCredentialProvider() throws Exception {
+        KinesisSink sink = new KinesisSink();
+
+        final String accesKey = "ak";
+        final String secretKey = "sk";
+        Map<String, String> credentialParam = Maps.newHashMap();
+        credentialParam.put(KinesisSink.ACCESS_KEY_NAME, accesKey);
+        credentialParam.put(KinesisSink.SECRET_KEY_NAME, secretKey);
+        String awsCredentialPluginParam = new Gson().toJson(credentialParam);
+        AWSCredentialsProvider credentialProvider = sink.createCredentialProvider(null, awsCredentialPluginParam)
+                .getCredentialProvider();
+        Assert.assertEquals(credentialProvider.getCredentials().getAWSAccessKeyId(), accesKey);
+        Assert.assertEquals(credentialProvider.getCredentials().getAWSSecretKey(), secretKey);
+
+        credentialProvider = sink.createCredentialProvider(AwsCredentialProviderPluginImpl.class.getName(), "{}")
+                .getCredentialProvider();
+        Assert.assertNotNull(credentialProvider);
+        Assert.assertEquals(credentialProvider.getCredentials().getAWSAccessKeyId(),
+                AwsCredentialProviderPluginImpl.accessKey);
+        Assert.assertEquals(credentialProvider.getCredentials().getAWSSecretKey(),
+                AwsCredentialProviderPluginImpl.secretKey);
+        Assert.assertEquals(((BasicSessionCredentials) credentialProvider.getCredentials()).getSessionToken(),
+                AwsCredentialProviderPluginImpl.sessionToken);
+
+        sink.close();
+    }
+
+    @Test
+    public void testCredentialProviderPlugin() throws Exception {
+        KinesisSink sink = new KinesisSink();
+
+        AWSCredentialsProvider credentialProvider = sink
+                .createCredentialProviderWithPlugin(AwsCredentialProviderPluginImpl.class.getName(), "{}")
+                .getCredentialProvider();
+        Assert.assertNotNull(credentialProvider);
+        Assert.assertEquals(credentialProvider.getCredentials().getAWSAccessKeyId(),
+                AwsCredentialProviderPluginImpl.accessKey);
+        Assert.assertEquals(credentialProvider.getCredentials().getAWSSecretKey(),
+                AwsCredentialProviderPluginImpl.secretKey);
+        Assert.assertEquals(((BasicSessionCredentials) credentialProvider.getCredentials()).getSessionToken(),
+                AwsCredentialProviderPluginImpl.sessionToken);
+
+        sink.close();
+    }
+
+    public static class AwsCredentialProviderPluginImpl implements AwsCredentialProviderPlugin {
+
+        public static final String accessKey = "ak";
+        public static final String secretKey = "sk";
+        public static final String sessionToken = "st";
+
+        public void init(String param) {
+            // no-op
+        }
+
+        @Override
+        public AWSCredentialsProvider getCredentialProvider() {
+            return new AWSCredentialsProvider() {
+                @Override
+                public AWSCredentials getCredentials() {
+                    return new BasicSessionCredentials(accessKey, secretKey, sessionToken) {
+
+                        @Override
+                        public String getAWSAccessKeyId() {
+                            return accessKey;
+                        }
+                        @Override
+                        public String getAWSSecretKey() {
+                            return secretKey;
+                        }
+                        @Override
+                        public String getSessionToken() {
+                            return sessionToken;
+                        }
+                    };
+                }
+                @Override
+                public void refresh() {
+                    // TODO Auto-generated method stub
+                }
+            };
+        }
+        @Override
+        public void close() throws IOException {
+            // TODO Auto-generated method stub
+        }
+    }
+
+}

--- a/pulsar-io/kinesis/src/test/java/org/apache/pulsar/io/kinesis/KinesisSinkTest.java
+++ b/pulsar-io/kinesis/src/test/java/org/apache/pulsar/io/kinesis/KinesisSinkTest.java
@@ -18,137 +18,150 @@
  */
 package org.apache.pulsar.io.kinesis;
 
-import java.io.IOException;
-import java.util.Map;
-
-import org.apache.pulsar.io.aws.AwsCredentialProviderPlugin;
-import org.testng.Assert;
+import lombok.SneakyThrows;
+import org.apache.pulsar.functions.api.Record;
+import org.apache.pulsar.io.core.SinkContext;
+import org.awaitility.Awaitility;
+import org.mockito.Mockito;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+import org.testcontainers.containers.localstack.LocalStackContainer;
+import org.testcontainers.utility.DockerImageName;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
-import org.testng.collections.Maps;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.AwsCredentials;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.kinesis.KinesisAsyncClient;
+import software.amazon.awssdk.services.kinesis.model.CreateStreamRequest;
+import software.amazon.awssdk.services.kinesis.model.GetRecordsRequest;
+import software.amazon.awssdk.services.kinesis.model.GetRecordsResponse;
+import software.amazon.awssdk.services.kinesis.model.GetShardIteratorRequest;
+import software.amazon.awssdk.services.kinesis.model.ListShardsRequest;
+import software.amazon.awssdk.services.kinesis.model.ShardIteratorType;
 
-import com.amazonaws.auth.AWSCredentials;
-import com.amazonaws.auth.AWSCredentialsProvider;
-import com.amazonaws.auth.BasicSessionCredentials;
-import com.google.gson.Gson;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicBoolean;
 
-/**
- * Unit test of {@link KinesisSink}.
- */
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+
 public class KinesisSinkTest {
 
-    @Test
-    public void testDefaultCredentialProvider() throws Exception {
-        KinesisSink sink = new KinesisSink();
-        Map<String, String> credentialParam = Maps.newHashMap();
-        String awsCredentialPluginParam = new Gson().toJson(credentialParam);
-        try {
-            sink.defaultCredentialProvider(awsCredentialPluginParam);
-            Assert.fail("accessKey and SecretKey validation not applied");
-        } catch (IllegalArgumentException ie) {
-            // Ok..
-        }
+    public static final String STREAM_NAME = "my-stream-1";
+    public static LocalStackContainer LOCALSTACK_CONTAINER = new LocalStackContainer(DockerImageName.parse("localstack/localstack:latest"))
+            .withServices(LocalStackContainer.Service.KINESIS);
 
-        final String accesKey = "ak";
-        final String secretKey = "sk";
-        credentialParam.put(KinesisSink.ACCESS_KEY_NAME, accesKey);
-        credentialParam.put(KinesisSink.SECRET_KEY_NAME, secretKey);
-        awsCredentialPluginParam = new Gson().toJson(credentialParam);
-        AWSCredentialsProvider credentialProvider = sink.defaultCredentialProvider(awsCredentialPluginParam)
-                .getCredentialProvider();
-        Assert.assertNotNull(credentialProvider);
-        Assert.assertEquals(credentialProvider.getCredentials().getAWSAccessKeyId(), accesKey);
-        Assert.assertEquals(credentialProvider.getCredentials().getAWSSecretKey(), secretKey);
+    @BeforeClass(alwaysRun = true)
+    public void beforeClass() throws Exception {
+        LOCALSTACK_CONTAINER.start();
+        createClient().createStream(CreateStreamRequest.builder().streamName(STREAM_NAME).shardCount(1).build()).get();
+    }
 
-        sink.close();
+    @AfterClass(alwaysRun = true)
+    public void afterClass() throws Exception {
+        LOCALSTACK_CONTAINER.stop();
     }
 
     @Test
-    public void testCredentialProvider() throws Exception {
-        KinesisSink sink = new KinesisSink();
+    public void testWrite() throws Exception {
+        final Record mockRecord = mock(Record.class);
+        AtomicBoolean ackCalled = new AtomicBoolean();
+        Mockito.doAnswer((Answer<Void>) invocation -> {
+            ackCalled.set(true);
+            return null;
+        }).when(mockRecord).ack();
+        when(mockRecord.getKey()).thenAnswer(new Answer<Optional<String>>() {
+            long sequenceCounter = 0;
+            public Optional<String> answer(InvocationOnMock invocation) throws Throwable {
+                return Optional.of( "key-" + sequenceCounter++);
+            }});
 
-        final String accesKey = "ak";
-        final String secretKey = "sk";
-        Map<String, String> credentialParam = Maps.newHashMap();
-        credentialParam.put(KinesisSink.ACCESS_KEY_NAME, accesKey);
-        credentialParam.put(KinesisSink.SECRET_KEY_NAME, secretKey);
-        String awsCredentialPluginParam = new Gson().toJson(credentialParam);
-        AWSCredentialsProvider credentialProvider = sink.createCredentialProvider(null, awsCredentialPluginParam)
-                .getCredentialProvider();
-        Assert.assertEquals(credentialProvider.getCredentials().getAWSAccessKeyId(), accesKey);
-        Assert.assertEquals(credentialProvider.getCredentials().getAWSSecretKey(), secretKey);
+        when(mockRecord.getValue()).thenReturn("hello".getBytes(StandardCharsets.UTF_8));
 
-        credentialProvider = sink.createCredentialProvider(AwsCredentialProviderPluginImpl.class.getName(), "{}")
-                .getCredentialProvider();
-        Assert.assertNotNull(credentialProvider);
-        Assert.assertEquals(credentialProvider.getCredentials().getAWSAccessKeyId(),
-                AwsCredentialProviderPluginImpl.accessKey);
-        Assert.assertEquals(credentialProvider.getCredentials().getAWSSecretKey(),
-                AwsCredentialProviderPluginImpl.secretKey);
-        Assert.assertEquals(((BasicSessionCredentials) credentialProvider.getCredentials()).getSessionToken(),
-                AwsCredentialProviderPluginImpl.sessionToken);
+        try (final KinesisSink sink = new KinesisSink();) {
+            Map<String, Object> map = createConfig();
+            SinkContext mockSinkContext = mock(SinkContext.class);
 
-        sink.close();
+            sink.open(map, mockSinkContext);
+            for (int i = 0; i < 10; i++) {
+                sink.write(mockRecord);
+            }
+            Awaitility.await().untilAsserted(() -> {
+                assertTrue(ackCalled.get());
+            });
+            final GetRecordsResponse getRecords = getStreamRecords();
+            assertEquals(getRecords.records().size(), 10);
+
+            for (software.amazon.awssdk.services.kinesis.model.Record record : getRecords.records()) {
+                assertEquals(record.data().asString(StandardCharsets.UTF_8), "hello");
+            }
+        }
     }
 
-    @Test
-    public void testCredentialProviderPlugin() throws Exception {
-        KinesisSink sink = new KinesisSink();
-
-        AWSCredentialsProvider credentialProvider = sink
-                .createCredentialProviderWithPlugin(AwsCredentialProviderPluginImpl.class.getName(), "{}")
-                .getCredentialProvider();
-        Assert.assertNotNull(credentialProvider);
-        Assert.assertEquals(credentialProvider.getCredentials().getAWSAccessKeyId(),
-                AwsCredentialProviderPluginImpl.accessKey);
-        Assert.assertEquals(credentialProvider.getCredentials().getAWSSecretKey(),
-                AwsCredentialProviderPluginImpl.secretKey);
-        Assert.assertEquals(((BasicSessionCredentials) credentialProvider.getCredentials()).getSessionToken(),
-                AwsCredentialProviderPluginImpl.sessionToken);
-
-        sink.close();
+    private Map<String, Object> createConfig() {
+        final URI endpointOverride = LOCALSTACK_CONTAINER.getEndpointOverride(LocalStackContainer.Service.KINESIS);
+        Map<String, Object> map = new HashMap<>();
+        map.put("awsEndpoint", endpointOverride.getHost());
+        map.put("awsEndpointPort", endpointOverride.getPort());
+        map.put("skipCertificateValidation", true);
+        map.put("awsKinesisStreamName", STREAM_NAME);
+        map.put("awsRegion", "us-east-1");
+        map.put("awsCredentialPluginParam", "{\"accessKey\":\"access\",\"secretKey\":\"secret\"}");
+        return map;
     }
 
-    public static class AwsCredentialProviderPluginImpl implements AwsCredentialProviderPlugin {
+    private KinesisAsyncClient createClient() {
+        final KinesisAsyncClient client = KinesisAsyncClient.builder()
+                .credentialsProvider(new AwsCredentialsProvider() {
+                    @Override
+                    public AwsCredentials resolveCredentials() {
+                        return AwsBasicCredentials.create(
+                                "access",
+                                "secret");
+                    }
+                })
+                .region(Region.US_EAST_1)
+                .endpointOverride(LOCALSTACK_CONTAINER.getEndpointOverride(LocalStackContainer.Service.KINESIS))
+                .build();
+        return client;
+    }
 
-        public static final String accessKey = "ak";
-        public static final String secretKey = "sk";
-        public static final String sessionToken = "st";
+    @SneakyThrows
+    private GetRecordsResponse getStreamRecords() {
+        final KinesisAsyncClient client = createClient();
+        final String shardId = client.listShards(
+                        ListShardsRequest.builder()
+                                .streamName(STREAM_NAME)
+                                .build()
+                ).get()
+                .shards()
+                .get(0)
+                .shardId();
 
-        public void init(String param) {
-            // no-op
-        }
-
-        @Override
-        public AWSCredentialsProvider getCredentialProvider() {
-            return new AWSCredentialsProvider() {
-                @Override
-                public AWSCredentials getCredentials() {
-                    return new BasicSessionCredentials(accessKey, secretKey, sessionToken) {
-
-                        @Override
-                        public String getAWSAccessKeyId() {
-                            return accessKey;
-                        }
-                        @Override
-                        public String getAWSSecretKey() {
-                            return secretKey;
-                        }
-                        @Override
-                        public String getSessionToken() {
-                            return sessionToken;
-                        }
-                    };
-                }
-                @Override
-                public void refresh() {
-                    // TODO Auto-generated method stub
-                }
-            };
-        }
-        @Override
-        public void close() throws IOException {
-            // TODO Auto-generated method stub
-        }
+        final String iterator = client.getShardIterator(GetShardIteratorRequest.builder()
+                        .streamName(STREAM_NAME)
+                        .shardId(shardId)
+                        .shardIteratorType(ShardIteratorType.TRIM_HORIZON)
+                        .build())
+                .get()
+                .shardIterator();
+        final GetRecordsResponse response = client.getRecords(
+                        GetRecordsRequest
+                                .builder()
+                                .shardIterator(iterator)
+                                .build())
+                .get();
+        return response;
     }
 
 }

--- a/tests/docker-images/latest-version-image/Dockerfile
+++ b/tests/docker-images/latest-version-image/Dockerfile
@@ -117,6 +117,7 @@ COPY --from=pulsar-all /pulsar/connectors/pulsar-io-jdbc-postgres-*.nar /pulsar/
 COPY --from=pulsar-all /pulsar/connectors/pulsar-io-kafka-*.nar /pulsar/connectors/
 COPY --from=pulsar-all /pulsar/connectors/pulsar-io-rabbitmq-*.nar /pulsar/connectors/
 COPY --from=pulsar-all /pulsar/connectors/pulsar-io-batch-data-generator-*.nar /pulsar/connectors/
+COPY --from=pulsar-all /pulsar/connectors/pulsar-io-kinesis-*.nar /pulsar/connectors/
 
 # download Oracle JDBC driver for Oracle Debezium Connector tests
 RUN mkdir -p META-INF/bundled-dependencies

--- a/tests/integration/pom.xml
+++ b/tests/integration/pom.xml
@@ -176,6 +176,25 @@
       <artifactId>awaitility</artifactId>
       <scope>test</scope>
     </dependency>
+
+<!--    kinesis-->
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>localstack</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>software.amazon.kinesis</groupId>
+      <artifactId>amazon-kinesis-client</artifactId>
+      <version>2.2.8</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.amazonaws</groupId>
+      <artifactId>aws-java-sdk-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 
   <build>

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/sinks/KinesisSinkTester.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/sinks/KinesisSinkTester.java
@@ -1,0 +1,132 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.tests.integration.io.sinks;
+
+import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.pulsar.tests.integration.topologies.PulsarCluster;
+import org.awaitility.Awaitility;
+import org.testcontainers.containers.localstack.LocalStackContainer;
+import org.testcontainers.utility.DockerImageName;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.AwsCredentials;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.kinesis.KinesisAsyncClient;
+import software.amazon.awssdk.services.kinesis.model.CreateStreamRequest;
+import software.amazon.awssdk.services.kinesis.model.GetRecordsRequest;
+import software.amazon.awssdk.services.kinesis.model.GetRecordsResponse;
+import software.amazon.awssdk.services.kinesis.model.GetShardIteratorRequest;
+import software.amazon.awssdk.services.kinesis.model.ListShardsRequest;
+import software.amazon.awssdk.services.kinesis.model.Record;
+import software.amazon.awssdk.services.kinesis.model.ShardIteratorType;
+
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+
+import static org.testng.Assert.assertTrue;
+
+@Slf4j
+public class KinesisSinkTester extends SinkTester<LocalStackContainer> {
+
+    private static final String NAME = "kinesis";
+    public static final String STREAM_NAME = "my-stream-1";
+    private KinesisAsyncClient client;
+
+    public KinesisSinkTester() {
+        super(NAME, SinkType.KINESIS);
+
+        sinkConfig.put("awsKinesisStreamName", STREAM_NAME);
+        sinkConfig.put("awsRegion", "us-east-1");
+        sinkConfig.put("awsCredentialPluginParam", "{\"accessKey\":\"access\",\"secretKey\":\"secret\"}");
+    }
+
+
+    @Override
+    public void prepareSink() throws Exception {
+        final LocalStackContainer localStackContainer = getServiceContainer();
+        final URI endpointOverride = localStackContainer.getEndpointOverride(LocalStackContainer.Service.KINESIS);
+        sinkConfig.put("awsEndpoint", NAME);
+        sinkConfig.put("awsEndpointPort", endpointOverride.getPort());
+        sinkConfig.put("skipCertificateValidation", true);
+        client = KinesisAsyncClient.builder().credentialsProvider(new AwsCredentialsProvider() {
+                    @Override
+                    public AwsCredentials resolveCredentials() {
+                        return AwsBasicCredentials.create(
+                                "access",
+                                "secret");
+                    }
+                })
+                .region(Region.US_EAST_1)
+                .endpointOverride(endpointOverride)
+                .build();
+        log.info("prepareSink for kinesis: creating stream {}, endpoint {}", STREAM_NAME, endpointOverride);
+        client.createStream(CreateStreamRequest.builder()
+                .streamName(STREAM_NAME)
+                .shardCount(1)
+                .build())
+                .get();
+        log.info("prepareSink for kinesis: created stream {}", STREAM_NAME);
+
+
+    }
+
+    @Override
+    protected LocalStackContainer createSinkService(PulsarCluster cluster) {
+        return new LocalStackContainer(DockerImageName.parse("localstack/localstack:latest"))
+                .withServices(LocalStackContainer.Service.KINESIS);
+    }
+
+    @Override
+    @SneakyThrows
+    public void validateSinkResult(Map<String, String> kvs) {
+        Awaitility.await().untilAsserted(() -> validateSinkResult());
+    }
+
+    @SneakyThrows
+    private void validateSinkResult() {
+        final String shardId = client.listShards(
+                ListShardsRequest.builder()
+                        .streamName(STREAM_NAME)
+                        .build()
+        ).get()
+                .shards()
+                .get(0)
+                .shardId();
+
+        final String iterator = client.getShardIterator(GetShardIteratorRequest.builder()
+                .streamName(STREAM_NAME)
+                .shardId(shardId)
+                .shardIteratorType(ShardIteratorType.TRIM_HORIZON)
+                .build())
+                .get()
+                .shardIterator();
+        final GetRecordsResponse response = client.getRecords(
+                GetRecordsRequest
+                        .builder()
+                        .shardIterator(iterator)
+                        .build())
+                .get();
+        assertTrue(response.hasRecords());
+        for (Record record : response.records()) {
+            assertTrue(record.data().asString(StandardCharsets.UTF_8).startsWith("value-"));
+        }
+    }
+}

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/sinks/PulsarSinksTest.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/sinks/PulsarSinksTest.java
@@ -70,4 +70,9 @@ public class PulsarSinksTest extends PulsarIOTestBase {
         testSink(new RabbitMQSinkTester(containerName), true, new RabbitMQSourceTester(containerName));
     }
 
+    @Test(groups = "sink")
+    public void testKinesis() throws Exception {
+        testSink(new KinesisSinkTester(), true);
+    }
+
 }

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/sinks/SinkTester.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/sinks/SinkTester.java
@@ -41,6 +41,7 @@ public abstract class SinkTester<ServiceContainerT extends GenericContainer> {
         UNDEFINED("undefined"),
         CASSANDRA("cassandra"),
         KAFKA("kafka"),
+        KINESIS("kinesis"),
         JDBC_POSTGRES("jdbc-postgres"),
         HDFS("hdfs"),
         ELASTIC_SEARCH("elastic_search"),


### PR DESCRIPTION
### Motivation

Kinesis sink doesn't have integration tests.

### Modifications
* Added two config props needed for testing:
  * skipCertificateValidation: Boolean, default false
  * awsEndpointPort: Integer, default null, if null will use the default client port
* Added integration tests with mock pulsar (under pulsar-io/kinesis dir) using localstack image and testcontainers.
* Added integration tests with real pulsar (under integrations dir) using localstack image and testcontainers.

- [x] `no-need-doc` 
