### PR TITLE
Call setLoadBalancerOverrideBrokerNicSpeedGbps during test setup

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/MockedPulsarServiceBaseTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/MockedPulsarServiceBaseTest.java
@@ -177,6 +177,7 @@ public abstract class MockedPulsarServiceBaseTest extends TestRetrySupport {
         this.conf.setWebServicePortTls(Optional.of(0));
         this.conf.setNumExecutorThreadPoolSize(5);
         this.conf.setExposeBundlesMetricsInPrometheus(true);
+        this.conf.setLoadBalancerOverrideBrokerNicSpeedGbps(Optional.of(5.0));
     }
 
     protected final void init() throws Exception {


### PR DESCRIPTION
### Motivation

#14648 is causing unit tests to fail if the NIC speed information is not found; found this out while trying to set up an AWS based dev environment.

### Modifications

Manually set the NIC speed information.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change is already covered by existing tests, such as TableViewTest.

### Documentation

- [x] `no-need-doc` 
