### PR TITLE
[doc][tiered storage] read data from filesystem

### DIFF
--- a/site2/docs/client-libraries-node.md
+++ b/site2/docs/client-libraries-node.md
@@ -602,3 +602,38 @@ This section provides step-by-step instructions on how to use the end-to-end enc
     my-message-8
     my-message-9
     ```
+### Read data from fileSystem
+
+This section provides detailed instructions about how to read data out as Ledger Entry in the file system.
+
+ * The data was offloaded as `MapFile` to the following path:
+   ```properties
+     path = storageBasePath + "/" + managedLedgerName + "/" + ledgerId + "-" + uuid.toString();
+   ```
+     1. storageBasePath is the value of `hadoop.tmp.dir`, configured in `broker.conf` and `filesystem_offload_core_site.xml`
+     2. managedLedgerName is the name of the persistentTopic manager Ledger
+   ```shell
+      managedLedgerName of persistent://public/default/topics-name is  public/default/persistent/topics-name.
+   ```
+   Considering the iteration of versions,  you can use the following method to get the managedLedgerName:
+   ```shell
+      String managedLedgerName = TopicName.get("persistent://public/default/topics-name").getPersistenceNamingEncoding(); 
+   ```
+
+ * Create a reader to read `MapFile` according to the above path and the `configuration` of the file system
+   ```shell
+      MapFile.Reader reader = new MapFile.Reader(new Path(dataFilePath),  configuration); 
+   ```
+ * Read data as `LedgerEntry` from FileSystem.
+   ```java
+      LongWritable key = new LongWritable();
+      BytesWritable value = new BytesWritable();
+      key.set(nextExpectedId - 1);
+      reader.seek(key);
+      reader.next(key, value);
+      int length = value.getLength();
+      long entryId = key.get();
+      ByteBuf buf = PooledByteBufAllocator.DEFAULT.buffer(length, length);
+      buf.writeBytes(value.copyBytes());
+      LedgerEntryImpl ledgerEntry = LedgerEntryImpl.create(ledgerId, entryId, length, buf);
+   ```

--- a/site2/docs/client-libraries-node.md
+++ b/site2/docs/client-libraries-node.md
@@ -602,38 +602,3 @@ This section provides step-by-step instructions on how to use the end-to-end enc
     my-message-8
     my-message-9
     ```
-### Read data from fileSystem
-
-This section provides detailed instructions about how to read data out as Ledger Entry in the file system.
-
- * The data was offloaded as `MapFile` to the following path:
-   ```properties
-     path = storageBasePath + "/" + managedLedgerName + "/" + ledgerId + "-" + uuid.toString();
-   ```
-     1. storageBasePath is the value of `hadoop.tmp.dir`, configured in `broker.conf` and `filesystem_offload_core_site.xml`
-     2. managedLedgerName is the name of the persistentTopic manager Ledger
-   ```shell
-      managedLedgerName of persistent://public/default/topics-name is  public/default/persistent/topics-name.
-   ```
-   Considering the iteration of versions,  you can use the following method to get the managedLedgerName:
-   ```shell
-      String managedLedgerName = TopicName.get("persistent://public/default/topics-name").getPersistenceNamingEncoding(); 
-   ```
-
- * Create a reader to read `MapFile` according to the above path and the `configuration` of the file system
-   ```shell
-      MapFile.Reader reader = new MapFile.Reader(new Path(dataFilePath),  configuration); 
-   ```
- * Read data as `LedgerEntry` from FileSystem.
-   ```java
-      LongWritable key = new LongWritable();
-      BytesWritable value = new BytesWritable();
-      key.set(nextExpectedId - 1);
-      reader.seek(key);
-      reader.next(key, value);
-      int length = value.getLength();
-      long entryId = key.get();
-      ByteBuf buf = PooledByteBufAllocator.DEFAULT.buffer(length, length);
-      buf.writeBytes(value.copyBytes());
-      LedgerEntryImpl ledgerEntry = LedgerEntryImpl.create(ledgerId, entryId, length, buf);
-   ```

--- a/site2/docs/tiered-storage-filesystem.md
+++ b/site2/docs/tiered-storage-filesystem.md
@@ -522,7 +522,7 @@ Execute the following commands in the repository where you download Pulsar tarba
 
     ![](assets/FileSystem-8.png)
 
-## Read data from fileSystem
+## Read offloaded data from fileSystem
 
 This section provides detailed instructions about how to read data out as Ledger Entry in the file system.
 
@@ -530,12 +530,12 @@ This section provides detailed instructions about how to read data out as Ledger
   ```properties
     path = storageBasePath + "/" + managedLedgerName + "/" + ledgerId + "-" + uuid.toString();
   ```
