### PR TITLE
[improve][broker] Make some methods of `ClusterBase` pure async.

### DIFF
--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/resources/NamespaceResources.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/resources/NamespaceResources.java
@@ -176,6 +176,10 @@ public class NamespaceResources extends BaseResources<Policies> {
             }, operationTimeoutSec);
         }
 
+        public CompletableFuture<Optional<NamespaceIsolationPolicies>> getIsolationDataPoliciesAsync(String cluster) {
+            return getAsync(joinPath(BASE_CLUSTERS_PATH, cluster, NAMESPACE_ISOLATION_POLICIES))
+                    .thenApply(isolationData -> isolationData.map(NamespaceIsolationPolicies::new));
+        }
         public Optional<NamespaceIsolationPolicies> getIsolationDataPolicies(String cluster)
                 throws MetadataStoreException {
             Optional<Map<String, NamespaceIsolationDataImpl>> data =

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/resources/NamespaceResources.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/resources/NamespaceResources.java
@@ -176,15 +176,16 @@ public class NamespaceResources extends BaseResources<Policies> {
             }, operationTimeoutSec);
         }
 
-        public CompletableFuture<Optional<NamespaceIsolationPolicies>> getIsolationDataPoliciesAsync(String cluster) {
-            return getAsync(joinPath(BASE_CLUSTERS_PATH, cluster, NAMESPACE_ISOLATION_POLICIES))
-                    .thenApply(isolationData -> isolationData.map(NamespaceIsolationPolicies::new));
-        }
         public Optional<NamespaceIsolationPolicies> getIsolationDataPolicies(String cluster)
                 throws MetadataStoreException {
             Optional<Map<String, NamespaceIsolationDataImpl>> data =
                     super.get(joinPath(BASE_CLUSTERS_PATH, cluster, NAMESPACE_ISOLATION_POLICIES));
             return data.isPresent() ? Optional.of(new NamespaceIsolationPolicies(data.get())) : Optional.empty();
+        }
+
+        public CompletableFuture<Optional<NamespaceIsolationPolicies>> getIsolationDataPoliciesAsync(String cluster) {
+            return getAsync(joinPath(BASE_CLUSTERS_PATH, cluster, NAMESPACE_ISOLATION_POLICIES))
+                    .thenApply(data -> data.map(NamespaceIsolationPolicies::new));
         }
 
         public void deleteIsolationData(String cluster) throws MetadataStoreException {

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/resources/NamespaceResources.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/resources/NamespaceResources.java
@@ -187,11 +187,6 @@ public class NamespaceResources extends BaseResources<Policies> {
             return data.isPresent() ? Optional.of(new NamespaceIsolationPolicies(data.get())) : Optional.empty();
         }
 
-        public CompletableFuture<Optional<NamespaceIsolationPolicies>> getIsolationDataPoliciesAsync(String cluster) {
-            return getAsync(joinPath(BASE_CLUSTERS_PATH, cluster, NAMESPACE_ISOLATION_POLICIES))
-                    .thenApply(data -> data.map(NamespaceIsolationPolicies::new));
-        }
-
         public void deleteIsolationData(String cluster) throws MetadataStoreException {
             delete(joinPath(BASE_CLUSTERS_PATH, cluster, NAMESPACE_ISOLATION_POLICIES));
         }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/ClustersBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/ClustersBase.java
@@ -32,7 +32,6 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/ClustersBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/ClustersBase.java
@@ -522,9 +522,8 @@ public class ClustersBase extends AdminResource {
             NamespaceIsolationPolicyImpl nsPolicyImpl = new NamespaceIsolationPolicyImpl(policyData);
             if (nsPolicyImpl.isPrimaryBroker(broker) || nsPolicyImpl.isSecondaryBroker(broker)) {
                 namespaceRegexes.addAll(policyData.getNamespaces());
-                if (nsPolicyImpl.isPrimaryBroker(broker)) {
-                    brokerIsolationData.primary(true);
-                }
+                brokerIsolationData.primary(nsPolicyImpl.isPrimaryBroker(broker));
+                brokerIsolationData.policyName(name);
             }
         });
         brokerIsolationData.namespaceRegex(namespaceRegexes);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/NamespaceService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/NamespaceService.java
