### PR TITLE
[Proxy] Exit if proxy service fails to start

### DIFF
--- a/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/ProxyServiceStarter.java
+++ b/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/ProxyServiceStarter.java
@@ -192,7 +192,12 @@ public class ProxyServiceStarter {
 
     public static void main(String[] args) throws Exception {
         ProxyServiceStarter serviceStarter = new ProxyServiceStarter(args);
-        serviceStarter.start();
+        try {
+            serviceStarter.start();
+        } catch (Throwable t) {
+            log.error("Failed to start proxy.", t);
+            Runtime.getRuntime().halt(1);
+        }
     }
 
     public void start() throws Exception {


### PR DESCRIPTION
### Motivation

The proxy service should exit if one of its servers fails to start. I discovered the current behavior when I hit the following error, but the proxy didn't exit:

```
2022-04-07T21:22:27,116Z [jdk.internal.loader.ClassLoaders$AppClassLoader@5ffd2b27] error Uncaught exception in thread main: Failed to start HTTP server on ports [8080, 8443]
java.io.IOException: Failed to start HTTP server on ports [8080, 8443]
	at org.apache.pulsar.proxy.server.WebServer.start(WebServer.java:242)
	at org.apache.pulsar.proxy.server.ProxyServiceStarter.start(ProxyServiceStarter.java:231)
	at org.apache.pulsar.proxy.server.ProxyServiceStarter.main(ProxyServiceStarter.java:195)
Caused by: java.lang.NullPointerException
	at org.apache.pulsar.common.util.keystoretls.KeyStoreSSLContext.createSSLContext(KeyStoreSSLContext.java:143)
	at org.apache.pulsar.common.util.keystoretls.KeyStoreSSLContext.createServerKeyStoreSslContext(KeyStoreSSLContext.java:259)
	at org.apache.pulsar.common.util.keystoretls.KeyStoreSSLContext.createServerSslContext(KeyStoreSSLContext.java:276)
	at org.apache.pulsar.common.util.keystoretls.NetSslContextBuilder.update(NetSslContextBuilder.java:72)
	at org.apache.pulsar.common.util.keystoretls.NetSslContextBuilder.update(NetSslContextBuilder.java:30)
	at org.apache.pulsar.common.util.SslContextAutoRefreshBuilder.get(SslContextAutoRefreshBuilder.java:79)
	at org.apache.pulsar.common.util.keystoretls.JettySslContextFactoryWithAutoRefresh.getSslContext(JettySslContextFactoryWithAutoRefresh.java:68)
	at org.eclipse.jetty.util.ssl.SslContextFactory.newSSLEngine(SslContextFactory.java:1903)
	at org.eclipse.jetty.server.SslConnectionFactory.doStart(SslConnectionFactory.java:99)
	at org.eclipse.jetty.util.component.AbstractLifeCycle.start(AbstractLifeCycle.java:73)
	at org.eclipse.jetty.util.component.ContainerLifeCycle.start(ContainerLifeCycle.java:169)
	at org.eclipse.jetty.util.component.ContainerLifeCycle.doStart(ContainerLifeCycle.java:117)
	at org.eclipse.jetty.server.AbstractConnector.doStart(AbstractConnector.java:321)
	at org.eclipse.jetty.server.AbstractNetworkConnector.doStart(AbstractNetworkConnector.java:81)
	at org.eclipse.jetty.server.ServerConnector.doStart(ServerConnector.java:234)
	at org.eclipse.jetty.util.component.AbstractLifeCycle.start(AbstractLifeCycle.java:73)
	at org.eclipse.jetty.server.Server.doStart(Server.java:401)
	at org.eclipse.jetty.util.component.AbstractLifeCycle.start(AbstractLifeCycle.java:73)
	at org.apache.pulsar.proxy.server.WebServer.start(WebServer.java:220)
	... 2 more
```

### Modifications

* Catch any throwable exception on the main thread and exit.

### Verifying this change

This is a trivial change.

### Does this pull request potentially affect one of the following parts:

It changes the behavior of the proxy when there is any error during startup. This behavior isn't surprising, though.