### PR TITLE
[doc][elasticsearch-sink] Remove 'compatibilityMode' from the Pulsar 2.10 docs

### DIFF
--- a/site2/website/versioned_docs/version-2.10.0/io-elasticsearch-sink.md
+++ b/site2/website/versioned_docs/version-2.10.0/io-elasticsearch-sink.md
@@ -78,7 +78,6 @@ The configuration of the Elasticsearch sink connector has the following properti
 | `username` | String| false |" " (empty string)| The username used by the connector to connect to the elastic search cluster. <br><br>If `username` is set, then `password` should also be provided. |
 | `password` | String| false | " " (empty string)|The password used by the connector to connect to the elastic search cluster. <br><br>If `username` is set, then `password` should also be provided.  |
 | `ssl` | ElasticSearchSslConfig | false |  | Configuration for TLS encrypted communication |
-| `compatibilityMode` | enum (AUTO,ELASTICSEARCH,ELASTICSEARCH_7,OPENSEARCH) | AUTO |  | Specify compatibility mode with the ElasticSearch cluster. `AUTO` value will try to auto detect the correct compatibility mode to use. Use `ELASTICSEARCH_7` if the target cluster is running ElasticSearch 7 or prior. Use `ELASTICSEARCH` if the target cluster is running ElasticSearch 8 or higher. Use `OPENSEARCH` if the target cluster is running OpenSearch. |
 
 ### Definition of ElasticSearchSslConfig structure:
 


### PR DESCRIPTION
### Motivation
ElasticSearch Sink configuration doc contains a parameter which is not included in Pulsar 2.10.0
The parameter is `compatibilityMode`.

https://pulsar.apache.org/docs/en/io-elasticsearch-sink/#configuration
https://github.com/apache/pulsar/pull/14805

### Modifications

Removed the parameter from 2.10 doc
  
- [x] `doc` 
