### PR TITLE
Ensure NamespaceEphemeralData has equals() operator

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/NamespaceEphemeralData.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/NamespaceEphemeralData.java
@@ -22,16 +22,12 @@ import com.google.common.collect.Maps;
 import java.util.Collections;
 import java.util.Map;
 import javax.validation.constraints.NotNull;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
+import lombok.Data;
 import lombok.NoArgsConstructor;
-import lombok.ToString;
 import org.apache.pulsar.policies.data.loadbalancer.AdvertisedListener;
 
-@Getter
+@Data
 @NoArgsConstructor
-@EqualsAndHashCode
-@ToString
 public class NamespaceEphemeralData {
     private String nativeUrl;
     private String nativeUrlTls;

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/namespace/NamespaceEphemeralDataTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/namespace/NamespaceEphemeralDataTest.java
@@ -1,0 +1,62 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.namespace;
+
+import static org.testng.Assert.assertEquals;
+import java.net.URI;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.pulsar.policies.data.loadbalancer.AdvertisedListener;
+import org.testng.annotations.Test;
+
+@Test(groups = "broker")
+public class NamespaceEphemeralDataTest {
+
+    private static void setFields(NamespaceEphemeralData ned) throws Exception {
+        ned.setNativeUrl("pulsar://localhost:6650");
+        ned.setNativeUrlTls("pulsar+ssl://localhost:6651");
+        ned.setHttpUrl("http://localhost:8080");
+        ned.setHttpUrlTls("https://localhost:8443");
+        ned.setDisabled(false);
+
+        Map<String, AdvertisedListener> advertisedListeners = new HashMap<>();
+        advertisedListeners.put("test-listener", AdvertisedListener.builder()
+                .brokerServiceUrl(new URI("pulsar://adv-addr:6650"))
+                .brokerServiceUrlTls(new URI("pulsar+ssl://adv-addr:6651"))
+                .build());
+        ned.setAdvertisedListeners(advertisedListeners);
+    }
+
+    /**
+     * We must ensure NamespaceEphemeralData respect the equals() properties because it's used as a resource lock,
+     * where equality is checked in the revalidation phase.
+     */
+    @Test
+    public void testEquals() throws Exception {
+        NamespaceEphemeralData ned1 = new NamespaceEphemeralData();
+        setFields(ned1);
+
+        NamespaceEphemeralData ned2 = new NamespaceEphemeralData();
+        setFields(ned2);
+
+        assertEquals(ned1.hashCode(), ned2.hashCode());
+        assertEquals(ned1, ned2);
+    }
+
+}

--- a/pulsar-common/src/main/java/org/apache/pulsar/policies/data/loadbalancer/AdvertisedListener.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/policies/data/loadbalancer/AdvertisedListener.java
@@ -21,10 +21,8 @@ package org.apache.pulsar.policies.data.loadbalancer;
 import java.net.URI;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
-import lombok.Getter;
+import lombok.Data;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
-import lombok.ToString;
 
 /**
  * The advertisedListener for broker with brokerServiceUrl and brokerServiceUrlTls.
@@ -32,27 +30,19 @@ import lombok.ToString;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-@ToString
+@Data
 public class AdvertisedListener {
     //
-    @Getter
-    @Setter
     // the broker service uri without ssl
     private URI brokerServiceUrl;
     //
-    @Getter
-    @Setter
     // the broker service uri with ssl
     private URI brokerServiceUrlTls;
 
     //
-    @Getter
-    @Setter
     // the broker service uri without ssl
     private URI brokerHttpUrl;
     //
-    @Getter
-    @Setter
     // the broker service uri with ssl
     private URI brokerHttpsUrl;
 


### PR DESCRIPTION
### Motivation

Fixes #14736 

The problem lies in that we are checking the lock content to establish that it's revalidated. In the specific case, the equality operator fails because `AdvertisedListener` class doesn't have `equals()`. 

This makes the lock revalidation logic to enter a loop in which we delete the lock, recreate and re-check and it always looks different content, although it also looks as created in the same ZK session.

This only happens where `AdvertisedListener` are configured in the broker.

### Modifications

Ensure `NamespaceEphemeralData` has a valid `equals()` operator to avoid the revalidation failures.

