### PR TITLE
[CI] Upgrade zlib version to 1.2.12

### DIFF
--- a/pulsar-client-cpp/docker/alpine/Dockerfile
+++ b/pulsar-client-cpp/docker/alpine/Dockerfile
@@ -43,12 +43,12 @@ RUN curl -O -L https://boostorg.jfrog.io/artifactory/main/release/1.72.0/source/
     rm -rf /boost_1_72_0.tar.gz /boost_1_72_0
 
 # ZLib
-RUN curl -O -L https://zlib.net/zlib-1.2.11.tar.gz  && \
-    tar xfz zlib-1.2.11.tar.gz && \
-    cd zlib-1.2.11 && \
+RUN curl -O -L https://zlib.net/zlib-1.2.12.tar.gz  && \
+    tar xfz zlib-1.2.12.tar.gz && \
+    cd zlib-1.2.12 && \
     CFLAGS="-fPIC -O3" ./configure && \
     make -j4 && make install && \
-    rm -rf /zlib-1.2.11.tar.gz /zlib-1.2.11
+    rm -rf /zlib-1.2.12.tar.gz /zlib-1.2.12
 
 # Compile OpenSSL
 RUN curl -O -L https://github.com/openssl/openssl/archive/OpenSSL_1_1_0j.tar.gz && \

--- a/pulsar-client-cpp/docker/alpine/Dockerfile-alpine-3.8
+++ b/pulsar-client-cpp/docker/alpine/Dockerfile-alpine-3.8
@@ -43,12 +43,12 @@ RUN curl -O -L https://boostorg.jfrog.io/artifactory/main/release/1.72.0/source/
     rm -rf /boost_1_72_0.tar.gz /boost_1_72_0
 
 # ZLib
-RUN curl -O -L https://zlib.net/zlib-1.2.11.tar.gz  && \
-    tar xfz zlib-1.2.11.tar.gz && \
-    cd zlib-1.2.11 && \
+RUN curl -O -L https://zlib.net/zlib-1.2.12.tar.gz  && \
+    tar xfz zlib-1.2.12.tar.gz && \
+    cd zlib-1.2.12 && \
     CFLAGS="-fPIC -O3" ./configure && \
     make -j4 && make install && \
-    rm -rf /zlib-1.2.11.tar.gz /zlib-1.2.11
+    rm -rf /zlib-1.2.12.tar.gz /zlib-1.2.12
 
 # Compile OpenSSL
 RUN curl -O -L https://github.com/openssl/openssl/archive/OpenSSL_1_1_0j.tar.gz && \

--- a/pulsar-client-cpp/docker/manylinux1/Dockerfile
+++ b/pulsar-client-cpp/docker/manylinux1/Dockerfile
@@ -46,12 +46,12 @@ RUN curl -O -L https://www.cpan.org/src/5.0/perl-5.10.0.tar.gz && \
 ####################################
 
 # ZLib
-RUN curl -O -L https://zlib.net/zlib-1.2.11.tar.gz && \
-    tar xvfz zlib-1.2.11.tar.gz && \
-    cd zlib-1.2.11 && \
+RUN curl -O -L https://zlib.net/zlib-1.2.12.tar.gz && \
+    tar xvfz zlib-1.2.12.tar.gz && \
+    cd zlib-1.2.12 && \
     CFLAGS="-fPIC -O3" ./configure && \
     make && make install && \
-    rm -rf /zlib-1.2.11.tar.gz /zlib-1.2.11
+    rm -rf /zlib-1.2.12.tar.gz /zlib-1.2.12
 
 # Compile OpenSSL
 RUN curl -O -L https://github.com/openssl/openssl/archive/OpenSSL_1_1_0j.tar.gz && \

--- a/pulsar-client-cpp/docker/manylinux2014/Dockerfile
+++ b/pulsar-client-cpp/docker/manylinux2014/Dockerfile
@@ -46,12 +46,12 @@ RUN curl -O -L https://www.cpan.org/src/5.0/perl-5.10.0.tar.gz && \
 ####################################
 
 # ZLib
-RUN curl -O -L https://zlib.net/zlib-1.2.11.tar.gz && \
-    tar xvfz zlib-1.2.11.tar.gz && \
-    cd zlib-1.2.11 && \
+RUN curl -O -L https://zlib.net/zlib-1.2.12.tar.gz && \
+    tar xvfz zlib-1.2.12.tar.gz && \
+    cd zlib-1.2.12 && \
     CFLAGS="-fPIC -O3" ./configure && \
     make && make install && \
