### PR TITLE
[improve][transaction] Solve rest api exceptions don't throw on broker server side

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v3/Transactions.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v3/Transactions.java
@@ -83,19 +83,15 @@ public class Transactions extends TransactionsBase {
                                             @PathParam("topic") @Encoded String encodedTopic,
                                             @PathParam("mostSigBits") String mostSigBits,
                                             @PathParam("leastSigBits") String leastSigBits) {
-        try {
-            checkTransactionCoordinatorEnabled();
-            validateTopicName(tenant, namespace, encodedTopic);
-            internalGetTransactionInBufferStats(authoritative, Long.parseLong(mostSigBits),
-                    Long.parseLong(leastSigBits))
-                    .thenAccept(stat -> asyncResponse.resume(stat))
-                    .exceptionally(ex -> {
-                        resumeAsyncResponseExceptionally(asyncResponse, ex);
-                        return null;
-                    });
-        } catch (Exception ex) {
-            resumeAsyncResponseExceptionally(asyncResponse, ex);
-        }
+        checkTransactionCoordinatorEnabled();
+        validateTopicName(tenant, namespace, encodedTopic);
+        internalGetTransactionInBufferStats(asyncResponse, authoritative, Long.parseLong(mostSigBits),
+                Long.parseLong(leastSigBits))
+                .thenAccept(stat -> asyncResponse.resume(stat))
+                .exceptionally(ex -> {
+                    resumeAsyncResponseExceptionally(asyncResponse, ex);
+                    return null;
+                });
     }
 
     @GET
@@ -117,19 +113,15 @@ public class Transactions extends TransactionsBase {
                                                 @PathParam("mostSigBits") String mostSigBits,
                                                 @PathParam("leastSigBits") String leastSigBits,
                                                 @PathParam("subName") String subName) {
-        try {
-            checkTransactionCoordinatorEnabled();
-            validateTopicName(tenant, namespace, encodedTopic);
-            internalGetTransactionInPendingAckStats(authoritative, Long.parseLong(mostSigBits),
-                    Long.parseLong(leastSigBits), subName)
-                    .thenAccept(stat -> asyncResponse.resume(stat))
-                    .exceptionally(ex -> {
-                        resumeAsyncResponseExceptionally(asyncResponse, ex);
-                        return null;
-                    });
-        } catch (Exception ex) {
-            resumeAsyncResponseExceptionally(asyncResponse, ex);
-        }
+        checkTransactionCoordinatorEnabled();
+        validateTopicName(tenant, namespace, encodedTopic);
+        internalGetTransactionInPendingAckStats(asyncResponse, authoritative, Long.parseLong(mostSigBits),
+                Long.parseLong(leastSigBits), subName)
+                .thenAccept(stat -> asyncResponse.resume(stat))
+                .exceptionally(ex -> {
+                    resumeAsyncResponseExceptionally(asyncResponse, ex);
+                    return null;
+                });
     }
 
     @GET
@@ -148,18 +140,14 @@ public class Transactions extends TransactionsBase {
                                           @PathParam("tenant") String tenant,
                                           @PathParam("namespace") String namespace,
                                           @PathParam("topic") @Encoded String encodedTopic) {
-        try {
-            checkTransactionCoordinatorEnabled();
-            validateTopicName(tenant, namespace, encodedTopic);
-            internalGetTransactionBufferStats(authoritative)
-                    .thenAccept(stat -> asyncResponse.resume(stat))
-                    .exceptionally(ex -> {
-                        resumeAsyncResponseExceptionally(asyncResponse, ex);
-                        return null;
-                    });
-        } catch (Exception ex) {
-            resumeAsyncResponseExceptionally(asyncResponse, ex);
-        }
+        checkTransactionCoordinatorEnabled();
+        validateTopicName(tenant, namespace, encodedTopic);
+        internalGetTransactionBufferStats(asyncResponse, authoritative)
+                .thenAccept(stat -> asyncResponse.resume(stat))
+                .exceptionally(ex -> {
+                    resumeAsyncResponseExceptionally(asyncResponse, ex);
+                    return null;
+                });
     }
 
     @GET
