### PR TITLE
[fix][elasticsearch-sink] enable bulk flushing scheduling by default

### DIFF
--- a/pulsar-io/elastic-search/src/main/java/org/apache/pulsar/io/elasticsearch/ElasticSearchConfig.java
+++ b/pulsar-io/elastic-search/src/main/java/org/apache/pulsar/io/elasticsearch/ElasticSearchConfig.java
@@ -167,10 +167,10 @@ public class ElasticSearchConfig implements Serializable {
 
     @FieldDoc(
             required = false,
-            defaultValue = "-1",
-            help = "The bulk flush interval flushing any bulk request pending if the interval passes. Default is -1 meaning not set."
+            defaultValue = "1000",
+            help = "The bulk flush interval flushing any bulk request pending if the interval passes. -1 or zero means the scheduled flushing is disabled."
     )
-    private long bulkFlushIntervalInMs = -1;
+    private long bulkFlushIntervalInMs = 1000L;
 
     // connection settings, see https://www.elastic.co/guide/en/elasticsearch/client/java-rest/current/java-rest-low-config.html
     @FieldDoc(

--- a/pulsar-io/elastic-search/src/test/java/org/apache/pulsar/io/elasticsearch/ElasticSearchClientTests.java
+++ b/pulsar-io/elastic-search/src/test/java/org/apache/pulsar/io/elasticsearch/ElasticSearchClientTests.java
@@ -207,6 +207,7 @@ public abstract class ElasticSearchClientTests extends ElasticSearchTestBase {
                 .setElasticSearchUrl("http://"+container.getHttpHostAddress())
                 .setIndexName(index)
                 .setBulkEnabled(true)
+                .setBulkFlushIntervalInMs(-1L)
                 .setMalformedDocAction(ElasticSearchConfig.MalformedDocAction.FAIL);
         try (ElasticSearchClient client = new ElasticSearchClient(config);) {
             MockRecord<GenericObject> mockRecord = new MockRecord<>();
@@ -230,6 +231,7 @@ public abstract class ElasticSearchClientTests extends ElasticSearchTestBase {
                 .setElasticSearchUrl("http://"+container.getHttpHostAddress())
                 .setIndexName(index)
                 .setBulkEnabled(true)
+                .setBulkFlushIntervalInMs(-1)
                 .setMalformedDocAction(ElasticSearchConfig.MalformedDocAction.IGNORE);
         try (ElasticSearchClient client = new ElasticSearchClient(config);) {
             MockRecord<GenericObject> mockRecord = new MockRecord<>();

--- a/pulsar-io/elastic-search/src/test/java/org/apache/pulsar/io/elasticsearch/ElasticSearchConfigTests.java
+++ b/pulsar-io/elastic-search/src/test/java/org/apache/pulsar/io/elasticsearch/ElasticSearchConfigTests.java
@@ -80,7 +80,7 @@ public class ElasticSearchConfigTests {
         assertEquals(config.isBulkEnabled(), false);
         assertEquals(config.getBulkActions(), 1000L);
         assertEquals(config.getBulkSizeInMb(), 5L);
-        assertEquals(config.getBulkFlushIntervalInMs(), -1L);
+        assertEquals(config.getBulkFlushIntervalInMs(), 1000L);
         assertEquals(config.getBulkConcurrentRequests(), 0L);
 
         assertEquals(config.isCompressionEnabled(), false);

--- a/site2/docs/io-elasticsearch-sink.md
+++ b/site2/docs/io-elasticsearch-sink.md
@@ -60,7 +60,7 @@ The configuration of the Elasticsearch sink connector has the following properti
 | `bulkActions` | Integer | false | 1000 | The maximum number of actions per elasticsearch bulk request. Use -1 to disable it. |
 | `bulkSizeInMb` | Integer | false |5 | The maximum size in megabytes of elasticsearch bulk requests. Use -1 to disable it. |
 | `bulkConcurrentRequests` | Integer | false | 0 | The maximum number of in flight elasticsearch bulk requests. The default 0 allows the execution of a single request. A value of 1 means 1 concurrent request is allowed to be executed while accumulating new bulk requests. |
-| `bulkFlushIntervalInMs` | Integer | false | -1 | The maximum period of time to wait for flushing pending writes when bulk writes are enabled. Default is -1 meaning not set. |
+| `bulkFlushIntervalInMs` | Long | false | 1000 | The maximum period of time to wait for flushing pending writes when bulk writes are enabled. -1 or zero means the scheduled flushing is disabled. |
 | `compressionEnabled` | Boolean | false |false | Enable elasticsearch request compression. |
 | `connectTimeoutInMs` | Integer | false |5000 | The elasticsearch client connection timeout in milliseconds. |
 | `connectionRequestTimeoutInMs` | Integer | false |1000 | The time in milliseconds for getting a connection from the elasticsearch connection pool. |


### PR DESCRIPTION
### Motivation
In the ElasticSearch sink connector the `bulkFlushIntervalInMs` is currently disabled by default.

This option is used to control the maximum time that the messages are retained in memory before being flushed to the ES server (along with `bulkActions` and `bulkSizeInMb`) when bulk mode is enabled.

`bulkActions` and `bulkSizeInMb` are based on the traffic and if `bulkFlushIntervalInMs` is disabled, the messages can be blocked in the sink forever. This is a problem because then the function subscriptions are stuck (messages are not acked since correctly sent to elastic).
  
`bulkFlushIntervalInMs` is a time-based setting and it will avoid this kind of scenario by design. However this could increase the overhead with low-traffic. With high traffic there should not be visible changes.

### Modifications
Enable `bulkFlushIntervalInMs` by default with 1 second as value. 1 second is just a reasonable value, nothing special behind it

- [x] `doc` 