-    rm -rf /zlib-1.2.11.tar.gz /zlib-1.2.11
+    rm -rf /zlib-1.2.12.tar.gz /zlib-1.2.12
 
 # Compile OpenSSL
 RUN curl -O -L https://github.com/openssl/openssl/archive/OpenSSL_1_1_0j.tar.gz && \

--- a/pulsar-client-cpp/pkg/deb/Dockerfile
+++ b/pulsar-client-cpp/pkg/deb/Dockerfile
@@ -49,12 +49,12 @@ RUN curl -O -L  https://github.com/google/protobuf/releases/download/v3.3.0/prot
     rm -rf /protobuf-cpp-3.3.0.tar.gz /protobuf-3.3.0
 
 # ZLib
-RUN curl -O -L https://github.com/madler/zlib/archive/v1.2.11.tar.gz && \
-    tar xvfz v1.2.11.tar.gz && \
-    cd zlib-1.2.11 && \
+RUN curl -O -L https://github.com/madler/zlib/archive/v1.2.12.tar.gz && \
+    tar xvfz v1.2.12.tar.gz && \
+    cd zlib-1.2.12 && \
     CFLAGS="-fPIC -O3" ./configure && \
     make && make install && \
-    rm -rf /v1.2.11.tar.gz /zlib-1.2.11
+    rm -rf /v1.2.12.tar.gz /zlib-1.2.12
 
 # Zstandard
 RUN curl -O -L https://github.com/facebook/zstd/releases/download/v1.3.7/zstd-1.3.7.tar.gz && \

--- a/pulsar-client-cpp/pkg/licenses/LICENSE-zlib.txt
+++ b/pulsar-client-cpp/pkg/licenses/LICENSE-zlib.txt
@@ -1,5 +1,5 @@
 zlib.h -- interface of the 'zlib' general purpose compression library
-  version 1.2.12, March 11th, 2022
+  version 1.2.12, March 27th, 2022
 
   Copyright (C) 1995-2022 Jean-loup Gailly and Mark Adler
 

--- a/pulsar-client-cpp/pkg/licenses/LICENSE-zlib.txt
+++ b/pulsar-client-cpp/pkg/licenses/LICENSE-zlib.txt
@@ -1,7 +1,7 @@
 zlib.h -- interface of the 'zlib' general purpose compression library
-  version 1.2.11, January 15th, 2017
+  version 1.2.12, March 11th, 2022
 
-  Copyright (C) 1995-2017 Jean-loup Gailly and Mark Adler
+  Copyright (C) 1995-2022 Jean-loup Gailly and Mark Adler
 
   This software is provided 'as-is', without any express or implied
   warranty.  In no event will the authors be held liable for any damages

--- a/pulsar-client-cpp/pkg/rpm/Dockerfile
+++ b/pulsar-client-cpp/pkg/rpm/Dockerfile
@@ -49,12 +49,12 @@ RUN curl -O -L  https://github.com/google/protobuf/releases/download/v3.3.0/prot
     rm -rf /protobuf-cpp-3.3.0.tar.gz /protobuf-3.3.0
 
 # ZLib
-RUN curl -O -L https://github.com/madler/zlib/archive/v1.2.11.tar.gz && \
-    tar xvfz v1.2.11.tar.gz && \
-    cd zlib-1.2.11 && \
+RUN curl -O -L https://github.com/madler/zlib/archive/v1.2.12.tar.gz && \
+    tar xvfz v1.2.12.tar.gz && \
+    cd zlib-1.2.12 && \
     CFLAGS="-fPIC -O3" ./configure && \
     make && make install && \
-    rm -rf /v1.2.11.tar.gz /zlib-1.2.11
+    rm -rf /v1.2.12.tar.gz /zlib-1.2.12
 
 # Zstandard
 RUN curl -O -L https://github.com/facebook/zstd/releases/download/v1.3.7/zstd-1.3.7.tar.gz && \


### PR DESCRIPTION
### Motivation

Currently, `zlib` 1.2.11 version cannot be downloaded from [zlib](https://zlib.net/), and the CI python build is blocked, this pr upgrades `zlib` version to 1.2.12 to fix this problem

### Modifications

Anywhere which uses zlib v1.2.11.

### Verifying this change

- [x] Make sure that the change passes the CI checks.


### Documentation

Check the box below or label this PR directly (if you have committer privilege).

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)
