### PR TITLE
[Doc] Add missing parameters to CommandAck

### DIFF
--- a/site2/docs/developing-binary-protocol.md
+++ b/site2/docs/developing-binary-protocol.md
@@ -361,7 +361,7 @@ message CommandFlow {
 ```
 
 Parameters:
-* `consumer_id` → Id of an already established consumer
+* `consumer_id` → ID of an already established consumer
 * `messagePermits` → Number of additional permits to grant to the broker for
     pushing more messages
 
@@ -406,18 +406,18 @@ message CommandAck {
 ```
 
 Parameters:
- * `consumer_id` → Id of an already established consumer
+ * `consumer_id` → ID of an already established consumer
  * `ack_type` → Type of acknowledgment: `Individual` or `Cumulative`
- * `message_id` → Id of the message to acknowledge
+ * `message_id` → ID of the message to acknowledge
  * `validation_error` → *(optional)* Indicates that the consumer has discarded
    the messages due to: `UncompressedSizeCorruption`,
    `DecompressionError`, `ChecksumMismatch`, `BatchDeSerializeError`
  * `properties` -> *(optional)* Reserved configuration items
- * `txnid_most_bits` -> *(optional)* Same as TC Id, `txnid_most_bits` and `txnid_least_bits`
+ * `txnid_most_bits` -> *(optional)* Same as TC ID, `txnid_most_bits` and `txnid_least_bits`
    uniquely identify a transaction.
  * `txnid_least_bits` -> *(optional)* The id of the transaction opened in a TC,
    `txnid_most_bits` and `txnid_least_bits`uniquely identify a transaction.
- * `request_id` -> *(optional)* Id for handling response and timeout.
+ * `request_id` -> *(optional)* ID for handling response and timeout.
    
 
 ##### Command CloseConsumer
@@ -453,9 +453,9 @@ messages are coming from the consumer.
 This command is sent by the client to retrieve Subscriber and Consumer level 
 stats from the broker.
 Parameters:
- * `request_id` → Id of the request, used to correlate the request 
+ * `request_id` → ID of the request, used to correlate the request 
       and the response.
- * `consumer_id` → Id of an already established consumer.
+ * `consumer_id` → ID of an already established consumer.
 
 ##### Command ConsumerStatsResponse
 
@@ -467,8 +467,8 @@ If the `error_code` or the `error_message` field is set it indicates that the re
 
 This command is sent by the client to unsubscribe the `consumer_id` from the associated topic.
 Parameters:
- * `request_id` → Id of the request.
- * `consumer_id` → Id of an already established consumer which needs to unsubscribe.
+ * `request_id` → ID of the request.
+ * `consumer_id` → ID of an already established consumer which needs to unsubscribe.
 
 
 ## Service discovery
@@ -511,7 +511,7 @@ message CommandLookupTopic {
 
 Fields:
  * `topic` → Topic name to lookup
- * `request_id` → Id of the request that will be passed with its response
+ * `request_id` → ID of the request that will be passed with its response
  * `authoritative` → Initial lookup request should use false. When following a
    redirect response, client should pass the same value contained in the
    response
@@ -573,7 +573,7 @@ message CommandPartitionedTopicMetadata {
 
 Fields:
  * `topic` → the topic for which to check the partitions metadata
- * `request_id` → Id of the request that will be passed with its response
+ * `request_id` → ID of the request that will be passed with its response
 
 
 ##### Command PartitionedTopicMetadataResponse

--- a/site2/docs/developing-binary-protocol.md
+++ b/site2/docs/developing-binary-protocol.md
@@ -413,10 +413,11 @@ Parameters:
    the messages due to: `UncompressedSizeCorruption`,
    `DecompressionError`, `ChecksumMismatch`, `BatchDeSerializeError`
  * `properties` -> *(optional)* Reserved configuration items
- * `txnid_most_bits` -> *(optional)* Same as TC Id, uniquely identify a transaction with `txnid_least_bits`
- * `txnid_least_bits` -> *(optional)* The id of the transaction opened in a TC, 
-   uniquely identify a transaction with `txnid_most_bits`
- * `request_id` -> *(optional)* Id for handling response and timeout
+ * `txnid_most_bits` -> *(optional)* Same as TC Id, `txnid_most_bits` and `txnid_least_bits`
+   uniquely identify a transaction.
+ * `txnid_least_bits` -> *(optional)* The id of the transaction opened in a TC,
+   `txnid_most_bits` and `txnid_least_bits`uniquely identify a transaction.
+ * `request_id` -> *(optional)* Id for handling response and timeout.
    
 
 ##### Command CloseConsumer

--- a/site2/docs/developing-binary-protocol.md
+++ b/site2/docs/developing-binary-protocol.md
@@ -415,7 +415,7 @@ Parameters:
  * `properties` -> *(optional)* Reserved configuration items
  * `txnid_most_bits` -> *(optional)* Same as TC ID, `txnid_most_bits` and `txnid_least_bits`
    uniquely identify a transaction.
- * `txnid_least_bits` -> *(optional)* The id of the transaction opened in a TC,
+ * `txnid_least_bits` -> *(optional)* The ID of the transaction opened in a TC,
    `txnid_most_bits` and `txnid_least_bits`uniquely identify a transaction.
  * `request_id` -> *(optional)* ID for handling response and timeout.
    

--- a/site2/docs/developing-binary-protocol.md
+++ b/site2/docs/developing-binary-protocol.md
@@ -412,6 +412,12 @@ Parameters:
  * `validation_error` → *(optional)* Indicates that the consumer has discarded
    the messages due to: `UncompressedSizeCorruption`,
    `DecompressionError`, `ChecksumMismatch`, `BatchDeSerializeError`
+ * `properties` -> *(optional)* Reserved configuration items
+ * `txnid_most_bits` -> *(optional)* Same as TC Id, uniquely identify a transaction with `txnid_least_bits`
+ * `txnid_least_bits` -> *(optional)* The id of the transaction opened in a TC, 
+   uniquely identify a transaction with `txnid_most_bits`
+ * `request_id` -> *(optional)* Id for handling response and timeout
+   
 
 ##### Command CloseConsumer
 


### PR DESCRIPTION
Fix https://github.com/apache/pulsar/issues/11272
### Motivation & Modification
Add missing parameters to CommandAck.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API: (yes / no)
  - The schema: (yes / no / don't know)
  - The default values of configurations: (yes / no)
  - The wire protocol: (yes / no)
  - The rest endpoints: (yes / no)
  - The admin cli options: (yes / no)
  - Anything that affects deployment: (yes / no / don't know)

### Documentation

Check the box below or label this PR directly.

Need to update docs? 

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)
  
- [ ] `no-need-doc` 
(Please explain why)
  
- [ ] `doc` 
(Your PR contains doc changes)

- [x] `doc-added`
(Docs have been already added)