### PR TITLE
[CI] Change the required checks to match refactored Pulsar CI

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -64,19 +64,20 @@ github:
           - Build Pulsar java-test-image docker image
           - CI - Integration - Backwards Compatibility
           - CI - Integration - Cli
-          - CI - Integration - Function
           - CI - Integration - Messaging
-          - CI - Integration - Schema
           - CI - Integration - Shade
           - CI - Integration - Standalone
           - CI - Integration - Transaction
           - Build Pulsar docker image
+          - CI - System - Function
           - CI - System - Pulsar Connectors - Process
           - CI - System - Pulsar Connectors - Thread
           - CI - System - Pulsar IO
-          - CI - System - Sql
+          - CI - System - Schema
           - CI - System - Tiered FileSystem
           - CI - System - Tiered JCloud
+# Sql integration tests are disabled until https://github.com/apache/pulsar/issues/14951 has been resolved
+#          - CI - System - Sql
 
       required_pull_request_reviews:
         dismiss_stale_reviews: false


### PR DESCRIPTION
### Motivation

- revisit #14939 changes for #14819

- Python client is required for Functions and Schema tests and
  tests were needed to move to a different category

- Sql integration tests ("CI - System - Sql") are disabled until
  https://github.com/apache/pulsar/issues/14951 has been resolved

### Additional context:

- comments: 
   - https://github.com/apache/pulsar/pull/14819#issuecomment-1082786305
   - https://github.com/apache/pulsar/pull/14819#issuecomment-1083200635

### Modifications

- rename `CI - Integration - Function` to `CI - System - Function` and
  `CI - Integration - Schema` to `CI - System - Schema`

- remove Sql integration tests ("CI - System - Sql") from required checks