### PR TITLE
[improve][doc] Support configurable transactionBufferClientOperationTimeoutInMills

### DIFF
--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -1394,6 +1394,9 @@ transactionBufferSnapshotMinTimeInMillis=5000
 # The max concurrent requests for transaction buffer client, default is 1000
 transactionBufferClientMaxConcurrentRequests=1000
 
+# The transaction buffer client's operation timeout in milliseconds.
+transactionBufferClientOperationTimeoutInMills=3000
+
 ### --- Packages management service configuration variables (begin) --- ###
 
 # Enable the packages management service or not

--- a/conf/standalone.conf
+++ b/conf/standalone.conf
@@ -1050,6 +1050,9 @@ transactionBufferSnapshotMaxTransactionCount=1000
 # Unit : millisecond
 transactionBufferSnapshotMinTimeInMillis=5000
 
+# The transaction buffer client's operation timeout in milliseconds.
+transactionBufferClientOperationTimeoutInMills=3000
+
 ### --- Packages management service configuration variables (begin) --- ###
 
 # Enable the packages management service or not

--- a/site2/docs/reference-configuration.md
+++ b/site2/docs/reference-configuration.md
@@ -703,6 +703,7 @@ You can set the log level and configuration in the  [log4j2.yaml](https://github
 |replicationConnectionsPerBroker|   |16|
 |replicationProducerQueueSize|    |1000|
 | replicationPolicyCheckDurationSeconds | Duration to check replication policy to avoid replicator inconsistency due to missing ZooKeeper watch. When the value is set to 0, disable checking replication policy. | 600 |
+|transactionBufferClientOperationTimeoutInMills|The transaction buffer client's operation timeout in milliseconds.|3000|
 |defaultRetentionTimeInMinutes|   |0|
 |defaultRetentionSizeInMB|    |0|
 |keepAliveIntervalSeconds|    |30|

--- a/site2/docs/reference-configuration.md
+++ b/site2/docs/reference-configuration.md
@@ -334,6 +334,7 @@ brokerServiceCompactionThresholdInBytes|If the estimated backlog size is greater
 |replicationConnectionsPerBroker| Max number of connections to open for each broker in a remote cluster More connections host-to-host lead to better throughput over high-latency links.  |16|
 |replicationProducerQueueSize|  Replicator producer queue size  |1000|
 |replicatorPrefix|  Replicator prefix used for replicator producer name and cursor name pulsar.repl||
+|transactionBufferClientOperationTimeoutInMills|The transaction buffer client's operation timeout in milliseconds.|3000|
 |transactionCoordinatorEnabled|Whether to enable transaction coordinator in broker.|true|
 |transactionMetadataStoreProviderClassName| |org.apache.pulsar.transaction.coordinator.impl.InMemTransactionMetadataStoreProvider|
 |defaultRetentionTimeInMinutes| Default message retention time  |0|


### PR DESCRIPTION
### Motivation

Add doc for #15011.

### Modifications

Add  `transactionBufferClientOperationTimeoutInMills` at `reference-configuration.md`

### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Documentation

- [x] `doc-added`