### PR TITLE
[fix][kinesis-sink] Handle Avro collections native types (GenericData.Array and Utf8 map keys)

### DIFF
--- a/pulsar-io/kinesis/src/main/java/org/apache/pulsar/io/kinesis/json/JsonConverter.java
+++ b/pulsar-io/kinesis/src/main/java/org/apache/pulsar/io/kinesis/json/JsonConverter.java
@@ -33,6 +33,7 @@ import org.apache.avro.Conversion;
 import org.apache.avro.Conversions;
 import org.apache.avro.Schema;
 import org.apache.avro.data.TimeConversions;
+import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericFixed;
 import org.apache.avro.generic.GenericRecord;
 
@@ -85,18 +86,26 @@ public class JsonConverter {
             case ARRAY: {
                 Schema elementSchema = schema.getElementType();
                 ArrayNode arrayNode = jsonNodeFactory.arrayNode();
-                for (Object elem : (Object[]) value) {
+                Object[] iterable;
+                if (value instanceof GenericData.Array) {
+                    iterable = ((GenericData.Array) value).toArray();
+                } else {
+                    iterable = (Object[]) value;
+                }
+                for (Object elem : iterable) {
                     JsonNode fieldValue = toJson(elementSchema, elem);
                     arrayNode.add(fieldValue);
                 }
                 return arrayNode;
             }
             case MAP: {
-                Map<String, Object> map = (Map<String, Object>) value;
+                Map<Object, Object> map = (Map<Object, Object>) value;
                 ObjectNode objectNode = jsonNodeFactory.objectNode();
-                for (Map.Entry<String, Object> entry : map.entrySet()) {
+                for (Map.Entry<Object, Object> entry : map.entrySet()) {
                     JsonNode jsonNode = toJson(schema.getValueType(), entry.getValue());
-                    objectNode.set(entry.getKey(), jsonNode);
+                    // can be a String or org.apache.avro.util.Utf8
+                    final String entryKey = entry.getKey() == null ? null : entry.getKey().toString();
+                    objectNode.set(entryKey, jsonNode);
                 }
                 return objectNode;
             }

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/sinks/KinesisSinkTester.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/sinks/KinesisSinkTester.java
@@ -20,8 +20,10 @@ package org.apache.pulsar.tests.integration.io.sinks;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectReader;
-import java.util.LinkedHashMap;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Cleanup;
@@ -54,7 +56,9 @@ import software.amazon.kinesis.retrieval.KinesisClientRecord;
 import java.io.UncheckedIOException;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
+import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import static org.testng.Assert.assertEquals;
 
@@ -144,10 +148,20 @@ public class KinesisSinkTester extends SinkTester<LocalStackContainer> {
             for (int i = 0; i < numMessages; i++) {
                 String key = String.valueOf(i);
                 kvs.put(key, key);
-                KeyValue<SimplePojo, SimplePojo> value = new KeyValue<>(new SimplePojo("f1_" + i, "f2_" + i),
-                        new SimplePojo(String.valueOf(i), "v2_" + i));
+                final SimplePojo keyPojo = new SimplePojo(
+                        "f1_" + i,
+                        "f2_" + i,
+                        Arrays.asList(i, i +1),
+                        new HashSet<>(Arrays.asList((long) i)),
+                        ImmutableMap.of("map1_k_" + i, "map1_kv_" + i));
+                final SimplePojo valuePojo = new SimplePojo(
+                        String.valueOf(i),
+                        "v2_" + i,
+                        Arrays.asList(i, i +1),
+                        new HashSet<>(Arrays.asList((long) i)),
+                        ImmutableMap.of("map1_v_" + i, "map1_vv_" + i));
                 producer.newMessage()
-                        .value(value)
+                        .value(new KeyValue<>(keyPojo, valuePojo))
                         .send();
             }
         } else {
@@ -251,5 +265,8 @@ public class KinesisSinkTester extends SinkTester<LocalStackContainer> {
     public static final class SimplePojo {
         private String field1;
         private String field2;
+        private List<Integer> list1;
+        private Set<Long> set1;
+        private Map<String, String> map1;
     }
 }

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/sinks/KinesisSinkTester.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/sinks/KinesisSinkTester.java
@@ -20,6 +20,7 @@ package org.apache.pulsar.tests.integration.io.sinks;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectReader;
+import com.google.common.collect.ImmutableMap;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;


### PR DESCRIPTION
### Motivation
Avro native objects for Arrays and Maps are not supported by the sink.

If you try to use a Java POJO with a java.util.List/java.util.Set field with Avro Schema, you get:
```
022-04-26T11:56:51.477776276Z Caused by: java.lang.ClassCastException: class org.apache.avro.generic.GenericData$Array cannot be cast to class [Ljava.lang.Object; (org.apache.avro.generic.GenericData$Array is in unnamed module of loader 'app'; [Ljava.lang.Object; is in module java.base of loader 'bootstrap')
```

For java.util.Map

```
2022-04-26T12:03:34.776219894Z java.lang.IllegalArgumentException: Error while converting a value of type class java.util.HashMap to a MAP: java.lang.ClassCastException: class org.apache.avro.util.Utf8 cannot be cast to class java.lang.String (org.apache.avro.util.Utf8 is in unnamed module of loader 'app'; java.lang.String is in module java.base of loader 'bootstrap')
```

### Modifications

* Handle GenericData.Array instances
* Handle Map with UUID as entry key

See the same issue in the ElasticSearch sink https://github.com/apache/pulsar/pull/15430
- [x] `no-need-doc` 
