### PR TITLE
[improve][transaction] support configurable ``transactionBufferClientOperationTimeoutInMills``

### DIFF
--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -2479,7 +2479,7 @@ public class ServiceConfiguration implements PulsarConfiguration {
             category = CATEGORY_TRANSACTION,
             doc = "The transaction buffer client's operation timeout in milliseconds."
     )
-    private long transactionBufferClientOperationTimeoutInMills = 3000;
+    private long transactionBufferClientOperationTimeoutInMills = 3000L;
 
     /**** --- KeyStore TLS config variables. --- ****/
     @FieldContext(

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -2475,6 +2475,12 @@ public class ServiceConfiguration implements PulsarConfiguration {
     )
     private int transactionBufferClientMaxConcurrentRequests = 1000;
 
+    @FieldContext(
+            category = CATEGORY_TRANSACTION,
+            doc = "The transaction buffer client's operation timeout in milliseconds."
+    )
+    private long transactionBufferClientOperationTimeoutInMills = 1000;
+
     /**** --- KeyStore TLS config variables. --- ****/
     @FieldContext(
             category = CATEGORY_KEYSTORE_TLS,

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -2479,7 +2479,7 @@ public class ServiceConfiguration implements PulsarConfiguration {
             category = CATEGORY_TRANSACTION,
             doc = "The transaction buffer client's operation timeout in milliseconds."
     )
-    private long transactionBufferClientOperationTimeoutInMills = 1000;
+    private long transactionBufferClientOperationTimeoutInMills = 3000;
 
     /**** --- KeyStore TLS config variables. --- ****/
     @FieldContext(

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
@@ -752,7 +752,8 @@ public class PulsarService implements AutoCloseable, ShutdownService {
                 this.transactionTimer =
                         new HashedWheelTimer(new DefaultThreadFactory("pulsar-transaction-timer"));
                 transactionBufferClient = TransactionBufferClientImpl.create(getClient(), transactionTimer,
-                        config.getTransactionBufferClientMaxConcurrentRequests());
+                        config.getTransactionBufferClientMaxConcurrentRequests(),
+                        config.getTransactionBufferClientOperationTimeoutInMills());
 
                 transactionMetadataStoreService = new TransactionMetadataStoreService(TransactionMetadataStoreProvider
                         .newProvider(config.getTransactionMetadataStoreProviderClassName()), this,

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/TransactionBufferClientImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/TransactionBufferClientImpl.java
@@ -40,9 +40,9 @@ public class TransactionBufferClientImpl implements TransactionBufferClient {
     }
 
     public static TransactionBufferClient create(PulsarClient pulsarClient, HashedWheelTimer timer,
-             int maxConcurrentRequests) {
+             int maxConcurrentRequests, long operationTimeoutInMills) {
         TransactionBufferHandler handler = new TransactionBufferHandlerImpl(pulsarClient, timer,
-                maxConcurrentRequests);
+                maxConcurrentRequests, operationTimeoutInMills);
         return new TransactionBufferClientImpl(handler);
     }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/TransactionBufferHandlerImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/TransactionBufferHandlerImpl.java
@@ -76,11 +76,11 @@ public class TransactionBufferHandlerImpl implements TransactionBufferHandler {
             });
 
     public TransactionBufferHandlerImpl(PulsarClient pulsarClient,
-                                        HashedWheelTimer timer, int maxConcurrentRequests) {
+                                        HashedWheelTimer timer, int maxConcurrentRequests, long operationTimeoutInMills) {
         this.pulsarClient = pulsarClient;
         this.outstandingRequests = new ConcurrentSkipListMap<>();
         this.pendingRequests = new GrowableArrayBlockingQueue<>();
-        this.operationTimeoutInMills = 3000L;
+        this.operationTimeoutInMills = operationTimeoutInMills;
         this.timer = timer;
         this.requestCredits = Math.max(100, maxConcurrentRequests);
     }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/TransactionBufferHandlerImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/TransactionBufferHandlerImpl.java
@@ -75,8 +75,8 @@ public class TransactionBufferHandlerImpl implements TransactionBufferHandler {
                 }
             });
 
