### PR TITLE
[Python] Generate universal2 wheel files for MacOS

### DIFF
--- a/pulsar-client-cpp/CMakeLists.txt
+++ b/pulsar-client-cpp/CMakeLists.txt
@@ -97,7 +97,7 @@ else() # GCC or Clang are mostly compatible:
     add_compile_options(-Wall -Wformat-security -Wvla -Werror) 
     # Turn off certain warnings that are too much pain for too little gain:
     add_compile_options(-Wno-sign-compare -Wno-deprecated-declarations -Wno-error=cpp)
-    if (CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64")
+    if (CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64" OR APPLE)
         add_compile_options(-msse4.2 -mpclmul)
     endif()
     # Options unique to Clang or GCC:


### PR DESCRIPTION
### Motivation

Generate MacOS universal wheel files for the Python clients. 

These wheels will contain the binary for both x86_64 and arm64, irrespective of the architecture of the Mac where the build is running.