### PR TITLE
[dependency] Upgrade Grpc to 1.45.1

### DIFF
--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -461,21 +461,21 @@ The Apache Software License, Version 2.0
      - org.jetbrains.kotlin-kotlin-stdlib-jdk8-1.4.32.jar
      - org.jetbrains-annotations-13.0.jar
  * gRPC
-    - io.grpc-grpc-all-1.42.1.jar
-    - io.grpc-grpc-auth-1.42.1.jar
-    - io.grpc-grpc-context-1.42.1.jar
-    - io.grpc-grpc-core-1.42.1.jar
-    - io.grpc-grpc-netty-1.42.1.jar
-    - io.grpc-grpc-protobuf-1.42.1.jar
-    - io.grpc-grpc-protobuf-lite-1.42.1.jar
-    - io.grpc-grpc-stub-1.42.1.jar
-    - io.grpc-grpc-alts-1.42.1.jar
-    - io.grpc-grpc-api-1.42.1.jar
-    - io.grpc-grpc-grpclb-1.42.1.jar
-    - io.grpc-grpc-netty-shaded-1.42.1.jar
-    - io.grpc-grpc-services-1.42.1.jar
-    - io.grpc-grpc-xds-1.42.1.jar
-    - io.grpc-grpc-rls-1.42.1.jar
+    - io.grpc-grpc-all-1.45.1.jar
+    - io.grpc-grpc-auth-1.45.1.jar
+    - io.grpc-grpc-context-1.45.1.jar
+    - io.grpc-grpc-core-1.45.1.jar
+    - io.grpc-grpc-netty-1.45.1.jar
+    - io.grpc-grpc-protobuf-1.45.1.jar
+    - io.grpc-grpc-protobuf-lite-1.45.1.jar
+    - io.grpc-grpc-stub-1.45.1.jar
+    - io.grpc-grpc-alts-1.45.1.jar
+    - io.grpc-grpc-api-1.45.1.jar
+    - io.grpc-grpc-grpclb-1.45.1.jar
+    - io.grpc-grpc-netty-shaded-1.45.1.jar
+    - io.grpc-grpc-services-1.45.1.jar
+    - io.grpc-grpc-xds-1.45.1.jar
+    - io.grpc-grpc-rls-1.45.1.jar
     - com.google.auto.service-auto-service-annotations-1.0.jar
   * Perfmark
     - io.perfmark-perfmark-api-0.19.0.jar
@@ -526,7 +526,7 @@ The Apache Software License, Version 2.0
   * Google HTTP Client
     - com.google.http-client-google-http-client-jackson2-1.38.0.jar
     - com.google.http-client-google-http-client-1.38.0.jar
-    - com.google.auto.value-auto-value-annotations-1.7.4.jar
+    - com.google.auto.value-auto-value-annotations-1.9.jar
     - com.google.re2j-re2j-1.5.jar
   * Jetcd
     - io.etcd-jetcd-common-0.5.11.jar
@@ -536,7 +536,7 @@ The Apache Software License, Version 2.0
 
 BSD 3-clause "New" or "Revised" License
  * Google auth library
-    - com.google.auth-google-auth-library-credentials-0.22.2.jar -- licenses/LICENSE-google-auth-library.txt
+    - com.google.auth-google-auth-library-credentials-1.4.0.jar -- licenses/LICENSE-google-auth-library.txt
     - com.google.auth-google-auth-library-oauth2-http-0.22.2.jar -- licenses/LICENSE-google-auth-library.txt
  * LevelDB -- (included in org.rocksdb.*.jar) -- licenses/LICENSE-LevelDB.txt
  * JSR305 -- com.google.code.findbugs-jsr305-3.0.2.jar -- licenses/LICENSE-JSR305.txt

--- a/pom.xml
+++ b/pom.xml
@@ -133,7 +133,7 @@ flexible messaging model and an intuitive client API.</description>
     <typetools.version>0.5.0</typetools.version>
     <protobuf3.version>3.16.1</protobuf3.version>
     <protoc3.version>${protobuf3.version}</protoc3.version>
-    <grpc.version>1.42.1</grpc.version>
+    <grpc.version>1.45.1</grpc.version>
     <perfmark.version>0.19.0</perfmark.version>
     <protoc-gen-grpc-java.version>${grpc.version}</protoc-gen-grpc-java.version>
     <gson.version>2.8.9</gson.version>


### PR DESCRIPTION
### Motivation

Currently, the grpc `1.42.1` import a shaded netty `4.1.51.Final` package, it has some issues https://github.com/advisories/GHSA-9vjp-v76f-g363, https://github.com/advisories/GHSA-grg4-wf29-r9vv, since `io.grpc:grpc-all:1.44.0`, it upgraded the netty to `4.1.72.Final`, refer to https://github.com/grpc/grpc-java/blob/v1.44.0/build.gradle#L58 and https://github.com/grpc/grpc-java/pull/8780. So we need to upgrade the grpc to `1.44.0+`.

### Modifications

Bump the grpc to `1.45.1`.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (yes)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

Check the box below or label this PR directly.

Need to update docs? 

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)
  
- [x] `no-need-doc` 
(Please explain why)
  
- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-added`
(Docs have been already added)