### PR TITLE
[fix][broker] BookieRackAffinityMapping compatible with use bk metadataServiceUri.

### DIFF
--- a/pulsar-broker-common/pom.xml
+++ b/pulsar-broker-common/pom.xml
@@ -75,6 +75,13 @@
       <artifactId>awaitility</artifactId>
       <scope>test</scope>
     </dependency>
+
+    <dependency>
+      <groupId>org.apache.pulsar</groupId>
+      <artifactId>testmocks</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/bookie/rackawareness/BookieRackAffinityMapping.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/bookie/rackawareness/BookieRackAffinityMapping.java
@@ -19,6 +19,7 @@
 package org.apache.pulsar.bookie.rackawareness;
 
 import static org.apache.pulsar.metadata.bookkeeper.AbstractMetadataDriver.METADATA_STORE_SCHEME;
+import com.google.common.base.Joiner;
 import java.net.InetAddress;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -79,7 +80,7 @@ public class BookieRackAffinityMapping extends AbstractDNSToSwitchMapping
             store = (MetadataStore) storeProperty;
         } else {
             String url;
-            String metadataServiceUri = (String) conf.getProperty("metadataServiceUri");
+            String metadataServiceUri = conf.getString("metadataServiceUri");
             if (StringUtils.isNotBlank(metadataServiceUri)) {
                 try {
                     url = metadataServiceUri.replaceFirst(METADATA_STORE_SCHEME + ":", "")
@@ -92,7 +93,7 @@ public class BookieRackAffinityMapping extends AbstractDNSToSwitchMapping
                     throw new MetadataException(Code.METADATA_SERVICE_ERROR, e);
                 }
             } else {
-                String zkServers = (String) conf.getProperty("zkServers");
+                String zkServers = Joiner.on(",").join(conf.getStringArray("zkServers"));
                 if (StringUtils.isBlank(zkServers)) {
                     String errorMsg = String.format("Neither %s configuration set in the BK client configuration nor "
                             + "metadataServiceUri/zkServers set in bk server configuration", METADATA_STORE_INSTANCE);
@@ -101,7 +102,7 @@ public class BookieRackAffinityMapping extends AbstractDNSToSwitchMapping
                 url = zkServers;
             }
             try {
-                int zkTimeout = Integer.parseInt((String) conf.getProperty("zkTimeout"));
+                int zkTimeout = conf.getInt("zkTimeout");
                 store = MetadataStoreExtended.create(url,
                         MetadataStoreConfig.builder()
                                 .sessionTimeoutMillis(zkTimeout)

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/bookie/rackawareness/BookieRackAffinityMapping.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/bookie/rackawareness/BookieRackAffinityMapping.java
@@ -84,6 +84,10 @@ public class BookieRackAffinityMapping extends AbstractDNSToSwitchMapping
                 try {
                     url = metadataServiceUri.replaceFirst(METADATA_STORE_SCHEME + ":", "")
                             .replace(";", ",");
+                    String idx = "://";
+                    if (url.indexOf(idx) != -1) {
+                        url = url.substring(url.indexOf(idx) + idx.length());
+                    }
                 } catch (Exception e) {
                     throw new MetadataException(Code.METADATA_SERVICE_ERROR, e);
                 }

--- a/pulsar-broker-common/src/test/java/org/apache/pulsar/bookie/rackawareness/BookieRackAffinityMappingTest.java
+++ b/pulsar-broker-common/src/test/java/org/apache/pulsar/bookie/rackawareness/BookieRackAffinityMappingTest.java
@@ -19,6 +19,7 @@
 package org.apache.pulsar.bookie.rackawareness;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNull;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.Lists;
@@ -33,6 +34,7 @@ import org.apache.pulsar.common.util.ObjectMapperFactory;
 import org.apache.pulsar.metadata.api.MetadataStore;
 import org.apache.pulsar.metadata.api.MetadataStoreConfig;
 import org.apache.pulsar.metadata.api.MetadataStoreFactory;
+import org.apache.zookeeper.TestZKServer;
 import org.awaitility.Awaitility;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
@@ -58,6 +60,23 @@ public class BookieRackAffinityMappingTest {
     @AfterMethod(alwaysRun = true)
     void teardown() throws Exception {
         store.close();
+    }
+
+
+    @Test
+    public void testCreateMetadataStoreWithBkMetadataServiceUri() throws Exception {
+        TestZKServer zkServer = new TestZKServer();
+        String zkConnection = zkServer.getConnectionString();
+        ClientConfiguration conf = new ClientConfiguration();
+        conf.setZkTimeout(3000);
+
+        conf.setMetadataServiceUri("zk+hierarchical://" + zkConnection + "/ledgers");
+        assertNotNull(BookieRackAffinityMapping.createMetadataStore(conf));
+
+        conf.setMetadataServiceUri("zk+null://" + zkConnection + "/ledgers");
+        assertNotNull(BookieRackAffinityMapping.createMetadataStore(conf));
+
+        zkServer.close();
     }
 
     @Test

--- a/pulsar-broker-common/src/test/java/org/apache/pulsar/bookie/rackawareness/BookieRackAffinityMappingTest.java
+++ b/pulsar-broker-common/src/test/java/org/apache/pulsar/bookie/rackawareness/BookieRackAffinityMappingTest.java
@@ -62,7 +62,6 @@ public class BookieRackAffinityMappingTest {
         store.close();
     }
 
-
     @Test
     public void testCreateMetadataStoreWithBkMetadataServiceUri() throws Exception {
         TestZKServer zkServer = new TestZKServer();
@@ -77,6 +76,25 @@ public class BookieRackAffinityMappingTest {
         assertNotNull(BookieRackAffinityMapping.createMetadataStore(conf));
 
         zkServer.close();
+    }
+
+    @Test
+    public void testCreateMetadataStoreWithBkZkServers() throws Exception {
+        TestZKServer zks1 = new TestZKServer();
+        String zk1 = zks1.getConnectionString();
+
+        TestZKServer zks2 = new TestZKServer();
+        String zk2 = zks2.getConnectionString();
+
+        ClientConfiguration conf = new ClientConfiguration();
+        conf.setZkTimeout(3000);
+        conf.setMetadataServiceUri(null);
+        conf.setZkServers(zk1 + "," + zk2);
+
+        assertNotNull(BookieRackAffinityMapping.createMetadataStore(conf));
+
+        zks1.close();
+        zks2.close();
     }
 
     @Test

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/MultiBrokerLeaderElectionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/MultiBrokerLeaderElectionTest.java
@@ -38,10 +38,10 @@ import org.apache.pulsar.broker.MultiBrokerBaseTest;
 import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.admin.PulsarAdminException;
-import org.apache.pulsar.metadata.TestZKServer;
 import org.apache.pulsar.metadata.api.MetadataStoreConfig;
 import org.apache.pulsar.metadata.api.MetadataStoreException;
 import org.apache.pulsar.metadata.api.extended.MetadataStoreExtended;
+import org.apache.zookeeper.TestZKServer;
 import org.awaitility.Awaitility;
 import org.testng.annotations.Test;
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/zookeeper/MultiBrokerMetadataConsistencyTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/zookeeper/MultiBrokerMetadataConsistencyTest.java
@@ -24,10 +24,10 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.broker.MultiBrokerBaseTest;
 import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.admin.PulsarAdminException;
-import org.apache.pulsar.metadata.TestZKServer;
 import org.apache.pulsar.metadata.api.MetadataStoreConfig;
 import org.apache.pulsar.metadata.api.MetadataStoreException;
 import org.apache.pulsar.metadata.api.extended.MetadataStoreExtended;
+import org.apache.zookeeper.TestZKServer;
 import org.testng.annotations.Test;
 
 @Slf4j

--- a/pulsar-metadata/pom.xml
+++ b/pulsar-metadata/pom.xml
@@ -72,6 +72,13 @@
     </dependency>
 
     <dependency>
+      <groupId>org.apache.pulsar</groupId>
+      <artifactId>testmocks</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>org.awaitility</groupId>
       <artifactId>awaitility</artifactId>
       <scope>test</scope>

--- a/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/BaseMetadataStoreTest.java
+++ b/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/BaseMetadataStoreTest.java
@@ -30,6 +30,7 @@ import java.util.function.Predicate;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import org.apache.pulsar.tests.TestRetrySupport;
+import org.apache.zookeeper.TestZKServer;
 import org.assertj.core.util.Files;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;

--- a/testmocks/src/main/java/org/apache/zookeeper/TestZKServer.java
+++ b/testmocks/src/main/java/org/apache/zookeeper/TestZKServer.java
@@ -16,10 +16,9 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.pulsar.metadata;
+package org.apache.zookeeper;
 
 import static org.testng.Assert.assertTrue;
-
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
@@ -27,13 +26,10 @@ import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.net.InetSocketAddress;
 import java.net.Socket;
-
 import java.nio.charset.StandardCharsets;
-
 import lombok.extern.slf4j.Slf4j;
-
 import org.apache.commons.io.FileUtils;
-import org.apache.zookeeper.KeeperException;
+import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.zookeeper.server.ContainerManager;
 import org.apache.zookeeper.server.NIOServerCnxnFactory;
 import org.apache.zookeeper.server.Request;
@@ -41,7 +37,6 @@ import org.apache.zookeeper.server.RequestProcessor;
 import org.apache.zookeeper.server.ServerCnxnFactory;
 import org.apache.zookeeper.server.SessionTracker;
 import org.apache.zookeeper.server.ZooKeeperServer;
-import org.assertj.core.util.Files;
 
 @Slf4j
 public class TestZKServer implements AutoCloseable {
@@ -54,7 +49,7 @@ public class TestZKServer implements AutoCloseable {
     private int zkPort = 0;
 
     public TestZKServer() throws Exception {
-        this.zkDataDir = Files.newTemporaryFolder();
+        this.zkDataDir = new File(FileUtils.getTempDirectory(), RandomStringUtils.randomAlphabetic(5));
         this.zkDataDir.deleteOnExit();
         // Allow all commands on ZK control port
         System.setProperty("zookeeper.4lw.commands.whitelist", "*");


### PR DESCRIPTION
### Motivation

when we use the `metadataServiceUri` instead of the `zkServers` & `zkLedgersRootPath` in the bookkeeper.conf and enable the rack-aware, the BookieRackAffinityMapping doesn't work well, config as follow :

```xml
metadataServiceUri=zk+hierarchical://10.206.128.154:2181;10.206.128.155:2181;10.206.128.156:2181;10.206.128.157:2181;10.206.128.158:2181/ledgers
# zkServers=10.206.128.154:2181,10.206.128.155:2181,10.206.128.156:2181,10.206.128.157:2181,10.206.128.158:2181
# zkLedgersRootPath=/ledgers

ensemblePlacementPolicy=org.apache.pulsar.bookie.rackawareness.IsolatedBookieEnsemblePlacementPolicy
reppDnsResolverClass=org.apache.pulsar.bookie.rackawareness.BookieRackAffinityMapping

```

https://github.com/apache/pulsar/blob/0a38fce64f9caba68eb9d7e6828f9833815f5adc/pulsar-broker-common/src/main/java/org/apache/pulsar/bookie/rackawareness/BookieRackAffinityMapping.java#L85-L86

**the root cause was the we doesn't process the prefix `zk+hierarchical://` or `zk+null` logic in the `BookieRackAffinityMapping`.**

```
2022-04-24 11:22:25,023 INFO  [Main#117] [main] Using configuration file conf/bookkeeper1.conf
2022-04-24 11:22:25,040 INFO  [Main#265] [main] Hello, I'm your bookie, bookieId is <not-set>, listening on port 3181. Metadata service uri is zk+null://10.206.128.154:2181;10.206.128.155:2181;10.206.128.156:2181;10.206.128.157:2181;10.206.128.158:2181/ledgers. Journals are in [/tmp/bk-journal-1]. Ledgers are stored in [data/bookkeeper/ledgers].
2022-04-24 11:22:25,059 INFO  [Main#301] [main] Load lifecycle component : org.apache.bookkeeper.server.service.StatsProviderService
2022-04-24 11:22:25,331 INFO  [BookieServer#111] [main] {
  "readBufferSizeBytes" : "4096",
  "statsProviderClass" : "org.apache.bookkeeper.stats.prometheus.PrometheusMetricsProvider",
  "majorCompactionThreshold" : "0.5",
  "numJournalCallbackThreads" : "8",
  "httpServerPort" : "8000",
  "lostBookieRecoveryDelay" : "0",
  "journalAlignmentSize" : "4096",
  "compactionRateByBytes" : "1000000",
  "httpServerClass" : "org.apache.bookkeeper.http.vertx.VertxHttpServer",
  "minNumRacksPerWriteQuorum" : "2",
  "dbStorage_rocksDB_numFilesInLevel0" : "4",
  "minUsableSizeForIndexFileCreation" : "1073741824",
  "gcOverreplicatedLedgerWaitTime" : "86400000",
  "journalMaxGroupWaitMSec" : "1",
  "dbStorage_rocksDB_numLevels" : "-1",
  "dbStorage_rocksDB_bloomFilterBitsPerKey" : "10",
  "nettyMaxFrameSizeBytes" : "5253120",
  "readWorkerThreadsThrottlingEnabled" : "true",
  "ledgerStorageClass" : "org.apache.bookkeeper.bookie.storage.ldb.DbLedgerStorage",
  "auditorPeriodicBookieCheckInterval" : "86400",
  "gcWaitTime" : "900000",
  "compactionRate" : "1000",
  "fileInfoFormatVersionToWrite" : "0",
  "entryLogFilePreallocationEnabled" : "true",
  "//metadataServiceUri" : "zk+hierarchical://10.206.128.154:2181;10.206.128.155:2181;10.206.128.156:2181;10.206.128.157:2181;10.206.128.158:2181/ledgers",
  "journalSyncData" : "true",
  "compactionRateByEntries" : "1000",
  "dbStorage_rocksDB_maxSizeInLevel1MB" : "256",
  "diskCheckInterval" : "10000",
  "auditorPeriodicCheckInterval" : "604800",
  "dbStorage_rocksDB_writeBufferSizeMB" : "64",
  "autoRecoveryDaemonEnabled" : "true",
  "maxPendingAddRequestsPerThread" : "10000",
  "flushEntrylogBytes" : "268435456",
  "majorCompactionInterval" : "86400",
  "httpServerEnabled" : "false",
  "flushInterval" : "60000",
  "enforceMinNumRacksPerWriteQuorum" : "false",
  "journalFlushWhenQueueEmpty" : "false",
  "minorCompactionInterval" : "3600",
  "dbStorage_rocksDB_blockCacheSize" : "",
  "isThrottleByBytes" : "false",
  "ensemblePlacementPolicy" : "org.apache.pulsar.bookie.rackawareness.IsolatedBookieEnsemblePlacementPolicy",
  "numAddWorkerThreads" : "0",
  "dbStorage_rocksDB_sstSizeInMB" : "64",
  "journalWriteBufferSizeKB" : "64",
  "diskUsageThreshold" : "0.95",
  "openFileLimit" : "0",
  "prometheusStatsHttpPort" : "8000",
  "enableBusyWait" : "false",
  "journalMaxSizeMB" : "2048",
  "journalAdaptiveGroupWrites" : "true",
  "openLedgerRereplicationGracePeriod" : "30000",
  "ledgerDirectories" : "data/bookkeeper/ledgers",
  "zkTimeout" : "30000",
  "dbStorage_rocksDB_blockSize" : "65536",
  "journalMaxBackups" : "5",
  "metadataServiceUri" : "zk+null://10.206.128.154:2181;10.206.128.155:2181;10.206.128.156:2181;10.206.128.157:2181;10.206.128.158:2181/ledgers",
  "useV2WireProtocol" : "true",
  "journalDirectories" : "/tmp/bk-journal-1",
  "maxPendingReadRequestsPerThread" : "2500",
  "useHostNameAsBookieID" : "true",
  "rereplicationEntryBatchSize" : "100",
  "allowLoopback" : "false",
  "readOnlyModeEnabled" : "true",
  "reppDnsResolverClass" : "org.apache.pulsar.bookie.rackawareness.BookieRackAffinityMapping",
  "journalRemoveFromPageCache" : "true",
  "dbStorage_readAheadCacheMaxSizeMb" : "",
  "zkEnableSecurity" : "false",
  "numHighPriorityWorkerThreads" : "8",
  "dbStorage_readAheadCacheBatchSize" : "1000",
  "journalFormatVersionToWrite" : "5",
  "writeBufferSizeBytes" : "65536",
  "bookiePort" : "3181",
  "dbStorage_writeCacheMaxSizeMb" : "",
  "pageLimit" : "0",
  "logSizeLimit" : "1073741824",
  "advertisedAddress" : "",
  "bookieDeathWatchInterval" : "1000",
  "numReadWorkerThreads" : "8",
  "minorCompactionThreshold" : "0.2",
  "serverTcpNoDelay" : "true",
  "journalBufferedWritesThreshold" : "524288",
  "compactionMaxOutstandingRequests" : "100000",
  "journalPreAllocSizeMB" : "16",
  "journalWriteData" : "false"
}
2022-04-24 11:22:25,947 INFO  [BookieNettyServer#357] [main] Binding bookie-rpc endpoint to 0.0.0.0/0.0.0.0:3181
2022-04-24 11:22:26,256 INFO  [MetadataDrivers#105] [main] BookKeeper metadata driver manager initialized
2022-04-24 11:22:26,264 INFO  [ZKMetadataDriverBase#197] [main] Initialize zookeeper metadata driver at metadata service uri zk+null://10.206.128.154:2181;10.206.128.155:2181;10.206.128.156:2181;10.206.128.157:2181;10.206.128.158:2181/ledgers : zkServers = 10.206.128.154:2181,10.206.128.155:2181,10.206.128.156:2181,10.206.128.157:2181,10.206.128.158:2181, ledgersRootPath = /ledgers.
2022-04-24 11:22:26,269 INFO  [Environment#98] [main] Client environment:zookeeper.version=3.8.0-5a02a05eddb59aee6ac762f7ea82e92a68eb9c0f, built on 2022-02-25 08:49 UTC
2022-04-24 11:22:26,269 INFO  [Environment#98] [main] Client environment:java.version=17.0.2
2022-04-24 11:22:26,269 INFO  [Environment#98] [main] Client environment:java.vendor=BellSoft
2022-04-24 11:22:26,269 INFO  [Environment#98] [main] Client environment:java.home=D:\JAVA\jdk-17-full
2022-04-24 11:22:26,269 INFO  [Environment#98] [main] Client environment:java.class.path=
2022-04-24 11:22:26,270 INFO  [Environment#98] [main] Client environment:java.compiler=<NA>
2022-04-24 11:22:26,270 INFO  [Environment#98] [main] Client environment:os.name=Windows 7
2022-04-24 11:22:26,270 INFO  [Environment#98] [main] Client environment:os.arch=amd64
2022-04-24 11:22:26,271 INFO  [Environment#98] [main] Client environment:os.version=6.1
2022-04-24 11:22:26,271 INFO  [Environment#98] [main] Client environment:user.dir=D:\opensource\pulsar
2022-04-24 11:22:26,271 INFO  [Environment#98] [main] Client environment:os.memory.free=204MB
2022-04-24 11:22:26,271 INFO  [Environment#98] [main] Client environment:os.memory.max=4074MB
2022-04-24 11:22:26,271 INFO  [Environment#98] [main] Client environment:os.memory.total=256MB
2022-04-24 11:22:26,276 INFO  [ZooKeeper#637] [main] Initiating client connection, connectString=10.206.128.154:2181,10.206.128.155:2181,10.206.128.156:2181,10.206.128.157:2181,10.206.128.158:2181 sessionTimeout=30000 watcher=org.apache.bookkeeper.zookeeper.ZooKeeperWatcherBase@7e8e8651
2022-04-24 11:22:26,280 INFO  [X509Util#77] [main] Setting -D jdk.tls.rejectClientInitiatedRenegotiation=true to disable client-initiated TLS renegotiation
2022-04-24 11:22:26,285 INFO  [ClientCnxnSocket#239] [main] jute.maxbuffer value is 1048575 Bytes
2022-04-24 11:22:26,294 INFO  [ClientCnxn#1732] [main] zookeeper.request.timeout value is 0. feature enabled=false
2022-04-24 11:22:26,304 INFO  [ClientCnxn$SendThread#1171] [main-SendThread(10.206.128.157:2181)] Opening socket connection to server bookie34/10.206.128.157:2181.
2022-04-24 11:22:26,305 INFO  [ClientCnxn$SendThread#1173] [main-SendThread(10.206.128.157:2181)] SASL config status: Will not attempt to authenticate using SASL (unknown error)
2022-04-24 11:22:26,310 INFO  [ClientCnxn$SendThread#1005] [main-SendThread(10.206.128.157:2181)] Socket connection established, initiating session, client: /192.168.255.10:60376, server: bookie34/10.206.128.157:2181
2022-04-24 11:22:26,904 INFO  [ClientCnxn$SendThread#1444] [main-SendThread(10.206.128.157:2181)] Session establishment complete on server bookie34/10.206.128.157:2181, session id = 0x4000000f2840009, negotiated timeout = 30000
2022-04-24 11:22:26,908 INFO  [ZooKeeperWatcherBase#130] [main-EventThread] ZooKeeper client is connected now.
2022-04-24 11:22:27,136 INFO  [Bookie#413] [main] Stamping new cookies on all dirs [\tmp\bk-journal-1\current] [data\bookkeeper\ledgers\current]
2022-04-24 11:22:27,215 INFO  [Bookie#736] [main] instantiate ledger manager org.apache.bookkeeper.meta.HierarchicalLedgerManagerFactory
2022-04-24 11:22:27,256 INFO  [Bookie#654] [main] Using ledger storage: org.apache.bookkeeper.bookie.storage.ldb.DbLedgerStorage
2022-04-24 11:22:27,257 INFO  [DbLedgerStorage#108] [main] Started Db Ledger Storage
2022-04-24 11:22:27,258 INFO  [DbLedgerStorage#109] [main]  - Number of directories: 1
2022-04-24 11:22:27,258 INFO  [DbLedgerStorage#110] [main]  - Write cache size: 1018 MB
2022-04-24 11:22:27,258 INFO  [DbLedgerStorage#111] [main]  - Read Cache: 1018 MB
2022-04-24 11:22:27,262 INFO  [SingleDirectoryDbLedgerStorage#149] [main] Creating single directory db ledger storage on data\bookkeeper\ledgers\current
2022-04-24 11:22:34,976 INFO  [ScanAndCompareGarbageCollector#102] [main] Over Replicated Ledger Deletion : enabled=true, interval=86400000
2022-04-24 11:22:35,024 INFO  [GarbageCollectorThread#245] [main] Minor Compaction : enabled=true, threshold=0.2, interval=3600000
2022-04-24 11:22:35,024 INFO  [GarbageCollectorThread#247] [main] Major Compaction : enabled=true, threshold=0.5, interval=86400000
2022-04-24 11:22:35,095 INFO  [Main#308] [main] Load lifecycle component : org.apache.bookkeeper.server.service.BookieService
2022-04-24 11:22:35,202 INFO  [ZKMetadataDriverBase#197] [main] Initialize zookeeper metadata driver at metadata service uri zk+null://10.206.128.154:2181;10.206.128.155:2181;10.206.128.156:2181;10.206.128.157:2181;10.206.128.158:2181/ledgers : zkServers = 10.206.128.154:2181,10.206.128.155:2181,10.206.128.156:2181,10.206.128.157:2181,10.206.128.158:2181, ledgersRootPath = /ledgers.
2022-04-24 11:22:35,203 INFO  [ZooKeeper#637] [main] Initiating client connection, connectString=10.206.128.154:2181,10.206.128.155:2181,10.206.128.156:2181,10.206.128.157:2181,10.206.128.158:2181 sessionTimeout=30000 watcher=org.apache.bookkeeper.zookeeper.ZooKeeperWatcherBase@58112bc4
2022-04-24 11:22:35,208 INFO  [ClientCnxnSocket#239] [main] jute.maxbuffer value is 1048575 Bytes
2022-04-24 11:22:35,209 INFO  [ClientCnxn#1732] [main] zookeeper.request.timeout value is 0. feature enabled=false
2022-04-24 11:22:35,215 INFO  [ClientCnxn$SendThread#1171] [main-SendThread(10.206.128.156:2181)] Opening socket connection to server bookie33/10.206.128.156:2181.
2022-04-24 11:22:35,215 INFO  [ClientCnxn$SendThread#1173] [main-SendThread(10.206.128.156:2181)] SASL config status: Will not attempt to authenticate using SASL (unknown error)
2022-04-24 11:22:35,219 INFO  [ClientCnxn$SendThread#1005] [main-SendThread(10.206.128.156:2181)] Socket connection established, initiating session, client: /192.168.255.10:60386, server: bookie33/10.206.128.156:2181
2022-04-24 11:22:35,816 INFO  [ClientCnxn$SendThread#1444] [main-SendThread(10.206.128.156:2181)] Session establishment complete on server bookie33/10.206.128.156:2181, session id = 0x303a43aba0002da, negotiated timeout = 30000
2022-04-24 11:22:35,817 INFO  [ZooKeeperWatcherBase#130] [main-EventThread] ZooKeeper client is connected now.
2022-04-24 11:22:43,495 ERROR [Main#228] [main] Failed to build bookie server
java.lang.RuntimeException: METADATA_STORE_INSTANCE failed initialized
	at org.apache.pulsar.bookie.rackawareness.IsolatedBookieEnsemblePlacementPolicy.initialize(IsolatedBookieEnsemblePlacementPolicy.java:78) ~[classes/:?]
	at org.apache.pulsar.bookie.rackawareness.IsolatedBookieEnsemblePlacementPolicy.initialize(IsolatedBookieEnsemblePlacementPolicy.java:52) ~[classes/:?]
	at org.apache.bookkeeper.client.BookKeeper.initializeEnsemblePlacementPolicy(BookKeeper.java:581) ~[bookkeeper-server-4.14.4.jar:4.14.4]
	at org.apache.bookkeeper.client.BookKeeper.<init>(BookKeeper.java:505) ~[bookkeeper-server-4.14.4.jar:4.14.4]
	at org.apache.bookkeeper.client.BookKeeper$Builder.build(BookKeeper.java:306) ~[bookkeeper-server-4.14.4.jar:4.14.4]
	at org.apache.bookkeeper.replication.Auditor.createBookKeeperClient(Auditor.java:280) ~[bookkeeper-server-4.14.4.jar:4.14.4]
	at org.apache.bookkeeper.replication.AutoRecoveryMain.<init>(AutoRecoveryMain.java:95) ~[bookkeeper-server-4.14.4.jar:4.14.4]
	at org.apache.bookkeeper.server.service.AutoRecoveryService.<init>(AutoRecoveryService.java:41) ~[bookkeeper-server-4.14.4.jar:4.14.4]
	at org.apache.bookkeeper.server.Main.buildBookieServer(Main.java:320) ~[bookkeeper-server-4.14.4.jar:4.14.4]
	at org.apache.bookkeeper.server.Main.doMain(Main.java:226) [bookkeeper-server-4.14.4.jar:4.14.4]
	at org.apache.bookkeeper.server.Main.main(Main.java:208) [bookkeeper-server-4.14.4.jar:4.14.4]
	at org.apache.bookkeeper.proto.BookieServer.main(BookieServer.java:334) [bookkeeper-server-4.14.4.jar:4.14.4]
Disconnected from the target VM, address: '127.0.0.1:60340', transport: 'socket'
```

### Modifications

1. delete the `zk+hierarchical://` or `zk+null://` prefix
2. move the `TestZKServer` to the `testmocks` module 
3.  add the testcase 

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API: (yes / no)
  - The schema: (yes / no / don't know)
  - The default values of configurations: (yes / no)
  - The wire protocol: (yes / no)
  - The rest endpoints: (yes / no)
  - The admin cli options: (yes / no)
  - Anything that affects deployment: (yes / no / don't know)

### Documentation

Check the box below or label this PR directly.

Need to update docs? 

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)
  
- [x] `no-need-doc` 
(Please explain why)
  
- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-added`
(Docs have been already added)