### PR TITLE
[improve][client] Refactor create https ssl context based on netty

### DIFF
--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/http/AsyncHttpConnector.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/http/AsyncHttpConnector.java
@@ -21,7 +21,6 @@ package org.apache.pulsar.client.admin.internal.http;
 import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.HttpResponse;
 import io.netty.handler.ssl.SslContext;
-import io.netty.handler.ssl.SslProvider;
 import io.netty.util.concurrent.DefaultThreadFactory;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -37,7 +36,6 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeoutException;
 import java.util.function.Function;
 import java.util.function.Supplier;
-import javax.net.ssl.SSLContext;
 import javax.ws.rs.client.Client;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.Response.Status;
@@ -47,13 +45,11 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.pulsar.PulsarVersion;
 import org.apache.pulsar.client.admin.internal.PulsarAdminImpl;
-import org.apache.pulsar.client.api.AuthenticationDataProvider;
-import org.apache.pulsar.client.api.KeyStoreParams;
+import org.apache.pulsar.client.api.PulsarClientException;
+import org.apache.pulsar.client.http.PulsarJsseSslEngineFactory;
 import org.apache.pulsar.client.impl.PulsarServiceNameResolver;
 import org.apache.pulsar.client.impl.conf.ClientConfigurationData;
 import org.apache.pulsar.common.util.FutureUtil;
-import org.apache.pulsar.common.util.SecurityUtility;
-import org.apache.pulsar.common.util.keystoretls.KeyStoreSSLContext;
 import org.asynchttpclient.AsyncHttpClient;
 import org.asynchttpclient.BoundRequestBuilder;
 import org.asynchttpclient.DefaultAsyncHttpClient;
@@ -61,7 +57,6 @@ import org.asynchttpclient.DefaultAsyncHttpClientConfig;
 import org.asynchttpclient.Request;
 import org.asynchttpclient.Response;
 import org.asynchttpclient.channel.DefaultKeepAliveStrategy;
-import org.asynchttpclient.netty.ssl.JsseSslEngineFactory;
 import org.glassfish.jersey.client.ClientProperties;
 import org.glassfish.jersey.client.ClientRequest;
 import org.glassfish.jersey.client.ClientResponse;
@@ -114,58 +109,19 @@ public class AsyncHttpConnector implements Connector {
         });
 
         serviceNameResolver = new PulsarServiceNameResolver();
