### PR TITLE
[fix][txn]: fix transaction producer stuck problem

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
@@ -273,6 +273,7 @@ public class PulsarService implements AutoCloseable, ShutdownService {
     // key is listener name , value is pulsar address and pulsar ssl address
     private Map<String, AdvertisedListener> advertisedListeners;
     private NamespaceName heartbeatNamespaceV2;
+    private NamespaceName heartbeatNamespaceV1;
 
     public PulsarService(ServiceConfiguration config) {
         this(config, Optional.empty(), (exitCode) -> {
@@ -684,6 +685,7 @@ public class PulsarService implements AutoCloseable, ShutdownService {
 
             this.addWebServerHandlers(webService, metricsServlet, this.config);
             this.webService.start();
+            heartbeatNamespaceV1 = NamespaceService.getHeartbeatNamespace(this.advertisedAddress, this.config);
             heartbeatNamespaceV2 = NamespaceService.getHeartbeatNamespaceV2(this.advertisedAddress, this.config);
 
             // Refresh addresses and update configuration, since the port might have been dynamically assigned

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
@@ -2679,6 +2679,7 @@ public class BrokerService implements Closeable {
 
     public boolean isSystemTopic(TopicName topicName) {
         if (topicName.getNamespaceObject().equals(NamespaceName.SYSTEM_NAMESPACE)
+                || topicName.getNamespaceObject().equals(pulsar.getHeartbeatNamespaceV1())
                 || topicName.getNamespaceObject().equals(pulsar.getHeartbeatNamespaceV2())) {
             return true;
         }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
@@ -1256,6 +1256,7 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
                                     Throwable cause = exception.getCause();
                                     log.error("producerId {}, requestId {} : TransactionBuffer recover failed",
                                             producerId, requestId, exception);
+                                    producers.remove(producerId, producerFuture);
                                     commandSender.sendErrorResponse(requestId,
                                             ServiceUnitNotReadyException.getClientErrorCode(cause),
                                             cause.getMessage());

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/TopicTransactionBufferRecoverTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/TopicTransactionBufferRecoverTest.java
@@ -74,6 +74,7 @@ import org.apache.pulsar.common.policies.data.TopicStats;
 import org.apache.pulsar.common.util.FutureUtil;
 import org.apache.pulsar.common.util.collections.ConcurrentOpenHashMap;
 import org.awaitility.Awaitility;
+import org.powermock.reflect.Whitebox;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.DataProvider;
@@ -598,9 +599,7 @@ public class TopicTransactionBufferRecoverTest extends TransactionTestBase {
         bufferFuture.completeExceptionally(new BrokerServiceException.ServiceUnitNotReadyException("test"));
 
         // set fail future to topic transaction buffer
-        Field field = TopicTransactionBuffer.class.getDeclaredField("transactionBufferFuture");
-        field.setAccessible(true);
-        field.set(topicTransactionBuffer, bufferFuture);
+        Whitebox.setInternalState(topicTransactionBuffer, "transactionBufferFuture", bufferFuture);
 
         originalTopic.getProducers().get(originalTopic.getProducers().keySet().toArray()[0]).disconnect().get();
         // client producer has been close and reconnect
@@ -613,7 +612,7 @@ public class TopicTransactionBufferRecoverTest extends TransactionTestBase {
         // recover the buffer future
         bufferFuture = new CompletableFuture<>();
         bufferFuture.complete(null);
-        field.set(topicTransactionBuffer, bufferFuture);
+        Whitebox.setInternalState(topicTransactionBuffer, "transactionBufferFuture", bufferFuture);
 
         // client producer can't connect to broker
         Awaitility.await().until(producer::isConnected);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/TopicTransactionBufferRecoverTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/TopicTransactionBufferRecoverTest.java
@@ -46,6 +46,7 @@ import org.apache.commons.lang3.RandomUtils;
 import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.broker.service.AbstractTopic;
 import org.apache.pulsar.broker.service.BrokerService;
+import org.apache.pulsar.broker.service.BrokerServiceException;
 import org.apache.pulsar.broker.service.Topic;
 import org.apache.pulsar.broker.service.TransactionBufferSnapshotService;
 import org.apache.pulsar.broker.service.persistent.PersistentTopic;
@@ -569,4 +570,52 @@ public class TopicTransactionBufferRecoverTest extends TransactionTestBase {
         assertTrue(stats.getSubscriptions().keySet().contains("__compaction"));
     }
 
+    @Test
+    public void transactionBufferRecoverFailRemoveProducerFuture() throws Exception {
+        String topic = NAMESPACE1 + "/transactionBufferRecoverFailRemoveProducerFuture";
+
+        @Cleanup
+        Producer<byte[]> producer = pulsarClient
+                .newProducer()
+                .topic(topic)
+                .sendTimeout(0, TimeUnit.SECONDS)
+                .create();
+
+
+        // txn buffer init success
+        Transaction txn = pulsarClient.newTransaction()
+                .withTransactionTimeout(5, TimeUnit.SECONDS)
+                .build().get();
+        producer.newMessage(txn).value("test".getBytes()).sendAsync();
+        producer.newMessage(txn).value("test".getBytes()).sendAsync();
+        txn.commit().get();
+
+        PersistentTopic originalTopic = (PersistentTopic) getPulsarServiceList().get(0)
+                .getBrokerService().getTopic(TopicName.get(topic).toString(), false).get().get();
+        TopicTransactionBuffer topicTransactionBuffer = (TopicTransactionBuffer) originalTopic.getTransactionBuffer();
+
+        CompletableFuture<Void> bufferFuture = new CompletableFuture<>();
+        bufferFuture.completeExceptionally(new BrokerServiceException.ServiceUnitNotReadyException("test"));
+
+        // set fail future to topic transaction buffer
+        Field field = TopicTransactionBuffer.class.getDeclaredField("transactionBufferFuture");
+        field.setAccessible(true);
+        field.set(topicTransactionBuffer, bufferFuture);
+
+        originalTopic.getProducers().get(originalTopic.getProducers().keySet().toArray()[0]).disconnect().get();
+        // client producer has been close and reconnect
+        Awaitility.await().untilAsserted(() -> assertFalse(producer.isConnected()));
+        // producer is dis connect
+        Awaitility.await().until(() -> !producer.isConnected());
+        // client producer can't reconnect to broker
+        Awaitility.await().during(5, TimeUnit.SECONDS).until(() -> !producer.isConnected());
+
+        // recover the buffer future
+        bufferFuture = new CompletableFuture<>();
+        bufferFuture.complete(null);
+        field.set(topicTransactionBuffer, bufferFuture);
+
+        // client producer can't connect to broker
+        Awaitility.await().until(producer::isConnected);
+    }
 }


### PR DESCRIPTION
### Motivation

when transaction buffer recover fail, we don't remove the producer future from the producer map. If producer reconnect to this broker, it will throw 
```
pulsar-io-5-1] WARN  org.apache.pulsar.broker.service.ServerCnx - [/10.124.4.69:49108][persistent://public/default/s_topic-partition-5] Producer with id is already present on the connection, producerId=45",2022-04-02T06:34:17.042900012Z
```
and if client don't restart, we can't recover this producer the producer has been stucked
### Modifications

when topic transaction buffer recvoer fail, remove the producer from the map.

in master branch, https://github.com/apache/pulsar/pull/14467 has fixed this problem

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

Check the box below and label this PR (if you have committer privilege).

Need to update docs? 
  
- [x] `no-need-doc` 
bug fix.