### PR TITLE
[fix][transaction] Fix transaction REST API redirect issue.

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/TransactionsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/TransactionsBase.java
@@ -18,11 +18,9 @@
  */
 package org.apache.pulsar.broker.admin.impl;
 
-import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
 import static javax.ws.rs.core.Response.Status.METHOD_NOT_ALLOWED;
 import static javax.ws.rs.core.Response.Status.NOT_FOUND;
 import static javax.ws.rs.core.Response.Status.SERVICE_UNAVAILABLE;
-import static javax.ws.rs.core.Response.Status.TEMPORARY_REDIRECT;
 import com.google.common.collect.Lists;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -46,6 +44,7 @@ import org.apache.pulsar.client.api.transaction.TxnID;
 import org.apache.pulsar.common.naming.NamespaceName;
 import org.apache.pulsar.common.naming.TopicDomain;
 import org.apache.pulsar.common.naming.TopicName;
+import org.apache.pulsar.common.policies.data.TransactionBufferStats;
 import org.apache.pulsar.common.policies.data.TransactionCoordinatorInternalStats;
 import org.apache.pulsar.common.policies.data.TransactionCoordinatorStats;
 import org.apache.pulsar.common.policies.data.TransactionInBufferStats;
@@ -53,6 +52,7 @@ import org.apache.pulsar.common.policies.data.TransactionInPendingAckStats;
 import org.apache.pulsar.common.policies.data.TransactionLogStats;
 import org.apache.pulsar.common.policies.data.TransactionMetadata;
 import org.apache.pulsar.common.policies.data.TransactionPendingAckInternalStats;
+import org.apache.pulsar.common.policies.data.TransactionPendingAckStats;
 import org.apache.pulsar.common.util.Codec;
 import org.apache.pulsar.common.util.FutureUtil;
 import org.apache.pulsar.transaction.coordinator.TransactionCoordinatorID;
