### PR TITLE
[fix][ci] Owasp check: do not use 'install verify' to avoid build failures

### DIFF
--- a/.github/workflows/ci-owasp-dep-check.yaml
+++ b/.github/workflows/ci-owasp-dep-check.yaml
@@ -87,9 +87,9 @@ jobs:
           df -h
 
       # Projects dependent on flume, hdfs, hbase, and presto currently excluded from the scan.
-      - name: run "clean install verify" to trigger dependency check
+      - name: run "clean verify" to trigger dependency check
         if: ${{ steps.changes.outputs.poms == 'true' }}
-        run: mvn -q -B -ntp clean install verify -PskipDocker,owasp-dependency-check -DskipTests -pl '!pulsar-sql,!distribution/io,!distribution/offloaders,!tiered-storage/file-system,!pulsar-io/flume,!pulsar-io/hbase,!pulsar-io/hdfs2,!pulsar-io/hdfs3,!pulsar-io/docs'
+        run: mvn -q -B -ntp clean verify -PskipDocker,owasp-dependency-check -DskipTests -pl '!pulsar-sql,!distribution/io,!distribution/offloaders,!tiered-storage/file-system,!pulsar-io/flume,!pulsar-io/hbase,!pulsar-io/hdfs2,!pulsar-io/hdfs3,!pulsar-io/docs'
 
       - name: Upload report
         uses: actions/upload-artifact@v2

--- a/.github/workflows/ci-owasp-dep-check.yaml
+++ b/.github/workflows/ci-owasp-dep-check.yaml
@@ -57,6 +57,7 @@ jobs:
               - '**/pom.xml'
               - 'src/owasp-dependency-check-false-positives.xml'
               - 'src/owasp-dependency-check-suppressions.xml'
+              - '.github/workflows/ci-owasp-dep-check.yaml'
 
       - name: Cache local Maven repository
         if: ${{ steps.changes.outputs.poms == 'true' }}


### PR DESCRIPTION
### Motivation
The OWASP check uses `mvn clean install verify` that can cause compilation failures
For example: https://github.com/apache/pulsar/runs/5968671592?check_suite_focus=true#step:8:50

### Modifications

* Use `mvn clean verify`

- [x] `no-need-doc` 