### PR TITLE
[feature][doc] Add doc for how to configure chunking for readers

### DIFF
--- a/site2/docs/client-libraries-java.md
+++ b/site2/docs/client-libraries-java.md
@@ -1123,6 +1123,22 @@ pulsarClient.newReader()
 Total hash range size is 65536, so the max end of the range should be less than or equal to 65535.
 
 
+### Configure chunking
+
+Configuring chuncking for readers is similar to that for consumers. See [configure chunking for consumers](#configure-chunking) for more information.
+
+The following is an example of how to configure message chunking for a reader.
+
+```java
+Reader<byte[]> reader = pulsarClient.newReader()
+        .topic(topicName)
+        .startMessageId(MessageId.earliest)
+        .maxPendingChunkedMessage(12)
+        .autoAckOldestChunkedMessageOnQueueFull(true)
+        .expireTimeOfIncompleteChunkedMessage(12, TimeUnit.MILLISECONDS)
+        .create();
+```
+
 ## TableView
 
 The TableView interface serves an encapsulated access pattern, providing a continuously updated key-value map view of the compacted topic data. Messages without keys will be ignored.


### PR DESCRIPTION
### Motivation
Add docs for code PR #15143 

### Modifications

Add a section for how to configure msg chunking for readers (java client).


The preview looks good.
<img width="1407" alt="image" src="https://user-images.githubusercontent.com/60642177/163937348-c0582896-afe3-4472-9c4f-65f207c9d387.png">



### Documentation

- [x] `doc` 

