### PR TITLE
Offloader: add basic metrics about operations

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedLedgerMXBean.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedLedgerMXBean.java
@@ -127,4 +127,16 @@ public interface ManagedLedgerMXBean {
     long[] getLedgerAddEntryLatencyBuckets();
 
     StatsBuckets getInternalLedgerAddEntryLatencyBuckets();
+
+    long getOffloadLedgerOffloadOp();
+
+    long getOffloadLedgerOffloadErrors();
+
+    long getOffloadLedgerOpenOp();
+
+    long getOffloadLedgerOpenErrors();
+
+    long getOffloadLedgerDeleteOp();
+
+    long getOffloadLedgerDeleteErrors();
 }

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
@@ -1812,7 +1812,7 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
 
             LedgerInfo info = ledgers.get(ledgerId);
             CompletableFuture<ReadHandle> openFuture;
-
+            final boolean fromOffloader;
             if (config.getLedgerOffloader() != null
                     && config.getLedgerOffloader().getOffloadPolicies() != null
                     && config.getLedgerOffloader().getOffloadPolicies()
@@ -1821,22 +1821,27 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
                     && !info.getOffloadContext().getBookkeeperDeleted()) {
                 openFuture = bookKeeper.newOpenLedgerOp().withRecovery(!isReadOnly()).withLedgerId(ledgerId)
                         .withDigestType(config.getDigestType()).withPassword(config.getPassword()).execute();
-
+                fromOffloader = false;
             } else if (info != null && info.hasOffloadContext() && info.getOffloadContext().getComplete()) {
-
+                fromOffloader = true;
                 UUID uid = new UUID(info.getOffloadContext().getUidMsb(), info.getOffloadContext().getUidLsb());
                 // TODO: improve this to load ledger offloader by driver name recorded in metadata
                 Map<String, String> offloadDriverMetadata = OffloadUtils.getOffloadDriverMetadata(info);
                 offloadDriverMetadata.put("ManagedLedgerName", name);
+                mbean.recordOffloadLedgerOpenOp();
                 openFuture = config.getLedgerOffloader().readOffloaded(ledgerId, uid,
                         offloadDriverMetadata);
             } else {
                 openFuture = bookKeeper.newOpenLedgerOp().withRecovery(!isReadOnly()).withLedgerId(ledgerId)
                         .withDigestType(config.getDigestType()).withPassword(config.getPassword()).execute();
+                fromOffloader = false;
             }
             openFuture.whenCompleteAsync((res, ex) -> {
                 mbean.endDataLedgerOpenOp();
                 if (ex != null) {
+                    if (fromOffloader) {
+                        mbean.recordOffloadLedgerOpenError();
+                    }
                     ledgerCache.remove(ledgerId, promise);
                     promise.completeExceptionally(createManagedLedgerException(ex));
                 } else {
@@ -2951,6 +2956,7 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
             String driverName = config.getLedgerOffloader().getOffloadDriverName();
             Map<String, String> driverMetadata = config.getLedgerOffloader().getOffloadDriverMetadata();
 
+            mbean.recordOffloadLedgerOffloadOp();
             prepareLedgerInfoForOffloaded(ledgerId, uuid, driverName, driverMetadata)
                 .thenCompose((ignore) -> getLedgerHandle(ledgerId))
                 .thenCompose(readHandle -> config.getLedgerOffloader().offload(readHandle, uuid, extraMetadata))
@@ -2973,6 +2979,7 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
                     })
                 .whenComplete((ignore, exception) -> {
                         if (exception != null) {
+                            mbean.recordOffloadLedgerOffloadError();
                             lastOffloadFailureTimestamp = System.currentTimeMillis();
                             log.warn("[{}] Exception occurred for ledgerId {} timestamp {} during offload", name,
                                     ledgerId, lastOffloadFailureTimestamp, exception);
@@ -3164,12 +3171,13 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
         Map<String, String> metadataMap = Maps.newHashMap();
         metadataMap.putAll(offloadDriverMetadata);
         metadataMap.put("ManagedLedgerName", name);
-
+        mbean.recordOffloadLedgerDeleteOp();
         Retries.run(Backoff.exponentialJittered(TimeUnit.SECONDS.toMillis(1), TimeUnit.SECONDS.toHours(1)).limit(10),
                 Retries.NonFatalPredicate,
                 () -> config.getLedgerOffloader().deleteOffloaded(ledgerId, uuid, metadataMap),
                 scheduledExecutor, name).whenComplete((ignored, exception) -> {
                     if (exception != null) {
+                        mbean.recordOffloadLedgerDeleteError();
                         log.warn("[{}] Error cleaning up offload for {}, (cleanup reason: {})",
                                 name, ledgerId, cleanupReason, exception);
                     }

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerMBeanImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerMBeanImpl.java
@@ -50,6 +50,13 @@ public class ManagedLedgerMBeanImpl implements ManagedLedgerMXBean {
     private final LongAdder cursorLedgerCreateOp = new LongAdder();
     private final LongAdder cursorLedgerDeleteOp = new LongAdder();
 
+    private final LongAdder offloadLedgerOffloadOp = new LongAdder();
+    private final LongAdder offloadLedgerOffloadErrors = new LongAdder();
+    private final LongAdder offloadLedgerOpenOp = new LongAdder();
+    private final LongAdder offloadLedgerOpenErrors = new LongAdder();
+    private final LongAdder offloadLedgerDeleteOp = new LongAdder();
+    private final LongAdder offloadLedgerDeleteErrors = new LongAdder();
+
     // addEntryLatencyStatsUsec measure total latency including time entry spent while waiting in queue
     private final StatsBuckets addEntryLatencyStatsUsec = new StatsBuckets(ENTRY_LATENCY_BUCKETS_USEC);
     // ledgerAddEntryLatencyStatsUsec measure latency to persist entry into ledger
@@ -317,6 +324,55 @@ public class ManagedLedgerMBeanImpl implements ManagedLedgerMXBean {
         result.cursorLedgerCreateOp = cursorLedgerCreateOp.longValue();
         result.cursorLedgerDeleteOp = cursorLedgerDeleteOp.longValue();
         return result;
+    }
+
+    @Override
+    public long getOffloadLedgerOffloadOp() {
+        return offloadLedgerOffloadOp.longValue();
+    }
+
+    @Override
+    public long getOffloadLedgerOffloadErrors() {
+        return offloadLedgerOffloadErrors.longValue();
+    }
+
+    @Override
+    public long getOffloadLedgerOpenOp() {
+        return offloadLedgerOpenOp.longValue();
+    }
+
+    @Override
+    public long getOffloadLedgerOpenErrors() {
+        return offloadLedgerOpenErrors.longValue();
+    }
+
+    @Override
+    public long getOffloadLedgerDeleteOp() {
+        return offloadLedgerDeleteOp.longValue();
+    }
+
+    @Override
+    public long getOffloadLedgerDeleteErrors() {
+        return offloadLedgerDeleteErrors.longValue();
+    }
+
+    public void recordOffloadLedgerOffloadOp() {
+        offloadLedgerOffloadOp.increment();
+    }
+    public void recordOffloadLedgerOffloadError() {
+        offloadLedgerOffloadErrors.increment();
+    }
+    public void recordOffloadLedgerOpenOp() {
+        offloadLedgerOpenOp.increment();
+    }
+    public void recordOffloadLedgerOpenError() {
+        offloadLedgerOpenErrors.increment();
+    }
+    public void recordOffloadLedgerDeleteOp() {
+        offloadLedgerDeleteOp.increment();
+    }
+    public void recordOffloadLedgerDeleteError() {
+        offloadLedgerDeleteErrors.increment();
     }
 
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/metrics/ManagedLedgerMetrics.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/metrics/ManagedLedgerMetrics.java
@@ -23,12 +23,14 @@ import com.google.common.collect.Maps;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.bookkeeper.mledger.ManagedLedgerMXBean;
 import org.apache.bookkeeper.mledger.impl.ManagedLedgerFactoryImpl;
 import org.apache.bookkeeper.mledger.impl.ManagedLedgerImpl;
 import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.common.stats.Metrics;
 
+@Slf4j
 public class ManagedLedgerMetrics extends AbstractMetrics {
 
     private List<Metrics> metricsCollection;
@@ -86,6 +88,9 @@ public class ManagedLedgerMetrics extends AbstractMetrics {
 
             for (ManagedLedgerImpl ledger : ledgers) {
                 ManagedLedgerMXBean lStats = ledger.getStats();
+                log.info("aggregate metrics for ledger {} getOffloadLedgerOffloadOp {}", ledger.getName(),
+                        lStats.getOffloadLedgerOffloadOp());
+
 
                 populateAggregationMapWithSum(tempAggregatedMetricsMap, "brk_ml_AddEntryBytesRate",
                         lStats.getAddEntryBytesRate());

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/ManagedLedgerStats.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/ManagedLedgerStats.java
@@ -28,6 +28,13 @@ public class ManagedLedgerStats {
     long offloadedStorageUsed;
     long storageLogicalSize;
 
+    long offloadLedgerOffloadOp;
+    long offloadLedgerOffloadErrors;
+    long offloadLedgerOpenOp;
+    long offloadLedgerOpenErrors;
+    long offloadLedgerDeleteOp;
+    long offloadLedgerDeleteErrors;
+
     StatsBuckets storageWriteLatencyBuckets = new StatsBuckets(ManagedLedgerMBeanImpl.ENTRY_LATENCY_BUCKETS_USEC);
     StatsBuckets storageLedgerWriteLatencyBuckets = new StatsBuckets(ManagedLedgerMBeanImpl.ENTRY_LATENCY_BUCKETS_USEC);
     StatsBuckets entrySizeBuckets = new StatsBuckets(ManagedLedgerMBeanImpl.ENTRY_SIZE_BUCKETS_BYTES);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/NamespaceStatsAggregator.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/NamespaceStatsAggregator.java
@@ -162,6 +162,13 @@ public class NamespaceStatsAggregator {
             stats.backlogQuotaLimitTime = topic
                     .getBacklogQuota(BacklogQuota.BacklogQuotaType.message_age).getLimitTime();
 
+            stats.managedLedgerStats.offloadLedgerOffloadOp = mlStats.getOffloadLedgerOffloadOp();
+            stats.managedLedgerStats.offloadLedgerOffloadErrors = mlStats.getOffloadLedgerOffloadErrors();
+            stats.managedLedgerStats.offloadLedgerOpenOp = mlStats.getOffloadLedgerOpenOp();
+            stats.managedLedgerStats.offloadLedgerOpenErrors = mlStats.getOffloadLedgerOpenErrors();
+            stats.managedLedgerStats.offloadLedgerDeleteOp = mlStats.getOffloadLedgerDeleteOp();
+            stats.managedLedgerStats.offloadLedgerDeleteErrors = mlStats.getOffloadLedgerDeleteErrors();
+
             stats.managedLedgerStats.storageWriteLatencyBuckets
                     .addAll(mlStats.getInternalAddEntryLatencyBuckets());
             stats.managedLedgerStats.storageWriteLatencyBuckets.refresh();
@@ -335,6 +342,18 @@ public class NamespaceStatsAggregator {
         metric(stream, cluster, namespace, "pulsar_storage_backlog_size", stats.managedLedgerStats.backlogSize);
         metric(stream, cluster, namespace, "pulsar_storage_offloaded_size",
                 stats.managedLedgerStats.offloadedStorageUsed);
+        metric(stream, cluster, namespace, "pulsar_offloader_offload_ops",
+                stats.managedLedgerStats.offloadLedgerOffloadOp);
+        metric(stream, cluster, namespace, "pulsar_offloader_offload_errors",
+                stats.managedLedgerStats.offloadLedgerOffloadErrors);
+        metric(stream, cluster, namespace, "pulsar_offloader_open_ops",
+                stats.managedLedgerStats.offloadLedgerOpenOp);
+        metric(stream, cluster, namespace, "pulsar_offloader_open_errors",
+                stats.managedLedgerStats.offloadLedgerOpenErrors);
+        metric(stream, cluster, namespace, "pulsar_offloader_delete_ops",
+                stats.managedLedgerStats.offloadLedgerDeleteOp);
+        metric(stream, cluster, namespace, "pulsar_offloader_delete_errors",
+                stats.managedLedgerStats.offloadLedgerDeleteErrors);
 
         metric(stream, cluster, namespace, "pulsar_storage_write_rate", stats.managedLedgerStats.storageWriteRate);
         metric(stream, cluster, namespace, "pulsar_storage_read_rate", stats.managedLedgerStats.storageReadRate);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/TopicStats.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/TopicStats.java
@@ -139,6 +139,18 @@ class TopicStats {
                 splitTopicAndPartitionIndexLabel);
         metric(stream, cluster, namespace, topic, "pulsar_storage_offloaded_size", stats.managedLedgerStats
                 .offloadedStorageUsed, splitTopicAndPartitionIndexLabel);
+        metric(stream, cluster, namespace, topic, "pulsar_offloader_offload_ops",
+                stats.managedLedgerStats.offloadLedgerOffloadOp, splitTopicAndPartitionIndexLabel);
+        metric(stream, cluster, namespace, topic, "pulsar_offloader_offload_errors",
+                stats.managedLedgerStats.offloadLedgerOffloadErrors, splitTopicAndPartitionIndexLabel);
+        metric(stream, cluster, namespace, topic, "pulsar_offloader_open_ops",
+                stats.managedLedgerStats.offloadLedgerOpenOp, splitTopicAndPartitionIndexLabel);
+        metric(stream, cluster, namespace, topic, "pulsar_offloader_open_errors",
+                stats.managedLedgerStats.offloadLedgerOpenErrors, splitTopicAndPartitionIndexLabel);
+        metric(stream, cluster, namespace, topic, "pulsar_offloader_delete_ops",
+                stats.managedLedgerStats.offloadLedgerDeleteOp, splitTopicAndPartitionIndexLabel);
+        metric(stream, cluster, namespace, topic, "pulsar_offloader_delete_errors",
+                stats.managedLedgerStats.offloadLedgerDeleteErrors, splitTopicAndPartitionIndexLabel);
         metric(stream, cluster, namespace, topic, "pulsar_storage_backlog_quota_limit", stats.backlogQuotaLimit,
                 splitTopicAndPartitionIndexLabel);
         metric(stream, cluster, namespace, topic, "pulsar_storage_backlog_quota_limit_time",

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/TransactionAggregator.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/TransactionAggregator.java
@@ -144,6 +144,12 @@ public class TransactionAggregator {
         managedLedgerStats.storageLogicalSize = mlStats.getStoredMessagesLogicalSize();
         managedLedgerStats.backlogSize = managedLedger.getEstimatedBacklogSize();
         managedLedgerStats.offloadedStorageUsed = managedLedger.getOffloadedSize();
+        managedLedgerStats.offloadLedgerOffloadOp = mlStats.getOffloadLedgerOffloadOp();
+        managedLedgerStats.offloadLedgerOffloadErrors = mlStats.getOffloadLedgerOffloadErrors();
+        managedLedgerStats.offloadLedgerOpenOp = mlStats.getOffloadLedgerOpenOp();
+        managedLedgerStats.offloadLedgerOpenErrors = mlStats.getOffloadLedgerOpenErrors();
+        managedLedgerStats.offloadLedgerDeleteOp = mlStats.getOffloadLedgerDeleteOp();
+        managedLedgerStats.offloadLedgerDeleteErrors = mlStats.getOffloadLedgerDeleteErrors();
 
         managedLedgerStats.storageWriteLatencyBuckets
                 .addAll(mlStats.getInternalAddEntryLatencyBuckets());


### PR DESCRIPTION
### Motivation
Currently (2.10) we don't have any metrics about operations on Tiered Storage. So it is hard to monitor the activity.

### Modifications

Add per-namespace metrics for:
- offload operations and errors
- offload open for read and errors
- offload delete operations and errors

### Verifying this change


### Documentation

There is currently no documentation about Metrics and Tiered Storage, it would be great to add a brand new section about how to monitor Tiered Storage.
There are other PRs related to observability of Tiered Storage, like https://github.com/apache/pulsar/pull/14930

I am marking this PR as no-need-docs
