### PR TITLE
[fix][security] Upgrade Spring Context in Pulsar IO batch-data-generator

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -203,7 +203,7 @@ flexible messaging model and an intuitive client API.</description>
     <kotlin-stdlib.version>1.4.32</kotlin-stdlib.version>
     <nsq-client.version>1.0</nsq-client.version>
     <cron-utils.version>9.1.6</cron-utils.version>
-    <spring-context.version>5.3.15</spring-context.version>
+    <spring-context.version>5.3.18</spring-context.version>
     <apache-http-client.version>4.5.13</apache-http-client.version>
     <jetcd.version>0.5.11</jetcd.version>
     <snakeyaml.version>1.30</snakeyaml.version>


### PR DESCRIPTION
### Motivation

`spring-beans` < 5.3.18 has a high vulnerability https://tanzu.vmware.com/security/cve-2022-22965

Even if `spring-beans` is not explicitly listed in the CVE description, the vulnerability is under further research and most of the Security orgs recommend to update to 5.3.18. e.g. https://blog.sonatype.com/new-0-day-spring-framework-vulnerability-confirmed  

### Modifications

* Update from 5.3.15 to 5.3.18

Note: spring in not used in Pulsar codebase.
For Pulsar IO, it is used in `batch-data-generator` (addressed by this pull) and in Canal connector.
Since there's no test in Canal connector I haven't done the upgrade (we can do another pull)

- [x] `no-need-doc` 