### PR TITLE
Upgrade Netty to 4.1.76.Final, Netty Tcnative, grpc and protobuf

### DIFF
--- a/buildtools/pom.xml
+++ b/buildtools/pom.xml
@@ -134,7 +134,7 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-common</artifactId>
-      <version>4.1.74.Final</version>
+      <version>4.1.76.Final</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -466,27 +466,27 @@ The Apache Software License, Version 2.0
      - org.jetbrains.kotlin-kotlin-stdlib-jdk8-1.4.32.jar
      - org.jetbrains-annotations-13.0.jar
  * gRPC
-    - io.grpc-grpc-all-1.42.1.jar
-    - io.grpc-grpc-auth-1.42.1.jar
-    - io.grpc-grpc-context-1.42.1.jar
-    - io.grpc-grpc-core-1.42.1.jar
-    - io.grpc-grpc-netty-1.42.1.jar
-    - io.grpc-grpc-protobuf-1.42.1.jar
-    - io.grpc-grpc-protobuf-lite-1.42.1.jar
-    - io.grpc-grpc-stub-1.42.1.jar
-    - io.grpc-grpc-alts-1.42.1.jar
-    - io.grpc-grpc-api-1.42.1.jar
-    - io.grpc-grpc-grpclb-1.42.1.jar
-    - io.grpc-grpc-netty-shaded-1.42.1.jar
-    - io.grpc-grpc-services-1.42.1.jar
-    - io.grpc-grpc-xds-1.42.1.jar
-    - io.grpc-grpc-rls-1.42.1.jar
+    - io.grpc-grpc-all-1.45.1.jar
+    - io.grpc-grpc-auth-1.45.1.jar
+    - io.grpc-grpc-context-1.45.1.jar
+    - io.grpc-grpc-core-1.45.1.jar
+    - io.grpc-grpc-netty-1.45.1.jar
+    - io.grpc-grpc-protobuf-1.45.1.jar
+    - io.grpc-grpc-protobuf-lite-1.45.1.jar
+    - io.grpc-grpc-stub-1.45.1.jar
+    - io.grpc-grpc-alts-1.45.1.jar
+    - io.grpc-grpc-api-1.45.1.jar
+    - io.grpc-grpc-grpclb-1.45.1.jar
+    - io.grpc-grpc-netty-shaded-1.45.1.jar
+    - io.grpc-grpc-services-1.45.1.jar
+    - io.grpc-grpc-xds-1.45.1.jar
+    - io.grpc-grpc-rls-1.45.1.jar
     - com.google.auto.service-auto-service-annotations-1.0.jar
   * Perfmark
     - io.perfmark-perfmark-api-0.19.0.jar
   * OpenCensus
-    - io.opencensus-opencensus-api-0.18.0.jar
-    - io.opencensus-opencensus-contrib-http-util-0.24.0.jar
+    - io.opencensus-opencensus-api-0.28.0.jar
+    - io.opencensus-opencensus-contrib-http-util-0.28.0.jar
     - io.opencensus-opencensus-proto-0.2.0.jar
   * Jodah
     - net.jodah-typetools-0.5.0.jar
@@ -529,9 +529,10 @@ The Apache Software License, Version 2.0
   * Snappy Java
     - org.xerial.snappy-snappy-java-1.1.7.jar
   * Google HTTP Client
-    - com.google.http-client-google-http-client-jackson2-1.38.0.jar
-    - com.google.http-client-google-http-client-1.38.0.jar
-    - com.google.auto.value-auto-value-annotations-1.7.4.jar
+    - com.google.http-client-google-http-client-jackson2-1.41.0.jar
+    - com.google.http-client-google-http-client-gson-1.41.0.jar
+    - com.google.http-client-google-http-client-1.41.0.jar
+    - com.google.auto.value-auto-value-annotations-1.9.jar
     - com.google.re2j-re2j-1.5.jar
   * Jetcd
     - io.etcd-jetcd-common-0.5.11.jar
