### PR TITLE
[fix][Broker] fix bug in contructor of RocksdbMetadataStore

### DIFF
--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/RocksdbMetadataStore.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/RocksdbMetadataStore.java
@@ -221,7 +221,7 @@ public class RocksdbMetadataStore extends AbstractMetadataStore {
         try {
             Files.createDirectories(dataPath);
         } catch (IOException e) {
-            e.printStackTrace();
+            throw new MetadataStoreException("Fail to create RocksDB file directory", e);
         }
 
         db = openDB(dataPath.toString(), metadataStoreConfig.getConfigFilePath());


### PR DESCRIPTION
### Motivation
The contructor of RocksdbMetadataStore  should throw expception when rocksdb file directory create failed，instead of just printing the exception message。

### Modifications
throw MetadataStoreException instead of exception printStackTrace

### Does this pull request potentially affect one of the following parts:
  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation
- [x] `no-need-doc` 