### PR TITLE
[fix][txn]: fix transaction buffer recover reader and writer fail

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/systopic/TransactionBufferSystemTopicClient.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/systopic/TransactionBufferSystemTopicClient.java
@@ -128,10 +128,17 @@ public class TransactionBufferSystemTopicClient extends SystemTopicClientBase<Tr
 
         @Override
         public CompletableFuture<Void> closeAsync() {
-            return producer.closeAsync().thenCompose(v -> {
+            CompletableFuture<Void> completableFuture = new CompletableFuture<>();
+            producer.closeAsync().whenComplete((v, e) -> {
+                // if close fail, also need remove the producer
                 transactionBufferSystemTopicClient.removeWriter(this);
-                return CompletableFuture.completedFuture(null);
+                if (e != null) {
+                    completableFuture.completeExceptionally(e);
+                    return;
+                }
+                completableFuture.complete(null);
             });
+            return completableFuture;
         }
 
         @Override
@@ -179,10 +186,17 @@ public class TransactionBufferSystemTopicClient extends SystemTopicClientBase<Tr
 
         @Override
         public CompletableFuture<Void> closeAsync() {
-            return reader.closeAsync().thenCompose(v -> {
+            CompletableFuture<Void> completableFuture = new CompletableFuture<>();
+            reader.closeAsync().whenComplete((v, e) -> {
+                // if close fail, also need remove the reader
                 transactionBufferSystemTopicClient.removeReader(this);
-                return CompletableFuture.completedFuture(null);
+                if (e != null) {
+                    completableFuture.completeExceptionally(e);
+                    return;
+                }
+                completableFuture.complete(null);
             });
+            return completableFuture;
         }
 
         @Override

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/TopicTransactionBuffer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/TopicTransactionBuffer.java
@@ -184,7 +184,7 @@ public class TopicTransactionBuffer extends TopicTransactionBufferState implemen
                         if (e instanceof PulsarClientException) {
                             log.warn("Closing topic {} due to read transaction buffer snapshot while recovering the "
                                     + "transaction buffer throw exception", topic.getName(), e);
-                            topic.close();
+                            topic.close(true);
                         }
                         transactionBufferFuture.completeExceptionally(e);
                     }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/TopicTransactionBuffer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/TopicTransactionBuffer.java
@@ -179,6 +179,7 @@ public class TopicTransactionBuffer extends TopicTransactionBufferState implemen
 
                     @Override
                     public void recoverExceptionally(Throwable e) {
+                        transactionBufferFuture.completeExceptionally(e);
                         // when create reader or writer fail throw PulsarClientException,
                         // should close this topic and then reinit this topic
                         if (e instanceof PulsarClientException) {
@@ -186,7 +187,6 @@ public class TopicTransactionBuffer extends TopicTransactionBufferState implemen
                                     + "transaction buffer throw exception", topic.getName(), e);
                             topic.close(true);
                         }
-                        transactionBufferFuture.completeExceptionally(e);
                     }
                 }, this.topic, this, takeSnapshotWriter));
     }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/TopicTransactionBuffer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/TopicTransactionBuffer.java
@@ -188,13 +188,13 @@ public class TopicTransactionBuffer extends TopicTransactionBufferState implemen
                             // we need to change the PulsarClientException to ServiceUnitNotReadyException,
                             // the tc do op will retry
                             transactionBufferFuture.completeExceptionally
-                                    (new BrokerServiceException.ServiceUnitNotReadyException(e.getMessage()));
+                                    (new BrokerServiceException.ServiceUnitNotReadyException(e.getMessage(), e));
                             log.warn("Closing topic {} due to read transaction buffer snapshot while recovering the "
                                     + "transaction buffer throw exception", topic.getName(), e);
-                            topic.close(true);
                         } else {
                             transactionBufferFuture.completeExceptionally(e);
                         }
+                        topic.close(true);
                     }
                 }, this.topic, this, takeSnapshotWriter));
     }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/TopicTransactionBuffer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/TopicTransactionBuffer.java
@@ -178,15 +178,17 @@ public class TopicTransactionBuffer extends TopicTransactionBufferState implemen
                     }
 
                     @Override
