### PR TITLE
[fix][package-management] Fix the new path `/data` introduced regression

### DIFF
--- a/pulsar-package-management/core/src/main/java/org/apache/pulsar/packages/management/core/PackagesStorage.java
+++ b/pulsar-package-management/core/src/main/java/org/apache/pulsar/packages/management/core/PackagesStorage.java
@@ -83,4 +83,25 @@ public interface PackagesStorage {
      * @return
      */
     CompletableFuture<Void> closeAsync();
+
+    /**
+     * The extra path for saving package data.
+     *
+     * For example, we have a package function://public/default/package@v0.1,
+     * it will save the meta to the path function/public/default/package/v0.1/meta,
+     * and save the data to the path function/public/default/package/v0.1.
+     * By default, we are using distributed log as the package storage, and it supports
+     * saving data at a directory.
+     * But some storage like filesystem don't have the similar ability, it needs another path
+     * for saving the data.
+     * This api provides the ability to support saving the data in another place.
+     * If you specify the data path as `/data`, the package will saved into
+     * function/public/default/package/v0.1/data.
+     *
+     * @return
+     *      the data path
+     */
+    default String dataPath() {
+        return "";
+    }
 }

--- a/pulsar-package-management/core/src/main/java/org/apache/pulsar/packages/management/core/impl/PackagesManagementImpl.java
+++ b/pulsar-package-management/core/src/main/java/org/apache/pulsar/packages/management/core/impl/PackagesManagementImpl.java
@@ -243,11 +243,11 @@ public class PackagesManagementImpl implements PackagesManagement {
         return future;
     }
 
