### PR TITLE
[cherry-pick][pulsar-sql] Java version trim agent presto332 branch2.9

### DIFF
--- a/conf/presto/jvm.config
+++ b/conf/presto/jvm.config
@@ -27,3 +27,4 @@
 -XX:+ExitOnOutOfMemoryError
 -Dpresto-temporarily-allow-java8=true
 -Djdk.attach.allowAttachSelf=true
+-javaagent:java-version-trim-agent.jar

--- a/pulsar-sql/java-version-trim-agent/pom.xml
+++ b/pulsar-sql/java-version-trim-agent/pom.xml
@@ -1,0 +1,58 @@
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>pulsar-sql</artifactId>
+        <groupId>org.apache.pulsar</groupId>
+        <version>2.11.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>java-version-trim-agent</artifactId>
+    <name>Pulsar SQL :: Java Version Trim Agent</name>
+
+    <build>
+        <finalName>java-version-trim-agent</finalName>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>3.1.0</version>
+                <configuration>
+                    <archive>
+                        <manifest>
+                            <addClasspath>true</addClasspath>
+                        </manifest>
+                        <manifestEntries>
+                            <Premain-Class>org.apache.pulsar.sql.agent.TrimJavaVersionAgent</Premain-Class>
+                            <Agent-Class>org.apache.pulsar.sql.agent.TrimJavaVersionAgent</Agent-Class>
+                            <Can-Redefine-Classes>true</Can-Redefine-Classes>
+                            <Can-Retransform-Classes>true</Can-Retransform-Classes>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/pulsar-sql/java-version-trim-agent/pom.xml
+++ b/pulsar-sql/java-version-trim-agent/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <artifactId>pulsar-sql</artifactId>
         <groupId>org.apache.pulsar</groupId>
-        <version>2.11.0-SNAPSHOT</version>
+        <version>2.9.2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/pulsar-sql/java-version-trim-agent/src/main/java/org/apache/pulsar/sql/agent/TrimJavaVersionAgent.java
+++ b/pulsar-sql/java-version-trim-agent/src/main/java/org/apache/pulsar/sql/agent/TrimJavaVersionAgent.java
@@ -1,0 +1,51 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.sql.agent;
+
+import java.lang.instrument.Instrumentation;
+import java.util.logging.Logger;
+
+/**
+ * The presto 332 couldn't parse Java version like this `11.0.14.1`,
+ * so add java version trim agent to walk around the problem.
+ *
+ * After the presto upgrade to 332+, we could remove this.
+ */
+public class TrimJavaVersionAgent {
+
+    private static final Logger logger = Logger.getLogger(TrimJavaVersionAgent.class.getName());
+
+    private static final String JAVA_VERSION = "java.version";
+
+    public static String trimJavaVersion(String javaVersion) {
+        String[] arr = javaVersion.split("\\.");
+        if (arr.length <= 3) {
+            return javaVersion;
+        }
+        return arr[0] + "." + arr[1] + "." + arr[2];
+    }
+
+    public static void premain(String agentArgs, Instrumentation inst) {
+        String javaVersion = System.getProperty(JAVA_VERSION);
+        String trimVersion = trimJavaVersion(javaVersion);
+        logger.info("original java version " + javaVersion + " => trim java version " + trimVersion);
+        System.setProperty(JAVA_VERSION, trimVersion);
+    }
+
+}

--- a/pulsar-sql/java-version-trim-agent/src/main/java/org/apache/pulsar/sql/agent/package-info.java
+++ b/pulsar-sql/java-version-trim-agent/src/main/java/org/apache/pulsar/sql/agent/package-info.java
@@ -1,0 +1,22 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+/**
+ * Implementation of the connector to the Presto engine.
+ */
+package org.apache.pulsar.sql.agent;

--- a/pulsar-sql/pom.xml
+++ b/pulsar-sql/pom.xml
@@ -34,6 +34,7 @@
     <modules>
         <module>presto-pulsar</module>
         <module>presto-pulsar-plugin</module>
