### PR TITLE
Upgrade async-http-client to 2.12.3

### DIFF
--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -423,8 +423,8 @@ The Apache Software License, Version 2.0
  * AirCompressor
     - io.airlift-aircompressor-0.20.jar
  * AsyncHttpClient
-    - org.asynchttpclient-async-http-client-2.12.1.jar
-    - org.asynchttpclient-async-http-client-netty-utils-2.12.1.jar
+    - org.asynchttpclient-async-http-client-2.12.3.jar
+    - org.asynchttpclient-async-http-client-netty-utils-2.12.3.jar
  * Jetty
     - org.eclipse.jetty-jetty-client-9.4.44.v20210927.jar
     - org.eclipse.jetty-jetty-continuation-9.4.44.v20210927.jar

--- a/pom.xml
+++ b/pom.xml
@@ -174,7 +174,7 @@ flexible messaging model and an intuitive client API.</description>
     <kafka.confluent.schemaregistryclient.version>5.3.0</kafka.confluent.schemaregistryclient.version>
     <kafka.confluent.avroserializer.version>5.3.0</kafka.confluent.avroserializer.version>
     <aircompressor.version>0.20</aircompressor.version>
-    <asynchttpclient.version>2.12.1</asynchttpclient.version>
+    <asynchttpclient.version>2.12.3</asynchttpclient.version>
     <jcommander.version>1.78</jcommander.version>
     <commons-lang3.version>3.11</commons-lang3.version>
     <commons-configuration.version>1.10</commons-configuration.version>

--- a/pulsar-sql/presto-distribution/LICENSE
+++ b/pulsar-sql/presto-distribution/LICENSE
@@ -426,8 +426,8 @@ The Apache Software License, Version 2.0
     - jctools-core-2.1.2.jar
   * Asynchronous Http Client
     - async-http-client-1.6.5.jar
-    - async-http-client-2.12.1.jar
-    - async-http-client-netty-utils-2.12.1.jar
+    - async-http-client-2.12.3.jar
+    - async-http-client-netty-utils-2.12.3.jar
   * Apache Bookkeeper
     - bookkeeper-common-4.14.4.jar
     - bookkeeper-common-allocator-4.14.4.jar

--- a/pulsar-sql/presto-distribution/pom.xml
+++ b/pulsar-sql/presto-distribution/pom.xml
@@ -44,7 +44,7 @@
     <jackson.databind.version>2.13.2.1</jackson.databind.version>
     <maven.version>3.0.5</maven.version>
     <guava.version>31.0.1-jre</guava.version>
-    <asynchttpclient.version>2.12.1</asynchttpclient.version>
+    <asynchttpclient.version>2.12.3</asynchttpclient.version>
     <errorprone.version>2.5.1</errorprone.version>
     <javax.servlet-api>4.0.1</javax.servlet-api>
   </properties>

--- a/src/owasp-dependency-check-suppressions.xml
+++ b/src/owasp-dependency-check-suppressions.xml
@@ -480,4 +480,11 @@
         <cve>CVE-2021-46667</cve>
     </suppress>
 
+    <suppress>
+        <notes><![CDATA[
+   file name: async-http-client-netty-utils-2.12.3.jar
+   ]]></notes>
+        <sha1>ad99d8622931ed31367d0fef7fa17eb62e033fb3</sha1>
+        <cve>CVE-2021-43138</cve>
+    </suppress>
 </suppressions>


### PR DESCRIPTION
### Motivation

- keep the dependency up-to-date
  - contains a few bug fixes compared to 2.12.1
    https://github.com/AsyncHttpClient/async-http-client/compare/async-http-client-project-2.12.1...async-http-client-project-2.12.3

### Modifications

- upgrade async-http-client to 2.12.3