### PR TITLE
[fix][broker] filter the virtual NIC with relative path

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/LinuxBrokerHostUsageImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/LinuxBrokerHostUsageImpl.java
@@ -227,10 +227,10 @@ public class LinuxBrokerHostUsageImpl implements BrokerHostUsage {
     }
 
     private boolean isPhysicalNic(Path path) {
-        if (path.toString().contains("/virtual/")) {
-            return false;
-        }
         try {
+            if (path.toString().contains("/virtual/") || path.toRealPath().toString().contains("/virtual/")) {
+                return false;
+            }
             // Check the type to make sure it's ethernet (type "1")
             String type = new String(Files.readAllBytes(path.resolve("type")), StandardCharsets.UTF_8).trim();
             // wireless NICs don't report speed, ignore them.

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/LinuxBrokerHostUsageImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/LinuxBrokerHostUsageImpl.java
@@ -228,7 +228,7 @@ public class LinuxBrokerHostUsageImpl implements BrokerHostUsage {
 
     private boolean isPhysicalNic(Path path) {
         try {
-            if (path.toString().contains("/virtual/") || path.toRealPath().toString().contains("/virtual/")) {
+            if (path.toRealPath().toString().contains("/virtual/")) {
                 return false;
             }
             // Check the type to make sure it's ethernet (type "1")


### PR DESCRIPTION
Master issue: https://github.com/apache/pulsar/issues/14820
Fixes: #14820

### Motivation
The `loadBalancerOverrideBrokerNicSpeedGbps` to setting to correct the max NIC speed failed, because `org.apache.pulsar.broker.loadbalance.impl.LinuxBrokerHostUsageImpl isPhysicalNic(Path path)` fail to filter the virtual NIC with relative path.

### Modifications
add filter the virtual NIC with realPath

- [x] `no-need-doc` 
  
  (Please explain why)