### PR TITLE
[improve][client] improve logic when ACK grouping tracker checks duplicated message id

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PersistentAcknowledgmentsGroupingTracker.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PersistentAcknowledgmentsGroupingTracker.java
@@ -118,10 +118,7 @@ public class PersistentAcknowledgmentsGroupingTracker implements Acknowledgments
     @Override
     public boolean isDuplicate(@NonNull MessageId messageId) {
         final MessageId messageIdOfLastAck = lastCumulativeAck.messageId;
-        if (messageIdOfLastAck == null) {
-            return false;
-        }
-        if (messageId.compareTo(messageIdOfLastAck) <= 0) {
+        if (messageIdOfLastAck != null && messageId.compareTo(messageIdOfLastAck) <= 0) {
             // Already included in a cumulative ack
             return true;
         } else {


### PR DESCRIPTION
### Motivation

#10586 introduces NPE check to avoid problems caused by recycling race conditions, but another conditional judgment in `isDuplicate` logic is not strongly dependent on the `messageIdOfLastAck`, we can still use `pendingIndividualAcks.contains(messageId)` to judge again.

### Modifications

- Use `pendingIndividualAcks.contains(messageId)` to judgement when `messageIdOfLastAck` is null.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Documentation

- [x] `no-need-doc` 
