### PR TITLE
[pulsar-broker] Fix delete empty namespace with partitioned-topic metadata

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/NamespacesBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/NamespacesBase.java
@@ -68,7 +68,6 @@ import org.apache.pulsar.common.naming.NamespaceBundleFactory;
 import org.apache.pulsar.common.naming.NamespaceBundleSplitAlgorithm;
 import org.apache.pulsar.common.naming.NamespaceBundles;
 import org.apache.pulsar.common.naming.NamespaceName;
-import org.apache.pulsar.common.naming.TopicDomain;
 import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.policies.data.AuthAction;
 import org.apache.pulsar.common.policies.data.AutoSubscriptionCreationOverride;
@@ -225,12 +224,9 @@ public abstract class NamespacesBase extends AdminResource {
         boolean isEmpty;
         List<String> topics;
         try {
-            topics = pulsar().getNamespaceService().getListOfPersistentTopics(namespaceName)
+            topics = pulsar().getNamespaceService().getFullListOfTopics(namespaceName)
                     .get(config().getMetadataStoreOperationTimeoutSeconds(), TimeUnit.SECONDS);
-            topics.addAll(getPartitionedTopicList(TopicDomain.persistent));
-            topics.addAll(getPartitionedTopicList(TopicDomain.non_persistent));
             isEmpty = topics.isEmpty();
-
         } catch (Exception e) {
             asyncResponse.resume(new RestException(e));
             return;

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/NamespacesTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/NamespacesTest.java
@@ -729,20 +729,19 @@ public class NamespacesTest extends MockedPulsarServiceBaseTest {
 
         response = mock(AsyncResponse.class);
         namespaces.deleteNamespace(response, testNs.getTenant(), testNs.getCluster(), testNs.getLocalName(), false, false);
-        errorCaptor = ArgumentCaptor.forClass(RestException.class);
         // Ok, namespace not empty
-        verify(response, timeout(5000).times(1)).resume(errorCaptor.capture());
-        assertEquals(errorCaptor.getValue().getResponse().getStatus(), Status.CONFLICT.getStatusCode());
-
-        mockZooKeeperGlobal.delete("/admin/partitioned-topics/" + topicName.getPersistenceNamingEncoding(), -1);
+        ArgumentCaptor<Response> responseCaptor = ArgumentCaptor.forClass(Response.class);
+        verify(response, timeout(5000).times(1)).resume(responseCaptor.capture());
+        assertEquals(responseCaptor.getValue().getStatus(), Status.NO_CONTENT.getStatusCode());
 
         testNs = this.testGlobalNamespaces.get(0);
+        namespaces.setNamespaceReplicationClusters(testNs.getTenant(), testNs.getCluster(), testNs.getLocalName(), Lists.newArrayList("use"));
         // setup ownership to localhost
         doReturn(Optional.of(localWebServiceUrl)).when(nsSvc).getWebServiceUrl(testNs, options);
         doReturn(true).when(nsSvc).isServiceUnitOwned(testNs);
         response = mock(AsyncResponse.class);
         namespaces.deleteNamespace(response, testNs.getTenant(), testNs.getCluster(), testNs.getLocalName(), false, false);
-        ArgumentCaptor<Response> responseCaptor = ArgumentCaptor.forClass(Response.class);
+        responseCaptor = ArgumentCaptor.forClass(Response.class);
         verify(response, timeout(5000).times(1)).resume(responseCaptor.capture());
         assertEquals(responseCaptor.getValue().getStatus(), Status.NO_CONTENT.getStatusCode());
 
@@ -755,12 +754,11 @@ public class NamespacesTest extends MockedPulsarServiceBaseTest {
         responseCaptor = ArgumentCaptor.forClass(Response.class);
         verify(response, timeout(5000).times(1)).resume(responseCaptor.capture());
         assertEquals(responseCaptor.getValue().getStatus(), Status.NO_CONTENT.getStatusCode());
-        List<String> nsList = Lists.newArrayList(this.testLocalNamespaces.get(1).toString(),
-                this.testLocalNamespaces.get(2).toString());
+        List<String> nsList = Lists.newArrayList(this.testLocalNamespaces.get(2).toString());
         nsList.sort(null);
         assertEquals(namespaces.getTenantNamespaces(this.testTenant), nsList);
 
-        testNs = this.testLocalNamespaces.get(1);
+        testNs = this.testLocalNamespaces.get(2);
         // setup ownership to localhost
         doReturn(Optional.of(localWebServiceUrl)).when(nsSvc).getWebServiceUrl(testNs, options);
         doReturn(true).when(nsSvc).isServiceUnitOwned(testNs);


### PR DESCRIPTION
### Motivation
Right now, broker gives below error while deleting empty namespace without any topic under the namespace but namespace was having partitioned-topic metadata.
```
pulsar-admin namespaces delete prop/us-west/my-ns
Cannot delete non empty namespace

Reason: Cannot delete non empty namespace
```

### Modification
It's because broker was incorrectly assuming topic existence by checking partitioned-topic metadata. delete-admin API cleans up partitioned-metadata after successfully deleting namespace and it it should not incorrectly depend on partitioned-metadata check. this issue is already fixed with forcefully delete-ns admin-api and delete-admin also needs the same fix.


### Result
User can delete namespace after successfully deleting all topics under the namespace.