### PR TITLE
support dynamic config for authenticationEnabled

### DIFF
--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -1338,6 +1338,7 @@ public class ServiceConfiguration implements PulsarConfiguration {
     /***** --- Authentication. --- ****/
     @FieldContext(
         category = CATEGORY_AUTHENTICATION,
+        dynamic = true,
         doc = "Enable authentication"
     )
     private boolean authenticationEnabled = false;


### PR DESCRIPTION
### Motivation
When we want to enable authentication on an already running cluster, the broker must be restarted in rotation. During the rotation restart, the connection between the authenticated broker and the temporarily unauthenticated broker may be abnormal.

We have a scenario where the client doesn't want to stop all. 
So our upgrade process is:

The client restarts in turn to enable the authentication configuration;
After the client completes the upgrade, it will restart the broker in turn to enable the authentication of the broker, but at this time, in order to prevent the connection between the brokers from being abnormal during the rotational restart process, it is necessary to configure: authenticationEnabled=false
After the broker is upgraded, change the configuration through dynamic settings: authenticationEnabled=true

### Documentation

Check the box below or label this PR directly.

Need to update docs? 

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)
  
- [x] `no-need-doc` 
(Please explain why)
  
- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-added`
(Docs have been already added)