### PR TITLE
[pulsar-io] KCA: properly handle KeyValue that getNativeObject() returns: corrected type + support for KeyValue<GenericRecord, GenericRecord>

### DIFF
--- a/pulsar-io/kafka-connect-adaptor/src/main/java/org/apache/pulsar/io/kafka/connect/KafkaConnectSink.java
+++ b/pulsar-io/kafka-connect-adaptor/src/main/java/org/apache/pulsar/io/kafka/connect/KafkaConnectSink.java
@@ -51,6 +51,7 @@ import org.apache.kafka.connect.sink.SinkTask;
 import org.apache.pulsar.client.api.SubscriptionType;
 import org.apache.pulsar.client.api.schema.GenericObject;
 import org.apache.pulsar.client.api.schema.KeyValueSchema;
+import org.apache.pulsar.common.schema.KeyValue;
 import org.apache.pulsar.common.schema.SchemaType;
 import org.apache.pulsar.functions.api.Record;
 import org.apache.pulsar.io.core.Sink;
@@ -259,12 +260,8 @@ public class KafkaConnectSink implements Sink<GenericObject> {
 
             Object nativeObject = sourceRecord.getValue().getNativeObject();
 
-            if (nativeObject instanceof org.apache.pulsar.common.schema.KeyValue) {
-                org.apache.pulsar.common.schema.KeyValue kv = (org.apache.pulsar.common.schema.KeyValue) nativeObject;
-                key = KafkaConnectData.getKafkaConnectData(kv.getKey(), keySchema);
-                value = KafkaConnectData.getKafkaConnectData(kv.getValue(), valueSchema);
-            } else if (nativeObject instanceof org.apache.pulsar.io.core.KeyValue) {
-                org.apache.pulsar.io.core.KeyValue kv = (org.apache.pulsar.io.core.KeyValue) nativeObject;
+            if (nativeObject instanceof KeyValue) {
+                KeyValue kv = (KeyValue) nativeObject;
                 key = KafkaConnectData.getKafkaConnectData(kv.getKey(), keySchema);
                 value = KafkaConnectData.getKafkaConnectData(kv.getValue(), valueSchema);
             } else if (nativeObject != null) {

--- a/pulsar-io/kafka-connect-adaptor/src/main/java/org/apache/pulsar/io/kafka/connect/KafkaConnectSink.java
+++ b/pulsar-io/kafka-connect-adaptor/src/main/java/org/apache/pulsar/io/kafka/connect/KafkaConnectSink.java
@@ -261,12 +261,12 @@ public class KafkaConnectSink implements Sink<GenericObject> {
 
             if (nativeObject instanceof org.apache.pulsar.common.schema.KeyValue) {
                 org.apache.pulsar.common.schema.KeyValue kv = (org.apache.pulsar.common.schema.KeyValue) nativeObject;
-                key = kv.getKey();
-                value = kv.getValue();
+                key = KafkaConnectData.getKafkaConnectData(kv.getKey(), keySchema);
+                value = KafkaConnectData.getKafkaConnectData(kv.getValue(), valueSchema);
             } else if (nativeObject instanceof org.apache.pulsar.io.core.KeyValue) {
                 org.apache.pulsar.io.core.KeyValue kv = (org.apache.pulsar.io.core.KeyValue) nativeObject;
-                key = kv.getKey();
-                value = kv.getValue();
+                key = KafkaConnectData.getKafkaConnectData(kv.getKey(), keySchema);
+                value = KafkaConnectData.getKafkaConnectData(kv.getValue(), valueSchema);
             } else if (nativeObject != null) {
                 throw new IllegalStateException("Cannot extract KeyValue data from " + nativeObject.getClass());
             } else {

--- a/pulsar-io/kafka-connect-adaptor/src/main/java/org/apache/pulsar/io/kafka/connect/schema/KafkaConnectData.java
+++ b/pulsar-io/kafka-connect-adaptor/src/main/java/org/apache/pulsar/io/kafka/connect/schema/KafkaConnectData.java
@@ -32,6 +32,7 @@ import org.apache.kafka.connect.data.Field;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.errors.DataException;
+import org.apache.pulsar.client.api.schema.GenericRecord;
 
 public class KafkaConnectData {
     public static Object getKafkaConnectData(Object nativeObject, Schema kafkaSchema) {
@@ -49,6 +50,10 @@ public class KafkaConnectData {
         } else if (nativeObject instanceof GenericData.Record) {
             GenericData.Record avroRecord = (GenericData.Record) nativeObject;
             return avroAsConnectData(avroRecord, kafkaSchema);
+        } else if (nativeObject instanceof GenericRecord) {
+            // Pulsar's GenericRecord
+            GenericRecord pulsarGenericRecord = (GenericRecord) nativeObject;
+            return pulsarGenericRecordAsConnectData(pulsarGenericRecord, kafkaSchema);
         }
 
         return nativeObject;
@@ -65,6 +70,21 @@ public class KafkaConnectData {
         Struct struct = new Struct(kafkaSchema);
         for (Field field : kafkaSchema.fields()) {
             struct.put(field, getKafkaConnectData(avroRecord.get(field.name()), field.schema()));
+        }
+        return struct;
+    }
+
+    static Object pulsarGenericRecordAsConnectData(GenericRecord genericRecord, Schema kafkaSchema) {
+        if (kafkaSchema == null) {
+            if (genericRecord == null) {
+                return null;
+            }
+            throw new DataException("Don't know how to convert " + genericRecord + " to Connect data (schema is null).");
+        }
+
+        Struct struct = new Struct(kafkaSchema);
+        for (Field field : kafkaSchema.fields()) {
+            struct.put(field, getKafkaConnectData(genericRecord.getField(field.name()), field.schema()));
         }
         return struct;
     }

--- a/pulsar-io/kafka-connect-adaptor/src/test/java/org/apache/pulsar/io/kafka/connect/KafkaConnectSinkTest.java
+++ b/pulsar-io/kafka-connect-adaptor/src/test/java/org/apache/pulsar/io/kafka/connect/KafkaConnectSinkTest.java
@@ -43,6 +43,7 @@ import org.apache.pulsar.client.impl.schema.AvroSchema;
 import org.apache.pulsar.client.impl.schema.JSONSchema;
 import org.apache.pulsar.client.impl.schema.generic.GenericAvroRecord;
 import org.apache.pulsar.client.util.MessageIdUtils;
+import org.apache.pulsar.common.schema.KeyValue;
 import org.apache.pulsar.functions.api.Record;
 import org.apache.pulsar.functions.source.PulsarRecord;
 import org.apache.pulsar.io.core.SinkContext;
@@ -515,20 +516,8 @@ public class KafkaConnectSinkTest extends ProducerConsumerBase  {
     }
 
     @Test
-    public void coreKeyValueSchemaTest() throws Exception {
-        org.apache.pulsar.io.core.KeyValue<Integer, String> kv =
-                new org.apache.pulsar.io.core.KeyValue<>(11, "value");
-        SinkRecord sinkRecord = recordSchemaTest(kv, Schema.KeyValue(Schema.INT32, Schema.STRING), 11, "INT32", "value", "STRING");
-        String val = (String) sinkRecord.value();
-        Assert.assertEquals(val, "value");
-        int key = (int) sinkRecord.key();
-        Assert.assertEquals(key, 11);
-    }
-
-    @Test
     public void schemaKeyValueSchemaTest() throws Exception {
-        org.apache.pulsar.common.schema.KeyValue<Integer, String> kv =
-                new org.apache.pulsar.common.schema.KeyValue<>(11, "value");
+        KeyValue<Integer, String> kv = new KeyValue<>(11, "value");
         SinkRecord sinkRecord = recordSchemaTest(kv, Schema.KeyValue(Schema.INT32, Schema.STRING), 11, "INT32", "value", "STRING");
         String val = (String) sinkRecord.value();
         Assert.assertEquals(val, "value");
@@ -563,9 +552,7 @@ public class KafkaConnectSinkTest extends ProducerConsumerBase  {
         // integer is coming back from ObjectMapper
         expectedValue.put("field3", 100);
 
-        org.apache.pulsar.common.schema.KeyValue<GenericRecord, GenericRecord> kv =
-                new org.apache.pulsar.common.schema.KeyValue<>(
-                            getGenericRecord(key, pulsarAvroSchema),
+        KeyValue<GenericRecord, GenericRecord> kv = new KeyValue<>(getGenericRecord(key, pulsarAvroSchema),
                             getGenericRecord(value, pulsarAvroSchema));
 
         SinkRecord sinkRecord = recordSchemaTest(kv, Schema.KeyValue(pulsarAvroSchema, pulsarAvroSchema),


### PR DESCRIPTION
### Motivation

KCA is confused between two KeyValue classes that we have: `org.apache.pulsar.common.schema.KeyValue` and `org.apache.pulsar.io.core.KeyValue`

`getNativeObject()` returns `common.schema.KeyValue` while the KCA expects `io.core.KeyValue`.
As result, sink fails with `ClassCastException: class org.apache.pulsar.common.schema.KeyValue cannot be cast to class org.apache.pulsar.io.core.KeyValue`

Long term it makes sense to get rid of the `io.core.KeyValue` (in the pulsar-io only) and replace its uses with newer `common.schema.KeyValue` (TBD)

### Modifications

Updated `KeyValue<>` to the type that `AutoConsumeSchema` returns, 
added handling of `[KeyValue<GenericRecord, GenericRecord>`.

### Verifying this change

Added unit tests

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API: (yes / no)
  - The schema: (yes / no / don't know)
  - The default values of configurations: (yes / no)
  - The wire protocol: (yes / no)
  - The rest endpoints: (yes / no)
  - The admin cli options: (yes / no)
  - Anything that affects deployment: (yes / no / don't know)

### Documentation

Check the box below or label this PR directly (if you have committer privilege).

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)


