### PR TITLE
[fix][CI] Check Pulsar SQL / Trino license files

### DIFF
--- a/.github/workflows/pulsar-ci.yaml
+++ b/.github/workflows/pulsar-ci.yaml
@@ -623,6 +623,10 @@ jobs:
           -Pmain,docker -Dmaven.test.skip=true -Ddocker.squash=true \
           -Dspotbugs.skip=true -Dlicense.skip=true -Dcheckstyle.skip=true -Drat.skip=true
 
+      # Checks also Trino license files
+      - name: Check binary licenses
+        run: src/check-binary-license.sh ./distribution/server/target/apache-pulsar-*-bin.tar.gz
+
       - name: Clean up disk space
         run: |
           # release disk space since saving docker image consumes local disk space
@@ -646,10 +650,6 @@ jobs:
           echo "::group::Available diskspace after cleaning maven repository"
           time df -BM / /mnt
           echo "::endgroup::"          
-
-      # Checks also Trino license files
-      - name: Check binary licenses
-        run: src/check-binary-license.sh ./distribution/server/target/apache-pulsar-*-bin.tar.gz
 
       - name: save docker image apachepulsar/pulsar-test-latest-version:latest to Github artifact cache
         run: |

--- a/.github/workflows/pulsar-ci.yaml
+++ b/.github/workflows/pulsar-ci.yaml
@@ -647,6 +647,10 @@ jobs:
           time df -BM / /mnt
           echo "::endgroup::"          
 
+      # Checks also Trino license files
+      - name: Check binary licenses
+        run: src/check-binary-license.sh ./distribution/server/target/apache-pulsar-*-bin.tar.gz
+
       - name: save docker image apachepulsar/pulsar-test-latest-version:latest to Github artifact cache
         run: |
           $GITHUB_WORKSPACE/build/pulsar_ci_tool.sh docker_save_image_to_github_actions_artifacts apachepulsar/pulsar-test-latest-version:latest pulsar-test-latest-version-image


### PR DESCRIPTION
Fixes #16783

### Motivation

The new "Pulsar CI" workflow doesn't currently check Pulsar SQL (Trino) license files.
The existing "build-and-license-check" builds only the core-modules profile because of performance reasons.

### Modifications

Add license check to the step that builds the full apachepulsar/pulsar-test-latest-version:latest docker image.
