### PR TITLE
[cleanup][broker] PIP 45: Deprecate zookeeper settings

### DIFF
--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -1021,12 +1021,6 @@ managedLedgerMaxUnackedRangesToPersist=10000
 # MetadataStore.
 managedLedgerMaxUnackedRangesToPersistInMetadataStore=1000
 
-# Max number of "acknowledgment holes" that can be stored in Zookeeper. If number of unack message range is higher
-# than this limit then broker will persist unacked ranges into bookkeeper to avoid additional data overhead into
-# zookeeper.
-# Deprecated: use managedLedgerMaxUnackedRangesToPersistInMetadataStore
-managedLedgerMaxUnackedRangesToPersistInZooKeeper=1000
-
 # Skip reading non-recoverable/unreadable data-ledger under managed-ledger's list. It helps when data-ledgers gets
 # corrupted at bookkeeper and managed-cursor is stuck at that ledger.
 autoSkipNonRecoverableData=false
@@ -1440,3 +1434,9 @@ tlsEnabled=false
 # Enable Key_Shared subscription (default is enabled)
 # @deprecated since 2.8.0 subscriptionTypesEnabled is preferred over subscriptionKeySharedEnable.
 subscriptionKeySharedEnable=true
+
+# Max number of "acknowledgment holes" that can be stored in Zookeeper. If number of unack message range is higher
+# than this limit then broker will persist unacked ranges into bookkeeper to avoid additional data overhead into
+# zookeeper.
+# Deprecated: use managedLedgerMaxUnackedRangesToPersistInMetadataStore
+managedLedgerMaxUnackedRangesToPersistInZooKeeper=1000

--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -1016,9 +1016,15 @@ managedLedgerCursorRolloverTimeInSeconds=14400
 # crashes.
 managedLedgerMaxUnackedRangesToPersist=10000
 
+# Max number of "acknowledgment holes" that can be stored in MetadataStore. If number of unack message range is higher
+# than this limit then broker will persist unacked ranges into bookkeeper to avoid additional data overhead into
+# MetadataStore.
+managedLedgerMaxUnackedRangesToPersistInMetadataStore=1000
+
 # Max number of "acknowledgment holes" that can be stored in Zookeeper. If number of unack message range is higher
 # than this limit then broker will persist unacked ranges into bookkeeper to avoid additional data overhead into
 # zookeeper.
+# Deprecated: use metadataStoreSessionTimeoutMillis
 managedLedgerMaxUnackedRangesToPersistInZooKeeper=1000
 
 # Skip reading non-recoverable/unreadable data-ledger under managed-ledger's list. It helps when data-ledgers gets

--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -1439,4 +1439,4 @@ subscriptionKeySharedEnable=true
 # than this limit then broker will persist unacked ranges into bookkeeper to avoid additional data overhead into
 # zookeeper.
 # Deprecated: use managedLedgerMaxUnackedRangesToPersistInMetadataStore
-managedLedgerMaxUnackedRangesToPersistInZooKeeper=1000
+managedLedgerMaxUnackedRangesToPersistInZooKeeper=-1

--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -1024,7 +1024,7 @@ managedLedgerMaxUnackedRangesToPersistInMetadataStore=1000
 # Max number of "acknowledgment holes" that can be stored in Zookeeper. If number of unack message range is higher
 # than this limit then broker will persist unacked ranges into bookkeeper to avoid additional data overhead into
 # zookeeper.
-# Deprecated: use metadataStoreSessionTimeoutMillis
+# Deprecated: use managedLedgerMaxUnackedRangesToPersistInMetadataStore
 managedLedgerMaxUnackedRangesToPersistInZooKeeper=1000
 
 # Skip reading non-recoverable/unreadable data-ledger under managed-ledger's list. It helps when data-ledgers gets

--- a/conf/standalone.conf
+++ b/conf/standalone.conf
@@ -710,9 +710,15 @@ managedLedgerMaxSizePerLedgerMbytes=2048
 # crashes.
 managedLedgerMaxUnackedRangesToPersist=10000
 
+# Max number of "acknowledgment holes" that can be stored in MetadataStore. If number of unack message range is higher
+# than this limit then broker will persist unacked ranges into bookkeeper to avoid additional data overhead into
+# MetadataStore.
+managedLedgerMaxUnackedRangesToPersistInMetadataStore=1000
+
 # Max number of "acknowledgment holes" that can be stored in Zookeeper. If number of unack message range is higher
 # than this limit then broker will persist unacked ranges into bookkeeper to avoid additional data overhead into
 # zookeeper.
