### PR TITLE
[CI] Remove required checks workaround from pulsar-ci.yaml

### DIFF
--- a/.github/workflows/pulsar-ci.yaml
+++ b/.github/workflows/pulsar-ci.yaml
@@ -765,19 +765,3 @@ jobs:
       - name: Delete maven repository binaries from GitHub Actions Artifacts
         run: |
           gh-actions-artifact-client.js delete pulsar-maven-repository-binaries.tar.zst
-
-  # temporary workaround to make the required checks defined in .asf.yaml to pass
-  # these will be removed in later PRs once .asf.yaml has been edited
-  required-checks-workaround:
-    name: ${{ matrix.name }}
-    runs-on: ubuntu-20.04
-    strategy:
-      matrix:
-        name:
-          - CI - Integration - Function
-          - CI - Integration - Schema
-          - CI - System - Sql
-    steps:
-      - name: No-op step
-        run: |
-          echo "This is just to make the required checks to pass and will be removed in later PR to change .asf.yaml"


### PR DESCRIPTION
### Modifications

- remove workaround from pulsar-ci.yaml which was needed to make
  the required checks pass. Workaround isn't needed after #14944 changes to `.asf.yaml`.