### PR TITLE
[fix][loadbalance] Fix wrong unit of NIC speed on linux

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/LinuxInfoUtils.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/LinuxInfoUtils.java
@@ -243,7 +243,7 @@ public class LinuxInfoUtils {
 
     @AllArgsConstructor
     public enum NICUnit {
-        Kbps(1024);
+        Kbps(1000);
 
         private final int convertUnit;
 
@@ -254,7 +254,7 @@ public class LinuxInfoUtils {
 
     @AllArgsConstructor
     public enum UsageUnit {
-        Kbps(8 / 1024);
+        Kbps(1024);
 
         private final int convertUnit;
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/LinuxInfoUtils.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/LinuxInfoUtils.java
@@ -254,7 +254,7 @@ public class LinuxInfoUtils {
 
     @AllArgsConstructor
     public enum UsageUnit {
-        Kbps(1024);
+        Kbps(8 / 1000);
 
         private final int convertUnit;
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/LinuxBrokerHostUsageImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/LinuxBrokerHostUsageImpl.java
@@ -125,7 +125,7 @@ public class LinuxBrokerHostUsageImpl implements BrokerHostUsage {
     private double getTotalNicLimitWithConfiguration(List<String> nics) {
         // Use the override value as configured. Return the total max speed across all available NICs, converted
         // from Gbps into Kbps
-        return overrideBrokerNicSpeedGbps.map(aDouble -> aDouble * nics.size() * 1024 * 1024)
+        return overrideBrokerNicSpeedGbps.map(aDouble -> aDouble * nics.size() * 1000 * 1000)
                 .orElseGet(() -> getTotalNicLimit(nics, NICUnit.Kbps));
     }
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/LoadReportNetworkLimitTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/LoadReportNetworkLimitTest.java
@@ -56,8 +56,8 @@ public class LoadReportNetworkLimitTest extends MockedPulsarServiceBaseTest {
         LoadManagerReport report = admin.brokerStats().getLoadReport();
 
         if (SystemUtils.IS_OS_LINUX) {
-            assertEquals(report.getBandwidthIn().limit, nicCount * 5.4 * 1024 * 1024);
-            assertEquals(report.getBandwidthOut().limit, nicCount * 5.4 * 1024 * 1024);
+            assertEquals(report.getBandwidthIn().limit, nicCount * 5.4 * 1000 * 1000);
+            assertEquals(report.getBandwidthOut().limit, nicCount * 5.4 * 1000 * 1000);
         } else {
             // On non-Linux system we don't report the network usage
             assertEquals(report.getBandwidthIn().limit, -1.0);


### PR DESCRIPTION
Fixes #15229

### Motivation
conversion of NIC bandwidth  and tx_bytes rx_bytes is wrong on linux platform.



### Modifications
1. For NIC bandwidth:
1,000 bit/s = 1 [kbit/s](https://en.wikipedia.org/wiki/Kbit/s) (one [thousand](https://en.wikipedia.org/wiki/Thousand) bits per second)

2. For tx_bytes and rx_bytes, the unit should same with NICLimit , so it should be bytes*8/1000=kbit rather than 8/1024.


### Documentation

Check the box below or label this PR directly.

Need to update docs? 

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)
  
- [x] `no-need-doc` 
(Please explain why)
  
- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-added`
(Docs have been already added)