### PR TITLE
[improve][tieredstorage] Add API to scan objects on Tiered Storage

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/LedgerOffloader.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/LedgerOffloader.java
@@ -218,5 +218,17 @@ public interface LedgerOffloader {
      * Close the resources if necessary.
      */
     void close();
+
+    /**
+     * Scans all the ManagedLedgers stored on this Offloader (usually a Bucket).
+     * The callback should not modify/delete the ledgers.
+     * @param consumer receives the
+     * @param offloadDriverMetadata additional metadata
+     * @throws ManagedLedgerException
+     */
+    default void scanLedgers(OffloadedLedgerMetadataConsumer consumer,
+                             Map<String, String> offloadDriverMetadata) throws ManagedLedgerException {
+        throw ManagedLedgerException.getManagedLedgerException(new UnsupportedOperationException());
+    }
 }
 

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedLedgerInfo.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedLedgerInfo.java
@@ -45,6 +45,7 @@ public class ManagedLedgerInfo {
         public Long size;
         public Long timestamp;
         public boolean isOffloaded;
+        public String offloadedContextUuid;
     }
 
     public static class CursorInfo {

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/OffloadedLedgerMetadata.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/OffloadedLedgerMetadata.java
@@ -18,11 +18,10 @@
  */
 package org.apache.bookkeeper.mledger;
 
+import java.util.Map;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.ToString;
-
-import java.util.Map;
 
 @Builder
 @Getter

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/OffloadedLedgerMetadata.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/OffloadedLedgerMetadata.java
@@ -1,0 +1,39 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.bookkeeper.mledger;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.ToString;
+
+import java.util.Map;
+
+@Builder
+@Getter
+@ToString
+public final class OffloadedLedgerMetadata {
+    private final long ledgerId;
+    private final long lastModified;
+    private final String name;
+    private final String bucketName;
+    private final String uri;
+    private final long size;
+    private final String uuid;
+    private final Map<String, String> userMetadata;
+}

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/OffloadedLedgerMetadataConsumer.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/OffloadedLedgerMetadataConsumer.java
@@ -1,0 +1,32 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.bookkeeper.mledger;
+
+public interface OffloadedLedgerMetadataConsumer {
+
+    /**
+     * Accepts metadata about a ledger.
+     * This function should not modify the ledger or delete it.
+     *
+     * @param ledger metadata
+     * @throws Exception
+     * @return return false in order to gracefully stop the scan
+     */
+    boolean accept(OffloadedLedgerMetadata ledger) throws Exception;
+}

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerFactoryImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerFactoryImpl.java
@@ -28,6 +28,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.ConcurrentHashMap;
@@ -718,6 +719,11 @@ public class ManagedLedgerFactoryImpl implements ManagedLedgerFactory {
                     ledgerInfo.entries = pbLedgerInfo.hasEntries() ? pbLedgerInfo.getEntries() : null;
                     ledgerInfo.size = pbLedgerInfo.hasSize() ? pbLedgerInfo.getSize() : null;
                     ledgerInfo.isOffloaded = pbLedgerInfo.hasOffloadContext();
+                    if (pbLedgerInfo.hasOffloadContext()) {
+                        MLDataFormats.OffloadContext offloadContext = pbLedgerInfo.getOffloadContext();
+                        UUID uuid = new UUID(offloadContext.getUidMsb(), offloadContext.getUidLsb());
+                        ledgerInfo.offloadedContextUuid = uuid.toString();
+                    }
                     info.ledgers.add(ledgerInfo);
                 }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/NamespacesBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/NamespacesBase.java
@@ -27,6 +27,7 @@ import com.google.common.collect.Sets;
 import java.lang.reflect.Field;
 import java.net.URI;
 import java.net.URL;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -36,10 +37,12 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.SortedSet;
+import java.util.TreeMap;
 import java.util.TreeSet;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -48,6 +51,10 @@ import javax.ws.rs.container.AsyncResponse;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 import javax.ws.rs.core.UriBuilder;
+import org.apache.bookkeeper.mledger.LedgerOffloader;
+import org.apache.bookkeeper.mledger.ManagedLedgerException;
+import org.apache.bookkeeper.mledger.ManagedLedgerFactory;
+import org.apache.bookkeeper.mledger.ManagedLedgerInfo;
 import org.apache.commons.lang.mutable.MutableObject;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.pulsar.broker.PulsarServerException;
@@ -2795,6 +2802,111 @@ public abstract class NamespacesBase extends AdminResource {
         internalSetPolicies("resource_group_name", rgName);
     }
 
+    protected Map<String, Object> internalScanOffloadedLedgers() throws Exception {
+        log.info("internalScanOffloadedLedgers {}", namespaceName);
+        validateNamespacePolicyOperation(namespaceName, PolicyName.OFFLOAD, PolicyOperation.READ);
+
+        Policies policies = getNamespacePolicies(namespaceName);
+        LedgerOffloader managedLedgerOffloader = pulsar()
+                .getManagedLedgerOffloader(namespaceName, (OffloadPoliciesImpl) policies.offload_policies);
+
+        String localClusterName = pulsar().getConfiguration().getClusterName();
+        Map<String, Object> topLevelResult = new HashMap<>();
+        List<Map<String, Object>> objects = new ArrayList<>();
+        topLevelResult.put("objects", objects);
+        AtomicInteger totalCount = new AtomicInteger();
+        AtomicInteger totalErrors = new AtomicInteger();
+        AtomicInteger totalUnknown = new AtomicInteger();
+        managedLedgerOffloader.scanLedgers((md -> {
+            log.info("Found ledger {}", md);
+            Map<String, Object> objectInfo = new HashMap<>();
+            objectInfo.put("ledger", md.getLedgerId());
+            objectInfo.put("name", md.getName());
+            objectInfo.put("uri", md.getUri());
+            objectInfo.put("uuid", md.getUuid());
+            objectInfo.put("size", md.getSize());
+            objectInfo.put("lastModified", md.getLastModified());
+            objectInfo.put("userMetadata", md.getUserMetadata());
+
+            String status = "UNKNOWN";
+
+            if (md.getUserMetadata() != null) {
+                // non case sensistive
+                TreeMap<String, String> userMetadata = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+                userMetadata.putAll(md.getUserMetadata());
+                String clusterName = userMetadata.get(LedgerOffloader.METADATA_PULSAR_CLUSTER_NAME);
+                if (localClusterName.equals(clusterName)) {
+                    String managedLedgerName = userMetadata.get("managedledgername");
+                    if (managedLedgerName != null) {
+                        objectInfo.put("managedLedgerName", managedLedgerName);
+                        try {
+                            status = checkLedgerShouldBeOnTieredStorage(md.getLedgerId(), md.getUuid(),
+                                    managedLedgerName, objectInfo, pulsar().getManagedLedgerFactory());
+                        } catch (InterruptedException err) {
+                            Thread.currentThread().interrupt();
+                            throw new RuntimeException(err);
+                        } catch (ManagedLedgerException err) {
+                            log.error("Error while checking managed ledger {}", managedLedgerName);
+                            throw new RuntimeException(err);
+                        }
+                    }
+                }
+            }
+            totalCount.incrementAndGet();
+            objectInfo.put("status", status);
+            switch (status) {
+                case "OK":
+                    break;
+                case "UNKNOWN":
+                    totalUnknown.incrementAndGet();
+                    break;
+                default:
+                    totalErrors.incrementAndGet();
+                    break;
+            }
+
+            objects.add(objectInfo);
+            return true;
+        }), managedLedgerOffloader.getOffloadDriverMetadata());
+        topLevelResult.put("errors", totalErrors.intValue());
+        topLevelResult.put("total", totalCount.intValue());
+        topLevelResult.put("unknownObjects", totalUnknown.intValue());
+        log.info("internalScanOffloadedLedgers {} scan finished");
+
+        return topLevelResult;
+    }
+
+    private static String checkLedgerShouldBeOnTieredStorage(long ledgerId, String uuid,
+                                                      String managedLedgerName,
+                                                      Map<String, Object> data,
+                                                      ManagedLedgerFactory managedLedgerFactory)
+            throws InterruptedException, ManagedLedgerException  {
+        try {
+            ManagedLedgerInfo managedLedgerInfo = managedLedgerFactory.getManagedLedgerInfo(managedLedgerName);
+            ManagedLedgerInfo.LedgerInfo ledgerInfo = managedLedgerInfo
+                    .ledgers.stream().filter(l -> l.ledgerId == ledgerId).findAny().orElse(null);
+            if (ledgerInfo == null) {
+                log.info("Managed ledger {} does not contain ledger {}", managedLedgerName, ledgerId);
+                return "NOT-FOUND";
+            }
+            data.put("numEntries", ledgerInfo.entries);
+            data.put("offloaded", ledgerInfo.isOffloaded);
+            if (!ledgerInfo.isOffloaded) {
+                log.info("Ledger {} is not marked as OFFLOADED in {}", ledgerId, managedLedgerName);
+                return "NOT-OFFLOADED";
+            }
+            String uuidOnMetadata = ledgerInfo.offloadedContextUuid;
+            if (!Objects.equals(uuidOnMetadata, uuid)) {
+                log.info("Ledger {} uuid {} does not match name uuid {}", ledgerId, uuidOnMetadata, uuid);
+                return "BAD-UUID";
+            }
+            return "OK";
+        }  catch (ManagedLedgerException.ManagedLedgerNotFoundException
+                | ManagedLedgerException.MetadataNotFoundException notFound) {
+            log.info("Managed ledger {} does not exist (maybe the topic has been deleted)", managedLedgerName);
+            return "NOT-FOUND";
+        }
+    }
 
     private static final Logger log = LoggerFactory.getLogger(NamespacesBase.class);
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/OffloaderObjectsScannerUtils.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/OffloaderObjectsScannerUtils.java
@@ -1,0 +1,143 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.admin.impl;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.TreeMap;
+import java.util.concurrent.atomic.AtomicInteger;
+import lombok.experimental.UtilityClass;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.bookkeeper.mledger.LedgerOffloader;
+import org.apache.bookkeeper.mledger.ManagedLedgerException;
+import org.apache.bookkeeper.mledger.ManagedLedgerFactory;
+import org.apache.bookkeeper.mledger.ManagedLedgerInfo;
+
+@Slf4j
+@UtilityClass
+public class OffloaderObjectsScannerUtils {
+
+    private static final String STATUS_OK = "OK";
+    private static final String STATUS_UNKNOWN = "UNKNOWN";
+    private static final String STATUS_BAD_UUID = "BAD-UUID";
+    private static final String STATUS_NOT_FOUND = "NOT-FOUND";
+    private static final String STATUS_NOT_OFFLOADED = "NOT-OFFLOADED";
+
+    public interface ScannerResultSink {
+
+        void object(Map<String, Object> data) throws Exception;
+        void finished(int total, int errors, int unknown) throws Exception;
+    }
+
+    static void scanOffloadedLedgers(LedgerOffloader managedLedgerOffloader,
+                                                              String localClusterName,
+                                                              ManagedLedgerFactory managedLedgerFactory,
+                                                              ScannerResultSink sink) throws Exception {
+        AtomicInteger totalCount = new AtomicInteger();
+        AtomicInteger totalErrors = new AtomicInteger();
+        AtomicInteger totalUnknown = new AtomicInteger();
+        managedLedgerOffloader.scanLedgers((md -> {
+            log.info("Found ledger {}", md);
+            Map<String, Object> objectInfo = new HashMap<>();
+            objectInfo.put("ledger", md.getLedgerId());
+            objectInfo.put("name", md.getName());
+            objectInfo.put("uri", md.getUri());
+            objectInfo.put("uuid", md.getUuid());
+            objectInfo.put("size", md.getSize());
+            objectInfo.put("lastModified", md.getLastModified());
+            objectInfo.put("userMetadata", md.getUserMetadata());
+
+            String status = STATUS_UNKNOWN;
+
+            if (md.getUserMetadata() != null) {
+                // non case sensitive
+                TreeMap<String, String> userMetadata = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+                userMetadata.putAll(md.getUserMetadata());
+                String clusterName = userMetadata.get(LedgerOffloader.METADATA_PULSAR_CLUSTER_NAME);
+                if (localClusterName.equals(clusterName)) {
+                    String managedLedgerName = userMetadata.get("managedledgername");
+                    if (managedLedgerName != null) {
+                        objectInfo.put("managedLedgerName", managedLedgerName);
+                        try {
+                            status = checkLedgerShouldBeOnTieredStorage(md.getLedgerId(), md.getUuid(),
+                                    managedLedgerName, objectInfo, managedLedgerFactory);
+                        } catch (InterruptedException err) {
+                            Thread.currentThread().interrupt();
+                            throw new RuntimeException(err);
+                        } catch (ManagedLedgerException err) {
+                            log.error("Error while checking managed ledger {}", managedLedgerName);
+                            throw new RuntimeException(err);
+                        }
+                    }
+                }
+            }
+            totalCount.incrementAndGet();
+            objectInfo.put("status", status);
+            switch (status) {
+                case STATUS_OK:
+                    break;
+                case STATUS_UNKNOWN:
+                    totalUnknown.incrementAndGet();
+                    break;
+                default:
+                    totalErrors.incrementAndGet();
+                    break;
+            }
+
+            sink.object(objectInfo);
+            return true;
+        }), managedLedgerOffloader.getOffloadDriverMetadata());
+
+        sink.finished(totalCount.get(), totalErrors.get(), totalUnknown.get());
+    }
+
+    private static String checkLedgerShouldBeOnTieredStorage(long ledgerId, String uuid,
+            String managedLedgerName,
+            Map<String, Object> data,
+            ManagedLedgerFactory managedLedgerFactory)
+        throws InterruptedException, ManagedLedgerException  {
+        try {
+            ManagedLedgerInfo managedLedgerInfo = managedLedgerFactory.getManagedLedgerInfo(managedLedgerName);
+            ManagedLedgerInfo.LedgerInfo ledgerInfo = managedLedgerInfo
+                    .ledgers.stream().filter(l -> l.ledgerId == ledgerId).findAny().orElse(null);
+            if (ledgerInfo == null) {
+                log.info("Managed ledger {} does not contain ledger {}", managedLedgerName, ledgerId);
+                return STATUS_NOT_FOUND;
+            }
+            data.put("numEntries", ledgerInfo.entries);
+            data.put("offloaded", ledgerInfo.isOffloaded);
+            if (!ledgerInfo.isOffloaded) {
+                log.info("Ledger {} is not marked as OFFLOADED in {}", ledgerId, managedLedgerName);
+                return STATUS_NOT_OFFLOADED;
+            }
+            String uuidOnMetadata = ledgerInfo.offloadedContextUuid;
+            if (!Objects.equals(uuidOnMetadata, uuid)) {
+                log.info("Ledger {} uuid {} does not match name uuid {}", ledgerId, uuidOnMetadata, uuid);
+                return STATUS_BAD_UUID;
+            }
+            return "OK";
+        }  catch (ManagedLedgerException.ManagedLedgerNotFoundException
+                | ManagedLedgerException.MetadataNotFoundException notFound) {
+            log.info("Managed ledger {} does not exist (maybe the topic has been deleted)", managedLedgerName);
+            return STATUS_NOT_FOUND;
+        }
+    }
+
+}

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/Namespaces.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/Namespaces.java
@@ -42,6 +42,7 @@ import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.container.AsyncResponse;
 import javax.ws.rs.container.Suspended;
 import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
 import org.apache.pulsar.broker.admin.impl.NamespacesBase;
 import org.apache.pulsar.broker.web.RestException;
 import org.apache.pulsar.client.api.SubscriptionType;
@@ -1963,6 +1964,23 @@ public class Namespaces extends NamespacesBase {
                                           @PathParam("namespace") String namespace) {
         validateNamespaceName(tenant, namespace);
         internalSetNamespaceResourceGroup(null);
+    }
+
+    @GET
+    @Path("/{tenant}/{namespace}/scanOffloadedLedgers")
+    @ApiOperation(value = "Trigger the scan of offloaded Ledgers on the LedgerOffloader for the given namespace")
+    @ApiResponses(value = { @ApiResponse(code = 403, message = "Don't have admin permission"),
+            @ApiResponse(code = 404, message = "Namespace doesn't exist") })
+    public Map<String, Object> scanOffloadedLedgers(@PathParam("tenant") String tenant,
+            @PathParam("namespace") String namespace) {
+        validateNamespaceName(tenant, namespace);
+        try {
+            return internalScanOffloadedLedgers();
+        } catch (Throwable err) {
+            log.error("Error while scanning offloaded ledgers for namespace {}", namespaceName, err);
+            throw new RestException(Response.Status.INTERNAL_SERVER_ERROR,
+                    "Error while scanning ledgers for " + namespaceName);
+        }
     }
 
     private static final Logger log = LoggerFactory.getLogger(Namespaces.class);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/Namespaces.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/Namespaces.java
@@ -25,6 +25,8 @@ import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
+import java.io.OutputStreamWriter;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -43,7 +45,9 @@ import javax.ws.rs.container.AsyncResponse;
 import javax.ws.rs.container.Suspended;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
+import javax.ws.rs.core.StreamingOutput;
 import org.apache.pulsar.broker.admin.impl.NamespacesBase;
+import org.apache.pulsar.broker.admin.impl.OffloaderObjectsScannerUtils;
 import org.apache.pulsar.broker.web.RestException;
 import org.apache.pulsar.client.api.SubscriptionType;
 import org.apache.pulsar.common.api.proto.CommandGetTopicsOfNamespace.Mode;
@@ -71,6 +75,7 @@ import org.apache.pulsar.common.policies.data.SchemaCompatibilityStrategy;
 import org.apache.pulsar.common.policies.data.SubscribeRate;
 import org.apache.pulsar.common.policies.data.SubscriptionAuthMode;
 import org.apache.pulsar.common.policies.data.impl.DispatchRateImpl;
+import org.apache.pulsar.common.util.ObjectMapperFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -1971,11 +1976,44 @@ public class Namespaces extends NamespacesBase {
     @ApiOperation(value = "Trigger the scan of offloaded Ledgers on the LedgerOffloader for the given namespace")
     @ApiResponses(value = { @ApiResponse(code = 403, message = "Don't have admin permission"),
             @ApiResponse(code = 404, message = "Namespace doesn't exist") })
-    public Map<String, Object> scanOffloadedLedgers(@PathParam("tenant") String tenant,
+    public Response scanOffloadedLedgers(@PathParam("tenant") String tenant,
             @PathParam("namespace") String namespace) {
         validateNamespaceName(tenant, namespace);
         try {
-            return internalScanOffloadedLedgers();
+            StreamingOutput output = (outputStream) -> {
+                try {
+                    OutputStreamWriter out = new OutputStreamWriter(outputStream, StandardCharsets.UTF_8);
+                    out.append("{objects:[\n");
+                    internalScanOffloadedLedgers(new OffloaderObjectsScannerUtils.ScannerResultSink() {
+                        boolean first = true;
+                        @Override
+                        public void object(Map<String, Object> data) throws Exception {
+                            if (!first) {
+                                out.write(',');
+                            } else {
+                                first = true;
+                            }
+                            String json = ObjectMapperFactory.getThreadLocal().writeValueAsString(data);
+                            out.write(json);
+                        }
+
+                        @Override
+                        public void finished(int total, int errors, int unknown) throws Exception {
+                            out.append("]\n");
+                            out.append("\"total\": " + total + ",\n");
+                            out.append("\"errors\": " + errors + ",\n");
+                            out.append("\"unknown\": " + unknown + "\n");
+                        }
+                    });
+                    out.append("}");
+                    out.flush();
+                    outputStream.flush();
+                } catch (Exception err) {
+                    log.error("error", err);
+                    throw new RuntimeException(err);
+                }
+            };
+            return Response.ok(output).type(MediaType.APPLICATION_JSON_TYPE).build();
         } catch (Throwable err) {
             log.error("Error while scanning offloaded ledgers for namespace {}", namespaceName, err);
             throw new RestException(Response.Status.INTERNAL_SERVER_ERROR,

--- a/tiered-storage/jcloud/src/main/java/org/apache/bookkeeper/mledger/offload/jcloud/impl/BlobStoreManagedLedgerOffloader.java
+++ b/tiered-storage/jcloud/src/main/java/org/apache/bookkeeper/mledger/offload/jcloud/impl/BlobStoreManagedLedgerOffloader.java
@@ -22,7 +22,10 @@ import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import java.io.IOException;
+import java.net.URI;
 import java.time.Duration;
+import java.util.Collections;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
@@ -43,6 +46,9 @@ import org.apache.bookkeeper.mledger.Entry;
 import org.apache.bookkeeper.mledger.LedgerOffloader;
 import org.apache.bookkeeper.mledger.LedgerOffloader.OffloadHandle.OfferEntryResult;
 import org.apache.bookkeeper.mledger.ManagedLedger;
+import org.apache.bookkeeper.mledger.ManagedLedgerException;
+import org.apache.bookkeeper.mledger.OffloadedLedgerMetadata;
+import org.apache.bookkeeper.mledger.OffloadedLedgerMetadataConsumer;
 import org.apache.bookkeeper.mledger.Position;
 import org.apache.bookkeeper.mledger.impl.EntryImpl;
 import org.apache.bookkeeper.mledger.impl.OffloadSegmentInfoImpl;
@@ -62,6 +68,10 @@ import org.jclouds.blobstore.domain.Blob;
 import org.jclouds.blobstore.domain.BlobBuilder;
 import org.jclouds.blobstore.domain.MultipartPart;
 import org.jclouds.blobstore.domain.MultipartUpload;
+import org.jclouds.blobstore.domain.PageSet;
+import org.jclouds.blobstore.domain.StorageMetadata;
+import org.jclouds.blobstore.domain.StorageType;
+import org.jclouds.blobstore.options.ListContainerOptions;
 import org.jclouds.blobstore.options.PutOptions;
 import org.jclouds.domain.Location;
 import org.jclouds.domain.LocationBuilder;
@@ -124,7 +134,6 @@ public class BlobStoreManagedLedgerOffloader implements LedgerOffloader {
         //ensure buffer can have enough content to fill a block
         this.maxBufferLength = Math.max(config.getWriteBufferSizeInBytes(), config.getMinBlockSizeInBytes());
         this.segmentBeginTimeMillis = System.currentTimeMillis();
-
         if (!Strings.isNullOrEmpty(config.getRegion())) {
             this.writeLocation = new LocationBuilder()
                     .scope(LocationScope.REGION)
@@ -162,6 +171,8 @@ public class BlobStoreManagedLedgerOffloader implements LedgerOffloader {
                                            UUID uuid,
                                            Map<String, String> extraMetadata) {
         final BlobStore writeBlobStore = blobStores.get(config.getBlobStoreLocation());
+        log.info("offload {} uuid {} extraMetadata {} to {} {}", readHandle.getId(), uuid, extraMetadata,
+                config.getBlobStoreLocation(), writeBlobStore);
         CompletableFuture<Void> promise = new CompletableFuture<>();
         scheduler.chooseThread(readHandle.getId()).submit(() -> {
             if (readHandle.getLength() == 0 || !readHandle.isClosed() || readHandle.getLastAddConfirmed() < 0) {
@@ -189,6 +200,7 @@ public class BlobStoreManagedLedgerOffloader implements LedgerOffloader {
                 }
                 DataBlockUtils.addVersionInfo(blobBuilder, objectMetadata);
                 Blob blob = blobBuilder.build();
+                log.info("initiateMultipartUpload bucket {}, metadata {} ", config.getBucket(), blob.getMetadata());
                 mpu = writeBlobStore.initiateMultipartUpload(config.getBucket(), blob.getMetadata(), new PutOptions());
             } catch (Throwable t) {
                 promise.completeExceptionally(t);
@@ -230,7 +242,8 @@ public class BlobStoreManagedLedgerOffloader implements LedgerOffloader {
                     dataObjectLength += blockSize;
                 }
 
-                writeBlobStore.completeMultipartUpload(mpu, parts);
+                String etag = writeBlobStore.completeMultipartUpload(mpu, parts);
+                log.info("Ledger {}, upload finished, etag {}", readHandle.getId(), etag);
                 mpu = null;
             } catch (Throwable t) {
                 try {
@@ -621,4 +634,75 @@ public class BlobStoreManagedLedgerOffloader implements LedgerOffloader {
             }
         }
     }
+
+    @Override
+    public void scanLedgers(OffloadedLedgerMetadataConsumer consumer, Map<String, String> offloadDriverMetadata) throws ManagedLedgerException {
+        BlobStoreLocation bsKey = getBlobStoreLocation(offloadDriverMetadata);
+        String endpoint = bsKey.getEndpoint();
+        String readBucket = bsKey.getBucket();
+        log.info("Scanning bucket {}, bsKey {}, location {} endpoint{} ", readBucket, bsKey,
+                config.getBlobStoreLocation(), endpoint);
+        BlobStore readBlobstore = blobStores.get(config.getBlobStoreLocation());
+        int batchSize = 100;
+        String bucketName = config.getBucket();
+        String marker = null;
+        do {
+            marker = scanContainer(consumer, readBlobstore, bucketName, marker, batchSize);
+        } while (marker != null);
+
+    }
+
+    private String scanContainer(OffloadedLedgerMetadataConsumer consumer, BlobStore readBlobstore,
+                                 String bucketName,
+                                 String lastMarker,
+                                 int batchSize) throws ManagedLedgerException {
+        ListContainerOptions options = new ListContainerOptions()
+                .maxResults(batchSize)
+                .withDetails();
+        if (lastMarker != null) {
+            options.afterMarker(lastMarker);
+        }
+        PageSet<? extends StorageMetadata> pages = readBlobstore.list(bucketName, options);
+        for (StorageMetadata md : pages) {
+            log.info("Found {} ",md);
+            String name = md.getName();
+            Long size = md.getSize();
+            Date lastModified = md.getLastModified();
+            StorageType type = md.getType();
+            if (type != StorageType.BLOB) {
+                continue;
+            }
+            URI uri = md.getUri();
+            Map<String, String> userMetadata = md.getUserMetadata();
+            Long ledgerId = DataBlockUtils.parseLedgerId(name);
+            String contextUuid = DataBlockUtils.parseContextUuid(name, ledgerId);
+            log.info("info {} {} {} {} {} {} ledgerId {}", name, size, lastModified, type, uri, userMetadata, ledgerId);
+            OffloadedLedgerMetadata offloadedLedgerMetadata = OffloadedLedgerMetadata.builder()
+                    .name(name)
+                    .bucketName(bucketName)
+                    .uuid(contextUuid)
+                    .ledgerId(ledgerId != null ? ledgerId : -1)
+                    .lastModified(lastModified != null ? lastModified.getTime() : 0)
+                    .size(size != null ? size : -1)
+                    .uri(uri != null ? uri.toString() : null)
+                    .userMetadata(userMetadata != null ? userMetadata : Collections.emptyMap())
+                    .build();
+            try {
+                boolean canContinue = consumer.accept(offloadedLedgerMetadata);
+                if (!canContinue) {
+                    log.info("Iteration stopped by the OffloadedLedgerMetadataConsumer");
+                    return null;
+                }
+            } catch (Exception err) {
+                log.error("Error in the OffloadedLedgerMetadataConsumer", err);
+                if (err instanceof InterruptedException) {
+                    Thread.currentThread().interrupt();
+                }
+                throw ManagedLedgerException.getManagedLedgerException(err);
+            }
+        }
+        log.info("NextMarker is {}", pages.getNextMarker());
+        return pages.getNextMarker();
+    }
+
 }

--- a/tiered-storage/jcloud/src/main/java/org/apache/bookkeeper/mledger/offload/jcloud/impl/BlobStoreManagedLedgerOffloader.java
+++ b/tiered-storage/jcloud/src/main/java/org/apache/bookkeeper/mledger/offload/jcloud/impl/BlobStoreManagedLedgerOffloader.java
@@ -636,7 +636,8 @@ public class BlobStoreManagedLedgerOffloader implements LedgerOffloader {
     }
 
     @Override
-    public void scanLedgers(OffloadedLedgerMetadataConsumer consumer, Map<String, String> offloadDriverMetadata) throws ManagedLedgerException {
+    public void scanLedgers(OffloadedLedgerMetadataConsumer consumer, Map<String,
+            String> offloadDriverMetadata) throws ManagedLedgerException {
         BlobStoreLocation bsKey = getBlobStoreLocation(offloadDriverMetadata);
         String endpoint = bsKey.getEndpoint();
         String readBucket = bsKey.getBucket();
@@ -664,7 +665,7 @@ public class BlobStoreManagedLedgerOffloader implements LedgerOffloader {
         }
         PageSet<? extends StorageMetadata> pages = readBlobstore.list(bucketName, options);
         for (StorageMetadata md : pages) {
-            log.info("Found {} ",md);
+            log.info("Found {} ", md);
             String name = md.getName();
             Long size = md.getSize();
             Date lastModified = md.getLastModified();

--- a/tiered-storage/jcloud/src/main/java/org/apache/bookkeeper/mledger/offload/jcloud/impl/DataBlockUtils.java
+++ b/tiered-storage/jcloud/src/main/java/org/apache/bookkeeper/mledger/offload/jcloud/impl/DataBlockUtils.java
@@ -76,4 +76,34 @@ public class DataBlockUtils {
                 version, key, CURRENT_VERSION));
         }
     };
+
+    public static Long parseLedgerId(String name) {
+        if (name == null || name.isEmpty()) {
+            return null;
+        }
+        if (name.endsWith("-index")) {
+            name = name.substring(0, name.length() - "-index".length());
+        }
+        int pos = name.indexOf("-ledger-");
+        if (pos < 0) {
+            return null;
+        }
+        try {
+            return Long.parseLong(name.substring(pos + 8));
+        } catch (NumberFormatException err) {
+            return null;
+        }
+    }
+
+    public static String parseContextUuid(String name, Long ledgerId) {
+        if (ledgerId == null || name == null) {
+            return null;
+        }
+        int pos = name.indexOf("-ledger-" + ledgerId);
+        if (pos <= 0) {
+            return null;
+        }
+        return name.substring(0, pos);
+    }
+
 }

--- a/tiered-storage/jcloud/src/test/java/org/apache/bookkeeper/mledger/offload/jcloud/impl/BlobStoreManagedLedgerOffloaderTest.java
+++ b/tiered-storage/jcloud/src/test/java/org/apache/bookkeeper/mledger/offload/jcloud/impl/BlobStoreManagedLedgerOffloaderTest.java
@@ -23,13 +23,16 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.mock;
+import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.fail;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 import java.util.Random;
 import java.util.UUID;
@@ -41,6 +44,7 @@ import org.apache.bookkeeper.client.api.LedgerEntries;
 import org.apache.bookkeeper.client.api.LedgerEntry;
 import org.apache.bookkeeper.client.api.ReadHandle;
 import org.apache.bookkeeper.mledger.LedgerOffloader;
+import org.apache.bookkeeper.mledger.OffloadedLedgerMetadata;
 import org.apache.bookkeeper.mledger.offload.jcloud.provider.JCloudBlobStoreProvider;
 import org.apache.bookkeeper.mledger.offload.jcloud.provider.TieredStorageConfiguration;
 import org.jclouds.blobstore.BlobStore;
@@ -121,7 +125,7 @@ public class BlobStoreManagedLedgerOffloaderTest extends BlobStoreManagedLedgerO
         offloader.offload(toWrite, uuid, new HashMap<>()).get();
 
         ReadHandle toTest = offloader.readOffloaded(toWrite.getId(), uuid, Collections.emptyMap()).get();
-        Assert.assertEquals(toTest.getLastAddConfirmed(), toWrite.getLastAddConfirmed());
+        assertEquals(toTest.getLastAddConfirmed(), toWrite.getLastAddConfirmed());
 
         try (LedgerEntries toWriteEntries = toWrite.read(0, toWrite.getLastAddConfirmed());
              LedgerEntries toTestEntries = toTest.read(0, toTest.getLastAddConfirmed())) {
@@ -132,10 +136,10 @@ public class BlobStoreManagedLedgerOffloaderTest extends BlobStoreManagedLedgerO
                 LedgerEntry toWriteEntry = toWriteIter.next();
                 LedgerEntry toTestEntry = toTestIter.next();
 
-                Assert.assertEquals(toWriteEntry.getLedgerId(), toTestEntry.getLedgerId());
-                Assert.assertEquals(toWriteEntry.getEntryId(), toTestEntry.getEntryId());
-                Assert.assertEquals(toWriteEntry.getLength(), toTestEntry.getLength());
-                Assert.assertEquals(toWriteEntry.getEntryBuffer(), toTestEntry.getEntryBuffer());
+                assertEquals(toWriteEntry.getLedgerId(), toTestEntry.getLedgerId());
+                assertEquals(toWriteEntry.getEntryId(), toTestEntry.getEntryId());
+                assertEquals(toWriteEntry.getLength(), toTestEntry.getLength());
+                assertEquals(toWriteEntry.getEntryBuffer(), toTestEntry.getEntryBuffer());
             }
             Assert.assertFalse(toWriteIter.hasNext());
             Assert.assertFalse(toTestIter.hasNext());
@@ -286,7 +290,7 @@ public class BlobStoreManagedLedgerOffloaderTest extends BlobStoreManagedLedgerO
         offloader.offload(toWrite, uuid, new HashMap<>()).get();
 
         ReadHandle toTest = offloader.readOffloaded(toWrite.getId(), uuid, Collections.emptyMap()).get();
-        Assert.assertEquals(toTest.getLastAddConfirmed(), toWrite.getLastAddConfirmed());
+        assertEquals(toTest.getLastAddConfirmed(), toWrite.getLastAddConfirmed());
 
         for (long[] access : randomAccesses) {
             try (LedgerEntries toWriteEntries = toWrite.read(access[0], access[1]);
@@ -298,10 +302,10 @@ public class BlobStoreManagedLedgerOffloaderTest extends BlobStoreManagedLedgerO
                     LedgerEntry toWriteEntry = toWriteIter.next();
                     LedgerEntry toTestEntry = toTestIter.next();
 
-                    Assert.assertEquals(toWriteEntry.getLedgerId(), toTestEntry.getLedgerId());
-                    Assert.assertEquals(toWriteEntry.getEntryId(), toTestEntry.getEntryId());
-                    Assert.assertEquals(toWriteEntry.getLength(), toTestEntry.getLength());
-                    Assert.assertEquals(toWriteEntry.getEntryBuffer(), toTestEntry.getEntryBuffer());
+                    assertEquals(toWriteEntry.getLedgerId(), toTestEntry.getLedgerId());
+                    assertEquals(toWriteEntry.getEntryId(), toTestEntry.getEntryId());
+                    assertEquals(toWriteEntry.getLength(), toTestEntry.getLength());
+                    assertEquals(toWriteEntry.getEntryBuffer(), toTestEntry.getEntryBuffer());
                 }
                 Assert.assertFalse(toWriteIter.hasNext());
                 Assert.assertFalse(toTestIter.hasNext());
@@ -317,7 +321,7 @@ public class BlobStoreManagedLedgerOffloaderTest extends BlobStoreManagedLedgerO
         offloader.offload(toWrite, uuid, new HashMap<>()).get();
 
         ReadHandle toTest = offloader.readOffloaded(toWrite.getId(), uuid, Collections.emptyMap()).get();
-        Assert.assertEquals(toTest.getLastAddConfirmed(), toWrite.getLastAddConfirmed());
+        assertEquals(toTest.getLastAddConfirmed(), toWrite.getLastAddConfirmed());
 
         try {
             toTest.read(-1, -1);
@@ -399,7 +403,7 @@ public class BlobStoreManagedLedgerOffloaderTest extends BlobStoreManagedLedgerO
             offloader.offload(readHandle, uuid, new HashMap<>()).get();
             Assert.fail("Shouldn't have been able to offload");
         } catch (ExecutionException e) {
-            Assert.assertEquals(e.getCause().getClass(), IllegalArgumentException.class);
+            assertEquals(e.getCause().getClass(), IllegalArgumentException.class);
         }
     }
 
@@ -426,7 +430,7 @@ public class BlobStoreManagedLedgerOffloaderTest extends BlobStoreManagedLedgerO
             Assert.fail("Shouldn't have been able to read");
         } catch (ExecutionException e) {
             log.error("Exception: ", e);
-            Assert.assertEquals(e.getCause().getClass(), IOException.class);
+            assertEquals(e.getCause().getClass(), IOException.class);
             Assert.assertTrue(e.getCause().getMessage().contains("Error reading from BlobStore"));
         }
 
@@ -437,7 +441,7 @@ public class BlobStoreManagedLedgerOffloaderTest extends BlobStoreManagedLedgerO
             toRead.readAsync(0, 0).get();
             Assert.fail("Shouldn't have been able to read");
         } catch (ExecutionException e) {
-            Assert.assertEquals(e.getCause().getClass(), IOException.class);
+            assertEquals(e.getCause().getClass(), IOException.class);
             Assert.assertTrue(e.getCause().getMessage().contains("Error reading from BlobStore"));
         }
     }
@@ -463,7 +467,7 @@ public class BlobStoreManagedLedgerOffloaderTest extends BlobStoreManagedLedgerO
             offloader.readOffloaded(toWrite.getId(), uuid, Collections.emptyMap()).get();
             Assert.fail("Shouldn't have been able to open");
         } catch (ExecutionException e) {
-            Assert.assertEquals(e.getCause().getClass(), IOException.class);
+            assertEquals(e.getCause().getClass(), IOException.class);
             Assert.assertTrue(e.getCause().getMessage().contains("Invalid object version"));
         }
 
@@ -474,7 +478,7 @@ public class BlobStoreManagedLedgerOffloaderTest extends BlobStoreManagedLedgerO
             offloader.readOffloaded(toWrite.getId(), uuid, config.getOffloadDriverMetadata()).get();
             Assert.fail("Shouldn't have been able to open");
         } catch (ExecutionException e) {
-            Assert.assertEquals(e.getCause().getClass(), IOException.class);
+            assertEquals(e.getCause().getClass(), IOException.class);
             Assert.assertTrue(e.getCause().getMessage().contains("Invalid object version"));
         }
     }
@@ -495,5 +499,33 @@ public class BlobStoreManagedLedgerOffloaderTest extends BlobStoreManagedLedgerO
         } catch (Exception e) {
             fail("Get unexpected exception when reading entries", e);
         }
+    }
+
+    @Test(timeOut = 600000)  // 10 minutes.
+    public void testScanLedgers() throws Exception {
+        ReadHandle toWrite = buildReadHandle(DEFAULT_BLOCK_SIZE, 3);
+        LedgerOffloader offloader = getOffloader();
+
+        UUID uuid = UUID.randomUUID();
+        offloader.offload(toWrite, uuid, new HashMap<>()).get();
+
+        List<OffloadedLedgerMetadata> result = new ArrayList<>();
+        offloader.scanLedgers(
+                (m) -> {
+                    log.info("found {}", m);
+                    if (m.getLedgerId() == toWrite.getId()) {
+                        result.add(m);
+                    }
+                    return true;
+                }, offloader.getOffloadDriverMetadata());
+        assertEquals(2, result.size());
+
+        // data and index
+
+        OffloadedLedgerMetadata offloadedLedgerMetadata = result.get(0);
+        assertEquals(toWrite.getId(), offloadedLedgerMetadata.getLedgerId());
+
+        OffloadedLedgerMetadata offloadedLedgerMetadata2 = result.get(1);
+        assertEquals(toWrite.getId(), offloadedLedgerMetadata2.getLedgerId());
     }
 }

