### PR TITLE
[metadata] fix MetadataStore#put may get unexcepted exception

### DIFF
--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/ZKMetadataStore.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/ZKMetadataStore.java
@@ -386,7 +386,7 @@ public class ZKMetadataStore extends AbstractBatchedMetadataStore
                                 put(opPut.getPath(), opPut.getData(), Optional.of(-1L)).thenAccept(
                                                 s -> future.complete(s))
                                         .exceptionally(ex -> {
-                                            if (ex instanceof BadVersionException) {
+                                            if (ex.getCause() instanceof BadVersionException) {
                                                 // The z-node exist now, let's overwrite it
                                                 internalStorePut(opPut);
                                             } else {

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/ZKMetadataStore.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/ZKMetadataStore.java
@@ -386,7 +386,12 @@ public class ZKMetadataStore extends AbstractBatchedMetadataStore
                                 put(opPut.getPath(), opPut.getData(), Optional.of(-1L)).thenAccept(
                                                 s -> future.complete(s))
                                         .exceptionally(ex -> {
-                                            future.completeExceptionally(MetadataStoreException.wrap(ex.getCause()));
+                                            if (ex instanceof BadVersionException) {
+                                                // The z-node exist now, let's overwrite it
+                                                internalStorePut(opPut);
+                                            } else {
+                                                future.completeExceptionally(MetadataStoreException.wrap(ex.getCause()));
+                                            }
                                             return null;
                                         });
                             }

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/ZKMetadataStore.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/ZKMetadataStore.java
@@ -390,7 +390,8 @@ public class ZKMetadataStore extends AbstractBatchedMetadataStore
                                                 // The z-node exist now, let's overwrite it
                                                 internalStorePut(opPut);
                                             } else {
-                                                future.completeExceptionally(MetadataStoreException.wrap(ex.getCause()));
+                                                future.completeExceptionally(
+                                                        MetadataStoreException.wrap(ex.getCause()));
                                             }
                                             return null;
                                         });

--- a/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/MetadataStoreTest.java
+++ b/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/MetadataStoreTest.java
@@ -38,6 +38,7 @@ import java.util.function.Supplier;
 import lombok.Cleanup;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.pulsar.common.util.FutureUtil;
 import org.apache.pulsar.metadata.api.GetResult;
 import org.apache.pulsar.metadata.api.MetadataStore;
 import org.apache.pulsar.metadata.api.MetadataStoreConfig;
@@ -81,6 +82,30 @@ public class MetadataStoreTest extends BaseMetadataStoreTest {
             assertTrue(NotFoundException.class.isInstance(e.getCause()) || BadVersionException.class.isInstance(
                     e.getCause()));
         }
+    }
+
+    @Test(dataProvider = "impl")
+    public void concurrentPutTest(String provider, Supplier<String> urlSupplier) throws Exception {
+        if (!provider.equals("ZooKeeper")) {
+            return;
+        }
+        @Cleanup
+        MetadataStore store = MetadataStoreFactory.create(urlSupplier.get(), MetadataStoreConfig.builder().build());
+
+        String data = "data";
+        String path = "/non-existing-key";
+        int concurrent = 50;
+        List<CompletableFuture<Stat>> resultList = new ArrayList<>();
+        while (concurrent > 0) {
+            concurrent --;
+            resultList.add(store.put(path, data.getBytes(), Optional.empty()).exceptionally(ex -> {
+                fail("fail to execute concurrent put", ex);
+                return null;
+            }));
+        }
+        FutureUtil.waitForAll(resultList).join();
+
+        assertEquals(store.get(path).join().get().getValue(), data.getBytes());
     }
 
     @Test(dataProvider = "impl")


### PR DESCRIPTION
### Motivation

call MetadataStore#put without version by `MetadataStore.put(path, data, Optional.empty())` concurrently with same node may get `BadVersionException`

At first the node is not exist, put operation will fail and fall back to create node with `MetadataStore.put(path, data, -1)`.
`version=-1` means create the node, and if the node was just created by other thread, it will thow `BadVersionException`.

### Modifications

Since original call does not set `version`, `BadVersionException` is not excepted for caller.
We could just overwrite the value in this case.

### Documentation

Check the box below or label this PR directly (if you have committer privilege).

- [x] `no-need-doc` 



