### PR TITLE
[CI] Change python cp35-cp35m lib build version to manylinux1

### DIFF
--- a/pulsar-client-cpp/docker/python-versions.sh
+++ b/pulsar-client-cpp/docker/python-versions.sh
@@ -20,7 +20,7 @@
 PYTHON_VERSIONS=(
    '2.7  cp27-cp27mu manylinux1    x86_64'
    '2.7  cp27-cp27m  manylinux1    x86_64'
-   '3.5  cp35-cp35m  manylinux2014 x86_64'
+   '3.5  cp35-cp35m  manylinux1    x86_64'
    '3.6  cp36-cp36m  manylinux2014 x86_64'
    '3.7  cp37-cp37m  manylinux2014 x86_64'
    '3.8  cp38-cp38   manylinux2014 x86_64'


### PR DESCRIPTION
### Motivation

For 3.5, there is no support in manylinux2014, so we need to stick with manylinux1

### Modifications


### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Documentation

Check the box below or label this PR directly.

Need to update docs? 

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)
  
- [x] `no-need-doc` 
(Please explain why)
  
- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-added`
(Docs have been already added)