+        <module>java-version-trim-agent</module>
         <module>presto-distribution</module>
     </modules>
 

--- a/pulsar-sql/presto-distribution/pom.xml
+++ b/pulsar-sql/presto-distribution/pom.xml
@@ -200,6 +200,13 @@
       <version>${jackson.version}</version>
     </dependency>
 
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>java-version-trim-agent</artifactId>
+      <version>${project.version}</version>
+      <scope>provided</scope>
+    </dependency>
+
   </dependencies>
 
   <dependencyManagement>

--- a/pulsar-sql/presto-distribution/src/assembly/assembly.xml
+++ b/pulsar-sql/presto-distribution/src/assembly/assembly.xml
@@ -40,6 +40,11 @@
             <outputDirectory>bin/</outputDirectory>
             <fileMode>644</fileMode>
         </file>
+        <file>
+            <source>${basedir}/../java-version-trim-agent/target/java-version-trim-agent.jar</source>
+            <destName>java-version-trim-agent.jar</destName>
+            <outputDirectory>/</outputDirectory>
+        </file>
     </files>
     <fileSets>
         <fileSet>

--- a/pulsar-sql/presto-pulsar/pom.xml
+++ b/pulsar-sql/presto-pulsar/pom.xml
@@ -108,6 +108,12 @@
         </dependency>
 
         <dependency>
+            <groupId>javax.annotation</groupId>
+            <artifactId>javax.annotation-api</artifactId>
+            <version>${javax.annotation-api.version}</version>
+        </dependency>
+
+        <dependency>
             <groupId>io.prestosql</groupId>
             <artifactId>presto-main</artifactId>
             <version>${presto.version}</version>

--- a/pulsar-sql/presto-pulsar/pom.xml
+++ b/pulsar-sql/presto-pulsar/pom.xml
@@ -110,7 +110,6 @@
         <dependency>
             <groupId>javax.annotation</groupId>
             <artifactId>javax.annotation-api</artifactId>
-            <version>${javax.annotation-api.version}</version>
         </dependency>
 
         <dependency>

--- a/tests/docker-images/latest-version-image/conf/presto/jvm.config
+++ b/tests/docker-images/latest-version-image/conf/presto/jvm.config
@@ -28,3 +28,4 @@
 -XX:+ExitOnOutOfMemoryError
 -Dpresto-temporarily-allow-java8=true
 -Djdk.attach.allowAttachSelf=true
+-javaagent:java-version-trim-agent.jar

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/presto/TestPrestoQueryTieredStorage.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/presto/TestPrestoQueryTieredStorage.java
@@ -41,7 +41,6 @@ import org.testcontainers.shaded.org.apache.commons.lang.StringUtils;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
-
 /**
  * Test presto query from tiered storage, the Pulsar SQL is cluster mode.
  */

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/suites/PulsarSQLTestSuite.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/suites/PulsarSQLTestSuite.java
@@ -23,6 +23,7 @@ import java.sql.DriverManager;
 import java.sql.SQLException;
 import java.util.HashMap;
 import java.util.Map;
+
 import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.client.api.PulsarClientException;


### PR DESCRIPTION
Fix #14951

# Motivation

The presto 332 couldn't parse Java version like this `11.0.14.1`, so add a Java version trim agent to walk around the problem.

This is a temporary patch, after the presto upgrade to 332+, we could remove this.

(cherry picked from commit a1aa18f1a856d074bb23d68f5c330d3558bdf6cb)

### Modifications

Add a Java version trim agent to format the system property `java.version` for the Pulsar SQL plugin.

### Verifying this change

This change is already covered by existing tests.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (yes)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (yes)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

Check the box below or label this PR directly.

Need to update docs? 

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)
  
- [x] `no-need-doc` 
(Please explain why)
  
- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-added`
(Docs have been already added)