### PR TITLE
[WebSocket Proxy] Make websocket proxy thread pool size configurable

### DIFF
--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -1219,6 +1219,9 @@ webSocketServiceEnabled=false
 # Number of IO threads in Pulsar Client used in WebSocket proxy
 webSocketNumIoThreads=
 
+# Number of threads used by Websocket service
+webSocketNumServiceThreads=
+
 # Number of connections per Broker in Pulsar Client used in WebSocket proxy
 webSocketConnectionsPerBroker=
 

--- a/conf/websocket.conf
+++ b/conf/websocket.conf
@@ -52,6 +52,9 @@ clusterName=
 # Number of IO threads in Pulsar Client used in WebSocket proxy
 webSocketNumIoThreads=
 
+# Number of threads used by Websocket service
+webSocketNumServiceThreads=
+
 # Number of threads to use in HTTP server. Default is Runtime.getRuntime().availableProcessors()
 numHttpServerThreads=
 

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -2270,6 +2270,11 @@ public class ServiceConfiguration implements PulsarConfiguration {
         doc = "Number of IO threads in Pulsar Client used in WebSocket proxy"
     )
     private int webSocketNumIoThreads = Runtime.getRuntime().availableProcessors();
+
+    @FieldContext(category = CATEGORY_WEBSOCKET,
+            doc = "Number of threads used by Websocket service")
+    private int webSocketNumServiceThreads = 20;
+
     @FieldContext(
         category = CATEGORY_WEBSOCKET,
         doc = "Number of connections per Broker in Pulsar Client used in WebSocket proxy"

--- a/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/service/WebSocketProxyConfiguration.java
+++ b/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/service/WebSocketProxyConfiguration.java
@@ -31,14 +31,6 @@ import org.apache.pulsar.common.configuration.PulsarConfiguration;
 @Getter
 @Setter
 public class WebSocketProxyConfiguration implements PulsarConfiguration {
-
-    // Number of threads used by Proxy server
-    public static final int PROXY_SERVER_EXECUTOR_THREADS = 2 * Runtime.getRuntime().availableProcessors();
-    // Number of threads used by Websocket service
-    public static final int WEBSOCKET_SERVICE_THREADS = 20;
-    // Number of threads used by Global ZK
-    public static final int GLOBAL_ZK_THREADS = 8;
-
     @FieldContext(required = true, doc = "Name of the cluster to which this broker belongs to")
     private String clusterName;
 
@@ -139,6 +131,9 @@ public class WebSocketProxyConfiguration implements PulsarConfiguration {
 
     @FieldContext(doc = "Number of threads to used in HTTP server")
     private int numHttpServerThreads = Math.max(6, Runtime.getRuntime().availableProcessors());
+
+    @FieldContext(doc = "Number of threads used by Websocket service")
+    private int webSocketNumServiceThreads = 20;
 
     @FieldContext(doc = "Number of connections per broker in Pulsar client used in WebSocket proxy")
     private int webSocketConnectionsPerBroker = Runtime.getRuntime().availableProcessors();


### PR DESCRIPTION
### Motivation

- The thread pool size was hard coded to 20 threads

### Modifications

- make thread pool size configurable by `webSocketNumServiceThreads`
- remove unused orderedExecutor