### PR TITLE
[owasp] Suppress MariaDB false positives

### DIFF
--- a/src/owasp-dependency-check-false-positives.xml
+++ b/src/owasp-dependency-check-false-positives.xml
@@ -142,83 +142,16 @@
    ]]></notes>
     <sha1>9dd29797ecabe7d2e7fa892ec6713a5552cfcc59</sha1>
     <cve>CVE-2022-27376</cve>
-  </suppress>
-  <suppress>
-    <notes><![CDATA[
-   file name: mariadb-java-client-2.7.5.jar
-   ]]></notes>
-    <sha1>9dd29797ecabe7d2e7fa892ec6713a5552cfcc59</sha1>
     <cve>CVE-2022-27377</cve>
-  </suppress>
-  <suppress>
-    <notes><![CDATA[
-   file name: mariadb-java-client-2.7.5.jar
-   ]]></notes>
-    <sha1>9dd29797ecabe7d2e7fa892ec6713a5552cfcc59</sha1>
     <cve>CVE-2022-27378</cve>
-  </suppress>
-  <suppress>
-    <notes><![CDATA[
-   file name: mariadb-java-client-2.7.5.jar
-   ]]></notes>
-    <sha1>9dd29797ecabe7d2e7fa892ec6713a5552cfcc59</sha1>
     <cve>CVE-2022-27379</cve>
-  </suppress>
-  <suppress>
-    <notes><![CDATA[
-   file name: mariadb-java-client-2.7.5.jar
-   ]]></notes>
-    <sha1>9dd29797ecabe7d2e7fa892ec6713a5552cfcc59</sha1>
     <cve>CVE-2022-27380</cve>
-  </suppress>
-  <suppress>
-    <notes><![CDATA[
-   file name: mariadb-java-client-2.7.5.jar
-   ]]></notes>
-    <sha1>9dd29797ecabe7d2e7fa892ec6713a5552cfcc59</sha1>
     <cve>CVE-2022-27381</cve>
-  </suppress>
-  <suppress>
-    <notes><![CDATA[
-   file name: mariadb-java-client-2.7.5.jar
-   ]]></notes>
-    <sha1>9dd29797ecabe7d2e7fa892ec6713a5552cfcc59</sha1>
     <cve>CVE-2022-27382</cve>
-  </suppress>
-  <suppress>
-    <notes><![CDATA[
-   file name: mariadb-java-client-2.7.5.jar
-   ]]></notes>
-    <sha1>9dd29797ecabe7d2e7fa892ec6713a5552cfcc59</sha1>
     <cve>CVE-2022-27383</cve>
-  </suppress>
-  <suppress>
-    <notes><![CDATA[
-   file name: mariadb-java-client-2.7.5.jar
-   ]]></notes>
-    <sha1>9dd29797ecabe7d2e7fa892ec6713a5552cfcc59</sha1>
     <cve>CVE-2022-27384</cve>
-  </suppress>
-  <suppress>
-    <notes><![CDATA[
-   file name: mariadb-java-client-2.7.5.jar
-   ]]></notes>
-    <sha1>9dd29797ecabe7d2e7fa892ec6713a5552cfcc59</sha1>
     <cve>CVE-2022-27385</cve>
-  </suppress>
-  <suppress>
-    <notes><![CDATA[
-   file name: mariadb-java-client-2.7.5.jar
-   ]]></notes>
-    <sha1>9dd29797ecabe7d2e7fa892ec6713a5552cfcc59</sha1>
     <cve>CVE-2022-27386</cve>
-  </suppress>
-  <suppress>
-    <notes><![CDATA[
-   file name: mariadb-java-client-2.7.5.jar
-   ]]></notes>
-    <sha1>9dd29797ecabe7d2e7fa892ec6713a5552cfcc59</sha1>
     <cve>CVE-2022-27387</cve>
   </suppress>
-
 </suppressions>

--- a/src/owasp-dependency-check-false-positives.xml
+++ b/src/owasp-dependency-check-false-positives.xml
@@ -134,4 +134,91 @@
     <cve>CVE-2021-23214</cve>
   </suppress>
 
