### PR TITLE
[fix][jdk17] remove illegal access warning and enable reads optimization on jdk17

### DIFF
--- a/bin/bookkeeper
+++ b/bin/bookkeeper
@@ -172,7 +172,7 @@ IS_JAVA_8=`java -version 2>&1 |grep version|grep '"1\.8'`
 if [[ -z "$IS_JAVA_8" ]]; then
   # BookKeeper: enable posix_fadvise usage
   OPTS="$OPTS --add-opens java.base/java.io=ALL-UNNAMED"
-  # Netty: enable java.nio.ByteBuffer and java.nio.Bits optimizations
+  # Netty: enable java.nio.DirectByteBuffer
   # https://github.com/netty/netty/blob/4.1/common/src/main/java/io/netty/util/internal/PlatformDependent0.java
   OPTS="$OPTS --add-opens java.base/sun.nio=ALL-UNNAMED"
 fi

--- a/bin/bookkeeper
+++ b/bin/bookkeeper
@@ -174,7 +174,7 @@ if [[ -z "$IS_JAVA_8" ]]; then
   OPTS="$OPTS --add-opens java.base/java.io=ALL-UNNAMED"
   # Netty: enable java.nio.DirectByteBuffer
   # https://github.com/netty/netty/blob/4.1/common/src/main/java/io/netty/util/internal/PlatformDependent0.java
-  OPTS="$OPTS --add-opens java.base/sun.nio=ALL-UNNAMED"
+  OPTS="$OPTS --add-opens java.base/java.nio=ALL-UNNAMED"
 fi
 
 OPTS="-cp $BOOKIE_CLASSPATH $OPTS"

--- a/bin/bookkeeper
+++ b/bin/bookkeeper
@@ -165,11 +165,16 @@ OPTS="$OPTS -Dlog4j.configurationFile=`basename $BOOKIE_LOG_CONF`"
 
 # Allow Netty to use reflection access
 OPTS="$OPTS -Dio.netty.tryReflectionSetAccessible=true"
+
 IS_JAVA_8=`java -version 2>&1 |grep version|grep '"1\.8'`
+# Start --add-opens options
+# '--add-opens' option is not supported in jdk8
 if [[ -z "$IS_JAVA_8" ]]; then
-  # enable posix_fadvise usage on BookKeeper
-  # '--add-opens' option is not supported in jdk8
+  # BookKeeper: enable posix_fadvise usage
   OPTS="$OPTS --add-opens java.base/java.io=ALL-UNNAMED"
+  # Netty: enable java.nio.ByteBuffer and java.nio.Bits optimizations
+  # https://github.com/netty/netty/blob/4.1/common/src/main/java/io/netty/util/internal/PlatformDependent0.java
+  OPTS="$OPTS --add-opens java.base/sun.nio=ALL-UNNAMED"
 fi
 
 OPTS="-cp $BOOKIE_CLASSPATH $OPTS"

--- a/bin/bookkeeper
+++ b/bin/bookkeeper
@@ -165,6 +165,12 @@ OPTS="$OPTS -Dlog4j.configurationFile=`basename $BOOKIE_LOG_CONF`"
 
 # Allow Netty to use reflection access
 OPTS="$OPTS -Dio.netty.tryReflectionSetAccessible=true"
+IS_JAVA_8=`java -version 2>&1 |grep version|grep '"1\.8'`
+if [[ -z "$IS_JAVA_8" ]]; then
+  # enable posix_fadvise usage on BookKeeper
+  # '--add-opens' option is not supported in jdk8
+  OPTS="$OPTS --add-opens java.base/java.io=ALL-UNNAMED"
+fi
 
 OPTS="-cp $BOOKIE_CLASSPATH $OPTS"
 

