### PR TITLE
[fix][transaction] avoid too many ServiceUnitNotReadyException for transaction buffer handler

### DIFF
--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -1369,6 +1369,9 @@ transactionBufferSnapshotMaxTransactionCount=1000
 # Unit : millisecond
 transactionBufferSnapshotMinTimeInMillis=5000
 
+# The max concurrent requests for transaction buffer client, default is 1000
+transactionBufferClientMaxConcurrentRequests=1000
+
 ### --- Packages management service configuration variables (begin) --- ###
 
 # Enable the packages management service or not

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -2469,6 +2469,12 @@ public class ServiceConfiguration implements PulsarConfiguration {
     )
     private int transactionBufferSnapshotMinTimeInMillis = 5000;
 
+    @FieldContext(
+            category = CATEGORY_TRANSACTION,
+            doc = "The max concurrent requests for transaction buffer client."
+    )
+    private int transactionBufferClientMaxConcurrentRequests = 1000;
+
     /**** --- KeyStore TLS config variables. --- ****/
     @FieldContext(
             category = CATEGORY_KEYSTORE_TLS,

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
@@ -751,7 +751,8 @@ public class PulsarService implements AutoCloseable, ShutdownService {
                 this.transactionBufferSnapshotService = new SystemTopicBaseTxnBufferSnapshotService(getClient());
                 this.transactionTimer =
                         new HashedWheelTimer(new DefaultThreadFactory("pulsar-transaction-timer"));
-                transactionBufferClient = TransactionBufferClientImpl.create(getClient(), transactionTimer);
+                transactionBufferClient = TransactionBufferClientImpl.create(getClient(), transactionTimer,
+                        config.getTransactionBufferClientMaxConcurrentRequests());
 
                 transactionMetadataStoreService = new TransactionMetadataStoreService(TransactionMetadataStoreProvider
                         .newProvider(config.getTransactionMetadataStoreProviderClassName()), this,

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/TransactionBufferClientImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/TransactionBufferClientImpl.java
@@ -18,7 +18,6 @@
  */
 package org.apache.pulsar.broker.transaction.buffer.impl;
 
-import com.google.common.annotations.VisibleForTesting;
 import io.netty.util.HashedWheelTimer;
 import java.util.concurrent.CompletableFuture;
 import lombok.extern.slf4j.Slf4j;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/TransactionBufferClientImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/TransactionBufferClientImpl.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pulsar.broker.transaction.buffer.impl;
 
+import com.google.common.annotations.VisibleForTesting;
 import io.netty.util.HashedWheelTimer;
 import java.util.concurrent.CompletableFuture;
 import lombok.extern.slf4j.Slf4j;
@@ -39,8 +40,10 @@ public class TransactionBufferClientImpl implements TransactionBufferClient {
         this.tbHandler = tbHandler;
     }
 
-    public static TransactionBufferClient create(PulsarClient pulsarClient, HashedWheelTimer timer) {
-        TransactionBufferHandler handler = new TransactionBufferHandlerImpl(pulsarClient, timer);
+    public static TransactionBufferClient create(PulsarClient pulsarClient, HashedWheelTimer timer,
+             int maxConcurrentRequests) {
+        TransactionBufferHandler handler = new TransactionBufferHandlerImpl(pulsarClient, timer,
+                maxConcurrentRequests);
         return new TransactionBufferClientImpl(handler);
     }
 
@@ -73,5 +76,15 @@ public class TransactionBufferClientImpl implements TransactionBufferClient {
     @Override
     public void close() {
         tbHandler.close();
+    }
+
+    @Override
+    public int getAvailableRequestCredits() {
+        return tbHandler.getAvailableRequestCredits();
+    }
+
+    @Override
+    public int getPendingRequestsCount() {
+        return tbHandler.getPendingRequestsCount();
     }
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/TransactionBufferHandlerImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/TransactionBufferHandlerImpl.java
@@ -280,8 +280,6 @@ public class TransactionBufferHandlerImpl implements TransactionBufferHandler {
                     } else {
                         REQUEST_CREDITS_UPDATER.incrementAndGet(this);
                     }
-                } else {
-                    checkPendingRequests();
                 }
             } else {
                 break;

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/buffer/TransactionBufferClientTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/buffer/TransactionBufferClientTest.java
@@ -164,15 +164,15 @@ public class TransactionBufferClientTest extends TransactionTestBase {
         CompletableFuture<TxnID> endFuture =
                 transactionBufferHandler.endTxnOnTopic("test", 1, 1, TxnAction.ABORT, 1);
 
-        Field field = TransactionBufferHandlerImpl.class.getDeclaredField("pendingRequests");
+        Field field = TransactionBufferHandlerImpl.class.getDeclaredField("outstandingRequests");
         field.setAccessible(true);
-        ConcurrentSkipListMap<Long, Object> pendingRequests =
+        ConcurrentSkipListMap<Long, Object> outstandingRequests =
                 (ConcurrentSkipListMap<Long, Object>) field.get(transactionBufferHandler);
 
-        assertEquals(pendingRequests.size(), 1);
+        assertEquals(outstandingRequests.size(), 1);
 
         Awaitility.await().atLeast(2, TimeUnit.SECONDS).until(() -> {
-            if (pendingRequests.size() == 0) {
+            if (outstandingRequests.size() == 0) {
                 return true;
             }
             return false;

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/buffer/TransactionBufferClientTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/buffer/TransactionBufferClientTest.java
@@ -27,12 +27,9 @@ import io.netty.util.concurrent.DefaultThreadFactory;
 import lombok.Cleanup;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 
-import org.apache.pulsar.broker.service.Topic;
-import org.apache.pulsar.broker.service.persistent.PersistentSubscription;
 import org.apache.pulsar.broker.transaction.TransactionTestBase;
 import org.apache.pulsar.broker.transaction.buffer.impl.TransactionBufferClientImpl;
 import org.apache.pulsar.broker.transaction.buffer.impl.TransactionBufferHandlerImpl;
@@ -84,7 +81,7 @@ public class TransactionBufferClientTest extends TransactionTestBase {
         admin.namespaces().createNamespace(namespace, 10);
         admin.topics().createPartitionedTopic(partitionedTopicName.getPartitionedTopicName(), partitions);
         tbClient = TransactionBufferClientImpl.create(pulsarClient,
-                new HashedWheelTimer(new DefaultThreadFactory("transaction-buffer")));
+                new HashedWheelTimer(new DefaultThreadFactory("transaction-buffer")), 1000);
     }
 
     @Override
@@ -163,7 +160,7 @@ public class TransactionBufferClientTest extends TransactionTestBase {
         @Cleanup("stop")
         HashedWheelTimer hashedWheelTimer = new HashedWheelTimer();
         TransactionBufferHandlerImpl transactionBufferHandler =
-                new TransactionBufferHandlerImpl(mockClient, hashedWheelTimer);
+                new TransactionBufferHandlerImpl(mockClient, hashedWheelTimer, 1000);
         CompletableFuture<TxnID> endFuture =
                 transactionBufferHandler.endTxnOnTopic("test", 1, 1, TxnAction.ABORT, 1);
 
@@ -206,7 +203,7 @@ public class TransactionBufferClientTest extends TransactionTestBase {
         @Cleanup("stop")
         HashedWheelTimer hashedWheelTimer = new HashedWheelTimer();
         TransactionBufferHandlerImpl transactionBufferHandler =
-                new TransactionBufferHandlerImpl(mockClient, hashedWheelTimer);
+                new TransactionBufferHandlerImpl(mockClient, hashedWheelTimer, 1000);
         try {
             transactionBufferHandler.endTxnOnTopic("test", 1, 1, TxnAction.ABORT, 1).get();
             fail();
@@ -246,8 +243,8 @@ public class TransactionBufferClientTest extends TransactionTestBase {
     }
 
     @Test
-    public void testTransactionBufferHandlerSemaphore() throws Exception {
-        String topic = "persistent://" + namespace + "/testTransactionBufferHandlerSemaphore";
+    public void testTransactionBufferRequestCredits() throws Exception {
+        String topic = "persistent://" + namespace + "/testTransactionBufferRequestCredits";
         String subName = "test";
 
         String abortTopic = topic + "_abort_sub";
@@ -260,11 +257,17 @@ public class TransactionBufferClientTest extends TransactionTestBase {
         admin.topics().createSubscription(commitTopic, subName, MessageId.earliest);
 
         tbClient.abortTxnOnSubscription(abortTopic, "test", 1L, 1L, -1L).get();
-
         tbClient.commitTxnOnSubscription(commitTopic, "test", 1L, 1L, -1L).get();
 
         tbClient.abortTxnOnTopic(abortTopic, 1L, 1L, -1L).get();
         tbClient.commitTxnOnTopic(commitTopic, 1L, 1L, -1L).get();
+
+        assertEquals(tbClient.getAvailableRequestCredits(), 1000);
+    }
+
+    @Test
+    public void testTransactionBufferPendingRequests() throws Exception {
+
     }
 
     @Test
@@ -290,23 +293,5 @@ public class TransactionBufferClientTest extends TransactionTestBase {
 
         tbClient.abortTxnOnSubscription(topic + "_abort_topic", sub, 1L, 1L, -1L).get();
         tbClient.abortTxnOnSubscription(topic + "_commit_topic", sub, 1L, 1L, -1L).get();
-    }
-
-    private void waitPendingAckInit(String topic, String sub) throws Exception {
-
-        boolean exist = false;
-        for (int i = 0; i < getPulsarServiceList().size(); i++) {
-            CompletableFuture<Optional<Topic>> completableFuture = getPulsarServiceList().get(i)
-                    .getBrokerService().getTopics().get(topic);
-            if (completableFuture != null) {
-                PersistentSubscription persistentSubscription =
-                        (PersistentSubscription) completableFuture.get().get().getSubscription(sub);
-                Awaitility.await().untilAsserted(() ->
-                        assertEquals(persistentSubscription.getTransactionPendingAckStats().state, "Ready"));
-                exist = true;
-            }
-        }
-
-        assertTrue(exist);
     }
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/buffer/TransactionBufferHandlerImplTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/buffer/TransactionBufferHandlerImplTest.java
@@ -1,0 +1,67 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.transaction.buffer;
+
+import org.apache.pulsar.broker.transaction.buffer.impl.TransactionBufferHandlerImpl;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+
+import org.apache.pulsar.client.impl.ClientCnx;
+import org.apache.pulsar.client.impl.PulsarClientImpl;
+import org.apache.pulsar.common.api.proto.TxnAction;
+import org.testng.annotations.Test;
+
+import java.util.concurrent.CompletableFuture;
+
+@Test(groups = "broker")
+public class TransactionBufferHandlerImplTest {
+
+    @Test
+    public void testRequestCredits() {
+        PulsarClientImpl pulsarClient = mock(PulsarClientImpl.class);
+        when(pulsarClient.getConnection(anyString())).thenReturn(CompletableFuture.completedFuture(mock(ClientCnx.class)));
+        TransactionBufferHandlerImpl handler = spy(new TransactionBufferHandlerImpl(pulsarClient, null, 1000));
+        doNothing().when(handler).endTxn(any());
+        for (int i = 0; i < 500; i++) {
+            handler.endTxnOnTopic("t", 1L, 1L, TxnAction.COMMIT, 1L);
+        }
+        assertEquals(handler.getAvailableRequestCredits(), 500);
+        for (int i = 0; i < 500; i++) {
+            handler.endTxnOnTopic("t", 1L, 1L, TxnAction.COMMIT, 1L);
+        }
+        assertEquals(handler.getAvailableRequestCredits(), 0);
+        handler.endTxnOnTopic("t", 1L, 1L, TxnAction.COMMIT, 1L);
+        assertEquals(handler.getPendingRequestsCount(), 1);
+        handler.onResponse(null);
+        assertEquals(handler.getAvailableRequestCredits(), 0);
+        assertEquals(handler.getPendingRequestsCount(), 0);
+    }
+
+    @Test
+    public void testMinRequestCredits() {
+        TransactionBufferHandlerImpl handler = spy(new TransactionBufferHandlerImpl(null, null, 50));
+        assertEquals(handler.getAvailableRequestCredits(), 100);
+    }
+}

--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/transaction/TransactionBufferClient.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/transaction/TransactionBufferClient.java
@@ -91,4 +91,8 @@ public interface TransactionBufferClient {
                                                     long lowWaterMark);
 
     void close();
+
+    int getAvailableRequestCredits();
+
+    int getPendingRequestsCount();
 }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/transaction/TransactionBufferHandler.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/transaction/TransactionBufferHandler.java
@@ -72,4 +72,8 @@ public interface TransactionBufferHandler {
      * Release resources.
      */
     void close();
+
+    int getAvailableRequestCredits();
+
+    int getPendingRequestsCount();
 }


### PR DESCRIPTION
### Motivation

1. Added max concurrent request limitation for transaction buffer client
2. Add the request to the pending request queue after reaching the concurrent request limitation
3. Avoid duplicated lookup cache invalidation

### Documentation

Check the box below or label this PR directly (if you have committer privilege).

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)


