### PR TITLE
Improve skipping of DNS resolution when creating AuthenticationDataHttp instance

### DIFF
--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authentication/AuthenticationDataHttp.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authentication/AuthenticationDataHttp.java
@@ -18,7 +18,6 @@
  */
 package org.apache.pulsar.broker.authentication;
 
-import io.netty.util.NetUtil;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import javax.servlet.http.HttpServletRequest;
@@ -35,9 +34,7 @@ public class AuthenticationDataHttp implements AuthenticationDataSource {
             throw new IllegalArgumentException();
         }
         this.request = request;
-        this.remoteAddress =
-                new InetSocketAddress(NetUtil.createInetAddressFromIpAddressString(request.getRemoteAddr()),
-                        request.getRemotePort());
+        this.remoteAddress = InetSocketAddress.createUnresolved(request.getRemoteAddr(), request.getRemotePort());
     }
 
     /*


### PR DESCRIPTION
### Motivation

- improves solution added in #15221
  - It's better to use the JDK provided `InetSocketAddress.createUnresolved` method
    to prevent unnecessary DNS resolution

### Modifications

- use `InetSocketAddress.createUnresolved` method to prevent unnecessary DNS resolution
