### PR TITLE
[owasp] suppress debezium-connector-postgres CVE-2021-23214 false positive

### DIFF
--- a/.github/workflows/ci-owasp-dep-check.yaml
+++ b/.github/workflows/ci-owasp-dep-check.yaml
@@ -51,6 +51,8 @@ jobs:
             poms:
               - 'pom.xml'
               - '**/pom.xml'
+              - 'src/owasp-dependency-check-false-positives.xml'
+              - 'src/owasp-dependency-check-suppressions.xml'
 
       - name: Cache local Maven repository
         if: ${{ steps.changes.outputs.poms == 'true' }}

--- a/src/owasp-dependency-check-false-positives.xml
+++ b/src/owasp-dependency-check-false-positives.xml
@@ -125,4 +125,13 @@
     <cve>CVE-2021-34429</cve>
   </suppress>
 
+  <!-- CVE-2021-23214 is about PostGre server -->
+  <suppress>
+    <notes><![CDATA[
+   file name: debezium-connector-postgres-1.7.2.Final.jar
+   ]]></notes>
+    <sha1>69c1edfa7d89531af511fcd07e8516fa450f746a</sha1>
+    <cve>CVE-2021-23214</cve>
+  </suppress>
+
 </suppressions>


### PR DESCRIPTION
### Motivation
debezium-connector-postgres is incorrectly targeted with CVE-2021-23214 and the owasp check fails. 
It's a false positive since the CVE is for PostGre server.
https://nvd.nist.gov/vuln/detail/CVE-2021-23214

### Modifications
* Added the suppression
* Add OWASP GH check if a owasp file changes in the PR  

- [x] `no-need-doc` 
