### PR TITLE
[website] Fix script to generate python docs for website

### DIFF
--- a/site2/tools/build-site.sh
+++ b/site2/tools/build-site.sh
@@ -110,4 +110,4 @@ cp -R ${ROOT_DIR}/generated-site/api ${ROOT_DIR}/generated-site/content
 cp -R ./build/pulsar/* ${ROOT_DIR}/generated-site/content
 cp -R ${ROOT_DIR}/generated-site/tools ${ROOT_DIR}/generated-site/content
 cp -R ${ROOT_DIR}/site2/website/static/swagger/* ${ROOT_DIR}/generated-site/content/swagger/
-cp -R ${ROOT_DIR}/site2/website/static/python ${ROOT_DIR}/generated-site/content/python
+cp -R ${ROOT_DIR}/site2/website/static/python-client ${ROOT_DIR}/generated-site/content/python


### PR DESCRIPTION
Fix an incorrectly referenced directory in the website build. I introduced the bug here: https://github.com/apache/pulsar/pull/14788.

See https://github.com/apache/pulsar/runs/5666378801?check_suite_focus=true for sample failure.