### PR TITLE
[improve][test] Upgrade awaitility to 4.2.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -227,7 +227,7 @@ flexible messaging model and an intuitive client API.</description>
     <javassist.version>3.25.0-GA</javassist.version>
     <skyscreamer.version>1.5.0</skyscreamer.version>
     <objenesis.version>3.1</objenesis.version>
-    <awaitility.version>4.0.3</awaitility.version>
+    <awaitility.version>4.2.0</awaitility.version>
 
     <!-- Plugin dependencies -->
     <protobuf-maven-plugin.version>0.6.1</protobuf-maven-plugin.version>


### PR DESCRIPTION
### Motivation

The awaitility version 4.0.3 is outdated. Upgrade to the latest stable 4.2.0 version.

### Modifications

Upgrade awaitility to 4.2.0

### Documentation

Check the box below or label this PR directly (if you have committer privilege).

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)


