### PR TITLE
Use tlsCertRefreshCheckDurationSec instead of 0 for refresh value

### DIFF
--- a/pulsar-common/src/main/java/org/apache/pulsar/common/util/SecurityUtility.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/util/SecurityUtility.java
@@ -548,7 +548,7 @@ public class SecurityUtility {
         SslContextFactory sslCtxFactory = null;
         if (autoRefresh) {
             sslCtxFactory = new SslContextFactoryWithAutoRefresh(tlsAllowInsecureConnection, tlsTrustCertsFilePath,
-                tlsCertificateFilePath, tlsKeyFilePath, tlsRequireTrustedClientCertOnConnect, 0);
+                tlsCertificateFilePath, tlsKeyFilePath, tlsRequireTrustedClientCertOnConnect, certRefreshInSec);
         } else {
             sslCtxFactory = new SslContextFactory();
             SSLContext sslCtx = createSslContext(tlsAllowInsecureConnection, tlsTrustCertsFilePath,


### PR DESCRIPTION
### Motivation

The configuration value named `tlsCertRefreshCheckDurationSec` was not being used. Instead, the value was 0, which meant that the Pulsar component checked the cert for an update every time. Instead, we should honor the configuration.

### Modifications

* Use `tlsCertRefreshCheckDurationSec`, not 0.

### Verifying this change

This is a trivial change to use the configured value.

### Does this pull request potentially affect one of the following parts:

This will change behavior to decrease filesystem usage.