### PR TITLE
[improve][tx] enhance validation when updating transaction topic

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/PulsarTransactionCoordinatorMetadataSetup.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/PulsarTransactionCoordinatorMetadataSetup.java
@@ -51,6 +51,9 @@ public class PulsarTransactionCoordinatorMetadataSetup {
         }, description = "Num transaction coordinators will assigned in cluster")
         private int numTransactionCoordinators = 16;
 
+        @Parameter(names = { "-f", "--force" }, description = "Update partitions of transaction topic forcefully")
+        private boolean force = false;
+
         @Parameter(names = { "-h", "--help" }, description = "Show this help message")
         private boolean help = false;
 
@@ -105,7 +108,7 @@ public class PulsarTransactionCoordinatorMetadataSetup {
             // Create transaction coordinator assign partitioned topic
             PulsarClusterMetadataSetup.createPartitionedTopic(configStore,
                     SystemTopicNames.TRANSACTION_COORDINATOR_ASSIGN,
-                    arguments.numTransactionCoordinators);
+                    arguments.numTransactionCoordinators, arguments.force);
         }
 
         System.out.println("Transaction coordinator metadata setup success");


### PR DESCRIPTION
Master issue: #15302

### Motivation

Currently executing the command `bin/pulsar initialize-transaction-coordinator-metadata` will directly update the number of partitions of `persistent://pulsar/system/transaction_coordinator_assign`.

When accidentally misoperation, the number of partitions is directly modified, and there is no way to roll back (the number of partitions cannot be reduced).

### Modifications

Simplely add an argument to determine whether forced update is allowed.

### Verifying this change

This change added tests and can be verified as follows:

*(example:)*
```shell
bin/pulsar initialize-transaction-coordinator-metadata -cs 127.0.0.1:2181 -c standalone -c 1
bin/pulsar initialize-transaction-coordinator-metadata -cs 127.0.0.1:2181 -c standalone -c 2

# Check for changes of partitions
bin/pulsar-admin topics get-partitioned-topic-metadata persistent://pulsar/system/transaction_coordinator_assign
```

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - **The admin cli options: (yes)**
  - Anything that affects deployment: (no)

### Documentation

Check the box below or label this PR directly.

Need to update docs? 
  
- [x] `no-need-doc` 
I think command description is sufficient.
- [x] `doc-not-needed`
