### PR TITLE
[fix][pulsar-io] Fix memory leak in ElasticSearch sink

### DIFF
--- a/pulsar-io/elastic-search/src/main/java/org/apache/pulsar/io/elasticsearch/client/BulkProcessor.java
+++ b/pulsar-io/elastic-search/src/main/java/org/apache/pulsar/io/elasticsearch/client/BulkProcessor.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.util.List;
 import lombok.Builder;
 import lombok.Getter;
+import org.apache.pulsar.functions.api.Record;
 
 /**
  * Processor for "bulk" call to the Elastic REST Endpoint.
@@ -32,7 +33,7 @@ public interface BulkProcessor extends Closeable {
     @Builder
     @Getter
     class BulkOperationRequest {
-        private long operationId;
+        private Record pulsarRecord;
     }
 
     @Builder
@@ -57,6 +58,7 @@ public interface BulkProcessor extends Closeable {
     @Builder
     @Getter
     class BulkIndexRequest {
+        private Record record;
         private long requestId;
         private String index;
         private String documentId;
@@ -66,6 +68,7 @@ public interface BulkProcessor extends Closeable {
     @Builder
     @Getter
     class BulkDeleteRequest {
+        private Record record;
         private long requestId;
         private String index;
         private String documentId;

--- a/pulsar-io/elastic-search/src/test/java/org/apache/pulsar/io/elasticsearch/ElasticSearchClientTests.java
+++ b/pulsar-io/elastic-search/src/test/java/org/apache/pulsar/io/elasticsearch/ElasticSearchClientTests.java
@@ -344,13 +344,39 @@ public abstract class ElasticSearchClientTests extends ElasticSearchTestBase {
                     Awaitility.await().untilAsserted(() -> {
                         assertEquals(mockRecord.acked, 15);
                         assertEquals(mockRecord.failed, 0);
-                        assertEquals(client.records.size(), 0);
                     });
 
                 } finally {
                     client.getRestClient().deleteIndex(index);
                 }
             }
+        }
+    }
+
+    @Test
+    public void testBulkIndexAndDelete() throws Exception {
+        final String index = "indexbulktest-" + UUID.randomUUID();
+        ElasticSearchConfig config = new ElasticSearchConfig()
+                .setElasticSearchUrl("http://"+container.getHttpHostAddress())
+                .setIndexName(index)
+                .setBulkEnabled(true)
+                .setBulkActions(10)
+                .setBulkFlushIntervalInMs(-1L);
+
+        try (ElasticSearchClient client = new ElasticSearchClient(config)) {
+            assertTrue(client.createIndexIfNeeded(index));
+            MockRecord<GenericObject> mockRecord = new MockRecord<>();
+            for (int i = 0; i < 5; i++) {
+                client.bulkIndex(mockRecord, Pair.of("key" + i, "{\"a\":" + i + "}"));
+                client.bulkDelete(mockRecord, "key" + i);
+            }
+            assertEquals(mockRecord.acked, 10);
+            assertEquals(mockRecord.failed, 0);
+            assertEquals(client.getRestClient().totalHits(index), 0);
+            // no effect
+            client.flush();
+
+            assertEquals(mockRecord.acked, 10);
         }
     }
 


### PR DESCRIPTION
### Motivation
After https://github.com/apache/pulsar/pull/14805, there's a memory leak while using the OpenSearch client.
Every request is kept in a collection, mapping the request with an unique id. The collection is never clear and the objects never collected by the GC.

### Modifications

* Refactor the internal mapping needed for access the pulsar record removing the collection and passing the object directly into the callback (using a wrapper object)

Note: this only affects current pulsar master. 

- [x] `no-need-doc` 