@@ -733,8 +733,10 @@ public class NamespaceService implements AutoCloseable {
     }
 
     public CompletableFuture<Map<String, NamespaceOwnershipStatus>> getOwnedNameSpacesStatusAsync() {
-       return getLocalNamespaceIsolationPoliciesAsync()
-                .thenCompose(namespaceIsolationPolicies -> {
+       return pulsar.getPulsarResources().getNamespaceResources().getIsolationPolicies()
+               .getIsolationDataPoliciesAsync(pulsar.getConfiguration().getClusterName())
+               .thenApply(nsIsolationPoliciesOpt -> nsIsolationPoliciesOpt.orElseGet(NamespaceIsolationPolicies::new))
+               .thenCompose(namespaceIsolationPolicies -> {
                     Collection<CompletableFuture<OwnedBundle>> futures =
                             ownershipCache.getOwnedBundlesAsync().values();
                     return FutureUtil.waitForAll(futures)

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/NamespaceService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/NamespaceService.java
@@ -770,13 +770,6 @@ public class NamespaceService implements AutoCloseable {
         return nsOwnedStatus;
     }
 
-    private CompletableFuture<NamespaceIsolationPolicies> getLocalNamespaceIsolationPoliciesAsync() {
-        String localCluster = pulsar.getConfiguration().getClusterName();
-        return pulsar.getPulsarResources().getNamespaceResources().getIsolationPolicies()
-                .getIsolationDataPoliciesAsync(localCluster)
-                .thenApply(nsIsolationPolicies -> nsIsolationPolicies.orElseGet(NamespaceIsolationPolicies::new));
-    }
-
     public boolean isNamespaceBundleDisabled(NamespaceBundle bundle) throws Exception {
         try {
             // Does ZooKeeper says that the namespace is disabled?

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApi2Test.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApi2Test.java
@@ -1029,6 +1029,7 @@ public class AdminApi2Test extends MockedPulsarServiceBaseTest {
         assertEquals(brokerIsolationDataList.get(0).getBrokerName(), brokerAddress);
         assertEquals(brokerIsolationDataList.get(0).getNamespaceRegex().size(), 1);
         assertEquals(brokerIsolationDataList.get(0).getNamespaceRegex().get(0), namespaceRegex);
+        assertEquals(brokerIsolationDataList.get(0).getPolicyName(), policyName1);
 
         BrokerNamespaceIsolationDataImpl brokerIsolationData = (BrokerNamespaceIsolationDataImpl) admin.clusters()
                 .getBrokerWithNamespaceIsolationPolicy(cluster, brokerAddress);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminTest.java
@@ -408,8 +408,8 @@ public class AdminTest extends MockedPulsarServiceBaseTest {
         } catch (RestException e) {
             assertEquals(e.getResponse().getStatus(), Status.PRECONDITION_FAILED.getStatusCode());
         }
-        verify(clusters, times(17)).validateSuperUserAccessAsync();
-        verify(clusters, times(7)).validateSuperUserAccess();
+        verify(clusters, times(22)).validateSuperUserAccessAsync();
+        verify(clusters, times(2)).validateSuperUserAccess();
     }
 
     Object asynRequests(Consumer<TestAsyncResponse> function) throws Exception {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminTest.java
@@ -202,6 +202,7 @@ public class AdminTest extends MockedPulsarServiceBaseTest {
     }
 
     @Test
+    @SuppressWarnings("unchecked")
     public void clusters() throws Exception {
         assertEquals(asynRequests(ctx -> clusters.getClusters(ctx)), Sets.newHashSet());
         verify(clusters, never()).validateSuperUserAccessAsync();
@@ -239,7 +240,7 @@ public class AdminTest extends MockedPulsarServiceBaseTest {
                 ClusterData.builder().serviceUrl("http://new-broker.messaging.use.example.com:8080").build());
 
         try {
-            clusters.getNamespaceIsolationPolicies("use");
+            asynRequests(ctx -> clusters.getNamespaceIsolationPolicies(ctx, "use"));
             fail("should have failed");
         } catch (RestException e) {
             assertEquals(e.getResponse().getStatus(), 404);
@@ -259,7 +260,7 @@ public class AdminTest extends MockedPulsarServiceBaseTest {
                 .build();
         AsyncResponse response = mock(AsyncResponse.class);
         clusters.setNamespaceIsolationPolicy(response,"use", "policy1", policyData);
-        clusters.getNamespaceIsolationPolicies("use");
+        asynRequests(ctx -> clusters.getNamespaceIsolationPolicies(ctx, "use"));
 
         try {
             asynRequests(ctx -> clusters.deleteCluster(ctx, "use"));
@@ -269,7 +270,8 @@ public class AdminTest extends MockedPulsarServiceBaseTest {
         }
 
         clusters.deleteNamespaceIsolationPolicy("use", "policy1");
-        assertTrue(clusters.getNamespaceIsolationPolicies("use").isEmpty());
+        assertTrue(((Map<String, NamespaceIsolationDataImpl>) asynRequests(ctx ->
+                clusters.getNamespaceIsolationPolicies(ctx, "use"))).isEmpty());
 
         asynRequests(ctx -> clusters.deleteCluster(ctx, "use"));
         assertEquals(asynRequests(ctx -> clusters.getClusters(ctx)), Sets.newHashSet());
@@ -289,7 +291,7 @@ public class AdminTest extends MockedPulsarServiceBaseTest {
         }
 
         try {
-            clusters.getNamespaceIsolationPolicies("use");
+            asynRequests(ctx -> clusters.getNamespaceIsolationPolicies(ctx, "use"));
             fail("should have failed");
         } catch (RestException e) {
             assertEquals(e.getResponse().getStatus(), 404);
@@ -406,8 +408,8 @@ public class AdminTest extends MockedPulsarServiceBaseTest {
         } catch (RestException e) {
             assertEquals(e.getResponse().getStatus(), Status.PRECONDITION_FAILED.getStatusCode());
         }
-        verify(clusters, times(18)).validateSuperUserAccessAsync();
-        verify(clusters, times(6)).validateSuperUserAccess();
+        verify(clusters, times(17)).validateSuperUserAccessAsync();
+        verify(clusters, times(7)).validateSuperUserAccess();
     }
 
     Object asynRequests(Consumer<TestAsyncResponse> function) throws Exception {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/v1/V1_AdminApiTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/v1/V1_AdminApiTest.java
@@ -287,6 +287,7 @@ public class V1_AdminApiTest extends MockedPulsarServiceBaseTest {
             List<BrokerNamespaceIsolationData> isoList = admin.clusters().getBrokersWithNamespaceIsolationPolicy("use");
             assertEquals(isoList.size(), 1);
             assertTrue(isoList.get(0).isPrimary());
+            assertEquals(isoList.get(0).getPolicyName(), policyName1);
 
             // verify update of primary
             nsPolicyData1.getPrimary().remove(0);


### PR DESCRIPTION
### Motivation

See PIP #14365  and change tracker #15043. 

### Modifications

- Make `ClusterBase` `getNamespaceIsolationPolicies` / `getNamespaceIsolationPolicy` / `getBrokersWithNamespaceIsolationPolicy`

### Verifying this change

- [x] Make sure that the change passes the CI checks.

`AdminApi2Test#brokerNamespaceIsolationPolicies` and `AdminTest#clusters` already cover this change.

### Documentation

- [x] `no-need-doc` 
(Please explain why)