### PR TITLE
[feat][pulsar-io] ElasticSearch Sink: option to disable SSL certificate validation

### DIFF
--- a/pulsar-io/elastic-search/src/main/java/org/apache/pulsar/io/elasticsearch/ElasticSearchSslConfig.java
+++ b/pulsar-io/elastic-search/src/main/java/org/apache/pulsar/io/elasticsearch/ElasticSearchSslConfig.java
@@ -46,16 +46,16 @@ public class ElasticSearchSslConfig implements Serializable {
     @FieldDoc(
             required = false,
             defaultValue = "true",
-            help = "Whether or not to validate node hostnames when using SSL. " +
-                    "Changing this value is high insecure and you should not use it in production environment."
+            help = "Whether or not to validate node hostnames when using SSL. "
+                    + "Changing this value is high insecure and you should not use it in production environment."
     )
     private boolean hostnameVerification = true;
 
     @FieldDoc(
             required = false,
             defaultValue = "false",
-            help = "Whether or not to disable the node certificate validation. " +
-                    "Changing this value is high insecure and you should not use it in production environment."
+            help = "Whether or not to disable the node certificate validation. "
+                    + "Changing this value is high insecure and you should not use it in production environment."
     )
     private boolean disableCertificateValidation;
 

--- a/pulsar-io/elastic-search/src/main/java/org/apache/pulsar/io/elasticsearch/ElasticSearchSslConfig.java
+++ b/pulsar-io/elastic-search/src/main/java/org/apache/pulsar/io/elasticsearch/ElasticSearchSslConfig.java
@@ -46,9 +46,16 @@ public class ElasticSearchSslConfig implements Serializable {
     @FieldDoc(
             required = false,
             defaultValue = "true",
-            help = "Whether or not to validate node hostnames when using SSL"
+            help = "Whether or not to validate node hostnames when using SSL. Changing this value is high insecure and you should not use it in production environment."
     )
     private boolean hostnameVerification = true;
+
+    @FieldDoc(
+            required = false,
+            defaultValue = "false",
+            help = "Whether or not to disable the node certificate validation. Changing this value is high insecure and you should not use it in production environment."
+    )
+    private boolean disableCertificateValidation;
 
     @FieldDoc(
             required = false,

--- a/pulsar-io/elastic-search/src/main/java/org/apache/pulsar/io/elasticsearch/ElasticSearchSslConfig.java
+++ b/pulsar-io/elastic-search/src/main/java/org/apache/pulsar/io/elasticsearch/ElasticSearchSslConfig.java
@@ -46,14 +46,16 @@ public class ElasticSearchSslConfig implements Serializable {
     @FieldDoc(
             required = false,
             defaultValue = "true",
-            help = "Whether or not to validate node hostnames when using SSL. Changing this value is high insecure and you should not use it in production environment."
+            help = "Whether or not to validate node hostnames when using SSL. " +
+                    "Changing this value is high insecure and you should not use it in production environment."
     )
     private boolean hostnameVerification = true;
 
     @FieldDoc(
             required = false,
             defaultValue = "false",
-            help = "Whether or not to disable the node certificate validation. Changing this value is high insecure and you should not use it in production environment."
+            help = "Whether or not to disable the node certificate validation. " +
+                    "Changing this value is high insecure and you should not use it in production environment."
     )
     private boolean disableCertificateValidation;
 

--- a/pulsar-io/elastic-search/src/main/java/org/apache/pulsar/io/elasticsearch/client/RestClient.java
+++ b/pulsar-io/elastic-search/src/main/java/org/apache/pulsar/io/elasticsearch/client/RestClient.java
@@ -38,7 +38,6 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.SSLContext;
-
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.http.Header;

--- a/pulsar-io/elastic-search/src/main/java/org/apache/pulsar/io/elasticsearch/client/RestClient.java
+++ b/pulsar-io/elastic-search/src/main/java/org/apache/pulsar/io/elasticsearch/client/RestClient.java
@@ -49,6 +49,7 @@ import org.apache.http.config.Registry;
 import org.apache.http.config.RegistryBuilder;
 import org.apache.http.conn.ssl.NoopHostnameVerifier;
 import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
+import org.apache.http.conn.ssl.TrustAllStrategy;
 import org.apache.http.impl.client.BasicCredentialsProvider;
 import org.apache.http.impl.nio.client.HttpAsyncClientBuilder;
 import org.apache.http.impl.nio.conn.PoolingNHttpClientConnectionManager;
@@ -182,6 +183,9 @@ public abstract class RestClient implements Closeable {
                     && !Strings.isNullOrEmpty(sslConfig.getTruststorePassword())) {
                 sslContextBuilder.loadTrustMaterial(new File(sslConfig.getTruststorePath()),
                         sslConfig.getTruststorePassword().toCharArray());
+            }
+            if (sslConfig.isDisableCertificateValidation()) {
+                sslContextBuilder.loadTrustMaterial(null, TrustAllStrategy.INSTANCE);
             }
             if (!Strings.isNullOrEmpty(sslConfig.getKeystorePath())
                     && !Strings.isNullOrEmpty(sslConfig.getKeystorePassword())) {

--- a/pulsar-io/elastic-search/src/test/java/org/apache/pulsar/io/elasticsearch/ElasticSearchClientSslTests.java
+++ b/pulsar-io/elastic-search/src/test/java/org/apache/pulsar/io/elasticsearch/ElasticSearchClientSslTests.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pulsar.io.elasticsearch;
 
+import lombok.SneakyThrows;
 import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.elasticsearch.ElasticsearchContainer;
 import org.testcontainers.utility.MountableFile;
@@ -145,6 +146,39 @@ public abstract class ElasticSearchClientSslTests extends ElasticSearchTestBase 
                             .setTruststorePassword("changeit")
                             .setKeystorePath(sslResourceDir + "/keystore.jks")
                             .setKeystorePassword("changeit"));
+            testClientWithConfig(config);
+        }
+    }
+
+    @Test
+    public void testSslDisableCertificateValidation() throws IOException {
+        try (ElasticsearchContainer container = createElasticsearchContainer()
+                .withFileSystemBind(sslResourceDir, configDir + "/ssl")
+                .withPassword("elastic")
+                .withEnv("xpack.license.self_generated.type", "trial")
+                .withEnv("xpack.security.enabled", "true")
+                .withEnv("xpack.security.http.ssl.enabled", "true")
+                .withEnv("xpack.security.http.ssl.client_authentication", "optional")
+                .withEnv("xpack.security.http.ssl.key", configDir + "/ssl/elasticsearch.key")
+                .withEnv("xpack.security.http.ssl.certificate", configDir + "/ssl/elasticsearch.crt")
+                .withEnv("xpack.security.http.ssl.certificate_authorities", configDir + "/ssl/cacert.crt")
+                .withEnv("xpack.security.transport.ssl.enabled", "true")
+                .withEnv("xpack.security.transport.ssl.verification_mode", "certificate")
+                .withEnv("xpack.security.transport.ssl.key", configDir + "/ssl/elasticsearch.key")
+                .withEnv("xpack.security.transport.ssl.certificate", configDir + "/ssl/elasticsearch.crt")
+                .withEnv("xpack.security.transport.ssl.certificate_authorities", configDir + "/ssl/cacert.crt")
+                .waitingFor(Wait.forLogMessage(".*(Security is enabled|Active license).*", 1)
+                        .withStartupTimeout(Duration.ofMinutes(2)))) {
+            container.start();
+
+            ElasticSearchConfig config = new ElasticSearchConfig()
+                    .setElasticSearchUrl("https://" + container.getHttpHostAddress())
+                    .setIndexName(INDEX)
+                    .setUsername("elastic")
+                    .setPassword("elastic")
+                    .setSsl(new ElasticSearchSslConfig()
+                            .setEnabled(true)
+                            .setDisableCertificateValidation(true));
             testClientWithConfig(config);
         }
     }

--- a/pulsar-io/elastic-search/src/test/java/org/apache/pulsar/io/elasticsearch/ElasticSearchClientSslTests.java
+++ b/pulsar-io/elastic-search/src/test/java/org/apache/pulsar/io/elasticsearch/ElasticSearchClientSslTests.java
@@ -18,7 +18,6 @@
  */
 package org.apache.pulsar.io.elasticsearch;
 
-import lombok.SneakyThrows;
 import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.elasticsearch.ElasticsearchContainer;
 import org.testcontainers.utility.MountableFile;

--- a/site2/docs/io-elasticsearch-sink.md
+++ b/site2/docs/io-elasticsearch-sink.md
@@ -94,6 +94,7 @@ The configuration of the Elasticsearch sink connector has the following properti
 |------|----------|----------|---------|-------------|
 | `enabled` | Boolean| false | false | Enable SSL/TLS. |
 | `hostnameVerification` | Boolean| false | true | Whether or not to validate node hostnames when using SSL. |
+| `disableCertificateValidation` | Boolean| false | true | Whether or not to disable the node certificate validation. Changing this value is high insecure and you should not use it in production environment. |
 | `truststorePath` | String| false |" " (empty string)| The path to the truststore file. |
 | `truststorePassword` | String| false |" " (empty string)| Truststore password. |
 | `keystorePath` | String| false |" " (empty string)| The path to the keystore file. |


### PR DESCRIPTION
### Motivation
There's no way at the moment to connect to a ElasticSearch cluster without checking the SSL certificate.
This is very useful in dev environments when you have to use secure connections.

### Modifications

* New option `disableCertificateValidation` that set the client to not verify ssl certificates. Default is false.

- [x] `doc` 
 