### PR TITLE
[improve] [test] Improve timeout problem at SimpleProducerConsumerTest#testRedeliveryFailOverConsumer

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SimpleProducerConsumerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SimpleProducerConsumerTest.java
@@ -2425,9 +2425,9 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
         Producer<byte[]> producer = pulsarClient.newProducer().topic("persistent://my-property/my-ns/unacked-topic")
                 .create();
 
-        // (1) First round to produce-consume messages
+        // (1) send all message at once
         int consumeMsgInParts = 4;
-        for (int i = 0; i < receiverQueueSize; i++) {
+        for (int i = 0; i < receiverQueueSize * 2; i++) {
             String message = "my-message-" + i;
             producer.send(message.getBytes());
         }
@@ -2466,13 +2466,6 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
         assertEquals(messages1.size(), consumeMsgInParts);
         consumer.redeliverUnacknowledgedMessages();
         Thread.sleep(1000L);
-
-        // (2) Second round to produce-consume messages
-        for (int i = 0; i < receiverQueueSize; i++) {
-            String message = "my-message-" + i;
-            producer.send(message.getBytes());
-        }
-        producer.flush();
 
         int remainingMsgs = (2 * receiverQueueSize) - (2 * consumeMsgInParts);
         messages1.clear();


### PR DESCRIPTION
### Motivation
```
org.testng.internal.thread.ThreadTimeoutException: Method org.apache.pulsar.client.api.SimpleProducerConsumerTest.testRedeliveryFailOverConsumer() didn't finish within the time-out 300000
```

Now the tests maybe timeout. Make produce at once to reduce time of spend. It didn't change the intention of the test.



### Documentation

Check the box below or label this PR directly.

Need to update docs? 

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)
  
- [x] `no-need-doc` 
(Please explain why)
  
- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-added`
(Docs have been already added)