### PR TITLE
[fix][doc] Fix invalid parameter `topicName` in sink config

### DIFF
--- a/site2/docs/functions-runtime.md
+++ b/site2/docs/functions-runtime.md
@@ -231,7 +231,7 @@ You can create a secret in the namespace where your functions are deployed. For 
 tenant: "mytenant"
 namespace: "mynamespace"
 name: "myfunction"
-topicName: "persistent://mytenant/mynamespace/myfuncinput"
+inputs: [ "persistent://mytenant/mynamespace/myfuncinput" ]
 className: "com.company.pulsar.myfunction"
 
 secrets:

--- a/site2/docs/io-cdc-debezium.md
+++ b/site2/docs/io-cdc-debezium.md
@@ -75,7 +75,7 @@ You can use one of the following methods to create a configuration file.
     tenant: "public"
     namespace: "default"
     name: "debezium-mysql-source"
-    topicName: "debezium-mysql-topic"
+    inputs: [ "debezium-mysql-topic" ]
     archive: "connectors/pulsar-io-debezium-mysql-{{pulsar:version}}.nar"
     parallelism: 1
 
@@ -210,7 +210,7 @@ You can use one of the following methods to create a configuration file.
     tenant: "public"
     namespace: "default"
     name: "debezium-postgres-source"
-    topicName: "debezium-postgres-topic"
+    inputs: [ "debezium-postgres-topic" ]
     archive: "connectors/pulsar-io-debezium-postgres-{{pulsar:version}}.nar"
     parallelism: 1
 
@@ -344,7 +344,7 @@ You need to create a configuration file before using the Pulsar Debezium connect
     tenant: "public"
     namespace: "default"
     name: "debezium-mongodb-source"
-    topicName: "debezium-mongodb-topic"
+    inputs: [ "debezium-mongodb-topic" ]
     archive: "connectors/pulsar-io-debezium-mongodb-{{pulsar:version}}.nar"
     parallelism: 1
 

--- a/site2/docs/io-debezium-source.md
+++ b/site2/docs/io-debezium-source.md
@@ -94,7 +94,7 @@ You can use one of the following methods to create a configuration file.
     tenant: "public"
     namespace: "default"
     name: "debezium-mysql-source"
-    topicName: "debezium-mysql-topic"
+    inputs: [ "debezium-mysql-topic" ]
     archive: "connectors/pulsar-io-debezium-mysql-{{pulsar:version}}.nar"
     parallelism: 1
 
@@ -226,7 +226,7 @@ You can use one of the following methods to create a configuration file.
     tenant: "public"
     namespace: "default"
     name: "debezium-postgres-source"
-    topicName: "debezium-postgres-topic"
+    inputs: [ "debezium-postgres-topic" ]
     archive: "connectors/pulsar-io-debezium-postgres-{{pulsar:version}}.nar"
     parallelism: 1
 
@@ -370,7 +370,7 @@ You need to create a configuration file before using the Pulsar Debezium connect
     tenant: "public"
     namespace: "default"
     name: "debezium-mongodb-source"
-    topicName: "debezium-mongodb-topic"
+    inputs: [ "debezium-mongodb-topic" ]
     archive: "connectors/pulsar-io-debezium-mongodb-{{pulsar:version}}.nar"
     parallelism: 1
 
@@ -508,7 +508,7 @@ Using yaml as an example, you can create a debezium-oracle-source-config.yaml fi
 tenant: "public"
 namespace: "default"
 name: "debezium-oracle-source"
-topicName: "debezium-oracle-topic"
+inputs: [ "debezium-oracle-topic" ]
 parallelism: 1
 
 className: "org.apache.pulsar.io.debezium.oracle.DebeziumOracleSource"
@@ -576,7 +576,7 @@ Similarly to other connectors, you can use JSON or YAMl to configure the connect
 tenant: "public"
 namespace: "default"
 name: "debezium-mssql-source"
-topicName: "debezium-mssql-topic"
+inputs: [ "debezium-mssql-topic" ]
 parallelism: 1
 
 className: "org.apache.pulsar.io.debezium.mssql.DebeziumMsSqlSource"

--- a/site2/docs/io-jdbc-sink.md
+++ b/site2/docs/io-jdbc-sink.md
@@ -47,7 +47,7 @@ The configuration of all JDBC sink connectors has the following properties.
     tenant: "public"
     namespace: "default"
     name: "jdbc-clickhouse-sink"
-    topicName: "persistent://public/default/jdbc-clickhouse-topic"
+    inputs: [ "persistent://public/default/jdbc-clickhouse-topic" ]
     sinkType: "jdbc-clickhouse"    
     configs:
         userName: "clickhouse"
@@ -77,7 +77,7 @@ The configuration of all JDBC sink connectors has the following properties.
     tenant: "public"
     namespace: "default"
     name: "jdbc-mariadb-sink"
-    topicName: "persistent://public/default/jdbc-mariadb-topic"
+    inputs: [ "persistent://public/default/jdbc-mariadb-topic" ]
     sinkType: "jdbc-mariadb"    
     configs:
         userName: "mariadb"
@@ -105,7 +105,7 @@ The configuration of all JDBC sink connectors has the following properties.
     tenant: "public"
     namespace: "default"
     name: "jdbc-openmldb-sink"
-    topicName: "persistent://public/default/jdbc-openmldb-topic"
+    inputs: [ "persistent://public/default/jdbc-openmldb-topic" ]
     sinkType: "jdbc-openmldb"    
     configs:
         jdbcUrl: "jdbc:openmldb:///pulsar_openmldb_db?zk=localhost:6181&zkPath=/openmldb"
@@ -135,7 +135,7 @@ Before using the JDBC PostgreSQL sink connector, you need to create a configurat
     tenant: "public"
     namespace: "default"
     name: "jdbc-postgres-sink"
-    topicName: "persistent://public/default/jdbc-postgres-topic"
+    inputs: [ "persistent://public/default/jdbc-postgres-topic" ]
     sinkType: "jdbc-postgres"    
     configs:
         userName: "postgres"
@@ -165,7 +165,7 @@ For more information on **how to use this JDBC sink connector**, see [connect Pu
     tenant: "public"
     namespace: "default"
     name: "jdbc-sqlite-sink"
-    topicName: "persistent://public/default/jdbc-sqlite-topic"
+    inputs: [ "persistent://public/default/jdbc-sqlite-topic" ]
     sinkType: "jdbc-sqlite"    
     configs:
         jdbcUrl: "jdbc:sqlite:db.sqlite"


### PR DESCRIPTION
### Motivation

The parameter `topicName` in the sink connector config does not exists. But some documentation on the sink connector still uses it.

If we only set the topic of the sink connector to topicName in the config file. Then we will get the error like:
```
Must specify at least one topic of input via topicToSerdeClassName, topicsPattern, topicToSchemaType or inputSpecs
```

We need to replace it with `inputs`.

### Modifications

* Replace `topicName` with `inputs` in the doc of sink connectors.

### Documentation
  
- [x] `doc` 
(Your PR contains doc changes)
