### PR TITLE
[CI] Reduce verbosity of test-reporter to improve usability on GitHub mobile app

### DIFF
--- a/.github/workflows/pulsar-ci-test-report.yaml
+++ b/.github/workflows/pulsar-ci-test-report.yaml
@@ -36,3 +36,4 @@ jobs:
           max-annotations: 50
           token: ${{ secrets.GITHUB_TOKEN }}
           fail-on-error: false
+          only-summary: true


### PR DESCRIPTION
### Motivation

- the test-reporter action adds test reports to GitHub Actions UI. With information
  about all tests, this becomes too much information especially when using the GitHub
  mobile app.

![image](https://user-images.githubusercontent.com/66864/160984201-a6a8cbbb-ccd1-4a03-80b5-b252278aa6f1.png)


- report only summary of tests

### Modifications

- pass `only-summary: true` to [test-reporter](https://github.com/dorny/test-reporter#usage)