### PR TITLE
Upgrade to Apache HttpComponents Core version 4.4.15

### DIFF
--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -419,7 +419,7 @@ The Apache Software License, Version 2.0
     - org.apache.bookkeeper.stats-codahale-metrics-provider-4.14.4.jar
   * Apache HTTP Client
     - org.apache.httpcomponents-httpclient-4.5.13.jar
-    - org.apache.httpcomponents-httpcore-4.4.13.jar
+    - org.apache.httpcomponents-httpcore-4.4.15.jar
  * AirCompressor
     - io.airlift-aircompressor-0.20.jar
  * AsyncHttpClient

--- a/pom.xml
+++ b/pom.xml
@@ -207,10 +207,12 @@ flexible messaging model and an intuitive client API.</description>
     <cron-utils.version>9.1.6</cron-utils.version>
     <spring-context.version>5.3.18</spring-context.version>
     <apache-http-client.version>4.5.13</apache-http-client.version>
+    <apache-httpcomponents.version>4.4.15</apache-httpcomponents.version>
     <jetcd.version>0.5.11</jetcd.version>
     <snakeyaml.version>1.30</snakeyaml.version>
     <ant.version>1.10.12</ant.version>
     <seancfoley.ipaddress.version>5.3.3</seancfoley.ipaddress.version>
+
 
     <!-- test dependencies -->
     <cassandra.version>3.6.0</cassandra.version>
@@ -1228,6 +1230,12 @@ flexible messaging model and an intuitive client API.</description>
         <groupId>org.apache.httpcomponents</groupId>
         <artifactId>httpclient</artifactId>
         <version>${apache-http-client.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.apache.httpcomponents</groupId>
+        <artifactId>httpcore</artifactId>
+        <version>${apache-httpcomponents.version}</version>
       </dependency>
 
       <dependency>

--- a/pulsar-sql/presto-distribution/LICENSE
+++ b/pulsar-sql/presto-distribution/LICENSE
@@ -324,7 +324,7 @@ The Apache Software License, Version 2.0
     - units-1.6.jar
    * Apache HTTP Client
     - httpclient-4.5.13.jar
-    - httpcore-4.4.13.jar
+    - httpcore-4.4.15.jar
   * Error Prone Annotations
     - error_prone_annotations-2.5.1.jar
   * Esri Geometry API For Java


### PR DESCRIPTION
### Motivation

After #15105, Apache HttpComponents HttpClient is used in JClouds as the Http client.
The current HttpComponents Core library version 4.4.13 contains a severe bug https://issues.apache.org/jira/browse/HTTPCORE-634 which causes issues.

### Modifications

Upgrade to HttpComponents Core version 4.4.15 which contains fixes such as https://issues.apache.org/jira/browse/HTTPCORE-634 .