### PR TITLE
[fix][jdk17] Enable Netty and BookKeeper IO optimizations on jdk17

### DIFF
--- a/bin/bookkeeper
+++ b/bin/bookkeeper
@@ -170,11 +170,12 @@ IS_JAVA_8=`java -version 2>&1 |grep version|grep '"1\.8'`
 # Start --add-opens options
 # '--add-opens' option is not supported in jdk8
 if [[ -z "$IS_JAVA_8" ]]; then
-  # BookKeeper: enable posix_fadvise usage
-  OPTS="$OPTS --add-opens java.base/java.io=ALL-UNNAMED"
+  # BookKeeper: enable posix_fadvise usage and DirectMemoryCRC32Digest (https://github.com/apache/bookkeeper/pull/3234)
+  OPTS="$OPTS --add-opens java.base/java.io=ALL-UNNAMED --add-opens java.base/java.util.zip=ALL-UNNAMED"
   # Netty: enable java.nio.DirectByteBuffer
   # https://github.com/netty/netty/blob/4.1/common/src/main/java/io/netty/util/internal/PlatformDependent0.java
-  OPTS="$OPTS --add-opens java.base/java.nio=ALL-UNNAMED"
+  # https://github.com/netty/netty/issues/12265
+  OPTS="$OPTS --add-opens java.base/java.nio=ALL-UNNAMED --add-opens java.base/jdk.internal.misc=ALL-UNNAMED"
 fi
 
 OPTS="-cp $BOOKIE_CLASSPATH $OPTS"

--- a/bin/function-localrunner
+++ b/bin/function-localrunner
@@ -94,7 +94,8 @@ OPTS="$OPTS -Dio.netty.tryReflectionSetAccessible=true"
 if [[ -z "$IS_JAVA_8" ]]; then
   # Netty: enable java.nio.DirectByteBuffer
   # https://github.com/netty/netty/blob/4.1/common/src/main/java/io/netty/util/internal/PlatformDependent0.java
-  OPTS="$OPTS --add-opens java.base/java.nio=ALL-UNNAMED"
+  # https://github.com/netty/netty/issues/12265
+  OPTS="$OPTS --add-opens java.base/java.nio=ALL-UNNAMED --add-opens java.base/jdk.internal.misc=ALL-UNNAMED"
 fi
 
 # Ensure we can read bigger content from ZK. (It might be

--- a/bin/pulsar
+++ b/bin/pulsar
@@ -277,11 +277,12 @@ IS_JAVA_8=`java -version 2>&1 |grep version|grep '"1\.8'`
 # Start --add-opens options
 # '--add-opens' option is not supported in jdk8
 if [[ -z "$IS_JAVA_8" ]]; then
-  # BookKeeper: enable posix_fadvise usage
-  OPTS="$OPTS --add-opens java.base/java.io=ALL-UNNAMED"
+  # BookKeeper: enable posix_fadvise usage and DirectMemoryCRC32Digest (https://github.com/apache/bookkeeper/pull/3234)
+  OPTS="$OPTS --add-opens java.base/java.io=ALL-UNNAMED --add-opens java.base/java.util.zip=ALL-UNNAMED"
   # Netty: enable java.nio.DirectByteBuffer
   # https://github.com/netty/netty/blob/4.1/common/src/main/java/io/netty/util/internal/PlatformDependent0.java
-  OPTS="$OPTS --add-opens java.base/java.nio=ALL-UNNAMED"
+  # https://github.com/netty/netty/issues/12265
+  OPTS="$OPTS --add-opens java.base/java.nio=ALL-UNNAMED --add-opens java.base/jdk.internal.misc=ALL-UNNAMED"
 fi
 
 OPTS="-cp $PULSAR_CLASSPATH $OPTS"


### PR DESCRIPTION
### Motivation
Follow up of https://github.com/apache/pulsar/pull/14999.

Based on https://github.com/netty/netty/issues/12265 and https://github.com/apache/bookkeeper/pull/3234 it is better to open other modules.

### Modifications

* Open `java.base/java.util.zip` module for BookKeeper
* Open `java.base/jdk.internal.misc` module for Netty
  

Note that the functions worker will spawn the process without these optimizations. It could be useful in case the connector uses Netty. Very unlikely that the function uses BookKeeper. I can follow up the Netty ones in another pull (with a lower priority).

- [x] `no-need-doc` 