### PR TITLE
[fix][function] Fix UserConfigFunction example

### DIFF
--- a/pulsar-functions/java-examples/src/main/java/org/apache/pulsar/functions/api/examples/UserConfigFunction.java
+++ b/pulsar-functions/java-examples/src/main/java/org/apache/pulsar/functions/api/examples/UserConfigFunction.java
@@ -18,7 +18,6 @@
  */
 package org.apache.pulsar.functions.api.examples;
 
-import java.util.Optional;
 import org.apache.pulsar.functions.api.Context;
 import org.apache.pulsar.functions.api.Function;
 
@@ -29,12 +28,7 @@ public class UserConfigFunction implements Function<String, String> {
 
     @Override
     public String process(String input, Context context) {
-        Optional<Object> whatToWrite = context.getUserConfigValue("WhatToWrite");
-        if (whatToWrite.get() != null) {
-            return (String) whatToWrite.get();
-        } else {
-            return "Not a nice way";
-        }
+        return (String) context.getUserConfigValue("WhatToWrite").orElse("Not a nice way");
     }
 }
 


### PR DESCRIPTION
### Motivation
UserConfigFunction example is incorrect as calling `get()` on an empty Optional will raise an exception. Also the result of `get()` will never be null so it's useless to check nullity.

### Modifications

trivial

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

no

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API: (yes / no)
  - The schema: (yes / no / don't know)
  - The default values of configurations: (yes / no)
  - The wire protocol: (yes / no)
  - The rest endpoints: (yes / no)
  - The admin cli options: (yes / no)
  - Anything that affects deployment: (yes / no / don't know)

### Documentation

Check the box below or label this PR directly.

Need to update docs? 

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)
  
- [x] `no-need-doc` 
(Please explain why)
  
- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-added`
(Docs have been already added)