### PR TITLE
[pulsar-client-tools] Ability to send a message with null body

### DIFF
--- a/pulsar-client-tools-test/src/test/java/org/apache/pulsar/client/cli/PulsarClientToolTest.java
+++ b/pulsar-client-tools-test/src/test/java/org/apache/pulsar/client/cli/PulsarClientToolTest.java
@@ -19,7 +19,6 @@
 package org.apache.pulsar.client.cli;
 
 import static org.testng.Assert.assertEquals;
-
 import java.time.Duration;
 import java.util.Properties;
 import java.util.UUID;
@@ -28,7 +27,6 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
-
 import lombok.Cleanup;
 import org.apache.pulsar.broker.service.BrokerTestBase;
 import org.apache.pulsar.client.admin.PulsarAdminException;
@@ -267,6 +265,29 @@ public class PulsarClientToolTest extends BrokerTestBase {
                 Assert.assertFalse(msg.getMessageId() instanceof BatchMessageIdImpl);
             }
         }
+    }
+
+    @Test
+    public void testNullBody() throws Exception {
+        Properties properties = new Properties();
+        properties.setProperty("serviceUrl", brokerUrl.toString());
+        properties.setProperty("useTls", "false");
+
+        String topicName = getTopicWithRandomSuffix("nullBody");
+        final String key = UUID.randomUUID().toString();
+
+        Consumer<byte[]> consumer = pulsarClient.newConsumer()
+                .topic(topicName)
+                .subscriptionName("nullBodyTest")
+                .subscribe();
+
+        PulsarClientTool pulsarClientToolProducer = new PulsarClientTool(properties);
+        String[] args = {"produce", "--null", "-k", key, topicName};
+        Assert.assertEquals(pulsarClientToolProducer.run(args), 0);
+
+        Message<byte[]> message = consumer.receive();
+        Assert.assertEquals(message.getKey(), key);
+        Assert.assertNull(message.getData());
     }
 
     private static String getTopicWithRandomSuffix(String localNameBase) {

--- a/site2/docs/reference-cli-tools.md
+++ b/site2/docs/reference-cli-tools.md
@@ -328,8 +328,8 @@ Options
 
 |Flag|Description|Default|
 |---|---|---|
-|`-f`, `--files`|Comma-separated file paths to send; either -m or -f must be specified|[]|
-|`-m`, `--messages`|Comma-separated string of messages to send; either -m or -f must be specified|[]|
+|`-f`, `--files`|Comma separated file paths to send, either -m or -f or --null must be specified.|[]|
+|`-m`, `--messages`|Messages to send, either -m or -f or --null must be specified. The default separator is comma|[]|
 |`-n`, `--num-produce`|The number of times to send the message(s); the count of messages/files * num-produce should be below 1000|1|
 |`-r`, `--rate`|Rate (in messages per second) at which to produce; a value 0 means to produce messages as fast as possible|0.0|
 |`-db`, `--disable-batching`|Disable batch sending of messages|false|
@@ -339,6 +339,7 @@ Options
 |`-p`, `--properties`|Properties to add. If you want to add multiple properties, use the comma as the separator, e.g. `k1=v1,k2=v2`.| |
 |`-ekn`, `--encryption-key-name`|The public key name to encrypt payload.| |
 |`-ekv`, `--encryption-key-value`|The URI of public key to encrypt payload. For example, `file:///path/to/public.key` or `data:application/x-pem-file;base64,*****`.| |
+|`--null`|Send a message with the body is null|false|
 
 
 ### `consume`

--- a/site2/docs/reference-cli-tools.md
+++ b/site2/docs/reference-cli-tools.md
@@ -328,8 +328,8 @@ Options
 
 |Flag|Description|Default|
 |---|---|---|
-|`-f`, `--files`|Comma separated file paths to send, either -m or -f or --null must be specified.|[]|
-|`-m`, `--messages`|Messages to send, either -m or -f or --null must be specified. The default separator is comma|[]|
+|`-f`, `--files`|Comma-separated file paths to send. At least one of the following values must be specified: `-m`, `-f` or `--null`.|[]|
+|`-m`, `--messages`|Messages to send. At least one of the following values must be specified: `-m`, `-f` or `--null`. The default separator is a comma. |[]|
 |`-n`, `--num-produce`|The number of times to send the message(s); the count of messages/files * num-produce should be below 1000|1|
 |`-r`, `--rate`|Rate (in messages per second) at which to produce; a value 0 means to produce messages as fast as possible|0.0|
 |`-db`, `--disable-batching`|Disable batch sending of messages|false|
@@ -339,7 +339,7 @@ Options
 |`-p`, `--properties`|Properties to add. If you want to add multiple properties, use the comma as the separator, e.g. `k1=v1,k2=v2`.| |
 |`-ekn`, `--encryption-key-name`|The public key name to encrypt payload.| |
 |`-ekv`, `--encryption-key-value`|The URI of public key to encrypt payload. For example, `file:///path/to/public.key` or `data:application/x-pem-file;base64,*****`.| |
-|`--null`|Send a message with the body is null|false|
+|`--null`|Send a message with a null body.|false|
 
 
 ### `consume`


### PR DESCRIPTION
### Motivation

Now it's not possible use `pulsar-client produce` send a message with `null` body, but it's needed in some scenes, e.g. delete topic policy manually or test topic compaction.

### Modifications

Add an explicit option `--null` to `pulsar-client produce` subcommand.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change added tests and can be verified as follows:

  - *Added unit test PulsarClientToolTest#testNullBody*

### Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

- [x] `doc-added`
(Docs have been already added)