### PR TITLE
[fix][client] Fix potentially unfinished CompletableFuture in doReconsumeLater

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
@@ -666,8 +666,8 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
                         typedMessageBuilderNew.key(message.getKey());
                     }
                     typedMessageBuilderNew.sendAsync()
-                            .thenAccept(__ -> doAcknowledge(finalMessageId, ackType, Collections.emptyMap(), null)
-                                    .thenAccept(v -> result.complete(null)))
+                            .thenCompose(__ -> doAcknowledge(finalMessageId, ackType, Collections.emptyMap(), null))
+                            .thenAccept(v -> result.complete(null))
                             .exceptionally(ex -> {
                                 result.completeExceptionally(ex);
                                 return null;


### PR DESCRIPTION
### Motivation

As the code is shown below, If the future returned by `doAcknowledge` is completed exceptionally, the ``result`` future can't complete.

```java
typedMessageBuilderNew.sendAsync()
          .thenAccept(__ -> doAcknowledge(finalMessageId, ackType, Collections.emptyMap(), null)
                     .thenAccept(v -> result.complete(null)))
           .exceptionally(ex -> {
                      result.completeExceptionally(ex);
                       return null;
           });
```

### Modifications

- Use ``thenCompose`` to instead of  ``thenAccept``.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Documentation

- [x] `no-need-doc` 
  

