### PR TITLE
[fix][client] Fix internal receive used wrong timeout type 

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBase.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBase.java
@@ -205,7 +205,7 @@ public abstract class ConsumerBase<T> extends HandlerState implements Consumer<T
         return internalReceive(timeout, unit);
     }
 
-    protected abstract Message<T> internalReceive(int timeout, TimeUnit unit) throws PulsarClientException;
+    protected abstract Message<T> internalReceive(long timeout, TimeUnit unit) throws PulsarClientException;
 
     @Override
     public Messages<T> batchReceive() throws PulsarClientException {

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
@@ -456,7 +456,7 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
     }
 
     @Override
-    protected Message<T> internalReceive(int timeout, TimeUnit unit) throws PulsarClientException {
+    protected Message<T> internalReceive(long timeout, TimeUnit unit) throws PulsarClientException {
         Message<T> message;
         long callTime = System.nanoTime();
         try {
@@ -467,10 +467,11 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
             messageProcessed(message);
             if (!isValidConsumerEpoch(message)) {
                 long executionTime = System.nanoTime() - callTime;
-                if (executionTime >= unit.toNanos(timeout)) {
+                long timeoutInNanos = unit.toNanos(timeout);
+                if (executionTime >= timeoutInNanos) {
                     return null;
                 } else {
-                    return internalReceive((int) (timeout - executionTime), TimeUnit.NANOSECONDS);
+                    return internalReceive(timeoutInNanos - executionTime, TimeUnit.NANOSECONDS);
                 }
             }
             return beforeConsume(message);

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiTopicsConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiTopicsConsumerImpl.java
@@ -360,7 +360,7 @@ public class MultiTopicsConsumerImpl<T> extends ConsumerBase<T> {
     }
 
     @Override
-    protected Message<T> internalReceive(int timeout, TimeUnit unit) throws PulsarClientException {
+    protected Message<T> internalReceive(long timeout, TimeUnit unit) throws PulsarClientException {
         Message<T> message;
 
         long callTime = System.nanoTime();
@@ -371,11 +371,12 @@ public class MultiTopicsConsumerImpl<T> extends ConsumerBase<T> {
                 checkArgument(message instanceof TopicMessageImpl);
                 if (!isValidConsumerEpoch(message)) {
                     long executionTime = System.nanoTime() - callTime;
-                    if (executionTime >= unit.toNanos(timeout)) {
+                    long timeoutInNanos = unit.toNanos(timeout);
+                    if (executionTime >= timeoutInNanos) {
                         return null;
                     } else {
                         resumeReceivingFromPausedConsumersIfNeeded();
-                        return internalReceive((int) (timeout - executionTime), TimeUnit.NANOSECONDS);
+                        return internalReceive(timeoutInNanos - executionTime, TimeUnit.NANOSECONDS);
                     }
                 }
                 unAckedMessageTracker.add(message.getMessageId(), message.getRedeliveryCount());


### PR DESCRIPTION
Fixes #15001

### Motivation

Currently, when we called `redeliverUnacknowledgedMessages` and consumer use receive with timeout unit is second, the timeout might not work.

When we use the second as receive timeout unit like `consumer.receive(3, TimeUnit.SECONDS);`, line 473 will pass a negative timeout to the next `internalReceive` calls, because we are subtracting nanoseconds from seconds.

https://github.com/apache/pulsar/blob/f3b87b65c6946eb197c1eece22cff8ff04e16fcb/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java#L459-L476


### Modifications

* Use the same type to subtract.
* Use long type as timeout argument.


### Documentation

Check the box below or label this PR directly (if you have committer privilege).

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
This is a bug fix, no need for docs.
  
- [ ] `doc` 
  
  (If this PR contains doc changes)


