### PR TITLE
[Issue 14786][c++ client] Fix C++ client compile error beacaus of keyword optional is redundant in PaddingDemo.proto

### DIFF
--- a/pulsar-client-cpp/tests/PaddingDemo.proto
+++ b/pulsar-client-cpp/tests/PaddingDemo.proto
@@ -22,5 +22,5 @@ package padding.demo;
 
 message Person {
   string name = 1;
-  optional int32 id = 2;
+  int32 id = 2;
 }


### PR DESCRIPTION
Fix #14849

### Motivation
Fix C++ client compile error beacaus of keyword optional is redundant in PaddingDemo.proto

### Modifications
Delete  keyword optional in PaddingDemo.proto directly.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: ( no )
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

Check the box below or label this PR directly (if you have committer privilege).

Need to update docs? 

- [x] `no-need-doc` 