@@ -179,18 +167,14 @@ public class Transactions extends TransactionsBase {
                                    @PathParam("namespace") String namespace,
                                    @PathParam("topic") @Encoded String encodedTopic,
                                    @PathParam("subName") String subName) {
-        try {
-            checkTransactionCoordinatorEnabled();
-            validateTopicName(tenant, namespace, encodedTopic);
-            internalGetPendingAckStats(authoritative, subName)
-                    .thenAccept(stats -> asyncResponse.resume(stats))
-                    .exceptionally(ex -> {
-                        resumeAsyncResponseExceptionally(asyncResponse, ex);
-                        return null;
-                    });
-        } catch (Exception ex) {
-            resumeAsyncResponseExceptionally(asyncResponse, ex);
-        }
+        checkTransactionCoordinatorEnabled();
+        validateTopicName(tenant, namespace, encodedTopic);
+        internalGetPendingAckStats(asyncResponse, authoritative, subName)
+                .thenAccept(stats -> asyncResponse.resume(stats))
+                .exceptionally(ex -> {
+                    resumeAsyncResponseExceptionally(asyncResponse, ex);
+                    return null;
+                });
     }
 
     @GET
@@ -272,27 +256,23 @@ public class Transactions extends TransactionsBase {
                                            @PathParam("topic") @Encoded String encodedTopic,
                                            @PathParam("subName") String subName,
                                            @QueryParam("metadata") @DefaultValue("false") boolean metadata) {
-        try {
-            checkTransactionCoordinatorEnabled();
-            validateTopicName(tenant, namespace, encodedTopic);
-            internalGetPendingAckInternalStats(authoritative, subName, metadata)
-                    .thenAccept(stats -> asyncResponse.resume(stats))
-                    .exceptionally(ex -> {
-                        Throwable cause = FutureUtil.unwrapCompletionException(ex);
-                        log.error("[{}] Failed to get pending ack internal stats {}", clientAppId(), topicName, cause);
-                        if (cause instanceof BrokerServiceException.ServiceUnitNotReadyException) {
-                            asyncResponse.resume(new RestException(SERVICE_UNAVAILABLE, cause));
-                        } else if (cause instanceof BrokerServiceException.NotAllowedException) {
-                            asyncResponse.resume(new RestException(METHOD_NOT_ALLOWED, cause));
-                        } else if (cause instanceof BrokerServiceException.SubscriptionNotFoundException) {
-                            asyncResponse.resume(new RestException(NOT_FOUND, cause));
-                        } else {
-                            asyncResponse.resume(new RestException(cause));
-                        }
-                        return null;
-                    });
-        } catch (Exception ex) {
-            resumeAsyncResponseExceptionally(asyncResponse, ex);
-        }
+        checkTransactionCoordinatorEnabled();
+        validateTopicName(tenant, namespace, encodedTopic);
+        internalGetPendingAckInternalStats(asyncResponse, authoritative, subName, metadata)
+                .thenAccept(asyncResponse::resume)
+                .exceptionally(ex -> {
+                    Throwable cause = FutureUtil.unwrapCompletionException(ex);
+                    log.error("[{}] Failed to get pending ack internal stats {}", clientAppId(), topicName, cause);
+                    if (cause instanceof BrokerServiceException.ServiceUnitNotReadyException) {
+                        asyncResponse.resume(new RestException(SERVICE_UNAVAILABLE, cause));
+                    } else if (cause instanceof BrokerServiceException.NotAllowedException) {
+                        asyncResponse.resume(new RestException(METHOD_NOT_ALLOWED, cause));
+                    } else if (cause instanceof BrokerServiceException.SubscriptionNotFoundException) {
+                        asyncResponse.resume(new RestException(NOT_FOUND, cause));
+                    } else {
+                        asyncResponse.resume(new RestException(cause));
+                    }
+                    return null;
+                });
     }
 }


### PR DESCRIPTION


Fixes #14851


### Motivation
Let exception thrown on broker server side.


### Modifications
Remove try  catching exception. handle exception by asyncResponse
### Documentation

Check the box below or label this PR directly.

Need to update docs? 
  
- [x] `no-need-doc` 

code optimize. no new feature added.
