### PR TITLE
Ingore case when obfuscating passwords in configuration scripts

### DIFF
--- a/docker/pulsar/scripts/apply-config-from-env-with-prefix.py
+++ b/docker/pulsar/scripts/apply-config-from-env-with-prefix.py
@@ -60,7 +60,7 @@ for conf_filename in conf_files:
         v = os.environ[k].strip()
 
         # Hide the value in logs if is password.
-        if "password" in k:
+        if "password" in k.lower():
             displayValue = "********"
         else:
             displayValue = v
@@ -80,7 +80,7 @@ for conf_filename in conf_files:
             continue
 
         # Hide the value in logs if is password.
-        if "password" in k:
+        if "password" in k.lower():
             displayValue = "********"
         else:
             displayValue = v

--- a/docker/pulsar/scripts/apply-config-from-env.py
+++ b/docker/pulsar/scripts/apply-config-from-env.py
@@ -62,7 +62,7 @@ for conf_filename in conf_files:
         v = os.environ[k].strip()
 
         # Hide the value in logs if is password.
-        if "password" in k:
+        if "password" in k.lower():
             displayValue = "********"
         else:
             displayValue = v
@@ -86,7 +86,7 @@ for conf_filename in conf_files:
             continue
 
         # Hide the value in logs if is password.
-        if "password" in k:
+        if "password" in k.lower():
             displayValue = "********"
         else:
             displayValue = v


### PR DESCRIPTION
### Motivation

We shouldn't print passwords, even if their environment variables have an upper case `P` (since they all do, this is an especially important fix).

### Modifications

* Make the python script logic case insensitive

### Verifying this change

I manually verified this by running the script before and after the change. You can observe my logs here:

```
mmarshall-rmbp16:pulsar michaelmarshall$ tlsKeyStorePassword=mysecret docker/pulsar/scripts/apply-config-from-env.py conf/broker.conf 
[conf/broker.conf] Applying config tlsKeyStorePassword = mysecret
mmarshall-rmbp16:pulsar michaelmarshall$ tlsKeyStorePassword=mysecret docker/pulsar/scripts/apply-config-from-env.py conf/broker.conf 
[conf/broker.conf] Applying config tlsKeyStorePassword = ********
```

### Does this pull request potentially affect one of the following parts:
This is a backwards compatible change.