### PR TITLE
[C++] Fix single message metadata not set correctly

### DIFF
--- a/pulsar-client-cpp/lib/Message.cc
+++ b/pulsar-client-cpp/lib/Message.cc
@@ -79,12 +79,38 @@ Message::Message(const MessageId& messageID, proto::MessageMetadata& metadata, S
     impl_->metadata.mutable_properties()->CopyFrom(singleMetadata.properties());
     impl_->topicName_ = &topicName;
 
+    impl_->metadata.clear_properties();
+    if (singleMetadata.properties_size() > 0) {
+        impl_->metadata.mutable_properties()->Reserve(singleMetadata.properties_size());
+        for (int i = 0; i < singleMetadata.properties_size(); i++) {
+            auto keyValue = proto::KeyValue().New();
+            *keyValue = singleMetadata.properties(i);
+            impl_->metadata.mutable_properties()->AddAllocated(keyValue);
+        }
+    }
+
     if (singleMetadata.has_partition_key()) {
         impl_->metadata.set_partition_key(singleMetadata.partition_key());
+    } else {
+        impl_->metadata.clear_partition_key();
+    }
+
+    if (singleMetadata.has_ordering_key()) {
+        impl_->metadata.set_ordering_key(singleMetadata.ordering_key());
+    } else {
+        impl_->metadata.clear_ordering_key();
     }
 
     if (singleMetadata.has_event_time()) {
         impl_->metadata.set_event_time(singleMetadata.event_time());
+    } else {
+        impl_->metadata.clear_event_time();
+    }
+
+    if (singleMetadata.has_sequence_id()) {
+        impl_->metadata.set_sequence_id(singleMetadata.sequence_id());
+    } else {
+        impl_->metadata.clear_sequence_id();
     }
 }
 

--- a/pulsar-client-cpp/tests/ProtobufNativeSchemaTest.cc
+++ b/pulsar-client-cpp/tests/ProtobufNativeSchemaTest.cc
@@ -121,6 +121,9 @@ TEST(ProtobufNativeSchemaTest, testEndToEnd) {
     receivedTestMessage.ParseFromArray(msg.getData(), msg.getLength());
     ASSERT_EQ(receivedTestMessage.testenum(), ::proto::TestEnum::FAILOVER);
 
+    ASSERT_TRUE(msg.hasSchemaVersion());
+    ASSERT_EQ(msg.getSchemaVersion(), std::string(8L, '\0'));
+
     client.close();
 }
 

--- a/pulsar-client-cpp/tests/SchemaTest.cc
+++ b/pulsar-client-cpp/tests/SchemaTest.cc
@@ -73,3 +73,37 @@ TEST(SchemaTest, testSchema) {
 
     client.close();
 }
+
+TEST(SchemaTest, testHasSchemaVersion) {
+    Client client(lookupUrl);
+    std::string topic = "SchemaTest-HasSchemaVersion";
+    SchemaInfo stringSchema(SchemaType::STRING, "String", "");
+
+    Consumer consumer;
+    ASSERT_EQ(ResultOk, client.subscribe(topic + "1", "sub", ConsumerConfiguration().setSchema(stringSchema),
+                                         consumer));
+    Producer batchedProducer;
+    ASSERT_EQ(ResultOk, client.createProducer(topic + "1", ProducerConfiguration().setSchema(stringSchema),
+                                              batchedProducer));
+    Producer nonBatchedProducer;
+    ASSERT_EQ(ResultOk, client.createProducer(topic + "1", ProducerConfiguration().setSchema(stringSchema),
+                                              nonBatchedProducer));
+
+    ASSERT_EQ(ResultOk, batchedProducer.send(MessageBuilder().setContent("msg-0").build()));
+    ASSERT_EQ(ResultOk, nonBatchedProducer.send(MessageBuilder().setContent("msg-1").build()));
+
+    Message msgs[2];
+    ASSERT_EQ(ResultOk, consumer.receive(msgs[0], 3000));
+    ASSERT_EQ(ResultOk, consumer.receive(msgs[1], 3000));
+
+    std::string schemaVersion(8, '\0');
+    ASSERT_EQ(msgs[0].getDataAsString(), "msg-0");
+    ASSERT_TRUE(msgs[0].hasSchemaVersion());
+    ASSERT_EQ(msgs[0].getSchemaVersion(), schemaVersion);
+
+    ASSERT_EQ(msgs[1].getDataAsString(), "msg-1");
+    ASSERT_TRUE(msgs[1].hasSchemaVersion());
+    ASSERT_EQ(msgs[1].getSchemaVersion(), schemaVersion);
+
+    client.close();
+}


### PR DESCRIPTION
Fixes #15036

### Motivation

Recently I found the messages sent by C++ producer don't have the schema
version, which causes Java consumer cannot consume them with
`AUTO_CONSUME` schema. After rechecking the code, I found the C++ client
doesn't set single message metadata correctly, i.e. when batching is
enabled, some messages' metadata could be wrong.

- In `initBatchMessageMetadata`, the schema version is not set.
- In `serializeSingleMessageInBatchWithPayload`, the ordering key and
  the sequence id are not set.

In addition, when a C++ consumer consumes batched messages from a Java
producer, some metadata might be wrong. Because even for batched
messages, Java producer also sets the partition key and the ordering
key. It's redundant because only keys in `SingleMessageMetadata` should
be set. To avoid 2nd and later single messages in the batch reuse the
keys in `MessageMetadata`, Java client clears these fields if the
`SingleMessageMetadata` doesn't contain them when a `MessageImpl` is
constructed.

### Modifications

- Set the fields that were not set before when creating a batch. Some
  fields like `null_value` and `null_partition_key` are not set because
  they are not supported by C++ client at this moment.
- Use a more efficient way to copy the repeated fields of ProtoBuf.
- Clear some fields when they are not contained by the
  `SingleMessageMetadata` object when creating a `MessageImpl` so that
  the bahavior could be consisitent with Java client.

### Verifying this change

Following tests are added:
- `BatchMessageTest.testSingleMessageMetadata`: test 3 single messages
  in batch are consumed successfully, i.e. the correct metadata is received.
- `SchemaTest.testHasSchemaVersion`: test when schema is configured, all
  messages should has the schema version.
- The validation for schema version is also added to
  `ProtobufNativeSchemaTest.testEndToEnd`.