### PR TITLE
TieredStorage: add debug information

### DIFF
--- a/jclouds-shaded/pom.xml
+++ b/jclouds-shaded/pom.xml
@@ -41,6 +41,11 @@
       <version>${jclouds.version}</version>
     </dependency>
     <dependency>
+      <groupId>org.apache.jclouds.driver</groupId>
+      <artifactId>jclouds-slf4j</artifactId>
+      <version>${jclouds.version}</version>
+    </dependency>
+    <dependency>
       <groupId>javax.annotation</groupId>
       <artifactId>javax.annotation-api</artifactId>
     </dependency>

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/LedgerOffloader.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/LedgerOffloader.java
@@ -90,6 +90,7 @@ public interface LedgerOffloader {
     // TODO: improve the user metadata in subsequent changes
     String METADATA_SOFTWARE_VERSION_KEY = "S3ManagedLedgerOffloaderSoftwareVersion";
     String METADATA_SOFTWARE_GITSHA_KEY = "S3ManagedLedgerOffloaderSoftwareGitSha";
+    String METADATA_PULSAR_CLUSTER_NAME = "pulsarClusterName";
 
     /**
      * Get offload driver name.

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
@@ -44,7 +44,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
@@ -44,6 +44,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -1258,7 +1259,8 @@ public class PulsarService implements AutoCloseable, ShutdownService {
                         offloadPolicies,
                         ImmutableMap.of(
                             LedgerOffloader.METADATA_SOFTWARE_VERSION_KEY.toLowerCase(), PulsarVersion.getVersion(),
-                            LedgerOffloader.METADATA_SOFTWARE_GITSHA_KEY.toLowerCase(), PulsarVersion.getGitSha()
+                            LedgerOffloader.METADATA_SOFTWARE_GITSHA_KEY.toLowerCase(), PulsarVersion.getGitSha(),
+                            LedgerOffloader.METADATA_PULSAR_CLUSTER_NAME.toLowerCase(), config.getClusterName()
                         ),
                         schemaStorage,
                         getOffloaderScheduler(offloadPolicies));

--- a/tiered-storage/jcloud/src/main/java/org/apache/bookkeeper/mledger/offload/jcloud/provider/JCloudBlobStoreProvider.java
+++ b/tiered-storage/jcloud/src/main/java/org/apache/bookkeeper/mledger/offload/jcloud/provider/JCloudBlobStoreProvider.java
@@ -36,6 +36,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.Serializable;
 import java.nio.charset.Charset;
+import java.util.Arrays;
 import java.util.Properties;
 import java.util.UUID;
 import lombok.extern.slf4j.Slf4j;
@@ -56,6 +57,7 @@ import org.jclouds.domain.LocationBuilder;
 import org.jclouds.domain.LocationScope;
 import org.jclouds.googlecloud.GoogleCredentialsFromJson;
 import org.jclouds.googlecloudstorage.GoogleCloudStorageProviderMetadata;
+import org.jclouds.logging.slf4j.config.SLF4JLoggingModule;
 import org.jclouds.providers.AnonymousProviderMetadata;
 import org.jclouds.providers.ProviderMetadata;
 import org.jclouds.s3.S3ApiMetadata;
@@ -136,6 +138,7 @@ public enum JCloudBlobStoreProvider implements Serializable, ConfigValidation, B
         @Override
         public BlobStore getBlobStore(TieredStorageConfiguration config) {
             ContextBuilder contextBuilder = ContextBuilder.newBuilder(config.getProviderMetadata());
+            contextBuilder.modules(Arrays.asList(new SLF4JLoggingModule()));
             contextBuilder.overrides(config.getOverrides());
 
             if (config.getProviderCredentials() != null) {
@@ -201,6 +204,7 @@ public enum JCloudBlobStoreProvider implements Serializable, ConfigValidation, B
         public BlobStore getBlobStore(TieredStorageConfiguration config) {
 
             ContextBuilder builder =  ContextBuilder.newBuilder("transient");
+            builder.modules(Arrays.asList(new SLF4JLoggingModule()));
             BlobStoreContext ctx = builder
                     .buildView(BlobStoreContext.class);
 
@@ -283,6 +287,7 @@ public enum JCloudBlobStoreProvider implements Serializable, ConfigValidation, B
 
     static final BlobStoreBuilder BLOB_STORE_BUILDER = (TieredStorageConfiguration config) -> {
         ContextBuilder contextBuilder = ContextBuilder.newBuilder(config.getProviderMetadata());
+        contextBuilder.modules(Arrays.asList(new SLF4JLoggingModule()));
         contextBuilder.overrides(config.getOverrides());
 
         if (StringUtils.isNotEmpty(config.getServiceEndpoint())) {
@@ -367,6 +372,7 @@ public enum JCloudBlobStoreProvider implements Serializable, ConfigValidation, B
 
     static final BlobStoreBuilder ALIYUN_OSS_BLOB_STORE_BUILDER = (TieredStorageConfiguration config) -> {
         ContextBuilder contextBuilder = ContextBuilder.newBuilder(config.getProviderMetadata());
+        contextBuilder.modules(Arrays.asList(new SLF4JLoggingModule()));
         Properties overrides = config.getOverrides();
         // For security reasons, OSS supports only virtual hosted style access.
         overrides.setProperty(S3Constants.PROPERTY_S3_VIRTUAL_HOST_BUCKETS, "true");


### PR DESCRIPTION
### Motivation
Currently it is very hard to debug Tiered Storage Offloading:
- no logs
- no way to match the objects with the Managed Ledger (and with the Pulsar cluster)


### Modifications
- enable SLF4 logging in JClouds
- add Pulsar Cluster name in Objects metadata
- log object names during offloading

### Verifying this change

This change is a trivial rework / code cleanup without any test coverage.



