### PR TITLE
[fix][doc] Add JDK 11 as recommended version

### DIFF
--- a/site2/docs/deploy-bare-metal-multi-cluster.md
+++ b/site2/docs/deploy-bare-metal-multi-cluster.md
@@ -25,7 +25,7 @@ A Pulsar instance consists of multiple Pulsar clusters working in unison. You ca
 
 ## System requirement
 
-Currently, Pulsar is available for 64-bit **macOS**, **Linux**, and **Windows**. You need to install 64-bit JRE/JDK 8 or later versions.
+Currently, Pulsar is available for 64-bit **macOS**, **Linux**, and **Windows**. You need to install 64-bit JRE/JDK 8 or later versions, JRE/JDK 11 is recommended.
 
 > **Note**
 >

--- a/site2/docs/deploy-bare-metal.md
+++ b/site2/docs/deploy-bare-metal.md
@@ -24,7 +24,7 @@ Deploying a Pulsar cluster consists of the following steps:
 
 ### Requirements
 
-Currently, Pulsar is available for 64-bit **macOS**, **Linux**, and **Windows**. To use Pulsar, you need to install 64-bit JRE/JDK 8 or later versions.
+Currently, Pulsar is available for 64-bit **macOS**, **Linux**, and **Windows**. To use Pulsar, you need to install 64-bit JRE/JDK 8 or later versions, JRE/JDK 11 is recommended.
 
 >**Tips**  
 > You can reuse existing Zookeeper clusters.

--- a/site2/docs/getting-started-standalone.md
+++ b/site2/docs/getting-started-standalone.md
@@ -15,7 +15,7 @@ This tutorial guides you through every step of installing Pulsar locally.
 
 ### System requirements
 
-Currently, Pulsar is available for 64-bit **macOS**, **Linux**, and **Windows**. To use Pulsar, you need to install 64-bit JRE/JDK 8 or later versions.
+Currently, Pulsar is available for 64-bit **macOS**, **Linux**, and **Windows**. To use Pulsar, you need to install 64-bit JRE/JDK 8 or later versions
 
 > **Tip**  
 > By default, Pulsar allocates 2G JVM heap memory to start. It can be changed in `conf/pulsar_env.sh` file under `PULSAR_MEM`. This is extra options passed into JVM. 

