### PR TITLE
[fix][test] Add receive timeout to avoid block thread.

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SimpleProducerConsumerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SimpleProducerConsumerTest.java
@@ -2436,7 +2436,7 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
         Message<byte[]> msg;
         List<Message<byte[]>> messages1 = Lists.newArrayList();
         for (int i = 0; i < consumeMsgInParts; i++) {
-            msg = consumer.receive();
+            msg = consumer.receive(RECEIVE_TIMEOUT_SECONDS, TimeUnit.SECONDS);
             if (msg != null) {
                 messages1.add(msg);
                 consumer.acknowledge(msg);
@@ -2452,7 +2452,7 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
         // (1.b) consume second consumeMsgInParts msgs and trigger redeliver
         messages1.clear();
         for (int i = 0; i < consumeMsgInParts; i++) {
-            msg = consumer.receive();
+            msg = consumer.receive(RECEIVE_TIMEOUT_SECONDS, TimeUnit.SECONDS);
             if (msg != null) {
                 messages1.add(msg);
                 consumer.acknowledge(msg);
@@ -2475,7 +2475,7 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
         int remainingMsgs = (2 * receiverQueueSize) - (2 * consumeMsgInParts);
         messages1.clear();
         for (int i = 0; i < remainingMsgs; i++) {
-            msg = consumer.receive();
+            msg = consumer.receive(RECEIVE_TIMEOUT_SECONDS, TimeUnit.SECONDS);
             if (msg != null) {
                 messages1.add(msg);
                 consumer.acknowledge(msg);


### PR DESCRIPTION
### Motivation

After #12420, we can use `RECEIVE_TIMEOUT_SECONDS` to avoid consumers blocking receiving messages until the Github Action task times out.

### Modifications

- Add timeout when the consumer receives messages.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Documentation

- [x] `no-need-doc` 
