### PR TITLE
[fix][client] ConsumerBuilderImpl can not set null to deadLetterPolicy.

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBuilderImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBuilderImpl.java
@@ -437,10 +437,9 @@ public class ConsumerBuilderImpl<T> implements ConsumerBuilder<T> {
             if (conf.getAckTimeoutMillis() == 0) {
                 conf.setAckTimeoutMillis(DEFAULT_ACK_TIMEOUT_MILLIS_FOR_DEAD_LETTER);
             }
-
             checkArgument(deadLetterPolicy.getMaxRedeliverCount() > 0, "MaxRedeliverCount must be > 0.");
-            conf.setDeadLetterPolicy(deadLetterPolicy);
         }
+        conf.setDeadLetterPolicy(deadLetterPolicy);
         return this;
     }
 

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/ConsumerBuilderImplTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/ConsumerBuilderImplTest.java
@@ -18,6 +18,17 @@
  */
 package org.apache.pulsar.client.impl;
 
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertNotNull;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.regex.Pattern;
 import org.apache.pulsar.client.api.BatchReceivePolicy;
 import org.apache.pulsar.client.api.Consumer;
 import org.apache.pulsar.client.api.DeadLetterPolicy;
@@ -28,19 +39,6 @@ import org.apache.pulsar.client.api.SubscriptionMode;
 import org.apache.pulsar.client.impl.conf.ConsumerConfigurationData;
 import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
-
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.TimeUnit;
-import java.util.regex.Pattern;
-
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-import static org.testng.Assert.assertNotNull;
 
 /**
  * Unit tests of {@link ConsumerBuilderImpl}.
@@ -297,6 +295,12 @@ public class ConsumerBuilderImplTest {
                 .deadLetterTopic("test-dead-letter-topic")
                 .retryLetterTopic("test-retry-letter-topic")
                 .build());
+    }
+
+    @Test
+    public void testNullDeadLetterPolicy() {
+        consumerBuilderImpl.deadLetterPolicy(null);
+        verify(consumerBuilderImpl.getConf()).setDeadLetterPolicy(null);
     }
 
     @Test


### PR DESCRIPTION

### Motivation

`ConsumerBuilderImpl` can not set null to deadLetterPolicy if it's already assigned a non-null value.


### Modifications

Calls `conf.setDeadLetterPolicy` if `deadLetterPolicy` is null.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change added tests and can be verified as follows:
  - *Added new unit test  testNullDeadLetterPolicy*
### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

Check the box below and label this PR (if you have committer privilege).

Need to update docs? 
  
- [x] `no-need-doc` 
bug fix
