### PR TITLE
[PIP-159][Improve][txn]Reuse transaction buffer reader

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/systopic/SystemTopicClient.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/systopic/SystemTopicClient.java
@@ -145,6 +145,16 @@ public interface SystemTopicClient<T> {
     interface Reader<T> {
 
         /**
+         * Read event from system topic by reused reader.
+         * @param topicName Need a topic name to distinguish different topic calls,
+         *                  when a Reader is shared by multiple topics
+         * @return pulsar event
+         */
+        default Message<T> readNext(String topicName) throws PulsarClientException {
+            return readNext();
+        }
+
+        /**
          * Read event from system topic.
          * @return pulsar event
          */

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/TopicTransactionBufferRecoverTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/TopicTransactionBufferRecoverTest.java
@@ -486,11 +486,10 @@ public class TopicTransactionBufferRecoverTest extends TransactionTestBase {
         TransactionBufferSnapshotService transactionBufferSnapshotServiceOriginal =
                 (TransactionBufferSnapshotService) field.get(getPulsarServiceList().get(0));
         // mock reader can't read snapshot fail
-        doThrow(new PulsarClientException("test")).when(reader).hasMoreEvents();
+        doThrow(new PulsarClientException("test")).when(reader).readNext(any());
         // check reader close topic
         checkCloseTopic(pulsarClient, transactionBufferSnapshotServiceOriginal,
                 transactionBufferSnapshotService, originalTopic, field, producer);
-        doReturn(true).when(reader).hasMoreEvents();
 
         // mock create reader fail
         doReturn(FutureUtil.failedFuture(new PulsarClientException("test")))


### PR DESCRIPTION
Master  https://github.com/apache/pulsar/issues/15334
### Motivation & Modification
Details can be found in https://github.com/apache/pulsar/issues/15334
Tests have been covered by TopicTransactionBufferRecoverTest.
### Verifying this change

- [x] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API: (yes / no)
  - The schema: (yes / no / don't know)
  - The default values of configurations: (yes / no)
  - The wire protocol: (yes / no)
  - The rest endpoints: (yes / no)
  - The admin cli options: (yes / no)
  - Anything that affects deployment: (yes / no / don't know)

### Documentation

Check the box below or label this PR directly.

Need to update docs? 

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)
  
- [x] `no-need-doc` 
(Please explain why)
  
- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-added`
(Docs have been already added)