### PR TITLE
Skip unnecessary DNS resolution when creating AuthenticationDataHttp instance

### DIFF
--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authentication/AuthenticationDataHttp.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authentication/AuthenticationDataHttp.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pulsar.broker.authentication;
 
+import io.netty.util.NetUtil;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import javax.servlet.http.HttpServletRequest;
@@ -34,7 +35,9 @@ public class AuthenticationDataHttp implements AuthenticationDataSource {
             throw new IllegalArgumentException();
         }
         this.request = request;
-        this.remoteAddress = new InetSocketAddress(request.getRemoteAddr(), request.getRemotePort());
+        this.remoteAddress =
+                new InetSocketAddress(NetUtil.createInetAddressFromIpAddressString(request.getRemoteAddr()),
+                        request.getRemotePort());
     }
 
     /*


### PR DESCRIPTION
### Motivation

Using the DNS resolution is a blocking operation in Java. In this case it's completely unnecessary to do a reverse lookup for the client's IP address.

### Modifications

- Use Netty's utility class to create a InetAddress instance from the IP address string without using DNS resolution.