### PR TITLE
[fix][env]Fix wrongly set jvm gc log dir

### DIFF
--- a/bin/pulsar
+++ b/bin/pulsar
@@ -52,7 +52,7 @@ then
 fi
 
 # Check pulsar env and load pulsar_env.sh
-if [ -f "$PULSAR_HOME/conf/pulsar_env.sh" ]
+if [[ -f "$PULSAR_HOME/conf/pulsar_env.sh" && $1 != "bookie" ]]
 then
     . "$PULSAR_HOME/conf/pulsar_env.sh"
 fi

--- a/bin/pulsar-daemon
+++ b/bin/pulsar-daemon
@@ -73,12 +73,15 @@ shift
 if [[ "$command" = "bookie" ]]
 then
   PULSAR_LOG_DIR=${BOOKIE_LOG_DIR:-"$PULSAR_HOME/logs"}
+  PULSAR_PID_DIR=${BOOKIE_PID_DIR:-"$PULSAR_HOME/bin"}
 else
   PULSAR_LOG_DIR=${PULSAR_LOG_DIR:-"$PULSAR_HOME/logs"}
+  PULSAR_PID_DIR=${PULSAR_PID_DIR:-"$PULSAR_HOME/bin"}
 fi
 PULSAR_LOG_APPENDER=${PULSAR_LOG_APPENDER:-"RollingFile"}
 PULSAR_STOP_TIMEOUT=${PULSAR_STOP_TIMEOUT:-30}
-PULSAR_PID_DIR=${PULSAR_PID_DIR:-$PULSAR_HOME/bin}
+mkdir -p "$PULSAR_LOG_DIR"
+mkdir -p "$PULSAR_PID_DIR"
 
 case $command in
     (broker)
@@ -212,8 +215,6 @@ stop ()
       echo no "$command to stop"
     fi
 }
-
-mkdir -p "$PULSAR_LOG_DIR"
 
 case $startStop in
   (start)

--- a/conf/bkenv.sh
+++ b/conf/bkenv.sh
@@ -47,7 +47,7 @@ else
   IS_JAVA_8=`$JAVA_HOME/bin/java -version 2>&1 |grep version|grep '"1\.8'`
 fi
 
-BOOKIE_GC_LOG_DIR = ${BOOKIE_LOG_DIR:-"logs"}
+BOOKIE_GC_LOG_DIR=${BOOKIE_LOG_DIR:-"logs"}
 # java version has space, use [[ -n $PARAM ]] to judge if variable exists
 if [[ -n $IS_JAVA_8 ]]; then
   BOOKIE_GC_LOG=${BOOKIE_GC_LOG:-${PULSAR_GC_LOG:-"-Xloggc:$BOOKIE_GC_LOG_DIR/pulsar_bookie_gc_%p.log -XX:+PrintGCDetails -XX:+PrintGCDateStamps -XX:+UseGCLogFileRotation -XX:NumberOfGCLogFiles=10 -XX:GCLogFileSize=20M"}}

--- a/conf/bkenv.sh
+++ b/conf/bkenv.sh
@@ -47,12 +47,13 @@ else
   IS_JAVA_8=`$JAVA_HOME/bin/java -version 2>&1 |grep version|grep '"1\.8'`
 fi
 
+BOOKIE_GC_LOG_DIR = ${BOOKIE_LOG_DIR:-"logs"}
 # java version has space, use [[ -n $PARAM ]] to judge if variable exists
 if [[ -n $IS_JAVA_8 ]]; then
-  BOOKIE_GC_LOG=${BOOKIE_GC_LOG:-${PULSAR_GC_LOG:-"-Xloggc:logs/pulsar_bookie_gc_%p.log -XX:+PrintGCDetails -XX:+PrintGCDateStamps -XX:+UseGCLogFileRotation -XX:NumberOfGCLogFiles=10 -XX:GCLogFileSize=20M"}}
+  BOOKIE_GC_LOG=${BOOKIE_GC_LOG:-${PULSAR_GC_LOG:-"-Xloggc:$BOOKIE_GC_LOG_DIR/pulsar_bookie_gc_%p.log -XX:+PrintGCDetails -XX:+PrintGCDateStamps -XX:+UseGCLogFileRotation -XX:NumberOfGCLogFiles=10 -XX:GCLogFileSize=20M"}}
 else
 # After jdk 9, gc log param should config like this. Ignoring version less than jdk 8
-  BOOKIE_GC_LOG=${BOOKIE_GC_LOG:-${PULSAR_GC_LOG:-"-Xlog:gc*:logs/pulsar_bookie_gc_%p.log:time,uptime,level,tags:filecount=10,filesize=20M"}}
+  BOOKIE_GC_LOG=${BOOKIE_GC_LOG:-${PULSAR_GC_LOG:-"-Xlog:gc*:$BOOKIE_GC_LOG_DIR/pulsar_bookie_gc_%p.log:time,uptime,level,tags:filecount=10,filesize=20M"}}
 fi
 
 # Extra options to be passed to the jvm

