### PR TITLE
[fix] [broker] fix duplicate calculation for msgRateIn and msgThroughputIn in replication PROM metric

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/NamespaceStatsAggregator.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/NamespaceStatsAggregator.java
@@ -250,15 +250,18 @@ public class NamespaceStatsAggregator {
         }
 
         topic.getReplicators().forEach((cluster, replicator) -> {
-            AggregatedReplicationStats aggReplStats = stats.replicationStats.computeIfAbsent(cluster,
-                    k -> new AggregatedReplicationStats());
-
             ReplicatorStatsImpl replStats = replicator.getStats();
+            AggregatedReplicationStats aggReplStats = stats.replicationStats.get(replicator.getRemoteCluster());
+            if (aggReplStats == null) {
+                aggReplStats = new AggregatedReplicationStats();
+                stats.replicationStats.put(replicator.getRemoteCluster(), aggReplStats);
+                aggReplStats.msgRateIn = replStats.msgRateIn;
+                aggReplStats.msgThroughputIn = replStats.msgThroughputIn;
+            }
+
             aggReplStats.msgRateOut += replStats.msgRateOut;
             aggReplStats.msgThroughputOut += replStats.msgThroughputOut;
             aggReplStats.replicationBacklog += replStats.replicationBacklog;
-            aggReplStats.msgRateIn += replStats.msgRateIn;
-            aggReplStats.msgThroughputIn += replStats.msgThroughputIn;
             aggReplStats.msgRateExpired += replStats.msgRateExpired;
             aggReplStats.connectedCount += replStats.connected ? 1 : 0;
             aggReplStats.replicationDelayInSeconds += replStats.replicationDelayInSeconds;


### PR DESCRIPTION
Fixes #15060 
### Motivation
See #15060 

### Modifications
Keep the replication metric calculation algorithms same as `org.apache.pulsar.broker.service.persistent.PersistentTopic#getStats`

<img width="871" alt="image" src="https://user-images.githubusercontent.com/4970972/162147581-a3853c85-7804-4fab-af9c-e94eedb058a0.png">


### Verifying this change

- [x]  Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.
### Does this pull request potentially affect one of the following parts:

If `yes` was chosen, please highlight the changes

- Dependencies (does it add or upgrade a dependency): (no)
- The public API: (no)
- The schema: (no)
- The default values of configurations: (no)
- The wire protocol: (no)
- The rest endpoints: (no)
- The admin cli options: (no)
- Anything that affects deployment: (no)

### Documentation
Check the box below and label this PR (if you have committer privilege).

Need to update docs? 
- [x] `no-need-doc` 
