### PR TITLE
[Client] Add test to ensure the message order in listener callbacks

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBase.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBase.java
@@ -955,8 +955,13 @@ public abstract class ConsumerBase<T> extends HandlerState implements Consumer<T
         }
     }
 
-    protected void triggerListener() {
-        // Use internalPinnedExecutor to maintain message ordering
+    protected void tryTriggerListener() {
+        if (listener != null) {
+            triggerListener();
+        }
+    }
+
+    private void triggerListener() {
         internalPinnedExecutor.execute(() -> {
             try {
                 // Listener should only have one pending/running executable to process a message
@@ -979,7 +984,6 @@ public abstract class ConsumerBase<T> extends HandlerState implements Consumer<T
                 }
             } catch (PulsarClientException e) {
                 log.warn("[{}] [{}] Failed to dequeue the message for listener", topic, subscription, e);
-                return;
             }
 
             if (log.isDebugEnabled()) {

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBase.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBase.java
@@ -984,6 +984,7 @@ public abstract class ConsumerBase<T> extends HandlerState implements Consumer<T
                 }
             } catch (PulsarClientException e) {
                 log.warn("[{}] [{}] Failed to dequeue the message for listener", topic, subscription, e);
+                return;
             }
 
             if (log.isDebugEnabled()) {

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
@@ -1343,12 +1343,6 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
 
     }
 
-    private void tryTriggerListener() {
-        if (listener != null) {
-            triggerListener();
-        }
-    }
-
     private ByteBuf processMessageChunk(ByteBuf compressedPayload, MessageMetadata msgMetadata, MessageIdImpl msgId,
             MessageIdData messageId, ClientCnx cnx) {
 

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiTopicsConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiTopicsConsumerImpl.java
@@ -305,9 +305,7 @@ public class MultiTopicsConsumerImpl<T> extends ConsumerBase<T> {
             notifyPendingBatchReceivedCallBack();
         }
 
-        if (listener != null) {
-            triggerListener();
-        }
+        tryTriggerListener();
     }
 
     @Override

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ZeroQueueConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ZeroQueueConsumerImpl.java
@@ -171,7 +171,7 @@ public class ZeroQueueConsumerImpl<T> extends ConsumerImpl<T> {
     }
 
     @Override
-    protected void triggerListener() {
+    protected void tryTriggerListener() {
         // Ignore since it was already triggered in the triggerZeroQueueSizeListener() call
     }
 


### PR DESCRIPTION
### Motivation

#13023 introduced a performance regression, see details in
https://github.com/apache/pulsar/pull/13023#issuecomment-1090045572.

It might be caused by the frequent thread switch. Because to ensure the
message order, we must execute `ConsumerBase#triggerListener` in a
single thread because it will deliver the received message to other
threads, see
https://github.com/apache/pulsar/blob/81da8d3cd199fd6c1e4510a1c1c2ac71418efd5e/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBase.java#L970-L977

However, it's necessary for the correctness because `triggerListener`
could be called in two places:
- `messageReceived`, which is called in `pulsar-io-xxx` thread.
- `callMessageListener`, which is called in
  `pulsar-external-listener-xxx` thread.

Then these two threads can retrieve the results concurrently and it
leads to the message disordering.

This PR is to add a test that verifies the message order when message
listener is configured so that the following PRs won't introduce the
regression to correctness.

### Modifications

- Add `SimpleProducerConsumerTest#testListenerOrdering`.
- Make `triggerListener` private and the derived classes of
  `ConsumerBase` must call `tryTriggerListener`. It makes the code more
  clear that the performance issue is related to `triggerListener`.

### Verifying this change

If we removed the `internalPinnedExecutor.execute` block in
`triggerListener`, the `testListenerOrdering` could fail easily.