### PR TITLE
[C++] Fix producer is never destructed until client is closed

### DIFF
--- a/pulsar-client-cpp/lib/ProducerImpl.h
+++ b/pulsar-client-cpp/lib/ProducerImpl.h
@@ -170,6 +170,8 @@ class ProducerImpl : public HandlerBase,
 
     DeadlineTimerPtr sendTimer_;
     void handleSendTimeout(const boost::system::error_code& err);
+    using DurationType = typename boost::asio::deadline_timer::duration_type;
+    void asyncWaitSendTimeout(DurationType expiryTime);
 
     Promise<Result, ProducerImplBaseWeakPtr> producerCreatedPromise_;
 

--- a/pulsar-client-cpp/tests/ClientTest.cc
+++ b/pulsar-client-cpp/tests/ClientTest.cc
@@ -19,6 +19,7 @@
 #include <gtest/gtest.h>
 
 #include "HttpHelper.h"
+#include "PulsarFriend.h"
 
 #include <future>
 #include <pulsar/Client.h>
@@ -187,5 +188,31 @@ TEST(ClientTest, testGetNumberOfReferences) {
     numberOfConsumers = 0;
     ASSERT_EQ(numberOfConsumers, client.getNumberOfConsumers());
 
+    client.close();
+}
+
+TEST(ClientTest, testReferenceCount) {
+    Client client(lookupUrl);
+    const std::string topic = "client-test-reference-count-" + std::to_string(time(nullptr));
+
+    auto &producers = PulsarFriend::getProducers(client);
+    auto &consumers = PulsarFriend::getConsumers(client);
+
+    {
+        Producer producer;
+        ASSERT_EQ(ResultOk, client.createProducer(topic, producer));
+        ASSERT_EQ(producers.size(), 1);
+        ASSERT_EQ(producers[0].use_count(), 1);
+
+        Consumer consumer;
+        ASSERT_EQ(ResultOk, client.subscribe(topic, "my-sub", consumer));
+        ASSERT_EQ(consumers.size(), 1);
+        ASSERT_EQ(consumers[0].use_count(), 1);
+    }
+
+    ASSERT_EQ(producers.size(), 1);
+    ASSERT_EQ(producers[0].use_count(), 0);
+    ASSERT_EQ(consumers.size(), 1);
+    ASSERT_EQ(consumers[0].use_count(), 0);
     client.close();
 }

--- a/pulsar-client-cpp/tests/PulsarFriend.h
+++ b/pulsar-client-cpp/tests/PulsarFriend.h
@@ -95,6 +95,14 @@ class PulsarFriend {
 
     static std::shared_ptr<ClientImpl> getClientImplPtr(Client client) { return client.impl_; }
 
+    static ClientImpl::ProducersList& getProducers(const Client& client) {
+        return getClientImplPtr(client)->producers_;
+    }
+
+    static ClientImpl::ConsumersList& getConsumers(const Client& client) {
+        return getClientImplPtr(client)->consumers_;
+    }
+
     static void setNegativeAckEnabled(Consumer consumer, bool enabled) {
         consumer.impl_->setNegativeAcknowledgeEnabledForTesting(enabled);
     }


### PR DESCRIPTION
Fixes #509

### Motivation

When a C++ producer is created successfully, it will start a send timer.
However the callback has captured the shared pointer of `ProducerImpl`
itself. It extends the lifetime of `ProducerImpl` so that even after the
`Producer` object destructs, the underlying `ProducerImpl` object won't
be destructed. It could only be destructed after `Client::close()` is
called.

### Modifications

- Pass a weak pointer of `ProducerImpl` to the send timer and add a
  `asyncWaitSendTimeout` method for the combination of
  `expires_from_now` and `async_wait` calls on the timer.
- Add `ClientTest.testReferenceCount` to verify the reference count will
  become 0 after the producer or consumer destructs.