### PR TITLE
[improve][CLI] Support filtering system topic when get list.

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
@@ -4934,4 +4934,10 @@ public class PersistentTopicsBase extends AdminResource {
                                     .updateTopicPoliciesAsync(topicName, topicPolicies);
                         }));
     }
+
+    protected List<String> filterSystemTopic(List<String> topics, boolean includeSystemTopic) {
+        return topics.stream()
+                .filter(topic -> includeSystemTopic ? true : !pulsar().getBrokerService().isSystemTopic(topic))
+                .collect(Collectors.toList());
+    }
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/NonPersistentTopics.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/NonPersistentTopics.java
@@ -430,10 +430,8 @@ public class NonPersistentTopics extends PersistentTopics {
                 final List<String> nonPersistentTopics =
                         topics.stream()
                                 .filter(name -> !TopicName.get(name).isPersistent())
-                                .filter(topic -> includeSystemTopic
-                                        ? true : !pulsar().getBrokerService().isSystemTopic(topic))
                                 .collect(Collectors.toList());
-                asyncResponse.resume(nonPersistentTopics);
+                asyncResponse.resume(filterSystemTopic(nonPersistentTopics, includeSystemTopic));
             }
         });
     }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/NonPersistentTopics.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/NonPersistentTopics.java
@@ -378,8 +378,8 @@ public class NonPersistentTopics extends PersistentTopics {
             @PathParam("namespace") String namespace,
             @ApiParam(value = "Specify the bundle name", required = false)
             @QueryParam("bundle") String nsBundle,
-            @ApiParam(value = "Include system topic", required = false)
-            @QueryParam("withSystemTopic") boolean withSystemTopic) {
+            @ApiParam(value = "Include system topic")
+            @QueryParam("includeSystemTopic") boolean includeSystemTopic) {
         Policies policies = null;
         try {
             validateNamespaceName(tenant, namespace);
@@ -430,7 +430,7 @@ public class NonPersistentTopics extends PersistentTopics {
                 final List<String> nonPersistentTopics =
                         topics.stream()
                                 .filter(name -> !TopicName.get(name).isPersistent())
-                                .filter(topic -> withSystemTopic
+                                .filter(topic -> includeSystemTopic
                                         ? true : !pulsar().getBrokerService().isSystemTopic(topic))
                                 .collect(Collectors.toList());
                 asyncResponse.resume(nonPersistentTopics);
@@ -468,6 +468,7 @@ public class NonPersistentTopics extends PersistentTopics {
 
         // check cluster ownership for a given global namespace: redirect if peer-cluster owns it
         validateGlobalNamespaceOwnership(namespaceName);
+
         isBundleOwnedByAnyBroker(namespaceName, policies.bundles, bundleRange).thenAccept(flag -> {
             if (!flag) {
                 log.info("[{}] Namespace bundle is not owned by any broker {}/{}", clientAppId(), namespaceName,

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/PersistentTopics.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/PersistentTopics.java
@@ -100,13 +100,13 @@ public class PersistentTopics extends PersistentTopicsBase {
             @PathParam("namespace") String namespace,
             @ApiParam(value = "Specify the bundle name", required = false)
             @QueryParam("bundle") String bundle,
-            @ApiParam(value = "Include system topic", required = false)
-            @QueryParam("withSystemTopic") boolean withSystemTopic) {
+            @ApiParam(value = "Include system topic")
+            @QueryParam("includeSystemTopic") boolean includeSystemTopic) {
         try {
             validateNamespaceName(tenant, namespace);
             List<String> topics = internalGetList(Optional.ofNullable(bundle))
                     .stream()
-                    .filter(topic -> withSystemTopic ? true : !pulsar().getBrokerService().isSystemTopic(topic))
+                    .filter(topic -> includeSystemTopic ? true : !pulsar().getBrokerService().isSystemTopic(topic))
                     .collect(Collectors.toList());
             asyncResponse.resume(topics);
         } catch (WebApplicationException wae) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/PersistentTopics.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/PersistentTopics.java
@@ -132,11 +132,11 @@ public class PersistentTopics extends PersistentTopicsBase {
             @ApiParam(value = "Specify the namespace", required = true)
             @PathParam("namespace") String namespace,
             @ApiParam(value = "Include system topic")
-            @QueryParam("withSystemTopic") boolean withSystemTopic) {
+            @QueryParam("includeSystemTopic") boolean includeSystemTopic) {
         validateNamespaceName(tenant, namespace);
         return internalGetPartitionedTopicList()
                 .stream()
-                .filter(topic -> withSystemTopic ? true : !pulsar().getBrokerService().isSystemTopic(topic))
+                .filter(topic -> includeSystemTopic ? true : !pulsar().getBrokerService().isSystemTopic(topic))
                 .collect(Collectors.toList());
     }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/PersistentTopics.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/PersistentTopics.java
@@ -29,7 +29,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.stream.Collectors;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.DefaultValue;
@@ -104,11 +103,7 @@ public class PersistentTopics extends PersistentTopicsBase {
             @QueryParam("includeSystemTopic") boolean includeSystemTopic) {
         try {
             validateNamespaceName(tenant, namespace);
-            List<String> topics = internalGetList(Optional.ofNullable(bundle))
-                    .stream()
-                    .filter(topic -> includeSystemTopic ? true : !pulsar().getBrokerService().isSystemTopic(topic))
-                    .collect(Collectors.toList());
-            asyncResponse.resume(topics);
+            asyncResponse.resume(filterSystemTopic(internalGetList(Optional.ofNullable(bundle)), includeSystemTopic));
         } catch (WebApplicationException wae) {
             asyncResponse.resume(wae);
         } catch (Exception e) {
@@ -134,10 +129,7 @@ public class PersistentTopics extends PersistentTopicsBase {
             @ApiParam(value = "Include system topic")
             @QueryParam("includeSystemTopic") boolean includeSystemTopic) {
         validateNamespaceName(tenant, namespace);
-        return internalGetPartitionedTopicList()
-                .stream()
-                .filter(topic -> includeSystemTopic ? true : !pulsar().getBrokerService().isSystemTopic(topic))
-                .collect(Collectors.toList());
+        return filterSystemTopic(internalGetPartitionedTopicList(), includeSystemTopic);
     }
 
     @GET

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/systopic/PartitionedSystemTopicTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/systopic/PartitionedSystemTopicTest.java
@@ -28,6 +28,7 @@ import org.apache.pulsar.broker.admin.impl.BrokersBase;
 import org.apache.pulsar.broker.namespace.NamespaceService;
 import org.apache.pulsar.broker.service.BrokerTestBase;
 import org.apache.pulsar.broker.service.persistent.PersistentTopic;
+import org.apache.pulsar.client.admin.Topics;
 import org.apache.pulsar.client.api.Consumer;
 import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.Producer;
@@ -49,6 +50,7 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
@@ -89,9 +91,12 @@ public class PartitionedSystemTopicTest extends BrokerTestBase {
 
         int partitions = admin.topics().getPartitionedTopicMetadata(
                 String.format("persistent://%s/%s", ns, SystemTopicNames.NAMESPACE_EVENTS_LOCAL_NAME)).partitions;
-        Assert.assertEquals(admin.topics().getPartitionedTopicList(ns).size(), 1);
+        List<String> partitionedTopicList = admin.topics().getPartitionedTopicList(ns,
+                Collections.singletonMap(Topics.QueryParam.Include_System_Topic, true));
+        Assert.assertEquals(partitionedTopicList.size(), 1);
         Assert.assertEquals(partitions, PARTITIONS);
-        Assert.assertEquals(admin.topics().getList(ns).size(), PARTITIONS);
+        Assert.assertEquals(admin.topics().getList(ns, null,
+                Collections.singletonMap(Topics.QueryParam.Include_System_Topic, true)).size(), PARTITIONS);
         reader.close();
     }
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/systopic/PartitionedSystemTopicTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/systopic/PartitionedSystemTopicTest.java
@@ -28,7 +28,7 @@ import org.apache.pulsar.broker.admin.impl.BrokersBase;
 import org.apache.pulsar.broker.namespace.NamespaceService;
 import org.apache.pulsar.broker.service.BrokerTestBase;
 import org.apache.pulsar.broker.service.persistent.PersistentTopic;
-import org.apache.pulsar.client.admin.Topics;
+import org.apache.pulsar.client.admin.ListTopicsOptions;
 import org.apache.pulsar.client.api.Consumer;
 import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.Producer;
@@ -50,7 +50,6 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
@@ -92,11 +91,11 @@ public class PartitionedSystemTopicTest extends BrokerTestBase {
         int partitions = admin.topics().getPartitionedTopicMetadata(
                 String.format("persistent://%s/%s", ns, SystemTopicNames.NAMESPACE_EVENTS_LOCAL_NAME)).partitions;
         List<String> partitionedTopicList = admin.topics().getPartitionedTopicList(ns,
-                Collections.singletonMap(Topics.QueryParam.Include_System_Topic, true));
+                ListTopicsOptions.builder().includeSystemTopic(true).build());
         Assert.assertEquals(partitionedTopicList.size(), 1);
         Assert.assertEquals(partitions, PARTITIONS);
         Assert.assertEquals(admin.topics().getList(ns, null,
-                Collections.singletonMap(Topics.QueryParam.Include_System_Topic, true)).size(), PARTITIONS);
+                ListTopicsOptions.builder().includeSystemTopic(true).build()).size(), PARTITIONS);
         reader.close();
     }
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/TransactionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/TransactionTest.java
@@ -149,7 +149,7 @@ public class TransactionTest extends TransactionTestBase {
 
         // getList does not include transaction system topic
         List<String> list = admin.topics().getList(NAMESPACE1);
-        assertEquals(list.size(), 4);
+        assertEquals(list.size(), 2);
         list.forEach(topic -> assertFalse(topic.contains(PENDING_ACK_STORE_SUFFIX)));
 
         try {

--- a/pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/admin/ListTopicsOptions.java
+++ b/pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/admin/ListTopicsOptions.java
@@ -1,0 +1,40 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.client.admin;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class ListTopicsOptions {
+
+    public static final ListTopicsOptions EMPTY = ListTopicsOptions.builder().build();
+
+    /**
+     * Namespace bundle.
+     */
+    private final String bundle;
+
+    /**
+     * Set to true to get topics including system topic, otherwise not.
+     */
+    private final boolean includeSystemTopic;
+
+}

--- a/pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/admin/Topics.java
+++ b/pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/admin/Topics.java
@@ -53,7 +53,7 @@ public interface Topics {
 
     enum QueryParam {
         Bundle("bundle"),
-        WITH_SYSTEM_TOPIC("with_system_topic");
+        Include_System_Topic("include_system_topic");
 
         public final String value;
 

--- a/pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/admin/Topics.java
+++ b/pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/admin/Topics.java
@@ -53,7 +53,7 @@ public interface Topics {
 
     enum QueryParam {
         Bundle("bundle"),
-        Include_System_Topic("include_system_topic");
+        Include_System_Topic("includeSystemTopic");
 
         public final String value;
 

--- a/pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/admin/Topics.java
+++ b/pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/admin/Topics.java
@@ -52,8 +52,7 @@ import org.apache.pulsar.common.policies.data.TopicStats;
 public interface Topics {
 
     enum QueryParam {
-        Bundle("bundle"),
-        Include_System_Topic("includeSystemTopic");
+        Bundle("bundle");
 
         public final String value;
 
@@ -114,6 +113,13 @@ public interface Topics {
     List<String> getList(String namespace, TopicDomain topicDomain) throws PulsarAdminException;
 
     /**
+     * @deprecated use {@link #getList(String, TopicDomain, ListTopicsOptions)} instead.
+     */
+    @Deprecated
+    List<String> getList(String namespace, TopicDomain topicDomain, Map<QueryParam, Object> params)
+            throws PulsarAdminException;
+
+    /**
      * Get the list of topics under a namespace.
      * <p/>
      * Response example:
@@ -131,8 +137,8 @@ public interface Topics {
      *            use {@link TopicDomain#non_persistent} to get non-persistent topics
      *            Use null to get both persistent and non-persistent topics
      *
-     * @param params
-     *            params to filter the results
+     * @param options
+     *            params to query the topics
      *
      * @return a list of topics
      *
@@ -143,7 +149,7 @@ public interface Topics {
      * @throws PulsarAdminException
      *             Unexpected error
      */
-    List<String> getList(String namespace, TopicDomain topicDomain, Map<QueryParam, Object> params)
+    List<String> getList(String namespace, TopicDomain topicDomain, ListTopicsOptions options)
             throws PulsarAdminException;
 
     /**
@@ -184,7 +190,12 @@ public interface Topics {
      */
     CompletableFuture<List<String>> getListAsync(String namespace, TopicDomain topicDomain);
 
-
+    /**
+     * @deprecated use {@link #getListAsync(String, TopicDomain, ListTopicsOptions)} instead.
+     */
+    @Deprecated
+    CompletableFuture<List<String>> getListAsync(String namespace, TopicDomain topicDomain,
+                                                 Map<QueryParam, Object> params);
     /**
      * Get the list of topics under a namespace asynchronously.
      * <p/>
@@ -203,13 +214,12 @@ public interface Topics {
      *            use {@link TopicDomain#non_persistent} to get non-persistent topics
      *            Use null to get both persistent and non-persistent topics
      *
-     * @param params
-     *            params to filter the results
+     * @param options
+     *            params to get the topics
      *
      * @return a list of topics
      */
-    CompletableFuture<List<String>> getListAsync(String namespace, TopicDomain topicDomain,
-            Map<QueryParam, Object> params);
+    CompletableFuture<List<String>> getListAsync(String namespace, TopicDomain topicDomain, ListTopicsOptions options);
 
     /**
      * Get the list of partitioned topics under a namespace.
@@ -262,8 +272,8 @@ public interface Topics {
      *
      * @param namespace
      *            Namespace name
-     * @param params
-     *            params to filter the results
+     * @param options
+     *            params to get the topics
      * @return a list of partitioned topics
      *
      * @throws NotAuthorizedException
@@ -273,7 +283,7 @@ public interface Topics {
      * @throws PulsarAdminException
      *             Unexpected error
      */
-    List<String> getPartitionedTopicList(String namespace, Map<QueryParam, Object> params) throws PulsarAdminException;
+    List<String> getPartitionedTopicList(String namespace, ListTopicsOptions options) throws PulsarAdminException;
 
     /**
      * Get the list of partitioned topics under a namespace asynchronously.
@@ -287,11 +297,11 @@ public interface Topics {
      *
      * @param namespace
      *            Namespace name
-     * @param params
+     * @param options
      *           params to filter the results
      * @return a list of partitioned topics
      */
-    CompletableFuture<List<String>> getPartitionedTopicListAsync(String namespace, Map<QueryParam, Object> params);
+    CompletableFuture<List<String>> getPartitionedTopicListAsync(String namespace, ListTopicsOptions options);
 
     /**
      * Get list of topics exist into given bundle.

--- a/pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/admin/Topics.java
+++ b/pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/admin/Topics.java
@@ -52,7 +52,8 @@ import org.apache.pulsar.common.policies.data.TopicStats;
 public interface Topics {
 
     enum QueryParam {
-        Bundle("bundle");
+        Bundle("bundle"),
+        WITH_SYSTEM_TOPIC("with_system_topic");
 
         public final String value;
 
@@ -248,6 +249,49 @@ public interface Topics {
      * @return a list of partitioned topics
      */
     CompletableFuture<List<String>> getPartitionedTopicListAsync(String namespace);
+
+    /**
+     * Get the list of partitioned topics under a namespace.
+     * <p/>
+     * Response example:
+     *
+     * <pre>
+     * <code>["persistent://my-tenant/my-namespace/topic-1",
+     *  "persistent://my-tenant/my-namespace/topic-2"]</code>
+     * </pre>
+     *
+     * @param namespace
+     *            Namespace name
+     * @param params
+     *            params to filter the results
+     * @return a list of partitioned topics
+     *
+     * @throws NotAuthorizedException
+     *             Don't have admin permission
+     * @throws NotFoundException
+     *             Namespace does not exist
+     * @throws PulsarAdminException
+     *             Unexpected error
+     */
+    List<String> getPartitionedTopicList(String namespace, Map<QueryParam, Object> params) throws PulsarAdminException;
+
+    /**
+     * Get the list of partitioned topics under a namespace asynchronously.
+     * <p/>
+     * Response example:
+     *
+     * <pre>
+     * <code>["persistent://my-tenant/my-namespace/topic-1",
+     *  "persistent://my-tenant/my-namespace/topic-2"]</code>
+     * </pre>
+     *
+     * @param namespace
+     *            Namespace name
+     * @param params
+     *           params to filter the results
+     * @return a list of partitioned topics
+     */
+    CompletableFuture<List<String>> getPartitionedTopicListAsync(String namespace, Map<QueryParam, Object> params);
 
     /**
      * Get list of topics exist into given bundle.

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/TopicsImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/TopicsImpl.java
@@ -235,18 +235,18 @@ public class TopicsImpl extends BaseResource implements Topics {
 
     @Override
     public List<String> getPartitionedTopicList(String namespace) throws PulsarAdminException {
-        return getPartitionedTopicList(namespace, null);
-    }
-
-    @Override
-    public CompletableFuture<List<String>> getPartitionedTopicListAsync(String namespace) {
-        return getPartitionedTopicListAsync(namespace, ListTopicsOptions.EMPTY);
+        return getPartitionedTopicList(namespace, ListTopicsOptions.EMPTY);
     }
 
     @Override
     public List<String> getPartitionedTopicList(String namespace, ListTopicsOptions options)
             throws PulsarAdminException {
         return sync(() -> getPartitionedTopicListAsync(namespace, options));
+    }
+
+    @Override
+    public CompletableFuture<List<String>> getPartitionedTopicListAsync(String namespace) {
+        return getPartitionedTopicListAsync(namespace, ListTopicsOptions.EMPTY);
     }
 
     @Override

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/TopicsImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/TopicsImpl.java
@@ -150,7 +150,7 @@ public class TopicsImpl extends BaseResource implements Topics {
             throws PulsarAdminException {
         ListTopicsOptions options = ListTopicsOptions
                 .builder()
-                .bundle((String) params.get(QueryParam.Bundle.value))
+                .bundle((String) params.get(QueryParam.Bundle))
                 .build();
         return getList(namespace, topicDomain, options);
     }

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/TopicsImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/TopicsImpl.java
@@ -43,6 +43,7 @@ import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 import org.apache.pulsar.client.admin.GetStatsOptions;
+import org.apache.pulsar.client.admin.ListTopicsOptions;
 import org.apache.pulsar.client.admin.LongRunningProcessStatus;
 import org.apache.pulsar.client.admin.OffloadProcessStatus;
 import org.apache.pulsar.client.admin.PulsarAdminException;
@@ -136,18 +137,28 @@ public class TopicsImpl extends BaseResource implements Topics {
 
     @Override
     public List<String> getList(String namespace) throws PulsarAdminException {
-        return getList(namespace, null, null);
+        return getList(namespace, null);
     }
 
     @Override
     public List<String> getList(String namespace, TopicDomain topicDomain) throws PulsarAdminException {
-        return getList(namespace, topicDomain, Collections.emptyMap());
+        return getList(namespace, topicDomain, ListTopicsOptions.EMPTY);
     }
 
     @Override
     public List<String> getList(String namespace, TopicDomain topicDomain, Map<QueryParam, Object> params)
             throws PulsarAdminException {
-        return sync(() -> getListAsync(namespace, topicDomain, params));
+        ListTopicsOptions options = ListTopicsOptions
+                .builder()
+                .bundle((String) params.get(QueryParam.Bundle.value))
+                .build();
+        return getList(namespace, topicDomain, options);
+    }
+
+    @Override
+    public List<String> getList(String namespace, TopicDomain topicDomain, ListTopicsOptions options)
+            throws PulsarAdminException {
+        return sync(() -> getListAsync(namespace, topicDomain, options));
     }
 
     @Override
@@ -157,21 +168,31 @@ public class TopicsImpl extends BaseResource implements Topics {
 
     @Override
     public CompletableFuture<List<String>> getListAsync(String namespace, TopicDomain topicDomain) {
-        return getListAsync(namespace, topicDomain, Collections.emptyMap());
+        return getListAsync(namespace, topicDomain, ListTopicsOptions.EMPTY);
     }
 
     @Override
     public CompletableFuture<List<String>> getListAsync(String namespace, TopicDomain topicDomain,
-            Map<QueryParam, Object> params) {
+                                                        Map<QueryParam, Object> params) {
+        ListTopicsOptions options = ListTopicsOptions
+                .builder()
+                .bundle((String) params.get(QueryParam.Bundle.value))
+                .build();
+        return getListAsync(namespace, topicDomain, options);
+    }
+
+    @Override
+    public CompletableFuture<List<String>> getListAsync(String namespace, TopicDomain topicDomain,
+                                                        ListTopicsOptions options) {
         NamespaceName ns = NamespaceName.get(namespace);
         WebTarget persistentPath = namespacePath("persistent", ns);
         WebTarget nonPersistentPath = namespacePath("non-persistent", ns);
-        if (params != null && !params.isEmpty()) {
-            for (Entry<QueryParam, Object> param : params.entrySet()) {
-                persistentPath = persistentPath.queryParam(param.getKey().value, param.getValue());
-                nonPersistentPath = nonPersistentPath.queryParam(param.getKey().value, param.getValue());
-            }
-        }
+        persistentPath = persistentPath
+                .queryParam("bundle", options.getBundle())
+                .queryParam("includeSystemTopic", options.isIncludeSystemTopic());
+        nonPersistentPath = nonPersistentPath
+                .queryParam("bundle", options.getBundle())
+                .queryParam("includeSystemTopic", options.isIncludeSystemTopic());
         final CompletableFuture<List<String>> persistentList = new CompletableFuture<>();
         final CompletableFuture<List<String>> nonPersistentList = new CompletableFuture<>();
         if (topicDomain == null || TopicDomain.persistent.equals(topicDomain)) {
@@ -214,32 +235,27 @@ public class TopicsImpl extends BaseResource implements Topics {
 
     @Override
     public List<String> getPartitionedTopicList(String namespace) throws PulsarAdminException {
-        return getPartitionedTopicList(namespace, Collections.emptyMap());
+        return getPartitionedTopicList(namespace, null);
     }
 
     @Override
     public CompletableFuture<List<String>> getPartitionedTopicListAsync(String namespace) {
-        return getPartitionedTopicListAsync(namespace, Collections.emptyMap());
+        return getPartitionedTopicListAsync(namespace, ListTopicsOptions.EMPTY);
     }
 
     @Override
-    public List<String> getPartitionedTopicList(String namespace, Map<QueryParam, Object> params)
+    public List<String> getPartitionedTopicList(String namespace, ListTopicsOptions options)
             throws PulsarAdminException {
-        return sync(() -> getPartitionedTopicListAsync(namespace, params));
+        return sync(() -> getPartitionedTopicListAsync(namespace, options));
     }
 
     @Override
-    public CompletableFuture<List<String>> getPartitionedTopicListAsync(String namespace,
-                                                                        Map<QueryParam, Object> params) {
+    public CompletableFuture<List<String>> getPartitionedTopicListAsync(String namespace, ListTopicsOptions options) {
         NamespaceName ns = NamespaceName.get(namespace);
         WebTarget persistentPath = namespacePath("persistent", ns, "partitioned");
         WebTarget nonPersistentPath = namespacePath("non-persistent", ns, "partitioned");
-        if (params != null && !params.isEmpty()) {
-            for (Entry<QueryParam, Object> param : params.entrySet()) {
-                persistentPath = persistentPath.queryParam(param.getKey().value, param.getValue());
-                nonPersistentPath = nonPersistentPath.queryParam(param.getKey().value, param.getValue());
-            }
-        }
+        persistentPath = persistentPath.queryParam("includeSystemTopic", options.isIncludeSystemTopic());
+        nonPersistentPath = nonPersistentPath.queryParam("includeSystemTopic", options.isIncludeSystemTopic());
         final CompletableFuture<List<String>> persistentList = new CompletableFuture<>();
         final CompletableFuture<List<String>> nonPersistentList = new CompletableFuture<>();
         asyncGetRequest(persistentPath,

--- a/pulsar-client-tools-test/src/test/java/org/apache/pulsar/admin/cli/PulsarAdminToolTest.java
+++ b/pulsar-client-tools-test/src/test/java/org/apache/pulsar/admin/cli/PulsarAdminToolTest.java
@@ -1858,7 +1858,7 @@ public class PulsarAdminToolTest {
         verify(mockTopics).createPartitionedTopic("non-persistent://myprop/ns1/ds1", 32, null);
 
         topics.run(split("list myprop/ns1"));
-        verify(mockTopics).getList("myprop/ns1", null, null);
+        verify(mockTopics).getList("myprop/ns1", null, Collections.singletonMap(Topics.QueryParam.Include_System_Topic, false));
 
         NonPersistentTopics mockNonPersistentTopics = mock(NonPersistentTopics.class);
         when(admin.nonPersistentTopics()).thenReturn(mockNonPersistentTopics);

--- a/pulsar-client-tools-test/src/test/java/org/apache/pulsar/admin/cli/PulsarAdminToolTest.java
+++ b/pulsar-client-tools-test/src/test/java/org/apache/pulsar/admin/cli/PulsarAdminToolTest.java
@@ -48,6 +48,7 @@ import org.apache.pulsar.client.admin.Bookies;
 import org.apache.pulsar.client.admin.BrokerStats;
 import org.apache.pulsar.client.admin.Brokers;
 import org.apache.pulsar.client.admin.Clusters;
+import org.apache.pulsar.client.admin.ListTopicsOptions;
 import org.apache.pulsar.client.admin.LongRunningProcessStatus;
 import org.apache.pulsar.client.admin.Lookup;
 import org.apache.pulsar.client.admin.Namespaces;
@@ -1316,7 +1317,7 @@ public class PulsarAdminToolTest {
         verify(mockTopics).revokePermissions("persistent://myprop/clust/ns1/ds1", "admin");
 
         cmdTopics.run(split("list myprop/clust/ns1"));
-        verify(mockTopics).getList("myprop/clust/ns1", null, Collections.singletonMap(Topics.QueryParam.Include_System_Topic, false));
+        verify(mockTopics).getList("myprop/clust/ns1", null, ListTopicsOptions.EMPTY);
 
         cmdTopics.run(split("lookup persistent://myprop/clust/ns1/ds1"));
         verify(mockLookup).lookupTopic("persistent://myprop/clust/ns1/ds1");
@@ -1425,7 +1426,7 @@ public class PulsarAdminToolTest {
         verify(mockTopics).createNonPartitionedTopic("persistent://myprop/clust/ns1/ds1", new HashMap<>());
 
         cmdTopics.run(split("list-partitioned-topics myprop/clust/ns1"));
-        verify(mockTopics).getPartitionedTopicList("myprop/clust/ns1", Collections.singletonMap(Topics.QueryParam.Include_System_Topic, false));
+        verify(mockTopics).getPartitionedTopicList("myprop/clust/ns1", ListTopicsOptions.EMPTY);
 
         cmdTopics.run(split("update-partitioned-topic persistent://myprop/clust/ns1/ds1 -p 6"));
         verify(mockTopics).updatePartitionedTopic("persistent://myprop/clust/ns1/ds1", 6, false, false);
@@ -1858,7 +1859,7 @@ public class PulsarAdminToolTest {
         verify(mockTopics).createPartitionedTopic("non-persistent://myprop/ns1/ds1", 32, null);
 
         topics.run(split("list myprop/ns1"));
-        verify(mockTopics).getList("myprop/ns1", null, Collections.singletonMap(Topics.QueryParam.Include_System_Topic, false));
+        verify(mockTopics).getList("myprop/ns1", null, ListTopicsOptions.EMPTY);
 
         NonPersistentTopics mockNonPersistentTopics = mock(NonPersistentTopics.class);
         when(admin.nonPersistentTopics()).thenReturn(mockNonPersistentTopics);

--- a/pulsar-client-tools-test/src/test/java/org/apache/pulsar/admin/cli/PulsarAdminToolTest.java
+++ b/pulsar-client-tools-test/src/test/java/org/apache/pulsar/admin/cli/PulsarAdminToolTest.java
@@ -1316,7 +1316,7 @@ public class PulsarAdminToolTest {
         verify(mockTopics).revokePermissions("persistent://myprop/clust/ns1/ds1", "admin");
 
         cmdTopics.run(split("list myprop/clust/ns1"));
-        verify(mockTopics).getList("myprop/clust/ns1", null, null);
+        verify(mockTopics).getList("myprop/clust/ns1", null, Collections.singletonMap(Topics.QueryParam.Include_System_Topic, false));
 
         cmdTopics.run(split("lookup persistent://myprop/clust/ns1/ds1"));
         verify(mockLookup).lookupTopic("persistent://myprop/clust/ns1/ds1");
@@ -1425,7 +1425,7 @@ public class PulsarAdminToolTest {
         verify(mockTopics).createNonPartitionedTopic("persistent://myprop/clust/ns1/ds1", new HashMap<>());
 
         cmdTopics.run(split("list-partitioned-topics myprop/clust/ns1"));
-        verify(mockTopics).getPartitionedTopicList("myprop/clust/ns1");
+        verify(mockTopics).getPartitionedTopicList("myprop/clust/ns1", Collections.singletonMap(Topics.QueryParam.Include_System_Topic, false));
 
         cmdTopics.run(split("update-partitioned-topic persistent://myprop/clust/ns1/ds1 -p 6"));
         verify(mockTopics).updatePartitionedTopic("persistent://myprop/clust/ns1/ds1", 6, false, false);

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdTopics.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdTopics.java
@@ -374,11 +374,19 @@ public class CmdTopics extends CmdBase {
                 "--bundle" }, description = "Namespace bundle to get list of topics")
         private String bundle;
 
+        @Parameter(names = { "-wst",
+                "--with-system-topic" }, description = "Include system topic")
+        private boolean withSystemTopic;
+
         @Override
         void run() throws PulsarAdminException {
             String namespace = validateNamespace(params);
-            print(getTopics().getList(namespace, topicDomain,
-                    StringUtils.isNotBlank(bundle) ? Collections.singletonMap(QueryParam.Bundle, bundle) : null));
+            Map<QueryParam, Object> queryMap = new HashMap<>();
+            if (StringUtils.isNotBlank(bundle)) {
+                queryMap.put(QueryParam.Bundle, bundle);
+            }
+            queryMap.put(QueryParam.WITH_SYSTEM_TOPIC, withSystemTopic);
+            print(getTopics().getList(namespace, topicDomain, queryMap));
         }
     }
 
@@ -387,10 +395,15 @@ public class CmdTopics extends CmdBase {
         @Parameter(description = "tenant/namespace", required = true)
         private java.util.List<String> params;
 
+        @Parameter(names = { "-wst",
+                "--with-system-topic" }, description = "Include system topic")
+        private boolean withSystemTopic;
+
         @Override
         void run() throws PulsarAdminException {
             String namespace = validateNamespace(params);
-            print(getTopics().getPartitionedTopicList(namespace));
+            print(getTopics().getPartitionedTopicList(namespace,
+                    Collections.singletonMap(QueryParam.WITH_SYSTEM_TOPIC, withSystemTopic)));
         }
     }
 

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdTopics.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdTopics.java
@@ -33,7 +33,6 @@ import io.netty.buffer.ByteBufUtil;
 import io.netty.buffer.Unpooled;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedList;
@@ -46,13 +45,12 @@ import java.util.concurrent.TimeoutException;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import lombok.Getter;
-import org.apache.commons.lang3.StringUtils;
+import org.apache.pulsar.client.admin.ListTopicsOptions;
 import org.apache.pulsar.client.admin.LongRunningProcessStatus;
 import org.apache.pulsar.client.admin.OffloadProcessStatus;
 import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.admin.PulsarAdminException;
 import org.apache.pulsar.client.admin.Topics;
-import org.apache.pulsar.client.admin.Topics.QueryParam;
 import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.client.api.SubscriptionType;
@@ -381,12 +379,11 @@ public class CmdTopics extends CmdBase {
         @Override
         void run() throws PulsarAdminException {
             String namespace = validateNamespace(params);
-            Map<QueryParam, Object> queryMap = new HashMap<>();
-            if (StringUtils.isNotBlank(bundle)) {
-                queryMap.put(QueryParam.Bundle, bundle);
-            }
-            queryMap.put(QueryParam.Include_System_Topic, includeSystemTopic);
-            print(getTopics().getList(namespace, topicDomain, queryMap));
+            ListTopicsOptions options = ListTopicsOptions.builder()
+                    .bundle(bundle)
+                    .includeSystemTopic(includeSystemTopic)
+                    .build();
+            print(getTopics().getList(namespace, topicDomain, options));
         }
     }
 
@@ -402,8 +399,8 @@ public class CmdTopics extends CmdBase {
         @Override
         void run() throws PulsarAdminException {
             String namespace = validateNamespace(params);
-            print(getTopics().getPartitionedTopicList(namespace,
-                    Collections.singletonMap(QueryParam.Include_System_Topic, includeSystemTopic)));
+            ListTopicsOptions options = ListTopicsOptions.builder().includeSystemTopic(includeSystemTopic).build();
+            print(getTopics().getPartitionedTopicList(namespace, options));
         }
     }
 

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdTopics.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdTopics.java
@@ -374,9 +374,9 @@ public class CmdTopics extends CmdBase {
                 "--bundle" }, description = "Namespace bundle to get list of topics")
         private String bundle;
 
-        @Parameter(names = { "-wst",
-                "--with-system-topic" }, description = "Include system topic")
-        private boolean withSystemTopic;
+        @Parameter(names = { "-ist",
+                "--include-system-topic" }, description = "Include system topic")
+        private boolean includeSystemTopic;
 
         @Override
         void run() throws PulsarAdminException {
@@ -385,7 +385,7 @@ public class CmdTopics extends CmdBase {
             if (StringUtils.isNotBlank(bundle)) {
                 queryMap.put(QueryParam.Bundle, bundle);
             }
-            queryMap.put(QueryParam.WITH_SYSTEM_TOPIC, withSystemTopic);
+            queryMap.put(QueryParam.Include_System_Topic, includeSystemTopic);
             print(getTopics().getList(namespace, topicDomain, queryMap));
         }
     }
@@ -395,15 +395,15 @@ public class CmdTopics extends CmdBase {
         @Parameter(description = "tenant/namespace", required = true)
         private java.util.List<String> params;
 
-        @Parameter(names = { "-wst",
-                "--with-system-topic" }, description = "Include system topic")
-        private boolean withSystemTopic;
+        @Parameter(names = { "-ist",
+                "--include-system-topic" }, description = "Include system topic")
+        private boolean includeSystemTopic;
 
         @Override
         void run() throws PulsarAdminException {
             String namespace = validateNamespace(params);
             print(getTopics().getPartitionedTopicList(namespace,
-                    Collections.singletonMap(QueryParam.WITH_SYSTEM_TOPIC, withSystemTopic)));
+                    Collections.singletonMap(QueryParam.Include_System_Topic, includeSystemTopic)));
         }
     }
 

--- a/pulsar-client-tools/src/test/java/org/apache/pulsar/admin/cli/TestCmdTopics.java
+++ b/pulsar-client-tools/src/test/java/org/apache/pulsar/admin/cli/TestCmdTopics.java
@@ -36,6 +36,7 @@ import java.io.PrintStream;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import org.apache.pulsar.client.admin.ListTopicsOptions;
 import org.apache.pulsar.client.admin.Lookup;
 import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.admin.Schemas;
@@ -113,7 +114,7 @@ public class TestCmdTopics {
 
         Topics topics = mock(Topics.class);
         doReturn(topicList).when(topics).getList(anyString(), any());
-        doReturn(topicList).when(topics).getList(anyString(), any(), any());
+        doReturn(topicList).when(topics).getList(anyString(), any(), any(ListTopicsOptions.class));
 
         PulsarAdmin admin = mock(PulsarAdmin.class);
         when(admin.topics()).thenReturn(topics);


### PR DESCRIPTION
### Motivation
When users use CLI or REST to get topic list, there is going to show all the topics including system topics. This may confuse users, because of not created by themselves.

In this patch, I decided to add an option `--include-system-topic` when getting the topic list.   The default value if `false`, only show user-created topics.

### Modification

- Add `--include-system-topic` for `list` and `list-partitioned-topics` for CLI.
- Use `ListTopicsOptions` instead of Map as the query condition.
- Deprecate `getList(String namespace, TopicDomain topicDomain, Map<QueryParam, Object> params)`

### Documentation

 
- [x] `no-need-doc` 
(Please explain why)