--- a/bin/function-localrunner
+++ b/bin/function-localrunner
@@ -31,7 +31,7 @@ PULSAR_GC=${PULSAR_GC:-"-XX:+UseG1GC -XX:MaxGCPauseMillis=10 -XX:+ParallelRefPro
 # Garbage collection log.
 IS_JAVA_8=`java -version 2>&1 |grep version|grep '"1\.8'`
 # java version has space, use [[ -n $PARAM ]] to judge if variable exists
-if [[ -n $IS_JAVA_8 ]]; then
+if [[ -n "$IS_JAVA_8" ]]; then
   PULSAR_GC_LOG=${PULSAR_GC_LOG:-"-Xloggc:logs/pulsar_gc_%p.log -XX:+PrintGCDetails -XX:+PrintGCDateStamps -XX:+UseGCLogFileRotation -XX:NumberOfGCLogFiles=10 -XX:GCLogFileSize=20M"}
 else
 # After jdk 9, gc log param should config like this. Ignoring version less than jdk 8

--- a/bin/function-localrunner
+++ b/bin/function-localrunner
@@ -92,7 +92,7 @@ OPTS="$OPTS -Dio.netty.tryReflectionSetAccessible=true"
 # Start --add-opens options
 # '--add-opens' option is not supported in jdk8
 if [[ -z "$IS_JAVA_8" ]]; then
-  # Netty: enable java.nio.ByteBuffer and java.nio.Bits optimizations
+  # Netty: enable java.nio.DirectByteBuffer
   # https://github.com/netty/netty/blob/4.1/common/src/main/java/io/netty/util/internal/PlatformDependent0.java
   OPTS="$OPTS --add-opens java.base/sun.nio=ALL-UNNAMED"
 fi

--- a/bin/function-localrunner
+++ b/bin/function-localrunner
@@ -89,6 +89,14 @@ OPTS="$OPTS -Dlog4j.configurationFile=`basename $PULSAR_LOG_CONF`"
 # Allow Netty to use reflection access
 OPTS="$OPTS -Dio.netty.tryReflectionSetAccessible=true"
 
+# Start --add-opens options
+# '--add-opens' option is not supported in jdk8
+if [[ -z "$IS_JAVA_8" ]]; then
+  # Netty: enable java.nio.ByteBuffer and java.nio.Bits optimizations
+  # https://github.com/netty/netty/blob/4.1/common/src/main/java/io/netty/util/internal/PlatformDependent0.java
+  OPTS="$OPTS --add-opens java.base/sun.nio=ALL-UNNAMED"
+fi
+
 # Ensure we can read bigger content from ZK. (It might be
 # rarely needed when trying to list many z-nodes under a
 # directory)

--- a/bin/function-localrunner
+++ b/bin/function-localrunner
@@ -94,7 +94,7 @@ OPTS="$OPTS -Dio.netty.tryReflectionSetAccessible=true"
 if [[ -z "$IS_JAVA_8" ]]; then
   # Netty: enable java.nio.DirectByteBuffer
   # https://github.com/netty/netty/blob/4.1/common/src/main/java/io/netty/util/internal/PlatformDependent0.java
-  OPTS="$OPTS --add-opens java.base/sun.nio=ALL-UNNAMED"
+  OPTS="$OPTS --add-opens java.base/java.nio=ALL-UNNAMED"
 fi
 
 # Ensure we can read bigger content from ZK. (It might be

--- a/bin/pulsar
+++ b/bin/pulsar
@@ -279,7 +279,7 @@ IS_JAVA_8=`java -version 2>&1 |grep version|grep '"1\.8'`
 if [[ -z "$IS_JAVA_8" ]]; then
   # BookKeeper: enable posix_fadvise usage
   OPTS="$OPTS --add-opens java.base/java.io=ALL-UNNAMED"
-  # Netty: enable java.nio.ByteBuffer and java.nio.Bits optimizations
+  # Netty: enable java.nio.DirectByteBuffer
   # https://github.com/netty/netty/blob/4.1/common/src/main/java/io/netty/util/internal/PlatformDependent0.java
   OPTS="$OPTS --add-opens java.base/sun.nio=ALL-UNNAMED"
 fi

--- a/bin/pulsar
+++ b/bin/pulsar
@@ -273,6 +273,12 @@ OPTS="$OPTS -Djute.maxbuffer=10485760 -Djava.net.preferIPv4Stack=true"
 
 # Allow Netty to use reflection access
 OPTS="$OPTS -Dio.netty.tryReflectionSetAccessible=true"
+IS_JAVA_8=`java -version 2>&1 |grep version|grep '"1\.8'`
+if [[ -z "$IS_JAVA_8" ]]; then
+  # enable posix_fadvise usage on BookKeeper
+  # '--add-opens' option is not supported in jdk8
+  OPTS="$OPTS --add-opens java.base/java.io=ALL-UNNAMED"
+fi
 
 OPTS="-cp $PULSAR_CLASSPATH $OPTS"
 

--- a/bin/pulsar
+++ b/bin/pulsar
@@ -274,10 +274,14 @@ OPTS="$OPTS -Djute.maxbuffer=10485760 -Djava.net.preferIPv4Stack=true"
 # Allow Netty to use reflection access
 OPTS="$OPTS -Dio.netty.tryReflectionSetAccessible=true"
 IS_JAVA_8=`java -version 2>&1 |grep version|grep '"1\.8'`
+# Start --add-opens options
+# '--add-opens' option is not supported in jdk8
 if [[ -z "$IS_JAVA_8" ]]; then
-  # enable posix_fadvise usage on BookKeeper
-  # '--add-opens' option is not supported in jdk8
+  # BookKeeper: enable posix_fadvise usage
   OPTS="$OPTS --add-opens java.base/java.io=ALL-UNNAMED"
+  # Netty: enable java.nio.ByteBuffer and java.nio.Bits optimizations
+  # https://github.com/netty/netty/blob/4.1/common/src/main/java/io/netty/util/internal/PlatformDependent0.java
+  OPTS="$OPTS --add-opens java.base/sun.nio=ALL-UNNAMED"
 fi
 
 OPTS="-cp $PULSAR_CLASSPATH $OPTS"

--- a/bin/pulsar
+++ b/bin/pulsar
@@ -281,7 +281,7 @@ if [[ -z "$IS_JAVA_8" ]]; then
   OPTS="$OPTS --add-opens java.base/java.io=ALL-UNNAMED"
   # Netty: enable java.nio.DirectByteBuffer
   # https://github.com/netty/netty/blob/4.1/common/src/main/java/io/netty/util/internal/PlatformDependent0.java
-  OPTS="$OPTS --add-opens java.base/sun.nio=ALL-UNNAMED"
+  OPTS="$OPTS --add-opens java.base/java.nio=ALL-UNNAMED"
 fi
 
 OPTS="-cp $PULSAR_CLASSPATH $OPTS"


### PR DESCRIPTION
### Motivation

In BookKeeper there's an optimization in order to improve file reads on Linux using [`posix_fadvise`](https://man7.org/linux/man-pages/man2/posix_fadvise.2.html) native instructions.
In order to do that it needs to access `java.io.FileDescriptor` using the reflection.

For Netty there is the `java.nio.DirectBuffer` usage with it's currently used in Pulsar and it _should_ improve the direct memory footprint.

At the moment:
- if you run the Bookie with jdk11, you see spammy warnings like: `Illegal reflective access by io.netty.util.internal.ReflectionUtil (file:/Users/nicolo.boschi/.m2/repository/io/netty/netty-common/4.1.74.Final/netty-common-4.1.74.Final.jar) to constructor java.nio.DirectByteBuffer(long,int)`
- if you run the Bookie with jdk11, the optimization is disabled 

This pull is also intended to keep the same behavior across JDK11 and JDK17.
### Modifications

* Add `--add-opens java.base/java.io=ALL-UNNAMED --add-opens java.base/sun.nio=ALL-UNNAMED` to the command line inside ´bin´ directory and allow reflections on java.io package. This option is available only starting from Java 9. 

note: this is not documented on BookKeeper project, I will follow-up there.
 
- [x] `no-need-doc` 
  