--- a/conf/pulsar_env.sh
+++ b/conf/pulsar_env.sh
@@ -55,7 +55,7 @@ else
   IS_JAVA_8=`$JAVA_HOME/bin/java -version 2>&1 |grep version|grep '"1\.8'`
 fi
 # java version has space, use [[ -n $PARAM ]] to judge if variable exists
-PULSAR_GC_LOG_DIR = ${PULSAR_LOG_DIR:-"logs"}
+PULSAR_GC_LOG_DIR=${PULSAR_LOG_DIR:-"logs"}
 if [[ -n $IS_JAVA_8 ]]; then
   PULSAR_GC_LOG=${PULSAR_GC_LOG:-"-Xloggc:$PULSAR_GC_LOG_DIR/pulsar_gc_%p.log -XX:+PrintGCDetails -XX:+PrintGCDateStamps -XX:+UseGCLogFileRotation -XX:NumberOfGCLogFiles=10 -XX:GCLogFileSize=20M"}
 else

--- a/conf/pulsar_env.sh
+++ b/conf/pulsar_env.sh
@@ -55,11 +55,12 @@ else
   IS_JAVA_8=`$JAVA_HOME/bin/java -version 2>&1 |grep version|grep '"1\.8'`
 fi
 # java version has space, use [[ -n $PARAM ]] to judge if variable exists
+PULSAR_GC_LOG_DIR = ${PULSAR_LOG_DIR:-"logs"}
 if [[ -n $IS_JAVA_8 ]]; then
-  PULSAR_GC_LOG=${PULSAR_GC_LOG:-"-Xloggc:logs/pulsar_gc_%p.log -XX:+PrintGCDetails -XX:+PrintGCDateStamps -XX:+UseGCLogFileRotation -XX:NumberOfGCLogFiles=10 -XX:GCLogFileSize=20M"}
+  PULSAR_GC_LOG=${PULSAR_GC_LOG:-"-Xloggc:$PULSAR_GC_LOG_DIR/pulsar_gc_%p.log -XX:+PrintGCDetails -XX:+PrintGCDateStamps -XX:+UseGCLogFileRotation -XX:NumberOfGCLogFiles=10 -XX:GCLogFileSize=20M"}
 else
 # After jdk 9, gc log param should config like this. Ignoring version less than jdk 8
-  PULSAR_GC_LOG=${PULSAR_GC_LOG:-"-Xlog:gc*:logs/pulsar_gc_%p.log:time,uptime:filecount=10,filesize=20M"}
+  PULSAR_GC_LOG=${PULSAR_GC_LOG:-"-Xlog:gc*:$PULSAR_GC_LOG_DIR/pulsar_gc_%p.log:time,uptime:filecount=10,filesize=20M"}
 fi
 
 # Extra options to be passed to the jvm


### PR DESCRIPTION
### Motivation
1、same as #14725, `BOOKIE_PID_DIR` in `bkenv.sh` took no effect.

2、If We set `BOOKIE_LOG_DIR` and `PULSAR_LOG_DIR` rather than default value `PULSAR_HOME/logs`. Error below would be thrown.
```
[0.002s][error][logging] Error opening log file 'logs/pulsar_bookie_gc_36230.log': No such file or directory
[0.002s][error][logging] Initialization of output 'file=logs/pulsar_bookie_gc_%p.log' using options 'filecount=10,filesize=20M' failed.
Invalid -Xlog option '-Xlog:gc*:logs/pulsar_bookie_gc_%p.log:time,uptime,level,tags:filecount=10,filesize=20M', see error log for details.
Error: Could not create the Java Virtual Machine.
Error: A fatal exception has occurred. Program will exit.
```

3. When set `BOOKIE_LOG_DIR` in `bkenv.sh`, it would be overwrite by `PULSAR_LOG_DIR` set in `pulsar_env.sh`, 

```
# Check bookkeeper env and load bkenv.sh
if [ -f "$PULSAR_HOME/conf/bkenv.sh" ]
then
    . "$PULSAR_HOME/conf/bkenv.sh"
fi

# Check pulsar env and load pulsar_env.sh
if [ -f "$PULSAR_HOME/conf/pulsar_env.sh"  ]
then
    . "$PULSAR_HOME/conf/pulsar_env.sh"
fi
```
After ` . "$PULSAR_HOME/conf/pulsar_env.sh"` commander,  the `PULSAR_LOG_DIR=${BOOKIE_LOG_DIR:-"$PULSAR_HOME/logs"}` which its value assigned in `pulsar-daemon`   would be overwrite by value set in  `pulsar_env.sh` 

### Modifications

1、If we use command `bookie`,  `BOOKIE_PID_DIR` passed to `PULSR_PID_DIR` instead of  `PULSR_PID_DIR` by default.

2、In env file, use `$PULSAR_LOG_DIR/pulsar_bookie_gc_%p.log` instead of `logs/pulsar_bookie_gc_%p.log`



### Documentation

Check the box below or label this PR directly.

Need to update docs? 

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)
  
- [x] `no-need-doc` 
(Please explain why)
  
- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-added`
(Docs have been already added)