### PR TITLE
[Broker/Client] Close connection if a ping message cannot be sent

### DIFF
--- a/pulsar-common/src/main/java/org/apache/pulsar/common/protocol/PulsarHandler.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/protocol/PulsarHandler.java
@@ -110,7 +110,14 @@ public abstract class PulsarHandler extends PulsarDecoder {
                 log.debug("[{}] Sending ping message", ctx.channel());
             }
             waitingForPingResponse = true;
-            ctx.writeAndFlush(Commands.newPing());
+            ctx.writeAndFlush(Commands.newPing())
+                    .addListener(future -> {
+                        if (!future.isSuccess()) {
+                            log.warn("[{}] Forcing connection to close since cannot send a ping message.",
+                                    ctx.channel(), future.cause());
+                            ctx.close();
+                        }
+                    });
         } else {
             if (log.isDebugEnabled()) {
                 log.debug("[{}] Peer doesn't support keep-alive", ctx.channel());


### PR DESCRIPTION
### Motivation

The keep alive implementation used in the Broker and the Java client ignores any failures that happen while writing the Ping message.
In Netty 4+, it's necessary to add a listener to detect failures when writing to outbound channels. 
The connection should be closed if a ping message cannot be sent. The future is notified once the OS level TCP/IP stack accepts the message for delivery.

This change will help detect the situation where writing to the outbound channel returns EBADF errno from the OS level and the connection isn't yet completely closed.
EBADF errno maps to java.nio.channels.ClosedChannelException which has this kind of explanation:
> Checked exception thrown when an attempt is made to invoke or complete an I/O operation upon channel that is closed, or at least closed to that operation. That this exception is thrown does not necessarily imply that the channel is completely closed. A socket channel whose write half has been shut down, for example, may still be open for reading.

### Modifications

Add a listener that closes the connection if sending the Ping message fails.