### PR TITLE
[fix][broker] Fix update topic partitions failed

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApi2Test.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApi2Test.java
@@ -2350,7 +2350,13 @@ public class AdminApi2Test extends MockedPulsarServiceBaseTest {
         }
         admin.topics().updatePartitionedTopic(partitionedTopicName, newPartitions, false, true);
         // validate subscription is created for new partition.
-        assertNotNull(admin.topics().getStats(partitionedTopicName + "-partition-" + 6).getSubscriptions().get(subName1));
+        for (int i = startPartitions; i < newPartitions; i++) {
+            assertNotNull(
+                    admin.topics().getStats(partitionedTopicName + "-partition-" + i).getSubscriptions().get(subName1));
+        }
+
+        // validate update partition is success
+        assertEquals(admin.topics().getPartitionedTopicMetadata(partitionedTopicName).partitions, newPartitions);
     }
 
     @Test(dataProvider = "topicType")


### PR DESCRIPTION
### Motivation
I encounter the same problem as #11682 described, and i notice two pr for it, #10374 and #11683

But I think they still remain problems.

Actually internalUpdatePartitionedTopic consist of three part:
1. tryCreatePartitionsAsync(): create the topic newPartition on metadataStore such as zk
2. createSubscriptions(): creates subscriptions for new partitions of existing partitioned-topics
3. updatePartitionedTopicAsync(): update the partitioned-topic metadata(update partition num to newPartition)

Suppose there are subscriptions in a partitioned-topic and we want to update its partition.

If part 1, 2 succeed, part 3 failed, it need to clean up managed-ledger znode. But it would throw zookeeper Directory not empty exception when clean-up, since znode would has successfully created subscription children node. 

![wecom-temp-977f0ae410a236f38d7822fc12d653b6](https://user-images.githubusercontent.com/13505225/163978509-150292e3-8ff8-4ccf-94e7-6bd465b479d8.png)


And when we retrying updatePartition again, it would throw the below error because part 2 complete 
![wecom-temp-96b53fea557f4984494a8d213872f1d3](https://user-images.githubusercontent.com/13505225/163978565-27750a2b-5fe8-4fa0-a30e-dd58296ad60e.png)


So we need to retry updatePartition again with "force=true". The "Subscription already exists" error would be catch, and it complete the updatePartition operation, while permanently skip the part 3.


### Modifications

After catch the "Subscription already exists" error, do updatePartitionedTopicAsync() operation

### discussions

When adding 'force=true' , the managed-ledger znode clean up operation seems not neccessary and can be removed?


### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): no
  - The public API: no
  - The schema: no
  - The default values of configurations: no
  - The wire protocol: no
  - The rest endpoints: no
  - The admin cli options: no
  - Anything that affects deployment: no

### Documentation

Check the box below or label this PR directly.

Need to update docs? 

- [x] `no-need-doc` 
(Please explain why)
  