### PR TITLE
[fix][security] Remove log4j for CVE-2022-23307

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -180,7 +180,6 @@ flexible messaging model and an intuitive client API.</description>
     <commons-io.version>2.8.0</commons-io.version>
     <commons-codec.version>1.15</commons-codec.version>
     <javax.ws.rs-api.version>2.1</javax.ws.rs-api.version>
-    <log4j.version>1.2.17</log4j.version>
     <hdrHistogram.version>2.1.9</hdrHistogram.version>
     <javax.servlet-api>3.1.0</javax.servlet-api>
     <caffeine.version>2.9.1</caffeine.version>
@@ -788,18 +787,6 @@ flexible messaging model and an intuitive client API.</description>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-databind</artifactId>
         <version>${jackson.databind.version}</version>
-      </dependency>
-
-      <dependency>
-        <artifactId>log4j</artifactId>
-        <groupId>log4j</groupId>
-        <version>${log4j.version}</version>
-        <exclusions>
-          <exclusion>
-            <groupId>com.sun.jmx</groupId>
-            <artifactId>jmxri</artifactId>
-          </exclusion>
-        </exclusions>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
### Motivation

Currently, there are a lot of security issues in Log4j 1.x. Including CVE-2021-4104, CVE-2020-9493, CVE-2022-23307, CVE-2022-23305, CVE-2019-17571, CVE-2022-23302

[CVE-2022-23307](https://www.cvedetails.com/cve/CVE-2022-23307/) is a critical severity in Log4j 1.x. 

See https://github.com/apache/pulsar/runs/5965626775?check_suite_focus=true

Since log4j is currently an unused dependency in the project, we'd better remove log4j

```
[INFO] --- maven-dependency-plugin:3.1.1:analyze (default-cli) @ buildtools ---
[WARNING] Used undeclared dependencies found:
[WARNING]    org.slf4j:slf4j-api:jar:1.7.25:compile
[WARNING] Unused declared dependencies found:
[WARNING]    org.yaml:snakeyaml:jar:1.30:compile
[WARNING]    org.apache.ant:ant:jar:1.10.12:compile
[WARNING]    com.google.guava:guava:jar:31.0.1-jre:compile
[WARNING]    com.google.inject:guice:jar:4.2.3:compile
[WARNING]    junit:junit:jar:4.13.1:compile
[WARNING]    org.apache.logging.log4j:log4j-api:jar:2.17.1:compile
[WARNING]    org.apache.logging.log4j:log4j-core:jar:2.17.1:compile
[WARNING]    org.apache.logging.log4j:log4j-slf4j-impl:jar:2.17.1:compile
[WARNING]    org.apache.logging.log4j:log4j-1.2-api:jar:2.17.1:compile
[WARNING]    org.slf4j:jcl-over-slf4j:jar:1.7.32:compile
```

### Modifications

* Remove log4j 1.x

### Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

### Documentation

- [x] `no-need-doc` 
  