@@ -541,8 +542,8 @@ The Apache Software License, Version 2.0
 
 BSD 3-clause "New" or "Revised" License
  * Google auth library
-    - com.google.auth-google-auth-library-credentials-0.22.2.jar -- licenses/LICENSE-google-auth-library.txt
-    - com.google.auth-google-auth-library-oauth2-http-0.22.2.jar -- licenses/LICENSE-google-auth-library.txt
+    - com.google.auth-google-auth-library-credentials-1.4.0.jar -- licenses/LICENSE-google-auth-library.txt
+    - com.google.auth-google-auth-library-oauth2-http-1.4.0.jar -- licenses/LICENSE-google-auth-library.txt
  * LevelDB -- (included in org.rocksdb.*.jar) -- licenses/LICENSE-LevelDB.txt
  * JSR305 -- com.google.code.findbugs-jsr305-3.0.2.jar -- licenses/LICENSE-JSR305.txt
  * JLine -- jline-jline-2.14.6.jar -- licenses/LICENSE-JLine.txt
@@ -561,8 +562,8 @@ MIT License
 
 Protocol Buffers License
  * Protocol Buffers
-   - com.google.protobuf-protobuf-java-3.16.1.jar -- licenses/LICENSE-protobuf.txt
-   - com.google.protobuf-protobuf-java-util-3.16.1.jar -- licenses/LICENSE-protobuf.txt
+   - com.google.protobuf-protobuf-java-3.19.2.jar -- licenses/LICENSE-protobuf.txt
+   - com.google.protobuf-protobuf-java-util-3.19.2.jar -- licenses/LICENSE-protobuf.txt
 
 CDDL-1.1 -- licenses/LICENSE-CDDL-1.1.txt
  * Java Annotations API

--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -352,26 +352,31 @@ The Apache Software License, Version 2.0
     - org.apache.commons-commons-compress-1.21.jar
     - org.apache.commons-commons-lang3-3.11.jar
  * Netty
