### PR TITLE
[fix][broker] Fix wrong state for non-durable cursor.

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
@@ -236,7 +236,7 @@ public class ManagedCursorImpl implements ManagedCursor {
         Closed // The managed cursor has been closed
     }
 
-    private static final AtomicReferenceFieldUpdater<ManagedCursorImpl, State> STATE_UPDATER =
+    protected static final AtomicReferenceFieldUpdater<ManagedCursorImpl, State> STATE_UPDATER =
         AtomicReferenceFieldUpdater.newUpdater(ManagedCursorImpl.class, State.class, "state");
     protected volatile State state = null;
 

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/NonDurableCursorImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/NonDurableCursorImpl.java
@@ -112,7 +112,6 @@ public class NonDurableCursorImpl extends ManagedCursorImpl {
     @Override
     public void asyncClose(CloseCallback callback, Object ctx) {
         STATE_UPDATER.set(this, State.Closed);
-        // No-Op
         callback.closeComplete(ctx);
     }
 

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/NonDurableCursorImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/NonDurableCursorImpl.java
@@ -62,7 +62,7 @@ public class NonDurableCursorImpl extends ManagedCursorImpl {
             // read-position
             recoverCursor(startCursorPosition);
         }
-
+        STATE_UPDATER.set(this, State.Open);
         log.info("[{}] Created non-durable cursor read-position={} mark-delete-position={}", ledger.getName(),
                 readPosition, markDeletePosition);
     }
@@ -111,6 +111,7 @@ public class NonDurableCursorImpl extends ManagedCursorImpl {
 
     @Override
     public void asyncClose(CloseCallback callback, Object ctx) {
+        STATE_UPDATER.set(this, State.Closed);
         // No-Op
         callback.closeComplete(ctx);
     }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/ReaderTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/ReaderTest.java
@@ -53,7 +53,12 @@ import org.apache.pulsar.client.api.Reader;
 import org.apache.pulsar.client.api.ReaderBuilder;
 import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.common.naming.TopicName;
-import org.apache.pulsar.common.policies.data.*;
+import org.apache.pulsar.common.policies.data.ClusterData;
+import org.apache.pulsar.common.policies.data.ManagedLedgerInternalStats;
+import org.apache.pulsar.common.policies.data.PersistentTopicInternalStats;
+import org.apache.pulsar.common.policies.data.RetentionPolicies;
+import org.apache.pulsar.common.policies.data.TenantInfoImpl;
+import org.apache.pulsar.common.policies.data.TopicStats;
 import org.apache.pulsar.common.util.Murmur3_32Hash;
 import org.apache.pulsar.schema.Schemas;
 import org.awaitility.Awaitility;
@@ -611,6 +616,9 @@ public class ReaderTest extends MockedPulsarServiceBaseTest {
         String key = new ArrayList<>(internalStats.cursors.keySet()).get(0);
         ManagedLedgerInternalStats.CursorStats cursor = internalStats.cursors.get(key);
         Assert.assertEquals(cursor.state, "Open");
+        reader.close();
+        internalStats = admin.topics().getInternalStats(readerNotAckTopic);
+        Assert.assertEquals(internalStats.cursors.size(), 0);
     }
 
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/ReaderTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/ReaderTest.java
@@ -36,7 +36,6 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
-
 import lombok.Cleanup;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.broker.auth.MockedPulsarServiceBaseTest;
@@ -54,10 +53,7 @@ import org.apache.pulsar.client.api.Reader;
 import org.apache.pulsar.client.api.ReaderBuilder;
 import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.common.naming.TopicName;
-import org.apache.pulsar.common.policies.data.ClusterData;
-import org.apache.pulsar.common.policies.data.RetentionPolicies;
-import org.apache.pulsar.common.policies.data.TenantInfoImpl;
-import org.apache.pulsar.common.policies.data.TopicStats;
+import org.apache.pulsar.common.policies.data.*;
 import org.apache.pulsar.common.util.Murmur3_32Hash;
 import org.apache.pulsar.schema.Schemas;
 import org.awaitility.Awaitility;
@@ -600,6 +596,21 @@ public class ReaderTest extends MockedPulsarServiceBaseTest {
             System.out.println("subscriptions size: " + topicStats.getSubscriptions().size());
             return topicStats.getSubscriptions().size() == 1;
         });
+    }
+
+    @Test
+    public void testReaderCursorStatsCorrect() throws Exception {
+        final String readerNotAckTopic = "persistent://my-property/my-ns/testReaderCursorStatsCorrect";
+        @Cleanup
+        Reader<byte[]> reader = pulsarClient.newReader()
+                .topic(readerNotAckTopic)
+                .startMessageId(MessageId.earliest)
+                .create();
+        PersistentTopicInternalStats internalStats = admin.topics().getInternalStats(readerNotAckTopic);
+        Assert.assertEquals(internalStats.cursors.size(), 1);
+        String key = new ArrayList<>(internalStats.cursors.keySet()).get(0);
+        ManagedLedgerInternalStats.CursorStats cursor = internalStats.cursors.get(key);
+        Assert.assertEquals(cursor.state, "Open");
     }
 
 }


### PR DESCRIPTION
### Motivation

The current non-durable cursor does not have the correct state.
For example, when the reader is created, I always see the cursor status as ``Uninitialized`` via the ``getInternalStats`` method.

```json
{
  "reader-xxxxx" : {
      "markDeletePosition" : "19785:18718",
      "readPosition" : "19807:42735",
      "waitingReadOp" : false,
      "pendingReadOps" : 0,
      "messagesConsumedCounter" : -2257,
      "cursorLedger" : -1,
      "cursorLedgerLastEntry" : -1,
      "individuallyDeletedMessages" : "[]",
      "lastLedgerSwitchTimestamp" : "2022-03-24T20:03:51.85Z",
      "state" : "Uninitialized",
      "numberOfEntriesSinceFirstNotAckedMessage" : 744993,
      "totalNonContiguousDeletedMessagesRange" : 0,
      "subscriptionHavePendingRead" : true,
      "subscriptionHavePendingReplayRead" : false,
      "properties" : { }
    }
}
```

### Modifications

- Correct the cursor state.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Documentation

- [x] `no-need-doc` 
  


