### PR TITLE
[fix][elasticseach] ElasticSearch sink: client 'close' method is never called

### DIFF
--- a/pulsar-io/elastic-search/src/main/java/org/apache/pulsar/io/elasticsearch/client/BulkProcessor.java
+++ b/pulsar-io/elastic-search/src/main/java/org/apache/pulsar/io/elasticsearch/client/BulkProcessor.java
@@ -79,6 +79,6 @@ public interface BulkProcessor extends Closeable {
 
     void flush();
 
-    void awaitClose(long timeout, TimeUnit unit) throws InterruptedException;
-
+    @Override
+    void close();
 }

--- a/pulsar-io/elastic-search/src/main/java/org/apache/pulsar/io/elasticsearch/client/RestClient.java
+++ b/pulsar-io/elastic-search/src/main/java/org/apache/pulsar/io/elasticsearch/client/RestClient.java
@@ -205,8 +205,11 @@ public abstract class RestClient implements Closeable {
         }).toArray(HttpHost[]::new);
     }
 
+    protected abstract void closeClient();
+
     @Override
     public void close() {
         executorService.shutdown();
+        closeClient();
     }
 }

--- a/pulsar-io/elastic-search/src/main/java/org/apache/pulsar/io/elasticsearch/client/elastic/ElasticSearchJavaRestClient.java
+++ b/pulsar-io/elastic-search/src/main/java/org/apache/pulsar/io/elasticsearch/client/elastic/ElasticSearchJavaRestClient.java
@@ -182,17 +182,11 @@ public class ElasticSearchJavaRestClient extends RestClient {
     }
 
     @Override
-    public void close() {
-        super.close();
-        try {
-            if (bulkProcessor != null) {
-                bulkProcessor.awaitClose(5000L, TimeUnit.MILLISECONDS);
-            }
-        } catch (InterruptedException e) {
-            log.warn("Elasticsearch bulk processor close error:", e);
+    public void closeClient() {
+        if (bulkProcessor != null) {
+            bulkProcessor.close();
         }
         client.shutdown();
-
     }
 
     public ElasticsearchClient getClient() {

--- a/pulsar-io/elastic-search/src/main/java/org/apache/pulsar/io/elasticsearch/client/opensearch/OpenSearchHighLevelRestClient.java
+++ b/pulsar-io/elastic-search/src/main/java/org/apache/pulsar/io/elasticsearch/client/opensearch/OpenSearchHighLevelRestClient.java
@@ -263,11 +263,10 @@ public class OpenSearchHighLevelRestClient extends RestClient implements BulkPro
     }
 
     @Override
-    public void awaitClose(long timeout, TimeUnit unit) throws InterruptedException {
-        super.close();
+    public void closeClient() {
         try {
             if (internalBulkProcessor != null) {
-                internalBulkProcessor.awaitClose(5000L, TimeUnit.MILLISECONDS);
+                internalBulkProcessor.awaitClose(5000, TimeUnit.MILLISECONDS);
                 internalBulkProcessor = null;
             }
         } catch (InterruptedException e) {

--- a/pulsar-io/elastic-search/src/main/java/org/apache/pulsar/io/elasticsearch/client/opensearch/OpenSearchHighLevelRestClient.java
+++ b/pulsar-io/elastic-search/src/main/java/org/apache/pulsar/io/elasticsearch/client/opensearch/OpenSearchHighLevelRestClient.java
@@ -282,7 +282,13 @@ public class OpenSearchHighLevelRestClient extends RestClient implements BulkPro
         }
     }
 
+    @VisibleForTesting
     public RestHighLevelClient getClient() {
         return client;
+    }
+
+    @VisibleForTesting
+    public org.opensearch.action.bulk.BulkProcessor getInternalBulkProcessor() {
+        return internalBulkProcessor;
     }
 }

--- a/pulsar-io/elastic-search/src/test/java/org/apache/pulsar/io/elasticsearch/ElasticSearchClientSslTests.java
+++ b/pulsar-io/elastic-search/src/test/java/org/apache/pulsar/io/elasticsearch/ElasticSearchClientSslTests.java
@@ -71,8 +71,7 @@ public abstract class ElasticSearchClientSslTests extends ElasticSearchTestBase 
                             .setEnabled(true)
                             .setTruststorePath(sslResourceDir + "/truststore.jks")
                             .setTruststorePassword("changeit"));
-            ElasticSearchClient client = new ElasticSearchClient(config);
-            testIndexExists(client);
+            testClientWithConfig(config);
         }
     }
 
