### PR TITLE
[feature][Function Worker] Support disabling non-TLS service port

### DIFF
--- a/conf/functions_worker.yml
+++ b/conf/functions_worker.yml
@@ -23,6 +23,7 @@
 
 workerId: standalone
 workerHostname: localhost
+# Set to null to disable the non-TLS service port.
 workerPort: 6750
 workerPortTls: 6751
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
@@ -1641,10 +1641,8 @@ public class PulsarService implements AutoCloseable, ShutdownService {
                                                                       String workerConfigFile) throws IOException {
         WorkerConfig workerConfig = WorkerConfig.load(workerConfigFile);
 
-        brokerConfig.getWebServicePort()
-            .map(port -> workerConfig.setWorkerPort(port));
-        brokerConfig.getWebServicePortTls()
-            .map(port -> workerConfig.setWorkerPortTls(port));
+        workerConfig.setWorkerPort(brokerConfig.getWebServicePort().orElse(null));
+        workerConfig.setWorkerPortTls(brokerConfig.getWebServicePortTls().orElse(null));
 
         // worker talks to local broker
         String hostname = ServiceConfigurationUtils.getDefaultOrConfiguredAddress(

--- a/pulsar-broker/src/test/java/org/apache/pulsar/io/PulsarFunctionTlsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/io/PulsarFunctionTlsTest.java
@@ -23,6 +23,7 @@ import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 import com.google.common.collect.Sets;
@@ -201,7 +202,7 @@ public class PulsarFunctionTlsTest {
         workerConfig.setFunctionAssignmentTopicName("assignment");
         workerConfig.setFunctionMetadataTopicName("metadata");
         workerConfig.setInstanceLivenessCheckFreqMs(100);
-        workerConfig.setWorkerPort(0);
+        workerConfig.setWorkerPort(null);
         workerConfig.setPulsarFunctionsCluster(config.getClusterName());
         String hostname = ServiceConfigurationUtils.getDefaultOrConfiguredAddress(config.getAdvertisedAddress());
         this.workerId = "c-" + config.getClusterName() + "-fw-" + hostname + "-" + workerConfig.getWorkerPort();
@@ -236,6 +237,11 @@ public class PulsarFunctionTlsTest {
         });
 
         return workerService;
+    }
+
+    @Test
+    public void testWorkerServerNonTlsNotStarted() {
+        assertFalse(workerServer.getListenPortHTTP().isPresent(), "Non-TLS worker service should not be set.");
     }
 
     @Test

--- a/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/worker/WorkerConfig.java
+++ b/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/worker/WorkerConfig.java
@@ -100,7 +100,7 @@ public class WorkerConfig implements Serializable, PulsarConfiguration {
     private String workerHostname;
     @FieldContext(
         category = CATEGORY_WORKER,
-        doc = "The port for serving worker http requests"
+        doc = "The port for serving worker http requests. Set to null to disable serving on the http port."
     )
     private Integer workerPort;
     @FieldContext(
@@ -724,7 +724,8 @@ public class WorkerConfig implements Serializable, PulsarConfiguration {
 
     public String getWorkerId() {
         if (isBlank(this.workerId)) {
-            this.workerId = String.format("%s-%s", this.getWorkerHostname(), this.getWorkerPort());
+            this.workerId = String.format("%s-%s", this.getWorkerHostname(), this.getWorkerPort() != null
+                    ? this.getWorkerPort() : this.getWorkerPortTls());
         }
         return this.workerId;
     }

--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/Worker.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/Worker.java
@@ -56,7 +56,7 @@ public class Worker {
         workerService.start(getAuthenticationService(), getAuthorizationService(), errorNotifier);
         server = new WorkerServer(workerService, getAuthenticationService());
         server.start();
-        log.info("/** Started worker server on port={} **/", this.workerConfig.getWorkerPort());
+        log.info("/** Started worker server **/");
 
         try {
             errorNotifier.waitForError();

--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/WorkerServer.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/WorkerServer.java
@@ -87,9 +87,12 @@ public class WorkerServer {
         }
 
         List<ServerConnector> connectors = new ArrayList<>();
-        httpConnector = new ServerConnector(server);
-        httpConnector.setPort(this.workerConfig.getWorkerPort());
-        connectors.add(httpConnector);
+        if (this.workerConfig.getWorkerPort() != null) {
+            log.info("Configuring http server on port={}", this.workerConfig.getWorkerPort());
+            httpConnector = new ServerConnector(server);
+            httpConnector.setPort(this.workerConfig.getWorkerPort());
+            connectors.add(httpConnector);
+        }
 
         List<Handler> handlers = new ArrayList<>(4);
         handlers.add(newServletContextHandler("/admin",
@@ -125,6 +128,7 @@ public class WorkerServer {
         server.setHandler(stats);
 
         if (this.workerConfig.getTlsEnabled()) {
+            log.info("Configuring https server on port={}", this.workerConfig.getWorkerPortTls());
             try {
                 SslContextFactory sslCtxFactory;
                 if (workerConfig.isTlsEnabledWithKeyStore()) {

--- a/site2/docs/functions-worker.md
+++ b/site2/docs/functions-worker.md
@@ -109,7 +109,7 @@ To run function-worker separately, you have to configure the following parameter
 
 - `workerId`: The type is string. It is unique across clusters, which is used to identify a worker machine.
 - `workerHostname`: The hostname of the worker machine.
-- `workerPort`: The port that the worker server listens on. Keep it as default if you don't customize it.
+- `workerPort`: The port that the worker server listens on. Keep it as default if you don't customize it. Set it to `null` to disable the plaintext port.
 - `workerPortTls`: The TLS port that the worker server listens on. Keep it as default if you don't customize it.
 
 #### Function package parameter


### PR DESCRIPTION
Master Issue: https://github.com/apache/pulsar/issues/11548

### Motivation

Some use security sensitive users prefer to disable plaintext ports to ensure that there is no accidentally non-encrypted traffic. We added the ability to disable the non-TLS server on the broker https://github.com/apache/pulsar/pull/11681, and this PR adds the same feature for the function worker.

I have two questions about the implementation:

1. Is it a breaking change to update the worker id logic? It looks like the existing logic has two different methods of construction. The first is modified in this PR and the second is below. They differ only slightly. https://github.com/apache/pulsar/blob/74eae1a729c33c9fead9d54594bdee5fac8ab153/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java#L1681-L1685
2. In the `initializeWorkerConfigFromBrokerConfig` method, I am updating the worker config so that it maps the broker's ports to the worker's ports for all values. This seems logical to me since there are so many other mapped ports, and when a user is disabling the plaintext port on the broker, it's highly likely that they'd also want to disable the plaintext port for the broker's function worker.

### Modifications

* Update log lines to accurately indicate when the Function Worker is starting the HTTP or the HTTPS servers
* Skip creation of the function worker's HTTP server when the `workerPort` is `null`
* Update `WorkerConfig#getWorkerId()` so that it uses the TLS port when the plaintext port is null.
* Update the documentation.
* Update the broker's `initializeWorkerConfigFromBrokerConfig` method to align with the new changes.
* Update a test to verify that the non-TLS port service does not get started.

### Verifying this change

I added a test and verified the associated logs, too.

### Does this pull request potentially affect one of the following parts:

This change does not affect any defaults.

### Documentation

- [x] `doc-added`
This PR includes updates to the docs.