### PR TITLE
[CI] Exit on errors in pulsar_ci_tool.sh

### DIFF
--- a/build/pulsar_ci_tool.sh
+++ b/build/pulsar_ci_tool.sh
@@ -20,6 +20,9 @@
 
 # shell function library for Pulsar CI builds
 
+set -e
+set -o pipefail
+
 ARTIFACT_RETENTION_DAYS="${ARTIFACT_RETENTION_DAYS:-3}"
 
 # lists all available functions in this tool


### PR DESCRIPTION
### Motivation

There was a recent CI problem where the Docker image failed to load. The command failed, but the build job didn't fail. When investigating the issue, it was noticed that pulsar_ci_tool.sh doesn't contain proper error handling options in the script.

### Modifications

Make script fail on errors by setting these options:
```
set -e
set -o pipefail
```