### PR TITLE
Use unique consumer name when create sub

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
@@ -239,8 +239,10 @@ public class BrokerService implements Closeable {
     protected volatile DispatchRateLimiter brokerDispatchRateLimiter = null;
 
     private DistributedIdGenerator producerNameGenerator;
+    private DistributedIdGenerator consumerNameGenerator;
 
     public static final String PRODUCER_NAME_GENERATOR_PATH = "/counters/producer-name";
+    public static final String CONSUMER_NAME_GENERATOR_PATH = "/counters/consumer-name";
 
     private final BacklogQuotaManager backlogQuotaManager;
 
@@ -458,6 +460,8 @@ public class BrokerService implements Closeable {
     public void start() throws Exception {
         this.producerNameGenerator = new DistributedIdGenerator(pulsar.getCoordinationService(),
                 PRODUCER_NAME_GENERATOR_PATH, pulsar.getConfiguration().getClusterName());
+        this.consumerNameGenerator = new DistributedIdGenerator(pulsar.getCoordinationService(),
+                CONSUMER_NAME_GENERATOR_PATH, pulsar.getConfiguration().getClusterName());
 
         ServiceConfiguration serviceConfig = pulsar.getConfiguration();
         List<BindAddress> bindAddresses = BindAddressValidator.validateBindAddresses(serviceConfig,
@@ -2116,6 +2120,10 @@ public class BrokerService implements Closeable {
 
     public String generateUniqueProducerName() {
         return producerNameGenerator.getNextId();
+    }
+
+    public String generateUniqueConsumerName() {
+        return consumerNameGenerator.getNextId();
     }
 
     public Map<String, TopicStatsImpl> getTopicStats() {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
@@ -945,7 +945,8 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
 
         final String subscriptionName = subscribe.getSubscription();
         final SubType subType = subscribe.getSubType();
-        final String consumerName = subscribe.hasConsumerName() ? subscribe.getConsumerName() : "";
+        final String consumerName = subscribe.hasConsumerName() ? subscribe.getConsumerName()
+                : service.generateUniqueConsumerName();
         final boolean isDurable = subscribe.isDurable();
         final MessageIdImpl startMessageId = subscribe.hasStartMessageId() ? new BatchMessageIdImpl(
                 subscribe.getStartMessageId().getLedgerId(), subscribe.getStartMessageId().getEntryId(),


### PR DESCRIPTION
Signed-off-by: xiaolongran <xiaolongran@tencent.com>


### Motivation


Currently, if the user does not specify the producerName when creating the producer, the broker will generate a unique ProducerName field:

```
        // Use producer name provided by client if present
        final String producerName = cmdProducer.hasProducerName() ? cmdProducer.getProducerName()
                : service.generateUniqueProducerName();
```

However, when the sub is created and the user does not specify a consumerName, an empty string is used instead:

```
final String consumerName = subscribe.hasConsumerName() ? subscribe.getConsumerName() : "";
```

Under normal circumstances, this seems to be no problem, but when many topics reuse the same client, and for some reason, the connection is frequently disconnected, reconnected, disconnected, and reconnected. In this way, we can see that there are many consumer objects with the same consumerName under the current subscription through `bin/pulsar-admin topics stats <topic-name>`.

The following is a phenomenon we encountered in the production environment. This `consumerName: exchange-wal-consumer-9.1x.1x.x-3953a` has a total of **997** consumer objects with the same name under this topic.


<img width="1685" alt="image" src="https://user-images.githubusercontent.com/20965307/167100529-f1d88a11-77ba-48c4-81d4-96d2f5b36e88.png">


### Modifications

- Following producerName impl, use unique consumerName when create sub
- Add test case and fix currently consumer test case

