### PR TITLE
[fix][security] Update spring library to fix CVE-2022-22965

### DIFF
--- a/pulsar-io/canal/pom.xml
+++ b/pulsar-io/canal/pom.xml
@@ -33,7 +33,7 @@
     <name>Pulsar IO :: Canal</name>
 
     <properties>
-        <spring.version>5.0.20.RELEASE</spring.version>
+        <spring.version>5.3.18</spring.version>
         <canal.version>1.1.5</canal.version>
     </properties>
 


### PR DESCRIPTION
Signed-off-by: Zixuan Liu <nodeces@gmail.com>

### Motivation

Fix CVE-2022-22965, see https://github.com/apache/pulsar/runs/5864286317?check_suite_focus=true#step:8:16

### Modifications

Update spring library from 5.0.20 to 5.3.18

### Documentation

- [x] `no-need-doc` 

