### PR TITLE
[CI] Fix issue in uploading surefire reports and container logs

### DIFF
--- a/.github/workflows/ci-cpp.yaml
+++ b/.github/workflows/ci-cpp.yaml
@@ -98,7 +98,7 @@ jobs:
         run: pulsar-client-cpp/docker-tests.sh
 
       - name: Upload test-logs
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: failure()
         continue-on-error: true
         with:

--- a/.github/workflows/ci-owasp-dep-check.yaml
+++ b/.github/workflows/ci-owasp-dep-check.yaml
@@ -93,7 +93,7 @@ jobs:
         run: mvn -q -B -ntp clean verify -PskipDocker,owasp-dependency-check -DskipTests -pl '!pulsar-sql,!distribution/io,!distribution/offloaders,!tiered-storage/file-system,!pulsar-io/flume,!pulsar-io/hbase,!pulsar-io/hdfs2,!pulsar-io/hdfs3,!pulsar-io/docs,!pulsar-io/jdbc/openmldb'
 
       - name: Upload report
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: ${{ cancelled() || failure() }}
         continue-on-error: true
         with:

--- a/.github/workflows/ci-owasp-dependency-check.yaml
+++ b/.github/workflows/ci-owasp-dependency-check.yaml
@@ -79,7 +79,7 @@ jobs:
         run: mvn -B -ntp -Pmain,skip-all,skipDocker,owasp-dependency-check initialize verify -pl distribution/offloaders,distribution/io,pulsar-sql/presto-distribution
 
       - name: Upload OWASP Dependency Check reports
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: always()
         with:
           name: owasp-dependency-check-reports-${{ matrix.checkout_branch }}

--- a/.github/workflows/pulsar-ci.yaml
+++ b/.github/workflows/pulsar-ci.yaml
@@ -201,11 +201,6 @@ jobs:
         if: ${{ needs.changed_files_job.outputs.docs_only != 'true' }}
         uses: apache/pulsar-test-infra/gh-actions-artifact-client/dist@master
 
-      - name: Cleanup log artifacts from possible previous failed build
-        if: ${{ needs.changed_files_job.outputs.docs_only != 'true' }}
-        run: |
-          gh-actions-artifact-client.js delete "Unit-${{ matrix.group }}-surefire-reports" &>/dev/null || true
-
       - name: Restore maven build results from Github artifact cache
         if: ${{ needs.changed_files_job.outputs.docs_only != 'true' }}
         run: |
@@ -396,12 +391,6 @@ jobs:
       - name: Install gh-actions-artifact-client.js
         if: ${{ needs.changed_files_job.outputs.docs_only != 'true' }}
         uses: apache/pulsar-test-infra/gh-actions-artifact-client/dist@master
-
-      - name: Cleanup log artifacts from possible previous failed build
-        if: ${{ needs.changed_files_job.outputs.docs_only != 'true' }}
-        run: |
-          gh-actions-artifact-client.js delete "Integration-${{ matrix.group }}-surefire-reports" &>/dev/null || true
-          gh-actions-artifact-client.js delete "Integration-${{ matrix.group }}-container-logs" &>/dev/null || true
 
       - name: Restore maven build results from Github artifact cache
         if: ${{ needs.changed_files_job.outputs.docs_only != 'true' }}
@@ -645,12 +634,6 @@ jobs:
       - name: Install gh-actions-artifact-client.js
         if: ${{ needs.changed_files_job.outputs.docs_only != 'true' }}
         uses: apache/pulsar-test-infra/gh-actions-artifact-client/dist@master
-
-      - name: Cleanup log artifacts from possible previous failed build
-        if: ${{ needs.changed_files_job.outputs.docs_only != 'true' }}
-        run: |
-          gh-actions-artifact-client.js delete "System-${{ matrix.group }}-surefire-reports" &>/dev/null || true
-          gh-actions-artifact-client.js delete "System-${{ matrix.group }}-container-logs" &>/dev/null || true
 
       - name: Restore maven build results from Github artifact cache
         if: ${{ needs.changed_files_job.outputs.docs_only != 'true' }}

--- a/.github/workflows/pulsar-ci.yaml
+++ b/.github/workflows/pulsar-ci.yaml
@@ -237,14 +237,14 @@ jobs:
           summary_title: 'Test Summary for Unit - ${{ matrix.name }}:'
 
       - name: Publish the Test reports in Junit xml format
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: ${{ always() && needs.changed_files_job.outputs.docs_only != 'true' }}
         with:
           name: Unit-${{ matrix.group }}-test-report
           path: test-reports
 
       - name: Upload Surefire reports
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: ${{ !success() && needs.changed_files_job.outputs.docs_only != 'true' }}
         with:
           name: Unit-${{ matrix.group }}-surefire-reports
