### PR TITLE
[fix][tiered storage]fix potential NPE in MockManagedLedger

### DIFF
--- a/tiered-storage/jcloud/src/test/java/org/apache/bookkeeper/mledger/offload/jcloud/impl/MockManagedLedger.java
+++ b/tiered-storage/jcloud/src/test/java/org/apache/bookkeeper/mledger/offload/jcloud/impl/MockManagedLedger.java
@@ -338,7 +338,7 @@ public class MockManagedLedger implements ManagedLedger {
 
     @Override
     public CompletableFuture<Position> asyncFindPosition(Predicate<Entry> predicate) {
-        return null;
+        return CompletableFuture.completedFuture(null);
     }
 
     @Override
@@ -359,7 +359,7 @@ public class MockManagedLedger implements ManagedLedger {
 
     @Override
     public CompletableFuture<ManagedLedgerInternalStats> getManagedLedgerInternalStats(boolean includeLedgerMetadata) {
-        return null;
+        return CompletableFuture.completedFuture(null);
     }
 
     @Override


### PR DESCRIPTION
### Motivation
```java
      public CompletableFuture<ManagedLedgerInternalStats> getManagedLedgerInternalStats(boolean includeLedgerMetadata) {
        return CompletableFuture.completedFuture(null);
    }
``` 
The return value null may cause potential NPE in ` getManagedLedgerInternalStats `.  The method does similarly： `public CompletableFuture<Position> asyncFindPosition(Predicate<Entry> predicate)`

### Modifications

Use ` return CompletableFuture.completedFuture(null);` instead of `return null;`

### Verifying this change

Make sure that the change passes the CI checks.

### Does this pull request potentially affect one of the following parts:

If `yes` was chosen, please highlight the changes

- Dependencies (does it add or upgrade a dependency): (no)
- The public API: (no)
- The schema: (no)
- The default values of configurations: (no)
- The wire protocol: (no)
- The rest endpoints: (no)
- The admin cli options: (no)
- Anything that affects deployment: (no)

### Documentation
Check the box below and label this PR (if you have committer privilege).

Need to update docs? 
- [x] `no-need-doc` 
