### PR TITLE
[cleanup][pom.xml] Could org.apache.pulsar:buildtools:2.10.0-SNAPSHOT drop off redundant dependencies?

### DIFF
--- a/buildtools/pom.xml
+++ b/buildtools/pom.xml
@@ -81,17 +81,47 @@
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
       <version>${guava.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>com.google.errorprone</groupId>
+          <artifactId>error_prone_annotations</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.google.guava</groupId>
+          <artifactId>listenablefuture</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.google.j2objc</groupId>
+          <artifactId>j2objc-annotations</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.google.code.findbugs</groupId>
+          <artifactId>jsr305</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.google.inject</groupId>
       <artifactId>guice</artifactId>
       <version>${guice.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>javax.inject</groupId>
+          <artifactId>javax.inject</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>
       <groupId>org.testng</groupId>
       <artifactId>testng</artifactId>
       <version>${testng.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>javax.inject</groupId>
+          <artifactId>javax.inject</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>junit</groupId>


### PR DESCRIPTION
Hi! I found the pom file of project **_org.apache.pulsar:buildtools:2.10.0-SNAPSHOT_** introduced **_28_** dependencies. However, among them, **_5_** libraries (**_17%_**) are not used by your project. I list the redundant dependencies below (labelled as red ones in the figure):
## Redundant dependencies
com.google.guava:listenablefuture:jar:9999.0-empty-to-avoid-conflict-with-guava:compile
com.google.code.findbugs:jsr305:jar:3.0.2:compile
com.google.errorprone:error_prone_annotations:jar:2.7.1:compile
com.google.j2objc:j2objc-annotations:jar:1.3:compile
javax.inject:javax.inject:jar:1:compile

---
Removing the redundant dependencies can reduce the size of project and prevent potential dependency conflict issues (i.e., multiple versions of the same library). More importantly, one of the redundant dependencies **_javax.inject:javax.inject:jar:1:compile_** induced dependency conflict in the dependency graph. As such, I suggest a refactoring operation for **_org.apache.pulsar:buildtools:2.10.0-SNAPSHOT_**’s pom file.

The attached PR helps resolve the reported problem. It is safe to remove the unused libraries (we considered Java reflection relations when analyzing the dependencies). These changes have passed **_org.apache.pulsar:buildtools:2.10.0-SNAPSHOT_**’s maven tests.

Best regards
![image](https://user-images.githubusercontent.com/78527112/160570037-07031397-71e3-4f2b-a13f-a555bf8dec76.png)
