### PR TITLE
[fix][license] Fix license branch 2.9

### DIFF
--- a/pulsar-sql/presto-distribution/LICENSE
+++ b/pulsar-sql/presto-distribution/LICENSE
@@ -257,16 +257,6 @@ The Apache Software License, Version 2.0
     - netty-transport-native-epoll-4.1.76.Final-linux-x86_64.jar
     - netty-transport-native-unix-common-4.1.76.Final.jar
     - netty-transport-native-unix-common-4.1.76.Final-linux-x86_64.jar
-    - netty-codec-http2-4.1.76.Final.jar
- * GRPC
-    - grpc-api-1.45.1.jar
-    - grpc-context-1.45.1.jar
-    - grpc-core-1.45.1.jar
-    - grpc-grpclb-1.45.1.jar
-    - grpc-netty-1.45.1.jar
-    - grpc-protobuf-1.45.1.jar
-    - grpc-protobuf-lite-1.45.1.jar
-    - grpc-stub-1.45.1.jar
  * Joda Time
     - joda-time-2.10.5.jar
   * Jetty
@@ -476,7 +466,6 @@ The Apache Software License, Version 2.0
 Protocol Buffers License
  * Protocol Buffers
    - protobuf-java-3.19.2.jar
-   - protobuf-java-util-3.19.2.jar
 
 BSD 3-clause "New" or "Revised" License
   *  RE2J TD -- re2j-td-1.4.jar


### PR DESCRIPTION
### Motivation

The cherry-pick https://github.com/apache/pulsar/commit/4fb5180f010cc2dab0698977c51755988e7d6a02 breaks LICENSE files.

```
netty-codec-http2-4.1.76.Final.jar mentioned in lib/presto/LICENSE, but not bundled
grpc-api-1.45.1.jar mentioned in lib/presto/LICENSE, but not bundled
grpc-context-1.45.1.jar mentioned in lib/presto/LICENSE, but not bundled
grpc-core-1.45.1.jar mentioned in lib/presto/LICENSE, but not bundled
grpc-grpclb-1.45.1.jar mentioned in lib/presto/LICENSE, but not bundled
grpc-netty-1.45.1.jar mentioned in lib/presto/LICENSE, but not bundled
grpc-protobuf-1.45.1.jar mentioned in lib/presto/LICENSE, but not bundled
grpc-protobuf-lite-1.45.1.jar mentioned in lib/presto/LICENSE, but not bundled
grpc-stub-1.45.1.jar mentioned in lib/presto/LICENSE, but not bundled
protobuf-java-util-3.1[9](https://github.com/apache/pulsar/runs/6112846265?check_suite_focus=true#step:10:9).2.jar mentioned in lib/presto/LICENSE, but not bundled
```

### Modifications

Fix LICENSE files.

### Documentation

Check the box below or label this PR directly.

Need to update docs? 

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)
  
- [x] `no-need-doc` 
(Please explain why)
  
- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-added`
(Docs have been already added)