### PR TITLE
[broker] fix parameter saslJaasBrokerSectionName in broker.conf

### DIFF
--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -765,7 +765,7 @@ saslJaasClientAllowedIds=
 
 # Service Principal, for login context name.
 # Default value `SaslConstants.JAAS_DEFAULT_BROKER_SECTION_NAME`, which is "Broker".
-saslJaasBrokerSectionName=
+saslJaasServerSectionName=
 
 ### --- HTTP Server config --- ###
 


### PR DESCRIPTION
### Motivation
when the parameter saslJaasBrokerSectionName is set, it does not take effect  ， becase  `ServiceConfiguration` is saslJaasServerSectionName  not match.
```
 @FieldContext(
        category = CATEGORY_SASL_AUTH,
        doc = "Service Principal, for login context name. Default value is \"PulsarBroker\"."
    )
    private String saslJaasServerSectionName = SaslConstants.JAAS_DEFAULT_BROKER_SECTION_NAME;
```

### Modifications
alert conf 
`# Service Principal, for login context name.`
`# Default value `SaslConstants.JAAS_DEFAULT_BROKER_SECTION_NAME`, which is "Broker".`
`saslJaasServerSectionName=`


### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API: (no)
  - The schema: (no )
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: ( no)
  - Anything that affects deployment: (yes)

### Documentation

Need to update docs? 

- [x] `no-need-doc` 
  