+
+<!--  MariaDB client is being confused with MariaDB server-->
+  <suppress>
+    <notes><![CDATA[
+   file name: mariadb-java-client-2.7.5.jar
+   ]]></notes>
+    <sha1>9dd29797ecabe7d2e7fa892ec6713a5552cfcc59</sha1>
+    <cve>CVE-2022-27376</cve>
+  </suppress>
+  <suppress>
+    <notes><![CDATA[
+   file name: mariadb-java-client-2.7.5.jar
+   ]]></notes>
+    <sha1>9dd29797ecabe7d2e7fa892ec6713a5552cfcc59</sha1>
+    <cve>CVE-2022-27377</cve>
+  </suppress>
+  <suppress>
+    <notes><![CDATA[
+   file name: mariadb-java-client-2.7.5.jar
+   ]]></notes>
+    <sha1>9dd29797ecabe7d2e7fa892ec6713a5552cfcc59</sha1>
+    <cve>CVE-2022-27378</cve>
+  </suppress>
+  <suppress>
+    <notes><![CDATA[
+   file name: mariadb-java-client-2.7.5.jar
+   ]]></notes>
+    <sha1>9dd29797ecabe7d2e7fa892ec6713a5552cfcc59</sha1>
+    <cve>CVE-2022-27379</cve>
+  </suppress>
+  <suppress>
+    <notes><![CDATA[
+   file name: mariadb-java-client-2.7.5.jar
+   ]]></notes>
+    <sha1>9dd29797ecabe7d2e7fa892ec6713a5552cfcc59</sha1>
+    <cve>CVE-2022-27380</cve>
+  </suppress>
+  <suppress>
+    <notes><![CDATA[
+   file name: mariadb-java-client-2.7.5.jar
+   ]]></notes>
+    <sha1>9dd29797ecabe7d2e7fa892ec6713a5552cfcc59</sha1>
+    <cve>CVE-2022-27381</cve>
+  </suppress>
+  <suppress>
+    <notes><![CDATA[
+   file name: mariadb-java-client-2.7.5.jar
+   ]]></notes>
+    <sha1>9dd29797ecabe7d2e7fa892ec6713a5552cfcc59</sha1>
+    <cve>CVE-2022-27382</cve>
+  </suppress>
+  <suppress>
+    <notes><![CDATA[
+   file name: mariadb-java-client-2.7.5.jar
+   ]]></notes>
+    <sha1>9dd29797ecabe7d2e7fa892ec6713a5552cfcc59</sha1>
+    <cve>CVE-2022-27383</cve>
+  </suppress>
+  <suppress>
+    <notes><![CDATA[
+   file name: mariadb-java-client-2.7.5.jar
+   ]]></notes>
+    <sha1>9dd29797ecabe7d2e7fa892ec6713a5552cfcc59</sha1>
+    <cve>CVE-2022-27384</cve>
+  </suppress>
+  <suppress>
+    <notes><![CDATA[
+   file name: mariadb-java-client-2.7.5.jar
+   ]]></notes>
+    <sha1>9dd29797ecabe7d2e7fa892ec6713a5552cfcc59</sha1>
+    <cve>CVE-2022-27385</cve>
+  </suppress>
+  <suppress>
+    <notes><![CDATA[
+   file name: mariadb-java-client-2.7.5.jar
+   ]]></notes>
+    <sha1>9dd29797ecabe7d2e7fa892ec6713a5552cfcc59</sha1>
+    <cve>CVE-2022-27386</cve>
+  </suppress>
+  <suppress>
+    <notes><![CDATA[
+   file name: mariadb-java-client-2.7.5.jar
+   ]]></notes>
+    <sha1>9dd29797ecabe7d2e7fa892ec6713a5552cfcc59</sha1>
+    <cve>CVE-2022-27387</cve>
+  </suppress>
+
 </suppressions>


### PR DESCRIPTION
### Motivation
Owasp check fails with [this error](https://github.com/apache/pulsar/runs/6102420129?check_suite_focus=true)
> mariadb-java-client-2.7.5.jar: CVE-2022-27376, CVE-2022-27377, CVE-2022-27378, CVE-2022-27379, CVE-2022-27380, CVE-2022-27381, CVE-2022-27382, CVE-2022-27383, CVE-2022-27384, CVE-2022-27385, CVE-2022-27386, CVE-2022-27387

These CVEs are about the server and they do not impact the client.

### Modifications

* Suppress owasp rules

- [x] `no-need-doc` 