--- a/tiered-storage/jcloud/src/test/java/org/apache/bookkeeper/mledger/offload/jcloud/impl/DataBlockUtilsTest.java
+++ b/tiered-storage/jcloud/src/test/java/org/apache/bookkeeper/mledger/offload/jcloud/impl/DataBlockUtilsTest.java
@@ -1,0 +1,65 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.bookkeeper.mledger.offload.jcloud.impl;
+
+import org.testng.annotations.Test;
+import java.util.UUID;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
+
+public class DataBlockUtilsTest {
+
+    @Test
+    public void parseLedgerIdTest() throws Exception {
+       UUID id = UUID.randomUUID();
+       long ledgerId = 123124;
+        String key = DataBlockUtils.dataBlockOffloadKey(ledgerId, id);
+        String keyIndex = DataBlockUtils.indexBlockOffloadKey(ledgerId, id);
+
+        assertEquals(ledgerId, DataBlockUtils.parseLedgerId(key).longValue());
+        assertEquals(ledgerId, DataBlockUtils.parseLedgerId(keyIndex).longValue());
+
+        assertNull(DataBlockUtils.parseLedgerId(null));
+        assertNull(DataBlockUtils.parseLedgerId(""));
+        assertNull(DataBlockUtils.parseLedgerId("-ledger-"));
+        assertNull(DataBlockUtils.parseLedgerId("something"));
+        assertNull(DataBlockUtils.parseLedgerId("-ledger-index"));
+    }
+
+    @Test
+    public void parseContextUuidTest() throws Exception {
+        UUID id = UUID.randomUUID();
+        long ledgerId = 123124;
+        String key = DataBlockUtils.dataBlockOffloadKey(ledgerId, id);
+        String keyIndex = DataBlockUtils.indexBlockOffloadKey(ledgerId, id);
+
+        assertEquals(ledgerId, DataBlockUtils.parseLedgerId(key).longValue());
+        assertEquals(ledgerId, DataBlockUtils.parseLedgerId(keyIndex).longValue());
+        assertEquals(id.toString(), DataBlockUtils.parseContextUuid(key, ledgerId));
+        assertEquals(id.toString(), DataBlockUtils.parseContextUuid(keyIndex, ledgerId));
+
+        assertNull(DataBlockUtils.parseContextUuid(null, null));
+        assertNull(DataBlockUtils.parseContextUuid(null, ledgerId));
+        assertNull(DataBlockUtils.parseContextUuid("foo", null));
+        assertNull(DataBlockUtils.parseContextUuid("-ledger-" + ledgerId, ledgerId));
+        assertNull(DataBlockUtils.parseContextUuid("something" + ledgerId, ledgerId));
+    }
+
+}


