### PR TITLE
[fix][Flaky-test] Fix bug in method testConsumerImpl of AutoScaledReceiverQueueSizeTest

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/AutoScaledReceiverQueueSizeTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/AutoScaledReceiverQueueSizeTest.java
@@ -80,6 +80,7 @@ public class AutoScaledReceiverQueueSizeTest extends MockedPulsarServiceBaseTest
         for (int i = 0; i < 5; i++) {
             producer.send(data);
             producer.send(data);
+            Awaitility.await().until(consumer.scaleReceiverQueueHint::get);
             Assert.assertNotNull(consumer.receive());
             Assert.assertNotNull(consumer.receive());
             // queue maybe full, but no empty receive, so no expanding

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/AutoScaledReceiverQueueSizeTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/AutoScaledReceiverQueueSizeTest.java
@@ -66,8 +66,8 @@ public class AutoScaledReceiverQueueSizeTest extends MockedPulsarServiceBaseTest
         byte[] data = "data".getBytes(StandardCharsets.UTF_8);
 
         producer.send(data);
-        Assert.assertNotNull(consumer.receive());
         Awaitility.await().until(consumer.scaleReceiverQueueHint::get);
+        Assert.assertNotNull(consumer.receive());
         log.info("getCurrentReceiverQueueSize={}", consumer.getCurrentReceiverQueueSize());
 
         //this will trigger receiver queue size expanding.


### PR DESCRIPTION
Fixes #15323

### Motivation
Method testConsumerImpl of AutoScaledReceiverQueueSizeTest throw error when running.

### Modifications
Modify the order of the two lines of code as follow:
   Awaitility.await().until(consumer.scaleReceiverQueueHint::get);
   Assert.assertNotNull(consumer.receive());

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

Check the box below or label this PR directly.

Need to update docs? 
- [x] `no-need-doc` 