### PR TITLE
Add a cache eviction policy：Evicting cache data by the slowest markDeletedPosition

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedLedgerConfig.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedLedgerConfig.java
@@ -79,7 +79,7 @@ public class ManagedLedgerConfig {
     private int inactiveLedgerRollOverTimeMs = 0;
     @Getter
     @Setter
-    private boolean cacheEvictionByMarkDeletedPosition = true;
+    private boolean cacheEvictionByMarkDeletedPosition = false;
 
     public boolean isCreateIfMissing() {
         return createIfMissing;

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedLedgerConfig.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedLedgerConfig.java
@@ -24,7 +24,6 @@ import java.time.Clock;
 import java.util.Arrays;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
-
 import lombok.Getter;
 import lombok.Setter;
 import org.apache.bookkeeper.client.EnsemblePlacementPolicy;

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedLedgerConfig.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedLedgerConfig.java
@@ -79,7 +79,7 @@ public class ManagedLedgerConfig {
     private int inactiveLedgerRollOverTimeMs = 0;
     @Getter
     @Setter
-    private boolean cacheEvictionByMarkDeletedPosition = false;
+    private boolean cacheEvictionByMarkDeletedPosition = true;
 
     public boolean isCreateIfMissing() {
         return createIfMissing;

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedLedgerConfig.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedLedgerConfig.java
@@ -24,6 +24,9 @@ import java.time.Clock;
 import java.util.Arrays;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
+
+import lombok.Getter;
+import lombok.Setter;
 import org.apache.bookkeeper.client.EnsemblePlacementPolicy;
 import org.apache.bookkeeper.client.api.DigestType;
 import org.apache.bookkeeper.common.annotation.InterfaceAudience;
@@ -75,6 +78,9 @@ public class ManagedLedgerConfig {
     private ManagedLedgerInterceptor managedLedgerInterceptor;
     private Map<String, String> properties;
     private int inactiveLedgerRollOverTimeMs = 0;
+    @Getter
+    @Setter
+    private boolean cacheEvictionByMarkDeletedPosition = false;
 
     public boolean isCreateIfMissing() {
         return createIfMissing;

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorContainer.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorContainer.java
@@ -108,6 +108,10 @@ public class ManagedCursorContainer implements Iterable<ManagedCursor> {
         return heap.isEmpty() ? null : (PositionImpl) heap.get(0).cursor.getReadPosition();
     }
 
+    public PositionImpl getSlowestMarkDeletedPositionForActiveCursors() {
+        return heap.isEmpty() ? null : (PositionImpl) heap.get(0).cursor.getMarkDeletedPosition();
+    }
+
     public ManagedCursor get(String name) {
         long stamp = rwLock.readLock();
         try {

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
@@ -2168,7 +2168,7 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
         }
         PositionImpl evictionPos;
         if (config.isCacheEvictionByMarkDeletedPosition()) {
-            evictionPos = getEarlierMarkDeletedPositionForActiveCursors();
+            evictionPos = getEarlierMarkDeletedPositionForActiveCursors().getNext();
         } else {
             // Always remove all entries already read by active cursors
             evictionPos = getEarlierReadPositionForActiveCursors();

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
@@ -2205,7 +2205,6 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
         return durablePosition.compareTo(nonDurablePosition) > 0 ? nonDurablePosition : durablePosition;
     }
 
-
     void updateCursor(ManagedCursorImpl cursor, PositionImpl newPosition) {
         Pair<PositionImpl, PositionImpl> pair = cursors.cursorUpdated(cursor, newPosition);
         if (pair == null) {

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
@@ -2166,10 +2166,15 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
         if (entryCache.getSize() <= 0) {
             return;
         }
-        // Always remove all entries already read by active cursors
-        PositionImpl slowestReaderPos = getEarlierReadPositionForActiveCursors();
-        if (slowestReaderPos != null) {
-            entryCache.invalidateEntries(slowestReaderPos);
+        PositionImpl evictionPos;
+        if (config.isCacheEvictionByMarkDeletedPosition()) {
+            evictionPos = getEarlierMarkDeletedPositionForActiveCursors();
+        } else {
+            // Always remove all entries already read by active cursors
+            evictionPos = getEarlierReadPositionForActiveCursors();
+        }
+        if (evictionPos != null) {
+            entryCache.invalidateEntries(evictionPos);
         }
 
         // Remove entries older than the cutoff threshold
@@ -2187,6 +2192,19 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
         }
         return durablePosition.compareTo(nonDurablePosition) > 0 ? nonDurablePosition : durablePosition;
     }
+
+    private PositionImpl getEarlierMarkDeletedPositionForActiveCursors() {
+        PositionImpl nonDurablePosition = nonDurableActiveCursors.getSlowestMarkDeletedPositionForActiveCursors();
+        PositionImpl durablePosition = activeCursors.getSlowestMarkDeletedPositionForActiveCursors();
+        if (nonDurablePosition == null) {
+            return durablePosition;
+        }
+        if (durablePosition == null) {
+            return nonDurablePosition;
+        }
+        return durablePosition.compareTo(nonDurablePosition) > 0 ? nonDurablePosition : durablePosition;
+    }
+
 
     void updateCursor(ManagedCursorImpl cursor, PositionImpl newPosition) {
         Pair<PositionImpl, PositionImpl> pair = cursors.cursorUpdated(cursor, newPosition);

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerTest.java
@@ -323,6 +323,8 @@ public class ManagedLedgerTest extends MockedBookKeeperTestCase {
                                         Entry entry = entries.get(0);
                                         final Position position = entry.getPosition();
                                         assertEquals(new String(entry.getDataAndRelease(), Encoding), message1);
+                                        ((ManagedLedgerImpl) ledger).doCacheEviction(
+                                                System.nanoTime() - TimeUnit.MILLISECONDS.toNanos(30000));
                                         assertEquals(((ManagedLedgerImpl) ledger).getCacheSize(), message1.getBytes(Encoding).length);
 
                                         log.debug("Mark-Deleting to position {}", position);
@@ -332,11 +334,8 @@ public class ManagedLedgerTest extends MockedBookKeeperTestCase {
                                                 log.debug("Mark delete complete");
                                                 ManagedCursor cursor = (ManagedCursor) ctx;
                                                 assertFalse(cursor.hasMoreEntries());
-                                                // wait eviction  finish.
-                                                try {
-                                                    Thread.sleep(100);
-                                                } catch (InterruptedException e) {
-                                                }
+                                                ((ManagedLedgerImpl) ledger).doCacheEviction(
+                                                        System.nanoTime() - TimeUnit.MILLISECONDS.toNanos(30000));
                                                 assertEquals(((ManagedLedgerImpl) ledger).getCacheSize(), 0);
 
                                                 counter.countDown();
@@ -414,11 +413,8 @@ public class ManagedLedgerTest extends MockedBookKeeperTestCase {
                                         Entry entry = entries.get(0);
                                         final Position position = entry.getPosition();
                                         assertEquals(new String(entry.getDataAndRelease(), Encoding), message1);
-                                        // wait eviction  finish.
-                                        try {
-                                            Thread.sleep(100);
-                                        } catch (InterruptedException e) {
-                                        }
+                                        ((ManagedLedgerImpl) ledger).doCacheEviction(
+                                                System.nanoTime() - TimeUnit.MILLISECONDS.toNanos(30000));
                                         assertEquals(((ManagedLedgerImpl) ledger).getCacheSize(), 0);
 
                                         log.debug("Mark-Deleting to position {}", position);

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerTest.java
@@ -295,6 +295,7 @@ public class ManagedLedgerTest extends MockedBookKeeperTestCase {
     public void testCacheEvictionByMarkDeletedPosition() throws Throwable {
         final CountDownLatch counter = new CountDownLatch(1);
         ManagedLedgerConfig config = new ManagedLedgerConfig();
+        config.setCacheEvictionByMarkDeletedPosition(true);
         factory.updateCacheEvictionTimeThreshold(TimeUnit.MILLISECONDS
                 .toNanos(30000));
         factory.asyncOpen("my_test_ledger", config, new OpenLedgerCallback() {
@@ -386,7 +387,6 @@ public class ManagedLedgerTest extends MockedBookKeeperTestCase {
     public void testCacheEvictionByReadPosition() throws Throwable {
         final CountDownLatch counter = new CountDownLatch(1);
         ManagedLedgerConfig config = new ManagedLedgerConfig();
-        config.setCacheEvictionByMarkDeletedPosition(false);
         factory.updateCacheEvictionTimeThreshold(TimeUnit.MILLISECONDS
                 .toNanos(30000));
         factory.asyncOpen("my_test_ledger", config, new OpenLedgerCallback() {

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -2424,8 +2424,8 @@ public class ServiceConfiguration implements PulsarConfiguration {
 
     @FieldContext(
             category = CATEGORY_STORAGE_ML,
-            doc = "Evicting cache data by the slowest markDeletedPosition or readPosition. " +
-                    "The default is to evict through readPosition."
+            doc = "Evicting cache data by the slowest markDeletedPosition or readPosition. "
+                    + "The default is to evict through readPosition."
     )
     private boolean cacheEvictionByMarkDeletedPosition = false;
 

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -2427,7 +2427,7 @@ public class ServiceConfiguration implements PulsarConfiguration {
             doc = "Evicting cache data by the slowest markDeletedPosition or readPosition. "
                     + "The default is to evict through readPosition."
     )
-    private boolean cacheEvictionByMarkDeletedPosition = true;
+    private boolean cacheEvictionByMarkDeletedPosition = false;
 
     /**** --- Transaction config variables. --- ****/
     @FieldContext(

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -2422,6 +2422,13 @@ public class ServiceConfiguration implements PulsarConfiguration {
         )
     private int managedLedgerInactiveLedgerRolloverTimeSeconds = 0;
 
+    @FieldContext(
+            category = CATEGORY_STORAGE_ML,
+            doc = "Evicting cache data by the slowest markDeletedPosition or readPosition. " +
+                    "The default is to evict through readPosition."
+    )
+    private boolean cacheEvictionByMarkDeletedPosition = false;
+
     /**** --- Transaction config variables. --- ****/
     @FieldContext(
             category = CATEGORY_TRANSACTION,

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -2427,7 +2427,7 @@ public class ServiceConfiguration implements PulsarConfiguration {
             doc = "Evicting cache data by the slowest markDeletedPosition or readPosition. "
                     + "The default is to evict through readPosition."
     )
-    private boolean cacheEvictionByMarkDeletedPosition = false;
+    private boolean cacheEvictionByMarkDeletedPosition = true;
 
     /**** --- Transaction config variables. --- ****/
     @FieldContext(

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
@@ -1598,6 +1598,8 @@ public class BrokerService implements Closeable {
                     managedLedgerConfig.setLazyCursorRecovery(serviceConfig.isLazyCursorRecovery());
                     managedLedgerConfig.setInactiveLedgerRollOverTime(
                             serviceConfig.getManagedLedgerInactiveLedgerRolloverTimeSeconds(), TimeUnit.SECONDS);
+                    managedLedgerConfig.setCacheEvictionByMarkDeletedPosition(
+                            serviceConfig.isCacheEvictionByMarkDeletedPosition());
 
                     OffloadPoliciesImpl nsLevelOffloadPolicies =
                             (OffloadPoliciesImpl) policies.map(p -> p.offload_policies).orElse(null);


### PR DESCRIPTION
### Motivation
We found a problem: even if we adjusted the cache eviction size and time a lot, there would still be some misscaches when the client restarted.The corresponding configuration is as follows:
 managedLedgerCacheSizeMB=40960
managedLedgerCacheEvictionTimeThresholdMillis=1800000

The current cache eviction strategy is to evict according to the read position, so there may be a miss cache when the data is pushed again.

In our scenario, there are tens of thousands of clients, and they are deployed on k8s. In order to save resources, they may dynamically expand or shrink, so that data re-pushing will happen from time to time:
<img width="1256" alt="image" src="https://user-images.githubusercontent.com/19296967/161375341-8d3fc5a4-a0aa-416f-8e97-7b9eb7c6476a.png">
<img width="1593" alt="image" src="https://user-images.githubusercontent.com/19296967/161375365-22c051b6-be86-44bd-879f-5c848a56ffd0.png">


### Modifications
Therefore, to improve the cache hit rate , I think a new cache eviction strategy should be added: evict data according to the markdelete position.

### Documentation

Check the box below or label this PR directly (if you have committer privilege).

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)


