### PR TITLE
[fix][auth] Athenz: do not use uber-jar and bump to 1.10.50 to remove jackson-databind shaded dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -115,7 +115,7 @@ flexible messaging model and an intuitive client API.</description>
     <jetty.version>9.4.44.v20210927</jetty.version>
     <conscrypt.version>2.5.2</conscrypt.version>
     <jersey.version>2.34</jersey.version>
-    <athenz.version>1.10.9</athenz.version>
+    <athenz.version>1.10.50</athenz.version>
     <prometheus.version>0.5.0</prometheus.version>
     <vertx.version>3.9.8</vertx.version>
     <rocksdb.version>6.10.2</rocksdb.version>
@@ -827,7 +827,7 @@ flexible messaging model and an intuitive client API.</description>
 
       <dependency>
         <groupId>com.yahoo.athenz</groupId>
-        <artifactId>athenz-zts-java-client</artifactId>
+        <artifactId>athenz-zts-java-client-core</artifactId>
         <version>${athenz.version}</version>
       </dependency>
 

--- a/pulsar-client-auth-athenz/pom.xml
+++ b/pulsar-client-auth-athenz/pom.xml
@@ -44,7 +44,7 @@
 
     <dependency>
       <groupId>com.yahoo.athenz</groupId>
-      <artifactId>athenz-zts-java-client</artifactId>
+      <artifactId>athenz-zts-java-client-core</artifactId>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
### Motivation
For the Athenz ZTS client we're using the fat jar `athenz-zts-java-client` which contains a vulnerable version of jacksond-databind (https://github.com/apache/pulsar/pull/14871#issuecomment-1079034179)
There's no need to use the fat jar since the only case would be if Jersey 1 is used (we use 2.34)

### Modifications
* Move to  athenz-zts-java-client-core which is the regular dependency
* Bump version to 1.10.50. This is useful because in the latest versions they reduced a lot the transitive dependencies. I checked all the new dependencies. There are two mismatch which should not be cause issues:
  * Jersey: athenz-zts-java-client-core use 2.35
  * Aws SDK 1: they use 1.12.x while Pulsar forces to 1.11.x. It shouldn't be necessary to upgrade to 1.12 

- [x] `no-need-doc` 

