### PR TITLE
Returns the new data set when use TableView.

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/TableViewTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/TableViewTest.java
@@ -128,6 +128,13 @@ public class TableViewTest extends MockedPulsarServiceBaseTest {
             Assert.assertEquals(tv.size(), count * 2);
         });
         Assert.assertEquals(tv.keySet(), keys2);
+        // Test return new collection
+        tv.keySet().clear();
+        tv.values().clear();
+        tv.entrySet().clear();
+        Assert.assertEquals(tv.keySet(), keys2);
+        Assert.assertEquals(tv.entrySet().size(), keys2.size());
+        Assert.assertEquals(tv.values().size(), keys2.size());
     }
 
     @Test(timeOut = 30 * 1000)

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/TableViewImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/TableViewImpl.java
@@ -133,17 +133,17 @@ public class TableViewImpl<T> implements TableView<T> {
 
     @Override
     public Set<Map.Entry<String, T>> entrySet() {
-       return data.entrySet();
+       return new HashSet<>(data.entrySet());
     }
 
     @Override
     public Set<String> keySet() {
-        return data.keySet();
+        return new HashSet<>(data.keySet());
     }
 
     @Override
     public Collection<T> values() {
-        return data.values();
+        return new ArrayList<>(data.values());
     }
 
     @Override


### PR DESCRIPTION
Fixes #14821

Master Issue: #14821

### Motivation

Currently TableViewImpl methods that access the underlying map, e.g., TableViewImpl::KeySet() (https://github.com/apache/pulsar/blob/master/pulsar-client/src/main/java/org/apache/pulsar/client/impl/TableViewImpl.java#L141) returns views of the underlying map, which means users could modify the returned value and accidentally change the internal state of TableViewImpl.

It's better to return a new data set to users.

### Documentation

- [x] `no-need-doc` 



