### PR TITLE
Download page must not refer to dist.apache.org

### DIFF
--- a/site2/website/pages/en/download.js
+++ b/site2/website/pages/en/download.js
@@ -28,11 +28,11 @@ function getLatestAdaptersMirrorUrl(version) {
 }
 
 function distUrl(version, type) {
-    return `https://www.apache.org/dist/pulsar/pulsar-${version}/apache-pulsar-${version}-${type}.tar.gz`
+    return `https://downloads.apache.org/pulsar/pulsar-${version}/apache-pulsar-${version}-${type}.tar.gz`
 }
 
 function distOffloadersUrl(version) {
-    return `https://www.apache.org/dist/pulsar/pulsar-${version}/apache-pulsar-offloaders-${version}-bin.tar.gz`
+    return `https://downloads.apache.org//pulsar/pulsar-${version}/apache-pulsar-offloaders-${version}-bin.tar.gz`
 }
 
 function distAdaptersUrl(version) {
@@ -52,7 +52,7 @@ function pularManagerArchiveUrl(version, type) {
 }
 
 function connectorDistUrl(name, version) {
-    return `https://www.apache.org/dist/pulsar/pulsar-${version}/connectors/pulsar-io-${name}-${version}.nar`
+    return `https://downloads.apache.org/pulsar/pulsar-${version}/connectors/pulsar-io-${name}-${version}.nar`
 }
 
 function connectorDownloadUrl(name, version) {
@@ -64,7 +64,7 @@ function getLatestPulsarManagerArchiveMirrorUrl(version, type) {
 }
 
 function pulsarManagerDistUrl(version, type) {
-  return `https://www.apache.org/dist/pulsar/pulsar-manager/pulsar-manager-${version}/apache-pulsar-manager-${version}-${type}.tar.gz`
+  return `https://downloads.apache.org/pulsar/pulsar-manager/pulsar-manager-${version}/apache-pulsar-manager-${version}-${type}.tar.gz`
 }
 
 class Download extends React.Component {
@@ -204,7 +204,7 @@ class Download extends React.Component {
             <MarkdownBlock>
               You must [verify](https://www.apache.org/info/verification.html) the integrity of the downloaded files.
               We provide OpenPGP signatures for every release file. This signature should be matched against the
-              [KEYS](https://www.apache.org/dist/pulsar/KEYS) file which contains the OpenPGP keys of
+              [KEYS](https://downloads.apache.org/pulsar/KEYS) file which contains the OpenPGP keys of
               Pulsar's Release Managers. We also provide `SHA-512` checksums for every release file.
               After you download the file, you should calculate a checksum for your download, and make sure it is
               the same as ours.


### PR DESCRIPTION
Must use https://downloads.apache.org to comply with ASF Release Policy
Need to update docs? 

- [X] `no-need-doc` 
  
Updates downloads page.
