### PR TITLE
[Fix][Broker] Fix race condition between timeout and completion  in `OpAddEntry` 

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
@@ -3829,12 +3829,13 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
         }
         OpAddEntry opAddEntry = pendingAddEntries.peek();
         if (opAddEntry != null) {
+            final long finalAddOpCount = opAddEntry.addOpCount;
             boolean isTimedOut = opAddEntry.lastInitTime != -1
                     && TimeUnit.NANOSECONDS.toSeconds(System.nanoTime() - opAddEntry.lastInitTime) >= timeoutSec;
             if (isTimedOut) {
                 log.error("Failed to add entry for ledger {} in time-out {} sec",
                         (opAddEntry.ledger != null ? opAddEntry.ledger.getId() : -1), timeoutSec);
-                opAddEntry.handleAddTimeoutFailure(opAddEntry.ledger, opAddEntry.addOpCount);
+                opAddEntry.handleAddTimeoutFailure(opAddEntry.ledger, finalAddOpCount);
             }
         }
     }


### PR DESCRIPTION
### Motivation

In #4455 and #10740, The `OpAddEntry` try to using `opAddEntry.addOpCount` to ensure the `opAddEntry` we got is what we want.(avoid recycle cause race condition)

It seems exists a case causing another race condition. consider the case as follow:

#### Precondition

- We have an `OpAddEntry` that name is A.
- We got two threads: a timeout check thread and another is a write thread that wants to complete and recycle this `OpAddEntry`.
- Relative code is as follow(timeout check logic):

https://github.com/apache/pulsar/blob/caf7648653c140c9f922e86425585ab7b5ed3ed6/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java#L3825-L3840

#### Race condition process

1. When the timeout checker thread gets `OpAddEntry` A and continues to run until line 3835.
2. At the same time, the writing thread also gets `OpAddEntry`A, completes and recycles.
3. After step 2, `OpAddEntry`A is taken out of the recycling pool by other threads as `OpAddEntry`B. But the timeout thread has passed the timeout check(line 3834), and `addOpCount` is also obtained from OpAddEntry B, which will cause the `compareAndSet` check to pass.

#### Affect

- The timeout checker will make a new `OpAddEntry` complete timeout.

### Modifications

- Record `opAddCount` before timeout judgment.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Documentation

- [x] `no-need-doc` 