### PR TITLE
Upgrade Rocksdb to 6.29.4.1

### DIFF
--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -446,7 +446,7 @@ The Apache Software License, Version 2.0
     - org.eclipse.jetty-jetty-alpn-conscrypt-server-9.4.44.v20210927.jar
     - org.eclipse.jetty-jetty-alpn-server-9.4.44.v20210927.jar
  * SnakeYaml -- org.yaml-snakeyaml-1.30.jar
- * RocksDB - org.rocksdb-rocksdbjni-6.10.2.jar
+ * RocksDB - org.rocksdb-rocksdbjni-6.29.4.1.jar
  * Google Error Prone Annotations - com.google.errorprone-error_prone_annotations-2.5.1.jar
  * Apache Thrift - org.apache.thrift-libthrift-0.14.2.jar
  * OkHttp3

--- a/pom.xml
+++ b/pom.xml
@@ -118,7 +118,7 @@ flexible messaging model and an intuitive client API.</description>
     <athenz.version>1.10.9</athenz.version>
     <prometheus.version>0.5.0</prometheus.version>
     <vertx.version>3.9.8</vertx.version>
-    <rocksdb.version>6.10.2</rocksdb.version>
+    <rocksdb.version>6.29.4.1</rocksdb.version>
     <slf4j.version>1.7.32</slf4j.version>
     <commons.collections.version>3.2.2</commons.collections.version>
     <log4j2.version>2.17.1</log4j2.version>

--- a/pulsar-sql/presto-distribution/LICENSE
+++ b/pulsar-sql/presto-distribution/LICENSE
@@ -406,7 +406,7 @@ The Apache Software License, Version 2.0
     - presto-spi-332.jar
     - presto-record-decoder-332.jar
   * RocksDB JNI
-    - rocksdbjni-6.10.2.jar
+    - rocksdbjni-6.29.4.1.jar
   * SnakeYAML
     - snakeyaml-1.30.jar
   * Bean Validation API


### PR DESCRIPTION
### Motivation

Upgrade to newest version of RocksDb which has support for Mac with M1 architecture.