### PR TITLE
[patch][pulsar-sql] Add Java version trim agent for presto 332

### DIFF
--- a/.github/workflows/pulsar-ci.yaml
+++ b/.github/workflows/pulsar-ci.yaml
@@ -359,9 +359,6 @@ jobs:
           - name: Transaction
             group: TRANSACTION
 
-          - name: SQL
-            group: SQL
-
     steps:
       - name: checkout
         if: ${{ needs.changed_files_job.outputs.docs_only != 'true' }}

--- a/.github/workflows/pulsar-ci.yaml
+++ b/.github/workflows/pulsar-ci.yaml
@@ -605,8 +605,8 @@ jobs:
             group: PULSAR_IO_ORA
 
           # disable Sql integration tests until https://github.com/apache/pulsar/issues/14951 has been resolved
-          #- name: Sql
-          #  group: SQL
+          - name: Sql
+            group: SQL
 
     steps:
       - name: checkout

--- a/.github/workflows/pulsar-ci.yaml
+++ b/.github/workflows/pulsar-ci.yaml
@@ -359,6 +359,9 @@ jobs:
           - name: Transaction
             group: TRANSACTION
 
+          - name: SQL
+            group: SQL
+
     steps:
       - name: checkout
         if: ${{ needs.changed_files_job.outputs.docs_only != 'true' }}
@@ -604,7 +607,6 @@ jobs:
           - name: Pulsar IO - Oracle
             group: PULSAR_IO_ORA
 
-          # disable Sql integration tests until https://github.com/apache/pulsar/issues/14951 has been resolved
           - name: Sql
             group: SQL
 

--- a/conf/presto/jvm.config
+++ b/conf/presto/jvm.config
@@ -27,3 +27,4 @@
 -XX:+ExitOnOutOfMemoryError
 -Dpresto-temporarily-allow-java8=true
 -Djdk.attach.allowAttachSelf=true
+-javaagent:java-version-trim-agent.jar

--- a/pulsar-sql/java-version-trim-agent/pom.xml
+++ b/pulsar-sql/java-version-trim-agent/pom.xml
@@ -29,6 +29,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>java-version-trim-agent</artifactId>
+    <name>Pulsar SQL :: Java Version Trim Agent</name>
 
     <dependencies>
         <dependency>

--- a/pulsar-sql/java-version-trim-agent/pom.xml
+++ b/pulsar-sql/java-version-trim-agent/pom.xml
@@ -31,17 +31,6 @@
     <artifactId>java-version-trim-agent</artifactId>
     <name>Pulsar SQL :: Java Version Trim Agent</name>
 
-    <dependencies>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>log4j-over-slf4j</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-jdk14</artifactId>
-        </dependency>
-    </dependencies>
-
     <build>
         <finalName>java-version-trim-agent</finalName>
         <plugins>

--- a/pulsar-sql/java-version-trim-agent/pom.xml
+++ b/pulsar-sql/java-version-trim-agent/pom.xml
@@ -50,7 +50,6 @@
                 <version>3.1.0</version>
                 <configuration>
                     <archive>
-                        <!--自动添加META-INF/MANIFEST.MF -->
                         <manifest>
                             <addClasspath>true</addClasspath>
                         </manifest>

--- a/pulsar-sql/java-version-trim-agent/pom.xml
+++ b/pulsar-sql/java-version-trim-agent/pom.xml
@@ -1,0 +1,69 @@
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>pulsar-sql</artifactId>
+        <groupId>org.apache.pulsar</groupId>
+        <version>2.11.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>java-version-trim-agent</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>log4j-over-slf4j</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-jdk14</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <finalName>java-version-trim-agent</finalName>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>3.1.0</version>
+                <configuration>
+                    <archive>
+                        <!--自动添加META-INF/MANIFEST.MF -->
+                        <manifest>
+                            <addClasspath>true</addClasspath>
+                        </manifest>
+                        <manifestEntries>
+                            <Premain-Class>org.apache.pulsar.sql.agent.TrimJavaVersionAgent</Premain-Class>
+                            <Agent-Class>org.apache.pulsar.sql.agent.TrimJavaVersionAgent</Agent-Class>
+                            <Can-Redefine-Classes>true</Can-Redefine-Classes>
+                            <Can-Retransform-Classes>true</Can-Retransform-Classes>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/pulsar-sql/java-version-trim-agent/src/main/java/org/apache/pulsar/sql/agent/TrimJavaVersionAgent.java
+++ b/pulsar-sql/java-version-trim-agent/src/main/java/org/apache/pulsar/sql/agent/TrimJavaVersionAgent.java
@@ -1,0 +1,51 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.sql.agent;
+
+import java.lang.instrument.Instrumentation;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * The presto 332 couldn't parse Java version like this `11.0.14.1`,
+ * so add java version trim agent to walk around the problem.
+ *
+ * After the presto upgrade to 332+, we could remove this.
+ */
+@Slf4j
+public class TrimJavaVersionAgent {
+
+    private static final String JAVA_VERSION = "java.version";
+
+    public static String trimJavaVersion(String javaVersion) {
+        String[] arr = javaVersion.split("\\.");
+        if (arr.length <= 3) {
+            return javaVersion;
+        }
+        return arr[0] + "." + arr[1] + "." + arr[2];
+    }
+
+    public static void premain(String agentArgs, Instrumentation inst) {
+        String javaVersion = System.getProperty(JAVA_VERSION);
+        log.info("original java version => {}", javaVersion);
+        String trimVersion = trimJavaVersion(javaVersion);
+        log.info("trim java version => {}", javaVersion);
+        System.setProperty(JAVA_VERSION, trimVersion);
+    }
+
+}