@@ -109,8 +108,7 @@ public abstract class ElasticSearchClientSslTests extends ElasticSearchTestBase 
                             .setHostnameVerification(true)
                             .setTruststorePath(sslResourceDir + "/truststore.jks")
                             .setTruststorePassword("changeit"));
-            ElasticSearchClient client = new ElasticSearchClient(config);
-            testIndexExists(client);
+            testClientWithConfig(config);
         }
     }
 
@@ -147,11 +145,15 @@ public abstract class ElasticSearchClientSslTests extends ElasticSearchTestBase 
                             .setTruststorePassword("changeit")
                             .setKeystorePath(sslResourceDir + "/keystore.jks")
                             .setKeystorePassword("changeit"));
-            ElasticSearchClient client = new ElasticSearchClient(config);
-            testIndexExists(client);
+            testClientWithConfig(config);
         }
     }
 
+    private void testClientWithConfig(ElasticSearchConfig config) throws IOException {
+        try (ElasticSearchClient client = new ElasticSearchClient(config);) {
+            testIndexExists(client);
+        }
+    }
 
     private void testIndexExists(ElasticSearchClient client) throws IOException {
         assertFalse(client.indexExists("mynewindex"));

--- a/pulsar-io/elastic-search/src/test/java/org/apache/pulsar/io/elasticsearch/ElasticSearchSinkRawDataTests.java
+++ b/pulsar-io/elastic-search/src/test/java/org/apache/pulsar/io/elasticsearch/ElasticSearchSinkRawDataTests.java
@@ -76,6 +76,7 @@ public abstract class ElasticSearchSinkRawDataTests extends ElasticSearchTestBas
     @AfterClass(alwaysRun = true)
     public static void closeAfterClass() {
         container.close();
+        container = null;
     }
 
     @SuppressWarnings("unchecked")

--- a/pulsar-io/elastic-search/src/test/java/org/apache/pulsar/io/elasticsearch/ElasticSearchSinkTests.java
+++ b/pulsar-io/elastic-search/src/test/java/org/apache/pulsar/io/elasticsearch/ElasticSearchSinkTests.java
@@ -99,6 +99,7 @@ public abstract class ElasticSearchSinkTests extends ElasticSearchTestBase {
     @AfterClass(alwaysRun = true)
     public static void closeAfterClass() {
         container.close();
+        container = null;
     }
 
     @SuppressWarnings("unchecked")

--- a/pulsar-io/elastic-search/src/test/java/org/apache/pulsar/io/elasticsearch/ElasticSearchSinkTests.java
+++ b/pulsar-io/elastic-search/src/test/java/org/apache/pulsar/io/elasticsearch/ElasticSearchSinkTests.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pulsar.io.elasticsearch;
 
+import co.elastic.clients.transport.ElasticsearchTransport;
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.client.api.schema.GenericObject;
@@ -28,6 +29,7 @@ import org.apache.pulsar.common.schema.KeyValueEncodingType;
 import org.apache.pulsar.common.schema.SchemaType;
 
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -40,13 +42,18 @@ import java.util.Optional;
 
 import org.apache.pulsar.functions.api.Record;
 import org.apache.pulsar.io.core.SinkContext;
+import org.apache.pulsar.io.elasticsearch.client.BulkProcessor;
+import org.apache.pulsar.io.elasticsearch.client.RestClient;
 import org.apache.pulsar.io.elasticsearch.client.elastic.ElasticSearchJavaRestClient;
 import org.apache.pulsar.io.elasticsearch.client.opensearch.OpenSearchHighLevelRestClient;
 import org.apache.pulsar.io.elasticsearch.data.UserProfile;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 import org.opensearch.client.Node;
+import org.opensearch.client.RestHighLevelClient;
+import org.powermock.reflect.Whitebox;
 import org.testcontainers.elasticsearch.ElasticsearchContainer;
 import org.testng.SkipException;
 import org.testng.annotations.AfterClass;
@@ -54,6 +61,8 @@ import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 import java.util.Locale;
+import java.util.concurrent.TimeUnit;
+
 import static org.testng.Assert.assertNull;
 
 public abstract class ElasticSearchSinkTests extends ElasticSearchTestBase {
@@ -358,5 +367,50 @@ public abstract class ElasticSearchSinkTests extends ElasticSearchTestBase {
         sink.write(new MockRecordNullValue());
         assertEquals(sink.getElasticsearchClient().getRestClient().totalHits(index), action.equals(ElasticSearchConfig.NullValueAction.DELETE) ? 0L : 1L);
         assertNull(sink.getElasticsearchClient().irrecoverableError.get());
+    }
+
+    @Test
+    public void testCloseClient() throws Exception {
+        final ElasticSearchSink sink = new ElasticSearchSink();
+        map.put("bulkEnabled", true);
+        try {
+            sink.open(map, mockSinkContext);
+            final ElasticSearchClient elasticSearchClient = spy(sink.getElasticsearchClient());
+            final RestClient restClient = spy(elasticSearchClient.getRestClient());
+            if (restClient instanceof ElasticSearchJavaRestClient) {
+                ElasticSearchJavaRestClient client = (ElasticSearchJavaRestClient) restClient;
+                final BulkProcessor bulkProcessor = spy(restClient.getBulkProcessor());
+                final ElasticsearchTransport transport = spy(client.getTransport());
+
+                Whitebox.setInternalState(client, "transport", transport);
+                Whitebox.setInternalState(client, "bulkProcessor", bulkProcessor);
+                Whitebox.setInternalState(elasticSearchClient, "client", restClient);
+                Whitebox.setInternalState(sink, "elasticsearchClient", elasticSearchClient);
+                sink.close();
+                verify(transport).close();
+                verify(bulkProcessor).close();
+                verify(client).close();
+                verify(restClient).close();
+
+            } else {
+                OpenSearchHighLevelRestClient client = (OpenSearchHighLevelRestClient) restClient;
+
+                final org.opensearch.action.bulk.BulkProcessor internalBulkProcessor = spy(
+                        client.getInternalBulkProcessor());
+                final RestHighLevelClient restHighLevelClient = spy(client.getClient());
+
+                Whitebox.setInternalState(client, "client", restHighLevelClient);
+                Whitebox.setInternalState(client, "internalBulkProcessor", internalBulkProcessor);
+                Whitebox.setInternalState(elasticSearchClient, "client", restClient);
+                Whitebox.setInternalState(sink, "elasticsearchClient", elasticSearchClient);
+                sink.close();
+                verify(restHighLevelClient).close();
+                verify(internalBulkProcessor).awaitClose(Mockito.anyLong(), Mockito.any(TimeUnit.class));
+                verify(client).close();
+                verify(restClient).close();
+            }
+        } finally {
+            sink.close();
+        }
     }
 }

--- a/pulsar-io/elastic-search/src/test/java/org/apache/pulsar/io/elasticsearch/client/RestClientFactoryTest.java
+++ b/pulsar-io/elastic-search/src/test/java/org/apache/pulsar/io/elasticsearch/client/RestClientFactoryTest.java
@@ -24,7 +24,8 @@ import org.apache.pulsar.io.elasticsearch.client.elastic.ElasticSearchJavaRestCl
 import org.apache.pulsar.io.elasticsearch.client.opensearch.OpenSearchHighLevelRestClient;
 import org.testng.annotations.Test;
 
-import static org.testng.Assert.*;
+import static org.testng.Assert.assertEquals;
+
 
 public class RestClientFactoryTest {
 
@@ -35,13 +36,19 @@ public class RestClientFactoryTest {
         config.setElasticSearchUrl("http://localhost:9200");
 
         config.setCompatibilityMode(ElasticSearchConfig.CompatibilityMode.ELASTICSEARCH_7);
-        assertTrue(RestClientFactory.createClient(config, null) instanceof OpenSearchHighLevelRestClient);
+        assertInstance(config, OpenSearchHighLevelRestClient.class);
 
         config.setCompatibilityMode(ElasticSearchConfig.CompatibilityMode.OPENSEARCH);
-        assertTrue(RestClientFactory.createClient(config, null) instanceof OpenSearchHighLevelRestClient);
+        assertInstance(config, OpenSearchHighLevelRestClient.class);
 
         config.setCompatibilityMode(ElasticSearchConfig.CompatibilityMode.ELASTICSEARCH);
-        assertTrue(RestClientFactory.createClient(config, null) instanceof ElasticSearchJavaRestClient);
+        assertInstance(config, ElasticSearchJavaRestClient.class);
+    }
 
+    @SneakyThrows
+    private static void assertInstance(ElasticSearchConfig config, Class<? extends RestClient> expectedClass) {
+        try (RestClient client = RestClientFactory.createClient(config, null)){
+            assertEquals(client.getClass(), expectedClass);
+        }
     }
 }


### PR DESCRIPTION
### Motivation

The ElasticSearch client is never disposed when the sink is closed. This is a big deal and a memory leak when function worker is in ´thread´ mode.

This is a regression of https://github.com/apache/pulsar/pull/14805 so it only impacts current master branch.

### Modifications
* Replaced `shutdown()` with the actual closing method in the Elastic java client (`shutdown` returns the shutdownClient 😲 
* Refactor `close` method to be more clear and actually close the resources
* Fix client leaks in some tests
* Added unit test

- [x] `no-need-doc` 
  