### PR TITLE
Tiered Storage: add OkHttp based provider for JClouds

### DIFF
--- a/jclouds-shaded/pom.xml
+++ b/jclouds-shaded/pom.xml
@@ -47,6 +47,17 @@
     </dependency>
     <dependency>
       <groupId>org.apache.jclouds.driver</groupId>
+      <artifactId>jclouds-okhttp</artifactId>
+      <version>${jclouds.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.jclouds.driver</groupId>
       <artifactId>jclouds-slf4j</artifactId>
       <version>${jclouds.version}</version>
     </dependency>

--- a/jclouds-shaded/src/main/java/org/apache/pulsar/jclouds/ShadedJCloudsUtils.java
+++ b/jclouds-shaded/src/main/java/org/apache/pulsar/jclouds/ShadedJCloudsUtils.java
@@ -23,6 +23,7 @@ import lombok.experimental.UtilityClass;
 import lombok.extern.slf4j.Slf4j;
 import org.jclouds.ContextBuilder;
 import org.jclouds.http.apachehc.config.ApacheHCHttpCommandExecutorServiceModule;
+import org.jclouds.http.okhttp.config.OkHttpCommandExecutorServiceModule;
 import org.jclouds.logging.slf4j.config.SLF4JLoggingModule;
 
 import java.util.ArrayList;
@@ -42,9 +43,12 @@ public class ShadedJCloudsUtils {
      * Apache Http Client module should work well in all the environments.
      */
     private static final boolean ENABLE_APACHE_HC_MODULE = Boolean
-            .parseBoolean(System.getProperty("pulsar.jclouds.use_apache_hc", "true"));
+            .parseBoolean(System.getProperty("pulsar.jclouds.use_apache_hc", "false"));
+    private static final boolean ENABLE_OKHTTP_MODULE = Boolean
+            .parseBoolean(System.getProperty("pulsar.jclouds.use_okhttp", "false"));
     static {
         log.info("Considering -Dpulsar.jclouds.use_apache_hc=" + ENABLE_APACHE_HC_MODULE);
+        log.info("Considering -Dpulsar.jclouds.use_okhttp=" + ENABLE_OKHTTP_MODULE);
     }
 
     /**
@@ -54,7 +58,9 @@ public class ShadedJCloudsUtils {
     public static void addStandardModules(ContextBuilder builder) {
         List<AbstractModule> modules = new ArrayList<>();
         modules.add(new SLF4JLoggingModule());
-        if (ENABLE_APACHE_HC_MODULE) {
+        if (ENABLE_OKHTTP_MODULE) {
+            modules.add(new OkHttpCommandExecutorServiceModule());
+        } else if (ENABLE_APACHE_HC_MODULE) {
             modules.add(new ApacheHCHttpCommandExecutorServiceModule());
         }
         builder.modules(modules);


### PR DESCRIPTION
### Motivation
In some test environment I have seen a problem using Apache HC based Driver.
I have filed this bug https://issues.apache.org/jira/browse/JCLOUDS-1605

Unfortunately the JClouds Apache HC driver looks not maintained.
The OkHttp based provider seems to work well and to not suffer from the problems reported using the standard HttpUrlConnection based Driver (hung TLS connections).

This patch disables Apache HC driver, adds the OkHttp driver, but both of them are disabled.

### Modifications

- add support for jclouds-okhttp
- you can enable it with -Dpulsar.jclouds.use_okhttp=true
- disable by default Apache HC based driver (pulsar.jclouds.use_apache_hc is now false by default)

### Verifying this change
Unfortunately this change can be tested only manually
