### PR TITLE
[improve][broker] Use for-each instead of the for-loop on pulsar collections

### DIFF
--- a/pulsar-common/src/main/java/org/apache/pulsar/common/util/collections/ConcurrentOpenLongPairRangeSet.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/util/collections/ConcurrentOpenLongPairRangeSet.java
@@ -28,7 +28,7 @@ import java.util.Map.Entry;
 import java.util.NavigableMap;
 import java.util.concurrent.ConcurrentSkipListMap;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicInteger;
+import org.apache.commons.lang.mutable.MutableInt;
 
 /**
  * A Concurrent set comprising zero or more ranges of type {@link LongPair}. This can be alternative of
@@ -245,12 +245,12 @@ public class ConcurrentOpenLongPairRangeSet<T extends Comparable<T>> implements 
     @Override
     public int size() {
         if (updatedAfterCachedForSize) {
-            AtomicInteger size = new AtomicInteger(0);
+            MutableInt size = new MutableInt(0);
             forEach((range) -> {
-                size.getAndIncrement();
+                size.increment();
                 return true;
             });
-            cachedSize = size.get();
+            cachedSize = size.intValue();
             updatedAfterCachedForSize = false;
         }
         return cachedSize;


### PR DESCRIPTION
### Motivation

In #15369, it introduced the for-loop to replace the for-each, but the for-loop will create many `Map.Entry` objects, we should use for-each instead for-loop.

Someplace are using atomic type, we can use `org.apache.commons.lang.mutable.MutableInt` here.

### Modifications

* Use for-each instead of for-each
* Use MutableInt instead of atomic type.

### Documentation

Check the box below or label this PR directly.

Need to update docs? 

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)
  
- [x] `no-need-doc` 
(Please explain why)
  
- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-added`
(Docs have been already added)