### PR TITLE
[Java Client] Fix wrong behavior of deduplication for key based batching

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/BatchMessageContainerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/BatchMessageContainerImpl.java
@@ -65,7 +65,7 @@ class BatchMessageContainerImpl extends AbstractBatchMessageContainer {
     }
 
     public BatchMessageContainerImpl(ProducerImpl<?> producer) {
-        super();
+        this();
         setProducer(producer);
     }
 

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/BatchMessageContainerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/BatchMessageContainerImpl.java
@@ -19,10 +19,13 @@
 package org.apache.pulsar.client.impl;
 
 import io.netty.buffer.ByteBuf;
+import io.netty.util.ReferenceCountUtil;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import lombok.Getter;
+import lombok.Setter;
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.impl.ProducerImpl.OpSendMsg;
 import org.apache.pulsar.common.allocator.PulsarByteBufAllocator;
@@ -46,13 +49,27 @@ class BatchMessageContainerImpl extends AbstractBatchMessageContainer {
 
     private MessageMetadata messageMetadata = new MessageMetadata();
     // sequence id for this batch which will be persisted as a single entry by broker
+    @Getter
+    @Setter
     private long lowestSequenceId = -1L;
+    @Getter
+    @Setter
     private long highestSequenceId = -1L;
     private ByteBuf batchedMessageMetadataAndPayload;
     private List<MessageImpl<?>> messages = new ArrayList<>();
     protected SendCallback previousCallback = null;
     // keep track of callbacks for individual messages being published in a batch
     protected SendCallback firstCallback;
+    @Getter
+    private boolean added = false;
+
+    public BatchMessageContainerImpl() {
+    }
+
+    public BatchMessageContainerImpl(ProducerImpl<?> producer) {
+        super();
+        setProducer(producer);
+    }
 
     @Override
     public boolean add(MessageImpl<?> msg, SendCallback callback) {
@@ -78,6 +95,7 @@ class BatchMessageContainerImpl extends AbstractBatchMessageContainer {
                     currentTxnidLeastBits = msg.getMessageBuilder().getTxnidLeastBits();
                 }
             } catch (Throwable e) {
+                added = false;
                 log.error("construct first message failed, exception is ", e);
                 if (batchedMessageMetadataAndPayload != null) {
                     // if payload has been allocated release it
@@ -101,7 +119,7 @@ class BatchMessageContainerImpl extends AbstractBatchMessageContainer {
         }
         highestSequenceId = msg.getSequenceId();
         ProducerImpl.LAST_SEQ_ID_PUSHED_UPDATER.getAndUpdate(producer, prev -> Math.max(prev, msg.getSequenceId()));
-
+        added = true;
         return isBatchFull();
     }
 
@@ -169,6 +187,10 @@ class BatchMessageContainerImpl extends AbstractBatchMessageContainer {
             if (firstCallback != null) {
                 firstCallback.sendComplete(ex);
             }
+            if (batchedMessageMetadataAndPayload != null) {
+                ReferenceCountUtil.safeRelease(batchedMessageMetadataAndPayload);
+                batchedMessageMetadataAndPayload = null;
+            }
         } catch (Throwable t) {
             log.warn("[{}] [{}] Got exception while completing the callback for msg {}:", topicName, producerName,
                     lowestSequenceId, t);
@@ -190,6 +212,7 @@ class BatchMessageContainerImpl extends AbstractBatchMessageContainer {
             return null;
         }
         messageMetadata.setNumMessagesInBatch(numMessagesInBatch);
+        messageMetadata.setSequenceId(lowestSequenceId);
         messageMetadata.setHighestSequenceId(highestSequenceId);
         if (currentTxnidMostBits != -1) {
             messageMetadata.setTxnidMostBits(currentTxnidMostBits);

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/BatchMessageContainerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/BatchMessageContainerImpl.java
@@ -60,8 +60,6 @@ class BatchMessageContainerImpl extends AbstractBatchMessageContainer {
     protected SendCallback previousCallback = null;
     // keep track of callbacks for individual messages being published in a batch
     protected SendCallback firstCallback;
-    @Getter
-    private boolean added = false;
 
     public BatchMessageContainerImpl() {
     }
@@ -95,12 +93,7 @@ class BatchMessageContainerImpl extends AbstractBatchMessageContainer {
                     currentTxnidLeastBits = msg.getMessageBuilder().getTxnidLeastBits();
                 }
             } catch (Throwable e) {
-                added = false;
                 log.error("construct first message failed, exception is ", e);
-                if (batchedMessageMetadataAndPayload != null) {
-                    // if payload has been allocated release it
-                    batchedMessageMetadataAndPayload.release();
-                }
                 discard(new PulsarClientException(e));
                 return false;
             }
@@ -119,7 +112,6 @@ class BatchMessageContainerImpl extends AbstractBatchMessageContainer {
         }
         highestSequenceId = msg.getSequenceId();
         ProducerImpl.LAST_SEQ_ID_PUSHED_UPDATER.getAndUpdate(producer, prev -> Math.max(prev, msg.getSequenceId()));
-        added = true;
         return isBatchFull();
     }
 

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/BatchMessageKeyBasedContainer.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/BatchMessageKeyBasedContainer.java
@@ -18,23 +18,12 @@
  */
 package org.apache.pulsar.client.impl;
 
-import com.google.common.collect.ComparisonChain;
-import io.netty.buffer.ByteBuf;
-import io.netty.util.ReferenceCountUtil;
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Base64;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import org.apache.pulsar.client.api.PulsarClientException;
-import org.apache.pulsar.common.allocator.PulsarByteBufAllocator;
-import org.apache.pulsar.common.api.proto.CompressionType;
-import org.apache.pulsar.common.api.proto.MessageMetadata;
-import org.apache.pulsar.common.compression.CompressionCodec;
-import org.apache.pulsar.common.protocol.ByteBufPair;
-import org.apache.pulsar.common.protocol.Commands;
+import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -49,7 +38,7 @@ import org.slf4j.LoggerFactory;
  */
 class BatchMessageKeyBasedContainer extends AbstractBatchMessageContainer {
 
-    private Map<String, KeyedBatch> batches = new HashMap<>();
+    private final Map<String, BatchMessageContainerImpl> batches = new HashMap<>();
 
     @Override
     public boolean add(MessageImpl<?> msg, SendCallback callback) {
@@ -57,29 +46,13 @@ class BatchMessageKeyBasedContainer extends AbstractBatchMessageContainer {
             log.debug("[{}] [{}] add message to batch, num messages in batch so far is {}", topicName, producerName,
                     numMessagesInBatch);
         }
-        numMessagesInBatch++;
-        currentBatchSizeBytes += msg.getDataBuffer().readableBytes();
         String key = getKey(msg);
-        KeyedBatch part = batches.get(key);
-        if (part == null) {
-            part = new KeyedBatch();
-            part.addMsg(msg, callback);
-            part.compressionType = compressionType;
-            part.compressor = compressor;
-            part.maxBatchSize = maxBatchSize;
-            part.topicName = topicName;
-            part.producerName = producerName;
-            batches.putIfAbsent(key, part);
-
-            if (msg.getMessageBuilder().hasTxnidMostBits() && currentTxnidMostBits == -1) {
-                currentTxnidMostBits = msg.getMessageBuilder().getTxnidMostBits();
-            }
-            if (msg.getMessageBuilder().hasTxnidLeastBits() && currentTxnidLeastBits == -1) {
-                currentTxnidLeastBits = msg.getMessageBuilder().getTxnidLeastBits();
-            }
-
-        } else {
-            part.addMsg(msg, callback);
+        final BatchMessageContainerImpl batchMessageContainer = batches.computeIfAbsent(key,
+                __ -> new BatchMessageContainerImpl(producer));
+        batchMessageContainer.add(msg, callback);
+        if (batchMessageContainer.isAdded()) {
+            numMessagesInBatch++;
+            currentBatchSizeBytes += msg.getDataBuffer().readableBytes();
         }
         return isBatchFull();
     }
@@ -88,7 +61,7 @@ class BatchMessageKeyBasedContainer extends AbstractBatchMessageContainer {
     public void clear() {
         numMessagesInBatch = 0;
         currentBatchSizeBytes = 0;
-        batches = new HashMap<>();
+        batches.clear();
         currentTxnidMostBits = -1L;
         currentTxnidLeastBits = -1L;
     }
@@ -100,13 +73,7 @@ class BatchMessageKeyBasedContainer extends AbstractBatchMessageContainer {
 
     @Override
     public void discard(Exception ex) {
-        try {
-            // Need to protect ourselves from any exception being thrown in the future handler from the application
-            batches.forEach((k, v) -> v.firstCallback.sendComplete(ex));
-        } catch (Throwable t) {
-            log.warn("[{}] [{}] Got exception while completing the callback", topicName, producerName, t);
-        }
-        batches.forEach((k, v) -> ReferenceCountUtil.safeRelease(v.batchedMessageMetadataAndPayload));
+        batches.forEach((k, v) -> v.discard(ex));
         clear();
     }
 
@@ -115,66 +82,46 @@ class BatchMessageKeyBasedContainer extends AbstractBatchMessageContainer {
         return true;
     }
 
-    private ProducerImpl.OpSendMsg createOpSendMsg(KeyedBatch keyedBatch) throws IOException {
-        ByteBuf encryptedPayload = producer.encryptMessage(keyedBatch.messageMetadata,
-                keyedBatch.getCompressedBatchMetadataAndPayload());
-        if (encryptedPayload.readableBytes() > ClientCnx.getMaxMessageSize()) {
-            keyedBatch.discard(new PulsarClientException.InvalidMessageException(
-                    "Message size is bigger than " + ClientCnx.getMaxMessageSize() + " bytes"));
-            return null;
-        }
-
-        final int numMessagesInBatch = keyedBatch.messages.size();
-        long currentBatchSizeBytes = 0;
-        for (MessageImpl<?> message : keyedBatch.messages) {
-            currentBatchSizeBytes += message.getDataBuffer().readableBytes();
-        }
-        keyedBatch.messageMetadata.setNumMessagesInBatch(numMessagesInBatch);
-        if (currentTxnidMostBits != -1) {
-            keyedBatch.messageMetadata.setTxnidMostBits(currentTxnidMostBits);
-        }
-        if (currentTxnidLeastBits != -1) {
-            keyedBatch.messageMetadata.setTxnidLeastBits(currentTxnidLeastBits);
-        }
-        ByteBufPair cmd = producer.sendMessage(producer.producerId, keyedBatch.sequenceId, numMessagesInBatch,
-                keyedBatch.messageMetadata, encryptedPayload);
-
-        ProducerImpl.OpSendMsg op = ProducerImpl.OpSendMsg.create(
-                keyedBatch.messages, cmd, keyedBatch.sequenceId, keyedBatch.firstCallback);
-
-        op.setNumMessagesInBatch(numMessagesInBatch);
-        op.setBatchSizeByte(currentBatchSizeBytes);
-        return op;
-    }
-
     @Override
     public List<ProducerImpl.OpSendMsg> createOpSendMsgs() throws IOException {
-        List<ProducerImpl.OpSendMsg> result = new ArrayList<>();
-        List<KeyedBatch> list = new ArrayList<>(batches.values());
-        list.sort(((o1, o2) -> ComparisonChain.start()
-                .compare(o1.sequenceId, o2.sequenceId)
-                .result()));
-        for (KeyedBatch keyedBatch : list) {
-            ProducerImpl.OpSendMsg op = createOpSendMsg(keyedBatch);
-            if (op != null) {
-                result.add(op);
+        try {
+            // In key based batching, the sequence ids might not be ordered, for example,
+            // | key | sequence id list |
+            // | :-- | :--------------- |
+            // | A | 0, 3, 4 |
+            // | B | 1, 2 |
+            // The message order should be 1, 2, 0, 3, 4 so that a message with a sequence id <= 4 should be dropped.
+            // However, for a MessageMetadata with both `sequence_id` and `highest_sequence_id` fields, the broker will
+            // expect a strict order so that the batch of key "A" (0, 3, 4) will be dropped.
+            // Therefore, we should update the `sequence_id` field to the highest sequence id and remove the
+            // `highest_sequence_id` field to allow the weak order.
+            batches.values().forEach(batchMessageContainer -> {
+                batchMessageContainer.setLowestSequenceId(batchMessageContainer.getHighestSequenceId());
+                batchMessageContainer.setHighestSequenceId(-1L);
+            });
+            return batches.values().stream().sorted((o1, o2) ->
+                    (int) (o1.getLowestSequenceId() - o2.getLowestSequenceId())
+            ).map(batchMessageContainer -> {
+                try {
+                    return batchMessageContainer.createOpSendMsg();
+                } catch (IOException e) {
+                    throw new IllegalStateException(e);
+                }
+            }).collect(Collectors.toList());
+        } catch (IllegalStateException e) {
+            if (e.getCause() instanceof IOException) {
+                throw (IOException) e.getCause();
+            } else {
+                throw e;
             }
         }
-        return result;
     }
 
     @Override
     public boolean hasSameSchema(MessageImpl<?> msg) {
         String key = getKey(msg);
-        KeyedBatch part = batches.get(key);
-        if (part == null || part.messages.isEmpty()) {
-            return true;
-        }
-        if (!part.messageMetadata.hasSchemaVersion()) {
-            return msg.getSchemaVersion() == null;
-        }
-        return Arrays.equals(msg.getSchemaVersion(),
-                             part.messageMetadata.getSchemaVersion());
+        BatchMessageContainerImpl batchMessageContainer = batches.get(key);
+        return batchMessageContainer == null || batchMessageContainer.hasSameSchema(msg);
     }
 
     private String getKey(MessageImpl<?> msg) {
@@ -182,78 +129,6 @@ class BatchMessageKeyBasedContainer extends AbstractBatchMessageContainer {
             return Base64.getEncoder().encodeToString(msg.getOrderingKey());
         }
         return msg.getKey();
-    }
-
-    private static class KeyedBatch {
-        private final MessageMetadata messageMetadata = new MessageMetadata();
-        // sequence id for this batch which will be persisted as a single entry by broker
-        private long sequenceId = -1;
-        private ByteBuf batchedMessageMetadataAndPayload;
-        private List<MessageImpl<?>> messages = new ArrayList<>();
-        private SendCallback previousCallback = null;
-        private CompressionType compressionType;
-        private CompressionCodec compressor;
-        private int maxBatchSize;
-        private String topicName;
-        private String producerName;
-
-        // keep track of callbacks for individual messages being published in a batch
-        private SendCallback firstCallback;
-
-        private ByteBuf getCompressedBatchMetadataAndPayload() {
-            for (MessageImpl<?> msg : messages) {
-                batchedMessageMetadataAndPayload = Commands.serializeSingleMessageInBatchWithPayload(
-                        msg.getMessageBuilder(), msg.getDataBuffer(), batchedMessageMetadataAndPayload);
-            }
-            int uncompressedSize = batchedMessageMetadataAndPayload.readableBytes();
-            ByteBuf compressedPayload = compressor.encode(batchedMessageMetadataAndPayload);
-            batchedMessageMetadataAndPayload.release();
-            if (compressionType != CompressionType.NONE) {
-                messageMetadata.setCompression(compressionType);
-                messageMetadata.setUncompressedSize(uncompressedSize);
-            }
-
-            // Update the current max batch size using the uncompressed size, which is what we need in any case to
-            // accumulate the batch content
-            maxBatchSize = Math.max(maxBatchSize, uncompressedSize);
-            return compressedPayload;
-        }
-
-        private void addMsg(MessageImpl<?> msg, SendCallback callback) {
-            if (messages.size() == 0) {
-                sequenceId = Commands.initBatchMessageMetadata(messageMetadata, msg.getMessageBuilder());
-                batchedMessageMetadataAndPayload = PulsarByteBufAllocator.DEFAULT
-                        .buffer(Math.min(maxBatchSize, ClientCnx.getMaxMessageSize()));
-                firstCallback = callback;
-            }
-            if (previousCallback != null) {
-                previousCallback.addCallback(msg, callback);
-            }
-            previousCallback = callback;
-            messages.add(msg);
-        }
-
-        public void discard(Exception ex) {
-            try {
-                // Need to protect ourselves from any exception being thrown in the future handler from the application
-                if (firstCallback != null) {
-                    firstCallback.sendComplete(ex);
-                }
-            } catch (Throwable t) {
-                log.warn("[{}] [{}] Got exception while completing the callback for msg {}:", topicName, producerName,
-                        sequenceId, t);
-            }
-            clear();
-        }
-
-        public void clear() {
-            messages = new ArrayList<>();
-            firstCallback = null;
-            previousCallback = null;
-            messageMetadata.clear();
-            sequenceId = -1;
-            batchedMessageMetadataAndPayload = null;
-        }
     }
 
     private static final Logger log = LoggerFactory.getLogger(BatchMessageKeyBasedContainer.class);

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/protocol/Commands.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/protocol/Commands.java
@@ -520,7 +520,6 @@ public class Commands {
         if (highestSequenceId >= 0) {
             send.setHighestSequenceId(highestSequenceId);
         } else {
-            // For key based batching, we need to clear this field
             send.clearHighestSequenceId();
         }
         if (numMessages > 1) {

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/protocol/Commands.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/protocol/Commands.java
@@ -519,6 +519,9 @@ public class Commands {
                 .setSequenceId(sequenceId);
         if (highestSequenceId >= 0) {
             send.setHighestSequenceId(highestSequenceId);
+        } else {
+            // For key based batching, we need to clear this field
+            send.clearHighestSequenceId();
         }
         if (numMessages > 1) {
             send.setNumMessages(numMessages);

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/protocol/Commands.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/protocol/Commands.java
@@ -519,8 +519,6 @@ public class Commands {
                 .setSequenceId(sequenceId);
         if (highestSequenceId >= 0) {
             send.setHighestSequenceId(highestSequenceId);
-        } else {
-            send.clearHighestSequenceId();
         }
         if (numMessages > 1) {
             send.setNumMessages(numMessages);


### PR DESCRIPTION
### Motivation

Currently message deduplication doesn't work well for key based
batching. First, the key based batch container doesn't update the
`lastSequenceIdPushed`. So a batch could contain both duplicated and not
duplicated messages. Second, when `createOpSendMsgs` is called, the
`OpSendMsg` objects are sorted by the lowest sequence ids, and the
highest sequence id is not set. If a batch contains sequence id 0,1,2,
then the message with sequence id 1 or 2 won't be dropped.

### Modifications

- Refactor the key based batch container that the
  `BatchMessageContainerImpl` is reused instead of maintaining a
  `KeyedBatch` class.
- When `createOpSendMsgs` is called, clear the highest sequence id field
  and configure the sequence id field with the highest sequence id to fix
  the second issue described before.
- Add `testKeyBasedBatchingOrder` to show and verify the current
  behavior.
- Add test for key based batching into
  `testProducerDeduplicationWithDiscontinuousSequenceId` to verify
  `lastSlastSequenceIdPushed` is updated correctly.

### Documentation

Check the box below or label this PR directly.

Need to update docs? 

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)
  
- [x] `no-need-doc` 
(Please explain why)
  
- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-added`
(Docs have been already added)