### PR TITLE
[Java Client] Fix flaky BatchMessageTest by initializing lastBatchSendNanoTime

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
@@ -255,6 +255,7 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
             }
             this.batchMessageContainer = (BatchMessageContainerBase) containerBuilder.build();
             this.batchMessageContainer.setProducer(this);
+            this.lastBatchSendNanoTime = System.nanoTime();
         } else {
             this.batchMessageContainer = null;
         }


### PR DESCRIPTION
### Motivation

`BatchMessageTest` is very flaky, some tests failed at checking the
backlog of a topic. This flakiness, maybe the bug, was introduced from
https://github.com/apache/pulsar/pull/14185. `batchFlushTask` calculates
the time duration between now and `lastBatchSendNanoTime`. However,
for the first time `batchFlushTask` is called, `lastBatchSendNanoTime`
is not initialized, so the time diff duration satified so that
`batchMessageAndSend` will always be called for the first time.

For example, if all messages can be split into two batches for a given
batch size limit, there is a chance that when first few messages are in
the batch, `batchFlushTask` is called at the same time and these
messages could be sent first.

Here are some extra logs added by myself:

```
2022-05-01T12:35:23,545+0800 [main] INFO  org.apache.pulsar.client.impl.BatchMessageKeyBasedContainer - XYZ add 0 | 1 (0) 12 (600) | false
2022-05-01T12:35:23,545+0800 [pulsar-client-io-35-1] INFO  org.apache.pulsar.client.impl.ProducerImpl - XYZ batchFlushTask 52779290583 us (5000000)
2022-05-01T12:35:23,545+0800 [pulsar-client-io-35-1] INFO  org.apache.pulsar.client.impl.BatchMessageKeyBasedContainer - XYZ before create: [0]
2022-05-01T12:35:23,546+0800 [pulsar-client-io-35-1] INFO  org.apache.pulsar.client.impl.BatchMessageKeyBasedContainer - XYZ create 1 Ops: 1 (0) 12 (600)
```

We can see `batchFlushTask` was called while the batch contains only 1
message. The time duration is nearly 15 hours, which is appearly wrong.

### Modifications

Initialize `lastBatchSendNanoTime` with the current time point
immediately after the batch container is constructed.

### Documentation

Check the box below or label this PR directly.

Need to update docs? 

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)
  
- [x] `no-need-doc` 
(Please explain why)
  
- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-added`
(Docs have been already added)