### PR TITLE
[improve][doc] Clarify the definition of message key

### DIFF
--- a/site2/docs/concepts-messaging.md
+++ b/site2/docs/concepts-messaging.md
@@ -17,7 +17,7 @@ Messages are the basic "unit" of Pulsar. The following table lists the component
 Component | Description
 :---------|:-------
 Value / data payload | The data carried by the message. All Pulsar messages contain raw bytes, although message data can also conform to data [schemas](schema-get-started.md).
-Key | Messages are optionally tagged with keys, which is useful for things like [topic compaction](concepts-topic-compaction.md).
+Key | The key (string type) of the message. It is a short name of message key or partition key. Messages are optionally tagged with keys, which is useful for features like [topic compaction](concepts-topic-compaction.md).
 Properties | An optional key/value map of user-defined properties.
 Producer name | The name of the producer who produces the message. If you do not specify a producer name, the default name is used. 
 Topic name | The name of the topic that the message is published to.


### PR DESCRIPTION

Fixes  #15380.

### Modifications

Add information to link with partition key and show its data type.

The preview looks good.

<img width="1425" alt="image" src="https://user-images.githubusercontent.com/60642177/167100720-d8e89e4d-76ce-40e5-a34d-bef1b47abb6f.png">


### Documentation
  
- [x] `doc` 
