### PR TITLE
[improve][connector] Add getSinkConfig method to SinkContext

### DIFF
--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/ContextImpl.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/ContextImpl.java
@@ -56,6 +56,7 @@ import org.apache.pulsar.client.api.SubscriptionType;
 import org.apache.pulsar.client.api.TypedMessageBuilder;
 import org.apache.pulsar.client.impl.MultiTopicsConsumerImpl;
 import org.apache.pulsar.client.impl.ProducerBuilderImpl;
+import org.apache.pulsar.common.io.SinkConfig;
 import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.util.FutureUtil;
 import org.apache.pulsar.functions.api.Context;
@@ -73,6 +74,7 @@ import org.apache.pulsar.functions.proto.Function.SinkSpec;
 import org.apache.pulsar.functions.secretsprovider.SecretsProvider;
 import org.apache.pulsar.functions.source.TopicSchema;
 import org.apache.pulsar.functions.utils.FunctionCommon;
+import org.apache.pulsar.functions.utils.SinkConfigUtils;
 import org.apache.pulsar.io.core.SinkContext;
 import org.apache.pulsar.io.core.SourceContext;
 import org.slf4j.Logger;
@@ -249,6 +251,11 @@ class ContextImpl implements Context, SinkContext, SourceContext, AutoCloseable 
     @Override
     public Collection<String> getInputTopics() {
         return config.getFunctionDetails().getSource().getInputSpecsMap().keySet();
+    }
+
+    @Override
+    public SinkConfig getSinkConfig() {
+        return SinkConfigUtils.convertFromDetails(config.getFunctionDetails());
     }
 
     @Override

--- a/pulsar-functions/instance/src/test/java/org/apache/pulsar/functions/instance/ContextImplTest.java
+++ b/pulsar-functions/instance/src/test/java/org/apache/pulsar/functions/instance/ContextImplTest.java
@@ -50,6 +50,7 @@ import org.apache.pulsar.client.impl.ProducerBuilderImpl;
 import org.apache.pulsar.client.impl.PulsarClientImpl;
 import org.apache.pulsar.client.impl.TypedMessageBuilderImpl;
 import org.apache.pulsar.client.impl.conf.ProducerConfigurationData;
+import org.apache.pulsar.common.io.SinkConfig;
 import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.functions.api.Record;
 import org.apache.pulsar.functions.instance.state.BKStateStoreImpl;
@@ -135,6 +136,12 @@ public class ContextImplTest {
     @Test(expectedExceptions = IllegalStateException.class)
     public void testGetStateStateDisabled() {
         context.getState("test-key");
+    }
+
+    @Test
+    public void testGetSinkConfig() {
+        SinkContext sinkContext = context;
+        Assert.assertNotNull(sinkContext.getSinkConfig());
     }
 
     @Test

--- a/pulsar-functions/instance/src/test/java/org/apache/pulsar/functions/instance/ContextImplTest.java
+++ b/pulsar-functions/instance/src/test/java/org/apache/pulsar/functions/instance/ContextImplTest.java
@@ -141,7 +141,8 @@ public class ContextImplTest {
     @Test
     public void testGetSinkConfig() {
         SinkContext sinkContext = context;
-        Assert.assertNotNull(sinkContext.getSinkConfig());
+        SinkConfig sinkConfig = sinkContext.getSinkConfig();
+        Assert.assertNotNull(sinkConfig);
     }
 
     @Test

--- a/pulsar-io/common/src/test/java/org/apache/pulsar/io/common/IOConfigUtilsTest.java
+++ b/pulsar-io/common/src/test/java/org/apache/pulsar/io/common/IOConfigUtilsTest.java
@@ -25,6 +25,7 @@ import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.client.api.TypedMessageBuilder;
+import org.apache.pulsar.common.io.SinkConfig;
 import org.apache.pulsar.io.core.SinkContext;
 import org.apache.pulsar.io.core.SourceContext;
 import org.apache.pulsar.io.core.annotations.FieldDoc;
@@ -281,6 +282,11 @@ public class IOConfigUtilsTest {
 
         @Override
         public Collection<String> getInputTopics() {
+            return null;
+        }
+
+        @Override
+        public SinkConfig getSinkConfig() {
             return null;
         }
 

--- a/pulsar-io/core/src/main/java/org/apache/pulsar/io/core/SinkContext.java
+++ b/pulsar-io/core/src/main/java/org/apache/pulsar/io/core/SinkContext.java
@@ -24,6 +24,7 @@ import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.api.SubscriptionType;
 import org.apache.pulsar.common.classification.InterfaceAudience;
 import org.apache.pulsar.common.classification.InterfaceStability;
+import org.apache.pulsar.common.io.SinkConfig;
 import org.apache.pulsar.functions.api.BaseContext;
 
 /**
@@ -45,6 +46,12 @@ public interface SinkContext extends BaseContext {
      * @return a list of all input topics
      */
     Collection<String> getInputTopics();
+
+    /**
+     * Get sink config at startup
+     * @return sink config
+     */
+    SinkConfig getSinkConfig();
 
     /**
      * Get subscription type used by the source providing data for the sink.

--- a/pulsar-io/core/src/main/java/org/apache/pulsar/io/core/SinkContext.java
+++ b/pulsar-io/core/src/main/java/org/apache/pulsar/io/core/SinkContext.java
@@ -48,7 +48,8 @@ public interface SinkContext extends BaseContext {
     Collection<String> getInputTopics();
 
     /**
-     * Get sink config at startup
+     * Get sink config at startup.
+     *
      * @return sink config
      */
     SinkConfig getSinkConfig();

--- a/pulsar-io/kafka/src/test/java/org/apache/pulsar/io/kafka/sink/KafkaAbstractSinkTest.java
+++ b/pulsar-io/kafka/src/test/java/org/apache/pulsar/io/kafka/sink/KafkaAbstractSinkTest.java
@@ -23,6 +23,7 @@ import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.security.auth.SecurityProtocol;
 import org.apache.pulsar.client.api.PulsarClient;
+import org.apache.pulsar.common.io.SinkConfig;
 import org.apache.pulsar.functions.api.Record;
 import org.apache.pulsar.io.core.KeyValue;
 import org.apache.pulsar.io.core.SinkContext;
@@ -94,6 +95,11 @@ public class KafkaAbstractSinkTest {
 
             @Override
             public Collection<String> getInputTopics() {
+                return null;
+            }
+
+            @Override
+            public SinkConfig getSinkConfig() {
                 return null;
             }
 


### PR DESCRIPTION
### Motivation

The configuration of SinkConfig is rich, and the user can flexibly specify it when registry the sink. But some sinks do not support these configurations, for example we want to disable autoAck.

So, add SinkConfig to SinkContext, enables the sink to validate the configuration when executing the `sink.open` method.


### Modifications
- Add getSinkConfig method to SinkContext


### Documentation

- [x] `no-need-doc` 

