### PR TITLE
Replaced unicode 'comma and space' as single glyph with regular comma and space characters

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/BundleSplitterTask.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/BundleSplitterTask.java
@@ -73,7 +73,7 @@ public class BundleSplitterTask implements BundleSplitStrategy {
                 final String bundle = entry.getKey();
                 final NamespaceBundleStats stats = entry.getValue();
                 if (stats.topics < 2) {
-                    log.info("The count of topics on the bundle {} is less than 2，skip split!", bundle);
+                    log.info("The count of topics on the bundle {} is less than 2, skip split!", bundle);
                     continue;
                 }
                 double totalMessageRate = 0;

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/InactiveTopicDeleteTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/InactiveTopicDeleteTest.java
@@ -460,7 +460,7 @@ public class InactiveTopicDeleteTest extends BrokerTestBase {
         });
         admin.topics().removeInactiveTopicPolicies(topic2);
         // The cache has been updated, but the system-event may not be consumed yet
-        // ，so wait for topic-policies update event
+        // , so wait for topic-policies update event
         Awaitility.await().untilAsserted(() -> {
             InactiveTopicPolicies nsPolicies = ((PersistentTopic) pulsar.getBrokerService()
                     .getTopic(topic2, false).get().get()).getInactiveTopicPolicies();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/io/PulsarFunctionE2ETest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/io/PulsarFunctionE2ETest.java
@@ -237,7 +237,7 @@ public class PulsarFunctionE2ETest extends AbstractPulsarE2ETest {
         String jarFilePathUrl = getPulsarApiExamplesJar().toURI().toString();
         admin.functions().createFunctionWithUrl(functionConfig, jarFilePathUrl);
 
-        // 5 Function should only read compacted value，so we will only receive compacted messages
+        // 5 Function should only read compacted value, so we will only receive compacted messages
         Consumer<String> consumer = pulsarClient.newConsumer(Schema.STRING).topic(sinkTopic).subscriptionName("sink-sub").subscribe();
         int count = 0;
         while (true) {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/io/PulsarSinkE2ETest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/io/PulsarSinkE2ETest.java
@@ -120,7 +120,7 @@ public class PulsarSinkE2ETest extends AbstractPulsarE2ETest {
         String jarFilePathUrl = getPulsarIODataGeneratorNar().toURI().toString();
         admin.sinks().createSinkWithUrl(sinkConfig, jarFilePathUrl);
 
-        // 5 Sink should only read compacted value，so we will only receive compacted messages
+        // 5 Sink should only read compacted value, so we will only receive compacted messages
         Awaitility.await().ignoreExceptions().untilAsserted(() -> {
             String prometheusMetrics = PulsarFunctionTestUtils.getPrometheusMetrics(pulsar.getListenPortHTTP().get());
             Map<String, PulsarFunctionTestUtils.Metric> metrics = PulsarFunctionTestUtils.parseMetrics(prometheusMetrics);

--- a/pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/admin/Namespaces.java
+++ b/pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/admin/Namespaces.java
@@ -2750,7 +2750,7 @@ public interface Namespaces {
     CompletableFuture<InactiveTopicPolicies> getInactiveTopicPoliciesAsync(String namespace);
 
     /**
-     * As same as setInactiveTopicPoliciesAsync，but it is synchronous.
+     * As same as setInactiveTopicPoliciesAsync, but it is synchronous.
      * @param namespace
      * @param inactiveTopicPolicies
      */

--- a/pulsar-sql/presto-pulsar/src/main/java/org/apache/pulsar/sql/presto/decoder/json/PulsarJsonRowDecoderFactory.java
+++ b/pulsar-sql/presto-pulsar/src/main/java/org/apache/pulsar/sql/presto/decoder/json/PulsarJsonRowDecoderFactory.java
@@ -124,7 +124,7 @@ public class PulsarJsonRowDecoderFactory implements PulsarRowDecoderFactory {
                 return createUnboundedVarcharType();
             case NULL:
                 throw new UnsupportedOperationException(format(
-                        "field '%s' NULL type code should not be reached ，"
+                        "field '%s' NULL type code should not be reached , "
                                 + "please check the schema or report the bug.", fieldname));
             case FIXED:
             case BYTES:

--- a/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/AbstractWebSocketHandler.java
+++ b/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/AbstractWebSocketHandler.java
@@ -243,7 +243,7 @@ public abstract class AbstractWebSocketHandler extends WebSocketAdapter implemen
         final NamespaceName namespace = isV2Format ? NamespaceName.get(parts.get(5), parts.get(6)) :
                 NamespaceName.get(parts.get(4), parts.get(5), parts.get(6));
 
-        // The topic name which contains slashes is also split，so it needs to be jointed
+        // The topic name which contains slashes is also split, so it needs to be jointed
         int startPosition = 7;
         boolean isConsumer = "consumer".equals(parts.get(2)) || "consumer".equals(parts.get(3));
         int endPosition = isConsumer ? parts.size() - 1 : parts.size();

--- a/site2/docs/client-libraries-cpp.md
+++ b/site2/docs/client-libraries-cpp.md
@@ -129,7 +129,7 @@ The `libpulsarwithdeps.a` does not include library openssl related libraries `li
 $ rpm -ivh apache-pulsar-client*.rpm
 ```
 
-After you install RPM successfully, Pulsar libraries are in the `/usr/lib` directory，for example：
+After you install RPM successfully, Pulsar libraries are in the `/usr/lib` directory, for example：
 ```bash
 lrwxrwxrwx 1 root root 18 Dec 30 22:21 libpulsar.so -> libpulsar.so.2.9.1
 lrwxrwxrwx 1 root root 23 Dec 30 22:21 libpulsarnossl.so -> libpulsarnossl.so.2.9.1

--- a/site2/website/release-notes.md
+++ b/site2/website/release-notes.md
@@ -1026,7 +1026,7 @@ It also includes fixes for some breaking changes introduced in 2.9.0.
 - Cancel scheduled tasks when deleting ManagedLedgerImpl [#12565](https://github.com/apache/pulsar/pull/12565)
 - Add git branch information for PulsarVersion [#12541](https://github.com/apache/pulsar/pull/12541)
 - Websocket should pass the encryption context to consumers [#12539](https://github.com/apache/pulsar/pull/12539)
-- The count of topics on the bundle is less than 2，skip split [#12527](https://github.com/apache/pulsar/pull/12527)
+- The count of topics on the bundle is less than 2, skip split [#12527](https://github.com/apache/pulsar/pull/12527)
 - Fix the reader skips compacted data which original ledger been removed [#12522](https://github.com/apache/pulsar/pull/12522)
 - Fix `messageDedup` delete inactive producer name [#12493](https://github.com/apache/pulsar/pull/12493)
 - Optimize the code: remove extra spaces [#12470](https://github.com/apache/pulsar/pull/12470)

--- a/site2/website/versioned_docs/version-2.10.0/client-libraries-cpp.md
+++ b/site2/website/versioned_docs/version-2.10.0/client-libraries-cpp.md
@@ -130,7 +130,7 @@ The `libpulsarwithdeps.a` does not include library openssl related libraries `li
 $ rpm -ivh apache-pulsar-client*.rpm
 ```
 
-After you install RPM successfully, Pulsar libraries are in the `/usr/lib` directory，for example：
+After you install RPM successfully, Pulsar libraries are in the `/usr/lib` directory, for example：
 ```bash
 lrwxrwxrwx 1 root root 18 Dec 30 22:21 libpulsar.so -> libpulsar.so.2.9.1
 lrwxrwxrwx 1 root root 23 Dec 30 22:21 libpulsarnossl.so -> libpulsarnossl.so.2.9.1

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/sinks/JdbcPostgresSinkTester.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/sinks/JdbcPostgresSinkTester.java
@@ -43,7 +43,7 @@ import static org.testng.Assert.fail;
 public class JdbcPostgresSinkTester extends SinkTester<PostgreSQLContainer> {
 
     /**
-     * A Simple class to test jdbc class，
+     * A Simple class to test jdbc class,
      */
     @Data
     public static class Foo {


### PR DESCRIPTION
### Motivation

I found log lines like
```
INFO  org.apache.pulsar.broker.loadbalance.BundleSplitStrategy - The count of topics on the bundle benchmark/ns-85SYDFY/0x4c000000_0x50000000 is less than 2ï¼Œskip split!
```

this is coming from 

```
log.info("The count of topics on the bundle {} is less than 2，skip split!", bundle);
```
where "，" is a single unicode character.

### Modifications

replaced "，" with regular comma and space, skipped text/files where it was next to hieroglyphs/other unicode characters.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

NO

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API: (yes / no)
  - The schema: (yes / no / don't know)
  - The default values of configurations: (yes / no)
  - The wire protocol: (yes / no)
  - The rest endpoints: (yes / no)
  - The admin cli options: (yes / no)
  - Anything that affects deployment: (yes / no / don't know)

### Documentation

Check the box below or label this PR directly.

Need to update docs? 

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)
  
- [x] `no-need-doc` 
(Please explain why)
  
- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-added`
(Docs have been already added)