### PR TITLE
[improve][broker] Support shrink for ConcurrentSortedLongPairSet 

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/MessageRedeliveryController.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/MessageRedeliveryController.java
@@ -36,7 +36,7 @@ public class MessageRedeliveryController {
     private final ConcurrentLongLongPairHashMap hashesToBeBlocked;
 
     public MessageRedeliveryController(boolean allowOutOfOrderDelivery) {
-        this.messagesToRedeliver = new ConcurrentSortedLongPairSet(128, 2);
+        this.messagesToRedeliver = new ConcurrentSortedLongPairSet(128, 2, true);
         this.hashesToBeBlocked = allowOutOfOrderDelivery
                 ? null
                 : ConcurrentLongLongPairHashMap

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/util/collections/ConcurrentLongPairSet.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/util/collections/ConcurrentLongPairSet.java
@@ -175,6 +175,7 @@ public class ConcurrentLongPairSet implements LongPairSet {
         return size;
     }
 
+    @Override
     public long capacity() {
         long capacity = 0;
         for (int i = 0; i < sections.length; i++) {

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/util/collections/ConcurrentSortedLongPairSet.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/util/collections/ConcurrentSortedLongPairSet.java
@@ -48,14 +48,15 @@ import org.apache.pulsar.common.util.collections.ConcurrentLongPairSet.LongPairC
 public class ConcurrentSortedLongPairSet implements LongPairSet {
 
     protected final NavigableMap<Long, ConcurrentLongPairSet> longPairSets = new ConcurrentSkipListMap<>();
-    private int expectedItems;
-    private int concurrencyLevel;
+    private final int expectedItems;
+    private final int concurrencyLevel;
     /**
      * If {@link #longPairSets} adds and removes the item-set frequently then it allocates and removes
      * {@link ConcurrentLongPairSet} for the same item multiple times which can lead to gc-puases. To avoid such
      * situation, avoid removing empty LogPairSet until it reaches max limit.
      */
-    private int maxAllowedSetOnRemove;
+    private final int maxAllowedSetOnRemove;
+    private final boolean autoShrink;
     private static final int DEFAULT_MAX_ALLOWED_SET_ON_REMOVE = 10;
 
     public ConcurrentSortedLongPairSet() {
@@ -70,10 +71,20 @@ public class ConcurrentSortedLongPairSet implements LongPairSet {
         this(expectedItems, concurrencyLevel, DEFAULT_MAX_ALLOWED_SET_ON_REMOVE);
     }
 
+    public ConcurrentSortedLongPairSet(int expectedItems, int concurrencyLevel, boolean autoShrink) {
+        this(expectedItems, concurrencyLevel, DEFAULT_MAX_ALLOWED_SET_ON_REMOVE, autoShrink);
+    }
+
     public ConcurrentSortedLongPairSet(int expectedItems, int concurrencyLevel, int maxAllowedSetOnRemove) {
+        this(expectedItems, concurrencyLevel, maxAllowedSetOnRemove, false);
+    }
+
+    public ConcurrentSortedLongPairSet(int expectedItems, int concurrencyLevel, int maxAllowedSetOnRemove,
+                                       boolean autoShrink) {
         this.expectedItems = expectedItems;
         this.concurrencyLevel = concurrencyLevel;
         this.maxAllowedSetOnRemove = maxAllowedSetOnRemove;
+        this.autoShrink = autoShrink;
     }
 
     @Override
@@ -82,6 +93,7 @@ public class ConcurrentSortedLongPairSet implements LongPairSet {
                 (key) -> ConcurrentLongPairSet.newBuilder()
                         .expectedItems(expectedItems)
                         .concurrencyLevel(concurrencyLevel)
+                        .autoShrink(autoShrink)
                         .build());
         return messagesToReplay.add(item1, item2);
     }
@@ -192,6 +204,15 @@ public class ConcurrentSortedLongPairSet implements LongPairSet {
             size.getAndAdd(longPairSet.size());
         });
         return size.get();
+    }
+
+    @Override
+    public long capacity() {
+        AtomicLong capacity = new AtomicLong(0);
+        longPairSets.forEach((item1, longPairSet) -> {
+            capacity.getAndAdd(longPairSet.capacity());
+        });
+        return capacity.get();
     }
 
     @Override

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/util/collections/LongPairSet.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/util/collections/LongPairSet.java
@@ -108,6 +108,13 @@ public interface LongPairSet {
     long size();
 
     /**
+     * Returns capacity of the set.
+     *
+     * @return
+     */
+    long capacity();
+
+    /**
      * Checks if given (item1,item2) composite value exists into set.
      *
      * @param item1

--- a/pulsar-common/src/test/java/org/apache/pulsar/common/util/collections/ConcurrentSortedLongPairSetTest.java
+++ b/pulsar-common/src/test/java/org/apache/pulsar/common/util/collections/ConcurrentSortedLongPairSetTest.java
@@ -22,6 +22,7 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotEquals;
 import static org.testng.Assert.assertTrue;
+import com.google.common.collect.ComparisonChain;
 import com.google.common.collect.Lists;
 import java.util.ArrayList;
 import java.util.List;
@@ -181,6 +182,20 @@ public class ConcurrentSortedLongPairSetTest {
         values = new ArrayList<>(set.items());
         values.sort(null);
         assertEquals(values, Lists.newArrayList(new LongPair(6, 6), new LongPair(7, 7)));
+
+        set = new ConcurrentSortedLongPairSet(128, 2, true);
+        set.add(2, 2);
+        set.add(1, 3);
+        set.add(3, 1);
+        set.add(2, 1);
+        set.add(3, 2);
+        set.add(1, 2);
+        set.add(1, 1);
+        removeItems = set.removeIf((ledgerId, entryId) -> {
+            return ComparisonChain.start().compare(ledgerId, 1).compare(entryId, 3)
+                    .result() <= 0;
+        });
+        assertEquals(removeItems, 3);
     }
 
     @Test

--- a/pulsar-common/src/test/java/org/apache/pulsar/common/util/collections/ConcurrentSortedLongPairSetTest.java
+++ b/pulsar-common/src/test/java/org/apache/pulsar/common/util/collections/ConcurrentSortedLongPairSetTest.java
@@ -245,4 +245,32 @@ public class ConcurrentSortedLongPairSetTest {
         set.add(1, 1);
         assertFalse(set.isEmpty());
     }
+
+    @Test
+    public void testShrink() {
+        LongPairSet set = new ConcurrentSortedLongPairSet(2, 1, true);
+        set.add(0, 0);
+        assertTrue(set.capacity() == 4);
+        set.add(0, 1);
+        assertTrue(set.capacity() == 4);
+        set.add(1, 1);
+        assertTrue(set.capacity() == 8);
+        set.add(1, 2);
+        assertTrue(set.capacity() == 8);
+        set.add(1, 3);
+        set.add(1, 4);
+        set.add(1, 5);
+        assertTrue(set.capacity() == 12);
+        set.remove(1, 5);
+        // not shrink
+        assertTrue(set.capacity() == 12);
+        set.remove(1, 4);
+        // the internal map does not keep shrinking at every remove() operation
+        assertTrue(set.capacity() == 12);
+        set.remove(1, 3);
+        set.remove(1, 2);
+        set.remove(1, 1);
+        // shrink
+        assertTrue(set.capacity() == 8);
+    }
 }


### PR DESCRIPTION
### Motivation
Sometimes the messages sent to consumers are delayed over 100ms and we find that the CPU is wasted on :
```
"BookKeeperClientWorker-OrderedExecutor-4-0" #64 prio=5 os_prio=0 cpu=12748552.31ms elapsed=42037.79s tid=0x00007f7b4dc05720 nid=0xaf runnable  [0x00007f7a376f4000]
   java.lang.Thread.State: RUNNABLE
	at org.apache.pulsar.common.util.collections.ConcurrentLongPairSet.forEach(ConcurrentLongPairSet.java:157)
	at org.apache.pulsar.common.util.collections.ConcurrentSortedLongPairSet.items(ConcurrentSortedLongPairSet.java:136)
	at org.apache.pulsar.common.util.collections.ConcurrentSortedLongPairSet.items(ConcurrentSortedLongPairSet.java:128)
	at org.apache.pulsar.common.util.collections.ConcurrentSortedLongPairSet.items(ConcurrentSortedLongPairSet.java:113)
	at org.apache.pulsar.broker.service.persistent.MessageRedeliveryController.getMessagesToReplayNow(MessageRedeliveryController.java:109)
	at 
```

Then we find there are many empty datas in the map from dump :
<img width="1129" alt="image" src="https://user-images.githubusercontent.com/6297296/165530721-e2da535f-f2a7-4d13-839f-f7bf157a1b5d.png">

ConcurrentSortedLongPairSet implements based on `ConcurrentLongPairSet`, and `ConcurrentLongPairSet` supports shrink, so support shrink for ConcurrentSortedLongPairSet to avoid iterator the empty data.

But the original `removeIf` has a bug if `autoShrink=true`, because when iterator the section, the internal `table` may change after `remove`, so result in some data not removed.

Reproduce Test:
```
LongPairSet set = new ConcurrentSortedLongPairSet(128, 2, true);
set.add(2, 2);
set.add(1, 3);
set.add(3, 1);
set.add(2, 1);
set.add(3, 2);
set.add(1, 2);
set.add(1, 1);
int removeItems = set.removeIf((ledgerId, entryId) -> {
    return ComparisonChain.start().compare(ledgerId, 1).compare(entryId, 3)
                    .result() <= 0;
 });
assertEquals(removeItems, 3);   // Will fail, removeItems = 2, (1,1) is not removed.
```


### Modification
- Fix `removeIf` and add related test.

### Documentation

  
- [x] `no-need-doc` 
(Please explain why)
