### PR TITLE
[feat][elasticsearch] Add hashed id support

### DIFF
--- a/pulsar-io/elastic-search/src/main/java/org/apache/pulsar/io/elasticsearch/ElasticSearchConfig.java
+++ b/pulsar-io/elastic-search/src/main/java/org/apache/pulsar/io/elasticsearch/ElasticSearchConfig.java
@@ -287,6 +287,13 @@ public class ElasticSearchConfig implements Serializable {
     )
     private boolean stripNonPrintableCharacters = true;
 
+    @FieldDoc(
+            defaultValue = "NONE",
+            help = "Hashing algorithm to use for the document id. This is useful in order to be compliant with "
+                    + "the ElasticSearch _id hard limit of 512 bytes."
+    )
+    private IdHashingAlgorithm idHashingAlgorithm = IdHashingAlgorithm.NONE;
+
     public enum MalformedDocAction {
         IGNORE,
         WARN,
@@ -304,6 +311,12 @@ public class ElasticSearchConfig implements Serializable {
         ELASTICSEARCH_7,
         ELASTICSEARCH,
         OPENSEARCH
+    }
+
+    public enum IdHashingAlgorithm {
+        NONE,
+        SHA256,
+        SHA512
     }
 
     public static ElasticSearchConfig load(String yamlFile) throws IOException {

--- a/pulsar-io/elastic-search/src/main/java/org/apache/pulsar/io/elasticsearch/client/RestClient.java
+++ b/pulsar-io/elastic-search/src/main/java/org/apache/pulsar/io/elasticsearch/client/RestClient.java
@@ -101,6 +101,7 @@ public abstract class RestClient implements Closeable {
     public abstract boolean deleteDocument(String index, String documentId) throws IOException;
 
     public abstract long totalHits(String index) throws IOException;
+    public abstract long totalHits(String index, String query) throws IOException;
 
     public abstract BulkProcessor getBulkProcessor();
 

--- a/pulsar-io/elastic-search/src/main/java/org/apache/pulsar/io/elasticsearch/client/elastic/ElasticSearchJavaRestClient.java
+++ b/pulsar-io/elastic-search/src/main/java/org/apache/pulsar/io/elasticsearch/client/elastic/ElasticSearchJavaRestClient.java
@@ -157,19 +157,29 @@ public class ElasticSearchJavaRestClient extends RestClient {
         }
     }
 
-    @VisibleForTesting
     public SearchResponse<Map> search(String indexName) throws IOException {
+        return search(indexName, "*:*");
+    }
+
+    @VisibleForTesting
+    public SearchResponse<Map> search(String indexName, String query) throws IOException {
         final RefreshRequest refreshRequest = new RefreshRequest.Builder().index(indexName).build();
         client.indices().refresh(refreshRequest);
 
+        query = query.replace("/", "\\/");
         return client.search(new SearchRequest.Builder().index(indexName)
-                .q("*:*")
+                .q(query)
                 .build(), Map.class);
     }
 
     @Override
     public long totalHits(String indexName) throws IOException {
-        final SearchResponse<Map> searchResponse = search(indexName);
+        return totalHits(indexName, "*:*");
+    }
+
+    @Override
+    public long totalHits(String indexName, String query) throws IOException {
+        final SearchResponse<Map> searchResponse = search(indexName, query);
         return searchResponse.hits().total().value();
     }
 

--- a/pulsar-io/elastic-search/src/test/java/org/apache/pulsar/io/elasticsearch/ElasticSearchConfigTests.java
+++ b/pulsar-io/elastic-search/src/test/java/org/apache/pulsar/io/elasticsearch/ElasticSearchConfigTests.java
@@ -109,6 +109,7 @@ public class ElasticSearchConfigTests {
         assertEquals(config.getSsl().getProtocols(), "TLSv1.2");
 
         assertEquals(config.getCompatibilityMode(), ElasticSearchConfig.CompatibilityMode.AUTO);
+        assertEquals(config.getIdHashingAlgorithm(), ElasticSearchConfig.IdHashingAlgorithm.NONE);
     }
 
     @Test

--- a/pulsar-io/elastic-search/src/test/java/org/apache/pulsar/io/elasticsearch/ElasticSearchSinkTests.java
+++ b/pulsar-io/elastic-search/src/test/java/org/apache/pulsar/io/elasticsearch/ElasticSearchSinkTests.java
@@ -40,12 +40,17 @@ import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
 
 import java.nio.charset.StandardCharsets;
-import java.util.concurrent.TimeUnit;
-import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
+import java.io.IOException;
+import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.apache.pulsar.functions.api.Record;
 import org.apache.pulsar.io.core.SinkContext;
 import org.apache.pulsar.io.elasticsearch.client.BulkProcessor;
@@ -67,19 +72,7 @@ import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
-<<<<<<< HEAD
-=======
-import java.util.Locale;
-import java.io.IOException;
-import java.util.HashMap;
-import java.util.Locale;
-import java.util.Map;
-import java.util.Optional;
-import java.util.UUID;
-import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
->>>>>>> 06dd1826954 ([feat][elasticsearch] Add hashed id support)
+
 
 import static org.testng.Assert.assertNull;
 

--- a/pulsar-io/elastic-search/src/test/java/org/apache/pulsar/io/elasticsearch/ElasticSearchSinkTests.java
+++ b/pulsar-io/elastic-search/src/test/java/org/apache/pulsar/io/elasticsearch/ElasticSearchSinkTests.java
@@ -25,6 +25,8 @@ import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.client.api.schema.GenericObject;
 import org.apache.pulsar.client.api.schema.GenericRecord;
 import org.apache.pulsar.client.api.schema.GenericSchema;
+import org.apache.pulsar.client.api.schema.RecordSchemaBuilder;
+import org.apache.pulsar.client.api.schema.SchemaBuilder;
 import org.apache.pulsar.client.impl.MessageImpl;
 import org.apache.pulsar.common.schema.KeyValue;
 import org.apache.pulsar.common.schema.KeyValueEncodingType;
@@ -63,7 +65,21 @@ import org.testng.SkipException;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
+<<<<<<< HEAD
+=======
+import java.util.Locale;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+>>>>>>> 06dd1826954 ([feat][elasticsearch] Add hashed id support)
 
 import static org.testng.Assert.assertNull;
 
@@ -254,14 +270,19 @@ public abstract class ElasticSearchSinkTests extends ElasticSearchTestBase {
         verify(mockRecord, times(1)).ack();
         assertEquals(sink.getElasticsearchClient().getRestClient().totalHits(index), 1L);
 
+        String value = getHitIdAtIndex(index, 0);
+        assertEquals(value, "bob");
+    }
+
+    private String getHitIdAtIndex(String indexName, int index) throws IOException {
         if (elasticImageName.equals(ELASTICSEARCH_8)) {
             final ElasticSearchJavaRestClient restClient = (ElasticSearchJavaRestClient)
                     sink.getElasticsearchClient().getRestClient();
-            assertEquals(restClient.search(index).hits().hits().get(0).id(), "bob");
+            return restClient.search(indexName).hits().hits().get(index).id();
         } else {
             final OpenSearchHighLevelRestClient restClient = (OpenSearchHighLevelRestClient)
                     sink.getElasticsearchClient().getRestClient();
-            assertEquals(restClient.search(index).getHits().getHits()[0].getId(), "bob");
+            return restClient.search(indexName).getHits().getHits()[0].getId();
         }
     }
 
@@ -275,15 +296,7 @@ public abstract class ElasticSearchSinkTests extends ElasticSearchTestBase {
         send(1);
         verify(mockRecord, times(1)).ack();
         assertEquals(sink.getElasticsearchClient().getRestClient().totalHits(index), 1L);
-        if (elasticImageName.equals(ELASTICSEARCH_8)) {
-            final ElasticSearchJavaRestClient restClient = (ElasticSearchJavaRestClient)
-                    sink.getElasticsearchClient().getRestClient();
-            assertEquals(restClient.search(index).hits().hits().get(0).id(), "[\"bob\",\"boby\"]");
-        } else {
-            final OpenSearchHighLevelRestClient restClient = (OpenSearchHighLevelRestClient)
-                    sink.getElasticsearchClient().getRestClient();
-            assertEquals(restClient.search(index).getHits().getHits()[0].getId(), "[\"bob\",\"boby\"]");
-        }
+        assertEquals("[\"bob\",\"boby\"]", getHitIdAtIndex(index, 0));
     }
 
     protected final void send(int numRecords) throws Exception {
@@ -450,4 +463,131 @@ public abstract class ElasticSearchSinkTests extends ElasticSearchTestBase {
             sink.close();
         }
     }
+
+    @DataProvider(name = "IdHashingAlgorithm")
+    public Object[] schemaType() {
+        return new Object[]{
+                ElasticSearchConfig.IdHashingAlgorithm.SHA256,
+                ElasticSearchConfig.IdHashingAlgorithm.SHA512
+        };
+    }
+
+    @Test(dataProvider = "IdHashingAlgorithm")
+    public final void testHashKey(ElasticSearchConfig.IdHashingAlgorithm algorithm) throws Exception {
+        when(mockRecord.getKey()).thenAnswer((Answer<Optional<String>>) invocation -> Optional.of( "record-key"));
+        final String indexName = "test-index" + UUID.randomUUID();
+        map.put("indexName", indexName);
+        map.put("keyIgnore", "false");
+        map.put("idHashingAlgorithm", algorithm.toString());
+        sink.open(map, mockSinkContext);
+        send(10);
+        verify(mockRecord, times(10)).ack();
+        final String expectedHashedValue = algorithm == ElasticSearchConfig.IdHashingAlgorithm.SHA256 ?
+                "gbY32PzSxtpjWeaWMROhFw3nleS3JbhNHgtM/Z7FjOk" :
+                "BBaia6VUM0KGsZVJGOyte6bDNXW0nfkV/zNntc737Nk7HwtDZjZmeyezYwEVQ5cfHIHDFR1e9yczUBwf8zw0rw";
+        final long count = sink.getElasticsearchClient().getRestClient()
+                .totalHits(indexName, "_id:" + expectedHashedValue);
+        assertEquals(count, 1);
+    }
+
+    @Test
+    public final void testKeyValueHashAndCanonicalOutput() throws Exception {
+        RecordSchemaBuilder keySchemaBuilder = SchemaBuilder.record("key");
+        keySchemaBuilder.field("keyFieldB").type(SchemaType.STRING).optional().defaultValue(null);
+        keySchemaBuilder.field("keyFieldA").type(SchemaType.STRING).optional().defaultValue(null);
+        GenericSchema<GenericRecord> keySchema = Schema.generic(keySchemaBuilder.build(SchemaType.JSON));
+
+        // more than 512 bytes to break the _id size limitation
+        final String keyFieldBValue = Stream.generate(() -> "keyB").limit(1000).collect(Collectors.joining());
+        GenericRecord keyGenericRecord = keySchema.newRecordBuilder()
+                .set("keyFieldB", keyFieldBValue)
+                .set("keyFieldA", "keyA")
+                .build();
+
+        GenericRecord keyGenericRecord2 = keySchema.newRecordBuilder()
+                .set("keyFieldA", "keyA")
+                .set("keyFieldB", keyFieldBValue)
+                .build();
+        Record<GenericObject> genericObjectRecord = createKeyValueGenericRecordWithGenericKeySchema(
+                keySchema, keyGenericRecord);
+        Record<GenericObject> genericObjectRecord2 = createKeyValueGenericRecordWithGenericKeySchema(
+                keySchema, keyGenericRecord2);
+        final String indexName = "test-index" + UUID.randomUUID();
+        map.put("indexName", indexName);
+        map.put("keyIgnore", "false");
+        map.put("nullValueAction", ElasticSearchConfig.NullValueAction.DELETE.toString());
+        map.put("canonicalKeyFields", "true");
+        map.put("idHashingAlgorithm", ElasticSearchConfig.IdHashingAlgorithm.SHA512);
+        sink.open(map, mockSinkContext);
+        for (int idx = 0; idx < 10; idx++) {
+            sink.write(genericObjectRecord);
+        }
+        for (int idx = 0; idx < 10; idx++) {
+            sink.write(genericObjectRecord2);
+        }
+        final String expectedHashedValue = "7BmM3pkYIbhm8cPN5ePd/BeZ7lYZnKhzmiJ62k0PsGNNAQdk" +
+                "S+/te9+NKpdy31lEN0jT1MVrBjYIj4O08QsU1g";
+        long count = sink.getElasticsearchClient().getRestClient()
+                .totalHits(indexName, "_id:" + expectedHashedValue);
+        assertEquals(count, 1);
+
+
+        Record<GenericObject> genericObjectRecordDelete = createKeyValueGenericRecordWithGenericKeySchema(
+                keySchema, keyGenericRecord, true);
+        sink.write(genericObjectRecordDelete);
+        count = sink.getElasticsearchClient().getRestClient()
+                .totalHits(indexName, "_id:" + expectedHashedValue);
+        assertEquals(count, 0);
+
+    }
+
+    private Record<GenericObject> createKeyValueGenericRecordWithGenericKeySchema(
+            GenericSchema<GenericRecord> keySchema,
+            GenericRecord keyGenericRecord) {
+        return createKeyValueGenericRecordWithGenericKeySchema(
+                keySchema,
+                keyGenericRecord,
+                false
+        );
+    }
+
+    private Record<GenericObject> createKeyValueGenericRecordWithGenericKeySchema(
+            GenericSchema<GenericRecord> keySchema,
+            GenericRecord keyGenericRecord, boolean emptyValue) {
+
+        Schema<KeyValue<GenericRecord, GenericRecord>> keyValueSchema =
+                Schema.KeyValue(keySchema, genericSchema, KeyValueEncodingType.INLINE);
+        KeyValue<GenericRecord, GenericRecord> keyValue = new KeyValue<>(keyGenericRecord,
+                emptyValue ? null: userProfile);
+        GenericObject genericObject = new GenericObject() {
+            @Override
+            public SchemaType getSchemaType() {
+                return SchemaType.KEY_VALUE;
+            }
+
+            @Override
+            public Object getNativeObject() {
+                return keyValue;
+            }
+        };
+        Record<GenericObject> genericObjectRecord = new Record<GenericObject>() {
+            @Override
+            public Optional<String> getTopicName() {
+                return Optional.of("topic-name");
+            }
+
+            @Override
+            public Schema  getSchema() {
+                return keyValueSchema;
+            }
+
+            @Override
+            public GenericObject getValue() {
+                return genericObject;
+            }
+        };
+        return genericObjectRecord;
+    }
+
+
 }

--- a/site2/docs/io-elasticsearch-sink.md
+++ b/site2/docs/io-elasticsearch-sink.md
@@ -88,6 +88,7 @@ The configuration of the Elasticsearch sink connector has the following properti
 | `apiKey` | String| false | " " (empty string)|The apiKey used by the connector to connect to the ElasticSearch cluster. Only one between basic/token/apiKey authentication mode must be configured. |
 | `canonicalKeyFields` | Boolean | false | false | Whether to sort the key fields for JSON and Avro or not. If it is set to `true` and the record key schema is `JSON` or `AVRO`, the serialized object does not consider the order of properties. |
 | `stripNonPrintableCharacters` | Boolean| false | true| Whether to remove all non-printable characters from the document or not. If it is set to true, all non-printable characters are removed from the document. |
+| `idHashingAlgorithm` | enum(NONE,SHA256,SHA512)| false | NONE|Hashing algorithm to use for the document id. This is useful in order to be compliant with the ElasticSearch _id hard limit of 512 bytes. |
 
 ### Definition of ElasticSearchSslConfig structure:
 


### PR DESCRIPTION
### Motivation
ElasticSearch has a size limitation for the document id. The hard limit is 512 bytes. It is not configurable.

>_id is limited to 512 bytes in size and larger values will be rejected.
https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-id-field.html

In order to by-pass this limitation without losing data integrity and uniqueness a new option is introduced to create an hash of the Pulsar record key.

### Modifications
* New option `idHashingAlgorithm`, enum NONE, SHA256, SHA512
* For the hashing computation we use Guava utility class `com.google.common.hash.Hashing`

Note that this option will add a CPU overhead in order to compute the hashed value.
It is suggested to use this option together with `canonicalKeyFields` in order to guarantee the same hashed value for the same key content regardless the key fields order. (https://github.com/apache/pulsar/pull/15426)
 
- [x] `doc` 