### PR TITLE
[Proxy] Suggestion put brokerProxyAllowedTargetPorts in proxy.conf

### DIFF
--- a/conf/proxy.conf
+++ b/conf/proxy.conf
@@ -82,6 +82,9 @@ webServiceTlsProtocols=
 # Examples:- [TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256]
 webServiceTlsCiphers=
 
+#Allowed broker target ports
+brokerProxyAllowedTargetPorts=6650,6651
+
 # Path for the file used to determine the rotation status for the proxy instance when responding
 # to service discovery health checks
 statusFilePath=

--- a/conf/proxy.conf
+++ b/conf/proxy.conf
@@ -82,7 +82,7 @@ webServiceTlsProtocols=
 # Examples:- [TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256]
 webServiceTlsCiphers=
 
-#Allowed broker target ports
+# Allowed broker target ports
 brokerProxyAllowedTargetPorts=6650,6651
 
 # Path for the file used to determine the rotation status for the proxy instance when responding


### PR DESCRIPTION

### Motivation
brokerProxyAllowedTargetPorts configure will check allowed broker target ports in proxy, but the configuration is not placed in proxy.conf, for many users who do not know how to modify it, if broker port not 6650 or 6651.



### Modifications
add conf 
`#Allowed broker target ports`
`brokerProxyAllowedTargetPorts=6650,6651`


### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API: (no)
  - The schema: (no )
  - The default values of configurations: (yes )
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: ( no)
  - Anything that affects deployment: (yes)

### Documentation

Need to update docs? 

- [x] `no-need-doc` 
  
