### PR TITLE
[Python] Removed dependencies only need by Python2

### DIFF
--- a/pulsar-client-cpp/docker/manylinux1/Dockerfile
+++ b/pulsar-client-cpp/docker/manylinux1/Dockerfile
@@ -1,3 +1,4 @@
+
 #
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
@@ -152,8 +153,6 @@ RUN curl -O -L  https://github.com/curl/curl/releases/download/curl-7_61_0/curl-
 
 RUN pip install twine
 RUN pip install fastavro
-RUN pip install six
-RUN pip install enum34
 
 
 ENV PYTHON_INCLUDE_DIR /opt/python/${PYTHON_SPEC}/include

--- a/pulsar-client-cpp/docker/manylinux2014/Dockerfile
+++ b/pulsar-client-cpp/docker/manylinux2014/Dockerfile
@@ -121,8 +121,6 @@ RUN curl -O -L  https://github.com/curl/curl/releases/download/curl-7_61_0/curl-
 
 RUN pip install twine
 RUN pip install fastavro
-RUN pip install six
-RUN pip install enum34
 
 
 ENV PYTHON_INCLUDE_DIR /opt/python/${PYTHON_SPEC}/include

--- a/pulsar-client-cpp/docker/manylinux_musl/Dockerfile
+++ b/pulsar-client-cpp/docker/manylinux_musl/Dockerfile
@@ -107,8 +107,6 @@ RUN curl -O -L  https://github.com/curl/curl/releases/download/curl-7_61_0/curl-
 
 RUN pip install twine
 RUN pip install fastavro
-RUN pip install six
-RUN pip install enum34
 
 
 ENV PYTHON_INCLUDE_DIR /opt/python/${PYTHON_SPEC}/include

--- a/pulsar-client-cpp/python/pulsar/schema/definition.py
+++ b/pulsar-client-cpp/python/pulsar/schema/definition.py
@@ -21,7 +21,6 @@ import copy
 from abc import abstractmethod
 from collections import OrderedDict
 from enum import Enum, EnumMeta
-from six import with_metaclass
 
 
 def _check_record_or_field(x):
@@ -54,7 +53,7 @@ class RecordMeta(type):
         return fields
 
 
-class Record(with_metaclass(RecordMeta, object)):
+class Record(metaclass=RecordMeta):
 
     # This field is used to set namespace for Avro Record schema.
     _avro_namespace = None

--- a/pulsar-client-cpp/python/setup.py
+++ b/pulsar-client-cpp/python/setup.py
@@ -21,7 +21,6 @@ from setuptools import setup
 from distutils.core import Extension
 from distutils.util import strtobool
 from os import environ
-import subprocess
 
 from distutils.command import build_ext
 
@@ -50,11 +49,13 @@ def get_name():
     base = 'pulsar-client'
     return base + postfix
 
+
 VERSION = get_version()
 NAME = get_name()
 
 print(VERSION)
 print(NAME)
+
 
 # This is a workaround to have setuptools to include
 # the already compiled _pulsar.so library
@@ -70,11 +71,10 @@ class my_build_ext(build_ext.build_ext):
                 raise
         shutil.copyfile('_pulsar.so', self.get_ext_fullpath(ext.name))
 
+
 # Core Client dependencies
 dependencies = [
-    'six',
     'certifi',
-    'enum34>=1.1.9; python_version < "3.4"'
 ]
 
 extras_require = {}


### PR DESCRIPTION
### Motivation

Since we have set the min python version to 3.7, we can get rid of some dependencies that were only related to Python2