### PR DESCRIPTION
### Motivation

Pulsar is missing some tool to verify the contents of the external TieredStorage.
In particular there is no easy way to perform this tasks:
- inspect the contents of the Buckets using Pulsar tools (you have to connect to GCP, AWS, Azure console or use their specific tools)
- find out if there are objects that should have been deleted by Pulsar but their are not
 
### Modifications
- add a new API `http://localhost:8080/admin/v2/namespaces/public/default/scanOffloadedLedgers` to scan all the objects for a given Namespace (please note that a bucket maybe shared by multiple namespaces, in that case listing one namespace will analyse all the objects in the bucket, as there is no way to map a object to a namespace)
- the new API returns this structure:

1. number of objects
2. number of "errors" (things that shouldn't be there)
3. number of "unknown" objects (objects not from Pulsar, not from the same Cluster, or from older versions that did not track pulsarClusterName and managedLedgerName metadata)
4. any useful information about each object

For each Object we set a 'status':
- "OK": all good
- "UNKNOWN": the object is not generated by this cluster
- all the other statuses are "errors"

This API is supposed to be used for two goals:

**Alerting**
check if "errors" is non zero -> the admin should do something

**Fixing problems**
if there is some error then you have to delete or fix the objects, and you can use the detailed data returned by this API


**How it works**
The new API uses "listObjects" API to scan all the objects in the Bucket (not recursively).
We are only performing a single request to S3 (with paging), we are not downloading the objects.
The API can be called on any broker.

For each object we compare the `pulsarClusterName` against the local `clustername`, and if there is a match then we get the name of the ManagedLedger from the Object metadata (se #14907).
Then we can get the ManagedLedgerInfo for the ManagedLedger, this way we know the list and the expected status of each Ledger.

For each ledger there is a UUID (offload context uuid) that allows us to verify that the object is exactly the object that is supposed to be there.

This way we can deal well with:
- multiple clusters sharing the same bucket
- multiple "lives" of the same "cluster" on the same bucket (in this case if there are objects left from the previous life of the same cluster they will be considered as 'errors')

Costs of executing this check:
- we are calling one the ListObject API on S3/GCP/Azure once
- we are executing a read request to ZooKeeper per each Object (in order to the the ManagedLedgerInfo)

It is suggested to run this scan only daily in order to not add too much burden on the ZooKeeper

### Verifying this change

This change added tests, but there is some manual testing to do. I have tested it manually against S3, GCP and Azure

### Documentation

I will follow up with a PR that explains the feature and how to setup alerts