### PR TITLE
[PIP-136]: Sync Pulsar policies across multiple clouds

### DIFF
--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -687,6 +687,12 @@ metadataStoreBatchingMaxOperations=1000
 # Maximum size of a batch
 metadataStoreBatchingMaxSizeKb=128
 
+# Event topic to sync metadata between separate pulsar clusters on different cloud platforms
+metadataSyncEventTopic=
+
+# Snapshot duration to sync metadata using event topic. (Default 0 to disable it)
+metadataSyncSnapshotDurationSecond=0
+
 
 ### --- Authentication --- ###
 

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -460,6 +460,18 @@ public class ServiceConfiguration implements PulsarConfiguration {
     private String metadataStoreConfigPath = null;
 
     @FieldContext(
+            category = CATEGORY_SERVER,
+            doc = "Event topic to sync metadata between separate pulsar clusters on different cloud platforms."
+    )
+    private String metadataSyncEventTopic = null;
+
+    @FieldContext(
+            category = CATEGORY_SERVER,
+            doc = "Snapshot duration to sync metadata using event topic. (Default 0 to disable it)"
+    )
+    private long metadataSyncSnapshotDurationSecond = 0;
+
+    @FieldContext(
         category = CATEGORY_POLICIES,
         doc = "Enable backlog quota check. Enforces actions on topic when the quota is reached"
     )

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/resources/BaseResources.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/resources/BaseResources.java
@@ -25,12 +25,14 @@ import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
 import java.util.function.Function;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.metadata.api.MetadataCache;
 import org.apache.pulsar.metadata.api.MetadataStore;
 import org.apache.pulsar.metadata.api.MetadataStoreException;
+import org.apache.pulsar.metadata.api.Notification;
 
 /**
  * Base class for all configuration resources to access configurations from metadata-store.
@@ -41,9 +43,9 @@ import org.apache.pulsar.metadata.api.MetadataStoreException;
 @Slf4j
 public class BaseResources<T> {
 
-    protected static final String BASE_POLICIES_PATH = "/admin/policies";
-    protected static final String BASE_CLUSTERS_PATH = "/admin/clusters";
-    protected static final String LOCAL_POLICIES_ROOT = "/admin/local-policies";
+    public static final String BASE_POLICIES_PATH = "/admin/policies";
+    public static final String BASE_CLUSTERS_PATH = "/admin/clusters";
+    public static final String LOCAL_POLICIES_ROOT = "/admin/local-policies";
 
     @Getter
     private final MetadataStore store;
@@ -189,6 +191,14 @@ public class BaseResources<T> {
 
     public int getOperationTimeoutSec() {
         return operationTimeoutSec;
+    }
+
+    protected void registerListener(String basePath, Consumer<Notification> listener) {
+        store.registerListener((n) -> {
+            if (n.getPath().startsWith(basePath)) {
+                listener.accept(n);
+            }
+        });
     }
 
     protected static String joinPath(String... parts) {

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/resources/TenantResources.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/resources/TenantResources.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pulsar.broker.resources;
 
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -27,6 +28,7 @@ import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.common.naming.NamespaceName;
 import org.apache.pulsar.common.policies.data.TenantInfo;
+import org.apache.pulsar.common.policies.data.TenantInfoImpl;
 import org.apache.pulsar.common.util.FutureUtil;
 import org.apache.pulsar.metadata.api.MetadataStore;
 import org.apache.pulsar.metadata.api.MetadataStoreException;
@@ -66,15 +68,22 @@ public class TenantResources extends BaseResources<TenantInfo> {
     }
 
     public void createTenant(String tenantName, TenantInfo ti) throws MetadataStoreException {
+        ((TenantInfoImpl) ti).setLastUpdatedTimestamp(Instant.now().toEpochMilli());
         create(joinPath(BASE_POLICIES_PATH, tenantName), ti);
     }
 
     public CompletableFuture<Void> createTenantAsync(String tenantName, TenantInfo ti) {
+        ((TenantInfoImpl) ti).setLastUpdatedTimestamp(Instant.now().toEpochMilli());
         return createAsync(joinPath(BASE_POLICIES_PATH, tenantName), ti);
     }
 
     public CompletableFuture<Void> updateTenantAsync(String tenantName, Function<TenantInfo, TenantInfo> f) {
-        return setAsync(joinPath(BASE_POLICIES_PATH, tenantName), f);
+        return setAsync(joinPath(BASE_POLICIES_PATH, tenantName), (p1) -> {
+            TenantInfoImpl p2 = (TenantInfoImpl) f.apply(p1);
+            p2.setLastUpdatedTimestamp(
+                    p2.getLastUpdatedTimestamp() > 0 ? p2.getLastUpdatedTimestamp() : Instant.now().toEpochMilli());
+            return p2;
+        });
     }
 
     public CompletableFuture<Boolean> tenantExistsAsync(String tenantName) {
@@ -112,6 +121,10 @@ public class TenantResources extends BaseResources<TenantInfo> {
 
     public CompletableFuture<List<String>> getActiveNamespaces(String tenant, String cluster) {
         return getChildrenAsync(joinPath(BASE_POLICIES_PATH, tenant, cluster));
+    }
+
+    public static String getPath(String tenant) {
+        return joinPath(BASE_POLICIES_PATH, tenant);
     }
 
     public CompletableFuture<Void> hasActiveNamespace(String tenant) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
@@ -100,6 +100,7 @@ import org.apache.pulsar.broker.resources.ClusterResources;
 import org.apache.pulsar.broker.resources.PulsarResources;
 import org.apache.pulsar.broker.service.BrokerService;
 import org.apache.pulsar.broker.service.GracefulExecutorServicesShutdown;
+import org.apache.pulsar.broker.service.MetadataStoreSynchronizer;
 import org.apache.pulsar.broker.service.SystemTopicBaseTxnBufferSnapshotService;
 import org.apache.pulsar.broker.service.SystemTopicBasedTopicPoliciesService;
 import org.apache.pulsar.broker.service.Topic;
@@ -258,6 +259,7 @@ public class PulsarService implements AutoCloseable, ShutdownService {
     private boolean shouldShutdownConfigurationMetadataStore;
 
     private PulsarResources pulsarResources;
+    private MetadataStoreSynchronizer metadataSyncer;
 
     private TransactionPendingAckStoreProvider transactionPendingAckStoreProvider;
     private final ExecutorProvider transactionExecutorProvider;
@@ -818,6 +820,7 @@ public class PulsarService implements AutoCloseable, ShutdownService {
                 this.resourceUsageTransportManager = (ResourceUsageTopicTransportManager) object;
             }
             this.resourceGroupServiceManager = new ResourceGroupService(this);
+            this.metadataSyncer = new MetadataStoreSynchronizer(this);
 
             long currentTimestamp = System.currentTimeMillis();
             final long bootstrapTimeSeconds = TimeUnit.MILLISECONDS.toSeconds(currentTimestamp - startTimestamp);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractMetadataStoreSynchronizer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractMetadataStoreSynchronizer.java
@@ -1,0 +1,336 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.service;
+
+import static org.apache.pulsar.broker.service.persistent.PersistentTopic.MESSAGE_RATE_BACKOFF_MS;
+import io.netty.util.concurrent.ScheduledFuture;
+import java.time.Instant;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.pulsar.broker.PulsarServerException;
+import org.apache.pulsar.broker.PulsarService;
+import org.apache.pulsar.broker.resources.BaseResources;
+import org.apache.pulsar.broker.service.MetadataChangeEvent.EventType;
+import org.apache.pulsar.broker.service.MetadataChangeEvent.ResourceType;
+import org.apache.pulsar.client.api.Consumer;
+import org.apache.pulsar.client.api.ConsumerBuilder;
+import org.apache.pulsar.client.api.ConsumerEventListener;
+import org.apache.pulsar.client.api.Message;
+import org.apache.pulsar.client.api.MessageRoutingMode;
+import org.apache.pulsar.client.api.Producer;
+import org.apache.pulsar.client.api.ProducerBuilder;
+import org.apache.pulsar.client.api.SubscriptionType;
+import org.apache.pulsar.client.impl.Backoff;
+import org.apache.pulsar.client.impl.PulsarClientImpl;
+import org.apache.pulsar.client.impl.schema.AvroSchema;
+import org.apache.pulsar.metadata.api.NotificationType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public abstract class AbstractMetadataStoreSynchronizer {
+
+    private static final Logger log = LoggerFactory.getLogger(AbstractMetadataStoreSynchronizer.class);
+
+    protected PulsarService pulsar;
+    protected BrokerService brokerService;
+    protected String topicName;
+    protected final PulsarClientImpl client;
+    protected volatile Producer<MetadataChangeEvent> producer;
+    protected ProducerBuilder<MetadataChangeEvent> producerBuilder;
+    private volatile ScheduledFuture<?> snapshotScheduler;
+
+    protected static final AtomicReferenceFieldUpdater<AbstractMetadataStoreSynchronizer, State> STATE_UPDATER =
+    AtomicReferenceFieldUpdater.newUpdater(AbstractMetadataStoreSynchronizer.class, State.class, "state");
+    private volatile State state = State.Stopped;
+    private volatile boolean isActive = false;
+    public static final String SUBSCRIPTION_NAME = "metadata-syncer";
+    protected final Backoff backOff = new Backoff(100, TimeUnit.MILLISECONDS, 1, TimeUnit.MINUTES, 0,
+            TimeUnit.MILLISECONDS);
+
+    protected enum State {
+        Stopped, Starting, Started, Stopping
+    }
+
+    public AbstractMetadataStoreSynchronizer(PulsarService pulsar) throws PulsarServerException {
+        this.pulsar = pulsar;
+        this.brokerService = pulsar.getBrokerService();
+        this.topicName = pulsar.getConfig().getMetadataSyncEventTopic();
+        this.client = (PulsarClientImpl) pulsar.getClient();
+
+        if (!StringUtils.isNotBlank(topicName)) {
+            log.info("Metadata synchronizer is disabled");
+            return;
+        }
+        @SuppressWarnings("serial")
+        ConsumerEventListener listener = new ConsumerEventListener() {
+            @Override
+            public void becameActive(Consumer<?> consumer, int partitionId) {
+                startProducer();
+                isActive = true;
+            }
+
+            @Override
+            public void becameInactive(Consumer<?> consumer, int partitionId) {
+                isActive = false;
+                closeProducerAsync();
+            }
+        };
+        ConsumerBuilder<MetadataChangeEvent> consumerBuilder = client
+                .newConsumer(AvroSchema.of(MetadataChangeEvent.class)).topic(topicName)
+                .subscriptionName(SUBSCRIPTION_NAME).ackTimeout(60, TimeUnit.SECONDS)
+                .subscriptionType(SubscriptionType.Failover).messageListener((c, msg) -> {
+                    updateMetadata(c, msg);
+                }).consumerEventListener(listener);
+
+        this.producerBuilder = client.newProducer(AvroSchema.of(MetadataChangeEvent.class)) //
+                .topic(topicName).messageRoutingMode(MessageRoutingMode.SinglePartition).enableBatching(false)
+                .sendTimeout(0, TimeUnit.SECONDS);
+
+        registerListeners();
+        startProducer();
+        startConsumer(consumerBuilder);
+    }
+
+    private void updateMetadata(Consumer<MetadataChangeEvent> c, Message<MetadataChangeEvent> msg) {
+        if (msg.getValue().getResource() == null) {
+            log.info("Metadata change event has null resource {}.. skipping event", msg.getMessageId());
+            c.acknowledgeAsync(msg);
+            return;
+        }
+
+        MetadataChangeEvent event = msg.getValue();
+        if (pulsar.getConfig().getClusterName().equals(event.getSourceCluster())) {
+            if (log.isDebugEnabled()) {
+                log.debug("ignoring event because source cluster is local cluster {}",
+                        pulsar.getConfig().getClusterName());
+            }
+            return;
+        }
+        if (log.isDebugEnabled()) {
+            log.debug("received metadata sync event {}", event);
+        }
+        CompletableFuture<Void> result;
+        switch (event.getResource()) {
+        case Tenants:
+            result = updateTenantMetadata(event);
+            break;
+        case Namespaces:
+            result = updateNamespaceMetadata(event);
+            break;
+        case TopicPartition:
+            result = updatePartitionMetadata(event);
+            break;
+        default:
+            result = CompletableFuture.completedFuture(null);
+            log.warn("Unknown metadata event resource {}, msgId={}", event.getResource(), msg.getMessageId());
+        }
+        result.thenAccept(__ -> c.acknowledgeAsync(msg)).exceptionally(ex -> {
+            log.warn("Failed to process {} on {}", msg.getMessageId(), topicName, ex.getCause());
+            return null;
+        });
+    }
+
+    /**
+     * Handle metadata change event and update namespace metadata into metadata store.
+     * @param event
+     * @return
+     */
+    public abstract CompletableFuture<Void> updateNamespaceMetadata(MetadataChangeEvent event);
+
+    /**
+     * Handle metadata change event and update tenant metadata into metadata store.
+     * @param event
+     * @return
+     */
+    public abstract CompletableFuture<Void> updateTenantMetadata(MetadataChangeEvent event);
+
+    /**
+     * Handle metadata change event and update partitioned metadata into metadata store.
+     * @param event
+     * @return
+     */
+    public abstract CompletableFuture<Void> updatePartitionMetadata(MetadataChangeEvent event);
+
+    /**
+     * Trigger snapshot synchronizer to publish metadata event for every metadata resources.
+     */
+    public abstract void triggerSyncSnapshot();
+
+    protected void publishAsync(String metadataStorePath, ResourceType resourceType, String resource, EventType type) {
+        if (STATE_UPDATER.get(this) == State.Stopping || STATE_UPDATER.get(this) == State.Stopped) {
+            log.warn("Producer is already closed. ignoring event publish for {}", metadataStorePath);
+            return;
+        }
+        pulsar.getConfigurationMetadataStore().get(metadataStorePath).thenAccept(result -> {
+            if (result.isPresent()) {
+                byte[] data = result.get().getValue();
+                publishAsync(data, resourceType, resource, type);
+            }
+        });
+    }
+
+    private void publishAsync(byte[] data, ResourceType resourceType, String resource, EventType type) {
+        if (STATE_UPDATER.get(this) == State.Stopping || STATE_UPDATER.get(this) == State.Stopped) {
+            log.warn("Producer is already closed. ignoring event publish for {}-{}", resource, resourceType);
+            return;
+        }
+        MetadataChangeEvent event = new MetadataChangeEvent(type, resourceType, resource, data,
+                pulsar.getConfig().getClusterName(), Instant.now().toEpochMilli());
+        producer.newMessage().value(event).sendAsync()
+                .thenAccept(__ -> log.info("successfully published metadata change event {}", event))
+                .exceptionally(ex -> {
+                    log.warn("failed to publish metadata update {}, will retry in {}", topicName,
+                            MESSAGE_RATE_BACKOFF_MS, ex);
+                    pulsar.getBrokerService().executor().schedule(
+                            () -> publishAsync(data, resourceType, resource, type), MESSAGE_RATE_BACKOFF_MS,
+                            TimeUnit.MILLISECONDS);
+                    return null;
+                });
+
+    }
+
+    private void registerListeners() {
+        pulsar.getPulsarResources().getNamespaceResources().registerListener(n -> {
+            String path = n.getPath();
+            if (!isActive || NotificationType.ChildrenChanged.equals(n.getType())
+                    || !path.startsWith(BaseResources.BASE_POLICIES_PATH)) {
+                log.warn("synchronizer is not active = {} or invalid resource path ={}", isActive, path);
+                return;
+            }
+            ResourceType resourceType = (n.getPath().split("/").length == 3) ? ResourceType.Tenants
+                    : ResourceType.Namespaces;
+            String resource = (n.getPath().split(BaseResources.BASE_POLICIES_PATH + "/")[1]);
+            EventType eventType;
+            switch (n.getType()) {
+            case Created:
+                eventType = EventType.Created;
+                break;
+            case Modified:
+                eventType = EventType.Modified;
+                break;
+            case Deleted:
+                eventType = EventType.Deleted;
+                break;
+            default:
+                return;
+            }
+            publishAsync(path, resourceType, resource, eventType);
+        });
+    }
+
+    public boolean isActive() {
+        return isActive;
+    }
+
+    // This method needs to be synchronized with disconnects else if there is a disconnect followed by startProducer
+    // the end result can be disconnect.
+    private synchronized void startProducer() {
+        if (STATE_UPDATER.get(this) == State.Stopping) {
+            long waitTimeMs = backOff.next();
+            if (log.isDebugEnabled()) {
+                log.debug("Waiting for change-event producer to close before attempting to reconnect, retrying in {} s",
+                        waitTimeMs / 1000.0);
+            }
+            // BackOff before retrying
+            brokerService.executor().schedule(this::startProducer, waitTimeMs, TimeUnit.MILLISECONDS);
+            return;
+        }
+        State state = STATE_UPDATER.get(this);
+        if (!STATE_UPDATER.compareAndSet(this, State.Stopped, State.Starting)) {
+            if (state == State.Started) {
+                // Already running
+                if (log.isDebugEnabled()) {
+                    log.debug("[{}][{} -> {}] Change-event producer already running");
+                }
+            } else {
+                log.info("[{}][{} -> {}] Change-event producer already being started. state: {}", state);
+            }
+
+            return;
+        }
+
+        log.info("[{}] Starting producer", topicName);
+        producerBuilder.createAsync().thenAccept(prod -> {
+            this.producer = prod;
+            startSnapshotScheduler();
+            log.info("producer is created successfully {}", topicName);
+        }).exceptionally(ex -> {
+            if (STATE_UPDATER.compareAndSet(this, State.Starting, State.Stopped)) {
+                long waitTimeMs = backOff.next();
+                log.warn("[{}] Failed to create remote producer ({}), retrying in {} s", topicName, ex.getMessage(),
+                        waitTimeMs / 1000.0);
+
+                // BackOff before retrying
+                brokerService.executor().schedule(this::startProducer, waitTimeMs, TimeUnit.MILLISECONDS);
+            } else {
+                log.warn("[{}] Failed to create remote producer. Replicator state: {}", topicName,
+                        STATE_UPDATER.get(this), ex);
+            }
+            return null;
+        });
+    }
+
+    private void startSnapshotScheduler() {
+        long interval = pulsar.getConfig().getMetadataSyncSnapshotDurationSecond();
+        if (interval > 0) {
+            this.snapshotScheduler = pulsar.getBrokerService().executor()
+                    .scheduleAtFixedRate(() -> triggerSyncSnapshot(), interval, interval, TimeUnit.SECONDS);
+        }
+    }
+
+    private void stopSnapshotScheduler() {
+        if (this.snapshotScheduler != null) {
+            this.snapshotScheduler.cancel(true);
+            this.snapshotScheduler = null;
+        }
+    }
+
+    private void startConsumer(ConsumerBuilder<MetadataChangeEvent> consumerBuilder) {
+        consumerBuilder.subscribeAsync().thenAccept(consumer -> {
+            log.info("successfully created consumer {}", topicName);
+        }).exceptionally(ex -> {
+            log.warn("failed to start consumer for {}. {}", topicName, ex.getMessage());
+            startConsumer(consumerBuilder);
+            return null;
+        });
+    }
+
+    private synchronized CompletableFuture<Void> closeProducerAsync() {
+        if (producer == null) {
+            STATE_UPDATER.set(this, State.Stopped);
+            return CompletableFuture.completedFuture(null);
+        }
+        CompletableFuture<Void> future = producer.closeAsync();
+        future.thenRun(() -> {
+            STATE_UPDATER.set(this, State.Stopped);
+            stopSnapshotScheduler();
+            this.producer = null;
+        }).exceptionally(ex -> {
+            long waitTimeMs = backOff.next();
+            log.warn("[{}] Exception: '{}' occurred while trying to close the producer." + " retrying again in {} s",
+                    topicName, ex.getMessage(), waitTimeMs / 1000.0);
+            // BackOff before retrying
+            brokerService.executor().schedule(this::closeProducerAsync, waitTimeMs, TimeUnit.MILLISECONDS);
+            return null;
+        });
+        return future;
+    }
+}

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/MetadataChangeEvent.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/MetadataChangeEvent.java
@@ -31,6 +31,7 @@ public class MetadataChangeEvent {
     private EventType type;
     private ResourceType resource;
     private String resourceName;
+    @ToString.Exclude
     private byte[] data;
     private String sourceCluster;
     private long eventTime;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/MetadataChangeEvent.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/MetadataChangeEvent.java
@@ -1,0 +1,45 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.service;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Data
+@ToString
+public class MetadataChangeEvent {
+    private EventType type;
+    private ResourceType resource;
+    private String resourceName;
+    private byte[] data;
+    private String sourceCluster;
+    private long eventTime;
+
+    public enum EventType {
+        Created, Modified, Deleted, Synchronize;
+    }
+
+    public enum ResourceType {
+        Tenants, Namespaces, TopicPartition;
+    }
+}

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/MetadataStoreSynchronizer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/MetadataStoreSynchronizer.java
@@ -1,0 +1,294 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.service;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import org.apache.pulsar.broker.PulsarServerException;
+import org.apache.pulsar.broker.PulsarService;
+import org.apache.pulsar.broker.resources.NamespaceResources;
+import org.apache.pulsar.broker.resources.TenantResources;
+import org.apache.pulsar.broker.service.MetadataChangeEvent.EventType;
+import org.apache.pulsar.broker.service.MetadataChangeEvent.ResourceType;
+import org.apache.pulsar.common.naming.NamespaceName;
+import org.apache.pulsar.common.naming.TopicName;
+import org.apache.pulsar.common.partition.PartitionedTopicMetadata;
+import org.apache.pulsar.common.policies.data.Policies;
+import org.apache.pulsar.common.policies.data.TenantInfoImpl;
+import org.apache.pulsar.common.util.ObjectMapperFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class MetadataStoreSynchronizer extends AbstractMetadataStoreSynchronizer {
+
+    private static final Logger log = LoggerFactory.getLogger(MetadataStoreSynchronizer.class);
+
+    public MetadataStoreSynchronizer(PulsarService pulsar) throws PulsarServerException {
+        super(pulsar);
+    }
+
+    @Override
+    public CompletableFuture<Void> updateNamespaceMetadata(MetadataChangeEvent event) {
+        CompletableFuture<Void> updateResult = new CompletableFuture<>();
+        NamespaceName namespaceName;
+        Policies policies;
+        try {
+            namespaceName = NamespaceName.get(event.getResourceName());
+            policies = ObjectMapperFactory.getThreadLocal().readValue(event.getData(), Policies.class);
+        } catch (Exception e) {
+            log.error("Failed to deserialize namespace-metadata event {}", topicName, e);
+            updateResult.complete(null);
+            return updateResult;
+        }
+
+        pulsar.getPulsarResources().getNamespaceResources().getPoliciesAsync(namespaceName).thenAccept(old -> {
+            Policies existingNamespace = old.isPresent() ? old.get() : null;
+            CompletableFuture<Void> result = null;
+            EventType type = event.getType() != EventType.Synchronize ? event.getType()
+                    : (old.isPresent() ? EventType.Modified : EventType.Created);
+            switch (type) {
+            case Created:
+                if (existingNamespace == null) {
+                    result = pulsar.getPulsarResources().getNamespaceResources().createPoliciesAsync(namespaceName,
+                            policies);
+                } else {
+                    log.info("skip change-event, namespace {} already exist", namespaceName);
+                }
+                break;
+            case Modified:
+                if (existingNamespace != null
+                // latest remote update or lexicographical-sorting on clustername if timestamp is same
+                        && ((existingNamespace.lastUpdatedTimestamp < policies.lastUpdatedTimestamp)
+                                || (event.getSourceCluster() != null
+                                        && existingNamespace.lastUpdatedTimestamp == policies.lastUpdatedTimestamp
+                                        && pulsar.getConfig().getClusterName()
+                                                .compareTo(event.getSourceCluster()) < 0))) {
+                    result = pulsar.getPulsarResources().getNamespaceResources().setPoliciesAsync(namespaceName, __ -> {
+                        return policies;
+                    });
+                } else {
+                    log.info("skip change-event with {} for namespace {} updated at {}", policies.lastUpdatedTimestamp,
+                            namespaceName, existingNamespace != null ? existingNamespace.lastUpdatedTimestamp : null);
+                }
+                break;
+            case Deleted:
+                if (existingNamespace != null && existingNamespace.lastUpdatedTimestamp < event.getEventTime()) {
+                    result = pulsar.getPulsarResources().getNamespaceResources().deletePoliciesAsync(namespaceName);
+                }
+                break;
+            default:
+                log.info("Skipped unknown namespace update with {}", event);
+            }
+            if (result != null) {
+                result.thenAccept(__ -> {
+                    log.info("successfully updated namespace-event {}", event);
+                    updateResult.complete(null);
+                }).exceptionally(ue -> {
+                    log.warn("Failed while updating namespace metadata {}", event, ue);
+                    updateResult.completeExceptionally(ue);
+                    return null;
+                });
+            } else {
+                updateResult.complete(null);
+            }
+        }).exceptionally(ex -> {
+            log.warn("Failed to update namespace metadata {}", event, ex);
+            updateResult.completeExceptionally(ex);
+            return null;
+        });
+        return updateResult;
+    }
+
+    @Override
+    public CompletableFuture<Void> updateTenantMetadata(MetadataChangeEvent event) {
+        CompletableFuture<Void> updateResult = new CompletableFuture<>();
+        String tenantName = event.getResourceName();
+        TenantInfoImpl tenant;
+        try {
+            tenant = ObjectMapperFactory.getThreadLocal().readValue(event.getData(), TenantInfoImpl.class);
+        } catch (Exception e) {
+            log.error("Failed to deserialize metadata event {}", topicName, e);
+            updateResult.complete(null);
+            return updateResult;
+        }
+
+        pulsar.getPulsarResources().getTenantResources().getTenantAsync(tenantName).thenAccept(old -> {
+            TenantInfoImpl existingTenant = old.isPresent() ? (TenantInfoImpl) old.get() : null;
+            CompletableFuture<Void> result = null;
+            EventType type = event.getType() != EventType.Synchronize ? event.getType()
+                    : (old.isPresent() ? EventType.Modified : EventType.Created);
+            switch (type) {
+            case Created:
+                if (existingTenant == null) {
+                    result = pulsar.getPulsarResources().getTenantResources().createTenantAsync(tenantName, tenant);
+                }
+                break;
+            case Modified:
+                if (existingTenant != null
+                     // latest remote update or lexicographical-sorting on clustername if timestamp is same
+                        && ((existingTenant.getLastUpdatedTimestamp() < tenant.getLastUpdatedTimestamp())
+                                || (event.getSourceCluster() != null
+                                        && (existingTenant.getLastUpdatedTimestamp() == tenant.getLastUpdatedTimestamp()
+                                                && pulsar.getConfig().getClusterName()
+                                                        .compareTo(event.getSourceCluster()) < 0)))) {
+                    result = pulsar.getPulsarResources().getTenantResources().updateTenantAsync(tenantName, __ -> {
+                        return tenant;
+                    });
+                } else {
+                    log.info("skip change-event with {} for tenant {} updated at {}", tenant.getLastUpdatedTimestamp(),
+                            tenantName, existingTenant != null ? existingTenant.getLastUpdatedTimestamp() : null);
+                }
+
+                break;
+            case Deleted:
+                if (existingTenant != null && existingTenant.getLastUpdatedTimestamp() < event.getEventTime()) {
+                    result = pulsar.getPulsarResources().getTenantResources().deleteTenantAsync(tenantName);
+                }
+                break;
+            default:
+                log.info("Skipped tenant update with {}", event);
+            }
+            if (result != null) {
+                result.thenAccept(__ -> {
+                    log.info("successfully updated tenant-event {}", event);
+                    updateResult.complete(null);
+                }).exceptionally(ue -> {
+                    log.warn("Failed while updating tenant metadata {}", event, ue);
+                    updateResult.completeExceptionally(ue);
+                    return null;
+                });
+            } else {
+                updateResult.complete(null);
+            }
+        }).exceptionally(ex -> {
+            log.warn("Failed to update tenant metadata {}", event, ex);
+            updateResult.completeExceptionally(ex);
+            return null;
+        });
+        return updateResult;
+    }
+
+    @Override
+    public CompletableFuture<Void> updatePartitionMetadata(MetadataChangeEvent event) {
+        CompletableFuture<Void> updateResult = new CompletableFuture<>();
+        String topic = event.getResourceName();
+        PartitionedTopicMetadata partitions;
+        TopicName topicName;
+        try {
+            topicName = TopicName.get(topic);
+            partitions = ObjectMapperFactory.getThreadLocal().readValue(event.getData(),
+                    PartitionedTopicMetadata.class);
+        } catch (Exception e) {
+            log.error("Failed to deserialize metadata event {}", event, e);
+            updateResult.complete(null);
+            return updateResult;
+        }
+
+        pulsar.getPulsarResources().getNamespaceResources().getPartitionedTopicResources()
+                .getPartitionedTopicMetadataAsync(topicName).thenAccept(old -> {
+                    PartitionedTopicMetadata existingPartitions = old.isPresent() ? old.get() : null;
+                    CompletableFuture<Void> result = null;
+                    try {
+                        switch (event.getType()) {
+                        case Created:
+                            if (existingPartitions == null) {
+                                result = pulsar.getAdminClient().topics().createPartitionedTopicAsync(topic,
+                                        partitions.partitions);
+                            }
+                            break;
+                        case Modified:
+                            if (existingPartitions != null
+                                 // latest remote update or lexicographical-sorting on clustername if timestamp is same
+                                    && ((existingPartitions.lastUpdatedTimestamp < partitions.lastUpdatedTimestamp)
+                                            || (event.getSourceCluster() != null
+                                                    && existingPartitions.lastUpdatedTimestamp
+                                                    == partitions.lastUpdatedTimestamp
+                                                    && pulsar.getConfig().getClusterName()
+                                                            .compareTo(event.getSourceCluster()) < 0))) {
+                                result = pulsar.getAdminClient().topics().updatePartitionedTopicAsync(topic,
+                                        partitions.partitions);
+                            } else {
+                                log.info("skip change-event with {} for partitions {} updated at {}",
+                                        partitions.lastUpdatedTimestamp, topic,
+                                        existingPartitions != null ? existingPartitions.lastUpdatedTimestamp : null);
+                            }
+                            break;
+                        case Deleted:
+                            if (existingPartitions != null
+                                    && existingPartitions.lastUpdatedTimestamp < event.getEventTime()) {
+                                result = pulsar.getAdminClient().topics().deletePartitionedTopicAsync(topic);
+                            }
+                            break;
+                        default:
+                            log.info("Skipped partitioned update with {}", event);
+                        }
+                    } catch (Exception e) {
+                        log.warn("Failed to get admin-client while updating partitioned metadata {}", event, e);
+                        updateResult.completeExceptionally(e);
+                        return;
+                    }
+                    if (result != null) {
+                        result.thenAccept(__ -> {
+                            log.info("successfully updated partitioned-event {}", event);
+                            updateResult.complete(null);
+                        }).exceptionally(ue -> {
+                            log.warn("Failed while updating partitioned metadata {}", event, ue);
+                            updateResult.completeExceptionally(ue);
+                            return null;
+                        });
+                    } else {
+                        updateResult.complete(null);
+                    }
+                }).exceptionally(ex -> {
+                    log.warn("Failed to update partitioned metadata {}", event, ex);
+                    updateResult.completeExceptionally(ex);
+                    return null;
+                });
+
+        return updateResult;
+    }
+
+    @Override
+    public void triggerSyncSnapshot() {
+        pulsar.getPulsarResources().getTenantResources().listTenantsAsync().thenAccept(tenants -> {
+            tenants.forEach(tenant -> {
+                if (log.isDebugEnabled()) {
+                    log.info("triggering tenant {} metadata-event", tenant);
+                }
+                publishAsync(TenantResources.getPath(tenant), ResourceType.Tenants, tenant, EventType.Synchronize);
+                brokerService.executor().execute(() -> {
+                    try {
+                        List<String> namespaces = pulsar.getPulsarResources().getTenantResources()
+                                .getListOfNamespaces(tenant);
+                        namespaces.forEach(ns -> {
+                            if (log.isDebugEnabled()) {
+                                log.info("triggering namespace {} metadata-event", ns);
+                            }
+                            publishAsync(NamespaceResources.getPath(ns), ResourceType.Namespaces, ns,
+                                    EventType.Synchronize);
+                        });
+                    } catch (Exception e) {
+                        log.warn("Failed to get list of namesapces for {}, {}", tenant, e.getMessage());
+                    }
+                });
+            });
+        });
+    }
+
+}

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/MetadataStoreSynchronizer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/MetadataStoreSynchronizer.java
@@ -60,8 +60,11 @@ public class MetadataStoreSynchronizer extends AbstractMetadataStoreSynchronizer
         pulsar.getPulsarResources().getNamespaceResources().getPoliciesAsync(namespaceName).thenAccept(old -> {
             Policies existingNamespace = old.isPresent() ? old.get() : null;
             CompletableFuture<Void> result = null;
+            // handle Synchronize-snapshot event with created/modified according to resource state
             EventType type = event.getType() != EventType.Synchronize ? event.getType()
                     : (old.isPresent() ? EventType.Modified : EventType.Created);
+            // if resource doesn't exist to local cluster then create the resource with modified content
+            type = !old.isPresent() && type == EventType.Modified ? EventType.Created : type;
             switch (type) {
             case Created:
                 if (existingNamespace == null) {
@@ -131,8 +134,11 @@ public class MetadataStoreSynchronizer extends AbstractMetadataStoreSynchronizer
         pulsar.getPulsarResources().getTenantResources().getTenantAsync(tenantName).thenAccept(old -> {
             TenantInfoImpl existingTenant = old.isPresent() ? (TenantInfoImpl) old.get() : null;
             CompletableFuture<Void> result = null;
+            // handle Synchronize-snapshot event with created/modified according to resource state
             EventType type = event.getType() != EventType.Synchronize ? event.getType()
                     : (old.isPresent() ? EventType.Modified : EventType.Created);
+            // if resource doesn't exist to local cluster then create the resource with modified content
+            type = !old.isPresent() && type == EventType.Modified ? EventType.Created : type;
             switch (type) {
             case Created:
                 if (existingTenant == null) {
@@ -204,6 +210,11 @@ public class MetadataStoreSynchronizer extends AbstractMetadataStoreSynchronizer
                 .getPartitionedTopicMetadataAsync(topicName).thenAccept(old -> {
                     PartitionedTopicMetadata existingPartitions = old.isPresent() ? old.get() : null;
                     CompletableFuture<Void> result = null;
+                    // handle Synchronize-snapshot event with created/modified according to resource state
+                    EventType type = event.getType() != EventType.Synchronize ? event.getType()
+                            : (old.isPresent() ? EventType.Modified : EventType.Created);
+                    // if resource doesn't exist to local cluster then create the resource with modified content
+                    type = !old.isPresent() && type == EventType.Modified ? EventType.Created : type;
                     try {
                         switch (event.getType()) {
                         case Created:

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiTest.java
@@ -1220,7 +1220,8 @@ public class AdminApiTest extends MockedPulsarServiceBaseTest {
 
         // partitioned internal stats
         PartitionedTopicInternalStats partitionedInternalStats = admin.topics().getPartitionedInternalStats(partitionedTopicName);
-
+        expectedInternalStats.metadata.lastUpdatedTimestamp = 0;
+        partitionedInternalStats.metadata.lastUpdatedTimestamp = 0;
         String expectedResult = ObjectMapperFactory.getThreadLocal().writeValueAsString(expectedInternalStats);
         String result = ObjectMapperFactory.getThreadLocal().writeValueAsString(partitionedInternalStats);
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/MetadataStoreSynchronizerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/MetadataStoreSynchronizerTest.java
@@ -1,0 +1,763 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.client.impl;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import org.apache.pulsar.broker.service.MetadataChangeEvent;
+import org.apache.pulsar.broker.service.MetadataChangeEvent.EventType;
+import org.apache.pulsar.broker.service.MetadataChangeEvent.ResourceType;
+import org.apache.pulsar.broker.service.MetadataStoreSynchronizer;
+import org.apache.pulsar.client.api.Consumer;
+import org.apache.pulsar.client.api.Message;
+import org.apache.pulsar.client.api.Producer;
+import org.apache.pulsar.client.api.ProducerConsumerBase;
+import org.apache.pulsar.client.impl.schema.AvroSchema;
+import org.apache.pulsar.common.naming.NamespaceName;
+import org.apache.pulsar.common.naming.TopicName;
+import org.apache.pulsar.common.partition.PartitionedTopicMetadata;
+import org.apache.pulsar.common.policies.data.Policies;
+import org.apache.pulsar.common.policies.data.TenantInfo;
+import org.apache.pulsar.common.policies.data.TenantInfoImpl;
+import org.apache.pulsar.common.util.ObjectMapperFactory;
+import org.awaitility.Awaitility;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
+
+import lombok.Cleanup;
+
+@Test(groups = "broker-impl")
+public class MetadataStoreSynchronizerTest extends ProducerConsumerBase {
+
+    @BeforeMethod
+    @Override
+    protected void setup() throws Exception {
+        super.internalSetup();
+        super.producerBaseSetup();
+    }
+
+    @AfterMethod(alwaysRun = true)
+    @Override
+    protected void cleanup() throws Exception {
+        super.internalCleanup();
+    }
+
+    @Test
+    public void testNamespaceMetadataEventSyncerPublish() throws Exception {
+        String metadataEventNs = "my-property/metadataTopic";
+        String metadataEventTopic = "persistent://" + metadataEventNs + "/event";
+        admin.namespaces().createNamespace(metadataEventNs, Sets.newHashSet("test"));
+        conf.setMetadataSyncEventTopic(metadataEventTopic);
+        restartBroker();
+
+        Awaitility.waitAtMost(5, TimeUnit.SECONDS).until(() -> pulsar.getMetadataSyncer().isActive());
+
+        Policies policies = new Policies();
+        policies.replication_clusters = Sets.newHashSet("test1", "test2");
+        byte[] data = ObjectMapperFactory.getThreadLocal().writer().writeValueAsBytes(policies);
+        // (1) create a new namespace
+        String ns2 = "my-property/brok-ns2";
+        MetadataChangeEvent event = new MetadataChangeEvent();
+        event.setResource(ResourceType.Namespaces);
+        event.setType(EventType.Created);
+        event.setSourceCluster("test2");
+        event.setResourceName(ns2);
+        event.setData(data);
+
+        @Cleanup
+        Producer<MetadataChangeEvent> producer1 = pulsarClient.newProducer(AvroSchema.of(MetadataChangeEvent.class))
+                .topic(metadataEventTopic).create();
+
+        // (1) create namespace
+        producer1.newMessage().value(event).send();
+        Awaitility.waitAtMost(5, TimeUnit.SECONDS).until(() -> {
+            try {
+                admin.namespaces().getPolicies(ns2);
+                return true;
+            } catch (Exception e) {
+                // ok
+                return false;
+            }
+        });
+        policies = admin.namespaces().getPolicies(ns2);
+        assertNotNull(policies);
+        assertEquals(policies.replication_clusters, Sets.newHashSet("test1", "test2"));
+
+        // (2) try to publish : create namespace message again. even should be acked successfully
+        policies.lastUpdatedTimestamp += 1;
+        data = ObjectMapperFactory.getThreadLocal().writer().writeValueAsBytes(policies);
+        event.setData(data);
+        producer1.newMessage().value(event).send();
+        Awaitility.waitAtMost(5, TimeUnit.SECONDS).until(() -> {
+            try {
+                return admin.topics().getStats(metadataEventTopic).getSubscriptions()
+                        .get(MetadataStoreSynchronizer.SUBSCRIPTION_NAME).getBacklogSize() == 0;
+            } catch (Exception e) {
+                // ok
+                return false;
+            }
+        });
+        assertEquals(admin.topics().getStats(metadataEventTopic).getSubscriptions()
+                .get(MetadataStoreSynchronizer.SUBSCRIPTION_NAME).getBacklogSize(), 0);
+        // check lastUpdated time of policies
+        long time = pulsar.getPulsarResources().getNamespaceResources().getPolicies(NamespaceName.get(ns2))
+                .get().lastUpdatedTimestamp;
+
+        // (3) update with old event time
+        event.setType(EventType.Modified);
+        policies.lastUpdatedTimestamp -= 1;
+        data = ObjectMapperFactory.getThreadLocal().writer().writeValueAsBytes(policies);
+        event.setData(data);
+        producer1.newMessage().value(event).send();
+        Awaitility.waitAtMost(5, TimeUnit.SECONDS).until(() -> {
+            try {
+                return admin.topics().getStats(metadataEventTopic).getSubscriptions()
+                        .get(MetadataStoreSynchronizer.SUBSCRIPTION_NAME).getBacklogSize() == 0;
+            } catch (Exception e) {
+                // ok
+                return false;
+            }
+        });
+        assertEquals(admin.topics().getStats(metadataEventTopic).getSubscriptions()
+                .get(MetadataStoreSynchronizer.SUBSCRIPTION_NAME).getBacklogSize(), 0);
+        // check lastUpdated time of policies
+        assertEquals(pulsar.getPulsarResources().getNamespaceResources().getPolicies(NamespaceName.get(ns2))
+                .get().lastUpdatedTimestamp, time);
+
+        // (4) update with new event time
+        event.setType(EventType.Modified);
+        time = policies.lastUpdatedTimestamp + 1;
+        policies.lastUpdatedTimestamp = time;
+        policies.replication_clusters = Sets.newHashSet("test1", "test2", "test3");
+        data = ObjectMapperFactory.getThreadLocal().writer().writeValueAsBytes(policies);
+        event.setData(data);
+        producer1.newMessage().value(event).send();
+        Awaitility.waitAtMost(5, TimeUnit.SECONDS).until(() -> {
+            try {
+                return admin.topics().getStats(metadataEventTopic).getSubscriptions()
+                        .get(MetadataStoreSynchronizer.SUBSCRIPTION_NAME).getBacklogSize() == 0;
+            } catch (Exception e) {
+                // ok
+                return false;
+            }
+        });
+        assertEquals(admin.topics().getStats(metadataEventTopic).getSubscriptions()
+                .get(MetadataStoreSynchronizer.SUBSCRIPTION_NAME).getBacklogSize(), 0);
+        // check lastUpdated time of policies
+        assertEquals(pulsar.getPulsarResources().getNamespaceResources().getPolicies(NamespaceName.get(ns2))
+                .get().lastUpdatedTimestamp, time);
+        assertEquals(pulsar.getPulsarResources().getNamespaceResources().getPolicies(NamespaceName.get(ns2))
+                .get().replication_clusters, Sets.newHashSet("test1", "test2", "test3"));
+
+        // (5) Invalid data
+        event.setType(EventType.Modified);
+        policies.lastUpdatedTimestamp += 1;
+        policies.replication_clusters = Sets.newHashSet("test1", "test2", "test3");
+        data = ObjectMapperFactory.getThreadLocal().writer().writeValueAsBytes("invalid-data");
+        event.setData(data);
+        producer1.newMessage().value(event).send();
+        Awaitility.waitAtMost(5, TimeUnit.SECONDS).until(() -> {
+            try {
+                return admin.topics().getStats(metadataEventTopic).getSubscriptions()
+                        .get(MetadataStoreSynchronizer.SUBSCRIPTION_NAME).getBacklogSize() == 0;
+            } catch (Exception e) {
+                // ok
+                return false;
+            }
+        });
+        assertEquals(admin.topics().getStats(metadataEventTopic).getSubscriptions()
+                .get(MetadataStoreSynchronizer.SUBSCRIPTION_NAME).getBacklogSize(), 0);
+        // check lastUpdated time of policies which should have not changed
+        assertEquals(pulsar.getPulsarResources().getNamespaceResources().getPolicies(NamespaceName.get(ns2))
+                .get().lastUpdatedTimestamp, time);
+
+        // (6) timestamp racecondition but pick cluster-name to win the update: local cluster will win
+        event.setType(EventType.Modified);
+        time = pulsar.getPulsarResources().getNamespaceResources().getPolicies(NamespaceName.get(ns2))
+                .get().lastUpdatedTimestamp;
+        policies.lastUpdatedTimestamp = time;
+        policies.replication_clusters = Sets.newHashSet("test1");
+        data = ObjectMapperFactory.getThreadLocal().writer().writeValueAsBytes(policies);
+        event.setSourceCluster("abc"); // "test" < "abc". event should be skipped
+        event.setData(data);
+        producer1.newMessage().value(event).send();
+        Awaitility.waitAtMost(5, TimeUnit.SECONDS).until(() -> {
+            try {
+                return admin.topics().getStats(metadataEventTopic).getSubscriptions()
+                        .get(MetadataStoreSynchronizer.SUBSCRIPTION_NAME).getBacklogSize() == 0;
+            } catch (Exception e) {
+                // ok
+                return false;
+            }
+        });
+        assertEquals(admin.topics().getStats(metadataEventTopic).getSubscriptions()
+                .get(MetadataStoreSynchronizer.SUBSCRIPTION_NAME).getBacklogSize(), 0);
+        // check lastUpdated time of policies
+        assertEquals(pulsar.getPulsarResources().getNamespaceResources().getPolicies(NamespaceName.get(ns2))
+                .get().lastUpdatedTimestamp, time);
+        assertEquals(pulsar.getPulsarResources().getNamespaceResources().getPolicies(NamespaceName.get(ns2))
+                .get().replication_clusters, Sets.newHashSet("test1", "test2", "test3"));
+
+        // (7) timestamp racecondition but pick cluster-name to win the update: remote cluster will win
+        event.setType(EventType.Modified);
+        policies.lastUpdatedTimestamp = time + 1;
+        policies.replication_clusters = Sets.newHashSet("test1");
+        data = ObjectMapperFactory.getThreadLocal().writer().writeValueAsBytes(policies);
+        event.setSourceCluster("uvw"); // "test" < "uvw". event should be skipped
+        event.setData(data);
+        producer1.newMessage().value(event).send();
+        Awaitility.waitAtMost(5, TimeUnit.SECONDS).until(() -> {
+            try {
+                return admin.topics().getStats(metadataEventTopic).getSubscriptions()
+                        .get(MetadataStoreSynchronizer.SUBSCRIPTION_NAME).getBacklogSize() == 0;
+            } catch (Exception e) {
+                // ok
+                return false;
+            }
+        });
+        assertEquals(admin.topics().getStats(metadataEventTopic).getSubscriptions()
+                .get(MetadataStoreSynchronizer.SUBSCRIPTION_NAME).getBacklogSize(), 0);
+        // check lastUpdated time of policies
+        assertEquals(pulsar.getPulsarResources().getNamespaceResources().getPolicies(NamespaceName.get(ns2))
+                .get().lastUpdatedTimestamp, time + 1);
+        assertEquals(pulsar.getPulsarResources().getNamespaceResources().getPolicies(NamespaceName.get(ns2))
+                .get().replication_clusters, Sets.newHashSet("test1"));
+
+        producer1.close();
+    }
+
+    @Test
+    public void testTenantMetadataEventSyncerPublish() throws Exception {
+        String metadataEventNs = "my-property/metadataTopic";
+        String metadataEventTopic = "persistent://" + metadataEventNs + "/event";
+        admin.namespaces().createNamespace(metadataEventNs, Sets.newHashSet("test"));
+        conf.setMetadataSyncEventTopic(metadataEventTopic);
+        restartBroker();
+
+        Awaitility.waitAtMost(5, TimeUnit.SECONDS).until(() -> pulsar.getMetadataSyncer().isActive());
+
+        TenantInfoImpl t1 = (TenantInfoImpl) TenantInfo.builder().allowedClusters(Sets.newHashSet("test")).build();
+        byte[] data = ObjectMapperFactory.getThreadLocal().writer().writeValueAsBytes(t1);
+        // (1) create a new namespace
+        String tenantName = "tenant1";
+        MetadataChangeEvent event = new MetadataChangeEvent();
+        event.setResource(ResourceType.Tenants);
+        event.setType(EventType.Created);
+        event.setSourceCluster("test2");
+        event.setResourceName(tenantName);
+        event.setData(data);
+
+        @Cleanup
+        Producer<MetadataChangeEvent> producer1 = pulsarClient.newProducer(AvroSchema.of(MetadataChangeEvent.class))
+                .topic(metadataEventTopic).create();
+
+        // (1) create namespace
+        producer1.newMessage().value(event).send();
+        Awaitility.waitAtMost(5, TimeUnit.SECONDS).until(() -> {
+            try {
+                admin.tenants().getTenantInfo(tenantName);
+                return true;
+            } catch (Exception e) {
+                // ok
+                return false;
+            }
+        });
+        t1 = (TenantInfoImpl) admin.tenants().getTenantInfo(tenantName);
+        assertNotNull(t1);
+        assertEquals(t1.getAllowedClusters(), Sets.newHashSet("test"));
+
+        // (2) try to publish : create namespace message again. even should be acked successfully
+        t1.setLastUpdatedTimestamp(t1.getLastUpdatedTimestamp() + 1);
+        data = ObjectMapperFactory.getThreadLocal().writer().writeValueAsBytes(t1);
+        event.setData(data);
+        producer1.newMessage().value(event).send();
+        Awaitility.waitAtMost(5, TimeUnit.SECONDS).until(() -> {
+            try {
+                return admin.topics().getStats(metadataEventTopic).getSubscriptions()
+                        .get(MetadataStoreSynchronizer.SUBSCRIPTION_NAME).getBacklogSize() == 0;
+            } catch (Exception e) {
+                // ok
+                return false;
+            }
+        });
+        assertEquals(admin.topics().getStats(metadataEventTopic).getSubscriptions()
+                .get(MetadataStoreSynchronizer.SUBSCRIPTION_NAME).getBacklogSize(), 0);
+        // check lastUpdated time of tenant
+        long time = ((TenantInfoImpl) pulsar.getPulsarResources().getTenantResources().getTenant(tenantName).get())
+                .getLastUpdatedTimestamp();
+
+        // (3) update with old event time
+        event.setType(EventType.Modified);
+        t1.setLastUpdatedTimestamp(t1.getLastUpdatedTimestamp() - 1);
+        data = ObjectMapperFactory.getThreadLocal().writer().writeValueAsBytes(t1);
+        event.setData(data);
+        producer1.newMessage().value(event).send();
+        Awaitility.waitAtMost(5, TimeUnit.SECONDS).until(() -> {
+            try {
+                return admin.topics().getStats(metadataEventTopic).getSubscriptions()
+                        .get(MetadataStoreSynchronizer.SUBSCRIPTION_NAME).getBacklogSize() == 0;
+            } catch (Exception e) {
+                // ok
+                return false;
+            }
+        });
+        assertEquals(admin.topics().getStats(metadataEventTopic).getSubscriptions()
+                .get(MetadataStoreSynchronizer.SUBSCRIPTION_NAME).getBacklogSize(), 0);
+        // check lastUpdated time of policies
+        assertEquals(((TenantInfoImpl) pulsar.getPulsarResources().getTenantResources().getTenant(tenantName).get())
+                .getLastUpdatedTimestamp(), time);
+
+        // (4) update with new event time
+        event.setType(EventType.Modified);
+        time = t1.getLastUpdatedTimestamp() + 1;
+        t1.setLastUpdatedTimestamp(time);
+        t1.setAdminRoles(Sets.newHashSet("test1", "test2", "test3"));
+        data = ObjectMapperFactory.getThreadLocal().writer().writeValueAsBytes(t1);
+        event.setData(data);
+        producer1.newMessage().value(event).send();
+        Awaitility.waitAtMost(5, TimeUnit.SECONDS).until(() -> {
+            try {
+                return admin.topics().getStats(metadataEventTopic).getSubscriptions()
+                        .get(MetadataStoreSynchronizer.SUBSCRIPTION_NAME).getBacklogSize() == 0;
+            } catch (Exception e) {
+                // ok
+                return false;
+            }
+        });
+        assertEquals(admin.topics().getStats(metadataEventTopic).getSubscriptions()
+                .get(MetadataStoreSynchronizer.SUBSCRIPTION_NAME).getBacklogSize(), 0);
+        // check lastUpdated time of policies
+        assertEquals(((TenantInfoImpl) pulsar.getPulsarResources().getTenantResources().getTenant(tenantName).get())
+                .getLastUpdatedTimestamp(), time);
+        assertEquals(pulsar.getPulsarResources().getTenantResources().getTenant(tenantName).get().getAdminRoles(),
+                Sets.newHashSet("test1", "test2", "test3"));
+
+        // (5) Invalid data
+        event.setType(EventType.Modified);
+        t1.setLastUpdatedTimestamp(t1.getLastUpdatedTimestamp() + 1);
+        t1.setAdminRoles(Sets.newHashSet("test1", "test2", "test3"));
+        data = ObjectMapperFactory.getThreadLocal().writer().writeValueAsBytes("invalid-data");
+        event.setData(data);
+        producer1.newMessage().value(event).send();
+        Awaitility.waitAtMost(5, TimeUnit.SECONDS).until(() -> {
+            try {
+                return admin.topics().getStats(metadataEventTopic).getSubscriptions()
+                        .get(MetadataStoreSynchronizer.SUBSCRIPTION_NAME).getBacklogSize() == 0;
+            } catch (Exception e) {
+                // ok
+                return false;
+            }
+        });
+        assertEquals(admin.topics().getStats(metadataEventTopic).getSubscriptions()
+                .get(MetadataStoreSynchronizer.SUBSCRIPTION_NAME).getBacklogSize(), 0);
+        // check lastUpdated time of policies which should have not changed
+        assertEquals(((TenantInfoImpl) pulsar.getPulsarResources().getTenantResources().getTenant(tenantName).get())
+                .getLastUpdatedTimestamp(), time);
+
+        // (6) timestamp racecondition but pick cluster-name to win the update: local cluster will win
+        event.setType(EventType.Modified);
+        time = ((TenantInfoImpl) pulsar.getPulsarResources().getTenantResources().getTenant(tenantName).get())
+                .getLastUpdatedTimestamp();
+        t1.setLastUpdatedTimestamp(time);
+        t1.setAdminRoles(Sets.newHashSet("test1"));
+        data = ObjectMapperFactory.getThreadLocal().writer().writeValueAsBytes(t1);
+        event.setSourceCluster("abc"); // "test" < "abc". event should be skipped
+        event.setData(data);
+        producer1.newMessage().value(event).send();
+        Awaitility.waitAtMost(5, TimeUnit.SECONDS).until(() -> {
+            try {
+                return admin.topics().getStats(metadataEventTopic).getSubscriptions()
+                        .get(MetadataStoreSynchronizer.SUBSCRIPTION_NAME).getBacklogSize() == 0;
+            } catch (Exception e) {
+                // ok
+                return false;
+            }
+        });
+        assertEquals(admin.topics().getStats(metadataEventTopic).getSubscriptions()
+                .get(MetadataStoreSynchronizer.SUBSCRIPTION_NAME).getBacklogSize(), 0);
+        // check lastUpdated time of policies
+        assertEquals(((TenantInfoImpl) pulsar.getPulsarResources().getTenantResources().getTenant(tenantName).get())
+                .getLastUpdatedTimestamp(), time);
+        assertEquals(pulsar.getPulsarResources().getTenantResources().getTenant(tenantName).get().getAdminRoles(),
+                Sets.newHashSet("test1", "test2", "test3"));
+
+        // (7) timestamp racecondition but pick cluster-name to win the update: remote cluster will win
+        event.setType(EventType.Modified);
+        t1.setLastUpdatedTimestamp(time + 1);
+        t1.setAdminRoles(Sets.newHashSet("test1"));
+        data = ObjectMapperFactory.getThreadLocal().writer().writeValueAsBytes(t1);
+        event.setSourceCluster("uvw"); // "test" < "uvw". event should be skipped
+        event.setData(data);
+        producer1.newMessage().value(event).send();
+        Awaitility.waitAtMost(5, TimeUnit.SECONDS).until(() -> {
+            try {
+                return admin.topics().getStats(metadataEventTopic).getSubscriptions()
+                        .get(MetadataStoreSynchronizer.SUBSCRIPTION_NAME).getBacklogSize() == 0;
+            } catch (Exception e) {
+                // ok
+                return false;
+            }
+        });
+        assertEquals(admin.topics().getStats(metadataEventTopic).getSubscriptions()
+                .get(MetadataStoreSynchronizer.SUBSCRIPTION_NAME).getBacklogSize(), 0);
+        // check lastUpdated time of policies
+        assertEquals(((TenantInfoImpl) pulsar.getPulsarResources().getTenantResources().getTenant(tenantName).get())
+                .getLastUpdatedTimestamp(), time + 1);
+        assertEquals(pulsar.getPulsarResources().getTenantResources().getTenant(tenantName).get().getAdminRoles(),
+                Sets.newHashSet("test1"));
+
+        producer1.close();
+    }
+
+    @Test
+    public void testPartitionedMetadataEventSyncerPublish() throws Exception {
+        String metadataEventNs = "my-property/metadataTopic";
+        String metadataEventTopic = "persistent://" + metadataEventNs + "/event";
+        admin.namespaces().createNamespace(metadataEventNs, Sets.newHashSet("test"));
+        conf.setMetadataSyncEventTopic(metadataEventTopic);
+        restartBroker();
+
+        Awaitility.waitAtMost(5, TimeUnit.SECONDS).until(() -> pulsar.getMetadataSyncer().isActive());
+
+        admin.namespaces().createNamespace("my-property/brok-ns2");
+        PartitionedTopicMetadata partitionedMetadata = new PartitionedTopicMetadata(3);
+        byte[] data = ObjectMapperFactory.getThreadLocal().writer().writeValueAsBytes(partitionedMetadata);
+        // (1) create a new namespace
+        String topicName = "persistent://my-property/brok-ns2/t1";
+        MetadataChangeEvent event = new MetadataChangeEvent();
+        event.setResource(ResourceType.TopicPartition);
+        event.setType(EventType.Created);
+        event.setSourceCluster("test2");
+        event.setResourceName(topicName);
+        event.setData(data);
+
+        @Cleanup
+        Producer<MetadataChangeEvent> producer1 = pulsarClient.newProducer(AvroSchema.of(MetadataChangeEvent.class))
+                .topic(metadataEventTopic).create();
+
+        // (1) create namespace
+        producer1.newMessage().value(event).send();
+        Awaitility.waitAtMost(5, TimeUnit.SECONDS).until(() -> {
+            try {
+                admin.topics().getPartitionedTopicMetadata(topicName);
+                return true;
+            } catch (Exception e) {
+                // ok
+                return false;
+            }
+        });
+        partitionedMetadata = admin.topics().getPartitionedTopicMetadata(topicName);
+        assertNotNull(partitionedMetadata);
+        assertEquals(partitionedMetadata.partitions, 3);
+
+        // (2) try to publish : create namespace message again. even should be acked successfully
+        partitionedMetadata.lastUpdatedTimestamp += 1;
+        data = ObjectMapperFactory.getThreadLocal().writer().writeValueAsBytes(partitionedMetadata);
+        event.setData(data);
+        producer1.newMessage().value(event).send();
+        Awaitility.waitAtMost(5, TimeUnit.SECONDS).until(() -> {
+            try {
+                return admin.topics().getStats(metadataEventTopic).getSubscriptions()
+                        .get(MetadataStoreSynchronizer.SUBSCRIPTION_NAME).getBacklogSize() == 0;
+            } catch (Exception e) {
+                // ok
+                return false;
+            }
+        });
+        assertEquals(admin.topics().getStats(metadataEventTopic).getSubscriptions()
+                .get(MetadataStoreSynchronizer.SUBSCRIPTION_NAME).getBacklogSize(), 0);
+        // check lastUpdated time of policies
+        long time = pulsar.getPulsarResources().getNamespaceResources().getPartitionedTopicResources()
+                .getPartitionedTopicMetadataAsync(TopicName.get(topicName)).get().get().lastUpdatedTimestamp;
+
+        // (3) update with old event time
+        event.setType(EventType.Modified);
+        partitionedMetadata.lastUpdatedTimestamp -= 1;
+        data = ObjectMapperFactory.getThreadLocal().writer().writeValueAsBytes(partitionedMetadata);
+        event.setData(data);
+        producer1.newMessage().value(event).send();
+        Awaitility.waitAtMost(5, TimeUnit.SECONDS).until(() -> {
+            try {
+                return admin.topics().getStats(metadataEventTopic).getSubscriptions()
+                        .get(MetadataStoreSynchronizer.SUBSCRIPTION_NAME).getBacklogSize() == 0;
+            } catch (Exception e) {
+                // ok
+                return false;
+            }
+        });
+        assertEquals(admin.topics().getStats(metadataEventTopic).getSubscriptions()
+                .get(MetadataStoreSynchronizer.SUBSCRIPTION_NAME).getBacklogSize(), 0);
+        // check lastUpdated time of policies
+        assertEquals(
+                pulsar.getPulsarResources().getNamespaceResources().getPartitionedTopicResources()
+                        .getPartitionedTopicMetadataAsync(TopicName.get(topicName)).get().get().lastUpdatedTimestamp,
+                time);
+
+        // (4) update with new event time
+        event.setType(EventType.Modified);
+        time = partitionedMetadata.lastUpdatedTimestamp + 1;
+        partitionedMetadata.lastUpdatedTimestamp = time;
+        partitionedMetadata.partitions = 4;
+        data = ObjectMapperFactory.getThreadLocal().writer().writeValueAsBytes(partitionedMetadata);
+        event.setData(data);
+        producer1.newMessage().value(event).send();
+        Awaitility.waitAtMost(5, TimeUnit.SECONDS).until(() -> {
+            try {
+                return admin.topics().getStats(metadataEventTopic).getSubscriptions()
+                        .get(MetadataStoreSynchronizer.SUBSCRIPTION_NAME).getBacklogSize() == 0;
+            } catch (Exception e) {
+                // ok
+                return false;
+            }
+        });
+        assertEquals(admin.topics().getStats(metadataEventTopic).getSubscriptions()
+                .get(MetadataStoreSynchronizer.SUBSCRIPTION_NAME).getBacklogSize(), 0);
+        // check lastUpdated time of partitioned-topic metadata
+        assertEquals(pulsar.getPulsarResources().getNamespaceResources().getPartitionedTopicResources()
+                .getPartitionedTopicMetadataAsync(TopicName.get(topicName)).get().get().partitions, 4);
+
+        // (5) Invalid data
+        event.setType(EventType.Modified);
+        partitionedMetadata.lastUpdatedTimestamp += 1;
+        partitionedMetadata.partitions = 10;
+        data = ObjectMapperFactory.getThreadLocal().writer().writeValueAsBytes("invalid-data");
+        event.setData(data);
+        producer1.newMessage().value(event).send();
+        Awaitility.waitAtMost(5, TimeUnit.SECONDS).until(() -> {
+            try {
+                return admin.topics().getStats(metadataEventTopic).getSubscriptions()
+                        .get(MetadataStoreSynchronizer.SUBSCRIPTION_NAME).getBacklogSize() == 0;
+            } catch (Exception e) {
+                // ok
+                return false;
+            }
+        });
+        assertEquals(admin.topics().getStats(metadataEventTopic).getSubscriptions()
+                .get(MetadataStoreSynchronizer.SUBSCRIPTION_NAME).getBacklogSize(), 0);
+       
+        // (6) timestamp racecondition but pick cluster-name to win the update: local cluster will win
+        event.setType(EventType.Modified);
+        time = pulsar.getPulsarResources().getNamespaceResources().getPartitionedTopicResources()
+                .getPartitionedTopicMetadataAsync(TopicName.get(topicName)).get().get().lastUpdatedTimestamp;
+        partitionedMetadata.lastUpdatedTimestamp = time;
+        partitionedMetadata.partitions = 10;
+        data = ObjectMapperFactory.getThreadLocal().writer().writeValueAsBytes(partitionedMetadata);
+        event.setSourceCluster("abc"); // "test" < "abc". event should be skipped
+        event.setData(data);
+        producer1.newMessage().value(event).send();
+        Awaitility.waitAtMost(5, TimeUnit.SECONDS).until(() -> {
+            try {
+                return admin.topics().getStats(metadataEventTopic).getSubscriptions()
+                        .get(MetadataStoreSynchronizer.SUBSCRIPTION_NAME).getBacklogSize() == 0;
+            } catch (Exception e) {
+                // ok
+                return false;
+            }
+        });
+        assertEquals(admin.topics().getStats(metadataEventTopic).getSubscriptions()
+                .get(MetadataStoreSynchronizer.SUBSCRIPTION_NAME).getBacklogSize(), 0);
+        // check lastUpdated time of policies
+        assertEquals(pulsar.getPulsarResources().getNamespaceResources().getPartitionedTopicResources()
+                .getPartitionedTopicMetadataAsync(TopicName.get(topicName)).get().get().partitions, 4);
+
+        // (7) timestamp racecondition but pick cluster-name to win the update: remote cluster will win
+        event.setType(EventType.Modified);
+        partitionedMetadata.lastUpdatedTimestamp = time + 1;
+        partitionedMetadata.partitions = 10;
+        data = ObjectMapperFactory.getThreadLocal().writer().writeValueAsBytes(partitionedMetadata);
+        event.setSourceCluster("uvw"); // "test" < "uvw". event should be skipped
+        event.setData(data);
+        producer1.newMessage().value(event).send();
+        Awaitility.waitAtMost(5, TimeUnit.SECONDS).until(() -> {
+            try {
+                return admin.topics().getStats(metadataEventTopic).getSubscriptions()
+                        .get(MetadataStoreSynchronizer.SUBSCRIPTION_NAME).getBacklogSize() == 0;
+            } catch (Exception e) {
+                // ok
+                return false;
+            }
+        });
+        assertEquals(admin.topics().getStats(metadataEventTopic).getSubscriptions()
+                .get(MetadataStoreSynchronizer.SUBSCRIPTION_NAME).getBacklogSize(), 0);
+        assertEquals(pulsar.getPulsarResources().getNamespaceResources().getPartitionedTopicResources()
+                .getPartitionedTopicMetadataAsync(TopicName.get(topicName)).get().get().partitions, 10);
+
+        producer1.close();
+    }
+
+    @Test
+    public void testPublishConsumeNamespaceMetadataEventSyncer() throws Exception {
+
+        String metadataEventNs = "my-property/metadataTopic";
+        String metadataEventTopic = "persistent://" + metadataEventNs + "/event";
+        admin.namespaces().createNamespace(metadataEventNs, Sets.newHashSet("test"));
+        conf.setMetadataSyncEventTopic(metadataEventTopic);
+        restartBroker();
+
+        Awaitility.waitAtMost(5, TimeUnit.SECONDS).until(() -> pulsar.getMetadataSyncer().isActive());
+
+        @Cleanup
+        Consumer<MetadataChangeEvent> consumer = pulsarClient.newConsumer(AvroSchema.of(MetadataChangeEvent.class))
+                .topic(metadataEventTopic).subscriptionName("my-subscriber-name").subscribe();
+
+        // (1) create a new namespace
+        final String ns1 = "my-property/brok-ns2";
+        admin.namespaces().createNamespace(ns1, Sets.newHashSet("test"));
+        // check event generation
+        Message<MetadataChangeEvent> msg = consumer.receive(5, TimeUnit.SECONDS);
+        assertNotNull(msg);
+        MetadataChangeEvent event = msg.getValue();
+        assertEquals(event.getResource(), ResourceType.Namespaces);
+        assertEquals(event.getType(), EventType.Created);
+        assertEquals(event.getResourceName(), ns1);
+        assertEquals(event.getSourceCluster(), conf.getClusterName());
+        assertNotNull(event.getData());
+
+        @Cleanup
+        Producer<MetadataChangeEvent> producer1 = pulsarClient.newProducer(AvroSchema.of(MetadataChangeEvent.class))
+                .topic(metadataEventTopic).create();
+
+        String ns2 = event.getResourceName() + "-2";
+        event.setResourceName(ns2);
+        event.setSourceCluster("test2");
+        producer1.newMessage().value(event).send();
+
+        Awaitility.waitAtMost(5, TimeUnit.SECONDS).until(() -> {
+            try {
+                admin.namespaces().getPolicies(ns2);
+                return true;
+            } catch (Exception e) {
+                // ok
+                return false;
+            }
+        });
+        assertNotNull(admin.namespaces().getPolicies(ns2));
+        producer1.close();
+        consumer.close();
+    }
+
+    @Test
+    public void testTriggerSnapshotMetadataEventSyncer() throws Exception {
+
+        String metadataEventNs = "my-property/metadataTopic";
+        String metadataEventTopic = "persistent://" + metadataEventNs + "/event";
+        admin.namespaces().createNamespace(metadataEventNs, Sets.newHashSet("test"));
+        conf.setMetadataSyncEventTopic(metadataEventTopic);
+        restartBroker();
+
+        Awaitility.waitAtMost(5, TimeUnit.SECONDS).until(() -> pulsar.getMetadataSyncer().isActive());
+
+        // (1) create a new namespace
+        String tenant1 = "my-tenant1";
+        String tenant2 = "my-tenant2";
+        TenantInfo tenantInfo = TenantInfo.builder().allowedClusters(Sets.newHashSet("test"))
+                .adminRoles(Sets.newHashSet("role1")).build();
+        admin.tenants().createTenant(tenant1, tenantInfo);
+        admin.tenants().createTenant(tenant2, tenantInfo);
+        final String ns1 = tenant1 + "/brok-ns1";
+        final String ns2 = tenant2 + "/brok-ns2";
+        admin.namespaces().createNamespace(ns1, Sets.newHashSet("test"));
+        admin.namespaces().createNamespace(ns2, Sets.newHashSet("test"));
+
+        Map<String, MetadataChangeEvent> eventResource = Maps.newHashMap();
+        @Cleanup
+        Consumer<MetadataChangeEvent> consumer = pulsarClient.newConsumer(AvroSchema.of(MetadataChangeEvent.class))
+                .topic(metadataEventTopic).subscriptionName("my-subscriber-name").messageListener((c, m) -> {
+                    MetadataChangeEvent event = m.getValue();
+                    eventResource.put(event.getResourceName(), event);
+                    c.acknowledgeAsync(m);
+                }).subscribe();
+
+        MetadataStoreSynchronizer syncer = pulsar.getMetadataSyncer();
+        syncer.triggerSyncSnapshot();
+
+        Awaitility.waitAtMost(135, TimeUnit.SECONDS).until(() -> {
+            return eventResource.size() > 6;
+        });
+
+        // verify tenant and namespace updates
+        // verify tenant-1
+        verifyTenant(eventResource, tenant1, tenant2);
+        verifyNamespace(eventResource, ns1, ns2);
+
+        consumer.unsubscribe();
+
+        // update tenant and namespaces
+        tenantInfo = TenantInfo.builder().allowedClusters(Sets.newHashSet("test"))
+                .adminRoles(Sets.newHashSet("role1", "role2")).build();
+        admin.tenants().updateTenant(tenant1, tenantInfo);
+        admin.tenants().updateTenant(tenant2, tenantInfo);
+
+        eventResource.clear();
+        @Cleanup
+        Consumer<MetadataChangeEvent> consumer2 = pulsarClient.newConsumer(AvroSchema.of(MetadataChangeEvent.class))
+                .topic(metadataEventTopic).subscriptionName("my-subscriber-name").messageListener((c, m) -> {
+                    MetadataChangeEvent event = m.getValue();
+                    eventResource.put(event.getResourceName(), event);
+                    c.acknowledgeAsync(m);
+                }).subscribe();
+
+        syncer.triggerSyncSnapshot();
+
+        Awaitility.waitAtMost(135, TimeUnit.SECONDS).until(() -> {
+            return eventResource.size() > 6;
+        });
+
+        verifyTenant(eventResource, tenant1, tenant2);
+        consumer2.close();
+    }
+
+    private void verifyNamespace(Map<String, MetadataChangeEvent> eventResource, String ns1, String ns2)
+            throws Exception {
+        // verify ns-1
+        Policies eventPolicies1 = ObjectMapperFactory.getThreadLocal().readValue(eventResource.get(ns1).getData(),
+                Policies.class);
+        Policies n1 = admin.namespaces().getPolicies(ns1);
+        assertEquals(eventPolicies1.replication_clusters, n1.replication_clusters);
+        assertEquals(eventPolicies1.lastUpdatedTimestamp, n1.lastUpdatedTimestamp);
+        Policies eventPolicies2 = ObjectMapperFactory.getThreadLocal().readValue(eventResource.get(ns2).getData(),
+                Policies.class);
+        Policies n2 = admin.namespaces().getPolicies(ns2);
+        assertEquals(eventPolicies2.replication_clusters, n2.replication_clusters);
+        assertEquals(eventPolicies2.lastUpdatedTimestamp, n2.lastUpdatedTimestamp);
+    }
+
+    private void verifyTenant(Map<String, MetadataChangeEvent> eventResource, String tenant1, String tenant2)
+            throws Exception {
+        TenantInfoImpl eventTenantInfo1 = ObjectMapperFactory.getThreadLocal()
+                .readValue(eventResource.get(tenant1).getData(), TenantInfoImpl.class);
+        TenantInfoImpl t1 = (TenantInfoImpl) admin.tenants().getTenantInfo(tenant1);
+        assertEquals(eventTenantInfo1.getLastUpdatedTimestamp(), t1.getLastUpdatedTimestamp());
+        assertEquals(eventTenantInfo1.getAdminRoles(), t1.getAdminRoles());
+        assertEquals(eventTenantInfo1.getAllowedClusters(), t1.getAllowedClusters());
+        // verify tenant-2
+        TenantInfoImpl eventTenantInfo2 = ObjectMapperFactory.getThreadLocal()
+                .readValue(eventResource.get(tenant2).getData(), TenantInfoImpl.class);
+        TenantInfoImpl t2 = (TenantInfoImpl) admin.tenants().getTenantInfo(tenant2);
+        assertEquals(eventTenantInfo2.getLastUpdatedTimestamp(), t2.getLastUpdatedTimestamp());
+        assertEquals(eventTenantInfo2.getAdminRoles(), t2.getAdminRoles());
+        assertEquals(eventTenantInfo2.getAllowedClusters(), t2.getAllowedClusters());
+    }
+}

--- a/pulsar-client-admin-api/src/main/java/org/apache/pulsar/common/partition/PartitionedTopicMetadata.java
+++ b/pulsar-client-admin-api/src/main/java/org/apache/pulsar/common/partition/PartitionedTopicMetadata.java
@@ -19,6 +19,7 @@
 package org.apache.pulsar.common.partition;
 
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * Metadata of a partitioned topic.
@@ -28,6 +29,7 @@ public class PartitionedTopicMetadata {
 
     /* Number of partitions for the topic */
     public int partitions;
+    public long lastUpdatedTimestamp;;
 
     /* Topic properties */
     public Map<String, String> properties;
@@ -44,6 +46,20 @@ public class PartitionedTopicMetadata {
     public PartitionedTopicMetadata(int partitions, Map<String, String> properties) {
         this.partitions = partitions;
         this.properties = properties;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(partitions, properties);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj instanceof PartitionedTopicMetadata) {
+            PartitionedTopicMetadata other = (PartitionedTopicMetadata) obj;
+            return Objects.equals(partitions, other.partitions) && Objects.equals(properties, other.properties);
+        }
+        return false;
     }
 
     /**

--- a/pulsar-client-admin-api/src/main/java/org/apache/pulsar/common/policies/data/Policies.java
+++ b/pulsar-client-admin-api/src/main/java/org/apache/pulsar/common/policies/data/Policies.java
@@ -124,6 +124,8 @@ public class Policies {
     @SuppressWarnings("checkstyle:MemberName")
     public String resource_group_name = null;
 
+    public long lastUpdatedTimestamp;
+
     public enum BundleType {
         LARGEST, HOT;
     }

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/TenantInfoImpl.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/TenantInfoImpl.java
@@ -21,6 +21,7 @@ package org.apache.pulsar.common.policies.data;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import java.util.HashSet;
+import java.util.Objects;
 import java.util.Set;
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -51,7 +52,12 @@ public class TenantInfoImpl implements TenantInfo {
             name = "allowedClusters"
     )
     private Set<String> allowedClusters;
+    private long lastUpdatedTimestamp;
 
+    public TenantInfoImpl(Set<String> adminRoles, Set<String> allowedClusters) {
+        this.adminRoles = adminRoles;
+        this.allowedClusters = allowedClusters;
+    }
 
     public static TenantInfoImplBuilder builder() {
         return new TenantInfoImplBuilder();
@@ -60,6 +66,7 @@ public class TenantInfoImpl implements TenantInfo {
     public static class TenantInfoImplBuilder implements TenantInfo.Builder {
         private Set<String> adminRoles;
         private Set<String> allowedClusters;
+        private long lastUpdatedTimestamp;
 
         TenantInfoImplBuilder() {
         }
@@ -81,7 +88,22 @@ public class TenantInfoImpl implements TenantInfo {
             if (allowedClusters == null) {
                 allowedClusters = new HashSet<>();
             }
-            return new TenantInfoImpl(adminRoles, allowedClusters);
+            return new TenantInfoImpl(adminRoles, allowedClusters, lastUpdatedTimestamp);
         }
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(adminRoles, allowedClusters);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj instanceof TenantInfoImpl) {
+            TenantInfoImpl other = (TenantInfoImpl) obj;
+            return Objects.equals(adminRoles, other.adminRoles)
+                    && Objects.equals(allowedClusters, other.allowedClusters);
+        }
+        return false;
     }
 }

--- a/site2/docs/reference-configuration.md
+++ b/site2/docs/reference-configuration.md
@@ -235,6 +235,8 @@ brokerServiceCompactionThresholdInBytes|If the estimated backlog size is greater
 | metadataStoreBatchingMaxDelayMillis | Maximum delay to impose on batching grouping. | 5 |
 | metadataStoreBatchingMaxOperations | Maximum number of operations to include in a singular batch. | 1000 |
 | metadataStoreBatchingMaxSizeKb | Maximum size of a batch. | 128 |
+| metadataSyncEventTopic | Event topic to sync metadata between separate pulsar clusters on different cloud platforms. | |
+| metadataSyncSnapshotDurationSecond | Snapshot duration to sync metadata using event topic. (Default 0 to disable it). | 0 |
 |ttlDurationDefaultInSeconds|The default Time to Live (TTL) for namespaces if the TTL is not configured at namespace policies. When the value is set to `0`, TTL is disabled. By default, TTL is disabled. |0|
 |tokenSettingPrefix| Configure the prefix of the token-related settings, such as `tokenSecretKey`, `tokenPublicKey`, `tokenAuthClaim`, `tokenPublicAlg`, `tokenAudienceClaim`, and `tokenAudience`. ||
 |tokenSecretKey| Configure the secret key to be used to validate auth tokens. The key can be specified like: `tokenSecretKey=data:;base64,xxxxxxxxx` or `tokenSecretKey=file:///my/secret.key`.  Note: key file must be DER-encoded.||
@@ -558,6 +560,8 @@ You can set the log level and configuration in the  [log4j2.yaml](https://github
 | metadataStoreBatchingMaxDelayMillis | Maximum delay to impose on batching grouping. | 5 |
 | metadataStoreBatchingMaxOperations | Maximum number of operations to include in a singular batch. | 1000 |
 | metadataStoreBatchingMaxSizeKb | Maximum size of a batch. | 128 |
+| metadataSyncEventTopic | Event topic to sync metadata between separate pulsar clusters on different cloud platforms. | |
+| metadataSyncSnapshotDurationSecond | Snapshot duration to sync metadata using event topic. (Default 0 to disable it). | 0 |
 | tlsCertRefreshCheckDurationSec | TLS certificate refresh duration in seconds. When the value is set to 0, check the TLS certificate on every new connection. | 300 |
 | tlsCertificateFilePath | Path for the TLS certificate file. | |
 | tlsKeyFilePath | Path for the TLS private key file. | |


### PR DESCRIPTION
### Motivation
Implementation of [PIP-136](https://github.com/apache/pulsar/issues/13728)
Sometimes it's not possible to share metadata-store (global zookeeper) between pulsar clusters deployed on separate cloud provider platforms, and synchronizing configuration metadata (policies) can be a critical path to share tenant/namespace/topic policies between clusters and administrate pulsar policies uniformly across all clusters. Therefore, we need a mechanism to sync configuration metadata between clusters deployed on the different cloud platforms.

[PIP-136](https://github.com/apache/pulsar/issues/13728) also has a section `Rejected alternative` with use of system-topic along with metadata-synchronizer to replicate and persist local topic policies with it.
