### PR TITLE
Fix Kinesis integration test

### DIFF
--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/sinks/KinesisSinkTester.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/sinks/KinesisSinkTester.java
@@ -81,6 +81,14 @@ public class KinesisSinkTester extends SinkTester<LocalStackContainer> {
     }
 
     @Override
+    public void stopServiceContainer(PulsarCluster cluster) {
+        if (client != null) {
+            client.close();
+        }
+        super.stopServiceContainer(cluster);
+    }
+
+    @Override
     protected LocalStackContainer createSinkService(PulsarCluster cluster) {
         return new LocalStackContainer(DockerImageName.parse("localstack/localstack:latest"))
                 .withServices(LocalStackContainer.Service.KINESIS);

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/sinks/KinesisSinkTester.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/sinks/KinesisSinkTester.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pulsar.tests.integration.io.sinks;
 
+import java.util.LinkedHashMap;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.tests.integration.topologies.PulsarCluster;
@@ -25,8 +26,6 @@ import org.awaitility.Awaitility;
 import org.testcontainers.containers.localstack.LocalStackContainer;
 import org.testcontainers.utility.DockerImageName;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
-import software.amazon.awssdk.auth.credentials.AwsCredentials;
-import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.kinesis.KinesisAsyncClient;
 import software.amazon.awssdk.services.kinesis.model.CreateStreamRequest;
@@ -34,19 +33,19 @@ import software.amazon.awssdk.services.kinesis.model.GetRecordsRequest;
 import software.amazon.awssdk.services.kinesis.model.GetRecordsResponse;
 import software.amazon.awssdk.services.kinesis.model.GetShardIteratorRequest;
 import software.amazon.awssdk.services.kinesis.model.ListShardsRequest;
-import software.amazon.awssdk.services.kinesis.model.Record;
 import software.amazon.awssdk.services.kinesis.model.ShardIteratorType;
 
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
 
-import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.assertEquals;
 
 @Slf4j
 public class KinesisSinkTester extends SinkTester<LocalStackContainer> {
 
     private static final String NAME = "kinesis";
+    private static final int LOCALSTACK_SERVICE_PORT = 4566;
     public static final String STREAM_NAME = "my-stream-1";
     private KinesisAsyncClient client;
 
@@ -64,16 +63,11 @@ public class KinesisSinkTester extends SinkTester<LocalStackContainer> {
         final LocalStackContainer localStackContainer = getServiceContainer();
         final URI endpointOverride = localStackContainer.getEndpointOverride(LocalStackContainer.Service.KINESIS);
         sinkConfig.put("awsEndpoint", NAME);
-        sinkConfig.put("awsEndpointPort", endpointOverride.getPort());
+        sinkConfig.put("awsEndpointPort", LOCALSTACK_SERVICE_PORT);
         sinkConfig.put("skipCertificateValidation", true);
-        client = KinesisAsyncClient.builder().credentialsProvider(new AwsCredentialsProvider() {
-                    @Override
-                    public AwsCredentials resolveCredentials() {
-                        return AwsBasicCredentials.create(
-                                "access",
-                                "secret");
-                    }
-                })
+        client = KinesisAsyncClient.builder().credentialsProvider(() -> AwsBasicCredentials.create(
+                "access",
+                "secret"))
                 .region(Region.US_EAST_1)
                 .endpointOverride(endpointOverride)
                 .build();
@@ -84,8 +78,6 @@ public class KinesisSinkTester extends SinkTester<LocalStackContainer> {
                 .build())
                 .get();
         log.info("prepareSink for kinesis: created stream {}", STREAM_NAME);
-
-
     }
 
     @Override
@@ -95,13 +87,12 @@ public class KinesisSinkTester extends SinkTester<LocalStackContainer> {
     }
 
     @Override
-    @SneakyThrows
     public void validateSinkResult(Map<String, String> kvs) {
-        Awaitility.await().untilAsserted(() -> validateSinkResult());
+        Awaitility.await().untilAsserted(() -> internalValidateSinkResult(kvs));
     }
 
     @SneakyThrows
-    private void validateSinkResult() {
+    private void internalValidateSinkResult(Map<String, String> kvs) {
         final String shardId = client.listShards(
                 ListShardsRequest.builder()
                         .streamName(STREAM_NAME)
@@ -118,15 +109,30 @@ public class KinesisSinkTester extends SinkTester<LocalStackContainer> {
                 .build())
                 .get()
                 .shardIterator();
+
+        Map<String, String> records = new LinkedHashMap<>();
+
+        // millisBehindLatest equals zero when record processing is caught up,
+        // and there are no new records to process at this moment.
+        // See https://docs.aws.amazon.com/kinesis/latest/APIReference/API_GetRecords.html#Streams-GetRecords-response-MillisBehindLatest
+        Awaitility.await().until(() -> addMoreRecordsAndGetMillisBehindLatest(records, iterator) == 0);
+
+        assertEquals(kvs, records);
+    }
+
+    @SneakyThrows
+    private Long addMoreRecordsAndGetMillisBehindLatest(Map<String, String> records, String iterator) {
         final GetRecordsResponse response = client.getRecords(
                 GetRecordsRequest
                         .builder()
                         .shardIterator(iterator)
                         .build())
                 .get();
-        assertTrue(response.hasRecords());
-        for (Record record : response.records()) {
-            assertTrue(record.data().asString(StandardCharsets.UTF_8).startsWith("value-"));
+        if(response.hasRecords()) {
+            response.records().forEach(
+                record -> records.put(record.partitionKey(), record.data().asString(StandardCharsets.UTF_8))
+            );
         }
+        return response.millisBehindLatest();
     }
 }


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - Name the pull request in the form "[Issue XYZ][component] Title of the pull request", where *XYZ* should be replaced by the actual issue number.
    Skip *Issue XYZ* if there is no associated github issue for this pull request.
    Skip *component* if you are unsure about which is the best component. E.g. `[docs] Fix typo in produce method`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.

**(The sections below can be removed for hotfixes of typos)**
-->

### Motivation
The current `PulsarSinksTest::testKinesis` is incorrect:
* If the `GetRecordsResponse` doesn't contain any record, it passes
* It configures the Sink to use the testcontainer mapped port instead of the internal one so the Sink can't connect to Localstack

### Modifications
* Use port 4566 for `awsEndpointPort` which is the unmapped Localstack service port
* Verify that all records received match exactly the one sent

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change added tests and can be verified as follows:
* Run test `PulsarSinksTest::testKinesis`

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (yes / no) no
  - The public API: (yes / no) no
  - The schema: (yes / no / don't know) no
  - The default values of configurations: (yes / no) no
  - The wire protocol: (yes / no) no
  - The rest endpoints: (yes / no) no
  - The admin cli options: (yes / no) no
  - Anything that affects deployment: (yes / no / don't know) no

### Documentation

Check the box below or label this PR directly (if you have committer privilege).

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why) it's a test
  
- [ ] `doc` 
  
  (If this PR contains doc changes)