-    1. storageBasePath is the value of `hadoop.tmp.dir`, configured in `broker.conf` and `filesystem_offload_core_site.xml`
+    1. storageBasePath is the value of `hadoop.tmp.dir`, configured in `broker.conf` or `filesystem_offload_core_site.xml`
     2. managedLedgerName is the name of the persistentTopic manager Ledger
   ```shell
-     managedLedgerName of persistent://public/default/topics-name is  public/default/persistent/topics-name.
+     managedLedgerName of persistent://public/default/topics-name is public/default/persistent/topics-name.
   ```
-  Considering the iteration of versions,  you can use the following method to get the managedLedgerName:
+  Can use the following method to get the managedLedgerName:
   ```shell
      String managedLedgerName = TopicName.get("persistent://public/default/topics-name").getPersistenceNamingEncoding(); 
   ```

--- a/site2/docs/tiered-storage-filesystem.md
+++ b/site2/docs/tiered-storage-filesystem.md
@@ -522,29 +522,28 @@ Execute the following commands in the repository where you download Pulsar tarba
 
     ![](assets/FileSystem-8.png)
 
-## Read offloaded data from fileSystem
+## Read offloaded data from filesystem
 
-This section provides detailed instructions about how to read data out as Ledger Entry in the file system.
-
-* The data was offloaded as `MapFile` to the following path:
+* The offloaded data is stored as `MapFile` in the following new path of the filesystem:
   ```properties
     path = storageBasePath + "/" + managedLedgerName + "/" + ledgerId + "-" + uuid.toString();
   ```
-    1. storageBasePath is the value of `hadoop.tmp.dir`, configured in `broker.conf` or `filesystem_offload_core_site.xml`
-    2. managedLedgerName is the name of the persistentTopic manager Ledger
+    * `storageBasePath` is the value of `hadoop.tmp.dir`, which is configured in `broker.conf` or `filesystem_offload_core_site.xml`.
+    * `managedLedgerName` is the ledger name of the persistentTopic manager.
   ```shell
      managedLedgerName of persistent://public/default/topics-name is public/default/persistent/topics-name.
   ```
-  Can use the following method to get the managedLedgerName:
+  You can use the following method to get `managedLedgerName`:
   ```shell
      String managedLedgerName = TopicName.get("persistent://public/default/topics-name").getPersistenceNamingEncoding(); 
   ```
 
-* Create a reader to read `MapFile` according to the above path and the `configuration` of the file system
+To read data out as ledger entries from the filesystem, complete the following steps.
+1. Create a reader to read both `MapFile` with a new path and the `configuration` of the filesystem.
   ```shell
      MapFile.Reader reader = new MapFile.Reader(new Path(dataFilePath),  configuration); 
   ```
-* Read data as `LedgerEntry` from FileSystem.
+2. Read the data as `LedgerEntry` from the filesystem.
   ```java
      LongWritable key = new LongWritable();
      BytesWritable value = new BytesWritable();
@@ -557,7 +556,7 @@ This section provides detailed instructions about how to read data out as Ledger
      buf.writeBytes(value.copyBytes());
      LedgerEntryImpl ledgerEntry = LedgerEntryImpl.create(ledgerId, entryId, length, buf);
   ```
-* Deserialize the `ledgerEntry` to `Message`.
+. Deserialize the `LedgerEntry` to `Message`.
   ```java
         ByteBuf metadataAndPayload = ledgerEntry.getDataBuffer();
         long totalSize = metadataAndPayload.readableBytes();

--- a/site2/docs/tiered-storage-filesystem.md
+++ b/site2/docs/tiered-storage-filesystem.md
@@ -556,7 +556,7 @@ To read data out as ledger entries from the filesystem, complete the following s
      buf.writeBytes(value.copyBytes());
      LedgerEntryImpl ledgerEntry = LedgerEntryImpl.create(ledgerId, entryId, length, buf);
   ```
-. Deserialize the `LedgerEntry` to `Message`.
+3. Deserialize the `LedgerEntry` to `Message`.
   ```java
         ByteBuf metadataAndPayload = ledgerEntry.getDataBuffer();
         long totalSize = metadataAndPayload.readableBytes();


### PR DESCRIPTION
Fix https://github.com/apache/pulsar/issues/14526
### Motivation & Modification
The current Filesystem Offload documentation has no documentation on how to directly read the data after offload, so consider adding documentation for this section

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API: (yes / no)
  - The schema: (yes / no / don't know)
  - The default values of configurations: (yes / no)
  - The wire protocol: (yes / no)
  - The rest endpoints: (yes / no)
  - The admin cli options: (yes / no)
  - Anything that affects deployment: (yes / no / don't know)

### Documentation

Check the box below or label this PR directly.

Need to update docs? 

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)
  
- [ ] `no-need-doc` 
(Please explain why)
  
- [x] `doc` 
(Your PR contains doc changes)

- [ ] `doc-added`
(Docs have been already added)