+# Deprecated: use metadataStoreSessionTimeoutMillis
 managedLedgerMaxUnackedRangesToPersistInZooKeeper=1000
 
 # Skip reading non-recoverable/unreadable data-ledger under managed-ledger's list. It helps when data-ledgers gets

--- a/conf/standalone.conf
+++ b/conf/standalone.conf
@@ -1090,4 +1090,4 @@ configurationStoreServers=
 # than this limit then broker will persist unacked ranges into bookkeeper to avoid additional data overhead into
 # zookeeper.
 # Deprecated: use managedLedgerMaxUnackedRangesToPersistInMetadataStore
-managedLedgerMaxUnackedRangesToPersistInZooKeeper=1000
+managedLedgerMaxUnackedRangesToPersistInZooKeeper=-1

--- a/conf/standalone.conf
+++ b/conf/standalone.conf
@@ -715,12 +715,6 @@ managedLedgerMaxUnackedRangesToPersist=10000
 # MetadataStore.
 managedLedgerMaxUnackedRangesToPersistInMetadataStore=1000
 
-# Max number of "acknowledgment holes" that can be stored in Zookeeper. If number of unack message range is higher
-# than this limit then broker will persist unacked ranges into bookkeeper to avoid additional data overhead into
-# zookeeper.
-# Deprecated: use managedLedgerMaxUnackedRangesToPersistInMetadataStore
-managedLedgerMaxUnackedRangesToPersistInZooKeeper=1000
-
 # Skip reading non-recoverable/unreadable data-ledger under managed-ledger's list. It helps when data-ledgers gets
 # corrupted at bookkeeper and managed-cursor is stuck at that ledger.
 autoSkipNonRecoverableData=false
@@ -1091,3 +1085,9 @@ zookeeperServers=
 
 # Configuration Store connection string
 configurationStoreServers=
+
+# Max number of "acknowledgment holes" that can be stored in Zookeeper. If number of unack message range is higher
+# than this limit then broker will persist unacked ranges into bookkeeper to avoid additional data overhead into
+# zookeeper.
+# Deprecated: use managedLedgerMaxUnackedRangesToPersistInMetadataStore
+managedLedgerMaxUnackedRangesToPersistInZooKeeper=1000

--- a/conf/standalone.conf
+++ b/conf/standalone.conf
@@ -718,7 +718,7 @@ managedLedgerMaxUnackedRangesToPersistInMetadataStore=1000
 # Max number of "acknowledgment holes" that can be stored in Zookeeper. If number of unack message range is higher
 # than this limit then broker will persist unacked ranges into bookkeeper to avoid additional data overhead into
 # zookeeper.
-# Deprecated: use metadataStoreSessionTimeoutMillis
+# Deprecated: use managedLedgerMaxUnackedRangesToPersistInMetadataStore
 managedLedgerMaxUnackedRangesToPersistInZooKeeper=1000
 
 # Skip reading non-recoverable/unreadable data-ledger under managed-ledger's list. It helps when data-ledgers gets

--- a/deployment/terraform-ansible/templates/broker.conf
+++ b/deployment/terraform-ansible/templates/broker.conf
@@ -830,12 +830,6 @@ managedLedgerMaxUnackedRangesToPersist=10000
 # MetadataStore.
 managedLedgerMaxUnackedRangesToPersistInMetadataStore=1000
 
-# Max number of "acknowledgment holes" that can be stored in Zookeeper. If number of unack message range is higher
-# than this limit then broker will persist unacked ranges into bookkeeper to avoid additional data overhead into
-# zookeeper.
-# Deprecated: use managedLedgerMaxUnackedRangesToPersistInMetadataStore
-managedLedgerMaxUnackedRangesToPersistInZooKeeper=1000
-
 # Skip reading non-recoverable/unreadable data-ledger under managed-ledger's list. It helps when data-ledgers gets
 # corrupted at bookkeeper and managed-cursor is stuck at that ledger.
 autoSkipNonRecoverableData=false