-    - io.netty-netty-buffer-4.1.74.Final.jar
-    - io.netty-netty-codec-4.1.74.Final.jar
-    - io.netty-netty-codec-dns-4.1.74.Final.jar
-    - io.netty-netty-codec-http-4.1.74.Final.jar
-    - io.netty-netty-codec-http2-4.1.74.Final.jar
-    - io.netty-netty-codec-socks-4.1.74.Final.jar
-    - io.netty-netty-codec-haproxy-4.1.74.Final.jar
-    - io.netty-netty-common-4.1.74.Final.jar
-    - io.netty-netty-handler-4.1.74.Final.jar
-    - io.netty-netty-handler-proxy-4.1.74.Final.jar
-    - io.netty-netty-resolver-4.1.74.Final.jar
-    - io.netty-netty-resolver-dns-4.1.74.Final.jar
-    - io.netty-netty-transport-4.1.74.Final.jar
-    - io.netty-netty-transport-classes-epoll-4.1.74.Final.jar
-    - io.netty-netty-transport-native-epoll-4.1.74.Final-linux-x86_64.jar
-    - io.netty-netty-transport-native-epoll-4.1.74.Final.jar
-    - io.netty-netty-transport-native-unix-common-4.1.74.Final.jar
-    - io.netty-netty-transport-native-unix-common-4.1.74.Final-linux-x86_64.jar
-    - io.netty-netty-tcnative-boringssl-static-2.0.48.Final.jar
-    - io.netty-netty-tcnative-classes-2.0.48.Final.jar
+    - io.netty-netty-buffer-4.1.76.Final.jar
+    - io.netty-netty-codec-4.1.76.Final.jar
+    - io.netty-netty-codec-dns-4.1.76.Final.jar
+    - io.netty-netty-codec-http-4.1.76.Final.jar
+    - io.netty-netty-codec-http2-4.1.76.Final.jar
+    - io.netty-netty-codec-socks-4.1.76.Final.jar
+    - io.netty-netty-codec-haproxy-4.1.76.Final.jar
+    - io.netty-netty-common-4.1.76.Final.jar
+    - io.netty-netty-handler-4.1.76.Final.jar
+    - io.netty-netty-handler-proxy-4.1.76.Final.jar
+    - io.netty-netty-resolver-4.1.76.Final.jar
+    - io.netty-netty-resolver-dns-4.1.76.Final.jar
+    - io.netty-netty-transport-4.1.76.Final.jar
+    - io.netty-netty-transport-classes-epoll-4.1.76.Final.jar
+    - io.netty-netty-transport-native-epoll-4.1.76.Final-linux-x86_64.jar
+    - io.netty-netty-transport-native-epoll-4.1.76.Final.jar
+    - io.netty-netty-transport-native-unix-common-4.1.76.Final.jar
+    - io.netty-netty-transport-native-unix-common-4.1.76.Final-linux-x86_64.jar
+    - io.netty-netty-tcnative-boringssl-static-2.0.51.Final.jar
+    - io.netty-netty-tcnative-boringssl-static-2.0.51.Final-linux-aarch_64.jar
+    - io.netty-netty-tcnative-boringssl-static-2.0.51.Final-linux-x86_64.jar
+    - io.netty-netty-tcnative-boringssl-static-2.0.51.Final-osx-aarch_64.jar
+    - io.netty-netty-tcnative-boringssl-static-2.0.51.Final-osx-x86_64.jar
+    - io.netty-netty-tcnative-boringssl-static-2.0.51.Final-windows-x86_64.jar
+    - io.netty-netty-tcnative-classes-2.0.51.Final.jar
  * Prometheus client
     - io.prometheus-simpleclient-0.5.0.jar
     - io.prometheus-simpleclient_common-0.5.0.jar

--- a/pom.xml
+++ b/pom.xml
@@ -131,9 +131,10 @@ flexible messaging model and an intuitive client API.</description>
     <puppycrawl.checkstyle.version>8.37</puppycrawl.checkstyle.version>
     <dockerfile-maven.version>1.4.13</dockerfile-maven.version>
     <typetools.version>0.5.0</typetools.version>
-    <protobuf3.version>3.16.1</protobuf3.version>
+    <protobuf3.version>3.19.2</protobuf3.version>
     <protoc3.version>${protobuf3.version}</protoc3.version>
-    <grpc.version>1.42.1</grpc.version>
+    <grpc.version>1.45.1</grpc.version>
+    <google-http-client.version>1.41.0</google-http-client.version>
     <perfmark.version>0.19.0</perfmark.version>
     <protoc-gen-grpc-java.version>${grpc.version}</protoc-gen-grpc-java.version>
     <gson.version>2.8.9</gson.version>
@@ -165,7 +166,7 @@ flexible messaging model and an intuitive client API.</description>
     <debezium.postgresql.version>42.3.3</debezium.postgresql.version>
     <debezium.mysql.version>8.0.28</debezium.mysql.version>
     <jsonwebtoken.version>0.11.1</jsonwebtoken.version>
-    <opencensus.version>0.18.0</opencensus.version>
+    <opencensus.version>0.28.0</opencensus.version>
     <hbase.version>2.4.9</hbase.version>
     <guava.version>31.0.1-jre</guava.version>
     <jcip.version>1.0</jcip.version>
@@ -1005,6 +1006,24 @@ flexible messaging model and an intuitive client API.</description>
       </dependency>
 
       <dependency>
