### PR TITLE
[fix][broker]fix potential NPE in Replicator

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractReplicator.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractReplicator.java
@@ -207,7 +207,7 @@ public abstract class AbstractReplicator {
 
     public CompletableFuture<Void> remove() {
         // No-op
-        return null;
+        return CompletableFuture.completedFuture(null);
     }
 
     protected boolean isWritable() {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentReplicator.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentReplicator.java
@@ -229,7 +229,7 @@ public class NonPersistentReplicator extends AbstractReplicator implements Repli
 
         @Override
         public CompletableFuture<MessageId> getFuture() {
-            return null;
+            return CompletableFuture.completedFuture(null);
         }
     }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentReplicator.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentReplicator.java
@@ -503,7 +503,7 @@ public class PersistentReplicator extends AbstractReplicator
 
         @Override
         public CompletableFuture<MessageId> getFuture() {
-            return null;
+            return CompletableFuture.completedFuture(null);
         }
     }
 


### PR DESCRIPTION
### Motivation
```java
       public CompletableFuture<MessageId> getFuture() {
            return null;
        }
``` 
The return value null may cause potential NPE in ` getFuture`.  The method does similarly： CompletableFuture<Void> remove()` & .

### Modifications

Use ` return CompletableFuture.completedFuture(null);` instead of `return null;`

### Verifying this change

Make sure that the change passes the CI checks.

### Does this pull request potentially affect one of the following parts:

If `yes` was chosen, please highlight the changes

- Dependencies (does it add or upgrade a dependency): (no)
- The public API: (no)
- The schema: (no)
- The default values of configurations: (no)
- The wire protocol: (no)
- The rest endpoints: (no)
- The admin cli options: (no)
- Anything that affects deployment: (no)

### Documentation
Check the box below and label this PR (if you have committer privilege).

Need to update docs? 
- [x] `no-need-doc` 