-    private String metadataPath(PackageName packageName) {
+    protected String metadataPath(PackageName packageName) {
         return packageName.toRestPath() + "/meta";
     }
 
-    private String packagePath(PackageName packageName) {
+    protected String packagePath(PackageName packageName) {
         return packageName.toRestPath() + storage.dataPath();
     }
 

--- a/pulsar-package-management/core/src/main/java/org/apache/pulsar/packages/management/core/impl/PackagesManagementImpl.java
+++ b/pulsar-package-management/core/src/main/java/org/apache/pulsar/packages/management/core/impl/PackagesManagementImpl.java
@@ -143,8 +143,7 @@ public class PackagesManagementImpl implements PackagesManagement {
     public CompletableFuture<Void> delete(PackageName packageName) {
         return CompletableFuture.allOf(
             storage.deleteAsync(metadataPath(packageName)),
-            storage.deleteAsync(packagePath(packageName)),
-            storage.deleteAsync(packageName.toRestPath()));
+            storage.deleteAsync(packagePath(packageName)));
     }
 
     @Override
@@ -249,7 +248,7 @@ public class PackagesManagementImpl implements PackagesManagement {
     }
 
     private String packagePath(PackageName packageName) {
-        return packageName.toRestPath() + "/data";
+        return packageName.toRestPath() + storage.dataPath();
     }
 
     private String packageWithoutVersionPath(PackageName packageName) {

--- a/pulsar-package-management/core/src/test/java/org/apache/pulsar/packages/management/core/impl/PackagesManagementImplTest.java
+++ b/pulsar-package-management/core/src/test/java/org/apache/pulsar/packages/management/core/impl/PackagesManagementImplTest.java
@@ -35,15 +35,15 @@ import org.apache.pulsar.packages.management.core.common.PackageMetadataUtil;
 import org.apache.pulsar.packages.management.core.common.PackageName;
 import org.apache.pulsar.packages.management.core.exceptions.PackagesManagementException;
 import org.testng.Assert;
-import org.testng.annotations.AfterClass;
-import org.testng.annotations.BeforeClass;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 public class PackagesManagementImplTest {
     private static PackagesStorage storage;
     private static PackagesManagement packagesManagement;
 
-    @BeforeClass
+    @BeforeMethod
     public static void setup() throws IOException {
         PackagesStorageProvider storageProvider = PackagesStorageProvider.newProvider(MockedPackagesStorageProvider.class.getName());
         DefaultPackagesStorageConfiguration packagesStorageConfiguration = new DefaultPackagesStorageConfiguration();
@@ -53,7 +53,7 @@ public class PackagesManagementImplTest {
         packagesManagement.initialize(storage);
     }
 
-    @AfterClass(alwaysRun = true)
+    @AfterMethod(alwaysRun = true)
     public static void teardown() throws ExecutionException, InterruptedException {
         storage.closeAsync().get();
     }

--- a/pulsar-package-management/core/src/test/java/org/apache/pulsar/packages/management/core/impl/PackagesManagementImplTest.java
+++ b/pulsar-package-management/core/src/test/java/org/apache/pulsar/packages/management/core/impl/PackagesManagementImplTest.java
@@ -21,7 +21,10 @@ package org.apache.pulsar.packages.management.core.impl;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import org.apache.pulsar.packages.management.core.MockedPackagesStorageProvider;
 import org.apache.pulsar.packages.management.core.PackagesManagement;
@@ -191,5 +194,63 @@ public class PackagesManagementImplTest {
         } catch (Exception e) {
             Assert.fail("should not throw any exception");
         }
+    }
+
+    @Test
+    public void testPackagePath() {
+        PackagesManagementImpl impl = (PackagesManagementImpl) packagesManagement;
+        PackageName pn = PackageName.get("function://public/default/test@v1");
+        String metaPath = impl.metadataPath(pn);
+        Assert.assertEquals(metaPath, "function/public/default/test/v1/meta");
+        String dataPath = impl.packagePath(pn);
+        Assert.assertEquals(dataPath, "function/public/default/test/v1");
+
+        impl.initialize(new PackagesStorage() {
+            @Override
+            public void initialize() {
+
+            }
+
+            @Override
+            public CompletableFuture<Void> writeAsync(String path, InputStream inputStream) {
+                return null;
+            }
+
+            @Override
+            public CompletableFuture<Void> readAsync(String path, OutputStream outputStream) {
+                return null;
+            }
+
+            @Override
+            public CompletableFuture<Void> deleteAsync(String path) {
+                return null;
+            }
+
+            @Override
+            public CompletableFuture<List<String>> listAsync(String path) {
+                return null;
+            }
+
+            @Override
+            public CompletableFuture<Boolean> existAsync(String path) {
+                return null;
+            }
+
+            @Override
+            public CompletableFuture<Void> closeAsync() {
+                return null;
+            }
+
+            @Override
+            public String dataPath() {
+                return "/tmp";
+            }
+        });
+
+
+        metaPath = impl.metadataPath(pn);
+        Assert.assertEquals(metaPath, "function/public/default/test/v1/meta");
+        dataPath = impl.packagePath(pn);
+        Assert.assertEquals(dataPath, "function/public/default/test/v1/tmp");
     }
 }

--- a/pulsar-package-management/filesystem-storage/src/main/java/org/apache/pulsar/packages/management/storage/filesystem/FileSystemPackagesStorage.java
+++ b/pulsar-package-management/filesystem-storage/src/main/java/org/apache/pulsar/packages/management/storage/filesystem/FileSystemPackagesStorage.java
@@ -147,4 +147,9 @@ public class FileSystemPackagesStorage implements PackagesStorage {
     public CompletableFuture<Void> closeAsync() {
         return CompletableFuture.completedFuture(null);
     }
+
+    @Override
+    public String dataPath() {
+        return "/data";
+    }
 }


### PR DESCRIPTION
---

Fixes #15362

*Motivation*

The PR https://github.com/apache/pulsar/pull/13218 supports saving
package data into filesystem. But it introduces a regression for the
old versions.
For example, we have a package function://public/default/package@v0.1,
it will save the meta to the path function/public/default/package/v0.1/meta,
and save the data to the path function/public/default/package/v0.1.
By default, we are using distributed log as the package storage, and
it supports saving data in a directory.
But some storage like filesystem doesn't have the similar ability, it
needs another path for saving data.
This API provides the ability to support saving the data in another place.
If you specify the data path as `/data`, the package will be saved into
function/public/default/package/v0.1/data.

*Modifications*

- make the data path configurable in the storage implementation.