-                    public void recoverExceptionally(Exception e) {
-                        if (e instanceof PulsarClientException.BrokerMetadataException) {
+                    public void recoverExceptionally(Throwable e) {
+                        // when create reader or writer fail throw PulsarClientException,
+                        // should close this topic and then reinit this topic
+                        if (e instanceof PulsarClientException) {
                             log.warn("Closing topic {} due to read transaction buffer snapshot while recovering the "
                                     + "transaction buffer throw exception", topic.getName(), e);
                             topic.close();
                         }
                         transactionBufferFuture.completeExceptionally(e);
                     }
-                }, this.topic, this));
+                }, this.topic, this, takeSnapshotWriter));
     }
 
     @Override
@@ -541,98 +543,112 @@ public class TopicTransactionBuffer extends TopicTransactionBufferState implemen
 
         private final TopicTransactionBuffer topicTransactionBuffer;
 
+        private final CompletableFuture<SystemTopicClient.Writer<TransactionBufferSnapshot>> takeSnapshotWriter;
+
         private TopicTransactionBufferRecover(TopicTransactionBufferRecoverCallBack callBack, PersistentTopic topic,
-                                              TopicTransactionBuffer transactionBuffer) {
+                                              TopicTransactionBuffer transactionBuffer, CompletableFuture<
+                SystemTopicClient.Writer<TransactionBufferSnapshot>> takeSnapshotWriter) {
             this.topic = topic;
             this.callBack = callBack;
             this.entryQueue = new SpscArrayQueue<>(2000);
             this.topicTransactionBuffer = transactionBuffer;
+            this.takeSnapshotWriter = takeSnapshotWriter;
         }
 
         @SneakyThrows
         @Override
         public void run() {
-            if (!this.topicTransactionBuffer.changeToInitializingState()) {
-                log.warn("TransactionBuffer {} of topic {} can not change state to Initializing",
-                        this, topic.getName());
-                return;
-            }
-            topic.getBrokerService().getPulsar().getTransactionBufferSnapshotService()
-                    .createReader(TopicName.get(topic.getName())).thenAcceptAsync(reader -> {
-                try {
-                    boolean hasSnapshot = false;
-                    while (reader.hasMoreEvents()) {
-                        Message<TransactionBufferSnapshot> message = reader.readNext();
-                        if (topic.getName().equals(message.getKey())) {
-                            TransactionBufferSnapshot transactionBufferSnapshot = message.getValue();
-                            if (transactionBufferSnapshot != null) {
-                                hasSnapshot = true;
-                                callBack.handleSnapshot(transactionBufferSnapshot);
-                                this.startReadCursorPosition = PositionImpl.get(
-                                        transactionBufferSnapshot.getMaxReadPositionLedgerId(),
-                                        transactionBufferSnapshot.getMaxReadPositionEntryId());
-                            }
-                        }
-                    }
-                    if (!hasSnapshot) {
-                        callBack.noNeedToRecover();
-                        return;
-                    }
-                } catch (PulsarClientException pulsarClientException) {
-                    log.error("[{}]Transaction buffer recover fail when read "
-                            + "transactionBufferSnapshot!", topic.getName(), pulsarClientException);
-                    callBack.recoverExceptionally(pulsarClientException);
-                    reader.closeAsync().exceptionally(e -> {
-                        log.error("[{}]Transaction buffer reader close error!", topic.getName(), e);
-                        return null;
-                    });
+            this.takeSnapshotWriter.thenRunAsync(() -> {
+                if (!this.topicTransactionBuffer.changeToInitializingState()) {
+                    log.warn("TransactionBuffer {} of topic {} can not change state to Initializing",
+                            this, topic.getName());
                     return;
                 }
-                reader.closeAsync().exceptionally(e -> {
-                    log.error("[{}]Transaction buffer reader close error!", topic.getName(), e);
-                    return null;
-                });
-
-                ManagedCursor managedCursor;
-                try {
-                    managedCursor = topic.getManagedLedger()
-                            .newNonDurableCursor(this.startReadCursorPosition, SUBSCRIPTION_NAME);
-                } catch (ManagedLedgerException e) {
-                    callBack.recoverExceptionally(e);
-                    log.error("[{}]Transaction buffer recover fail when open cursor!", topic.getName(), e);
-                    return;
-                }
-                PositionImpl lastConfirmedEntry = (PositionImpl) topic.getManagedLedger().getLastConfirmedEntry();
-                PositionImpl currentLoadPosition = (PositionImpl) this.startReadCursorPosition;
-                FillEntryQueueCallback fillEntryQueueCallback = new FillEntryQueueCallback(entryQueue,
-                        managedCursor, TopicTransactionBufferRecover.this);
-                if (lastConfirmedEntry.getEntryId() != -1) {
-                    while (lastConfirmedEntry.compareTo(currentLoadPosition) > 0
-                            && fillEntryQueueCallback.fillQueue()) {
-                        Entry entry = entryQueue.poll();
-                        if (entry != null) {
+                topic.getBrokerService().getPulsar().getTransactionBufferSnapshotService()
+                        .createReader(TopicName.get(topic.getName())).thenAcceptAsync(reader -> {
                             try {
-                                currentLoadPosition = PositionImpl.get(entry.getLedgerId(), entry.getEntryId());
-                                callBack.handleTxnEntry(entry);
-                            } finally {
-                                entry.release();
+                                boolean hasSnapshot = false;
+                                while (reader.hasMoreEvents()) {
+                                    Message<TransactionBufferSnapshot> message = reader.readNext();
+                                    if (topic.getName().equals(message.getKey())) {
+                                        TransactionBufferSnapshot transactionBufferSnapshot = message.getValue();
+                                        if (transactionBufferSnapshot != null) {
+                                            hasSnapshot = true;
+                                            callBack.handleSnapshot(transactionBufferSnapshot);
+                                            this.startReadCursorPosition = PositionImpl.get(
+                                                    transactionBufferSnapshot.getMaxReadPositionLedgerId(),
+                                                    transactionBufferSnapshot.getMaxReadPositionEntryId());
+                                        }
+                                    }
+                                }
+                                if (!hasSnapshot) {
+                                    callBack.noNeedToRecover();
+                                    return;
+                                }
+                            } catch (PulsarClientException pulsarClientException) {
+                                log.error("[{}]Transaction buffer recover fail when read "
+                                        + "transactionBufferSnapshot!", topic.getName(), pulsarClientException);
+                                callBack.recoverExceptionally(pulsarClientException);
+                                reader.closeAsync().exceptionally(e -> {
+                                    log.error("[{}]Transaction buffer reader close error!", topic.getName(), e);
+                                    return null;
+                                });
+                                return;
                             }
-                        } else {
-                            try {
-                                Thread.sleep(1);
-                            } catch (InterruptedException e) {
-                                //no-op
-                            }
-                        }
-                    }
-                }
+                            reader.closeAsync().exceptionally(e -> {
+                                log.error("[{}]Transaction buffer reader close error!", topic.getName(), e);
+                                return null;
+                            });
 
-                closeCursor(managedCursor);
-                callBack.recoverComplete();
-            }, topic.getBrokerService().getPulsar().getTransactionExecutorProvider().getExecutor(this))
-                    .exceptionally(e -> {
-                callBack.recoverExceptionally(new Exception(e));
-                log.error("[{}]Transaction buffer new snapshot reader fail!", topic.getName(), e);
+                            ManagedCursor managedCursor;
+                            try {
+                                managedCursor = topic.getManagedLedger()
+                                        .newNonDurableCursor(this.startReadCursorPosition, SUBSCRIPTION_NAME);
+                            } catch (ManagedLedgerException e) {
+                                callBack.recoverExceptionally(e);
+                                log.error("[{}]Transaction buffer recover fail when open cursor!", topic.getName(), e);
+                                return;
+                            }
+                            PositionImpl lastConfirmedEntry =
+                                    (PositionImpl) topic.getManagedLedger().getLastConfirmedEntry();
+                            PositionImpl currentLoadPosition = (PositionImpl) this.startReadCursorPosition;
+                            FillEntryQueueCallback fillEntryQueueCallback = new FillEntryQueueCallback(entryQueue,
+                                    managedCursor, TopicTransactionBufferRecover.this);
+                            if (lastConfirmedEntry.getEntryId() != -1) {
+                                while (lastConfirmedEntry.compareTo(currentLoadPosition) > 0
+                                        && fillEntryQueueCallback.fillQueue()) {
+                                    Entry entry = entryQueue.poll();
+                                    if (entry != null) {
+                                        try {
+                                            currentLoadPosition = PositionImpl.get(entry.getLedgerId(),
+                                                    entry.getEntryId());
+                                            callBack.handleTxnEntry(entry);
+                                        } finally {
+                                            entry.release();
+                                        }
+                                    } else {
+                                        try {
+                                            Thread.sleep(1);
+                                        } catch (InterruptedException e) {
+                                            //no-op
+                                        }
+                                    }
+                                }
+                            }
+
+                            closeCursor(managedCursor);
+                            callBack.recoverComplete();
+                        }, topic.getBrokerService().getPulsar().getTransactionExecutorProvider()
+                                .getExecutor(this)).exceptionally(e -> {
+                            callBack.recoverExceptionally(e.getCause());
+                            log.error("[{}]Transaction buffer new snapshot reader fail!", topic.getName(), e);
+                            return null;
+                        });
+            }, topic.getBrokerService().getPulsar().getTransactionExecutorProvider()
+                    .getExecutor(this)).exceptionally(e -> {
+                callBack.recoverExceptionally(e.getCause());
+                log.error("[{}]Transaction buffer create snapshot writer fail!",
+                        topic.getName(), e);
                 return null;
             });
         }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/TopicTransactionBufferRecoverCallBack.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/TopicTransactionBufferRecoverCallBack.java
@@ -51,5 +51,5 @@ public interface TopicTransactionBufferRecoverCallBack {
     /**
      * Topic transaction buffer recover exceptionally.
      */
-    void recoverExceptionally(Exception e);
+    void recoverExceptionally(Throwable e);
 }


### PR DESCRIPTION
### Motivation
When Transaction buffer recover create reader or create writer fail or read snapshot fail throw PulsarClientException, we should rerecover this topic so close this topic to reinit.

```
2022-03-21 20:16:18,599 -0700 [pulsar-io-20-7] ERROR org.apache.pulsar.client.impl.ProducerImpl - [[persistent://west]()::test/perf1/__transaction_buffer_snapshot] [p302-157-1193] Failed to create producer: {"errorMsg":"org.apache.pulsar.broker.service.BrokerServiceException$TopicFencedException: Topic is temporarily unavailable","reqId":4539058735693497090, "remote":"10.108.176.25/10.108.176.25:6650", "local":"/10.108.179.71:53422"}

 ERROR org.apache.pulsar.broker.transaction.buffer.impl.TransactionBufferHandlerImpl - [[persistent://west]()::test/perf1/Rattan_Transaction_Source_7] Got end txn on topic response for request 34166215 error PersistenceError

ERROR org.apache.pulsar.broker.transaction.buffer.impl.TransactionBufferHandlerImpl - [[persistent://west]()::test/perf1/Rattan_Transaction_Source_7] Got end txn on topic response for request 22777954 error ServiceNotReady
```

```
java.util.concurrent.CompletionException: java.lang.Exception: java.util.concurrent.CompletionException: org.apache.pulsar.client.api.PulsarClientException$BrokerPersistenceException: {"errorMsg":"org.apache.bookkeeper.mledger.ManagedLedgerException: Error while recovering ledger","reqId":3968841795105799606, "remote":"normal-pulsar-broker-2.normal-pulsar-broker.transaction.svc.cluster.local/10.36.17.10:6650", "local":"/10.36.22.8:44284"}
	at java.util.concurrent.CompletableFuture.encodeThrowable(CompletableFuture.java:331) ~[?:?]
	at java.util.concurrent.CompletableFuture.uniRunNow(CompletableFuture.java:809) ~[?:?]
	at java.util.concurrent.CompletableFuture.uniRunStage(CompletableFuture.java:799) ~[?:?]
	at java.util.concurrent.CompletableFuture.thenRun(CompletableFuture.java:2121) ~[?:?]
	at org.apache.pulsar.broker.transaction.buffer.impl.TopicTransactionBuffer.abortTxn(TopicTransactionBuffer.java:312) ~[io.streamnative-pulsar-broker-2.9.2.9.jar:2.9.2.9]
	at org.apache.pulsar.broker.service.persistent.PersistentTopic.endTxn(PersistentTopic.java:3062) ~[io.streamnative-pulsar-broker-2.9.2.9.jar:2.9.2.9]
	at org.apache.pulsar.broker.service.ServerCnx.lambda$handleEndTxnOnPartition$60(ServerCnx.java:2168) ~[io.streamnative-pulsar-broker-2.9.2.9.jar:2.9.2.9]
	at java.util.concurrent.CompletableFuture.uniAcceptNow(CompletableFuture.java:753) [?:?]
	at java.util.concurrent.CompletableFuture.uniAcceptStage(CompletableFuture.java:731) [?:?]
	at java.util.concurrent.CompletableFuture.thenAccept(CompletableFuture.java:2108) [?:?]
	at org.apache.pulsar.broker.service.ServerCnx.handleEndTxnOnPartition(ServerCnx.java:2166) [io.streamnative-pulsar-broker-2.9.2.9.jar:2.9.2.9]
	at org.apache.pulsar.common.protocol.PulsarDecoder.channelRead(PulsarDecoder.java:417) [io.streamnative-pulsar-common-2.9.2.9.jar:2.9.2.9]
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379) [io.netty-netty-transport-4.1.74.Final.jar:4.1.74.Final]
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365) [io.netty-netty-transport-4.1.74.Final.jar:4.1.74.Final]
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357) [io.netty-netty-transport-4.1.74.Final.jar:4.1.74.Final]
	at io.netty.handler.flow.FlowControlHandler.dequeue(FlowControlHandler.java:200) [io.netty-netty-handler-4.1.74.Final.jar:4.1.74.Final]
	at io.netty.handler.flow.FlowControlHandler.channelRead(FlowControlHandler.java:162) [io.netty-netty-handler-4.1.74.Final.jar:4.1.74.Final]
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379) [io.netty-netty-transport-4.1.74.Final.jar:4.1.74.Final]
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365) [io.netty-netty-transport-4.1.74.Final.jar:4.1.74.Final]
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357) [io.netty-netty-transport-4.1.74.Final.jar:4.1.74.Final]
	at io.netty.handler.codec.ByteToMessageDecoder.fireChannelRead(ByteToMessageDecoder.java:327) [io.netty-netty-codec-4.1.74.Final.jar:4.1.74.Final]
	at io.netty.handler.codec.ByteToMessageDecoder.fireChannelRead(ByteToMessageDecoder.java:314) [io.netty-netty-codec-4.1.74.Final.jar:4.1.74.Final]
	at io.netty.handler.codec.ByteToMessageDecoder.callDecode(ByteToMessageDecoder.java:435) [io.netty-netty-codec-4.1.74.Final.jar:4.1.74.Final]
	at io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:279) [io.netty-netty-codec-4.1.74.Final.jar:4.1.74.Final]
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379) [io.netty-netty-transport-4.1.74.Final.jar:4.1.74.Final]
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365) [io.netty-netty-transport-4.1.74.Final.jar:4.1.74.Final]
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357) [io.netty-netty-transport-4.1.74.Final.jar:4.1.74.Final]
	at io.netty.channel.DefaultChannelPipeline$HeadContext.channelRead(DefaultChannelPipeline.java:1410) [io.netty-netty-transport-4.1.74.Final.jar:4.1.74.Final]
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379) [io.netty-netty-transport-4.1.74.Final.jar:4.1.74.Final]
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365) [io.netty-netty-transport-4.1.74.Final.jar:4.1.74.Final]
	at io.netty.channel.DefaultChannelPipeline.fireChannelRead(DefaultChannelPipeline.java:919) [io.netty-netty-transport-4.1.74.Final.jar:4.1.74.Final]
	at io.netty.channel.epoll.AbstractEpollStreamChannel$EpollStreamUnsafe.epollInReady(AbstractEpollStreamChannel.java:795) [io.netty-netty-transport-classes-epoll-4.1.74.Final.jar:4.1.74.Final]
	at io.netty.channel.epoll.EpollEventLoop.processReady(EpollEventLoop.java:480) [io.netty-netty-transport-classes-epoll-4.1.74.Final.jar:4.1.74.Final]
	at io.netty.channel.epoll.EpollEventLoop.run(EpollEventLoop.java:378) [io.netty-netty-transport-classes-epoll-4.1.74.Final.jar:4.1.74.Final]
	at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:986) [io.netty-netty-common-4.1.74.Final.jar:4.1.74.Final]
	at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74) [io.netty-netty-common-4.1.74.Final.jar:4.1.74.Final]
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30) [io.netty-netty-common-4.1.74.Final.jar:4.1.74.Final]
	at java.lang.Thread.run(Thread.java:829) [?:?]
```

### Modifications
When transaction buffer recover fail throw PulsarClientException, we should close this topic and reinit
### Verifying this change
add test for it
### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

