### PR TITLE
[fix][tools] Only apply maxPendingMessagesAcrossPartitions if it presents

### DIFF
--- a/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceProducer.java
+++ b/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceProducer.java
@@ -597,10 +597,12 @@ public class PerformanceProducer {
                     .sendTimeout(arguments.sendTimeout, TimeUnit.SECONDS) //
                     .compressionType(arguments.compression) //
                     .maxPendingMessages(arguments.maxOutstanding) //
-                    .maxPendingMessagesAcrossPartitions(arguments.maxPendingMessagesAcrossPartitions)
                     .accessMode(arguments.producerAccessMode)
                     // enable round robin message routing if it is a partitioned topic
                     .messageRoutingMode(MessageRoutingMode.RoundRobinPartition);
+            if (arguments.maxPendingMessagesAcrossPartitions > 0) {
+                producerBuilder.maxPendingMessagesAcrossPartitions(arguments.maxPendingMessagesAcrossPartitions);
+            }
 
             AtomicReference<Transaction> transactionAtomicReference;
             if (arguments.isEnableTransaction) {

--- a/pulsar-testclient/src/test/java/org/apache/pulsar/testclient/PerformanceProducerTest.java
+++ b/pulsar-testclient/src/test/java/org/apache/pulsar/testclient/PerformanceProducerTest.java
@@ -190,4 +190,25 @@ public class PerformanceProducerTest extends MockedPulsarServiceBaseTest {
         Assert.assertTrue(msgFormatter instanceof DefaultMessageFormatter);
     }
 
+    @Test
+    public void testMaxOutstanding() throws Exception {
+        String argString = "%s -r 10 -u %s -au %s -m 5 -o 10000";
+        String topic = testTopic + UUID.randomUUID().toString();
+        String args = String.format(argString, topic, pulsar.getBrokerServiceUrl(), pulsar.getWebServiceAddress());
+        Consumer<byte[]> consumer = pulsarClient.newConsumer().topic(topic).subscriptionName("sub")
+                .subscriptionType(SubscriptionType.Key_Shared).subscribe();
+        new Thread(() -> {
+            try {
+                PerformanceProducer.main(args.split(" "));
+            } catch (Exception e) {
+                log.error("Failed to start perf producer");
+            }
+        }).start();
+        Awaitility.await()
+                .untilAsserted(() -> {
+                    Message<byte[]> message = consumer.receive(3, TimeUnit.SECONDS);
+                    assertNotNull(message);
+                });
+        consumer.close();
+    }
 }


### PR DESCRIPTION
### Motivation

After #13344, we have changed the default value of maxPendingMessagesAcrossPartitions to `0`,
for the performance producer, it will always apply the default value of maxPendingMessagesAcrossPartitions
while creating producers, so it will always use `0` for maxPendingMessagesAcrossPartitions.

But we have a check here https://github.com/apache/pulsar/blob/0a91196dcc4d31ae647867ed319b8c1af0cb93c6/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ProducerConfigurationData.java#L138-L142

This will lead the performance producer not able to create if users only set `-o` option

```
06:32:49.628 [pulsar-perf-producer-exec-1-1] ERROR org.apache.pulsar.testclient.PerformanceProducer - Got error
    java.lang.IllegalArgumentException: maxPendingMessagesAcrossPartitions needs to be >= maxPendingMessages
    	at org.apache.pulsar.shade.com.google.common.base.Preconditions.checkArgument(Preconditions.java:145) ~[pulsar-client-admin-2.10.0.2.jar:2.10.0.2]
    	at org.apache.pulsar.client.impl.conf.ProducerConfigurationData.setMaxPendingMessagesAcrossPartitions(ProducerConfigurationData.java:138) ~[pulsar-client-admin-2.10.0.2.jar:2.10.0.2]
    	at org.apache.pulsar.client.impl.ProducerBuilderImpl.maxPendingMessagesAcrossPartitions(ProducerBuilderImpl.java:148) ~[pulsar-client-admin-2.10.0.2.jar:2.10.0.2]
    	at org.apache.pulsar.testclient.PerformanceProducer.runProducer(PerformanceProducer.java:600) ~[pulsar-testclient-2.10.0.2.jar:2.10.0.2]
    	at org.apache.pulsar.testclient.PerformanceProducer.lambda$main$1(PerformanceProducer.java:464) ~[pulsar-testclient-2.10.0.2.jar:2.10.0.2]
    	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511) [?:1.8.0_332]
    	at java.util.concurrent.FutureTask.run(FutureTask.java:266) [?:1.8.0_332]
    	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149) [?:1.8.0_332]
    	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624) [?:1.8.0_332]
    	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30) [netty-common-4.1.74.Final.jar:4.1.74.Final]
    	at java.lang.Thread.run(Thread.java:750) [?:1.8.0_332]
```

### Modification

Change the performance producer to only call `.maxPendingMessagesAcrossPartitions()` if it presents.

### Verification

Added a new test to only use `-o` to start the performance producer, use a consumer to consume data from
the topic to make sure the performance producer has been created successfully.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

Check the box below or label this PR directly.

Need to update docs? 

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)
  
- [x] `no-need-doc` 
(Please explain why)
  
- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-added`
(Docs have been already added)