@@ -67,216 +67,144 @@ public abstract class TransactionsBase extends AdminResource {
 
     protected void internalGetCoordinatorStats(AsyncResponse asyncResponse, boolean authoritative,
                                                Integer coordinatorId) {
-        if (pulsar().getConfig().isTransactionCoordinatorEnabled()) {
-            if (coordinatorId != null) {
-                validateTopicOwnership(TopicName.TRANSACTION_COORDINATOR_ASSIGN.getPartition(coordinatorId),
-                        authoritative);
-                TransactionMetadataStore transactionMetadataStore =
-                        pulsar().getTransactionMetadataStoreService().getStores()
-                                .get(TransactionCoordinatorID.get(coordinatorId));
-                if (transactionMetadataStore == null) {
-                    asyncResponse.resume(new RestException(NOT_FOUND,
-                            "Transaction coordinator not found! coordinator id : " + coordinatorId));
+        if (coordinatorId != null) {
+            validateTopicOwnership(TopicName.TRANSACTION_COORDINATOR_ASSIGN.getPartition(coordinatorId),
+                    authoritative);
+            TransactionMetadataStore transactionMetadataStore =
+                    pulsar().getTransactionMetadataStoreService().getStores()
+                            .get(TransactionCoordinatorID.get(coordinatorId));
+            if (transactionMetadataStore == null) {
+                asyncResponse.resume(new RestException(NOT_FOUND,
+                        "Transaction coordinator not found! coordinator id : " + coordinatorId));
+                return;
+            }
+            asyncResponse.resume(transactionMetadataStore.getCoordinatorStats());
+        } else {
+            getPartitionedTopicMetadataAsync(TopicName.TRANSACTION_COORDINATOR_ASSIGN,
+                    false, false).thenAccept(partitionMetadata -> {
+                if (partitionMetadata.partitions == 0) {
+                    asyncResponse.resume(new RestException(Response.Status.NOT_FOUND,
+                            "Transaction coordinator not found"));
                     return;
                 }
-                asyncResponse.resume(transactionMetadataStore.getCoordinatorStats());
-            } else {
-                getPartitionedTopicMetadataAsync(TopicName.TRANSACTION_COORDINATOR_ASSIGN,
-                        false, false).thenAccept(partitionMetadata -> {
-                    if (partitionMetadata.partitions == 0) {
-                        asyncResponse.resume(new RestException(Response.Status.NOT_FOUND,
-                                "Transaction coordinator not found"));
+                List<CompletableFuture<TransactionCoordinatorStats>> transactionMetadataStoreInfoFutures =
+                        Lists.newArrayList();
+                for (int i = 0; i < partitionMetadata.partitions; i++) {
+                    try {
+                        transactionMetadataStoreInfoFutures
+                                .add(pulsar().getAdminClient().transactions().getCoordinatorStatsByIdAsync(i));
+                    } catch (PulsarServerException e) {
+                        asyncResponse.resume(new RestException(e));
                         return;
                     }
-                    List<CompletableFuture<TransactionCoordinatorStats>> transactionMetadataStoreInfoFutures =
-                            Lists.newArrayList();
-                    for (int i = 0; i < partitionMetadata.partitions; i++) {
+                }
+                Map<Integer, TransactionCoordinatorStats> stats = new HashMap<>();
+                FutureUtil.waitForAll(transactionMetadataStoreInfoFutures).whenComplete((result, e) -> {
+                    if (e != null) {
+                        asyncResponse.resume(new RestException(e));
+                        return;
+                    }
+
+                    for (int i = 0; i < transactionMetadataStoreInfoFutures.size(); i++) {
                         try {
-                            transactionMetadataStoreInfoFutures
-                                    .add(pulsar().getAdminClient().transactions().getCoordinatorStatsByIdAsync(i));
-                        } catch (PulsarServerException e) {
-                            asyncResponse.resume(new RestException(e));
+                            stats.put(i, transactionMetadataStoreInfoFutures.get(i).get());
+                        } catch (Exception exception) {
+                            asyncResponse.resume(new RestException(exception.getCause()));
                             return;
                         }
                     }
-                    Map<Integer, TransactionCoordinatorStats> stats = new HashMap<>();
-                    FutureUtil.waitForAll(transactionMetadataStoreInfoFutures).whenComplete((result, e) -> {
-                        if (e != null) {
-                            asyncResponse.resume(new RestException(e));
-                            return;
-                        }
 
-                        for (int i = 0; i < transactionMetadataStoreInfoFutures.size(); i++) {
-                            try {
-                                stats.put(i, transactionMetadataStoreInfoFutures.get(i).get());
-                            } catch (Exception exception) {
-                                asyncResponse.resume(new RestException(exception.getCause()));
-                                return;
-                            }
-                        }
-
-                        asyncResponse.resume(stats);
-                    });
-                }).exceptionally(ex -> {
-                    log.error("[{}] Failed to get transaction coordinator state.", clientAppId(), ex);
-                    resumeAsyncResponseExceptionally(asyncResponse, ex);
-                    return null;
+                    asyncResponse.resume(stats);
                 });
-            }
-        } else {
-            asyncResponse.resume(new RestException(SERVICE_UNAVAILABLE,
-                    "This Broker is not configured with transactionCoordinatorEnabled=true."));
+            }).exceptionally(ex -> {
+                log.error("[{}] Failed to get transaction coordinator state.", clientAppId(), ex);
+                resumeAsyncResponseExceptionally(asyncResponse, ex);
+                return null;
+            });
         }
     }
 
-    protected void internalGetTransactionInPendingAckStats(AsyncResponse asyncResponse, boolean authoritative,
-                                                           long mostSigBits, long leastSigBits, String subName) {
-        if (pulsar().getConfig().isTransactionCoordinatorEnabled()) {
-            validateTopicOwnership(topicName, authoritative);
+    protected CompletableFuture<TransactionInPendingAckStats> internalGetTransactionInPendingAckStats(
+            boolean authoritative, long mostSigBits, long leastSigBits, String subName) {
+        return validateTopicOwnershipAsync(topicName, authoritative).thenCompose(__ -> {
             CompletableFuture<Optional<Topic>> topicFuture = pulsar().getBrokerService()
                     .getTopics().get(topicName.toString());
-            if (topicFuture != null) {
-                topicFuture.whenComplete((optionalTopic, e) -> {
-                    if (e != null) {
-                        asyncResponse.resume(new RestException(e));
-                        return;
-                    }
-                    if (!optionalTopic.isPresent()) {
-                        asyncResponse.resume(new RestException(TEMPORARY_REDIRECT,
-                                "Topic is not owned by this broker!"));
-                        return;
-                    }
-                    Topic topicObject = optionalTopic.get();
-                    if (topicObject instanceof PersistentTopic) {
-                        asyncResponse.resume(((PersistentTopic) topicObject)
-                                .getTransactionInPendingAckStats(new TxnID(mostSigBits, leastSigBits), subName));
-                    } else {
-                        asyncResponse.resume(new RestException(BAD_REQUEST, "Topic is not a persistent topic!"));
-                    }
-                });
-            } else {
-                asyncResponse.resume(new RestException(TEMPORARY_REDIRECT, "Topic is not owned by this broker!"));
+            if (topicFuture == null) {
+                return FutureUtil.failedFuture(new RestException(NOT_FOUND, "Topic not found"));
             }
-        } else {
-            asyncResponse.resume(new RestException(SERVICE_UNAVAILABLE,
-                    "This Broker is not configured with transactionCoordinatorEnabled=true."));
-        }
+            return topicFuture.thenCompose(optionalTopic -> {
+                if (!optionalTopic.isPresent()) {
+                    return FutureUtil.failedFuture(new RestException(NOT_FOUND, "Topic not found"));
+                }
+                return CompletableFuture.completedFuture(((PersistentTopic) optionalTopic.get())
+                        .getTransactionInPendingAckStats(new TxnID(mostSigBits, leastSigBits), subName));
+            });
+        });
     }
 
-    protected void internalGetTransactionInBufferStats(AsyncResponse asyncResponse, boolean authoritative,
-                                                       long mostSigBits, long leastSigBits) {
-        if (pulsar().getConfig().isTransactionCoordinatorEnabled()) {
-            validateTopicOwnership(topicName, authoritative);
+    protected CompletableFuture<TransactionInBufferStats> internalGetTransactionInBufferStats(
+            boolean authoritative, long mostSigBits, long leastSigBits) {
+        return validateTopicOwnershipAsync(topicName, authoritative).thenCompose(__ -> {
             CompletableFuture<Optional<Topic>> topicFuture = pulsar().getBrokerService()
                     .getTopics().get(topicName.toString());
-            if (topicFuture != null) {
-                topicFuture.whenComplete((optionalTopic, e) -> {
-                    if (e != null) {
-                        asyncResponse.resume(new RestException(e));
-                        return;
-                    }
-                    if (!optionalTopic.isPresent()) {
-                        asyncResponse.resume(new RestException(TEMPORARY_REDIRECT,
-                                "Topic is not owned by this broker!"));
-                        return;
-                    }
-                    Topic topicObject = optionalTopic.get();
-                    if (topicObject instanceof PersistentTopic) {
-                        TransactionInBufferStats transactionInBufferStats = ((PersistentTopic) topicObject)
-                                .getTransactionInBufferStats(new TxnID(mostSigBits, leastSigBits));
-                        asyncResponse.resume(transactionInBufferStats);
-                    } else {
-                        asyncResponse.resume(new RestException(BAD_REQUEST, "Topic is not a persistent topic!"));
-                    }
-                });
-            } else {
-                asyncResponse.resume(new RestException(TEMPORARY_REDIRECT, "Topic is not owned by this broker!"));
+            if (topicFuture == null) {
+                return FutureUtil.failedFuture(new RestException(NOT_FOUND, "Topic not found"));
             }
-        } else {
-            asyncResponse.resume(new RestException(SERVICE_UNAVAILABLE,
-                    "This Broker is not configured with transactionCoordinatorEnabled=true."));
-        }
+            return topicFuture.thenCompose(optionalTopic -> {
+                if (!optionalTopic.isPresent()) {
+                    return FutureUtil.failedFuture(new RestException(NOT_FOUND, "Topic not found"));
+                }
+                return CompletableFuture.completedFuture(((PersistentTopic) optionalTopic.get())
+                        .getTransactionInBufferStats(new TxnID(mostSigBits, leastSigBits)));
+            });
+        });
     }
 
-    protected void internalGetTransactionBufferStats(AsyncResponse asyncResponse, boolean authoritative) {
-        if (pulsar().getConfig().isTransactionCoordinatorEnabled()) {
-            validateTopicOwnership(topicName, authoritative);
+    protected CompletableFuture<TransactionBufferStats> internalGetTransactionBufferStats(boolean authoritative) {
+        return validateTopicOwnershipAsync(topicName, authoritative).thenCompose(__ -> {
             CompletableFuture<Optional<Topic>> topicFuture = pulsar().getBrokerService()
                     .getTopics().get(topicName.toString());
-            if (topicFuture != null) {
-                topicFuture.whenComplete((optionalTopic, e) -> {
-                    if (e != null) {
-                        asyncResponse.resume(new RestException(e));
-                        return;
-                    }
-
-                    if (!optionalTopic.isPresent()) {
-                        asyncResponse.resume(new RestException(TEMPORARY_REDIRECT,
-                                "Topic is not owned by this broker!"));
-                        return;
-                    }
-                    Topic topicObject = optionalTopic.get();
-                    if (topicObject instanceof PersistentTopic) {
-                        asyncResponse.resume(((PersistentTopic) topicObject).getTransactionBufferStats());
-                    } else {
-                        asyncResponse.resume(new RestException(BAD_REQUEST, "Topic is not a persistent topic!"));
-                    }
-                });
-            } else {
-                asyncResponse.resume(new RestException(TEMPORARY_REDIRECT, "Topic is not owned by this broker!"));
+            if (topicFuture == null) {
+                return FutureUtil.failedFuture(new RestException(NOT_FOUND, "Topic not found"));
             }
-        } else {
-            asyncResponse.resume(new RestException(SERVICE_UNAVAILABLE, "Broker don't support transaction!"));
-        }
+            return topicFuture.thenCompose(optionalTopic -> {
+                if (!optionalTopic.isPresent()) {
+                    return FutureUtil.failedFuture(new RestException(NOT_FOUND, "Topic not found"));
+                }
+                return CompletableFuture.completedFuture(((PersistentTopic) optionalTopic.get())
+                        .getTransactionBufferStats());
+            });
+        });
     }
 
-    protected void internalGetPendingAckStats(AsyncResponse asyncResponse, boolean authoritative, String subName) {
-        if (pulsar().getConfig().isTransactionCoordinatorEnabled()) {
-            validateTopicOwnership(topicName, authoritative);
+    protected CompletableFuture<TransactionPendingAckStats> internalGetPendingAckStats(boolean authoritative,
+                                                                                       String subName) {
+        return validateTopicOwnershipAsync(topicName, authoritative).thenCompose(__ -> {
             CompletableFuture<Optional<Topic>> topicFuture = pulsar().getBrokerService()
                     .getTopics().get(topicName.toString());
-            if (topicFuture != null) {
-                topicFuture.whenComplete((optionalTopic, e) -> {
-                    if (e != null) {
-                        asyncResponse.resume(new RestException(e));
-                        return;
-                    }
-
-                    if (!optionalTopic.isPresent()) {
-                        asyncResponse.resume(new RestException(TEMPORARY_REDIRECT,
-                                "Topic is not owned by this broker!"));
-                        return;
-                    }
-                    Topic topicObject = optionalTopic.get();
-                    if (topicObject instanceof PersistentTopic) {
-                        asyncResponse.resume(((PersistentTopic) topicObject).getTransactionPendingAckStats(subName));
-                    } else {
-                        asyncResponse.resume(new RestException(BAD_REQUEST, "Topic is not a persistent topic!"));
-                    }
-                });
-            } else {
-                asyncResponse.resume(new RestException(TEMPORARY_REDIRECT, "Topic is not owned by this broker!"));
+            if (topicFuture == null) {
+                return FutureUtil.failedFuture(new RestException(NOT_FOUND, "Topic not found"));
             }
-        } else {
-            asyncResponse.resume(new RestException(SERVICE_UNAVAILABLE, "Broker don't support transaction!"));
-        }
+            return topicFuture.thenCompose(optionalTopic -> {
+                if (!optionalTopic.isPresent()) {
+                    return FutureUtil.failedFuture(new RestException(NOT_FOUND, "Topic not found"));
+                }
+                return CompletableFuture.completedFuture(
+                        ((PersistentTopic) optionalTopic.get()).getTransactionPendingAckStats(subName));
+            });
+        });
     }
 
     protected void internalGetTransactionMetadata(AsyncResponse asyncResponse,
                                                   boolean authoritative, int mostSigBits, long leastSigBits) {
         try {
-            if (pulsar().getConfig().isTransactionCoordinatorEnabled()) {
-                validateTopicOwnership(TopicName.TRANSACTION_COORDINATOR_ASSIGN.getPartition(mostSigBits),
-                        authoritative);
-                CompletableFuture<TransactionMetadata> transactionMetadataFuture = new CompletableFuture<>();
-                TxnMeta txnMeta = pulsar().getTransactionMetadataStoreService()
-                        .getTxnMeta(new TxnID(mostSigBits, leastSigBits)).get();
-                getTransactionMetadata(txnMeta, transactionMetadataFuture);
-                asyncResponse.resume(transactionMetadataFuture.get(10, TimeUnit.SECONDS));
-            } else {
-                asyncResponse.resume(new RestException(SERVICE_UNAVAILABLE,
-                        "This Broker is not configured with transactionCoordinatorEnabled=true."));
-            }
+            validateTopicOwnership(TopicName.TRANSACTION_COORDINATOR_ASSIGN.getPartition(mostSigBits),
+                    authoritative);
+            CompletableFuture<TransactionMetadata> transactionMetadataFuture = new CompletableFuture<>();
+            TxnMeta txnMeta = pulsar().getTransactionMetadataStoreService()
+                    .getTxnMeta(new TxnID(mostSigBits, leastSigBits)).get();
+            getTransactionMetadata(txnMeta, transactionMetadataFuture);
+            asyncResponse.resume(transactionMetadataFuture.get(10, TimeUnit.SECONDS));
         } catch (Exception e) {
             if (e instanceof ExecutionException) {
                 if (e.getCause() instanceof CoordinatorNotFoundException
@@ -378,91 +306,87 @@ public abstract class TransactionsBase extends AdminResource {
     protected void internalGetSlowTransactions(AsyncResponse asyncResponse,
                                                boolean authoritative, long timeout, Integer coordinatorId) {
         try {
-            if (pulsar().getConfig().isTransactionCoordinatorEnabled()) {
-                if (coordinatorId != null) {
-                    validateTopicOwnership(TopicName.TRANSACTION_COORDINATOR_ASSIGN.getPartition(coordinatorId),
-                            authoritative);
-                    TransactionMetadataStore transactionMetadataStore =
-                            pulsar().getTransactionMetadataStoreService().getStores()
-                                    .get(TransactionCoordinatorID.get(coordinatorId));
-                    if (transactionMetadataStore == null) {
-                        asyncResponse.resume(new RestException(NOT_FOUND,
-                                "Transaction coordinator not found! coordinator id : " + coordinatorId));
+            if (coordinatorId != null) {
+                validateTopicOwnership(TopicName.TRANSACTION_COORDINATOR_ASSIGN.getPartition(coordinatorId),
+                        authoritative);
+                TransactionMetadataStore transactionMetadataStore =
+                        pulsar().getTransactionMetadataStoreService().getStores()
+                                .get(TransactionCoordinatorID.get(coordinatorId));
+                if (transactionMetadataStore == null) {
+                    asyncResponse.resume(new RestException(NOT_FOUND,
+                            "Transaction coordinator not found! coordinator id : " + coordinatorId));
+                    return;
+                }
+                List<TxnMeta> transactions = transactionMetadataStore.getSlowTransactions(timeout);
+                List<CompletableFuture<TransactionMetadata>> completableFutures = new ArrayList<>();
+                for (TxnMeta txnMeta : transactions) {
+                    CompletableFuture<TransactionMetadata> completableFuture = new CompletableFuture<>();
+                    getTransactionMetadata(txnMeta, completableFuture);
+                    completableFutures.add(completableFuture);
+                }
+
+                FutureUtil.waitForAll(completableFutures).whenComplete((v, e) -> {
+                    if (e != null) {
+                        asyncResponse.resume(new RestException(e.getCause()));
                         return;
                     }
-                    List<TxnMeta> transactions = transactionMetadataStore.getSlowTransactions(timeout);
-                    List<CompletableFuture<TransactionMetadata>> completableFutures = new ArrayList<>();
-                    for (TxnMeta txnMeta : transactions) {
-                        CompletableFuture<TransactionMetadata> completableFuture = new CompletableFuture<>();
-                        getTransactionMetadata(txnMeta, completableFuture);
-                        completableFutures.add(completableFuture);
-                    }
 
-                    FutureUtil.waitForAll(completableFutures).whenComplete((v, e) -> {
+                    Map<String, TransactionMetadata> transactionMetadata = new HashMap<>();
+                    for (CompletableFuture<TransactionMetadata> future : completableFutures) {
+                        try {
+                            transactionMetadata.put(future.get().txnId, future.get());
+                        } catch (Exception exception) {
+                            asyncResponse.resume(new RestException(exception.getCause()));
+                            return;
+                        }
+                    }
+                    asyncResponse.resume(transactionMetadata);
+                });
+            } else {
+                getPartitionedTopicMetadataAsync(TopicName.TRANSACTION_COORDINATOR_ASSIGN,
+                        false, false).thenAccept(partitionMetadata -> {
+                    if (partitionMetadata.partitions == 0) {
+                        asyncResponse.resume(new RestException(Response.Status.NOT_FOUND,
+                                "Transaction coordinator not found"));
+                        return;
+                    }
+                    List<CompletableFuture<Map<String, TransactionMetadata>>> completableFutures =
+                            Lists.newArrayList();
+                    for (int i = 0; i < partitionMetadata.partitions; i++) {
+                        try {
+                            completableFutures
+                                    .add(pulsar().getAdminClient().transactions()
+                                            .getSlowTransactionsByCoordinatorIdAsync(i, timeout,
+                                                    TimeUnit.MILLISECONDS));
+                        } catch (PulsarServerException e) {
+                            asyncResponse.resume(new RestException(e));
+                            return;
+                        }
+                    }
+                    Map<String, TransactionMetadata> transactionMetadataMaps = new HashMap<>();
+                    FutureUtil.waitForAll(completableFutures).whenComplete((result, e) -> {
                         if (e != null) {
-                            asyncResponse.resume(new RestException(e.getCause()));
+                            asyncResponse.resume(new RestException(e));
                             return;
                         }
 
-                        Map<String, TransactionMetadata> transactionMetadata = new HashMap<>();
-                        for (CompletableFuture<TransactionMetadata> future : completableFutures) {
+                        for (CompletableFuture<Map<String, TransactionMetadata>> transactionMetadataMap
+                                : completableFutures) {
                             try {
-                                transactionMetadata.put(future.get().txnId, future.get());
+                                transactionMetadataMaps.putAll(transactionMetadataMap.get());
                             } catch (Exception exception) {
                                 asyncResponse.resume(new RestException(exception.getCause()));
                                 return;
                             }
                         }
-                        asyncResponse.resume(transactionMetadata);
+                        asyncResponse.resume(transactionMetadataMaps);
                     });
-                } else {
-                    getPartitionedTopicMetadataAsync(TopicName.TRANSACTION_COORDINATOR_ASSIGN,
-                            false, false).thenAccept(partitionMetadata -> {
-                        if (partitionMetadata.partitions == 0) {
-                            asyncResponse.resume(new RestException(Response.Status.NOT_FOUND,
-                                    "Transaction coordinator not found"));
-                            return;
-                        }
-                        List<CompletableFuture<Map<String, TransactionMetadata>>> completableFutures =
-                                Lists.newArrayList();
-                        for (int i = 0; i < partitionMetadata.partitions; i++) {
-                            try {
-                                completableFutures
-                                        .add(pulsar().getAdminClient().transactions()
-                                                .getSlowTransactionsByCoordinatorIdAsync(i, timeout,
-                                                        TimeUnit.MILLISECONDS));
-                            } catch (PulsarServerException e) {
-                                asyncResponse.resume(new RestException(e));
-                                return;
-                            }
-                        }
-                        Map<String, TransactionMetadata> transactionMetadataMaps = new HashMap<>();
-                        FutureUtil.waitForAll(completableFutures).whenComplete((result, e) -> {
-                            if (e != null) {
-                                asyncResponse.resume(new RestException(e));
-                                return;
-                            }
+                }).exceptionally(ex -> {
+                    log.error("[{}] Failed to get transaction coordinator state.", clientAppId(), ex);
+                    resumeAsyncResponseExceptionally(asyncResponse, ex);
+                    return null;
+                });
 
-                            for (CompletableFuture<Map<String, TransactionMetadata>> transactionMetadataMap
-                                    : completableFutures) {
-                                try {
-                                    transactionMetadataMaps.putAll(transactionMetadataMap.get());
-                                } catch (Exception exception) {
-                                    asyncResponse.resume(new RestException(exception.getCause()));
-                                    return;
-                                }
-                            }
-                            asyncResponse.resume(transactionMetadataMaps);
-                        });
-                    }).exceptionally(ex -> {
-                        log.error("[{}] Failed to get transaction coordinator state.", clientAppId(), ex);
-                        resumeAsyncResponseExceptionally(asyncResponse, ex);
-                        return null;
-                    });
-
-                }
-            } else {
-                asyncResponse.resume(new RestException(SERVICE_UNAVAILABLE, "Broker don't support transaction!"));
             }
         } catch (Exception e) {
             asyncResponse.resume(new RestException(e));
@@ -472,33 +396,28 @@ public abstract class TransactionsBase extends AdminResource {
     protected void internalGetCoordinatorInternalStats(AsyncResponse asyncResponse, boolean authoritative,
                                                        boolean metadata, int coordinatorId) {
         try {
-            if (pulsar().getConfig().isTransactionCoordinatorEnabled()) {
-                TopicName topicName = TopicName.TRANSACTION_COORDINATOR_ASSIGN.getPartition(coordinatorId);
-                validateTopicOwnership(topicName, authoritative);
-                TransactionMetadataStore metadataStore = pulsar().getTransactionMetadataStoreService()
-                        .getStores().get(TransactionCoordinatorID.get(coordinatorId));
-                if (metadataStore == null) {
-                    asyncResponse.resume(new RestException(NOT_FOUND,
-                            "Transaction coordinator not found! coordinator id : " + coordinatorId));
-                    return;
-                }
-                if (metadataStore instanceof MLTransactionMetadataStore) {
-                    ManagedLedger managedLedger = ((MLTransactionMetadataStore) metadataStore).getManagedLedger();
-                    TransactionCoordinatorInternalStats transactionCoordinatorInternalStats =
-                            new TransactionCoordinatorInternalStats();
-                    TransactionLogStats transactionLogStats = new TransactionLogStats();
-                    transactionLogStats.managedLedgerName = managedLedger.getName();
-                    transactionLogStats.managedLedgerInternalStats =
-                            managedLedger.getManagedLedgerInternalStats(metadata).get();
-                    transactionCoordinatorInternalStats.transactionLogStats = transactionLogStats;
-                    asyncResponse.resume(transactionCoordinatorInternalStats);
-                } else {
-                    asyncResponse.resume(new RestException(METHOD_NOT_ALLOWED,
-                            "Broker don't use MLTransactionMetadataStore!"));
-                }
+            TopicName topicName = TopicName.TRANSACTION_COORDINATOR_ASSIGN.getPartition(coordinatorId);
+            validateTopicOwnership(topicName, authoritative);
+            TransactionMetadataStore metadataStore = pulsar().getTransactionMetadataStoreService()
+                    .getStores().get(TransactionCoordinatorID.get(coordinatorId));
+            if (metadataStore == null) {
+                asyncResponse.resume(new RestException(NOT_FOUND,
+                        "Transaction coordinator not found! coordinator id : " + coordinatorId));
+                return;
+            }
+            if (metadataStore instanceof MLTransactionMetadataStore) {
+                ManagedLedger managedLedger = ((MLTransactionMetadataStore) metadataStore).getManagedLedger();
+                TransactionCoordinatorInternalStats transactionCoordinatorInternalStats =
+                        new TransactionCoordinatorInternalStats();
+                TransactionLogStats transactionLogStats = new TransactionLogStats();
+                transactionLogStats.managedLedgerName = managedLedger.getName();
+                transactionLogStats.managedLedgerInternalStats =
+                        managedLedger.getManagedLedgerInternalStats(metadata).get();
+                transactionCoordinatorInternalStats.transactionLogStats = transactionLogStats;
+                asyncResponse.resume(transactionCoordinatorInternalStats);
             } else {
-                asyncResponse.resume(new RestException(SERVICE_UNAVAILABLE,
-                        "This Broker is not configured with transactionCoordinatorEnabled=true."));
+                asyncResponse.resume(new RestException(METHOD_NOT_ALLOWED,
+                        "Broker don't use MLTransactionMetadataStore!"));
             }
         } catch (Exception e) {
             asyncResponse.resume(new RestException(e.getCause()));
@@ -507,10 +426,6 @@ public abstract class TransactionsBase extends AdminResource {
 
     protected CompletableFuture<TransactionPendingAckInternalStats> internalGetPendingAckInternalStats(
             boolean authoritative, TopicName topicName, String subName, boolean metadata) {
-        if (!pulsar().getConfig().isTransactionCoordinatorEnabled()) {
-            return FutureUtil.failedFuture(new RestException(SERVICE_UNAVAILABLE,
-                    "This Broker is not configured with transactionCoordinatorEnabled=true."));
-        }
         return validateTopicOwnershipAsync(topicName, authoritative)
                 .thenCompose(__ -> {
                     CompletableFuture<Optional<Topic>> topicFuture = pulsar().getBrokerService()
@@ -540,6 +455,13 @@ public abstract class TransactionsBase extends AdminResource {
                         }
                     });
                 });
+    }
+
+    protected void checkTransactionCoordinatorEnabled() {
+        if (!pulsar().getConfig().isTransactionCoordinatorEnabled()) {
+           throw new RestException(SERVICE_UNAVAILABLE,
+                    "This Broker is not configured with transactionCoordinatorEnabled=true.");
+        }
     }
 
     protected void validateTopicName(String property, String namespace, String encodedTopic) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v3/Transactions.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v3/Transactions.java
@@ -275,7 +275,7 @@ public class Transactions extends TransactionsBase {
         try {
             checkTransactionCoordinatorEnabled();
             validateTopicName(tenant, namespace, encodedTopic);
-            internalGetPendingAckInternalStats(authoritative, topicName, subName, metadata)
+            internalGetPendingAckInternalStats(authoritative, subName, metadata)
                     .thenAccept(stats -> asyncResponse.resume(stats))
                     .exceptionally(ex -> {
                         Throwable cause = FutureUtil.unwrapCompletionException(ex);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v3/Transactions.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v3/Transactions.java
@@ -61,6 +61,7 @@ public class Transactions extends TransactionsBase {
                                     @QueryParam("authoritative")
                                     @DefaultValue("false") boolean authoritative,
                                     @QueryParam("coordinatorId") Integer coordinatorId) {
+        checkTransactionCoordinatorEnabled();
         internalGetCoordinatorStats(asyncResponse, authoritative, coordinatorId);
     }
 
@@ -82,9 +83,19 @@ public class Transactions extends TransactionsBase {
                                             @PathParam("topic") @Encoded String encodedTopic,
                                             @PathParam("mostSigBits") String mostSigBits,
                                             @PathParam("leastSigBits") String leastSigBits) {
-        validateTopicName(tenant, namespace, encodedTopic);
-        internalGetTransactionInBufferStats(asyncResponse, authoritative,
-                Long.parseLong(mostSigBits), Long.parseLong(leastSigBits));
+        try {
+            checkTransactionCoordinatorEnabled();
+            validateTopicName(tenant, namespace, encodedTopic);
+            internalGetTransactionInBufferStats(authoritative, Long.parseLong(mostSigBits),
+                    Long.parseLong(leastSigBits))
+                    .thenAccept(stat -> asyncResponse.resume(stat))
+                    .exceptionally(ex -> {
+                        resumeAsyncResponseExceptionally(asyncResponse, ex);
+                        return null;
+                    });
+        } catch (Exception ex) {
+            resumeAsyncResponseExceptionally(asyncResponse, ex);
+        }
     }
 
     @GET
@@ -106,9 +117,19 @@ public class Transactions extends TransactionsBase {
                                                 @PathParam("mostSigBits") String mostSigBits,
                                                 @PathParam("leastSigBits") String leastSigBits,
                                                 @PathParam("subName") String subName) {
-        validateTopicName(tenant, namespace, encodedTopic);
-        internalGetTransactionInPendingAckStats(asyncResponse, authoritative, Long.parseLong(mostSigBits),
-                Long.parseLong(leastSigBits), subName);
+        try {
+            checkTransactionCoordinatorEnabled();
+            validateTopicName(tenant, namespace, encodedTopic);
+            internalGetTransactionInPendingAckStats(authoritative, Long.parseLong(mostSigBits),
+                    Long.parseLong(leastSigBits), subName)
+                    .thenAccept(stat -> asyncResponse.resume(stat))
+                    .exceptionally(ex -> {
+                        resumeAsyncResponseExceptionally(asyncResponse, ex);
+                        return null;
+                    });
+        } catch (Exception ex) {
+            resumeAsyncResponseExceptionally(asyncResponse, ex);
+        }
     }
 
     @GET
@@ -127,8 +148,18 @@ public class Transactions extends TransactionsBase {
                                           @PathParam("tenant") String tenant,
                                           @PathParam("namespace") String namespace,
                                           @PathParam("topic") @Encoded String encodedTopic) {
-        validateTopicName(tenant, namespace, encodedTopic);
-        internalGetTransactionBufferStats(asyncResponse, authoritative);
+        try {
+            checkTransactionCoordinatorEnabled();
+            validateTopicName(tenant, namespace, encodedTopic);
+            internalGetTransactionBufferStats(authoritative)
+                    .thenAccept(stat -> asyncResponse.resume(stat))
+                    .exceptionally(ex -> {
+                        resumeAsyncResponseExceptionally(asyncResponse, ex);
+                        return null;
+                    });
+        } catch (Exception ex) {
+            resumeAsyncResponseExceptionally(asyncResponse, ex);
+        }
     }
 
     @GET
@@ -148,8 +179,18 @@ public class Transactions extends TransactionsBase {
                                    @PathParam("namespace") String namespace,
                                    @PathParam("topic") @Encoded String encodedTopic,
                                    @PathParam("subName") String subName) {
-        validateTopicName(tenant, namespace, encodedTopic);
-        internalGetPendingAckStats(asyncResponse, authoritative, subName);
+        try {
+            checkTransactionCoordinatorEnabled();
+            validateTopicName(tenant, namespace, encodedTopic);
+            internalGetPendingAckStats(authoritative, subName)
+                    .thenAccept(stats -> asyncResponse.resume(stats))
+                    .exceptionally(ex -> {
+                        resumeAsyncResponseExceptionally(asyncResponse, ex);
+                        return null;
+                    });
+        } catch (Exception ex) {
+            resumeAsyncResponseExceptionally(asyncResponse, ex);
+        }
     }
 
     @GET
@@ -168,6 +209,7 @@ public class Transactions extends TransactionsBase {
                                        @DefaultValue("false") boolean authoritative,
                                        @PathParam("mostSigBits") String mostSigBits,
                                        @PathParam("leastSigBits") String leastSigBits) {
+        checkTransactionCoordinatorEnabled();
         internalGetTransactionMetadata(asyncResponse, authoritative, Integer.parseInt(mostSigBits),
                 Long.parseLong(leastSigBits));
     }
@@ -188,6 +230,7 @@ public class Transactions extends TransactionsBase {
                                     @DefaultValue("false") boolean authoritative,
                                     @PathParam("timeout") String timeout,
                                     @QueryParam("coordinatorId") Integer coordinatorId) {
+        checkTransactionCoordinatorEnabled();
         internalGetSlowTransactions(asyncResponse, authoritative, Long.parseLong(timeout), coordinatorId);
     }
 
@@ -205,6 +248,7 @@ public class Transactions extends TransactionsBase {
                                             @DefaultValue("false") boolean authoritative,
                                             @PathParam("coordinatorId") String coordinatorId,
                                             @QueryParam("metadata") @DefaultValue("false") boolean metadata) {
+        checkTransactionCoordinatorEnabled();
         internalGetCoordinatorInternalStats(asyncResponse, authoritative, metadata, Integer.parseInt(coordinatorId));
     }
 
@@ -229,6 +273,7 @@ public class Transactions extends TransactionsBase {
                                            @PathParam("subName") String subName,
                                            @QueryParam("metadata") @DefaultValue("false") boolean metadata) {
         try {
+            checkTransactionCoordinatorEnabled();
             validateTopicName(tenant, namespace, encodedTopic);
             internalGetPendingAckInternalStats(authoritative, topicName, subName, metadata)
                     .thenAccept(stats -> asyncResponse.resume(stats))


### PR DESCRIPTION
### Motivation

It's the same issue with patch #14876 fixed.

When topic does not exist, the original logic will return `TEMPORARY_REDIRECT`, it will cause the client below exception : 

```
Caused by: java.lang.NullPointerException: originalUrl
	at org.asynchttpclient.util.Assertions.assertNotNull(Assertions.java:23)
	at org.asynchttpclient.uri.UriParser.parse(UriParser.java:344)
	at org.asynchttpclient.uri.Uri.create(Uri.java:67)
	at org.asynchttpclient.netty.handler.intercept.Redirect30xInterceptor.exitAfterHandlingRedirect(Redirect30xInterceptor.java:128)
	at org.asynchttpclient.netty.handler.intercept.Interceptors.exitAfterIntercept(Interceptors.java:98)
	at org.asynchttpclient.netty.handler.HttpHandler.handleHttpResponse(HttpHandler.java:78)
	at org.asynchttpclient.netty.handler.HttpHandler.handleRead(HttpHandler.java:140)
```

### Modifications

- Add `checkTransactionCoordinatorEnabled`.
- Return `NOT_FOUND` instead of `TEMPORARY_REDIRECT`.
- Make `internalGetTransactionInPendingAckStats` fully async.
- Make `internalGetTransactionInBufferStats` fully async.
- Make `internalGetTransactionBufferStats` fully async.
- Make `internalGetPendingAckStats` fully async.

### Verifying this change

- [x] Make sure that the change passes the CI checks.


### Documentation

  
- [x] `no-need-doc` 
  



