### PR TITLE
[C++] Fix segmentation fault when creating socket failed

### DIFF
--- a/pulsar-client-cpp/lib/ClientConnection.cc
+++ b/pulsar-client-cpp/lib/ClientConnection.cc
@@ -1551,7 +1551,9 @@ void ClientConnection::close(Result result) {
         consumerStatsRequestTimer_.reset();
     }
 
-    connectTimeoutTask_->stop();
+    if (connectTimeoutTask_) {
+        connectTimeoutTask_->stop();
+    }
 
     lock.unlock();
     LOG_INFO(cnxString_ << "Connection closed");


### PR DESCRIPTION
### Motivation

https://github.com/apache/pulsar/pull/14823 fixes the flaky
`testConnectTimeout` but it's also a regression of
https://github.com/apache/pulsar/pull/14587. Because when the fd limit
is reached, the `connectionTimeoutTask_` won't be initialized with a
non-null value. Calling `stop` method on it directly will cause
segmentation fault.

See
https://github.com/apache/pulsar/blob/0fe921f32cefe7648ca428cd9861f9163c69767d/pulsar-client-cpp/lib/ClientConnection.cc#L178-L185

### Modifications

Add the null check for `connectionTimeoutTask_` in `ClientConnection::close`.