### PR TITLE
Tiered Storage: add JClouds HttpClient driver

### DIFF
--- a/jclouds-shaded/pom.xml
+++ b/jclouds-shaded/pom.xml
@@ -42,6 +42,11 @@
     </dependency>
     <dependency>
       <groupId>org.apache.jclouds.driver</groupId>
+      <artifactId>jclouds-apachehc</artifactId>
+      <version>${jclouds.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.jclouds.driver</groupId>
       <artifactId>jclouds-slf4j</artifactId>
       <version>${jclouds.version}</version>
     </dependency>
@@ -74,11 +79,13 @@
                   <include>org.apache.jclouds:*</include>
                   <include>org.apache.jclouds.api:*</include>
                   <include>org.apache.jclouds.common:*</include>
+                  <include>org.apache.jclouds.driver:*</include>
                   <include>org.apache.jclouds.provider:*</include>
                   <include>com.google.inject.extensions:guice-assistedinject</include>
                   <include>com.google.inject:guice</include>
                   <include>com.google.inject.extensions:guice-multibindings</include>
                   <include>com.google.code.gson:gson</include>
+                  <include>org.apache.httpcomponents:*</include>
                   <include>javax.ws.rs:*</include>
                   <include>com.jamesmurty.utils:*</include>
                   <include>net.iharder:*</include>

--- a/jclouds-shaded/src/main/java/org/apache/pulsar/jclouds/ShadedJCloudsUtils.java
+++ b/jclouds-shaded/src/main/java/org/apache/pulsar/jclouds/ShadedJCloudsUtils.java
@@ -1,0 +1,63 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.jclouds;
+
+import com.google.inject.AbstractModule;
+import lombok.experimental.UtilityClass;
+import lombok.extern.slf4j.Slf4j;
+import org.jclouds.ContextBuilder;
+import org.jclouds.http.apachehc.config.ApacheHCHttpCommandExecutorServiceModule;
+import org.jclouds.logging.slf4j.config.SLF4JLoggingModule;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * This utility class helps in dealing with shaded dependencies (especially Guice).
+ */
+@UtilityClass
+@Slf4j
+public class ShadedJCloudsUtils {
+
+    /**
+     * Use this System property to temporarily disable Apache Http Client Module.
+     * If you encounter problems and decide to use this flag please
+     * open a GH and share your problem.
+     * Apache Http Client module should work well in all the environments.
+     */
+    private static final boolean ENABLE_APACHE_HC_MODULE = Boolean
+            .parseBoolean(System.getProperty("pulsar.jclouds.use_apache_hc", "true"));
+    static {
+        log.info("Considering -Dpulsar.jclouds.use_apache_hc=" + ENABLE_APACHE_HC_MODULE);
+    }
+
+    /**
+     * Setup standard modules.
+     * @param builder the build
+     */
+    public static void addStandardModules(ContextBuilder builder) {
+        List<AbstractModule> modules = new ArrayList<>();
+        modules.add(new SLF4JLoggingModule());
+        if (ENABLE_APACHE_HC_MODULE) {
+            modules.add(new ApacheHCHttpCommandExecutorServiceModule());
+        }
+        builder.modules(modules);
+    }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -243,7 +243,7 @@ flexible messaging model and an intuitive client API.</description>
     <maven-compiler-plugin.version>3.9.0</maven-compiler-plugin.version>
     <maven-dependency-plugin.version>3.1.2</maven-dependency-plugin.version>
     <maven-modernizer-plugin.version>2.3.0</maven-modernizer-plugin.version>
-    <maven-shade-plugin>3.2.4</maven-shade-plugin>
+    <maven-shade-plugin>3.3.0</maven-shade-plugin>
     <maven-antrun-plugin.version>3.0.0</maven-antrun-plugin.version>
     <properties-maven-plugin.version>1.0.0</properties-maven-plugin.version>
     <nifi-nar-maven-plugin.version>1.2.0</nifi-nar-maven-plugin.version>

--- a/tiered-storage/jcloud/pom.xml
+++ b/tiered-storage/jcloud/pom.xml
@@ -68,6 +68,10 @@
           <groupId>org.apache.jclouds.provider</groupId>
           <artifactId>*</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>org.apache.jclouds.driver</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
 

--- a/tiered-storage/jcloud/src/main/java/org/apache/bookkeeper/mledger/offload/jcloud/provider/JCloudBlobStoreProvider.java
+++ b/tiered-storage/jcloud/src/main/java/org/apache/bookkeeper/mledger/offload/jcloud/provider/JCloudBlobStoreProvider.java
@@ -36,7 +36,6 @@ import java.io.File;
 import java.io.IOException;
 import java.io.Serializable;
 import java.nio.charset.Charset;
-import java.util.Arrays;
 import java.util.Properties;
 import java.util.UUID;
 import lombok.extern.slf4j.Slf4j;

--- a/tiered-storage/jcloud/src/main/java/org/apache/bookkeeper/mledger/offload/jcloud/provider/JCloudBlobStoreProvider.java
+++ b/tiered-storage/jcloud/src/main/java/org/apache/bookkeeper/mledger/offload/jcloud/provider/JCloudBlobStoreProvider.java
@@ -44,6 +44,7 @@ import org.apache.bookkeeper.mledger.offload.jcloud.provider.TieredStorageConfig
 import org.apache.bookkeeper.mledger.offload.jcloud.provider.TieredStorageConfiguration.ConfigValidation;
 import org.apache.bookkeeper.mledger.offload.jcloud.provider.TieredStorageConfiguration.CredentialBuilder;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.pulsar.jclouds.ShadedJCloudsUtils;
 import org.jclouds.ContextBuilder;
 import org.jclouds.aws.domain.SessionCredentials;
 import org.jclouds.aws.s3.AWSS3ProviderMetadata;
@@ -57,7 +58,6 @@ import org.jclouds.domain.LocationBuilder;
 import org.jclouds.domain.LocationScope;
 import org.jclouds.googlecloud.GoogleCredentialsFromJson;
 import org.jclouds.googlecloudstorage.GoogleCloudStorageProviderMetadata;
-import org.jclouds.logging.slf4j.config.SLF4JLoggingModule;
 import org.jclouds.providers.AnonymousProviderMetadata;
 import org.jclouds.providers.ProviderMetadata;
 import org.jclouds.s3.S3ApiMetadata;
@@ -138,7 +138,7 @@ public enum JCloudBlobStoreProvider implements Serializable, ConfigValidation, B
         @Override
         public BlobStore getBlobStore(TieredStorageConfiguration config) {
             ContextBuilder contextBuilder = ContextBuilder.newBuilder(config.getProviderMetadata());
-            contextBuilder.modules(Arrays.asList(new SLF4JLoggingModule()));
+            ShadedJCloudsUtils.addStandardModules(contextBuilder);
             contextBuilder.overrides(config.getOverrides());
 
             if (config.getProviderCredentials() != null) {
@@ -203,9 +203,9 @@ public enum JCloudBlobStoreProvider implements Serializable, ConfigValidation, B
         @Override
         public BlobStore getBlobStore(TieredStorageConfiguration config) {
 
-            ContextBuilder builder =  ContextBuilder.newBuilder("transient");
-            builder.modules(Arrays.asList(new SLF4JLoggingModule()));
-            BlobStoreContext ctx = builder
+            ContextBuilder contextBuilder =  ContextBuilder.newBuilder("transient");
+            ShadedJCloudsUtils.addStandardModules(contextBuilder);
+            BlobStoreContext ctx = contextBuilder
                     .buildView(BlobStoreContext.class);
 
             BlobStore bs = ctx.getBlobStore();
@@ -287,7 +287,7 @@ public enum JCloudBlobStoreProvider implements Serializable, ConfigValidation, B
 
     static final BlobStoreBuilder BLOB_STORE_BUILDER = (TieredStorageConfiguration config) -> {
         ContextBuilder contextBuilder = ContextBuilder.newBuilder(config.getProviderMetadata());
-        contextBuilder.modules(Arrays.asList(new SLF4JLoggingModule()));
+        ShadedJCloudsUtils.addStandardModules(contextBuilder);
         contextBuilder.overrides(config.getOverrides());
 
         if (StringUtils.isNotEmpty(config.getServiceEndpoint())) {
@@ -372,7 +372,7 @@ public enum JCloudBlobStoreProvider implements Serializable, ConfigValidation, B
 
     static final BlobStoreBuilder ALIYUN_OSS_BLOB_STORE_BUILDER = (TieredStorageConfiguration config) -> {
         ContextBuilder contextBuilder = ContextBuilder.newBuilder(config.getProviderMetadata());
-        contextBuilder.modules(Arrays.asList(new SLF4JLoggingModule()));
+        ShadedJCloudsUtils.addStandardModules(contextBuilder);
         Properties overrides = config.getOverrides();
         // For security reasons, OSS supports only virtual hosted style access.
         overrides.setProperty(S3Constants.PROPERTY_S3_VIRTUAL_HOST_BUCKETS, "true");


### PR DESCRIPTION
### Motivation

Apache JClouds supports Apache HttpClient as library to perform HTTP class, that is better of the standard JDK HttpUrlConnection based provider.

See https://github.com/jclouds/jclouds/tree/master/drivers/apachehc

### Modifications

Modifications:
- add ApacheHCHttpCommandExecutorServiceModule module
- add jclouds driver based on Apache HTTP Client
- add a new ShadedJCloudsUtils that is needed to workaround some problems with the shading of Guice (AbstractModule class is problematic)
- add system property pulsar.jclouds.use_apache_hc to disable the new driver in case of problems


### Verifying this change

I have tested this manually.

### Does this pull request potentially affect one of the following parts:

Tiered Storage
