### PR TITLE
Bump dependency check and spring version to avoid potential FP

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -262,7 +262,7 @@ flexible messaging model and an intuitive client API.</description>
     <errorprone-slf4j.version>0.1.4</errorprone-slf4j.version>
     <j2objc-annotations.version>1.3</j2objc-annotations.version>
     <lightproto-maven-plugin.version>0.4</lightproto-maven-plugin.version>
-    <dependency-check-maven.version>6.1.6</dependency-check-maven.version>
+    <dependency-check-maven.version>7.1.0</dependency-check-maven.version>
 
     <!-- Used to configure rename.netty.native. Libs -->
     <rename.netty.native.libs>rename-netty-native-libs.sh</rename.netty.native.libs>

--- a/pom.xml
+++ b/pom.xml
@@ -206,7 +206,7 @@ flexible messaging model and an intuitive client API.</description>
     <kotlin-stdlib.version>1.4.32</kotlin-stdlib.version>
     <nsq-client.version>1.0</nsq-client.version>
     <cron-utils.version>9.1.6</cron-utils.version>
-    <spring-context.version>5.3.18</spring-context.version>
+    <spring-context.version>5.3.19</spring-context.version>
     <apache-http-client.version>4.5.13</apache-http-client.version>
     <apache-httpcomponents.version>4.4.15</apache-httpcomponents.version>
     <jetcd.version>0.5.11</jetcd.version>

--- a/pulsar-io/canal/pom.xml
+++ b/pulsar-io/canal/pom.xml
@@ -33,7 +33,7 @@
     <name>Pulsar IO :: Canal</name>
 
     <properties>
-        <spring.version>5.3.18</spring.version>
+        <spring.version>5.3.19</spring.version>
         <canal.version>1.1.5</canal.version>
     </properties>
 


### PR DESCRIPTION
### Motivation
Bump dependency check version to avoid potential FP
Bump spring version to solve [CVE-2022-22968](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-22968)

### Modifications
- Bump dependency check version from 6.1.6 to 7.1.0
- Bump spring version from 5.3.18 to 5.3.19