### PR TITLE
[cleanup][broker]Cleanup getNamespacePolicies when update TopicPolicies

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -3031,7 +3031,6 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
         }
         updateTopicPolicy(policies);
 
-        Optional<Policies> namespacePolicies = getNamespacePolicies();
         initializeTopicDispatchRateLimiterIfNeeded(policies);
 
         dispatchRateLimiter.ifPresent(DispatchRateLimiter::updateDispatchRate);
@@ -3071,10 +3070,6 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
             log.error("[{}] update topic policy error: {}", topic, t.getMessage(), t);
             return null;
         });
-    }
-
-    private Optional<Policies> getNamespacePolicies() {
-        return DispatchRateLimiter.getPolicies(brokerService, topic);
     }
 
     private void initializeTopicDispatchRateLimiterIfNeeded(TopicPolicies policies) {


### PR DESCRIPTION
### Motivation

No need to get namespace policies when update topic policies, Because we have used `HierarchyTopicPolicies`

### Modifications

Remove  `getNamespacePolicies`

### Verifying this change

- [x] Make sure that the change passes the CI checks.


### Documentation

- [x] `no-need-doc` 
(Please explain why)