-    public TransactionBufferHandlerImpl(PulsarClient pulsarClient,
-                                        HashedWheelTimer timer, int maxConcurrentRequests, long operationTimeoutInMills) {
+    public TransactionBufferHandlerImpl(PulsarClient pulsarClient, HashedWheelTimer timer,
+                                        int maxConcurrentRequests, long operationTimeoutInMills) {
         this.pulsarClient = pulsarClient;
         this.outstandingRequests = new ConcurrentSkipListMap<>();
         this.pendingRequests = new GrowableArrayBlockingQueue<>();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/buffer/TransactionBufferClientTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/buffer/TransactionBufferClientTest.java
@@ -81,7 +81,7 @@ public class TransactionBufferClientTest extends TransactionTestBase {
         admin.namespaces().createNamespace(namespace, 10);
         admin.topics().createPartitionedTopic(partitionedTopicName.getPartitionedTopicName(), partitions);
         tbClient = TransactionBufferClientImpl.create(pulsarClient,
-                new HashedWheelTimer(new DefaultThreadFactory("transaction-buffer")), 1000);
+                new HashedWheelTimer(new DefaultThreadFactory("transaction-buffer")), 1000, 3000);
     }
 
     @Override
@@ -160,7 +160,7 @@ public class TransactionBufferClientTest extends TransactionTestBase {
         @Cleanup("stop")
         HashedWheelTimer hashedWheelTimer = new HashedWheelTimer();
         TransactionBufferHandlerImpl transactionBufferHandler =
-                new TransactionBufferHandlerImpl(mockClient, hashedWheelTimer, 1000);
+                new TransactionBufferHandlerImpl(mockClient, hashedWheelTimer, 1000, 3000);
         CompletableFuture<TxnID> endFuture =
                 transactionBufferHandler.endTxnOnTopic("test", 1, 1, TxnAction.ABORT, 1);
 
@@ -203,7 +203,7 @@ public class TransactionBufferClientTest extends TransactionTestBase {
         @Cleanup("stop")
         HashedWheelTimer hashedWheelTimer = new HashedWheelTimer();
         TransactionBufferHandlerImpl transactionBufferHandler =
-                new TransactionBufferHandlerImpl(mockClient, hashedWheelTimer, 1000);
+                new TransactionBufferHandlerImpl(mockClient, hashedWheelTimer, 1000, 3000);
         try {
             transactionBufferHandler.endTxnOnTopic("test", 1, 1, TxnAction.ABORT, 1).get();
             fail();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/buffer/TransactionBufferHandlerImplTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/buffer/TransactionBufferHandlerImplTest.java
@@ -42,7 +42,8 @@ public class TransactionBufferHandlerImplTest {
     public void testRequestCredits() {
         PulsarClientImpl pulsarClient = mock(PulsarClientImpl.class);
         when(pulsarClient.getConnection(anyString())).thenReturn(CompletableFuture.completedFuture(mock(ClientCnx.class)));
-        TransactionBufferHandlerImpl handler = spy(new TransactionBufferHandlerImpl(pulsarClient, null, 1000));
+        TransactionBufferHandlerImpl handler = spy(
+                new TransactionBufferHandlerImpl(pulsarClient, null, 1000, 3000));
         doNothing().when(handler).endTxn(any());
         for (int i = 0; i < 500; i++) {
             handler.endTxnOnTopic("t", 1L, 1L, TxnAction.COMMIT, 1L);
@@ -61,7 +62,8 @@ public class TransactionBufferHandlerImplTest {
 
     @Test
     public void testMinRequestCredits() {
-        TransactionBufferHandlerImpl handler = spy(new TransactionBufferHandlerImpl(null, null, 50));
+        TransactionBufferHandlerImpl handler = spy(
+                new TransactionBufferHandlerImpl(null, null, 50, 3000));
         assertEquals(handler.getAvailableRequestCredits(), 100);
     }
 }


### PR DESCRIPTION
### Motivation

Current ``operationTimeoutInMills`` configuration in ``TransactionBufferHandlerImpl`` is not configurable. we can change it to configurable.

### Modifications

- Make ``operationTimeoutInMills`` configurable.
- The default ``transactionBufferClientOperationTimeoutInMills`` is 3000.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Does this pull request potentially affect one of the following parts:

  - The default values of configurations: (yes)

### Documentation

- [x] `doc-required` 

