### PR TITLE
[branch-2.8] Fix license files

### DIFF
--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -445,7 +445,7 @@ The Apache Software License, Version 2.0
     - org.eclipse.jetty.websocket-websocket-servlet-9.4.43.v20210629.jar
     - org.eclipse.jetty-jetty-alpn-conscrypt-server-9.4.43.v20210629.jar
     - org.eclipse.jetty-jetty-alpn-server-9.4.43.v20210629.jar
- * SnakeYaml -- org.yaml-snakeyaml-1.27.jar
+ * SnakeYaml -- org.yaml-snakeyaml-1.30.jar
  * RocksDB - org.rocksdb-rocksdbjni-6.10.2.jar
  * Google Error Prone Annotations - com.google.errorprone-error_prone_annotations-2.5.1.jar
  * Apache Thrifth - org.apache.thrift-libthrift-0.14.2.jar

--- a/pulsar-sql/presto-distribution/LICENSE
+++ b/pulsar-sql/presto-distribution/LICENSE
@@ -393,7 +393,7 @@ The Apache Software License, Version 2.0
   * RocksDB JNI
     - rocksdbjni-6.10.2.jar
   * SnakeYAML
-    - snakeyaml-1.27.jar
+    - snakeyaml-1.30.jar
   * Bean Validation API
     - validation-api-2.0.1.Final.jar
   * Objectsize


### PR DESCRIPTION
### Motivation


License check fails in branch-2.8

```
org.yaml-snakeyaml-1.30.jar unaccounted for in LICENSE
org.yaml-snakeyaml-1.27.jar mentioned in LICENSE, but not bundled
snakeyaml-1.30.jar unaccounted for in lib/presto/LICENSE
snakeyaml-1.30.jar unaccounted for in lib/presto/LICENSE
snakeyaml-1.27.jar mentioned in lib/presto/LICENSE, but not bundled

It looks like there are issues with the LICENSE/NOTICE.
Error: Process completed with exit code 2.
```
### Modifications

Update snakeyaml version in license files

- [x] `no-need-doc` 