@@ -439,21 +439,21 @@ jobs:
           summary_title: 'Test Summary for Integration - ${{ matrix.name }}:'
 
       - name: Publish the Test reports in Junit xml format
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: ${{ always() && needs.changed_files_job.outputs.docs_only != 'true' }}
         with:
           name: Integration-${{ matrix.group }}-test-report
           path: test-reports
 
       - name: Upload Surefire reports
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: ${{ !success() && needs.changed_files_job.outputs.docs_only != 'true' }}
         with:
           name: Integration-${{ matrix.group }}-surefire-reports
           path: surefire-reports
 
       - name: Upload container logs
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: ${{ !success() && needs.changed_files_job.outputs.docs_only != 'true' }}
         continue-on-error: true
         with:
@@ -688,14 +688,14 @@ jobs:
           summary_title: 'Test Summary for System - ${{ matrix.name }}:'
 
       - name: Publish the Test reports in Junit xml format
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: ${{ always() && needs.changed_files_job.outputs.docs_only != 'true' }}
         with:
           name: System-${{ matrix.group }}-test-report
           path: test-reports
 
       - name: Upload container logs
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: ${{ !success() && needs.changed_files_job.outputs.docs_only != 'true' }}
         continue-on-error: true
         with:
@@ -703,7 +703,7 @@ jobs:
           path: tests/integration/target/container-logs
 
       - name: Upload Surefire reports
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: ${{ !success() && needs.changed_files_job.outputs.docs_only != 'true' }}
         with:
           name: System-${{ matrix.name }}-surefire-reports

--- a/.github/workflows/pulsar-ci.yaml
+++ b/.github/workflows/pulsar-ci.yaml
@@ -237,6 +237,7 @@ jobs:
         with:
           name: Unit-${{ matrix.group }}-test-report
           path: test-reports
+          retention-days: 7
 
       - name: Upload Surefire reports
         uses: actions/upload-artifact@v3
@@ -244,6 +245,7 @@ jobs:
         with:
           name: Unit-${{ matrix.group }}-surefire-reports
           path: surefire-reports
+          retention-days: 7
 
       - name: Wait for ssh connection when build fails
         # ssh access is enabled for builds in own forks
@@ -433,6 +435,7 @@ jobs:
         with:
           name: Integration-${{ matrix.group }}-test-report
           path: test-reports
+          retention-days: 7
 
       - name: Upload Surefire reports
         uses: actions/upload-artifact@v3
@@ -440,6 +443,7 @@ jobs:
         with:
           name: Integration-${{ matrix.group }}-surefire-reports
           path: surefire-reports
+          retention-days: 7
 
       - name: Upload container logs
         uses: actions/upload-artifact@v3
@@ -448,6 +452,7 @@ jobs:
         with:
           name: Integration-${{ matrix.group }}-container-logs
           path: tests/integration/target/container-logs
+          retention-days: 7
 
       - name: Wait for ssh connection when build fails
         # ssh access is enabled for builds in own forks
@@ -676,6 +681,7 @@ jobs:
         with:
           name: System-${{ matrix.group }}-test-report
           path: test-reports
+          retention-days: 7
 
       - name: Upload container logs
         uses: actions/upload-artifact@v3
@@ -684,6 +690,7 @@ jobs:
         with:
           name: System-${{ matrix.group }}-container-logs
           path: tests/integration/target/container-logs
+          retention-days: 7
 
       - name: Upload Surefire reports
         uses: actions/upload-artifact@v3
@@ -691,6 +698,7 @@ jobs:
         with:
           name: System-${{ matrix.name }}-surefire-reports
           path: surefire-reports
+          retention-days: 7
 
       - name: Wait for ssh connection when build fails
         # ssh access is enabled for builds in own forks


### PR DESCRIPTION
### Motivation

Uploading surefire reports and container logs has been broken in the new Pulsar CI workflow.

Example failure: https://github.com/apache/pulsar/runs/6301697885?check_suite_focus=true

```
Error: Create Artifact Container failed: The artifact name Unit-BROKER_GROUP_2-surefire-reports is not valid. Request URL https://pipelines.actions.githubusercontent.com/EXIZfX8ixSbQEfqDA00dMJrEtloTMSwjlUs9NqJqrTcJfd7NaR/_apis/pipelines/workflows/2269710766/artifacts?api-version=6.0-preview
```

This seems to be caused by the solution in Pulsar CI which attempts to delete logs from a previous test run.

### Modifications

- remove solution to delete possible previous logs
- upgrade upload-artifact to v3
- set retention to 7 days to save storage space