### PR TITLE
Improve WebSocket producerBuilderTest

### DIFF
--- a/pulsar-websocket/src/test/java/org/apache/pulsar/websocket/AbstractWebSocketHandlerTest.java
+++ b/pulsar-websocket/src/test/java/org/apache/pulsar/websocket/AbstractWebSocketHandlerTest.java
@@ -259,7 +259,7 @@ public class AbstractWebSocketHandlerTest {
             put("initialSequenceId", "1");
             put("hashingScheme", "Murmur3_32Hash");
             put("sendTimeoutMillis", "30001");
-            put("batchingEnabled", "false");
+            put("batchingEnabled", "true");
             put("batchingMaxMessages", "1001");
             put("maxPendingMessages", "1001");
             put("batchingMaxPublishDelay", "2");
@@ -287,14 +287,18 @@ public class AbstractWebSocketHandlerTest {
         assertEquals(conf.getInitialSequenceId().longValue(), 1L);
         assertEquals(conf.getHashingScheme(), HashingScheme.Murmur3_32Hash);
         assertEquals(conf.getSendTimeoutMs(), 30001);
-        assertFalse(conf.isBatchingEnabled() );
+        assertTrue(conf.isBatchingEnabled());
         assertEquals(conf.getBatchingMaxMessages(), 1001);
         assertEquals(conf.getMaxPendingMessages(), 1001);
+        assertEquals(conf.getBatchingMaxPublishDelayMicros(), 2000);
         assertEquals(conf.getMessageRoutingMode(), MessageRoutingMode.RoundRobinPartition);
         assertEquals(conf.getCompressionType(), CompressionType.LZ4);
 
         producerHandler.clearQueryParams();
         conf = producerHandler.getConf();
+        // By default batching is disabled, which is different with ProducerBuilder
+        assertFalse(conf.isBatchingEnabled());
+
         // The default message routing mode is SinglePartition, which is different with ProducerBuilder
         assertEquals(conf.getMessageRoutingMode(), MessageRoutingMode.SinglePartition);
 


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - Name the pull request in the form "[Issue XYZ][component] Title of the pull request", where *XYZ* should be replaced by the actual issue number.
    Skip *Issue XYZ* if there is no associated github issue for this pull request.
    Skip *component* if you are unsure about which is the best component. E.g. `[docs] Fix typo in produce method`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.

**(The sections below can be removed for hotfixes of typos)**
-->

### Motivation

Better test coverage

### Modifications

Trivial changes

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change added tests and can be verified as follows:

* Run AbstractWebSocketHandlerTest::producerBuilderTest

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (yes / no) no
  - The public API: (yes / no) no
  - The schema: (yes / no / don't know) no
  - The default values of configurations: (yes / no) no
  - The wire protocol: (yes / no) no
  - The rest endpoints: (yes / no) no
  - The admin cli options: (yes / no) no
  - Anything that affects deployment: (yes / no / don't know) no

### Documentation

Check the box below or label this PR directly (if you have committer privilege).

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)


