### PR TITLE
[Pulsar SQL] Align Airlift versions by using a BOM

### DIFF
--- a/pulsar-sql/pom.xml
+++ b/pulsar-sql/pom.xml
@@ -42,6 +42,7 @@
         <okhttp3.version>3.14.9</okhttp3.version>
         <!-- use okio version that matches the okhttp3 version -->
         <okio.version>1.17.2</okio.version>
+        <airlift.version>0.199</airlift.version>
     </properties>
 
     <dependencyManagement>
@@ -144,6 +145,14 @@
                 <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-jdk14</artifactId>
                 <version>${slf4j.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>io.airlift</groupId>
+                <artifactId>bom</artifactId>
+                <version>${airlift.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/pulsar-sql/presto-distribution/LICENSE
+++ b/pulsar-sql/presto-distribution/LICENSE
@@ -295,32 +295,27 @@ The Apache Software License, Version 2.0
     - aircompressor-0.20.jar
     - airline-0.8.jar
     - bootstrap-0.199.jar
-    - bootstrap-0.195.jar
-    - concurrent-0.195.jar
+    - concurrent-0.199.jar
     - configuration-0.199.jar
-    - configuration-0.195.jar
-    - discovery-0.195.jar
+    - discovery-0.199.jar
     - discovery-server-1.29.jar
-    - event-0.195.jar
-    - http-client-0.195.jar
-    - http-server-0.195.jar
-    - jmx-0.195.jar
-    - jmx-http-0.195.jar
-    - jmx-http-rpc-0.159.jar
+    - event-0.199.jar
+    - http-client-0.199.jar
+    - http-server-0.199.jar
+    - jmx-0.199.jar
+    - jmx-http-0.199.jar
+    - jmx-http-rpc-0.199.jar
     - joni-2.1.5.3.jar
     - json-0.199.jar
-    - json-0.195.jar
     - log-0.199.jar
-    - log-0.195.jar
     - log-manager-0.199.jar
-    - log-manager-0.195.jar
-    - node-0.195.jar
+    - node-0.199.jar
     - parameternames-1.4.jar
     - resolver-1.5.jar
-    - security-0.195.jar
+    - security-0.199.jar
     - slice-0.38.jar
-    - stats-0.195.jar
-    - trace-token-0.195.jar
+    - stats-0.199.jar
+    - trace-token-0.199.jar
     - units-1.6.jar
    * Apache HTTP Client
     - httpclient-4.5.13.jar
@@ -529,7 +524,7 @@ CDDL-1.1 -- licenses/LICENSE-CDDL-1.1.txt
    - hk2-utils-2.6.1.jar
    - aopalliance-repackaged-2.6.1.jar
  * Jersey
-    - jaxrs-0.195.jar
+    - jaxrs-0.199.jar
     - jersey-client-2.34.jar
     - jersey-container-servlet-2.34.jar
     - jersey-container-servlet-core-2.34.jar

--- a/pulsar-sql/presto-distribution/pom.xml
+++ b/pulsar-sql/presto-distribution/pom.xml
@@ -34,8 +34,6 @@
   <properties>
     <skipBuildDistribution>false</skipBuildDistribution>
     <jersey.version>2.34</jersey.version>
-    <presto.version>332</presto.version>
-    <airlift.version>0.170</airlift.version>
     <objenesis.version>2.6</objenesis.version>
     <objectsize.version>0.0.12</objectsize.version>
     <jackson.version>2.13.2</jackson.version>

--- a/pulsar-sql/presto-pulsar/pom.xml
+++ b/pulsar-sql/presto-pulsar/pom.xml
@@ -33,7 +33,6 @@
     <name>Pulsar SQL :: Pulsar Presto Connector Packaging</name>
 
     <properties>
-        <dep.airlift.version>0.199</dep.airlift.version>
         <jctools.version>2.1.2</jctools.version>
         <dslJson.verson>1.8.4</dslJson.verson>
     </properties>
@@ -42,13 +41,11 @@
         <dependency>
             <groupId>io.airlift</groupId>
             <artifactId>bootstrap</artifactId>
-            <version>${dep.airlift.version}</version>
         </dependency>
 
         <dependency>
             <groupId>io.airlift</groupId>
             <artifactId>json</artifactId>
-            <version>${dep.airlift.version}</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
### Motivation

- ensure that airlift versions aren't mixed

### Modifications

- prevent mixed airlift library versions by using a BOM
- remove duplication in setting presto and airlift versions