### PR TITLE
[fix][license] Fix LICENSE files for branch-2.8

### DIFF
--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -476,6 +476,7 @@ The Apache Software License, Version 2.0
     - io.grpc-grpc-services-1.45.1.jar
     - io.grpc-grpc-xds-1.45.1.jar
     - io.grpc-grpc-rls-1.45.1.jar
+    - io.grpc-grpc-okhttp-1.45.1.jar
   * Perfmark
     - io.perfmark-perfmark-api-0.19.0.jar
   * OpenCensus

--- a/pulsar-sql/presto-distribution/LICENSE
+++ b/pulsar-sql/presto-distribution/LICENSE
@@ -238,8 +238,6 @@ The Apache Software License, Version 2.0
     - netty-codec-dns-4.1.76.Final.jar
     - netty-codec-http-4.1.76.Final.jar
     - netty-codec-haproxy-4.1.76.Final.jar
-    - netty-codec-socks-4.1.76.Final.jar
-    - netty-handler-proxy-4.1.76.Final.jar
     - netty-common-4.1.76.Final.jar
     - netty-handler-4.1.76.Final.jar
     - netty-reactive-streams-2.0.4.jar
@@ -257,16 +255,6 @@ The Apache Software License, Version 2.0
     - netty-transport-native-epoll-4.1.76.Final-linux-x86_64.jar
     - netty-transport-native-unix-common-4.1.76.Final.jar
     - netty-transport-native-unix-common-4.1.76.Final-linux-x86_64.jar
-    - netty-codec-http2-4.1.76.Final.jar
- * GRPC
-    - grpc-api-1.45.1.jar
-    - grpc-context-1.45.1.jar
-    - grpc-core-1.45.1.jar
-    - grpc-grpclb-1.45.1.jar
-    - grpc-netty-1.45.1.jar
-    - grpc-protobuf-1.45.1.jar
-    - grpc-protobuf-lite-1.45.1.jar
-    - grpc-stub-1.45.1.jar
  * Joda Time
     - joda-time-2.10.5.jar
   * Jetty
@@ -477,7 +465,6 @@ The Apache Software License, Version 2.0
 Protocol Buffers License
  * Protocol Buffers
    - protobuf-java-3.19.2.jar
-   - protobuf-java-util-3.19.2.jar
 
 BSD 3-clause "New" or "Revised" License
   *  RE2J TD -- re2j-td-1.4.jar


### PR DESCRIPTION
### Motivation

The cherry-pick https://github.com/apache/pulsar/commit/a547163f32a1db59fc1a316f3b01b65056668764 breaks LICENSE files.

```
io.grpc-grpc-okhttp-1.45.1.jar unaccounted for in LICENSE
src/check-binary-license: line 69: echo: write error: Broken pipe
netty-codec-socks-4.1.76.Final.jar mentioned in lib/presto/LICENSE, but not bundled
netty-handler-proxy-4.1.76.Final.jar mentioned in lib/presto/LICENSE, but not bundled
netty-codec-http2-4.1.76.Final.jar mentioned in lib/presto/LICENSE, but not bundled
grpc-api-1.45.1.jar mentioned in lib/presto/LICENSE, but not bundled
grpc-context-1.45.1.jar mentioned in lib/presto/LICENSE, but not bundled
grpc-core-1.45.1.jar mentioned in lib/presto/LICENSE, but not bundled
grpc-grpclb-1.45.1.jar mentioned in lib/presto/LICENSE, but not bundled
grpc-netty-1.45.1.jar mentioned in lib/presto/LICENSE, but not bundled
grpc-protobuf-1.45.1.jar mentioned in lib/presto/LICENSE, but not bundled
grpc-protobuf-lite-1.45.1.jar mentioned in lib/presto/LICENSE, but not bundled
grpc-stub-1.45.1.jar mentioned in lib/presto/LICENSE, but not bundled
protobuf-java-util-3.19.2.jar mentioned in lib/presto/LICENSE, but not bundled
```

### Modifications

Fix LICENSE files.

### Documentation

Check the box below or label this PR directly.

Need to update docs? 

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)
  
- [x] `no-need-doc` 
(Please explain why)
  
- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-added`
(Docs have been already added)