### PR TITLE
[fix][test] Fix clear transaction buffer snapshot flaky test

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/TopicTransactionBufferRecoverTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/TopicTransactionBufferRecoverTest.java
@@ -391,7 +391,6 @@ public class TopicTransactionBufferRecoverTest extends TransactionTestBase {
     public void clearTransactionBufferSnapshotTest() throws Exception {
         String topic = NAMESPACE1 + "/tb-snapshot-delete-" + RandomUtils.nextInt();
 
-        @Cleanup
         Producer<byte[]> producer = pulsarClient
                 .newProducer()
                 .topic(topic)
@@ -404,6 +403,7 @@ public class TopicTransactionBufferRecoverTest extends TransactionTestBase {
         producer.newMessage(txn).value("test".getBytes()).sendAsync();
         producer.newMessage(txn).value("test".getBytes()).sendAsync();
         txn.commit().get();
+        producer.close();
 
         // take snapshot
         PersistentTopic originalTopic = (PersistentTopic) getPulsarServiceList().get(0)


### PR DESCRIPTION
### Motivation
```
java.lang.AssertionError: 
Expected :true
Actual   :false
<Click to see difference>
	at org.testng.Assert.fail(Assert.java:99)
	at org.testng.Assert.failNotEquals(Assert.java:1037)
	at org.testng.Assert.assertTrue(Assert.java:45)
	at org.testng.Assert.assertTrue(Assert.java:55)
	at org.apache.pulsar.broker.transaction.TopicTransactionBufferRecoverTest.checkSnapshotCount(TopicTransactionBufferRecoverTest.java:452)
	at org.apache.pulsar.broker.transaction.TopicTransactionBufferRecoverTest.clearTransactionBufferSnapshotTest(TopicTransactionBufferRecoverTest.java:427)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at org.testng.internal.MethodInvocationHelper.invokeMethod(MethodInvocationHelper.java:132)
// ...
```

Currently, the clear transaction buffer snapshot is flaky, because we used `@Cleanup` annotation, the `@Cleanup` annotation will put the close producer method to the bottom of the test method, then the producer will close after deleting the topic. 

When we delete the topic, all relevant producers will receive a `CLOSE_PRODUCER` command, then the producer client will try to reconnect to the broker, so it will send the `PRODUCER` command again, then the transaction buffer snapshot will take a new snapshot, so the test will fail.

### Modifications

Make the producer close before the topic deleting.

### Documentation

Check the box below or label this PR directly (if you have committer privilege).

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)


