### PR TITLE
[fix][pulsar-admin] Fix pulsar-admin not prompting message when there is a 500 error.

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/RestException.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/RestException.java
@@ -80,7 +80,7 @@ public class RestException extends WebApplicationException {
             return e.getResponse();
         } else {
             return Response
-                .status(Status.INTERNAL_SERVER_ERROR)
+                .status(Status.INTERNAL_SERVER_ERROR.getStatusCode(), t.getMessage())
                 .entity(new ErrorData(getExceptionData(t)))
                 .type(MediaType.APPLICATION_JSON)
                 .build();

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/RestException.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/RestException.java
@@ -81,8 +81,8 @@ public class RestException extends WebApplicationException {
         } else {
             return Response
                 .status(Status.INTERNAL_SERVER_ERROR)
-                .entity(getExceptionData(t))
-                .type(MediaType.TEXT_PLAIN)
+                .entity(new ErrorData(getExceptionData(t)))
+                .type(MediaType.APPLICATION_JSON)
                 .build();
         }
     }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminTest.java
@@ -40,8 +40,10 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
@@ -65,8 +67,10 @@ import org.apache.pulsar.broker.admin.v2.SchemasResource;
 import org.apache.pulsar.broker.auth.MockedPulsarServiceBaseTest;
 import org.apache.pulsar.broker.authentication.AuthenticationDataHttps;
 import org.apache.pulsar.broker.loadbalance.LeaderBroker;
+import org.apache.pulsar.broker.namespace.NamespaceService;
 import org.apache.pulsar.broker.web.PulsarWebResource;
 import org.apache.pulsar.broker.web.RestException;
+import org.apache.pulsar.common.api.proto.CommandGetTopicsOfNamespace;
 import org.apache.pulsar.common.conf.InternalConfigurationData;
 import org.apache.pulsar.common.naming.NamespaceName;
 import org.apache.pulsar.common.naming.TopicName;
@@ -77,6 +81,7 @@ import org.apache.pulsar.common.policies.data.BrokerInfo;
 import org.apache.pulsar.common.policies.data.BundlesData;
 import org.apache.pulsar.common.policies.data.ClusterData;
 import org.apache.pulsar.common.policies.data.ClusterDataImpl;
+import org.apache.pulsar.common.policies.data.ErrorData;
 import org.apache.pulsar.common.policies.data.NamespaceIsolationDataImpl;
 import org.apache.pulsar.common.policies.data.Policies;
 import org.apache.pulsar.common.policies.data.ResourceQuota;
@@ -826,6 +831,28 @@ public class AdminTest extends MockedPulsarServiceBaseTest {
 
         persistentTopics.updatePartitionedTopic(property, cluster, namespace, partitionedTopicName2, false, false,
                 false, 10);
+    }
+
+    @Test
+    public void test500Error() throws Exception {
+        final String property = "prop-xyz";
+        final String cluster = "use";
+        final String namespace = "ns";
+        final String partitionedTopicName = "error-500-topic";
+        AsyncResponse response1 = mock(AsyncResponse.class);
+        ArgumentCaptor<RestException> responseCaptor = ArgumentCaptor.forClass(RestException.class);
+        NamespaceName namespaceName = NamespaceName.get(property, cluster, namespace);
+        NamespaceService ns = spy(pulsar.getNamespaceService());
+        Field namespaceField = pulsar.getClass().getDeclaredField("nsService");
+        namespaceField.setAccessible(true);
+        namespaceField.set(pulsar, ns);
+        CompletableFuture<List<String>> future = new CompletableFuture();
+        future.completeExceptionally(new RuntimeException("500 error contains error message"));
+        doReturn(future).when(ns).getListOfTopics(namespaceName, CommandGetTopicsOfNamespace.Mode.ALL);
+        persistentTopics.createPartitionedTopic(response1, property, cluster, namespace, partitionedTopicName, 5, false);
+        verify(response1, timeout(5000).times(1)).resume(responseCaptor.capture());
+        Assert.assertEquals(responseCaptor.getValue().getResponse().getStatus(), Status.INTERNAL_SERVER_ERROR.getStatusCode());
+        Assert.assertTrue(((ErrorData)responseCaptor.getValue().getResponse().getEntity()).reason.contains("500 error contains error message"));
     }
 
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/web/RestExceptionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/web/RestExceptionTest.java
@@ -22,6 +22,7 @@ import static org.testng.Assert.assertEquals;
 
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Response.Status;
+import org.apache.pulsar.common.policies.data.ErrorData;
 import org.testng.annotations.Test;
 
 /**
@@ -54,7 +55,8 @@ public class RestExceptionTest {
         RestException testException = new RestException(otherException);
 
         assertEquals(Status.INTERNAL_SERVER_ERROR.getStatusCode(), testException.getResponse().getStatus());
-        assertEquals(RestException.getExceptionData(otherException), testException.getResponse().getEntity());
+        ErrorData errorData = (ErrorData)testException.getResponse().getEntity();
+        assertEquals(RestException.getExceptionData(otherException), errorData.reason);
     }
 
 }

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/BaseResource.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/BaseResource.java
@@ -220,7 +220,7 @@ public abstract class BaseResource {
                 ServerErrorException see = (ServerErrorException) e;
                 int statusCode = see.getResponse().getStatus();
                 String httpError = getReasonFromServer(see);
-                return new ServerSideErrorException(see, e.getMessage(), httpError, statusCode);
+                return new ServerSideErrorException(see, httpError, httpError, statusCode);
             } else if (e instanceof ClientErrorException) {
                 // Handle 4xx exceptions
                 ClientErrorException cee = (ClientErrorException) e;


### PR DESCRIPTION
### Motivation
When pulsar-admin occurs 500 error, it doesn't return the root cause message to the user, only prompt `Internal Server Error`.

The root cause is that: the broker side return 'TEXT_PLAIN' type message, 

https://github.com/apache/pulsar/blob/9644448fa2d85701e47fb8b6bf90ac149f70cf56/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/RestException.java#L77-L88


But client side tries to parse it as json type (line-222):

https://github.com/apache/pulsar/blob/9644448fa2d85701e47fb8b6bf90ac149f70cf56/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/BaseResource.java#L219-L224

https://github.com/apache/pulsar/blob/9644448fa2d85701e47fb8b6bf90ac149f70cf56/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/BaseResource.java#L272-L288

So if broker return 500, `getReasonFromServer` will throw exception 3 times and then use the original 500 message to the user.


So we need to keep the server to return JSON type data to keep consistent.

### Modification
- Change entity to return JSON type.
- Remove `getExceptionData`, it will not use anymore.

### Documentation
  
- [x] `no-need-doc` 



