### PR TITLE
[CI] Use Azure's Ubuntu apt repository mirror in CI

### DIFF
--- a/.github/workflows/pulsar-ci.yaml
+++ b/.github/workflows/pulsar-ci.yaml
@@ -264,7 +264,7 @@ jobs:
     timeout-minutes: 60
     needs: ['changed_files_job', 'build-and-license-check']
     env:
-      UBUNTU_MIRROR: mirror://mirrors.ubuntu.com/mirrors.txt
+      UBUNTU_MIRROR: http://azure.archive.ubuntu.com/ubuntu/
     steps:
       - name: checkout
         if: ${{ needs.changed_files_job.outputs.docs_only != 'true' }}
@@ -497,7 +497,7 @@ jobs:
     timeout-minutes: 60
     needs: ['changed_files_job', 'build-and-license-check']
     env:
-      UBUNTU_MIRROR: mirror://mirrors.ubuntu.com/mirrors.txt
+      UBUNTU_MIRROR: http://azure.archive.ubuntu.com/ubuntu/
     steps:
       - name: checkout
         if: ${{ needs.changed_files_job.outputs.docs_only != 'true' }}


### PR DESCRIPTION
### Motivation

- The refactored Pulsar CI workflow switched to use `UBUNTU_MIRROR=mirror://mirrors.ubuntu.com/mirrors.txt` setting.
- This gives inconsistent performance since sometimes access to the random mirror is bad.

### Modifications

- set `UBUNTU_MIRROR` to `http://azure.archive.ubuntu.com/ubuntu/` in pulsar-ci.yaml for jobs that build docker images.