### PR TITLE
[fix][java-client] Fix message publishing stuck when enabling batch

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/TopicTransactionBufferRecoverTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/TopicTransactionBufferRecoverTest.java
@@ -451,7 +451,6 @@ public class TopicTransactionBufferRecoverTest extends TransactionTestBase {
         reader.close();
     }
 
-
     @Test(timeOut=30000)
     public void testTransactionBufferRecoverThrowPulsarClientException() throws Exception {
         String topic = NAMESPACE1 + "/testTransactionBufferRecoverThrowPulsarClientException";
@@ -469,8 +468,6 @@ public class TopicTransactionBufferRecoverTest extends TransactionTestBase {
         producer.newMessage(txn).value("test".getBytes()).sendAsync();
         producer.newMessage(txn).value("test".getBytes()).sendAsync();
         txn.commit().get();
-
-        producer.close();
 
         PersistentTopic originalTopic = (PersistentTopic) getPulsarServiceList().get(0)
                 .getBrokerService().getTopic(TopicName.get(topic).toString(), false).get().get();
@@ -491,7 +488,7 @@ public class TopicTransactionBufferRecoverTest extends TransactionTestBase {
         doThrow(new PulsarClientException("test")).when(reader).hasMoreEvents();
         // check reader close topic
         checkCloseTopic(pulsarClient, transactionBufferSnapshotServiceOriginal,
-                transactionBufferSnapshotService, originalTopic, field);
+                transactionBufferSnapshotService, originalTopic, field, producer);
         doReturn(true).when(reader).hasMoreEvents();
 
         // mock create reader fail
@@ -501,7 +498,7 @@ public class TopicTransactionBufferRecoverTest extends TransactionTestBase {
         originalTopic = (PersistentTopic) getPulsarServiceList().get(0)
                 .getBrokerService().getTopic(TopicName.get(topic).toString(), false).get().get();
         checkCloseTopic(pulsarClient, transactionBufferSnapshotServiceOriginal,
-                transactionBufferSnapshotService, originalTopic, field);
+                transactionBufferSnapshotService, originalTopic, field, producer);
         doReturn(CompletableFuture.completedFuture(reader)).when(transactionBufferSnapshotService).createReader(any());
 
         // check create writer fail close topic
@@ -511,15 +508,15 @@ public class TopicTransactionBufferRecoverTest extends TransactionTestBase {
         doReturn(FutureUtil.failedFuture(new PulsarClientException("test")))
                 .when(transactionBufferSnapshotService).createWriter(any());
         checkCloseTopic(pulsarClient, transactionBufferSnapshotServiceOriginal,
-                transactionBufferSnapshotService, originalTopic, field);
-
+                transactionBufferSnapshotService, originalTopic, field, producer);
     }
 
     private void checkCloseTopic(PulsarClient pulsarClient,
                                  TransactionBufferSnapshotService transactionBufferSnapshotServiceOriginal,
                                  TransactionBufferSnapshotService transactionBufferSnapshotService,
                                  PersistentTopic originalTopic,
-                                 Field field) throws Exception {
+                                 Field field,
+                                 Producer<byte[]> producer) throws Exception {
         field.set(getPulsarServiceList().get(0), transactionBufferSnapshotService);
 
         // recover again will throw then close topic
@@ -537,15 +534,8 @@ public class TopicTransactionBufferRecoverTest extends TransactionTestBase {
                 .withTransactionTimeout(5, TimeUnit.SECONDS)
                 .build().get();
 
-        @Cleanup
-        Producer<byte[]> producer = pulsarClient
-                .newProducer()
-                .topic(originalTopic.getName())
-                .sendTimeout(0, TimeUnit.SECONDS)
-                .create();
-        producer.newMessage(txn).value("test".getBytes()).sendAsync();
+        producer.newMessage(txn).value("test".getBytes()).send();
         txn.commit().get();
-        producer.close();
     }
 
 }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
@@ -1803,9 +1803,6 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
                     return;
                 }
 
-                if (isBatchMessagingEnabled()) {
-                    batchMessageAndSend(false);
-                }
                 int messagesToResend = pendingMessages.messagesCount();
                 if (messagesToResend == 0) {
                     if (log.isDebugEnabled()) {
@@ -1813,6 +1810,7 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
                     }
                     if (changeToReadyState()) {
                         producerCreatedFuture.complete(ProducerImpl.this);
+                        scheduleBatchFlushTask(0);
                         return;
                     } else {
                         // Producer was closed while reconnecting, close the connection to make sure the broker
@@ -2037,7 +2035,7 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
     // must acquire semaphore before calling
     private void scheduleBatchFlushTask(long batchingDelayMicros) {
         ClientCnx cnx = cnx();
-        if (cnx != null) {
+        if (cnx != null && isBatchMessagingEnabled()) {
             this.batchFlushTask = cnx.ctx().executor().schedule(catchingAndLoggingThrowables(this::batchFlushTask),
                     batchingDelayMicros, TimeUnit.MICROSECONDS);
         }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
@@ -1802,7 +1802,10 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
                     cnx.channel().close();
                     return;
                 }
-                batchMessageAndSend(false);
+
+                if (isBatchMessagingEnabled()) {
+                    batchMessageAndSend(false);
+                }
                 int messagesToResend = pendingMessages.messagesCount();
                 if (messagesToResend == 0) {
                     if (log.isDebugEnabled()) {

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
@@ -1802,6 +1802,7 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
                     cnx.channel().close();
                     return;
                 }
+                batchMessageAndSend(false);
                 int messagesToResend = pendingMessages.messagesCount();
                 if (messagesToResend == 0) {
                     if (log.isDebugEnabled()) {


### PR DESCRIPTION
Fixes #14864 

### Motivation

Before PR #14185 there is a timer task to call the method `batchMessageContainer` to send messages in the batch container. The PR #14185 optimize batch flush logic, remove the timer task, add a scheduled task after adding messages.

If the producer enables batch,  the message will add to the batch container first, when the broker state is not `ready`, there is no subsequent logic to send messages in the batch container.


**Some Codes**

Code block in method `serializeAndSendMessage`
```
boolean isBatchFull = batchMessageContainer.add(msg, callback);
lastSendFuture = callback.getFuture();
payload.release();
if (isBatchFull) {
    batchMessageAndSend(false);
} else {
    maybeScheduleBatchFlushTask();
}
```

If the producer state is not ready, the batch flush task will not be scheduled.
```
private void maybeScheduleBatchFlushTask() {
    if (this.batchFlushTask != null || getState() != State.Ready) {
        log.info("xxxx [{}] MaybeScheduleBatchFlushTask state: {}", topic, getState());
        return;
    }
    scheduleBatchFlushTask(conf.getBatchingMaxPublishDelayMicros());
}
```

### Modifications

Call method `batchMessageAndSend` to make sure messages in the batch container execute send process after producer re-connect.

### Verifying this change

Add new unit test.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

Check the box below or label this PR directly (if you have committer privilege).

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)


