### PR TITLE
[fix][doc] Adjust python example in cpp client directory to fix string interpolation

### DIFF
--- a/pulsar-client-cpp/python/pulsar/__init__.py
+++ b/pulsar-client-cpp/python/pulsar/__init__.py
@@ -64,14 +64,15 @@ To install the Python bindings:
     import pulsar
 
     client = pulsar.Client('pulsar://localhost:6650')
+
     consumer = client.subscribe('my-topic', 'my-subscription')
 
     while True:
         msg = consumer.receive()
         try:
-            print("Received message '%s' id='%s'", msg.data().decode('utf-8'), msg.message_id())
+            print("Received message '{}' id='{}'".format(msg.data(), msg.message_id()))
             consumer.acknowledge(msg)
-        except:
+        except Exception:
             consumer.negative_acknowledge(msg)
 
     client.close()


### PR DESCRIPTION
This is just a small docstring fix. This example was fixed in other locations a long time ago in PR #1951 but it appears they were missed in the same example that lives in these docstrings. They show up in the pdoc generated docs: https://pulsar.apache.org/api/python/2.10.0/pulsar.html

### Documentation

Check the box below or label this PR directly.

Need to update docs? 

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)
  
- [ ] `no-need-doc` 
(Please explain why)
  
- [x] `doc` 
(Your PR contains doc changes)

- [ ] `doc-added`
(Docs have been already added)