+        <groupId>com.google.http-client</groupId>
+        <artifactId>google-http-client</artifactId>
+        <version>${google-http-client.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>com.google.http-client</groupId>
+        <artifactId>google-http-client-jackson2</artifactId>
+        <version>${google-http-client.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>com.google.http-client</groupId>
+        <artifactId>google-http-client-gson</artifactId>
+        <version>${google-http-client.version}</version>
+      </dependency>
+
+      <dependency>
         <groupId>io.grpc</groupId>
         <artifactId>grpc-netty-shaded</artifactId>
         <version>${grpc.version}</version>
@@ -1157,6 +1176,12 @@ flexible messaging model and an intuitive client API.</description>
       <dependency>
         <groupId>io.opencensus</groupId>
         <artifactId>opencensus-api</artifactId>
+        <version>${opencensus.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>io.opencensus</groupId>
+        <artifactId>opencensus-contrib-http-util</artifactId>
         <version>${opencensus.version}</version>
       </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -110,8 +110,8 @@ flexible messaging model and an intuitive client API.</description>
     <snappy.version>1.1.7</snappy.version> <!-- ZooKeeper server -->
     <dropwizardmetrics.version>3.2.5</dropwizardmetrics.version> <!-- ZooKeeper server -->
     <curator.version>5.1.0</curator.version>
-    <netty.version>4.1.74.Final</netty.version>
-    <netty-tc-native.version>2.0.48.Final</netty-tc-native.version>
+    <netty.version>4.1.76.Final</netty.version>
+    <netty-tc-native.version>2.0.51.Final</netty-tc-native.version>
     <jetty.version>9.4.44.v20210927</jetty.version>
     <conscrypt.version>2.5.2</conscrypt.version>
     <jersey.version>2.34</jersey.version>

--- a/pulsar-sql/presto-distribution/LICENSE
+++ b/pulsar-sql/presto-distribution/LICENSE
@@ -232,26 +232,31 @@ The Apache Software License, Version 2.0
     - commons-lang3-3.11.jar
  * Netty
     - netty-3.10.6.Final.jar
-    - netty-buffer-4.1.74.Final.jar
-    - netty-codec-4.1.74.Final.jar
-    - netty-codec-dns-4.1.74.Final.jar
-    - netty-codec-http-4.1.74.Final.jar
-    - netty-codec-haproxy-4.1.74.Final.jar
-    - netty-codec-socks-4.1.74.Final.jar
-    - netty-handler-proxy-4.1.74.Final.jar
-    - netty-common-4.1.74.Final.jar
-    - netty-handler-4.1.74.Final.jar
+    - netty-buffer-4.1.76.Final.jar
+    - netty-codec-4.1.76.Final.jar
+    - netty-codec-dns-4.1.76.Final.jar
+    - netty-codec-http-4.1.76.Final.jar
+    - netty-codec-haproxy-4.1.76.Final.jar
+    - netty-codec-socks-4.1.76.Final.jar
+    - netty-handler-proxy-4.1.76.Final.jar
+    - netty-common-4.1.76.Final.jar
+    - netty-handler-4.1.76.Final.jar
     - netty-reactive-streams-2.0.4.jar
-    - netty-resolver-4.1.74.Final.jar
-    - netty-resolver-dns-4.1.74.Final.jar
-    - netty-tcnative-boringssl-static-2.0.48.Final.jar
-    - netty-tcnative-classes-2.0.48.Final.jar
-    - netty-transport-4.1.74.Final.jar
-    - netty-transport-classes-epoll-4.1.74.Final.jar
-    - netty-transport-native-epoll-4.1.74.Final-linux-x86_64.jar
-    - netty-transport-native-unix-common-4.1.74.Final.jar
-    - netty-transport-native-unix-common-4.1.74.Final-linux-x86_64.jar
-    - netty-codec-http2-4.1.74.Final.jar
+    - netty-resolver-4.1.76.Final.jar
+    - netty-resolver-dns-4.1.76.Final.jar
+    - netty-tcnative-boringssl-static-2.0.51.Final.jar
+    - netty-tcnative-boringssl-static-2.0.51.Final-linux-aarch_64.jar
+    - netty-tcnative-boringssl-static-2.0.51.Final-linux-x86_64.jar
+    - netty-tcnative-boringssl-static-2.0.51.Final-osx-aarch_64.jar
+    - netty-tcnative-boringssl-static-2.0.51.Final-osx-x86_64.jar
+    - netty-tcnative-boringssl-static-2.0.51.Final-windows-x86_64.jar
+    - netty-tcnative-classes-2.0.51.Final.jar
+    - netty-transport-4.1.76.Final.jar
+    - netty-transport-classes-epoll-4.1.76.Final.jar
+    - netty-transport-native-epoll-4.1.76.Final-linux-x86_64.jar
+    - netty-transport-native-unix-common-4.1.76.Final.jar
+    - netty-transport-native-unix-common-4.1.76.Final-linux-x86_64.jar
+    - netty-codec-http2-4.1.76.Final.jar
  * GRPC
     - grpc-api-1.42.1.jar
     - grpc-context-1.42.1.jar

--- a/pulsar-sql/presto-distribution/LICENSE
+++ b/pulsar-sql/presto-distribution/LICENSE
@@ -258,14 +258,14 @@ The Apache Software License, Version 2.0
     - netty-transport-native-unix-common-4.1.76.Final-linux-x86_64.jar
     - netty-codec-http2-4.1.76.Final.jar
  * GRPC
-    - grpc-api-1.42.1.jar
-    - grpc-context-1.42.1.jar
-    - grpc-core-1.42.1.jar
-    - grpc-grpclb-1.42.1.jar
-    - grpc-netty-1.42.1.jar
-    - grpc-protobuf-1.42.1.jar
-    - grpc-protobuf-lite-1.42.1.jar
-    - grpc-stub-1.42.1.jar
+    - grpc-api-1.45.1.jar
+    - grpc-context-1.45.1.jar
+    - grpc-core-1.45.1.jar
+    - grpc-grpclb-1.45.1.jar
+    - grpc-netty-1.45.1.jar
+    - grpc-protobuf-1.45.1.jar
+    - grpc-protobuf-lite-1.45.1.jar
+    - grpc-stub-1.45.1.jar
   * JEtcd
     - jetcd-common-0.5.11.jar
     - jetcd-core-0.5.11.jar
@@ -483,8 +483,8 @@ The Apache Software License, Version 2.0
 
 Protocol Buffers License
  * Protocol Buffers
-   - protobuf-java-3.16.1.jar
-   - protobuf-java-util-3.16.1.jar
+   - protobuf-java-3.19.2.jar
+   - protobuf-java-util-3.19.2.jar
    - proto-google-common-protos-2.0.1.jar
 
 BSD 3-clause "New" or "Revised" License


### PR DESCRIPTION
Fixes #14015

### Motivation

- release notes for 4.1.76.Final https://netty.io/news/2022/04/12/4-1-76-Final.html
  - contains fix for https://github.com/netty/netty/issues/11695 which is expected to resolve #14015

Since the current version is 4.1.74.Final, the upgrade will also contain 4.1.75.Final changes,
  - release notes https://netty.io/news/2022/03/10/4-1-75-Final.html
     - most notable change is "Reduce the default PooledByteBufAllocator chunk size from 16 MiB to 4 MiB ([#12108](https://github.com/netty/netty/pull/12108))"

A notable change that comes with Netty Tcnative 2.0.51.Final is the change that boringssl native libraries are packaged in separate jar file. That change seems to have been made in https://github.com/netty/netty-tcnative/pull/696 in Netty Tcnative 2.0.49.Final .

grpc < 1.45.1 is not compatible with Netty > 4.1.74.Final: https://github.com/grpc/grpc-java/pull/9004


### Modifications

Upgrade Netty to 4.1.76.Final and Netty Tcnative to 2.0.51.Final
Upgrade grpc to 1.45.1
Upgrade protobuf to 3.19.2