--- a/pulsar-sql/java-version-trim-agent/src/main/java/org/apache/pulsar/sql/agent/TrimJavaVersionAgent.java
+++ b/pulsar-sql/java-version-trim-agent/src/main/java/org/apache/pulsar/sql/agent/TrimJavaVersionAgent.java
@@ -19,7 +19,7 @@
 package org.apache.pulsar.sql.agent;
 
 import java.lang.instrument.Instrumentation;
-import lombok.extern.slf4j.Slf4j;
+import java.util.logging.Logger;
 
 /**
  * The presto 332 couldn't parse Java version like this `11.0.14.1`,
@@ -27,8 +27,9 @@ import lombok.extern.slf4j.Slf4j;
  *
  * After the presto upgrade to 332+, we could remove this.
  */
-@Slf4j
 public class TrimJavaVersionAgent {
+
+    private static final Logger logger = Logger.getLogger(TrimJavaVersionAgent.class.getName());
 
     private static final String JAVA_VERSION = "java.version";
 
@@ -42,9 +43,8 @@ public class TrimJavaVersionAgent {
 
     public static void premain(String agentArgs, Instrumentation inst) {
         String javaVersion = System.getProperty(JAVA_VERSION);
-        log.info("original java version => {}", javaVersion);
         String trimVersion = trimJavaVersion(javaVersion);
-        log.info("trim java version => {}", javaVersion);
+        logger.info("original java version " + javaVersion + " => trim java version " + trimVersion);
         System.setProperty(JAVA_VERSION, trimVersion);
     }
 

--- a/pulsar-sql/java-version-trim-agent/src/main/java/org/apache/pulsar/sql/agent/package-info.java
+++ b/pulsar-sql/java-version-trim-agent/src/main/java/org/apache/pulsar/sql/agent/package-info.java
@@ -1,0 +1,22 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+/**
+ * Implementation of the connector to the Presto engine.
+ */
+package org.apache.pulsar.sql.agent;

--- a/pulsar-sql/pom.xml
+++ b/pulsar-sql/pom.xml
@@ -34,6 +34,7 @@
     <modules>
         <module>presto-pulsar</module>
         <module>presto-pulsar-plugin</module>
+        <module>java-version-trim-agent</module>
         <module>presto-distribution</module>
     </modules>
 

--- a/pulsar-sql/presto-distribution/pom.xml
+++ b/pulsar-sql/presto-distribution/pom.xml
@@ -194,6 +194,13 @@
       <version>${jackson.version}</version>
     </dependency>
 
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>java-version-trim-agent</artifactId>
+      <version>${project.version}</version>
+      <scope>provided</scope>
+    </dependency>
+
   </dependencies>
 
   <dependencyManagement>

--- a/pulsar-sql/presto-distribution/src/assembly/assembly.xml
+++ b/pulsar-sql/presto-distribution/src/assembly/assembly.xml
@@ -40,6 +40,11 @@
             <outputDirectory>bin/</outputDirectory>
             <fileMode>644</fileMode>
         </file>
+        <file>
+            <source>${basedir}/../java-version-trim-agent/target/java-version-trim-agent.jar</source>
+            <destName>java-version-trim-agent.jar</destName>
+            <outputDirectory>/</outputDirectory>
+        </file>
     </files>
     <fileSets>
         <fileSet>

--- a/pulsar-sql/presto-pulsar/pom.xml
+++ b/pulsar-sql/presto-pulsar/pom.xml
@@ -105,6 +105,12 @@
         </dependency>
 
         <dependency>
+            <groupId>javax.annotation</groupId>
+            <artifactId>javax.annotation-api</artifactId>
+            <version>${javax.annotation-api.version}</version>
+        </dependency>
+
+        <dependency>
             <groupId>io.prestosql</groupId>
             <artifactId>presto-main</artifactId>
             <version>${presto.version}</version>

--- a/tests/docker-images/latest-version-image/conf/presto/jvm.config
+++ b/tests/docker-images/latest-version-image/conf/presto/jvm.config
@@ -28,3 +28,4 @@
 -XX:+ExitOnOutOfMemoryError
 -Dpresto-temporarily-allow-java8=true
 -Djdk.attach.allowAttachSelf=true
+-javaagent:java-version-trim-agent.jar

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/presto/TestPrestoQueryTieredStorage.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/presto/TestPrestoQueryTieredStorage.java
@@ -36,15 +36,10 @@ import org.apache.pulsar.client.impl.schema.JSONSchema;
 import org.apache.pulsar.common.naming.NamespaceName;
 import org.apache.pulsar.common.naming.TopicDomain;
 import org.apache.pulsar.common.naming.TopicName;
-import org.apache.pulsar.tests.integration.containers.BrokerContainer;
 import org.apache.pulsar.tests.integration.containers.S3Container;
 import org.testcontainers.shaded.org.apache.commons.lang.StringUtils;
 import org.testng.Assert;
 import org.testng.annotations.Test;
-
-import java.util.HashMap;
-import java.util.Map;
-
 
 /**
  * Test presto query from tiered storage, the Pulsar SQL is cluster mode.
@@ -56,27 +51,6 @@ public class TestPrestoQueryTieredStorage extends TestPulsarSQLBase {
     private final String NAMESPACE = "ts";
 
     private S3Container s3Container;
-
-    @Override
-    protected void beforeStartCluster() throws Exception {
-        Map<String, String> envMap = new HashMap<>();
-        envMap.put("managedLedgerMaxEntriesPerLedger", String.valueOf(ENTRIES_PER_LEDGER));
-        envMap.put("managedLedgerMinLedgerRolloverTimeMinutes", "0");
-        envMap.put("managedLedgerOffloadDriver", OFFLOAD_DRIVER);
-        envMap.put("s3ManagedLedgerOffloadBucket", BUCKET);
-        envMap.put("s3ManagedLedgerOffloadServiceEndpoint", ENDPOINT);
-
-        for (BrokerContainer brokerContainer : pulsarCluster.getBrokers()) {
-            brokerContainer.withEnv(envMap);
-        }
-
-        s3Container = new S3Container(
-                pulsarCluster.getClusterName(),
-                S3Container.NAME)
-                .withNetwork(pulsarCluster.getNetwork())
-                .withNetworkAliases(S3Container.NAME);
-        s3Container.start();
-    }
 
     @Override
     public void setupCluster() throws Exception {
@@ -100,6 +74,13 @@ public class TestPrestoQueryTieredStorage extends TestPulsarSQLBase {
                 "namespaces",
                 "create", "--clusters", pulsarCluster.getClusterName(),
                 NamespaceName.get(TENANT, NAMESPACE).toString());
+
+        s3Container = new S3Container(
+                pulsarCluster.getClusterName(),
+                S3Container.NAME)
+                .withNetwork(pulsarCluster.getNetwork())
+                .withNetworkAliases(S3Container.NAME);
+        s3Container.start();
 
         String offloadProperties = getOffloadProperties(BUCKET, null, ENDPOINT);
         pulsarCluster.startPrestoWorker(OFFLOAD_DRIVER, offloadProperties);

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/suites/PulsarSQLTestSuite.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/suites/PulsarSQLTestSuite.java
@@ -21,13 +21,10 @@ package org.apache.pulsar.tests.integration.suites;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.SQLException;
-import java.util.HashMap;
-import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.common.protocol.Commands;
-import org.apache.pulsar.tests.integration.containers.BrokerContainer;
 import org.apache.pulsar.tests.integration.containers.S3Container;
 import org.apache.pulsar.tests.integration.topologies.PulsarClusterSpec;
 

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/suites/PulsarSQLTestSuite.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/suites/PulsarSQLTestSuite.java
@@ -55,20 +55,6 @@ public abstract class PulsarSQLTestSuite extends PulsarTestSuite {
     }
 
     @Override
-    protected void beforeStartCluster() throws Exception {
-        Map<String, String> envMap = new HashMap<>();
-        envMap.put("managedLedgerMaxEntriesPerLedger", String.valueOf(ENTRIES_PER_LEDGER));
-        envMap.put("managedLedgerMinLedgerRolloverTimeMinutes", "0");
-        envMap.put("managedLedgerOffloadDriver", OFFLOAD_DRIVER);
-        envMap.put("s3ManagedLedgerOffloadBucket", BUCKET);
-        envMap.put("s3ManagedLedgerOffloadServiceEndpoint", ENDPOINT);
-
-        for (BrokerContainer brokerContainer : pulsarCluster.getBrokers()) {
-            brokerContainer.withEnv(envMap);
-        }
-    }
-
-    @Override
     public void setupCluster() throws Exception {
         super.setupCluster();
         pulsarClient = PulsarClient.builder()


### PR DESCRIPTION
Fix #14951 

### Motivation

The presto 332 couldn't parse Java version like this `11.0.14.1`, so add a Java version trim agent to walk around the problem.

This is a temporary patch, after the presto upgrade to 332+, we could remove this.

### Modifications

Add a Java version trim agent to format the system property `java.version` for the Pulsar SQL plugin.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (yes)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

Check the box below or label this PR directly.

Need to update docs? 

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)
  
- [x] `no-need-doc` 
(Please explain why)
  
- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-added`
(Docs have been already added)