### PR TITLE
[fix][security] Upgrade MySQL client to 8.0.28 to get rid of CVE-2021-3711

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -162,6 +162,7 @@ flexible messaging model and an intuitive client API.</description>
     <scala-library.version>2.13.6</scala-library.version>
     <debezium.version>1.7.2.Final</debezium.version>
     <debezium.postgresql.version>42.2.25</debezium.postgresql.version>
+    <debezium.mysql.version>8.0.28</debezium.mysql.version>
     <jsonwebtoken.version>0.11.1</jsonwebtoken.version>
     <opencensus.version>0.18.0</opencensus.version>
     <hbase.version>2.4.9</hbase.version>

--- a/pulsar-io/debezium/mysql/pom.xml
+++ b/pulsar-io/debezium/mysql/pom.xml
@@ -46,6 +46,16 @@
 
   </dependencies>
 
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>mysql</groupId>
+        <artifactId>mysql-connector-java</artifactId>
+        <version>${debezium.mysql.version}</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
 
   <build>
     <plugins>


### PR DESCRIPTION
### Motivation

OWASP check fails due to 
```
Error:  Failed to execute goal org.owasp:dependency-check-maven:6.1.6:aggregate (default) on project pulsar: 
Error:  
Error:  One or more dependencies were identified with vulnerabilities that have a CVSS score greater than or equal to '7.0': 
Error:  
Error:  mysql-connector-java-8.0.27.jar: CVE-2021-3711
```
### Modifications

* Upgrade MySQL client to 8.0.28. It's used only in debezium-mysql connector.
  
- [x] `no-need-doc` 