@@ -1136,6 +1130,12 @@ replicationTlsEnabled=false
 
 # Deprecated. Use brokerDeleteInactiveTopicsFrequencySeconds
 brokerServicePurgeInactiveFrequencyInSeconds=60
+
+# Max number of "acknowledgment holes" that can be stored in Zookeeper. If number of unack message range is higher
+# than this limit then broker will persist unacked ranges into bookkeeper to avoid additional data overhead into
+# zookeeper.
+# Deprecated: use managedLedgerMaxUnackedRangesToPersistInMetadataStore
+managedLedgerMaxUnackedRangesToPersistInZooKeeper=1000
 
 ### --- Transaction config variables --- ###
 

--- a/deployment/terraform-ansible/templates/broker.conf
+++ b/deployment/terraform-ansible/templates/broker.conf
@@ -825,9 +825,15 @@ managedLedgerCursorRolloverTimeInSeconds=14400
 # crashes.
 managedLedgerMaxUnackedRangesToPersist=10000
 
+# Max number of "acknowledgment holes" that can be stored in MetadataStore. If number of unack message range is higher
+# than this limit then broker will persist unacked ranges into bookkeeper to avoid additional data overhead into
+# MetadataStore.
+managedLedgerMaxUnackedRangesToPersistInMetadataStore=1000
+
 # Max number of "acknowledgment holes" that can be stored in Zookeeper. If number of unack message range is higher
 # than this limit then broker will persist unacked ranges into bookkeeper to avoid additional data overhead into
 # zookeeper.
+# Deprecated: use metadataStoreSessionTimeoutMillis
 managedLedgerMaxUnackedRangesToPersistInZooKeeper=1000
 
 # Skip reading non-recoverable/unreadable data-ledger under managed-ledger's list. It helps when data-ledgers gets

--- a/deployment/terraform-ansible/templates/broker.conf
+++ b/deployment/terraform-ansible/templates/broker.conf
@@ -1135,7 +1135,7 @@ brokerServicePurgeInactiveFrequencyInSeconds=60
 # than this limit then broker will persist unacked ranges into bookkeeper to avoid additional data overhead into
 # zookeeper.
 # Deprecated: use managedLedgerMaxUnackedRangesToPersistInMetadataStore
-managedLedgerMaxUnackedRangesToPersistInZooKeeper=1000
+managedLedgerMaxUnackedRangesToPersistInZooKeeper=-1
 
 ### --- Transaction config variables --- ###
 

--- a/deployment/terraform-ansible/templates/broker.conf
+++ b/deployment/terraform-ansible/templates/broker.conf
@@ -833,7 +833,7 @@ managedLedgerMaxUnackedRangesToPersistInMetadataStore=1000
 # Max number of "acknowledgment holes" that can be stored in Zookeeper. If number of unack message range is higher
 # than this limit then broker will persist unacked ranges into bookkeeper to avoid additional data overhead into
 # zookeeper.
