### PR TITLE
[fix][transaction]fix potential NPE in TransactionBufferDisable

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/TransactionBufferDisable.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/TransactionBufferDisable.java
@@ -41,7 +41,7 @@ public class TransactionBufferDisable implements TransactionBuffer {
 
     @Override
     public CompletableFuture<TransactionMeta> getTransactionMeta(TxnID txnID) {
-        return null;
+        return CompletableFuture.completedFuture(null);
     }
 
     @Override
@@ -65,7 +65,7 @@ public class TransactionBufferDisable implements TransactionBuffer {
 
     @Override
     public CompletableFuture<Void> purgeTxns(List<Long> dataLedgers) {
-        return null;
+        return CompletableFuture.completedFuture(null);
     }
 
     @Override


### PR DESCRIPTION
### Motivation
```java
public CompletableFuture<TransactionMeta> getTransactionMeta(TxnID txnID) {
        return null;
    }
``` 
The return value null may cause potential NPE in ` getTransactionMeta`.  The method does similarly：CompletableFuture<Void> purgeTxns(List<Long> dataLedgers)`.

### Modifications

Use ` return CompletableFuture.completedFuture(null);` instead of `return null;`

### Verifying this change

Make sure that the change passes the CI checks.

### Does this pull request potentially affect one of the following parts:

If `yes` was chosen, please highlight the changes

- Dependencies (does it add or upgrade a dependency): (no)
- The public API: (no)
- The schema: (no)
- The default values of configurations: (no)
- The wire protocol: (no)
- The rest endpoints: (no)
- The admin cli options: (no)
- Anything that affects deployment: (no)

### Documentation
Check the box below and label this PR (if you have committer privilege).

Need to update docs? 
- [x] `no-need-doc` 
