### PR TITLE
[improve][client] Add log for reader acknowledge.

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiTopicsConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiTopicsConsumerImpl.java
@@ -1439,7 +1439,11 @@ public class MultiTopicsConsumerImpl<T> extends ConsumerBase<T> {
 
     public void tryAcknowledgeMessage(Message<T> msg) {
         if (msg != null) {
-            acknowledgeCumulativeAsync(msg);
+            acknowledgeCumulativeAsync(msg)
+                    .exceptionally(ex -> {
+                        log.error("[{}][{}] acknowledge cumulative fail.", topic, subscription, ex);
+                        return null;
+                    });
         }
     }
 }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiTopicsConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiTopicsConsumerImpl.java
@@ -1441,7 +1441,8 @@ public class MultiTopicsConsumerImpl<T> extends ConsumerBase<T> {
         if (msg != null) {
             acknowledgeCumulativeAsync(msg)
                     .exceptionally(ex -> {
-                        log.error("[{}][{}] acknowledge cumulative fail.", topic, subscription, ex);
+                        log.warn("[{}][{}] acknowledge message {} cumulative fail.", topic, subscription,
+                                msg.getMessageId(), ex);
                         return null;
                     });
         }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiTopicsReaderImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiTopicsReaderImpl.java
@@ -24,6 +24,7 @@ import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.pulsar.client.api.Consumer;
@@ -41,6 +42,7 @@ import org.apache.pulsar.client.impl.conf.ConsumerConfigurationData;
 import org.apache.pulsar.client.impl.conf.ReaderConfigurationData;
 import org.apache.pulsar.client.util.ExecutorProvider;
 
+@Slf4j
 public class MultiTopicsReaderImpl<T> implements Reader<T> {
 
     private final MultiTopicsConsumerImpl<T> multiTopicsConsumer;
@@ -129,7 +131,12 @@ public class MultiTopicsReaderImpl<T> implements Reader<T> {
     @Override
     public CompletableFuture<Message<T>> readNextAsync() {
         return multiTopicsConsumer.receiveAsync().thenApply(msg -> {
-            multiTopicsConsumer.acknowledgeCumulativeAsync(msg);
+            multiTopicsConsumer.acknowledgeCumulativeAsync(msg)
+                    .exceptionally(ex -> {
+                        log.error("[{}][{}] acknowledge cumulative fail.", getTopic(),
+                                getMultiTopicsConsumer().getSubscription(), ex);
+                        return null;
+                    });
             return msg;
         });
     }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiTopicsReaderImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiTopicsReaderImpl.java
@@ -133,8 +133,8 @@ public class MultiTopicsReaderImpl<T> implements Reader<T> {
         return multiTopicsConsumer.receiveAsync().thenApply(msg -> {
             multiTopicsConsumer.acknowledgeCumulativeAsync(msg)
                     .exceptionally(ex -> {
-                        log.error("[{}][{}] acknowledge cumulative fail.", getTopic(),
-                                getMultiTopicsConsumer().getSubscription(), ex);
+                        log.warn("[{}][{}] acknowledge message {} cumulative fail.", getTopic(),
+                                getMultiTopicsConsumer().getSubscription(), msg.getMessageId(), ex);
                         return null;
                     });
             return msg;

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ReaderImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ReaderImpl.java
@@ -144,8 +144,8 @@ public class ReaderImpl<T> implements Reader<T> {
         // Acknowledge message immediately because the reader is based on non-durable subscription. When it reconnects,
         // it will specify the subscription position anyway
         consumer.acknowledgeCumulativeAsync(msg).exceptionally(ex -> {
-            log.error("[{}][{}] acknowledge cumulative fail.", getTopic(),
-                    getConsumer().getSubscription(), ex);
+            log.warn("[{}][{}] acknowledge message {} cumulative fail.", getTopic(),
+                    getConsumer().getSubscription(), msg.getMessageId(), ex);
             return null;
         });
         return msg;
@@ -157,8 +157,8 @@ public class ReaderImpl<T> implements Reader<T> {
 
         if (msg != null) {
             consumer.acknowledgeCumulativeAsync(msg).exceptionally(ex -> {
-                log.error("[{}][{}] acknowledge cumulative fail.", getTopic(),
-                        getConsumer().getSubscription(), ex);
+                log.warn("[{}][{}] acknowledge message {} cumulative fail.", getTopic(),
+                        getConsumer().getSubscription(), msg.getMessageId(), ex);
                 return null;
             });
         }
@@ -171,8 +171,8 @@ public class ReaderImpl<T> implements Reader<T> {
         receiveFuture.whenComplete((msg, t) -> {
            if (msg != null) {
                consumer.acknowledgeCumulativeAsync(msg).exceptionally(ex -> {
-                   log.error("[{}][{}] acknowledge cumulative fail.", getTopic(),
-                           getConsumer().getSubscription(), ex);
+                   log.warn("[{}][{}] acknowledge message {} cumulative fail.", getTopic(),
+                           getConsumer().getSubscription(), msg.getMessageId(), ex);
                    return null;
                });
            }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ReaderImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ReaderImpl.java
@@ -147,7 +147,7 @@ public class ReaderImpl<T> implements Reader<T> {
             log.error("[{}][{}] acknowledge cumulative fail.", getTopic(),
                     getConsumer().getSubscription(), ex);
             return null;
-        });;
+        });
         return msg;
     }
 


### PR DESCRIPTION
### Motivation

The current reader asynchronously acknowledges that there is no error log, making it difficult for users to find the problem.

One case :
The reader has been reading messages since it was created, but the cursor does not update.

**broker.log**

> Created subscription on topic persistent://tenant/namespace/topic/ reader-a19805af61"
[persistent://tenant/namespace/topic][reader-a19805af61] Created new subscription for 0"
[persistent://tenant/namespace/topic] Rewind from 19785:18719 to 19785:18719"
[persistent://tenant/namespace/topic] Opened new cursor: NonDurableCursorImpl{ledger=xxx, ackPos=19785:18718, readPos=19785:18719}"
[persistent://tenant/namespace/topic] Created non-durable cursor read-position=19785:18719 mark-delete-position=19785:18718"
[persistent://tenant/namespace/topic][reader-a19805af61] Creating non-durable subscription at msg id 19785:18719: -1:139"
Subscribing on topic persistent://tenant/namespace/topic / reader-a19805af61"


**internal stats**

```json
{
    "reader-a19805af61" : {
      "markDeletePosition" : "19785:18718",
      "readPosition" : "19807:42735",
      "waitingReadOp" : false,
      "pendingReadOps" : 0,
      "messagesConsumedCounter" : -2257,
      "cursorLedger" : -1,
      "cursorLedgerLastEntry" : -1,
      "individuallyDeletedMessages" : "[]",
      "lastLedgerSwitchTimestamp" : "2022-03-24T20:03:51.85Z",
      "state" : "Uninitialized",
      "numberOfEntriesSinceFirstNotAckedMessage" : 744993,
      "totalNonContiguousDeletedMessagesRange" : 0,
      "subscriptionHavePendingRead" : true,
      "subscriptionHavePendingReplayRead" : false,
      "properties" : { }
    }
}
```

### Modifications

- Add log for reader ``readNext()``/``readerNextAsync()`` method.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Documentation

- [x] `no-need-doc` 
  