### PR TITLE
[Issue 13278][python client] Add python 3.10 generation for pulsar-client

### DIFF
--- a/pulsar-client-cpp/docker/build-wheels.sh
+++ b/pulsar-client-cpp/docker/build-wheels.sh
@@ -35,6 +35,7 @@ PYTHON_VERSIONS=(
    '3.7 cp37-cp37m'
    '3.8 cp38-cp38'
    '3.9 cp39-cp39'
+   '3.10 cp310-cp310'
 )
 
 function contains() {

--- a/pulsar-client-cpp/docker/create-images.sh
+++ b/pulsar-client-cpp/docker/create-images.sh
@@ -31,6 +31,7 @@ PYTHON_VERSIONS=(
    '3.7 cp37-cp37m manylinux2014'
    '3.8 cp38-cp38 manylinux2014'
    '3.9 cp39-cp39 manylinux2014'
+   '3.10 cp310-cp310 manylinux2014'
 )
 
 for line in "${PYTHON_VERSIONS[@]}"; do

--- a/pulsar-client-cpp/docker/create-images.sh
+++ b/pulsar-client-cpp/docker/create-images.sh
@@ -31,7 +31,7 @@ PYTHON_VERSIONS=(
    '3.7 cp37-cp37m manylinux2014'
    '3.8 cp38-cp38 manylinux2014'
    '3.9 cp39-cp39 manylinux2014'
-   '3.10 cp310-cp310 manylinux2014'
+   '3.10 cp310-cp310 manylinux_x_y'
 )
 
 for line in "${PYTHON_VERSIONS[@]}"; do

--- a/pulsar-client-cpp/docker/push-images.sh
+++ b/pulsar-client-cpp/docker/push-images.sh
@@ -33,6 +33,7 @@ PYTHON_VERSIONS=(
    '3.7 cp37-cp37m'
    '3.8 cp38-cp38'
    '3.9 cp39-cp39'
+   '3.10 cp310-cp310'
 )
 
 for line in "${PYTHON_VERSIONS[@]}"; do

--- a/pulsar-client-cpp/python/CMakeLists.txt
+++ b/pulsar-client-cpp/python/CMakeLists.txt
@@ -60,6 +60,10 @@ if (NOT DEFINED ${Boost_PYTHON39-MT_LIBRARY})
   set(Boost_PYTHON39-MT_LIBRARY ${Boost_PYTHON39_LIBRARY})
 endif()
 
+if (NOT DEFINED ${Boost_PYTHON310-MT_LIBRARY})
+  set(Boost_PYTHON310-MT_LIBRARY ${Boost_PYTHON310_LIBRARY})
+endif()
+
 # Try all possible boost-python variable namings
 set(PYTHON_WRAPPER_LIBS ${Boost_PYTHON_LIBRARY}
                         ${Boost_PYTHON3_LIBRARY}
@@ -69,7 +73,8 @@ set(PYTHON_WRAPPER_LIBS ${Boost_PYTHON_LIBRARY}
                         ${Boost_PYTHON35_LIBRARY}
                         ${Boost_PYTHON36_LIBRARY}
                         ${Boost_PYTHON38_LIBRARY}
-                        ${Boost_PYTHON39_LIBRARY})
+                        ${Boost_PYTHON39_LIBRARY}
+                        ${Boost_PYTHON310_LIBRARY})
 
 if (APPLE)
     if (Boost_PYTHON27-MT_LIBRARY_RELEASE)
@@ -84,6 +89,9 @@ if (APPLE)
     if (Boost_PYTHON39-MT_LIBRARY_RELEASE)
         set(PYTHON_WRAPPER_LIBS ${PYTHON_WRAPPER_LIBS} ${Boost_PYTHON39-MT_LIBRARY_RELEASE})
     endif ()
+    if (Boost_PYTHON310-MT_LIBRARY_RELEASE)
+            set(PYTHON_WRAPPER_LIBS ${PYTHON_WRAPPER_LIBS} ${Boost_PYTHON310-MT_LIBRARY_RELEASE})
+        endif ()
 endif()
 
 message(STATUS "Using Boost Python libs: ${PYTHON_WRAPPER_LIBS}")


### PR DESCRIPTION
https://github.com/apache/pulsar/issues/13278

### Motivation

* Support python 3.10 for pulsar client

### Modifications

* Add `3.10 cp310-cp310` to the build scripts
* Use manylinux_x_y for 3.10 support (manylinux_2014 does not support python 3.10)

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API: (yes / no)
  - The schema: (yes / no / don't know)
  - The default values of configurations: (yes / no)
  - The wire protocol: (yes / no)
  - The rest endpoints: (yes / no)
  - The admin cli options: (yes / no)
  - Anything that affects deployment: (yes / no / don't know)

### Documentation

Check the box below or label this PR directly (if you have committer privilege).

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [ ] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)


