### PR TITLE
[Branch-2.9][test] Fix AdminTest#test500Error.

### DIFF
--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -445,7 +445,7 @@ The Apache Software License, Version 2.0
     - org.eclipse.jetty.websocket-websocket-servlet-9.4.43.v20210629.jar
     - org.eclipse.jetty-jetty-alpn-conscrypt-server-9.4.43.v20210629.jar
     - org.eclipse.jetty-jetty-alpn-server-9.4.43.v20210629.jar
- * SnakeYaml -- org.yaml-snakeyaml-1.27.jar
+ * SnakeYaml -- org.yaml-snakeyaml-1.30.jar
  * RocksDB - org.rocksdb-rocksdbjni-6.10.2.jar
  * Google Error Prone Annotations - com.google.errorprone-error_prone_annotations-2.5.1.jar
  * Apache Thrift - org.apache.thrift-libthrift-0.14.2.jar

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractTopic.java
@@ -789,7 +789,7 @@ public abstract class AbstractTopic implements Topic {
     }
 
     public void updateMaxPublishRate(Policies policies) {
-        updatePublishDispatcher(Optional.of(policies));
+        updatePublishDispatcher(Optional.ofNullable(policies));
     }
 
     private void updatePublishDispatcher(Optional<Policies> optPolicies) {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminTest.java
@@ -844,10 +844,7 @@ public class AdminTest extends MockedPulsarServiceBaseTest {
         AsyncResponse response1 = mock(AsyncResponse.class);
         ArgumentCaptor<RestException> responseCaptor = ArgumentCaptor.forClass(RestException.class);
         NamespaceName namespaceName = NamespaceName.get(property, cluster, namespace);
-        NamespaceService ns = spy(pulsar.getNamespaceService());
-        Field namespaceField = pulsar.getClass().getDeclaredField("nsService");
-        namespaceField.setAccessible(true);
-        namespaceField.set(pulsar, ns);
+        NamespaceService ns = pulsar.getNamespaceService();
         CompletableFuture<List<String>> future = new CompletableFuture();
         future.completeExceptionally(new RuntimeException("500 error contains error message"));
         doReturn(future).when(ns).getListOfTopics(namespaceName, CommandGetTopicsOfNamespace.Mode.ALL);

--- a/pulsar-sql/presto-distribution/LICENSE
+++ b/pulsar-sql/presto-distribution/LICENSE
@@ -394,7 +394,7 @@ The Apache Software License, Version 2.0
   * RocksDB JNI
     - rocksdbjni-6.10.2.jar
   * SnakeYAML
-    - snakeyaml-1.27.jar
+    - snakeyaml-1.30.jar
   * Bean Validation API
     - validation-api-2.0.1.Final.jar
   * Objectsize


### PR DESCRIPTION
### Motivation

When cherry-pick #14856 to branch-2.9, the test failed.

Because in branch-2.9, the nsService  is already a mocked object.

```
Error:  Tests run: 17, Failures: 1, Errors: 0, Skipped: 9, Time elapsed: 28.159 s <<< FAILURE! - in org.apache.pulsar.broker.admin.AdminTest
Error:  test500Error(org.apache.pulsar.broker.admin.AdminTest)  Time elapsed: 0.025 s  <<< FAILURE!
java.lang.NoSuchFieldException: nsService
	at java.base/java.lang.Class.getDeclaredField(Class.java:2411)
	at org.apache.pulsar.broker.admin.AdminTest.test500Error(AdminTest.java:848)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at org.testng.internal.MethodInvocationHelper.invokeMethod(MethodInvocationHelper.java:132)
	at org.testng.internal.InvokeMethodRunnable.runOne(InvokeMethodRunnable.java:45)
	at org.testng.internal.InvokeMethodRunnable.call(InvokeMethodRunnable.java:73)
	at org.testng.internal.InvokeMethodRunnable.call(InvokeMethodRunnable.java:11)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:829)
```


### Documentation

- [x] `no-need-doc` 
(Please explain why)
  
