### PR TITLE
[fix] Set sinkType in config file

### DIFF
--- a/pulsar-client-admin-api/src/main/java/org/apache/pulsar/common/io/SinkConfig.java
+++ b/pulsar-client-admin-api/src/main/java/org/apache/pulsar/common/io/SinkConfig.java
@@ -77,6 +77,8 @@ public class SinkConfig {
     private Boolean autoAck;
     private Long timeoutMs;
     private Long negativeAckRedeliveryDelayMs;
+
+    private String sinkType;
     private String archive;
     // Whether the subscriptions the functions created/used should be deleted when the functions is deleted
     private Boolean cleanupSubscription;

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdSinks.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdSinks.java
@@ -518,7 +518,7 @@ public class CmdSinks extends CmdBase {
 
             if (sinkType != null) {
                 sinkConfig.setArchive(validateSinkType(sinkType));
-            } else if(sinkConfig.getSinkType() != null) {
+            } else if (sinkConfig.getSinkType() != null) {
                 sinkConfig.setArchive(validateSinkType(sinkConfig.getSinkType()));
             }
 

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdSinks.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdSinks.java
@@ -518,6 +518,8 @@ public class CmdSinks extends CmdBase {
 
             if (sinkType != null) {
                 sinkConfig.setArchive(validateSinkType(sinkType));
+            } else if(sinkConfig.getSinkType() != null) {
+                sinkConfig.setArchive(validateSinkType(sinkConfig.getSinkType()));
             }
 
             Resources resources = sinkConfig.getResources();

--- a/pulsar-client-tools/src/test/java/org/apache/pulsar/admin/cli/TestCmdSinks.java
+++ b/pulsar-client-tools/src/test/java/org/apache/pulsar/admin/cli/TestCmdSinks.java
@@ -482,13 +482,10 @@ public class TestCmdSinks {
             "-- Available sinks are: \\[\\]")
     public void testCmdSinkConfigFileInvalidSinkType() throws Exception {
         SinkConfig testSinkConfig = getSinkConfig();
-        testSinkConfig.setArchive(null);
+        // sinkType is prior than archive
         testSinkConfig.setSinkType("foo");
 
-        SinkConfig expectedSinkConfig = getSinkConfig();
-        expectedSinkConfig.setArchive(null);
-        testSinkConfig.setSinkType("foo");
-        testCmdSinkConfigFile(testSinkConfig, expectedSinkConfig);
+        testCmdSinkConfigFile(testSinkConfig, null);
     }
 
     private void testCmdSinkConfigFile(SinkConfig testSinkConfig, SinkConfig expectedSinkConfig) throws Exception {

--- a/pulsar-client-tools/src/test/java/org/apache/pulsar/admin/cli/TestCmdSinks.java
+++ b/pulsar-client-tools/src/test/java/org/apache/pulsar/admin/cli/TestCmdSinks.java
@@ -478,6 +478,19 @@ public class TestCmdSinks {
         testCmdSinkConfigFile(testSinkConfig, expectedSinkConfig);
     }
 
+    @Test(expectedExceptions = ParameterException.class, expectedExceptionsMessageRegExp = "Invalid sink type 'foo' " +
+            "-- Available sinks are: \\[\\]")
+    public void testCmdSinkConfigFileInvalidSinkType() throws Exception {
+        SinkConfig testSinkConfig = getSinkConfig();
+        testSinkConfig.setArchive(null);
+        testSinkConfig.setSinkType("foo");
+
+        SinkConfig expectedSinkConfig = getSinkConfig();
+        expectedSinkConfig.setArchive(null);
+        testSinkConfig.setSinkType("foo");
+        testCmdSinkConfigFile(testSinkConfig, expectedSinkConfig);
+    }
+
     private void testCmdSinkConfigFile(SinkConfig testSinkConfig, SinkConfig expectedSinkConfig) throws Exception {
 
         File file = Files.createTempFile("", "").toFile();


### PR DESCRIPTION
Fixes #12503

### Motivation

The sink config file doesn't support set 'sinkType', e.g. https://github.com/apache/pulsar/blob/a19a30a5e89bfd2c2da5460db6120c8e0a48d8f7/site2/docs/io-jdbc-sink.md?plain=1#L51

### Modifications

Add 'sinkType' to class `SinkConfig`. If no cmd arg '--sink-type' and 'sinkType' exists in config file, we will try to use the 'sinkType' built-in sink.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.


This change added tests and can be verified as follows:
- *Add tests for setting sink type in config file*

### Does this pull request potentially affect one of the following parts:

Nope

### Documentation

Check the box below or label this PR directly.

Need to update docs? 

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)
  
- [x] `no-need-doc` 
Just fix.
  
- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-added`
(Docs have been already added)