--- a/site2/website/versioned_docs/version-2.8.0/deploy-bare-metal-multi-cluster.md
+++ b/site2/website/versioned_docs/version-2.8.0/deploy-bare-metal-multi-cluster.md
@@ -33,7 +33,7 @@ If you want to deploy a single Pulsar cluster, see [Clusters and Brokers](gettin
 
 ## System requirement
 
-Currently, Pulsar is available for 64-bit **macOS*, **Linux**, and **Windows**. To use Pulsar, you need to install 64-bit JRE/JDK 8 or later versions.
+Currently, Pulsar is available for 64-bit **macOS*, **Linux**, and **Windows**. To use Pulsar, you need to install 64-bit JRE/JDK 8 or later versions, JRE/JDK 11 is recommended.
 
 > **Note**
 >

--- a/site2/website/versioned_docs/version-2.8.0/deploy-bare-metal.md
+++ b/site2/website/versioned_docs/version-2.8.0/deploy-bare-metal.md
@@ -31,7 +31,7 @@ Deploying a Pulsar cluster involves doing the following (in order):
 
 ### Requirements
 
-Currently, Pulsar is available for 64-bit **macOS*, **Linux**, and **Windows**. To use Pulsar, you need to install 64-bit JRE/JDK 8 or later versions.
+Currently, Pulsar is available for 64-bit **macOS*, **Linux**, and **Windows**. To use Pulsar, you need to install 64-bit JRE/JDK 8 or later versions, JRE/JDK 11 is recommended.
 
 > If you already have an existing ZooKeeper cluster and want to reuse it, you do not need to prepare the machines
 > for running ZooKeeper.

--- a/site2/website/versioned_docs/version-2.8.0/getting-started-standalone.md
+++ b/site2/website/versioned_docs/version-2.8.0/getting-started-standalone.md
@@ -16,7 +16,7 @@ This tutorial guides you through every step of the installation process.
 
 ### System requirements
 
-Currently, Pulsar is available for 64-bit **macOS**, **Linux**, and **Windows**. To use Pulsar, you need to install 64-bit JRE/JDK 8 or later versions.
+Currently, Pulsar is available for 64-bit **macOS**, **Linux**, and **Windows**. To use Pulsar, you need to install 64-bit JRE/JDK 8 or later versions, JRE/JDK 11 is recommended.
 
 > #### Tip
 > By default, Pulsar allocates 2G JVM heap memory to start. It can be changed in `conf/pulsar_env.sh` file under `PULSAR_MEM`. This is extra options passed into JVM. 

--- a/site2/website/versioned_docs/version-2.8.1/deploy-bare-metal-multi-cluster.md
+++ b/site2/website/versioned_docs/version-2.8.1/deploy-bare-metal-multi-cluster.md
@@ -33,7 +33,7 @@ If you want to deploy a single Pulsar cluster, see [Clusters and Brokers](gettin
 
 ## System requirement
 
-Currently, Pulsar is available for 64-bit **macOS*, **Linux**, and **Windows**. To use Pulsar, you need to install 64-bit JRE/JDK 8 or later versions.
+Currently, Pulsar is available for 64-bit **macOS*, **Linux**, and **Windows**. To use Pulsar, you need to install 64-bit JRE/JDK 8 or later versions, JRE/JDK 11 is recommended.
 
 > **Note**
 >

--- a/site2/website/versioned_docs/version-2.8.1/deploy-bare-metal.md
+++ b/site2/website/versioned_docs/version-2.8.1/deploy-bare-metal.md
@@ -31,7 +31,7 @@ Deploying a Pulsar cluster involves doing the following (in order):
 
 ### Requirements
 
-Currently, Pulsar is available for 64-bit **macOS*, **Linux**, and **Windows**. To use Pulsar, you need to install 64-bit JRE/JDK 8 or later versions.
+Currently, Pulsar is available for 64-bit **macOS*, **Linux**, and **Windows**. To use Pulsar, you need to install 64-bit JRE/JDK 8 or later versions, JRE/JDK 11 is recommended.
 
 > If you already have an existing ZooKeeper cluster and want to reuse it, you do not need to prepare the machines
 > for running ZooKeeper.

--- a/site2/website/versioned_docs/version-2.8.1/getting-started-standalone.md
+++ b/site2/website/versioned_docs/version-2.8.1/getting-started-standalone.md
@@ -16,7 +16,7 @@ This tutorial guides you through every step of the installation process.
 
 ### System requirements
 
-Currently, Pulsar is available for 64-bit **macOS**, **Linux**, and **Windows**. To use Pulsar, you need to install 64-bit JRE/JDK 8 or later versions.
+Currently, Pulsar is available for 64-bit **macOS**, **Linux**, and **Windows**. To use Pulsar, you need to install 64-bit JRE/JDK 8 or later versions, JRE/JDK 11 is recommended.
 
 > #### Tip
 > By default, Pulsar allocates 2G JVM heap memory to start. It can be changed in `conf/pulsar_env.sh` file under `PULSAR_MEM`. This is extra options passed into JVM. 

--- a/site2/website/versioned_docs/version-2.8.2/deploy-bare-metal-multi-cluster.md
+++ b/site2/website/versioned_docs/version-2.8.2/deploy-bare-metal-multi-cluster.md
@@ -33,7 +33,7 @@ If you want to deploy a single Pulsar cluster, see [Clusters and Brokers](gettin
 
 ## System requirement
 
-Currently, Pulsar is available for 64-bit **macOS*, **Linux**, and **Windows**. To use Pulsar, you need to install 64-bit JRE/JDK 8 or later versions.
+Currently, Pulsar is available for 64-bit **macOS*, **Linux**, and **Windows**. To use Pulsar, you need to install 64-bit JRE/JDK 8 or later versions, JRE/JDK 11 is recommended.
 
 > **Note**
 >

--- a/site2/website/versioned_docs/version-2.8.2/getting-started-standalone.md
+++ b/site2/website/versioned_docs/version-2.8.2/getting-started-standalone.md
@@ -16,7 +16,7 @@ This tutorial guides you through every step of the installation process.
 
 ### System requirements
 
-Currently, Pulsar is available for 64-bit **macOS**, **Linux**, and **Windows**. To use Pulsar, you need to install 64-bit JRE/JDK 8 or later versions.
+Currently, Pulsar is available for 64-bit **macOS**, **Linux**, and **Windows**. To use Pulsar, you need to install 64-bit JRE/JDK 8 or later versions, JRE/JDK 11 is recommended.
 
 > #### Tip
 > By default, Pulsar allocates 2G JVM heap memory to start. It can be changed in `conf/pulsar_env.sh` file under `PULSAR_MEM`. This is extra options passed into JVM. 

--- a/site2/website/versioned_docs/version-2.8.3/deploy-bare-metal-multi-cluster.md
+++ b/site2/website/versioned_docs/version-2.8.3/deploy-bare-metal-multi-cluster.md
@@ -33,7 +33,7 @@ If you want to deploy a single Pulsar cluster, see [Clusters and Brokers](gettin
 
 ## System requirement
 
-Currently, Pulsar is available for 64-bit **macOS*, **Linux**, and **Windows**. To use Pulsar, you need to install 64-bit JRE/JDK 8 or later versions.
+Currently, Pulsar is available for 64-bit **macOS*, **Linux**, and **Windows**. To use Pulsar, you need to install 64-bit JRE/JDK 8 or later versions, JRE/JDK 11 is recommended.
 
 > **Note**
 >

--- a/site2/website/versioned_docs/version-2.8.3/deploy-bare-metal.md
+++ b/site2/website/versioned_docs/version-2.8.3/deploy-bare-metal.md
@@ -31,7 +31,7 @@ Deploying a Pulsar cluster involves doing the following (in order):
 
 ### Requirements
 
-Currently, Pulsar is available for 64-bit **macOS*, **Linux**, and **Windows**. To use Pulsar, you need to install 64-bit JRE/JDK 8 or later versions.
+Currently, Pulsar is available for 64-bit **macOS*, **Linux**, and **Windows**. To use Pulsar, you need to install 64-bit JRE/JDK 8 or later versions, JRE/JDK 11 is recommended.
 
 > If you already have an existing ZooKeeper cluster and want to reuse it, you do not need to prepare the machines
 > for running ZooKeeper.

--- a/site2/website/versioned_docs/version-2.8.3/getting-started-standalone.md
+++ b/site2/website/versioned_docs/version-2.8.3/getting-started-standalone.md
@@ -16,7 +16,7 @@ This tutorial guides you through every step of the installation process.
 
 ### System requirements
 
-Currently, Pulsar is available for 64-bit **macOS**, **Linux**, and **Windows**. To use Pulsar, you need to install 64-bit JRE/JDK 8 or later versions.
+Currently, Pulsar is available for 64-bit **macOS**, **Linux**, and **Windows**. To use Pulsar, you need to install 64-bit JRE/JDK 8 or later versions, JRE/JDK 11 is recommended.
 
 > #### Tip
 > By default, Pulsar allocates 2G JVM heap memory to start. It can be changed in `conf/pulsar_env.sh` file under `PULSAR_MEM`. This is extra options passed into JVM. 

--- a/site2/website/versioned_docs/version-2.9.0/deploy-bare-metal-multi-cluster.md
+++ b/site2/website/versioned_docs/version-2.9.0/deploy-bare-metal-multi-cluster.md
@@ -26,7 +26,7 @@ A Pulsar instance consists of multiple Pulsar clusters working in unison. You ca
 
 ## System requirement
 
-Currently, Pulsar is available for 64-bit **macOS**, **Linux**, and **Windows**. You need to install 64-bit JRE/JDK 8 or later versions.
+Currently, Pulsar is available for 64-bit **macOS**, **Linux**, and **Windows**. You need to install 64-bit JRE/JDK 8 or later versions, JRE/JDK 11 is recommended.
 
 > **Note**
 >

--- a/site2/website/versioned_docs/version-2.9.0/deploy-bare-metal.md
+++ b/site2/website/versioned_docs/version-2.9.0/deploy-bare-metal.md
@@ -25,7 +25,7 @@ Deploying a Pulsar cluster consists of the following steps:
 
 ### Requirements
 
-Currently, Pulsar is available for 64-bit **macOS**, **Linux**, and **Windows**. To use Pulsar, you need to install 64-bit JRE/JDK 8 or later versions.
+Currently, Pulsar is available for 64-bit **macOS**, **Linux**, and **Windows**. To use Pulsar, you need to install 64-bit JRE/JDK 8 or later versions, JRE/JDK 11 is recommended.
 
 >**Tips**  
 > You can reuse existing Zookeeper clusters.

--- a/site2/website/versioned_docs/version-2.9.0/getting-started-standalone.md
+++ b/site2/website/versioned_docs/version-2.9.0/getting-started-standalone.md
@@ -16,7 +16,7 @@ This tutorial guides you through every step of installing Pulsar locally.
 
 ### System requirements
 
-Currently, Pulsar is available for 64-bit **macOS**, **Linux**, and **Windows**. To use Pulsar, you need to install 64-bit JRE/JDK 8 or later versions.
+Currently, Pulsar is available for 64-bit **macOS**, **Linux**, and **Windows**. To use Pulsar, you need to install 64-bit JRE/JDK 8 or later versions, JRE/JDK 11 is recommended.
 
 > **Tip**  
 > By default, Pulsar allocates 2G JVM heap memory to start. It can be changed in `conf/pulsar_env.sh` file under `PULSAR_MEM`. This is extra options passed into JVM. 

--- a/site2/website/versioned_docs/version-2.9.1/deploy-bare-metal-multi-cluster.md
+++ b/site2/website/versioned_docs/version-2.9.1/deploy-bare-metal-multi-cluster.md
@@ -26,7 +26,7 @@ A Pulsar instance consists of multiple Pulsar clusters working in unison. You ca
 
 ## System requirement
 
-Currently, Pulsar is available for 64-bit **macOS**, **Linux**, and **Windows**. You need to install 64-bit JRE/JDK 8 or later versions.
+Currently, Pulsar is available for 64-bit **macOS**, **Linux**, and **Windows**. You need to install 64-bit JRE/JDK 8 or later versions, JRE/JDK 11 is recommended.
 
 > **Note**
 >

--- a/site2/website/versioned_docs/version-2.9.1/deploy-bare-metal.md
+++ b/site2/website/versioned_docs/version-2.9.1/deploy-bare-metal.md
@@ -25,7 +25,7 @@ Deploying a Pulsar cluster consists of the following steps:
 
 ### Requirements
 
-Currently, Pulsar is available for 64-bit **macOS**, **Linux**, and **Windows**. To use Pulsar, you need to install 64-bit JRE/JDK 8 or later versions.
+Currently, Pulsar is available for 64-bit **macOS**, **Linux**, and **Windows**. To use Pulsar, you need to install 64-bit JRE/JDK 8 or later versions, JRE/JDK 11 is recommended.
 
 >**Tips**  
 > You can reuse existing Zookeeper clusters.

--- a/site2/website/versioned_docs/version-2.9.1/getting-started-standalone.md
+++ b/site2/website/versioned_docs/version-2.9.1/getting-started-standalone.md
@@ -16,7 +16,7 @@ This tutorial guides you through every step of installing Pulsar locally.
 
 ### System requirements
 
-Currently, Pulsar is available for 64-bit **macOS**, **Linux**, and **Windows**. To use Pulsar, you need to install 64-bit JRE/JDK 8 or later versions.
+Currently, Pulsar is available for 64-bit **macOS**, **Linux**, and **Windows**. To use Pulsar, you need to install 64-bit JRE/JDK 8 or later versions, JRE/JDK 11 is recommended.
 
 > **Tip**  
 > By default, Pulsar allocates 2G JVM heap memory to start. It can be changed in `conf/pulsar_env.sh` file under `PULSAR_MEM`. This is extra options passed into JVM. 


### PR DESCRIPTION
Signed-off-by: Zixuan Liu <nodeces@gmail.com>

### Motivation

Improve the  `Requirements` section, add recommended version for JDK.

### Modifications

- Add JDK recommended version in getting started and deploy doc of Pulsar 2.8-latest versions

### Documentation

- [x] `doc` 


