### PR TITLE
[improve][broker] Add log when update namespace policies with error.

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentTopic.java
@@ -1030,6 +1030,9 @@ public class NonPersistentTopic extends AbstractTopic implements Topic, TopicPol
 
             return FutureUtil.waitForAll(consumerCheckFutures)
                     .thenCompose((___) -> checkReplicationAndRetryOnFailure());
+        }).exceptionally(ex -> {
+            log.error("[{}] update namespace polices : {} error", this.getName(), data, ex);
+            throw FutureUtil.wrapToCompletionException(ex);
         });
     }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -2433,6 +2433,9 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
                 return CompletableFuture.allOf(replicationFuture, dedupFuture, persistentPoliciesFuture,
                         preCreateSubscriptionForCompactionIfNeeded());
             });
+        }).exceptionally(ex -> {
+            log.error("update namespace polices : {} error", data, ex);
+            throw FutureUtil.wrapToCompletionException(ex);
         });
     }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -2434,7 +2434,7 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
                         preCreateSubscriptionForCompactionIfNeeded());
             });
         }).exceptionally(ex -> {
-            log.error("update namespace polices : {} error", data, ex);
+            log.error("[{}] update namespace polices : {} error", this.getName(), data, ex);
             throw FutureUtil.wrapToCompletionException(ex);
         });
     }


### PR DESCRIPTION
### Motivation

When namespace policies update, it will update the cache. There is a long piece of logic in the method PersistentTopic#onPoliciesUpdate ：
https://github.com/apache/pulsar/blob/b5b0967f12174ba35baaf25092ac521f281e6b7d/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java#L2371-L2438

There is no log to track if some of the futures go to failure. so it's hard to troubleshoot the problem when error.
#14266 is one of the cases.

### Documentation
  
- [x] `no-need-doc` 
  



