### PR TITLE
[fix][broker] patch #5809: Fix the ledgerID not found cause NPE.

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
@@ -821,6 +821,8 @@ public class ManagedCursorImpl implements ManagedCursor {
                                 name, op.readPosition);
                     }
                     PENDING_READ_OPS_UPDATER.incrementAndGet(this);
+                    //Here maybe in schedule thread, recalculate readPosition, ledger maybe add some new entry.
+                    op.readPosition = ledger.startReadOperationOnLedger((PositionImpl) getReadPosition(), op);
                     ledger.asyncReadEntries(op);
                 } else {
                     if (log.isDebugEnabled()) {
@@ -2761,7 +2763,8 @@ public class ManagedCursorImpl implements ManagedCursor {
             }
 
             PENDING_READ_OPS_UPDATER.incrementAndGet(this);
-            opReadEntry.readPosition = (PositionImpl) getReadPosition();
+            //recalculate readPosition, cause ledger's add some new entry.
+            opReadEntry.readPosition = ledger.startReadOperationOnLedger((PositionImpl) getReadPosition(), opReadEntry);
             ledger.asyncReadEntries(opReadEntry);
         } else {
             // No one is waiting to be notified. Ignore

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
@@ -1752,7 +1752,7 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
         }
         if (opReadEntry.isInvalid()) {
             opReadEntry.readEntriesFailed(new ManagedLedgerException.NoMoreEntriesToReadException("The ceilingKey("
-                    + "opReadEntry.readPosition method is used to return the least key greater than or equal to the "
+                    + "opReadEntry.readPosition) method is used to return the least key greater than or equal to the "
                     + "given key, or null if there is no such key"), opReadEntry.ctx);
             return;
         }

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
@@ -2238,6 +2238,9 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
         if (null == ledgerId) {
             opReadEntry.makeInvalid();
             return null;
+        } else {
+            // for wait opReadEntry, the readPosition will recalculate.
+            opReadEntry.makeValid();
         }
 
         if (ledgerId != position.getLedgerId()) {

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
@@ -1751,9 +1751,9 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
             return;
         }
         if (opReadEntry.isInvalid()) {
-            opReadEntry.readEntriesFailed(new ManagedLedgerException.NoMoreEntriesToReadException("The ceilingKey(opReadEntry.readPosition"
-                    + ") method is used to return the least key greater than or equal to the given key, "
-                    + "or null if there is no such key"), opReadEntry.ctx);
+            opReadEntry.readEntriesFailed(new ManagedLedgerException.NoMoreEntriesToReadException("The ceilingKey("
+                    + "opReadEntry.readPosition method is used to return the least key greater than or equal to the "
+                    + "given key, or null if there is no such key"), opReadEntry.ctx);
             return;
         }
 

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
@@ -1750,6 +1750,12 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
             opReadEntry.readEntriesFailed(new ManagedLedgerFencedException(), opReadEntry.ctx);
             return;
         }
+        if (opReadEntry.isInvalid()) {
+            opReadEntry.readEntriesFailed(new ManagedLedgerException.NoMoreEntriesToReadException("The ceilingKey(opReadEntry.readPosition"
+                    + ") method is used to return the least key greater than or equal to the given key, "
+                    + "or null if there is no such key"), opReadEntry.ctx);
+            return;
+        }
 
         long ledgerId = opReadEntry.readPosition.getLedgerId();
 
@@ -2230,9 +2236,8 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
     PositionImpl startReadOperationOnLedger(PositionImpl position, OpReadEntry opReadEntry) {
         Long ledgerId = ledgers.ceilingKey(position.getLedgerId());
         if (null == ledgerId) {
-            opReadEntry.readEntriesFailed(new ManagedLedgerException.NoMoreEntriesToReadException("The ceilingKey(K key"
-                    + ") method is used to return the least key greater than or equal to the given key, "
-                    + "or null if there is no such key"), null);
+            opReadEntry.makeInvalid();
+            return null;
         }
 
         if (ledgerId != position.getLedgerId()) {

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/OpReadEntry.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/OpReadEntry.java
@@ -166,6 +166,10 @@ class OpReadEntry implements ReadEntriesCallback {
         this.invalid = true;
     }
 
+    public void makeValid() {
+        this.invalid = false;
+    }
+
     public boolean isInvalid() {
         return this.invalid;
     }


### PR DESCRIPTION
Master Issue:  #5669 #5809

### Motivation
Relational code:
https://github.com/apache/pulsar/blob/af351647710a9f5787d3cdc04cf9376895476eda/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/OpReadEntry.java#L48-L63


https://github.com/apache/pulsar/blob/af351647710a9f5787d3cdc04cf9376895476eda/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java#L2230-L2245


In #5809, there be 3 potential problem.

case 1: In `OpAddEntry` construction, it use `ManagedLedgerImpl#startReadOperationOnLedger`  to setup readPosition, in startReadOperationOnLedger, it will callback OpAddEntry, but now some property not initial yet(like curtos,callback, entries...), cause npe.
case 2:
in startReadOperationOnLedger, the callback did't pass on ctx, the callback process need it, also case npe.
case 3:
in startReadOperationOnLedger, it didn't return when not found ledger id. The judgement unbox also case npe.
https://github.com/apache/pulsar/blob/af351647710a9f5787d3cdc04cf9376895476eda/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java#L2238

### Modifications
patch #5809


### Documentation

- [x] `no-need-doc` 