### PR TITLE
[fix][transaction] Fix potentially unfinished CompletableFuture.

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/TransactionMetadataStoreService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/TransactionMetadataStoreService.java
@@ -443,8 +443,7 @@ public class TransactionMetadataStoreService {
 
     // when managedLedger fence will remove this tc and reload
     public void handleOpFail(Throwable e, TransactionCoordinatorID tcId) {
-        if (e.getCause() instanceof ManagedLedgerException.ManagedLedgerFencedException
-                || e instanceof ManagedLedgerException.ManagedLedgerFencedException) {
+        if (e instanceof ManagedLedgerException.ManagedLedgerFencedException) {
             removeTransactionMetadataStore(tcId);
         }
     }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
@@ -2135,24 +2135,23 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
         }
     }
     private Throwable handleTxnException(Throwable ex, String op, long requestId) {
-        if (ex instanceof CoordinatorException.CoordinatorNotFoundException || ex != null
-                && ex.getCause() instanceof CoordinatorException.CoordinatorNotFoundException) {
+        Throwable cause = FutureUtil.unwrapCompletionException(ex);
+        if (cause instanceof CoordinatorException.CoordinatorNotFoundException) {
             if (log.isDebugEnabled()) {
                 log.debug("The Coordinator was not found for the request {}", op);
             }
-            return ex;
+            return cause;
         }
-        if (ex instanceof ManagedLedgerException.ManagedLedgerFencedException || ex != null
-                && ex.getCause() instanceof ManagedLedgerException.ManagedLedgerFencedException) {
+        if (cause instanceof ManagedLedgerException.ManagedLedgerFencedException) {
             if (log.isDebugEnabled()) {
                 log.debug("Throw a CoordinatorNotFoundException to client "
                         + "with the message got from a ManagedLedgerFencedException for the request {}", op);
             }
-            return new CoordinatorException.CoordinatorNotFoundException(ex.getMessage());
+            return new CoordinatorException.CoordinatorNotFoundException(cause.getMessage());
 
         }
-        log.error("Send response error for {} request {}.", op, requestId, ex);
-        return ex;
+        log.error("Send response error for {} request {}.", op, requestId, cause);
+        return cause;
     }
     @Override
     protected void handleNewTxn(CommandNewTxn command) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/TopicTransactionBuffer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/TopicTransactionBuffer.java
@@ -202,7 +202,7 @@ public class TopicTransactionBuffer extends TopicTransactionBufferState implemen
 
     @Override
     public CompletableFuture<TransactionMeta> getTransactionMeta(TxnID txnID) {
-        return null;
+        return CompletableFuture.completedFuture(null);
     }
 
     @Override

--- a/pulsar-transaction/coordinator/src/main/java/org/apache/pulsar/transaction/coordinator/impl/MLTransactionMetadataStore.java
+++ b/pulsar-transaction/coordinator/src/main/java/org/apache/pulsar/transaction/coordinator/impl/MLTransactionMetadataStore.java
@@ -249,10 +249,10 @@ public class MLTransactionMetadataStore
 
     @Override
     public CompletableFuture<Void> addProducedPartitionToTxn(TxnID txnID, List<String> partitions) {
-        CompletableFuture<Void> completableFuture = new CompletableFuture<>();
+        CompletableFuture<Void> promise = new CompletableFuture<>();
         internalPinnedExecutor.execute(() -> {
             if (!checkIfReady()) {
-                completableFuture
+                promise
                         .completeExceptionally(new CoordinatorException.TransactionMetadataStoreStateException(tcID,
                         State.Ready, getState(), "add produced partition"));
                 return;
@@ -266,41 +266,42 @@ public class MLTransactionMetadataStore
                         .setLastModificationTime(System.currentTimeMillis())
                         .setMaxLocalTxnId(sequenceIdGenerator.getCurrentSequenceId());
 
-                return transactionLog.append(transactionMetadataEntry).thenAccept(position -> {
+                return transactionLog.append(transactionMetadataEntry)
+                        .thenAccept(position -> {
                             appendLogCount.increment();
                             try {
                                 synchronized (txnMetaListPair.getLeft()) {
                                     txnMetaListPair.getLeft().addProducedPartitions(partitions);
                                     txnMetaMap.get(txnID.getLeastSigBits()).getRight().add(position);
                                 }
-                                completableFuture.complete(null);
+                                promise.complete(null);
                             } catch (InvalidTxnStatusException e) {
                                 transactionLog.deletePosition(Collections.singletonList(position));
                                 log.error("TxnID : " + txnMetaListPair.getLeft().id().toString()
                                         + " add produced partition error with TxnStatus : "
                                         + txnMetaListPair.getLeft().status().name(), e);
-                                completableFuture.completeExceptionally(e);
+                                promise.completeExceptionally(e);
                             }
                         });
             }).exceptionally(ex -> {
-                completableFuture.completeExceptionally(ex);
+                promise.completeExceptionally(ex);
                 return null;
             });
         });
-        return completableFuture;
+        return promise;
     }
 
     @Override
     public CompletableFuture<Void> addAckedPartitionToTxn(TxnID txnID,
                                                           List<TransactionSubscription> txnSubscriptions) {
-        CompletableFuture<Void> completableFuture = new CompletableFuture<>();
+        CompletableFuture<Void> promise = new CompletableFuture<>();
         internalPinnedExecutor.execute(() -> {
             if (!checkIfReady()) {
-                completableFuture.completeExceptionally(new CoordinatorException
+                promise.completeExceptionally(new CoordinatorException
                         .TransactionMetadataStoreStateException(tcID, State.Ready, getState(), "add acked partition"));
                 return;
             }
-            getTxnPositionPair(txnID).thenAccept(txnMetaListPair -> {
+            getTxnPositionPair(txnID).thenCompose(txnMetaListPair -> {
                 TransactionMetadataEntry transactionMetadataEntry = new TransactionMetadataEntry()
                         .setTxnidMostBits(txnID.getMostSigBits())
                         .setTxnidLeastBits(txnID.getLeastSigBits())
@@ -309,47 +310,46 @@ public class MLTransactionMetadataStore
                         .setLastModificationTime(System.currentTimeMillis())
                         .setMaxLocalTxnId(sequenceIdGenerator.getCurrentSequenceId());
 
-                transactionLog.append(transactionMetadataEntry)
-                        .whenComplete((position, exception) -> {
-                            if (exception != null) {
-                                completableFuture.completeExceptionally(exception);
-                                return;
-                            }
+                return transactionLog.append(transactionMetadataEntry)
+                        .thenAccept(position -> {
                             appendLogCount.increment();
                             try {
                                 synchronized (txnMetaListPair.getLeft()) {
                                     txnMetaListPair.getLeft().addAckedPartitions(txnSubscriptions);
                                     txnMetaMap.get(txnID.getLeastSigBits()).getRight().add(position);
                                 }
-                                completableFuture.complete(null);
+                                promise.complete(null);
                             } catch (InvalidTxnStatusException e) {
                                 transactionLog.deletePosition(Collections.singletonList(position));
                                 log.error("TxnID : " + txnMetaListPair.getLeft().id().toString()
                                         + " add acked subscription error with TxnStatus : "
                                         + txnMetaListPair.getLeft().status().name(), e);
-                                completableFuture.completeExceptionally(e);
+                                promise.completeExceptionally(e);
                             }
                         });
+            }).exceptionally(ex -> {
+                promise.completeExceptionally(ex);
+                return null;
             });
         });
-        return completableFuture;
+        return promise;
     }
 
     @Override
     public CompletableFuture<Void> updateTxnStatus(TxnID txnID, TxnStatus newStatus,
                                                                 TxnStatus expectedStatus, boolean isTimeout) {
-        CompletableFuture<Void> completableFuture = new CompletableFuture<>();
+        CompletableFuture<Void> promise = new CompletableFuture<>();
         internalPinnedExecutor.execute(() -> {
             if (!checkIfReady()) {
-                completableFuture.completeExceptionally(new CoordinatorException
+                promise.completeExceptionally(new CoordinatorException
                         .TransactionMetadataStoreStateException(tcID,
                         State.Ready, getState(), "update transaction status"));
                 return;
             }
-            getTxnPositionPair(txnID).thenAccept(txnMetaListPair -> {
+            getTxnPositionPair(txnID).thenCompose(txnMetaListPair -> {
                 if (txnMetaListPair.getLeft().status() == newStatus) {
-                    completableFuture.complete(null);
-                    return;
+                    promise.complete(null);
+                    return promise;
                 }
                 TransactionMetadataEntry transactionMetadataEntry = new TransactionMetadataEntry()
                         .setTxnidMostBits(txnID.getMostSigBits())
@@ -360,51 +360,51 @@ public class MLTransactionMetadataStore
                         .setNewStatus(newStatus)
                         .setMaxLocalTxnId(sequenceIdGenerator.getCurrentSequenceId());
 
-                transactionLog.append(transactionMetadataEntry).whenComplete((position, throwable) -> {
-                    if (throwable != null) {
-                        completableFuture.completeExceptionally(throwable);
-                        return;
-                    }
-                    appendLogCount.increment();
-                    try {
-                        synchronized (txnMetaListPair.getLeft()) {
-                            txnMetaListPair.getLeft().updateTxnStatus(newStatus, expectedStatus);
-                            txnMetaListPair.getRight().add(position);
-                        }
-                        if (newStatus == TxnStatus.ABORTING && isTimeout) {
-                            this.transactionTimeoutCount.increment();
-                        }
-                        if (newStatus == TxnStatus.COMMITTED || newStatus == TxnStatus.ABORTED) {
-                            transactionLog.deletePosition(txnMetaListPair.getRight()).whenComplete((v, exception) -> {
-                                if (exception != null) {
-                                    completableFuture.completeExceptionally(exception);
+                return transactionLog.append(transactionMetadataEntry)
+                        .thenAccept(position -> {
+                            appendLogCount.increment();
+                            try {
+                                synchronized (txnMetaListPair.getLeft()) {
+                                    txnMetaListPair.getLeft().updateTxnStatus(newStatus, expectedStatus);
+                                    txnMetaListPair.getRight().add(position);
+                                }
+                                if (newStatus == TxnStatus.ABORTING && isTimeout) {
+                                    this.transactionTimeoutCount.increment();
+                                }
+                                if (newStatus == TxnStatus.COMMITTED || newStatus == TxnStatus.ABORTED) {
+                                    transactionLog.deletePosition(txnMetaListPair.getRight()).whenComplete((v, ex) -> {
+                                        if (ex != null) {
+                                            promise.completeExceptionally(ex);
+                                            return;
+                                        }
+                                        this.transactionMetadataStoreStats
+                                                .addTransactionExecutionLatencySample(System.currentTimeMillis()
+                                                        - txnMetaListPair.getLeft().getOpenTimestamp());
+                                        if (newStatus == TxnStatus.COMMITTED) {
+                                            committedTransactionCount.increment();
+                                        } else {
+                                            abortedTransactionCount.increment();
+                                        }
+                                        txnMetaMap.remove(txnID.getLeastSigBits());
+                                        promise.complete(null);
+                                    });
                                     return;
                                 }
-                                this.transactionMetadataStoreStats
-                                        .addTransactionExecutionLatencySample(System.currentTimeMillis()
-                                                - txnMetaListPair.getLeft().getOpenTimestamp());
-                                if (newStatus == TxnStatus.COMMITTED) {
-                                    committedTransactionCount.increment();
-                                } else {
-                                    abortedTransactionCount.increment();
-                                }
-                                txnMetaMap.remove(txnID.getLeastSigBits());
-                                completableFuture.complete(null);
-                            });
-                            return;
-                        }
-                        completableFuture.complete(null);
-                    } catch (InvalidTxnStatusException e) {
-                        transactionLog.deletePosition(Collections.singletonList(position));
-                        log.error("TxnID : " + txnMetaListPair.getLeft().id().toString()
-                                + " add update txn status error with TxnStatus : "
-                                + txnMetaListPair.getLeft().status().name(), e);
-                        completableFuture.completeExceptionally(e);
-                    }
-                });
+                                promise.complete(null);
+                            } catch (InvalidTxnStatusException e) {
+                                transactionLog.deletePosition(Collections.singletonList(position));
+                                log.error("TxnID : " + txnMetaListPair.getLeft().id().toString()
+                                        + " add update txn status error with TxnStatus : "
+                                        + txnMetaListPair.getLeft().status().name(), e);
+                                promise.completeExceptionally(e);
+                            }
+                        });
+            }).exceptionally(ex -> {
+                promise.completeExceptionally(ex);
+                return null;
             });
         });
-       return completableFuture;
+       return promise;
     }
 
     @Override


### PR DESCRIPTION
### Motivation

In MLTransactionMetadataStore#addProducedPartitionToTxn, the method getTxnPositionPair(txnID) may throw TransactionNotFoundException, but it does not catch it. It may cause the uncompleted future.
https://github.com/apache/pulsar/blob/02eb31b372b2bf72350e8f6cbab552e1627e6197/pulsar-transaction/coordinator/src/main/java/org/apache/pulsar/transaction/coordinator/impl/MLTransactionMetadataStore.java#L260-L290

https://github.com/apache/pulsar/blob/02eb31b372b2bf72350e8f6cbab552e1627e6197/pulsar-transaction/coordinator/src/main/java/org/apache/pulsar/transaction/coordinator/impl/MLTransactionMetadataStore.java#L435-L444

### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Documentation
  
- [x] `no-need-doc` 



