### PR TITLE
Enable Log4j2 async loggers

### DIFF
--- a/bin/pulsar
+++ b/bin/pulsar
@@ -309,8 +309,11 @@ OPTS="$OPTS -Dpulsar.log.dir=$PULSAR_LOG_DIR"
 OPTS="$OPTS -Dpulsar.log.level=$PULSAR_LOG_LEVEL"
 OPTS="$OPTS -Dpulsar.log.root.level=$PULSAR_LOG_ROOT_LEVEL"
 OPTS="$OPTS -Dpulsar.routing.appender.default=$PULSAR_ROUTING_APPENDER_DEFAULT"
+
+
 # Configure log4j2 to disable servlet webapp detection so that Garbage free logging can be used
-OPTS="$OPTS -Dlog4j2.is.webapp=false"
+PULSAR_LOG4J_CONF=${PULSAR_LOG4J_CONF:-"-Dlog4j2.is.webapp=false  -Dlog4j2.contextSelector=org.apache.logging.log4j.core.async.AsyncLoggerContextSelector -Dlog4j2.enableThreadlocals=true -Dlog4j2.enableDirectEncoders=true"}
+OPTS="$OPTS $PULSAR_LOG4J_CONF"
 
 # Functions related logging
 OPTS="$OPTS -Dpulsar.functions.process.container.log.dir=$PULSAR_LOG_DIR"

--- a/conf/log4j2.yaml
+++ b/conf/log4j2.yaml
@@ -53,6 +53,7 @@ Configuration:
     Console:
       name: Console
       target: SYSTEM_OUT
+      direct: true
       PatternLayout:
         Pattern: "%d{ISO8601_OFFSET_DATE_TIME_HHMM} [%t] %-5level %logger{36} - %msg%n"
 

--- a/distribution/server/pom.xml
+++ b/distribution/server/pom.xml
@@ -65,6 +65,11 @@
     </dependency>
 
     <dependency>
+      <groupId>com.lmax</groupId>
+      <artifactId>disruptor</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.apache.zookeeper</groupId>
       <artifactId>zookeeper-prometheus-metrics</artifactId>
       <version>${zookeeper.version}</version>

--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -533,6 +533,8 @@ The Apache Software License, Version 2.0
     - io.etcd-jetcd-core-0.5.11.jar
   * IPAddress
     - com.github.seancfoley-ipaddress-5.3.3.jar
+  * LMAX Disruptor
+    - com.lmax-disruptor-3.4.3.jar
 
 BSD 3-clause "New" or "Revised" License
  * Google auth library

--- a/pom.xml
+++ b/pom.xml
@@ -212,11 +212,11 @@ flexible messaging model and an intuitive client API.</description>
     <snakeyaml.version>1.30</snakeyaml.version>
     <ant.version>1.10.12</ant.version>
     <seancfoley.ipaddress.version>5.3.3</seancfoley.ipaddress.version>
+    <disruptor.version>3.4.3</disruptor.version>
 
 
     <!-- test dependencies -->
     <cassandra.version>3.6.0</cassandra.version>
-    <disruptor.version>3.4.0</disruptor.version>
     <testcontainers.version>1.15.3</testcontainers.version>
     <hamcrest.version>2.2</hamcrest.version>
 


### PR DESCRIPTION
### Motivation

Enable Log4j2 async logger using LMAX disruptor to reduce the impact of logging spikes on sensitive threads.