### PR TITLE
[pulsar-io] Specify the database when getting the table definition

### DIFF
--- a/pulsar-io/jdbc/core/src/main/java/org/apache/pulsar/io/jdbc/JdbcUtils.java
+++ b/pulsar-io/jdbc/core/src/main/java/org/apache/pulsar/io/jdbc/JdbcUtils.java
@@ -94,7 +94,7 @@ public class JdbcUtils {
      */
     public static TableId getTableId(Connection connection, String tableName) throws Exception {
         DatabaseMetaData metadata = connection.getMetaData();
-        try (ResultSet rs = metadata.getTables(null, null, tableName, new String[]{"TABLE"})) {
+        try (ResultSet rs = metadata.getTables(connection.getCatalog(), null, tableName, new String[]{"TABLE"})) {
             if (rs.next()) {
                 String catalogName = rs.getString(1);
                 String schemaName = rs.getString(2);


### PR DESCRIPTION

Fixes #15285 

### Motivation

Fix the problem of getting `db1.tebble1` but getting `db2.tebble1`.

### Modifications

Specify the current database when getting the table schema

### Verifying this change

- [ ] Make sure that the change passes the CI checks.


### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API: (yes / **no**)
  - The schema: (yes / **no** / don't know)
  - The default values of configurations: (yes / **no**)
  - The wire protocol: (yes / **no**)
  - The rest endpoints: (yes / **no**)
  - The admin cli options: (yes / **no**)
  - Anything that affects deployment: (yes / no / **don't know**)

### Documentation

Check the box below or label this PR directly.

Need to update docs? 

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)
  
- [x] `no-need-doc` 
(Please explain why)
  
- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-added`
(Docs have been already added)