### PR TITLE
[improve][component/connector]Replaced "Device" with "measurement"

### DIFF
--- a/pulsar-io/influxdb/src/main/java/org/apache/pulsar/io/influxdb/v2/InfluxDBSink.java
+++ b/pulsar-io/influxdb/src/main/java/org/apache/pulsar/io/influxdb/v2/InfluxDBSink.java
@@ -66,7 +66,7 @@ public class InfluxDBSink extends BatchSink<Point, GenericRecord> {
         // looking for measurement
         val measurementField = genericRecord.getField("measurement");
         if (null == measurementField) {
-            throw new SchemaSerializationException("device is a required field.");
+            throw new SchemaSerializationException("measurement is a required field.");
         }
         val measurement = (String) measurementField;
 


### PR DESCRIPTION
### Motivation

"measurement" is the actual mandatory field and the "device" error message is confusing in my opinion. Thus I propose to replace it so it is self-explainatory.

### Modifications

Replaced the word "device" (which is not a mandatory field) with "measurement" which is the correct one (check line 67)

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): no
  - The public API: no
  - The schema: no
  - The default values of configurations:  no
  - The wire protocol: no
  - The rest endpoints:  no
  - The admin cli options:  no
  - Anything that affects deployment:  no
(I am not really pro in Pulsar nor java, but my understanding is that this will only affect people trying to configure topics correctly)

### Documentation

Need to update docs? 

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)
  
- [x] `no-need-doc` 
At the moment there is no documentation as how the messages have to be built for the connector to be able to process them. Might want to do this documentation in the future, but first I need to figure out how & where to do that:) 
  
- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-added`
(Docs have been already added)