### PR TITLE
[improve][client] Should  use CompletableFuture#get(long, TimeUnit) 

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/TypedMessageBuilderImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/TypedMessageBuilderImpl.java
@@ -84,7 +84,7 @@ public class TypedMessageBuilderImpl<T> implements TypedMessageBuilder<T> {
                 producer.triggerFlush();
             }
 
-            return sendFuture.get();
+            return sendFuture.get(Integer.MAX_VALUE, TimeUnit.MILLISECONDS);
         } catch (Exception e) {
             throw PulsarClientException.unwrap(e);
         }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/TypedMessageBuilderImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/TypedMessageBuilderImpl.java
@@ -83,7 +83,8 @@ public class TypedMessageBuilderImpl<T> implements TypedMessageBuilder<T> {
                 // it out
                 producer.triggerFlush();
             }
-
+            // Use CompletableFuture#get(long, TimeUnit) instead of CompletableFuture#get()
+            // details see (https://bugs.openjdk.java.net/browse/JDK-8227018).
             return sendFuture.get(Integer.MAX_VALUE, TimeUnit.MILLISECONDS);
         } catch (Exception e) {
             throw PulsarClientException.unwrap(e);

--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/ContextImpl.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/ContextImpl.java
@@ -599,6 +599,8 @@ class ContextImpl implements Context, SinkContext, SourceContext, AutoCloseable 
         @Override
         public MessageId send() throws PulsarClientException {
             try {
+                // Use CompletableFuture#get(long, TimeUnit) instead of CompletableFuture#get()
+                // details see (https://bugs.openjdk.java.net/browse/JDK-8227018).
                 return sendAsync().get(Integer.MAX_VALUE, TimeUnit.MILLISECONDS);
             } catch (Exception e) {
                 throw PulsarClientException.unwrap(e);

--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/ContextImpl.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/ContextImpl.java
@@ -599,7 +599,7 @@ class ContextImpl implements Context, SinkContext, SourceContext, AutoCloseable 
         @Override
         public MessageId send() throws PulsarClientException {
             try {
-                return sendAsync().get();
+                return sendAsync().get(Integer.MAX_VALUE, TimeUnit.MILLISECONDS);
             } catch (Exception e) {
                 throw PulsarClientException.unwrap(e);
             }


### PR DESCRIPTION

<!--
### Contribution Checklist
  
  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://docs.google.com/document/d/1d8Pw6ZbWk-_pCKdOmdvx9rnhPiyuxwq60_TrD68d7BA/edit#heading=h.trs9rsex3xom)*. 

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.

**(The sections below can be removed for hotfixes of typos)**
-->


Fixes #15320

### Motivation
The client uses `CompletableFuture#get()` to convert async to sync, like this: 
```
            CompletableFuture<MessageId> sendFuture = sendAsync();

            if (!sendFuture.isDone()) {
                // the send request wasn't completed yet (e.g. not failing at enqueuing), then attempt to triggerFlush
                // it out
                producer.triggerFlush();
            }

            return sendFuture.get();
```
But CompletableFuture#get() has performance issues in some versions of JDK 8 such as JDK 1.8.0_202，[details](https://bugs.openjdk.java.net/browse/JDK-8227018).
So use `CompletableFuture#get(long, TimeUnit)` instead of `CompletableFuture#get()`.


### Documentation

Check the box below or label this PR directly.

Need to update docs? 

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)
  
- [x] `no-need-doc` 
(Please explain why)
  
- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-added`
(Docs have been already added)