### PR TITLE
[Pulsar SQL] Add workaround for Presto 332 java.version parsing issue

### DIFF
--- a/.github/workflows/pulsar-ci.yaml
+++ b/.github/workflows/pulsar-ci.yaml
@@ -556,6 +556,11 @@ jobs:
           -Pmain,docker -Dmaven.test.skip=true -Ddockerfile.build.squash=true \
           -Dspotbugs.skip=true -Dlicense.skip=true -Dcheckstyle.skip=true -Drat.skip=true
 
+      # Checks also Presto license files
+      - name: Check binary licenses
+        if: ${{ needs.changed_files_job.outputs.docs_only != 'true' }}
+        run: src/check-binary-license.sh ./distribution/server/target/apache-pulsar-*-bin.tar.gz
+
       - name: save docker image apachepulsar/pulsar-test-latest-version:latest to Github artifact cache
         if: ${{ needs.changed_files_job.outputs.docs_only != 'true' }}
         run: |
@@ -604,9 +609,8 @@ jobs:
           - name: Pulsar IO - Oracle
             group: PULSAR_IO_ORA
 
-          # disable Sql integration tests until https://github.com/apache/pulsar/issues/14951 has been resolved
-          #- name: Sql
-          #  group: SQL
+          - name: Sql
+            group: SQL
 
     steps:
       - name: checkout

--- a/bin/pulsar
+++ b/bin/pulsar
@@ -126,6 +126,15 @@ check_presto_libraries() {
     fi
 }
 
+presto_java11_workaround() {
+  local prefix="${1:-"-D"}"
+  # workaround https://github.com/apache/pulsar/issues/14951
+  local java_version_trimmed=$({ $JAVA -version 2>&1| head -1 | awk -F\" '{ print $2 }' | awk -F. '{ print $1 "." $2 "." $3 }' | grep -v -F ..; } 2>/dev/null)
+  if [ -n "$java_version_trimmed" ]; then
+    echo "${prefix}java.version=${java_version_trimmed}"
+  fi
+}
+
 pulsar_help() {
     cat <<EOF
 Usage: pulsar <command>
@@ -371,10 +380,10 @@ elif [ $COMMAND == "compact-topic" ]; then
     exec $JAVA $OPTS org.apache.pulsar.compaction.CompactorTool --broker-conf $PULSAR_BROKER_CONF $@
 elif [ $COMMAND == "sql" ]; then
     check_presto_libraries
-    exec $JAVA -cp "${PRESTO_HOME}/lib/*" io.prestosql.cli.Presto --server localhost:8081 "${@}"
+    exec $JAVA -cp "${PRESTO_HOME}/lib/*" $(presto_java11_workaround) io.prestosql.cli.Presto --server localhost:8081 "${@}"
 elif [ $COMMAND == "sql-worker" ]; then
     check_presto_libraries
-    exec ${PRESTO_HOME}/bin/launcher --etc-dir ${PULSAR_PRESTO_CONF} "${@}"
+    exec ${PRESTO_HOME}/bin/launcher $(presto_java11_workaround "-D ") --etc-dir ${PULSAR_PRESTO_CONF} "${@}"
 elif [ $COMMAND == "tokens" ]; then
     exec $JAVA $OPTS org.apache.pulsar.utils.auth.tokens.TokensCliUtils $@
 elif [ $COMMAND == "version" ]; then


### PR DESCRIPTION
Fixes #14951

### Motivation

- See #14951 

- Presto 332 cannot parse a version string with more than 2 dots, such as 11.0.14.1

### Modifications

  - Add a workaround in bin/pulsar startup script that overrides the java.version system property with a version with 2 dots in it. This is applied to "sql-worker" and "sql" commands.