### PR TITLE
[client]Check  consumer schema null in advance

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBuilderImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBuilderImpl.java
@@ -77,6 +77,7 @@ public class ConsumerBuilderImpl<T> implements ConsumerBuilder<T> {
     }
 
     ConsumerBuilderImpl(PulsarClientImpl client, ConsumerConfigurationData<T> conf, Schema<T> schema) {
+        checkArgument(schema != null, "schema should not be null");
         this.client = client;
         this.conf = conf;
         this.schema = schema;

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBuilderImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBuilderImpl.java
@@ -77,7 +77,7 @@ public class ConsumerBuilderImpl<T> implements ConsumerBuilder<T> {
     }
 
     ConsumerBuilderImpl(PulsarClientImpl client, ConsumerConfigurationData<T> conf, Schema<T> schema) {
-        checkArgument(schema != null, "schema should not be null");
+        checkArgument(schema != null, "Schema should not be null.");
         this.client = client;
         this.conf = conf;
         this.schema = schema;

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/ConsumerBuilderImplTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/ConsumerBuilderImplTest.java
@@ -66,6 +66,13 @@ public class ConsumerBuilderImplTest {
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testConsumerBuilderImplWhenSchemaIsNull() {
+        PulsarClientImpl client = mock(PulsarClientImpl.class);
+        ConsumerConfigurationData consumerConfigurationData = mock(ConsumerConfigurationData.class);
+        new ConsumerBuilderImpl(client, consumerConfigurationData, null);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
     public void testConsumerBuilderImplWhenTopicNamesVarargsIsNull() {
         consumerBuilderImpl.topic(null);
     }

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/ConsumerImplTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/ConsumerImplTest.java
@@ -35,6 +35,7 @@ import java.util.concurrent.TimeUnit;
 import org.apache.pulsar.client.api.Consumer;
 import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.Messages;
+import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.impl.conf.ClientConfigurationData;
 import org.apache.pulsar.client.impl.conf.ConsumerConfigurationData;
@@ -216,6 +217,18 @@ public class ConsumerImplTest {
                 true);
 
         Assert.assertTrue(consumer.paused);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testCreateConsumerWhenSchemaIsNull() throws PulsarClientException {
+        PulsarClient client = PulsarClient.builder()
+            .serviceUrl("pulsar://127.0.0.1:6650")
+            .build();
+
+        client.newConsumer(null)
+            .topic("topic_testCreateConsumerWhenSchemaIsNull")
+            .subscriptionName("testCreateConsumerWhenSchemaIsNull")
+            .subscribe();
     }
 
     @Test

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/PulsarClientImplTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/PulsarClientImplTest.java
@@ -53,7 +53,6 @@ import lombok.Cleanup;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.client.api.PulsarClientException;
-import org.apache.pulsar.client.api.SubscriptionType;
 import org.apache.pulsar.client.impl.conf.ClientConfigurationData;
 import org.apache.pulsar.client.impl.conf.ConsumerConfigurationData;
 import org.apache.pulsar.client.util.ExecutorProvider;
@@ -237,7 +236,6 @@ public class PulsarClientImplTest {
         assertThrows(IllegalArgumentException.class,
             () -> client.newConsumer(null)
                 .topic("topic_testSchemaNull")
-                .subscriptionType(SubscriptionType.Shared)
                 .subscriptionName("testSchemaNull")
                 .subscribe());
     }

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/PulsarClientImplTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/PulsarClientImplTest.java
@@ -51,7 +51,9 @@ import java.util.regex.Pattern;
 
 import lombok.Cleanup;
 import org.apache.commons.lang3.tuple.Pair;
+import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.client.api.PulsarClientException;
+import org.apache.pulsar.client.api.SubscriptionType;
 import org.apache.pulsar.client.impl.conf.ClientConfigurationData;
 import org.apache.pulsar.client.impl.conf.ConsumerConfigurationData;
 import org.apache.pulsar.client.util.ExecutorProvider;
@@ -223,6 +225,21 @@ public class PulsarClientImplTest {
             // Externally passed eventLoopGroup should not be shutdown.
             assertFalse(eventLoopGroup.isShutdown());
         }
+    }
+
+    @Test
+    public void testConsumerSchemaNull() throws PulsarClientException {
+        @Cleanup
+        PulsarClient client = PulsarClient.builder()
+            .serviceUrl("pulsar://127.0.0.1:6650")
+            .build();
+
+        assertThrows(IllegalArgumentException.class,
+            () -> client.newConsumer(null)
+                .topic("topic_testSchemaNull")
+                .subscriptionType(SubscriptionType.Shared)
+                .subscriptionName("testSchemaNull")
+                .subscribe());
     }
 
     @Test

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/PulsarClientImplTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/PulsarClientImplTest.java
@@ -51,7 +51,6 @@ import java.util.regex.Pattern;
 
 import lombok.Cleanup;
 import org.apache.commons.lang3.tuple.Pair;
-import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.impl.conf.ClientConfigurationData;
 import org.apache.pulsar.client.impl.conf.ConsumerConfigurationData;
@@ -224,20 +223,6 @@ public class PulsarClientImplTest {
             // Externally passed eventLoopGroup should not be shutdown.
             assertFalse(eventLoopGroup.isShutdown());
         }
-    }
-
-    @Test
-    public void testConsumerSchemaNull() throws PulsarClientException {
-        @Cleanup
-        PulsarClient client = PulsarClient.builder()
-            .serviceUrl("pulsar://127.0.0.1:6650")
-            .build();
-
-        assertThrows(IllegalArgumentException.class,
-            () -> client.newConsumer(null)
-                .topic("topic_testSchemaNull")
-                .subscriptionName("testSchemaNull")
-                .subscribe());
     }
 
     @Test


### PR DESCRIPTION
### Motivation

* If we set `scheam` as null when using `PulsarClient` new consumer  like this:
```
Consumer<?> consumer = client.newConsumer(null)
                .topic(topic)
                .subscriptionName(subscription)
                .subscribe();
```
It does not throw exceptions when building consumer, but will throw exceptions when `org.apache.pulsar.client.impl.ConsumerImpl#connectionOpened` invoked, then it will try to reconnect later. See the following log detail：
<img width="1772" alt="image" src="https://user-images.githubusercontent.com/10233437/165218210-0203a233-47f8-4223-9c5f-3cde3505f786.png">

* For detail, the code where throws exception is located at： 
https://github.com/apache/pulsar/blob/74eae1a729c33c9fead9d54594bdee5fac8ab153/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java#L827

### Modifications

If `schema` is null, throw exceptions when buiding the consumer

### Verifying this change

- [x] Make sure that the change passes the CI checks.



### Documentation
  
- [x] `no-need-doc` 
  
