### PR TITLE
[improve][broker] Make some methods of `ClusterBase` pure async. 

### DIFF
--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/resources/ClusterResources.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/resources/ClusterResources.java
@@ -25,9 +25,12 @@ import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 import lombok.Getter;
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.pulsar.common.policies.data.ClusterData;
 import org.apache.pulsar.common.policies.data.FailureDomainImpl;
+import org.apache.pulsar.common.util.FutureUtil;
 import org.apache.pulsar.metadata.api.MetadataStore;
 import org.apache.pulsar.metadata.api.MetadataStoreException;
 import org.apache.pulsar.metadata.api.Notification;
@@ -89,6 +92,25 @@ public class ClusterResources extends BaseResources<ClusterData> {
         delete(joinPath(BASE_CLUSTERS_PATH, clusterName));
     }
 
+    public CompletableFuture<Void> deleteClusterAsync(String clusterName) {
+        return deleteAsync(joinPath(BASE_CLUSTERS_PATH, clusterName));
+    }
+
+    public CompletableFuture<Boolean> isClusterUsedAsync(String clusterName) {
+        return getCache().getChildren(BASE_POLICIES_PATH)
+                .thenCompose(tenants -> {
+                    List<CompletableFuture<List<String>>> futures = tenants.stream()
+                            .map(tenant -> getCache().getChildren(joinPath(BASE_POLICIES_PATH, tenant, clusterName)))
+                            .collect(Collectors.toList());
+                    return FutureUtil.waitForAll(futures)
+                            .thenApply(__ -> {
+                                // We found a tenant that has at least a namespace in this cluster
+                                return futures.stream().map(CompletableFuture::join)
+                                        .anyMatch(CollectionUtils::isNotEmpty);
+                            });
+                });
+    }
+
     public boolean isClusterUsed(String clusterName) throws MetadataStoreException {
         for (String tenant : getCache().getChildren(BASE_POLICIES_PATH).join()) {
             if (!getCache().getChildren(joinPath(BASE_POLICIES_PATH, tenant, clusterName)).join().isEmpty()) {
@@ -136,6 +158,21 @@ public class ClusterResources extends BaseResources<ClusterData> {
         public void deleteFailureDomain(String clusterName, String domainName) throws MetadataStoreException {
             String path = joinPath(BASE_CLUSTERS_PATH, clusterName, FAILURE_DOMAIN, domainName);
             delete(path);
+        }
+
+        public CompletableFuture<Void> deleteFailureDomainsAsync(String clusterName) {
+            String failureDomainPath = joinPath(BASE_CLUSTERS_PATH, clusterName, FAILURE_DOMAIN);
+            return existsAsync(failureDomainPath)
+                    .thenCompose(exists -> {
+                        if (!exists) {
+                            return CompletableFuture.completedFuture(null);
+                        }
+                        return getChildrenAsync(failureDomainPath)
+                                .thenCompose(children -> FutureUtil.waitForAll(children.stream()
+                                        .map(domain -> deleteAsync(joinPath(failureDomainPath, domain)))
+                                        .collect(Collectors.toList())))
+                                .thenCompose(__ -> deleteAsync(failureDomainPath));
+                    });
         }
 
         public void deleteFailureDomains(String clusterName) throws MetadataStoreException {

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/resources/ClusterResources.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/resources/ClusterResources.java
@@ -83,11 +83,6 @@ public class ClusterResources extends BaseResources<ClusterData> {
         set(joinPath(BASE_CLUSTERS_PATH, clusterName), modifyFunction);
     }
 
-    public CompletableFuture<Void> updateClusterAsync(String clusterName,
-                                                      Function<ClusterData, ClusterData> modifyFunction) {
-        return setAsync(joinPath(BASE_CLUSTERS_PATH, clusterName), modifyFunction);
-    }
-
     public void deleteCluster(String clusterName) throws MetadataStoreException {
         delete(joinPath(BASE_CLUSTERS_PATH, clusterName));
     }

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/resources/ClusterResources.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/resources/ClusterResources.java
@@ -80,6 +80,11 @@ public class ClusterResources extends BaseResources<ClusterData> {
         set(joinPath(BASE_CLUSTERS_PATH, clusterName), modifyFunction);
     }
 
+    public CompletableFuture<Void> updateClusterAsync(String clusterName,
+                                                      Function<ClusterData, ClusterData> modifyFunction) {
+        return setAsync(joinPath(BASE_CLUSTERS_PATH, clusterName), modifyFunction);
+    }
+
     public void deleteCluster(String clusterName) throws MetadataStoreException {
         delete(joinPath(BASE_CLUSTERS_PATH, clusterName));
     }

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/resources/NamespaceResources.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/resources/NamespaceResources.java
@@ -183,10 +183,9 @@ public class NamespaceResources extends BaseResources<Policies> {
             return data.isPresent() ? Optional.of(new NamespaceIsolationPolicies(data.get())) : Optional.empty();
         }
 
-        public CompletableFuture<NamespaceIsolationPolicies> getIsolationDataPoliciesAsync(String cluster) {
+        public CompletableFuture<Optional<NamespaceIsolationPolicies>> getIsolationDataPoliciesAsync(String cluster) {
             return getAsync(joinPath(BASE_CLUSTERS_PATH, cluster, NAMESPACE_ISOLATION_POLICIES))
-                    .thenApply(data -> data.map(NamespaceIsolationPolicies::new)
-                            .orElseGet(NamespaceIsolationPolicies::new));
+                    .thenApply(data -> data.map(NamespaceIsolationPolicies::new));
         }
 
         public void deleteIsolationData(String cluster) throws MetadataStoreException {

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/resources/NamespaceResources.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/resources/NamespaceResources.java
@@ -176,6 +176,11 @@ public class NamespaceResources extends BaseResources<Policies> {
             }, operationTimeoutSec);
         }
 
+        public CompletableFuture<Optional<NamespaceIsolationPolicies>> getIsolationDataPoliciesAsync(String cluster) {
+            return getAsync(joinPath(BASE_CLUSTERS_PATH, cluster, NAMESPACE_ISOLATION_POLICIES))
+                    .thenApply(isolationData -> isolationData.map(NamespaceIsolationPolicies::new));
+        }
+
         public Optional<NamespaceIsolationPolicies> getIsolationDataPolicies(String cluster)
                 throws MetadataStoreException {
             Optional<Map<String, NamespaceIsolationDataImpl>> data =
@@ -191,6 +196,10 @@ public class NamespaceResources extends BaseResources<Policies> {
 
         public void deleteIsolationData(String cluster) throws MetadataStoreException {
             delete(joinPath(BASE_CLUSTERS_PATH, cluster, NAMESPACE_ISOLATION_POLICIES));
+        }
+
+        public CompletableFuture<Void> deleteIsolationDataAsync(String cluster) {
+            return deleteAsync(joinPath(BASE_CLUSTERS_PATH, cluster, NAMESPACE_ISOLATION_POLICIES));
         }
 
         public void createIsolationData(String cluster, Map<String, NamespaceIsolationDataImpl> id)

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/resources/NamespaceResources.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/resources/NamespaceResources.java
@@ -176,11 +176,6 @@ public class NamespaceResources extends BaseResources<Policies> {
             }, operationTimeoutSec);
         }
 
-        public CompletableFuture<Optional<NamespaceIsolationPolicies>> getIsolationDataPoliciesAsync(String cluster) {
-            return getAsync(joinPath(BASE_CLUSTERS_PATH, cluster, NAMESPACE_ISOLATION_POLICIES))
-                    .thenApply(isolationData -> isolationData.map(NamespaceIsolationPolicies::new));
-        }
-
         public Optional<NamespaceIsolationPolicies> getIsolationDataPolicies(String cluster)
                 throws MetadataStoreException {
             Optional<Map<String, NamespaceIsolationDataImpl>> data =

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/ClustersBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/ClustersBase.java
@@ -47,7 +47,6 @@ import javax.ws.rs.container.Suspended;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
-import org.apache.pulsar.broker.admin.AdminResource;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.pulsar.broker.admin.AdminResource;
 import org.apache.pulsar.broker.resources.ClusterResources.FailureDomainResources;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/ClustersBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/ClustersBase.java
@@ -372,10 +372,7 @@ public class ClustersBase extends AdminResource {
                     // check the namespaceIsolationPolicies associated with the cluster
                     return namespaceIsolationPolicies().getIsolationDataPoliciesAsync(cluster);
                 }).thenCompose(nsIsolationPolicies -> {
-                    if (!nsIsolationPolicies.isPresent()) {
-                        return CompletableFuture.completedFuture(null);
-                    }
-                    if (!nsIsolationPolicies.get().getPolicies().isEmpty()) {
+                    if (!nsIsolationPolicies.getPolicies().isEmpty()) {
                         throw new RestException(Status.PRECONDITION_FAILED, "Cluster not empty");
                     }
                     // Need to delete the isolation policies if present

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/ClustersBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/ClustersBase.java
@@ -318,7 +318,7 @@ public class ClustersBase extends AdminResource {
                 .thenAccept(clusterOpt -> {
                     ClusterData clusterData =
                             clusterOpt.orElseThrow(() -> new RestException(Status.NOT_FOUND, "Cluster does not exist"));
-                    asyncResponse.resume(clusterData);
+                    asyncResponse.resume(clusterData.getPeerClusterNames());
                 }).exceptionally(ex -> {
                     log.error("[{}] Failed to get cluster {}", clientAppId(), cluster, ex);
                     resumeAsyncResponseExceptionally(asyncResponse, ex);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/NamespaceService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/NamespaceService.java
@@ -771,7 +771,8 @@ public class NamespaceService implements AutoCloseable {
     private CompletableFuture<NamespaceIsolationPolicies> getLocalNamespaceIsolationPoliciesAsync() {
         String localCluster = pulsar.getConfiguration().getClusterName();
         return pulsar.getPulsarResources().getNamespaceResources().getIsolationPolicies()
-                .getIsolationDataPoliciesAsync(localCluster);
+                .getIsolationDataPoliciesAsync(localCluster)
+                .thenApply(nsIsolationPolicies -> nsIsolationPolicies.orElseGet(NamespaceIsolationPolicies::new));
     }
 
     public boolean isNamespaceBundleDisabled(NamespaceBundle bundle) throws Exception {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminTest.java
@@ -223,7 +223,7 @@ public class AdminTest extends MockedPulsarServiceBaseTest {
 
         // Check deleting non-existing cluster
         try {
-            clusters.deleteCluster("usc");
+            asynRequests(ctx -> clusters.deleteCluster(ctx, "usc"));
             fail("should have failed");
         } catch (RestException e) {
             assertEquals(e.getResponse().getStatus(), Status.NOT_FOUND.getStatusCode());
@@ -262,7 +262,7 @@ public class AdminTest extends MockedPulsarServiceBaseTest {
         clusters.getNamespaceIsolationPolicies("use");
 
         try {
-            clusters.deleteCluster("use");
+            asynRequests(ctx -> clusters.deleteCluster(ctx, "use"));
             fail("should have failed");
         } catch (RestException e) {
             assertEquals(e.getResponse().getStatus(), 412);
@@ -271,7 +271,7 @@ public class AdminTest extends MockedPulsarServiceBaseTest {
         clusters.deleteNamespaceIsolationPolicy("use", "policy1");
         assertTrue(clusters.getNamespaceIsolationPolicies("use").isEmpty());
 
-        clusters.deleteCluster("use");
+        asynRequests(ctx -> clusters.deleteCluster(ctx, "use"));
         assertEquals(asynRequests(ctx -> clusters.getClusters(ctx)), Sets.newHashSet());
 
         try {
@@ -359,7 +359,7 @@ public class AdminTest extends MockedPulsarServiceBaseTest {
             });
 
         try {
-            clusters.deleteCluster("use");
+            asynRequests(ctx -> clusters.deleteCluster(ctx, "use"));
             fail("should have failed");
         } catch (RestException e) {
             assertEquals(e.getResponse().getStatus(), Status.INTERNAL_SERVER_ERROR.getStatusCode());
@@ -373,7 +373,7 @@ public class AdminTest extends MockedPulsarServiceBaseTest {
         isolationPolicyCache.invalidateAll();
         store.invalidateAll();
         try {
-            clusters.deleteCluster("use");
+            asynRequests(ctx -> clusters.deleteCluster(ctx, "use"));
             fail("should have failed");
         } catch (RestException e) {
             assertEquals(e.getResponse().getStatus(), Status.INTERNAL_SERVER_ERROR.getStatusCode());
@@ -406,8 +406,8 @@ public class AdminTest extends MockedPulsarServiceBaseTest {
         } catch (RestException e) {
             assertEquals(e.getResponse().getStatus(), Status.PRECONDITION_FAILED.getStatusCode());
         }
-        verify(clusters, times(13)).validateSuperUserAccessAsync();
-        verify(clusters, times(11)).validateSuperUserAccess();
+        verify(clusters, times(18)).validateSuperUserAccessAsync();
+        verify(clusters, times(6)).validateSuperUserAccess();
     }
 
     Object asynRequests(Consumer<TestAsyncResponse> function) throws Exception {


### PR DESCRIPTION
### Motivation

See PIP #14365  and change tracker #15043. 

### Modifications

- Make `ClusterBase` `setPeerClusterNames / getPeerCluster / deleteCluster` methods to pure async.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

`AdminApi2Test#testPeerCluster` and `AdminTest#clusters` already cover this change.

### Documentation

- [x] `no-need-doc` 
(Please explain why)