### PR TITLE
[improve][client] Stop flush ack when the client reconnects.

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PersistentAcknowledgmentsGroupingTracker.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PersistentAcknowledgmentsGroupingTracker.java
@@ -457,7 +457,7 @@ public class PersistentAcknowledgmentsGroupingTracker implements Acknowledgments
     public void flush() {
         ClientCnx cnx = consumer.getClientCnx();
 
-        if (cnx == null) {
+        if (cnx == null || consumer.getState() != HandlerState.State.Ready) {
             if (log.isDebugEnabled()) {
                 log.debug("[{}] Cannot flush pending acks since we're not connected to broker", consumer);
             }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PersistentAcknowledgmentsGroupingTracker.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PersistentAcknowledgmentsGroupingTracker.java
@@ -457,9 +457,16 @@ public class PersistentAcknowledgmentsGroupingTracker implements Acknowledgments
     public void flush() {
         ClientCnx cnx = consumer.getClientCnx();
 
-        if (cnx == null || consumer.getState() != HandlerState.State.Ready) {
+        if (cnx == null) {
             if (log.isDebugEnabled()) {
                 log.debug("[{}] Cannot flush pending acks since we're not connected to broker", consumer);
+            }
+            return;
+        }
+
+        if (consumer.getState() != HandlerState.State.Ready) {
+            if (log.isDebugEnabled()) {
+                log.debug("[{}] Cannot flush pending acks since the consumer is not ready.", consumer);
             }
             return;
         }


### PR DESCRIPTION
### Motivation

Current, we use PersistentAcknowledgmentsGroupingTracker#isDuplicate to do our best effort to deduplicate messages.
the original comments as below:

```
Since the ack are delayed, we need to do some best-effort duplicate check to discard messages that are being
resent after a disconnection and for which the user has already sent an acknowledgement.
```

Following this principle, we can improve our logic in ack flush. when the consumer state is not ready, we don't need to flush the ack to the wrong broker. which can help `isDuplicate` be more effective in some cases.


### Modifications

- If the consumer state is not `ready`, we don't need to flush the ack.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Documentation

- [x] `no-need-doc` 