-# Deprecated: use metadataStoreSessionTimeoutMillis
+# Deprecated: use managedLedgerMaxUnackedRangesToPersistInMetadataStore
 managedLedgerMaxUnackedRangesToPersistInZooKeeper=1000
 
 # Skip reading non-recoverable/unreadable data-ledger under managed-ledger's list. It helps when data-ledgers gets

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedLedgerConfig.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedLedgerConfig.java
@@ -45,7 +45,7 @@ public class ManagedLedgerConfig {
     private int maxUnackedRangesToPersist = 10000;
     private int maxBatchDeletedIndexToPersist = 10000;
     private boolean deletionAtBatchIndexLevelEnabled = true;
-    private int maxUnackedRangesToPersistInZk = 1000;
+    private int maxUnackedRangesToPersistInMetadataStore = 1000;
     private int maxEntriesPerLedger = 50000;
     private int maxSizePerLedgerMb = 100;
     private int minimumRolloverTimeMs = 0;
@@ -483,12 +483,12 @@ public class ManagedLedgerConfig {
      * @return max unacked message ranges up to which it can store in Zookeeper
      *
      */
-    public int getMaxUnackedRangesToPersistInZk() {
-        return maxUnackedRangesToPersistInZk;
+    public int getMaxUnackedRangesToPersistInMetadataStore() {
+        return maxUnackedRangesToPersistInMetadataStore;
     }
 
-    public void setMaxUnackedRangesToPersistInZk(int maxUnackedRangesToPersistInZk) {
-        this.maxUnackedRangesToPersistInZk = maxUnackedRangesToPersistInZk;
+    public void setMaxUnackedRangesToPersistInMetadataStore(int maxUnackedRangesToPersistInMetadataStore) {
+        this.maxUnackedRangesToPersistInMetadataStore = maxUnackedRangesToPersistInMetadataStore;
     }
 
     /**

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
@@ -2326,7 +2326,7 @@ public class ManagedCursorImpl implements ManagedCursor {
         return cursorLedger != null
                 && !isCursorLedgerReadOnly
                 && config.getMaxUnackedRangesToPersist() > 0
-                && individualDeletedMessages.size() > config.getMaxUnackedRangesToPersistInZk();
+                && individualDeletedMessages.size() > config.getMaxUnackedRangesToPersistInMetadataStore();
     }
 
     private void persistPositionMetaStore(long cursorsLedgerId, PositionImpl position, Map<String, Long> properties,

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedCursorTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedCursorTest.java
@@ -2847,7 +2847,7 @@ public class ManagedCursorTest extends MockedBookKeeperTestCase {
         String cursorName = "c1";
         ManagedLedgerConfig managedLedgerConfig = new ManagedLedgerConfig();
         // metaStore is allowed to store only up to 10 deleted entries range
-        managedLedgerConfig.setMaxUnackedRangesToPersistInZk(10);
+        managedLedgerConfig.setMaxUnackedRangesToPersistInMetadataStore(10);
         ManagedLedgerImpl ledger = (ManagedLedgerImpl) factory.open(ledgerName, managedLedgerConfig);
 
         ManagedCursorImpl c1 = (ManagedCursorImpl) ledger.openCursor(cursorName);
@@ -3237,7 +3237,7 @@ public class ManagedCursorTest extends MockedBookKeeperTestCase {
     public void testBatchIndexesDeletionPersistAndRecover() throws ManagedLedgerException, InterruptedException {
         ManagedLedgerConfig managedLedgerConfig = new ManagedLedgerConfig();
         // Make sure the cursor metadata updated by the cursor ledger ID.
-        managedLedgerConfig.setMaxUnackedRangesToPersistInZk(-1);
+        managedLedgerConfig.setMaxUnackedRangesToPersistInMetadataStore(-1);
         ManagedLedger ledger = factory.open("test_batch_indexes_deletion_persistent", managedLedgerConfig);
         ManagedCursor cursor = ledger.openCursor("c1");
 

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -2735,7 +2735,7 @@ public class ServiceConfiguration implements PulsarConfiguration {
     }
 
     public int getManagedLedgerMaxUnackedRangesToPersistInMetadataStore() {
-        return managedLedgerMaxUnackedRangesToPersistInZooKeeper != 1000
+        return managedLedgerMaxUnackedRangesToPersistInZooKeeper > 0
                 ? managedLedgerMaxUnackedRangesToPersistInZooKeeper :
                 managedLedgerMaxUnackedRangesToPersistInMetadataStore;
     }

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -1814,12 +1814,19 @@ public class ServiceConfiguration implements PulsarConfiguration {
             + " will only be tracked in memory and messages will be redelivered in case of"
             + " crashes.")
     private int managedLedgerMaxUnackedRangesToPersist = 10000;
+    @Deprecated
     @FieldContext(
         category = CATEGORY_STORAGE_ML,
         doc = "Max number of `acknowledgment holes` that can be stored in Zookeeper.\n\n"
             + "If number of unack message range is higher than this limit then broker will persist"
             + " unacked ranges into bookkeeper to avoid additional data overhead into zookeeper.")
     private int managedLedgerMaxUnackedRangesToPersistInZooKeeper = 1000;
+    @FieldContext(
+            category = CATEGORY_STORAGE_ML,
+            doc = "Max number of `acknowledgment holes` that can be stored in MetadataStore.\n\n"
+                    + "If number of unack message range is higher than this limit then broker will persist"
+                    + " unacked ranges into bookkeeper to avoid additional data overhead into MetadataStore.")
+    private int managedLedgerMaxUnackedRangesToPersistInMetadataStore = 1000;
     @FieldContext(
             category = CATEGORY_STORAGE_OFFLOADING,
             doc = "Use Open Range-Set to cache unacked messages (it is memory efficient but it can take more cpu)"
@@ -2724,6 +2731,12 @@ public class ServiceConfiguration implements PulsarConfiguration {
             return SchemaCompatibilityStrategy.FULL;
         }
         return schemaCompatibilityStrategy;
+    }
+
+    public int getManagedLedgerMaxUnackedRangesToPersistInMetadataStore() {
+        return managedLedgerMaxUnackedRangesToPersistInZooKeeper != 1000 ?
+                managedLedgerMaxUnackedRangesToPersistInZooKeeper :
+                managedLedgerMaxUnackedRangesToPersistInMetadataStore;
     }
 
     public long getMetadataStoreSessionTimeoutMillis() {

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -2735,8 +2735,8 @@ public class ServiceConfiguration implements PulsarConfiguration {
     }
 
     public int getManagedLedgerMaxUnackedRangesToPersistInMetadataStore() {
-        return managedLedgerMaxUnackedRangesToPersistInZooKeeper != 1000 ?
-                managedLedgerMaxUnackedRangesToPersistInZooKeeper :
+        return managedLedgerMaxUnackedRangesToPersistInZooKeeper != 1000
+                ? managedLedgerMaxUnackedRangesToPersistInZooKeeper :
                 managedLedgerMaxUnackedRangesToPersistInMetadataStore;
     }
 

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -1817,6 +1817,7 @@ public class ServiceConfiguration implements PulsarConfiguration {
     @Deprecated
     @FieldContext(
         category = CATEGORY_STORAGE_ML,
+        deprecated = true,
         doc = "Max number of `acknowledgment holes` that can be stored in Zookeeper.\n\n"
             + "If number of unack message range is higher than this limit then broker will persist"
             + " unacked ranges into bookkeeper to avoid additional data overhead into zookeeper.")

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -1821,7 +1821,7 @@ public class ServiceConfiguration implements PulsarConfiguration {
         doc = "Max number of `acknowledgment holes` that can be stored in Zookeeper.\n\n"
             + "If number of unack message range is higher than this limit then broker will persist"
             + " unacked ranges into bookkeeper to avoid additional data overhead into zookeeper.")
-    private int managedLedgerMaxUnackedRangesToPersistInZooKeeper = 1000;
+    private int managedLedgerMaxUnackedRangesToPersistInZooKeeper = -1;
     @FieldContext(
             category = CATEGORY_STORAGE_ML,
             doc = "Max number of `acknowledgment holes` that can be stored in MetadataStore.\n\n"

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
@@ -1565,8 +1565,8 @@ public class BrokerService implements Closeable {
 
                     managedLedgerConfig
                             .setMaxUnackedRangesToPersist(serviceConfig.getManagedLedgerMaxUnackedRangesToPersist());
-                    managedLedgerConfig.setMaxUnackedRangesToPersistInZk(
-                            serviceConfig.getManagedLedgerMaxUnackedRangesToPersistInZooKeeper());
+                    managedLedgerConfig.setMaxUnackedRangesToPersistInMetadataStore(
+                            serviceConfig.getManagedLedgerMaxUnackedRangesToPersistInMetadataStore());
                     managedLedgerConfig.setMaxEntriesPerLedger(serviceConfig.getManagedLedgerMaxEntriesPerLedger());
                     managedLedgerConfig
                             .setMinimumRolloverTime(serviceConfig.getManagedLedgerMinLedgerRolloverTimeMinutes(),


### PR DESCRIPTION
### Motivation

To deprecate the zookeeper settings. PIP 45 introduced a unified metadata store API for Pulsar,
so we should make the metadata-related configuration start with `metadataStore`, not `zooKeeper`/`ZK`.

### Modifications

- Change `managedLedgerMaxUnackedRangesToPersistInZooKeeper` to `managedLedgerMaxUnackedRangesToPersistInMetadataStore`
- Change ML config `maxUnackedRangesToPersistInZk` to `maxUnackedRangesToPersistInMetadataStore`.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Does this pull request potentially affect one of the following parts:

  - The default values of configurations: (yes)

### Documentation

- [x] `doc-required` 
(Your PR needs to update docs and you will update later)

### Compatibility

Introduce `getManagedLedgerMaxUnackedRangesToPersistInMetadataStore` method to compatible with previous configurations.