### PR TITLE
[improve][broker] Add `individualDeletedMessagesSize` to log when cusor close.

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
@@ -2333,6 +2333,7 @@ public class ManagedCursorImpl implements ManagedCursor {
      */
     void persistPositionWhenClosing(PositionImpl position, Map<String, Long> properties,
             final AsyncCallbacks.CloseCallback callback, final Object ctx) {
+
         if (shouldPersistUnackRangesToLedger()) {
             persistPositionToLedger(cursorLedger, new MarkDeleteEntry(position, properties, null, null),
                     new VoidCallback() {

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
@@ -2339,8 +2339,9 @@ public class ManagedCursorImpl implements ManagedCursor {
                     new VoidCallback() {
                         @Override
                         public void operationComplete() {
-                            log.info("[{}][{}] Updated md-position={} into cursor-ledger {}", ledger.getName(), name,
-                                    markDeletePosition, cursorLedger.getId());
+                            log.info("[{}][{}] Updated md-position={} into cursor-ledger {}, "
+                                            + "individualDeletedMessagesSize={}", ledger.getName(), name,
+                                    markDeletePosition, cursorLedger.getId(), individualDeletedMessages.size());
                             asyncCloseCursorLedger(callback, ctx);
                         }
 
@@ -2355,7 +2356,8 @@ public class ManagedCursorImpl implements ManagedCursor {
             persistPositionMetaStore(-1, position, properties, new MetaStoreCallback<Void>() {
                 @Override
                 public void operationComplete(Void result, Stat stat) {
-                    log.info("[{}][{}] Closed cursor at md-position={}", ledger.getName(), name, markDeletePosition);
+                    log.info("[{}][{}] Closed cursor at md-position={} individualDeletedMessagesSize={}",
+                            ledger.getName(), name, markDeletePosition, individualDeletedMessages.size());
                     // At this point the position had already been safely stored in the cursor z-node
                     callback.closeComplete(ctx);
                     asyncDeleteLedger(cursorLedger);

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
@@ -2646,8 +2646,7 @@ public class ManagedCursorImpl implements ManagedCursor {
                 return rangeList.size() <= config.getMaxUnackedRangesToPersist();
             });
             this.individualDeletedMessagesSerializedSize = acksSerializedSize.get();
-            if (rangeList.size() == config.getMaxUnackedRangesToPersist()
-                    && individualDeletedMessages.size() > config.getMaxUnackedRangesToPersist()) {
+            if (rangeList.size() < individualDeletedMessages.size() ) {
                 log.warn("The current individualDeletedMessages size "
                         + "has exceeded the value of maxUnackedRangesToPersist during the persistence attempt."
                         + " individualDeletedMessages={}, maxUnackedRangesToPersist={}",

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
@@ -1906,6 +1906,11 @@ public class ManagedCursorImpl implements ManagedCursor {
                 decrementPendingMarkDeleteCount();
 
                 mdEntry.triggerComplete();
+                State cursorState = STATE_UPDATER.get(ManagedCursorImpl.this);
+                if (cursorState == State.Closed || cursorState == State.Closing) {
+                    log.warn("[{}] Message {} may be re-delivery because the current cursor is closing.",
+                            ledger.getName(), mdEntry.newPosition);
+                }
             }
 
             @Override

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
@@ -2338,15 +2338,17 @@ public class ManagedCursorImpl implements ManagedCursor {
      */
     void persistPositionWhenClosing(PositionImpl position, Map<String, Long> properties,
             final AsyncCallbacks.CloseCallback callback, final Object ctx) {
+        log.info("Persistence before cursor close is in progress. position={} "
+                + "md-position={} individualDeletedMessagesSize={}", position, markDeletePosition,
+                individualDeletedMessages.size());
 
         if (shouldPersistUnackRangesToLedger()) {
             persistPositionToLedger(cursorLedger, new MarkDeleteEntry(position, properties, null, null),
                     new VoidCallback() {
                         @Override
                         public void operationComplete() {
-                            log.info("[{}][{}] Updated md-position={} into cursor-ledger {}, "
-                                            + "individualDeletedMessagesSize={}", ledger.getName(), name,
-                                    markDeletePosition, cursorLedger.getId(), individualDeletedMessages.size());
+                            log.info("[{}][{}] Updated md-position={} into cursor-ledger {}", ledger.getName(), name,
+                                    markDeletePosition, cursorLedger.getId());
                             asyncCloseCursorLedger(callback, ctx);
                         }
 
@@ -2361,8 +2363,7 @@ public class ManagedCursorImpl implements ManagedCursor {
             persistPositionMetaStore(-1, position, properties, new MetaStoreCallback<Void>() {
                 @Override
                 public void operationComplete(Void result, Stat stat) {
-                    log.info("[{}][{}] Closed cursor at md-position={} individualDeletedMessagesSize={}",
-                            ledger.getName(), name, markDeletePosition, individualDeletedMessages.size());
+                    log.info("[{}][{}] Closed cursor at md-position={}", ledger.getName(), name, markDeletePosition);
                     // At this point the position had already been safely stored in the cursor z-node
                     callback.closeComplete(ctx);
                     asyncDeleteLedger(cursorLedger);

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
@@ -1906,11 +1906,6 @@ public class ManagedCursorImpl implements ManagedCursor {
                 decrementPendingMarkDeleteCount();
 
                 mdEntry.triggerComplete();
-                State cursorState = STATE_UPDATER.get(ManagedCursorImpl.this);
-                if (cursorState == State.Closed || cursorState == State.Closing) {
-                    log.warn("[{}] Message {} may be re-delivery because the current cursor is closing.",
-                            ledger.getName(), mdEntry.newPosition);
-                }
             }
 
             @Override


### PR DESCRIPTION
### Motivation

When the topic is unloaded, may cause the redelivery of messages. the cases as below:

- When `individualDeletedMessages` exceeds `maxUnackedRangesToPersist`.

We can add `individualDeletedMessagesSize` to the log to help pinpoint the problem.

### Modifications

- Add `individualDeletedMessagesSize` to log.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Documentation

- [x] `no-need-doc` 
(Please explain why)
  