-        if (conf != null && StringUtils.isNotBlank(conf.getServiceUrl())) {
+        if (StringUtils.isNotBlank(conf.getServiceUrl())) {
             serviceNameResolver.updateServiceUrl(conf.getServiceUrl());
-            if (conf.getServiceUrl().startsWith("https://")) {
-                // Set client key and certificate if available
-                AuthenticationDataProvider authData = conf.getAuthentication().getAuthData();
-
-                if (conf.isUseKeyStoreTls()) {
-                    KeyStoreParams params = authData.hasDataForTls() ? authData.getTlsKeyStoreParams() : null;
-
-                    final SSLContext sslCtx = KeyStoreSSLContext.createClientSslContext(
-                            conf.getSslProvider(),
-                            params != null ? params.getKeyStoreType() : null,
-                            params != null ? params.getKeyStorePath() : null,
-                            params != null ? params.getKeyStorePassword() : null,
-                            conf.isTlsAllowInsecureConnection() || !conf.isTlsHostnameVerificationEnable(),
-                            conf.getTlsTrustStoreType(),
-                            conf.getTlsTrustStorePath(),
-                            conf.getTlsTrustStorePassword(),
-                            conf.getTlsCiphers(),
-                            conf.getTlsProtocols());
-
-                    JsseSslEngineFactory sslEngineFactory = new JsseSslEngineFactory(sslCtx);
-                    confBuilder.setSslEngineFactory(sslEngineFactory);
-                } else {
-                    SslProvider sslProvider = null;
-                    if (conf.getSslProvider() != null) {
-                        sslProvider = SslProvider.valueOf(conf.getSslProvider());
-                    }
-                    SslContext sslCtx = null;
-                    if (authData.hasDataForTls()) {
-                        sslCtx = authData.getTlsTrustStoreStream() == null
-                                ? SecurityUtility.createAutoRefreshSslContextForClient(
-                                sslProvider,
-                                conf.isTlsAllowInsecureConnection() || !conf.isTlsHostnameVerificationEnable(),
-                                conf.getTlsTrustCertsFilePath(), authData.getTlsCerificateFilePath(),
-                                authData.getTlsPrivateKeyFilePath(), null, autoCertRefreshTimeSeconds, delayer)
-                                : SecurityUtility.createNettySslContextForClient(
-                                sslProvider,
-                                conf.isTlsAllowInsecureConnection() || !conf.isTlsHostnameVerificationEnable(),
-                                authData.getTlsTrustStoreStream(), authData.getTlsCertificates(),
-                                authData.getTlsPrivateKey(),
-                                conf.getTlsCiphers(),
-                                conf.getTlsProtocols());
+            if ("https".equals(serviceNameResolver.getServiceUri().getServiceName())) {
+                try {
+                    Supplier<SslContext> sslContextSupplier;
+                    if (conf.isUseKeyStoreTls()) {
+                        sslContextSupplier = conf.newKeyStoreSslContextSupplier();
                     } else {
-                        sslCtx = SecurityUtility.createNettySslContextForClient(
-                                sslProvider,
-                                conf.isTlsAllowInsecureConnection() || !conf.isTlsHostnameVerificationEnable(),
-                                conf.getTlsTrustCertsFilePath(),
-                                conf.getTlsCiphers(),
-                                conf.getTlsProtocols());
+                        sslContextSupplier = conf.newSslContextSupplier();
                     }
-                    confBuilder.setSslContext(sslCtx);
+                    confBuilder.setSslEngineFactory(new PulsarJsseSslEngineFactory(sslContextSupplier));
+                } catch (Exception e) {
+                    throw new PulsarClientException.InvalidConfigurationException(e);
                 }
             }
         }

--- a/pulsar-common/pom.xml
+++ b/pulsar-common/pom.xml
@@ -212,6 +212,11 @@
       <artifactId>awaitility</artifactId>
       <scope>test</scope>
     </dependency>
+
+    <dependency>
+      <groupId>org.asynchttpclient</groupId>
+      <artifactId>async-http-client</artifactId>
+    </dependency>
   </dependencies>
 
   <build>

--- a/pulsar-common/src/main/java/org/apache/pulsar/client/http/PulsarJsseSslEngineFactory.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/client/http/PulsarJsseSslEngineFactory.java
@@ -1,0 +1,41 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.client.http;
+
+import io.netty.buffer.ByteBufAllocator;
+import io.netty.handler.ssl.SslContext;
+import java.util.function.Supplier;
+import javax.net.ssl.SSLEngine;
+import org.asynchttpclient.AsyncHttpClientConfig;
+import org.asynchttpclient.netty.ssl.SslEngineFactoryBase;
+
+public class PulsarJsseSslEngineFactory extends SslEngineFactoryBase {
+    private final Supplier<SslContext> sslContextSupplier;
+
+    public PulsarJsseSslEngineFactory(Supplier<SslContext> sslContextSupplier) {
+        this.sslContextSupplier = sslContextSupplier;
+    }
+
+    @Override
+    public SSLEngine newSslEngine(AsyncHttpClientConfig config, String peerHost, int peerPort) {
+        SSLEngine sslEngine = sslContextSupplier.get().newEngine(ByteBufAllocator.DEFAULT, peerHost, peerPort);
+        configureSslEngine(sslEngine, config);
+        return sslEngine;
+    }
+}

--- a/pulsar-common/src/main/java/org/apache/pulsar/client/http/package-info.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/client/http/package-info.java
@@ -1,0 +1,19 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.client.http;

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/tls/KeyStoreSslContextConf.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/tls/KeyStoreSslContextConf.java
@@ -1,0 +1,51 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.common.tls;
+
+import java.io.InputStream;
+import java.util.Set;
+import java.util.function.Supplier;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class KeyStoreSslContextConf {
+    private String keyStoreType;
+    private String keyStorePassword;
+    private Supplier<InputStream> keyStoreStreamSupplier;
+
+    private String trustStoreType;
+    private String trustStorePassword;
+    private Supplier<InputStream> trustStoreStreamSupplier;
+
+    private String sslProvider; // java.security.Provider
+    private String sslContextProvider; // io.netty.handler.ssl.SslProvider
+
+    private Set<String> ciphers;
+    private Set<String> protocols;
+
+    private long refreshIntervalSeconds;
+    private boolean allowInsecureConnection;
+
+    private boolean requireTrustedClientCertOnConnect;
+
+    // client
+    private boolean forClient;
+}

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/tls/KeyStoreSslContextSupplier.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/tls/KeyStoreSslContextSupplier.java
@@ -1,0 +1,144 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.common.tls;
+
+import io.netty.handler.ssl.ClientAuth;
+import io.netty.handler.ssl.SslContext;
+import io.netty.handler.ssl.SslContextBuilder;
+import io.netty.handler.ssl.SslProvider;
+import java.io.IOException;
+import java.io.InputStream;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.security.Provider;
+import java.security.UnrecoverableKeyException;
+import java.security.cert.CertificateException;
+import java.time.Clock;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.TrustManager;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.pulsar.common.util.SecurityUtility;
+
+@Slf4j
+public class KeyStoreSslContextSupplier implements Supplier<SslContext> {
+    private volatile InputStream keyStoreStream;
+    private volatile InputStream trustStoreStream;
+
+    private final KeyStoreSslContextConf conf;
+
+    private volatile SslContext sslContext;
+
+    private final long refreshIntervalMillis;
+    private long lastRefreshTimestamp;
+    private final Clock clock = Clock.systemUTC();
+
+    public SslContext newSslContext()
+            throws IOException, KeyStoreException, UnrecoverableKeyException, NoSuchAlgorithmException,
+            CertificateException {
+
+        Provider sslContextProvider = SecurityUtility.getSslContextProvider(conf.getSslContextProvider());
+        SslProvider sslProvider = SecurityUtility.getSslProvider(conf.getSslProvider());
+
+        KeyManagerFactory keyManagerFactory;
+        if (conf.getKeyStoreStreamSupplier() != null) {
+            keyStoreStream = conf.getKeyStoreStreamSupplier().get();
+            keyManagerFactory = SecurityUtility.newKeyManagerFactory(conf.getKeyStoreType(),
+                    keyStoreStream,
+                    StringUtils.isEmpty(conf.getKeyStorePassword()) ? new char[]{} :
+                            conf.getKeyStorePassword().toCharArray());
+        } else {
+            keyManagerFactory = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
+        }
+
+        TrustManager[] trustManagers;
+        if (conf.getTrustStoreStreamSupplier() != null) {
+            trustStoreStream = conf.getTrustStoreStreamSupplier().get();
+            trustManagers = SecurityUtility.setupTrustCerts(conf.getTrustStoreType(), conf.isAllowInsecureConnection(),
+                    trustStoreStream,
+                    StringUtils.isEmpty(conf.getTrustStorePassword()) ? new char[]{} :
+                            conf.getTrustStorePassword().toCharArray(), sslContextProvider);
+        } else {
+            throw new IllegalArgumentException("Trust store cannot be null");
+        }
+
+        if (trustManagers == null || trustManagers.length != 1) {
+            throw new KeyStoreException("TrustManager size should be 1");
+        }
+
+        SslContextBuilder sslContextBuilder;
+        if (conf.isForClient()) {
+            sslContextBuilder = SslContextBuilder.forClient().keyManager(keyManagerFactory);
+        } else {
+            sslContextBuilder = SslContextBuilder.forServer(keyManagerFactory)
+                    .clientAuth(conf.isRequireTrustedClientCertOnConnect() ? ClientAuth.REQUIRE : ClientAuth.OPTIONAL);
+        }
+        sslContextBuilder.sslProvider(sslProvider)
+                .sslContextProvider(sslContextProvider)
+                .ciphers(conf.getCiphers())
+                .protocols(conf.getProtocols());
+        sslContextBuilder.trustManager(trustManagers[0]);
+        return sslContextBuilder.build();
+    }
+
+    public KeyStoreSslContextSupplier(KeyStoreSslContextConf conf) {
+        this.conf = conf;
+        this.refreshIntervalMillis = TimeUnit.SECONDS.toMillis(conf.getRefreshIntervalSeconds());
+    }
+
+    protected boolean needUpdate() {
+        if (refreshIntervalMillis == 0) {
+            return true;
+        }
+
+        if (sslContext == null) {
+            return true;
+        }
+
+        if (conf.getRefreshIntervalSeconds() < 0) {
+            return false;
+        }
+
+        long now = clock.millis();
+        if ((now - lastRefreshTimestamp) < refreshIntervalMillis) {
+            return false;
+        }
+
+        if (keyStoreStream != null && !keyStoreStream.equals(conf.getKeyStoreStreamSupplier().get())) {
+            return true;
+        }
+
+        return trustStoreStream != null && !trustStoreStream.equals(conf.getTrustStoreStreamSupplier().get());
+    }
+
+    @Override
+    public synchronized SslContext get() {
+        if (needUpdate()) {
+            try {
+                sslContext = newSslContext();
+                lastRefreshTimestamp = clock.millis();
+            } catch (Exception e) {
+                log.error("Exception while trying to refresh ssl Context {} ", e.getMessage(), e);
+            }
+        }
+        return sslContext;
+    }
+}

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/tls/SslContextConf.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/tls/SslContextConf.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.common.tls;
+
+import java.security.PrivateKey;
+import java.security.cert.X509Certificate;
+import java.util.Set;
+import java.util.function.Supplier;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class SslContextConf {
+    private Supplier<X509Certificate[]> trustCertSupplier;
+    private Supplier<PrivateKey> keySupplier;
+    private Supplier<X509Certificate[]> certSupplier;
+
+    private String sslProvider; // java.security.Provider
+    private String sslContextProvider; // io.netty.handler.ssl.SslProvider
+
+    private Set<String> ciphers;
+    private Set<String> protocols;
+
+    private long refreshIntervalSeconds;
+
+    private boolean allowInsecureConnection;
+
+    private boolean requireTrustedClientCertOnConnect;
+
+    private boolean forClient;
+}

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/tls/SslContextSupplier.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/tls/SslContextSupplier.java
@@ -1,0 +1,143 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.common.tls;
+
+import io.netty.handler.ssl.ClientAuth;
+import io.netty.handler.ssl.SslContext;
+import io.netty.handler.ssl.SslContextBuilder;
+import io.netty.handler.ssl.SslProvider;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.security.PrivateKey;
+import java.security.Provider;
+import java.security.UnrecoverableKeyException;
+import java.security.cert.X509Certificate;
+import java.time.Clock;
+import java.util.Arrays;
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.SSLException;
+import javax.net.ssl.TrustManager;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.pulsar.common.util.KeyStoreHolder;
+import org.apache.pulsar.common.util.SecurityUtility;
+
+@Slf4j
+public class SslContextSupplier implements Supplier<SslContext> {
+    private volatile X509Certificate[] trustCert;
+    private volatile PrivateKey key;
+    private volatile X509Certificate[] cert;
+
+    private final SslContextConf conf;
+
+    private volatile SslContext sslContext;
+
+    private final long refreshIntervalMillis;
+    private long lastRefreshTimestamp;
+    private final Clock clock = Clock.systemUTC();
+
+    public SslContext newSslContext()
+            throws SSLException, KeyStoreException, UnrecoverableKeyException, NoSuchAlgorithmException {
+        trustCert = conf.getTrustCertSupplier().get();
+        key = conf.getKeySupplier().get();
+        cert = conf.getCertSupplier().get();
+
+        Provider sslContextProvider = SecurityUtility.getSslContextProvider(conf.getSslContextProvider());
+        SslProvider sslProvider = SecurityUtility.getSslProvider(conf.getSslProvider());
+
+        KeyManagerFactory keyManagerFactory =
+                SecurityUtility.newKeyManagerFactory(key, cert);
+
+        TrustManager[] trustManagers =
+                SecurityUtility.setupTrustCerts(new KeyStoreHolder(), conf.isAllowInsecureConnection(),
+                        trustCert, sslContextProvider);
+        if (trustManagers != null && trustManagers.length != 1) {
+            throw new KeyStoreException("TrustManager size should be 1");
+        }
+
+        SslContextBuilder sslContextBuilder;
+        if (conf.isForClient()) {
+            sslContextBuilder = SslContextBuilder.forClient().keyManager(keyManagerFactory);
+        } else {
+            sslContextBuilder = SslContextBuilder.forServer(keyManagerFactory)
+                    .clientAuth(conf.isRequireTrustedClientCertOnConnect() ? ClientAuth.REQUIRE : ClientAuth.OPTIONAL);
+        }
+        sslContextBuilder.sslProvider(sslProvider)
+                .sslContextProvider(sslContextProvider)
+                .ciphers(conf.getCiphers())
+                .protocols(conf.getProtocols());
+        if (trustManagers != null) {
+            sslContextBuilder.trustManager(trustManagers[0]);
+        }
+        return sslContextBuilder.build();
+    }
+
+    public SslContextSupplier(SslContextConf conf) {
+        this.conf = conf;
+        this.refreshIntervalMillis = TimeUnit.SECONDS.toMillis(conf.getRefreshIntervalSeconds());
+    }
+
+    protected boolean needUpdate() {
+        if (refreshIntervalMillis == 0) {
+            return true;
+        }
+
+        if (sslContext == null) {
+            return true;
+        }
+
+        if (conf.getRefreshIntervalSeconds() < 0) {
+            return false;
+        }
+
+        long now = clock.millis();
+        if ((now - lastRefreshTimestamp) < refreshIntervalMillis) {
+            return false;
+        }
+
+        if (!Arrays.equals(conf.getTrustCertSupplier().get(), trustCert)) {
+            return true;
+        }
+
+        if (!Objects.equals(conf.getKeySupplier().get(), key)) {
+            return true;
+        }
+
+        if (!Arrays.equals(conf.getCertSupplier().get(), cert)) {
+            return true;
+        }
+
+        return false;
+    }
+
+    @Override
+    public synchronized SslContext get() {
+        if (needUpdate()) {
+            try {
+                sslContext = newSslContext();
+                lastRefreshTimestamp = clock.millis();
+            } catch (Exception e) {
+                log.error("Exception while trying to refresh ssl Context {} ", e.getMessage(), e);
+            }
+        }
+        return sslContext;
+    }
+}


### PR DESCRIPTION
Signed-off-by: Zixuan Liu <nodeces@gmail.com>

### Motivation

The client module has multiple duplication codes that create ssl context, and the way of creation is not consistent. 

Currently, we support using the KeyStore and CACert two formats, and using different ssl context, this will made us confused.

I suggest we use the netty ssl context to create the SSL work, no use java ssl context.

This PR is the beginning.

### Modifications

- Clean up duplication codes that create ssl context in the client
- Add `KeyStoreSslContextSupplier` and `SslContextSupplier` to create netty ssl context supplier, which supports refresh the key and cert by compare the cached object and new object.

### Documentation

- [x] `no-need-doc` 
