### PR TITLE
[improve][test] Add test for negative ack.

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/NegativeAcksTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/NegativeAcksTest.java
@@ -263,7 +263,7 @@ public class NegativeAcksTest extends ProducerConsumerBase {
         producer.close();
     }
 
-    @Test
+    @Test(timeOut = 10000)
     public void testNegativeAcksDeleteFromUnackedTracker() throws Exception {
         String topic = BrokerTestUtil.newUniqueName("testNegativeAcksDeleteFromUnackedTracker");
         @Cleanup
@@ -306,7 +306,7 @@ public class NegativeAcksTest extends ProducerConsumerBase {
         nackedMessages.clear();
     }
 
-    @Test
+    @Test(timeOut = 10000)
     public void testNegativeAcksWithBatchAckEnabled() throws Exception {
         stopBroker();
         conf.setAcknowledgmentAtBatchIndexLevelEnabled(true);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/NegativeAcksTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/NegativeAcksTest.java
@@ -279,6 +279,8 @@ public class NegativeAcksTest extends ProducerConsumerBase {
         MessageId messageId = new MessageIdImpl(3, 1, 0);
         TopicMessageIdImpl topicMessageId = new TopicMessageIdImpl("topic-1", "topic-1", messageId);
         BatchMessageIdImpl batchMessageId = new BatchMessageIdImpl(3, 1, 0, 0);
+        BatchMessageIdImpl batchMessageId2 = new BatchMessageIdImpl(3, 1, 0, 1);
+        BatchMessageIdImpl batchMessageId3 = new BatchMessageIdImpl(3, 1, 0, 2);
 
         UnAckedMessageTracker unAckedMessageTracker = ((ConsumerImpl) consumer).getUnAckedMessageTracker();
         unAckedMessageTracker.add(topicMessageId);
@@ -294,7 +296,11 @@ public class NegativeAcksTest extends ProducerConsumerBase {
         nackedMessages.clear();
         // negative batch message id
         unAckedMessageTracker.add(batchMessageId);
+        unAckedMessageTracker.add(batchMessageId2);
+        unAckedMessageTracker.add(batchMessageId3);
         consumer.negativeAcknowledge(batchMessageId);
+        consumer.negativeAcknowledge(batchMessageId2);
+        consumer.negativeAcknowledge(batchMessageId3);
         assertEquals(nackedMessages.size(), 1);
         assertEquals(unAckedMessageTracker.size(), 0);
         nackedMessages.clear();


### PR DESCRIPTION
### Motivation

Add test for negative ack API to ensure that when negative msg, the msg has been removed from `UnAckedMessageTracker`.

Before this test, there may exist that `negative ack doesn't remove the message id from UnAckedMessageTracker when message id is instance of BatchMessageIdImpl`with related issue #6869.

I think #6869 has been fixed by #9440 and after discussion,  we decide to add this test to ensure that negative ack would remove BatchMessageIdImpl.

### Modification
- Add test to verify the internal state.
- Add test to cover `enableBatchIndexAcknowledgment=true`.

### Documentation

- [x] `no-need-doc` 
(Please explain why)
