### PR TITLE
[cleanup] [broker] when serverCnx disabled auto read use same implements

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
@@ -2648,8 +2648,7 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
         if (++pendingSendRequest == maxPendingSendRequests || isPublishRateExceeded) {
             // When the quota of pending send requests is reached, stop reading from socket to cause backpressure on
             // client connection, possibly shared between multiple producers
-            ctx.channel().config().setAutoRead(false);
-            recordRateLimitMetrics(producers);
+            disableCnxAutoRead();
             autoReadDisabledRateLimiting = isPublishRateExceeded;
             throttledConnections.inc();
         }


### PR DESCRIPTION
### Motivation

https://github.com/apache/pulsar/blob/732049fc6ca1beb046deb43057be2b130736fbca/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java#L2645-L2652

`L2468-L2469` make serverCnx disabled auto read, but **there has a beter implements** at `L2723-L2728`:


https://github.com/apache/pulsar/blob/732049fc6ca1beb046deb43057be2b130736fbca/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java#L2723-L2728


At the better implements, can reduce false statistics( when a serverCnx already disabled auto read, will not increment another once). 

### Documentation
- [ ] `doc-required` 
- [x] `no-need-doc` 
- [ ] `doc` 
- [ ] `doc-added`
- [x] `doc-not-needed`
