### PR TITLE
[feature][admin] Support reset cluster replicator cursor

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
@@ -2308,7 +2308,7 @@ public class PersistentTopicsBase extends AdminResource {
                         boolean isResetReplicator = ((PersistentTopic) topic).isReplicatorName(name);
                         if (isResetReplicator) {
                             Replicator persistentReplicator = ((PersistentTopic) topic)
-                                    .getPersistentReplicator(((PersistentTopic) topic).getClusterName(name));
+                                    .getPersistentReplicator(((PersistentTopic) topic).getReplicatorClusterName(name));
                             if (persistentReplicator == null) {
                                 throw new RestException(Status.NOT_FOUND, "replicator not found");
                             }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v1/PersistentTopics.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v1/PersistentTopics.java
@@ -670,7 +670,7 @@ public class PersistentTopics extends PersistentTopicsBase {
             String decodeSubName = decode(encodedSubName);
             MessageIdImpl messageId = new  MessageIdImpl(resetCursorData.getLedgerId(), resetCursorData.getEntryId(),
                     resetCursorData.getPartitionIndex());
-            internalResetCursorOnPosition(decode(encodedSubName), authoritative, messageId,
+            internalResetCursorOnPosition(decodeSubName, authoritative, messageId,
                     resetCursorData.isExcluded(), resetCursorData.getBatchIndex())
                     .thenRun(() -> {
                         log.info("[{}][{}] successfully reset cursor on subscription {} to position {}", clientAppId(),

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/PersistentTopics.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/PersistentTopics.java
@@ -1537,7 +1537,7 @@ public class PersistentTopics extends PersistentTopicsBase {
             String decodeSubName = decode(encodedSubName);
             MessageIdImpl messageId = new  MessageIdImpl(resetCursorData.getLedgerId(), resetCursorData.getEntryId(),
                     resetCursorData.getPartitionIndex());
-            internalResetCursorOnPosition(decode(encodedSubName), authoritative, messageId,
+            internalResetCursorOnPosition(decodeSubName, authoritative, messageId,
                     resetCursorData.isExcluded(), resetCursorData.getBatchIndex())
                     .thenRun(() -> {
                         log.info("[{}][{}] successfully reset cursor on subscription/replicator {} to position {}",

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/PersistentTopics.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/PersistentTopics.java
@@ -1545,8 +1545,8 @@ public class PersistentTopics extends PersistentTopicsBase {
                         asyncResponse.resume(Response.noContent().build());
                     }).exceptionally(ex -> {
                         Throwable realCause = FutureUtil.unwrapCompletionException(ex);
-                        log.warn("[{}][{}] Failed to reset cursor on subscription/replicator {} to position {}", clientAppId(),
-                                topicName, decodeSubName, messageId, realCause);
+                        log.warn("[{}][{}] Failed to reset cursor on subscription/replicator {} to position {}"
+                                , clientAppId(), topicName, decodeSubName, messageId, realCause);
                         if (realCause instanceof BrokerServiceException.SubscriptionInvalidCursorPosition) {
                             asyncResponse.resume(new RestException(Response.Status.PRECONDITION_FAILED,
                                     "Unable to find position for position specified: " + realCause.getMessage()));

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/PersistentTopics.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/PersistentTopics.java
@@ -1541,6 +1541,45 @@ public class PersistentTopics extends PersistentTopicsBase {
         }
     }
 
+    @POST
+    @Path("/{tenant}/{namespace}/{topic}/replicator/{clusterName}/resetcursor")
+    @ApiOperation(value = "Reset replicator cursor to message position closest to given position.",
+            notes = "It fence cursor and disconnects all active consumers before reseting cursor.")
+    @ApiResponses(value = {
+            @ApiResponse(code = 307, message = "Current broker doesn't serve the namespace of this topic"),
+            @ApiResponse(code = 401, message = "Don't have permission to administrate resources on this tenant or"
+                    + "subscriber is not authorized to access this operation"),
+            @ApiResponse(code = 403, message = "Don't have admin permission"),
+            @ApiResponse(code = 404, message = "Topic/Subscription does not exist"),
+            @ApiResponse(code = 405, message = "Not supported for partitioned topics"),
+            @ApiResponse(code = 412, message = "Unable to find position for position specified"),
+            @ApiResponse(code = 500, message = "Internal server error"),
+            @ApiResponse(code = 503, message = "Failed to validate global cluster configuration")})
+    public void resetReplicatorCursor(
+            @Suspended final AsyncResponse asyncResponse,
+            @ApiParam(value = "Specify the tenant", required = true)
+            @PathParam("tenant") String tenant,
+            @ApiParam(value = "Specify the namespace", required = true)
+            @PathParam("namespace") String namespace,
+            @ApiParam(value = "Specify topic name", required = true)
+            @PathParam("topic") @Encoded String encodedTopic,
+            @ApiParam(name = "clusterName", value = "ClusterName to reset position on", required = true)
+            @PathParam("clusterName") String encodedClusterName,
+            @ApiParam(value = "Is authentication required to perform this operation")
+            @QueryParam("authoritative") @DefaultValue("false") boolean authoritative,
+            @ApiParam(name = "messageId", value = "messageId to reset back to (ledgerId:entryId)")
+                    ResetCursorData resetCursorData) {
+        try {
+            validateTopicName(tenant, namespace, encodedTopic);
+            internalResetCursorOnPosition(asyncResponse, decode(encodedClusterName), authoritative
+                    , new MessageIdImpl(resetCursorData.getLedgerId(),
+                            resetCursorData.getEntryId(), resetCursorData.getPartitionIndex())
+                    , resetCursorData.isExcluded(), resetCursorData.getBatchIndex());
+        } catch (Exception e) {
+            resumeAsyncResponseExceptionally(asyncResponse, e);
+        }
+    }
+
     @GET
     @Path("/{tenant}/{namespace}/{topic}/subscription/{subName}/position/{messagePosition}")
     @ApiOperation(value = "Peek nth message on a topic subscription.")

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractReplicator.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractReplicator.java
@@ -224,6 +224,10 @@ public abstract class AbstractReplicator {
         return (replicatorPrefix + "." + cluster).intern();
     }
 
+    public static String getClusterName(String replicatorPrefix, String replicatorName) {
+        return replicatorName.replace(replicatorPrefix + ".", "");
+    }
+
     /**
      * Replication can't be started on root-partitioned-topic to avoid producer startup conflict.
      *

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractReplicator.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractReplicator.java
@@ -225,6 +225,10 @@ public abstract class AbstractReplicator {
     }
 
     public static String getClusterName(String replicatorPrefix, String replicatorName) {
+        if (!replicatorName.startsWith(replicatorPrefix)) {
+            throw new IllegalArgumentException(
+                    String.format("%s is not a legal replicator name.", replicatorName));
+        }
         return replicatorName.replace(replicatorPrefix + ".", "");
     }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Replicator.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Replicator.java
@@ -20,9 +20,7 @@ package org.apache.pulsar.broker.service;
 
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
-
 import org.apache.bookkeeper.mledger.Position;
-import org.apache.bookkeeper.mledger.impl.PositionImpl;
 import org.apache.pulsar.broker.service.persistent.DispatchRateLimiter;
 import org.apache.pulsar.common.policies.data.stats.ReplicatorStatsImpl;
 import org.apache.pulsar.common.util.FutureUtil;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Replicator.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Replicator.java
@@ -20,8 +20,12 @@ package org.apache.pulsar.broker.service;
 
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
+
+import org.apache.bookkeeper.mledger.Position;
+import org.apache.bookkeeper.mledger.impl.PositionImpl;
 import org.apache.pulsar.broker.service.persistent.DispatchRateLimiter;
 import org.apache.pulsar.common.policies.data.stats.ReplicatorStatsImpl;
+import org.apache.pulsar.common.util.FutureUtil;
 
 public interface Replicator {
 
@@ -46,4 +50,8 @@ public interface Replicator {
     }
 
     boolean isConnected();
+
+    default CompletableFuture<Void> resetCursor(Position position) {
+         return FutureUtil.failedFuture(new UnsupportedOperationException("Unsupported operation"));
+    }
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentReplicator.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentReplicator.java
@@ -436,10 +436,10 @@ public class PersistentReplicator extends AbstractReplicator
                 // cursor should be rewinded since it was incremented when readMoreEntries
                 replicator.cursor.rewind();
             } else {
-//                if (log.isDebugEnabled()) {
+                if (log.isDebugEnabled()) {
                     log.info("[{}][{} -> {}] Message persisted on remote broker", replicator.topicName,
                             replicator.localCluster, replicator.remoteCluster);
-//                }
+                }
                 replicator.cursor.asyncDelete(entry.getPosition(), replicator, entry.getPosition());
             }
             entry.release();

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentReplicator.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentReplicator.java
@@ -426,7 +426,7 @@ public class PersistentReplicator extends AbstractReplicator
                 replicator.cursor.rewind();
             } else {
                 if (log.isDebugEnabled()) {
-                    log.info("[{}][{} -> {}] Message persisted on remote broker", replicator.topicName,
+                    log.debug("[{}][{} -> {}] Message persisted on remote broker", replicator.topicName,
                             replicator.localCluster, replicator.remoteCluster);
                 }
                 replicator.cursor.asyncDelete(entry.getPosition(), replicator, entry.getPosition());

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -2586,8 +2586,8 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
         return name.startsWith(replicatorPrefix);
     }
 
-    public String getClusterName(String replicatorName) {
-        return replicatorName.replace(replicatorPrefix + ".","");
+    public String getReplicatorClusterName(String replicatorName) {
+        return AbstractReplicator.getClusterName(replicatorPrefix, replicatorName);
     }
 
     public CompletableFuture<MessageId> terminate() {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -2582,6 +2582,14 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
         return !replicators.isEmpty();
     }
 
+    public boolean isReplicatorName(String name) {
+        return name.startsWith(replicatorPrefix);
+    }
+
+    public String getClusterName(String replicatorName) {
+        return replicatorName.replace(replicatorPrefix + ".","");
+    }
+
     public CompletableFuture<MessageId> terminate() {
         CompletableFuture<MessageId> future = new CompletableFuture<>();
         ledger.asyncTerminate(new TerminateCallback() {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatorTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatorTest.java
@@ -78,6 +78,7 @@ import org.apache.pulsar.client.api.RawReader;
 import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.client.api.SubscriptionType;
 import org.apache.pulsar.client.api.TypedMessageBuilder;
+import org.apache.pulsar.client.impl.MessageIdImpl;
 import org.apache.pulsar.client.impl.ProducerImpl;
 import org.apache.pulsar.client.impl.PulsarClientImpl;
 import org.apache.pulsar.client.impl.conf.ProducerConfigurationData;
@@ -595,6 +596,34 @@ public class ReplicatorTest extends ReplicatorTestBase {
         consumer1.receive(2);
 
         admin1.topics().resetCursor(dest.toString(), "sub-id", System.currentTimeMillis());
+    }
+
+    @Test(timeOut = 30000)
+    public void testResetReplicatorCursor() throws Exception {
+
+        log.info("--- Starting ReplicatorTest::testResetReplicatorCursor ---");
+        final TopicName topicName = TopicName
+                .get(BrokerTestUtil.newUniqueName("persistent://pulsar/ns/testResetReplicatorCursor"));
+
+        @Cleanup
+        MessageProducer producer1 = new MessageProducer(url1, topicName);
+        log.info("--- Starting producer --- " + url1);
+
+        @Cleanup
+        MessageConsumer consumer1 = new MessageConsumer(url1, topicName);
+        log.info("--- Starting Consumer --- " + url1);
+
+        @Cleanup
+        MessageConsumer consumer2 = new MessageConsumer(url2, topicName);
+        log.info("--- Starting Consumer --- " + url2);
+
+        producer1.produce(2);
+
+        consumer2.receive(2);
+
+        admin1.topics().resetCursor(topicName.toString(), "pulsar.repl.r2", new MessageIdImpl(0,0,-1));
+
+        consumer2.receive(2);
     }
 
     @Test

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatorTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatorTest.java
@@ -610,10 +610,6 @@ public class ReplicatorTest extends ReplicatorTestBase {
         log.info("--- Starting producer --- " + url1);
 
         @Cleanup
-        MessageConsumer consumer1 = new MessageConsumer(url1, topicName);
-        log.info("--- Starting Consumer --- " + url1);
-
-        @Cleanup
         MessageConsumer consumer2 = new MessageConsumer(url2, topicName);
         log.info("--- Starting Consumer --- " + url2);
 

--- a/pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/admin/Topics.java
+++ b/pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/admin/Topics.java
@@ -1697,13 +1697,13 @@ public interface Topics {
     void resetCursor(String topic, String subName, long timestamp) throws PulsarAdminException;
 
     /**
-     * Reset cursor position on a topic subscription.
+     * Reset cursor position on a topic subscription/replicator.
      * <p/>
      * and start consume messages from the next position of the reset position.
-     * @param topic
-     * @param subName
-     * @param messageId
-     * @param isExcluded
+     * @param topic topic name
+     * @param subName Subscription/replicator name
+     * @param messageId message id
+     * @param isExcluded if exclusive specific message id
      * @throws PulsarAdminException
      */
     void resetCursor(String topic, String subName, MessageId messageId, boolean isExcluded) throws PulsarAdminException;


### PR DESCRIPTION
### Motivation

Currently, we do not support resetting the cursor position on the cluster replicator.
After the check, I think we could support it based on ``PersistentTopics#resetCursorOnPosition``.

#### Usage

**Admin**

```java
admin1.topics().resetCursor(topicName.toString(), "pulsar.repl.r2", new MessageIdImpl(0,0,-1));
```
**cli**

```bash
bin/pulsar-admin topics reset-cursor -s pulsar.repl.r2 -m 0:0:-1  persistent://xxxx/xx/xxx
```

### Modifications

- Support for resetting cluster replicator cursor based on ``PersistentTopics#resetCursorOnPosition`` method

### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Does this pull request potentially affect one of the following parts:

  - The admin cli options: (yes)

### Documentation

- [x] `doc-required` 
  
