### PR TITLE
[fix] [client] auto release useless connections

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/AutoCloseUselessClientConMultiPartTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/AutoCloseUselessClientConMultiPartTest.java
@@ -1,0 +1,101 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.client.impl;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.UUID;
+import org.apache.pulsar.client.admin.PulsarAdmin;
+import org.apache.pulsar.client.admin.PulsarAdminException;
+import org.apache.pulsar.client.api.Consumer;
+import org.apache.pulsar.client.api.Producer;
+import org.apache.pulsar.client.api.Schema;
+import org.awaitility.Awaitility;
+import org.testng.Assert;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+public class AutoCloseUselessClientConMultiPartTest extends AutoCloseUselessClientConSupports {
+
+    private static String topicName = UUID.randomUUID().toString().replaceAll("-","");
+    private static String topicFullName = "persistent://public/default/" + topicName;
+
+    @BeforeMethod
+    public void before() throws PulsarAdminException {
+        // Create Topics
+        PulsarAdmin pulsarAdmin_0 = super.getAllAdmins().get(0);
+        List<String> topicList = pulsarAdmin_0.topics().getList("public/default");
+        if (!topicList.contains(topicName) && !topicList.contains(topicFullName + "-partition-0")
+                && !topicList.contains(topicFullName)){
+            pulsarAdmin_0.topics().createPartitionedTopic(topicFullName, 2);
+        }
+    }
+
+    @Test
+    public void testConnectionAutoReleasePartitionedTopic() throws Exception {
+        // Init clients
+        PulsarClientImpl pulsarClient = (PulsarClientImpl) super.getAllClients().get(0);
+        Consumer consumer = pulsarClient.newConsumer()
+                .topic(topicName)
+                .subscriptionName("my-subscription-x")
+                .subscribe();
+        Producer producer = pulsarClient.newProducer()
+                .topic(topicName)
+                .create();
+        // Ensure producer and consumer works
+        ensureProducerAndConsumerWorks(producer, consumer);
+        // Connection to every Broker
+        connectionToEveryBrokerWithUnloadBundle(pulsarClient);
+        try {
+            // Ensure that the consumer has reconnected finish after unload-bundle
+            Awaitility.waitAtMost(Duration.ofSeconds(30)).until(consumer::isConnected);
+        } catch (Exception e){
+            // When consumer reconnect failure, create a new one.
+            consumer.close();
+            consumer = pulsarClient.newConsumer(Schema.BYTES)
+                    .topic(topicName)
+                    .isAckReceiptEnabled(true)
+                    .subscriptionName("my-subscription-x")
+                    .subscribe();
+        }
+        try {
+            // Ensure that the producer has reconnected finish after unload-bundle
+            Awaitility.waitAtMost(Duration.ofSeconds(30)).until(producer::isConnected);
+        } catch (Exception e){
+            // When producer reconnect failure, create a new one.
+            producer.close();
+            producer = pulsarClient.newProducer(Schema.BYTES)
+                    .topic(topicName)
+                    .create();
+        }
+        // Assert "auto release works"
+        trigReleaseConnection(pulsarClient);
+        Awaitility.waitAtMost(Duration.ofSeconds(30)).until(()-> {
+            // wait for async task done, then assert auto release success
+            return pulsarClient.getCnxPool().getPoolSize() <= 2;
+        });
+        // Ensure all things still works
+        ensureProducerAndConsumerWorks(producer, consumer);
+        // Verify that the number of connections did not increase after the work was completed
+        Assert.assertTrue(pulsarClient.getCnxPool().getPoolSize() <= 2);
+        // Release sources
+        consumer.close();
+        producer.close();
+    }
+}

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/AutoCloseUselessClientConMultiTopicTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/AutoCloseUselessClientConMultiTopicTest.java
@@ -1,0 +1,119 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.client.impl;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.UUID;
+import org.apache.pulsar.client.admin.PulsarAdmin;
+import org.apache.pulsar.client.admin.PulsarAdminException;
+import org.apache.pulsar.client.api.Consumer;
+import org.apache.pulsar.client.api.Producer;
+import org.awaitility.Awaitility;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+public class AutoCloseUselessClientConMultiTopicTest extends AutoCloseUselessClientConSupports {
+
+    private static String topicName_1 = UUID.randomUUID().toString().replaceAll("-","");
+    private static String topicFullName_1 = "persistent://public/default/" + topicName_1;
+    private static String topicName_2 = UUID.randomUUID().toString().replaceAll("-","");
+    private static String topicFullName_2 = "persistent://public/default/" + topicName_2;
+
+    @BeforeMethod
+    public void before() throws PulsarAdminException {
+        // Create Topics
+        PulsarAdmin pulsarAdmin_0 = super.getAllAdmins().get(0);
+        List<String> topicList = pulsarAdmin_0.topics().getList("public/default");
+        if (!topicList.contains(topicName_1) && !topicList.contains(topicFullName_1 + "-partition-0")
+                && !topicList.contains(topicFullName_1)){
+            pulsarAdmin_0.topics().createNonPartitionedTopic(topicFullName_1);
+        }
+        if (!topicList.contains(topicName_2) && !topicList.contains(topicFullName_2 + "-partition-0")
+                && !topicList.contains(topicFullName_2)){
+            pulsarAdmin_0.topics().createNonPartitionedTopic(topicFullName_2);
+        }
+    }
+
+    @Test
+    public void testConnectionAutoReleaseMultiTopic() throws Exception {
+        // Init clients
+        PulsarClientImpl pulsarClient = (PulsarClientImpl) super.getAllClients().get(0);
+        Consumer consumer = pulsarClient.newConsumer()
+                .topic(topicName_1, topicName_2)
+                .subscriptionName("my-subscription-x")
+                .isAckReceiptEnabled(true)
+                .subscribe();
+        Producer producer_1 = pulsarClient.newProducer()
+                .topic(topicName_1)
+                .create();
+        Producer producer_2 = pulsarClient.newProducer()
+                .topic(topicName_2)
+                .create();
+        // Ensure producer and consumer works
+        ensureProducerAndConsumerWorks(producer_1, producer_2, consumer);
+        // Connection to every Broker
+        connectionToEveryBrokerWithUnloadBundle(pulsarClient);
+        // Ensure that the client has reconnected finish after unload-bundle
+        try {
+            // Ensure that the consumer has reconnected finish after unload-bundle
+            Awaitility.waitAtMost(Duration.ofSeconds(30)).until(consumer::isConnected);
+        } catch (Exception e){
+            // When consumer reconnect failure, create a new one.
+            consumer.close();
+            consumer = pulsarClient.newConsumer()
+                    .topic(topicName_1, topicName_2)
+                    .subscriptionName("my-subscription-x")
+                    .isAckReceiptEnabled(true)
+                    .subscribe();
+        }
+        try {
+            // Ensure that the producer has reconnected finish after unload-bundle
+            Awaitility.waitAtMost(Duration.ofSeconds(30)).until(producer_1::isConnected);
+        } catch (Exception e){
+            // When producer reconnect failure, create a new one.
+            producer_1.close();
+            producer_1 = pulsarClient.newProducer()
+                    .topic(topicName_1)
+                    .create();
+        }
+        try {
+            // Ensure that the producer has reconnected finish after unload-bundle
+            Awaitility.waitAtMost(Duration.ofSeconds(30)).until(producer_2::isConnected);
+        } catch (Exception e){
+            // When producer reconnect failure, create a new one.
+            producer_2.close();
+            producer_2 = pulsarClient.newProducer()
+                    .topic(topicName_2)
+                    .create();
+        }
+        // Assert "auto release works"
+        trigReleaseConnection(pulsarClient);
+        Awaitility.waitAtMost(Duration.ofSeconds(30)).until(()-> {
+            // Wait for async task done, then assert auto release success
+            return pulsarClient.getCnxPool().getPoolSize() == 1;
+        });
+        // Ensure all things still works
+        ensureProducerAndConsumerWorks(producer_1, producer_2, consumer);
+        // Release sources
+        consumer.close();
+        producer_1.close();
+        producer_2.close();
+    }
+}

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/AutoCloseUselessClientConNoPartTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/AutoCloseUselessClientConNoPartTest.java
@@ -1,0 +1,104 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.client.impl;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.UUID;
+import org.apache.pulsar.client.admin.PulsarAdmin;
+import org.apache.pulsar.client.admin.PulsarAdminException;
+import org.apache.pulsar.client.api.Consumer;
+import org.apache.pulsar.client.api.Producer;
+import org.apache.pulsar.client.api.Schema;
+import org.awaitility.Awaitility;
+import org.testng.Assert;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+public class AutoCloseUselessClientConNoPartTest extends AutoCloseUselessClientConSupports {
+
+    private static String topicName = UUID.randomUUID().toString().replaceAll("-","");
+    private static String topicFullName = "persistent://public/default/" + topicName;
+
+    @BeforeMethod
+    public void before() throws PulsarAdminException {
+        // Create Topics
+        PulsarAdmin pulsarAdmin_0 = super.getAllAdmins().get(0);
+        List<String> topicList = pulsarAdmin_0.topics().getList("public/default");
+        if (!topicList.contains(topicName) && !topicList.contains(topicFullName + "-partition-0")
+                && !topicList.contains(topicFullName)){
+            pulsarAdmin_0.topics().createNonPartitionedTopic(topicFullName);
+        }
+    }
+
+    @Test
+    public void testConnectionAutoReleaseUnPartitionedTopic() throws Exception {
+        // Init clients
+        PulsarClientImpl pulsarClient = (PulsarClientImpl) super.getAllClients().get(0);
+        Consumer consumer = pulsarClient.newConsumer(Schema.BYTES)
+                .topic(topicName)
+                .isAckReceiptEnabled(true)
+                .subscriptionName("my-subscription-x")
+                .subscribe();
+        Producer producer = pulsarClient.newProducer(Schema.BYTES)
+                .topic(topicName)
+                .create();
+        // Ensure producer and consumer works
+        ensureProducerAndConsumerWorks(producer, consumer);
+        // Connection to every Broker
+        connectionToEveryBrokerWithUnloadBundle(pulsarClient);
+        try {
+            // Ensure that the consumer has reconnected finish after unload-bundle
+            Awaitility.waitAtMost(Duration.ofSeconds(30)).until(consumer::isConnected);
+        } catch (Exception e){
+            // When consumer reconnect failure, create a new one.
+            consumer.close();
+            consumer = pulsarClient.newConsumer(Schema.BYTES)
+                    .topic(topicName)
+                    .isAckReceiptEnabled(true)
+                    .subscriptionName("my-subscription-x")
+                    .subscribe();
+        }
+        try {
+            // Ensure that the producer has reconnected finish after unload-bundle
+            Awaitility.waitAtMost(Duration.ofSeconds(30)).until(producer::isConnected);
+        } catch (Exception e){
+            // When producer reconnect failure, create a new one.
+            producer.close();
+            producer = pulsarClient.newProducer(Schema.BYTES)
+                    .topic(topicName)
+                    .create();
+        }
+        // Ensure producer and consumer works
+        ensureProducerAndConsumerWorks(producer, consumer);
+        // Assert "auto release works"
+        trigReleaseConnection(pulsarClient);
+        Awaitility.waitAtMost(Duration.ofSeconds(30)).until(()-> {
+            // Wait for async task done, then assert auto release success
+            return pulsarClient.getCnxPool().getPoolSize() == 1;
+        });
+        // Ensure all things still works
+        ensureProducerAndConsumerWorks(producer, consumer);
+        // Verify that the number of connections did not increase after the work was completed
+        Assert.assertEquals(pulsarClient.getCnxPool().getPoolSize(), 1);
+        // Release sources
+        consumer.close();
+        producer.close();
+    }
+}

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/AutoCloseUselessClientConSupports.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/AutoCloseUselessClientConSupports.java
@@ -1,0 +1,193 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.client.impl;
+
+import java.lang.reflect.Field;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.HashSet;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import org.apache.pulsar.broker.MultiBrokerBaseTest;
+import org.apache.pulsar.broker.PulsarService;
+import org.apache.pulsar.client.admin.PulsarAdmin;
+import org.apache.pulsar.client.api.Consumer;
+import org.apache.pulsar.client.api.Message;
+import org.apache.pulsar.client.api.Producer;
+import org.apache.pulsar.client.api.PulsarClientException;
+import org.apache.pulsar.client.api.transaction.Transaction;
+import org.awaitility.Awaitility;
+import org.testng.Assert;
+
+public class AutoCloseUselessClientConSupports extends MultiBrokerBaseTest {
+
+    protected int BROKER_COUNT = 5;
+
+    @Override
+    protected int numberOfAdditionalBrokers() {
+        return BROKER_COUNT -1;
+    }
+
+    /**
+     * To ensure that connection release is triggered in a short time, call manually.
+     * Why provide this method: prevents instability on one side
+     */
+    protected void trigReleaseConnection(PulsarClientImpl pulsarClient)
+            throws InterruptedException, NoSuchFieldException, IllegalAccessException {
+        // Wait for every request has been response.
+        Field field = ConnectionPool.class.getDeclaredField("pool");
+        field.setAccessible(true);
+        ConcurrentHashMap<InetSocketAddress,ConcurrentMap<Integer,
+                CompletableFuture<ConnectionPool.ClientCnxWrap>>> pool =
+                (ConcurrentHashMap<InetSocketAddress, ConcurrentMap<Integer,
+                        CompletableFuture<ConnectionPool.ClientCnxWrap>>>) field.get(pulsarClient.getCnxPool());
+        final List<CompletableFuture<ConnectionPool.ClientCnxWrap>> clientCnxWrapList =
+                pool.values().stream().flatMap(c -> c.values().stream()).collect(Collectors.toList());
+        Awaitility.waitAtMost(Duration.ofSeconds(15)).until(() -> {
+            for (CompletableFuture<ConnectionPool.ClientCnxWrap> clientCnxWrapFuture : clientCnxWrapList){
+                if (!clientCnxWrapFuture.isDone()){
+                    continue;
+                }
+                ConnectionPool.ClientCnxWrap clientCnxWrap = clientCnxWrapFuture.getNow(null);
+                if (clientCnxWrap == null){
+                    continue;
+                }
+                if (clientCnxWrap.getClientCnx().getPendingRequests().size() > 0) {
+                    return false;
+                }
+            }
+            return true;
+        });
+        // Shorten max idle time
+        pulsarClient.getCnxPool().maxIdleSeconds = 1;
+        // trig : mark useless connections
+        pulsarClient.getCnxPool().doMarkAndReleaseUselessConnections();
+        // trig : after 2 seconds, release useless connections
+        Thread.sleep(2000);
+        pulsarClient.getCnxPool().doMarkAndReleaseUselessConnections();
+    }
+
+    /**
+     * Create connections to all brokers using the "Unload Bundle"
+     * If can't create it in a short time, use direct implements {@link #connectionToEveryBroker}
+     * Why provide this method: prevents instability on one side
+     */
+    protected void connectionToEveryBrokerWithUnloadBundle(PulsarClientImpl pulsarClient){
+        try {
+            Awaitility.waitAtMost(Duration.ofSeconds(5)).until(() -> {
+                int afterSubscribe_trans = pulsarClient.getCnxPool().getPoolSize();
+                if (afterSubscribe_trans == BROKER_COUNT) {
+                    return true;
+                }
+                for (PulsarAdmin pulsarAdmin : super.getAllAdmins()) {
+                    pulsarAdmin.namespaces().unloadNamespaceBundle("public/default", "0x00000000_0xffffffff");
+                }
+                return false;
+            });
+        } catch (Exception e){
+            connectionToEveryBroker(pulsarClient);
+        }
+    }
+
+    /**
+     * Create connections directly to all brokers
+     * Why provide this method: prevents instability on one side
+     */
+    protected void connectionToEveryBroker(PulsarClientImpl pulsarClient){
+        for (PulsarService pulsarService : super.getAllBrokers()){
+            String url = pulsarService.getBrokerServiceUrl();
+            if (url.contains("//")){
+                url = url.split("//")[1];
+            }
+            String host = url;
+            int port = 6650;
+            if (url.contains(":")){
+                String[] hostAndPort = url.split(":");
+                host = hostAndPort[0];
+                port = Integer.valueOf(hostAndPort[1]);
+            }
+            pulsarClient.getCnxPool()
+                    .getConnection(new InetSocketAddress(host, port));
+        }
+    }
+
+    /**
+     * Ensure producer and consumer works
+     */
+    protected void ensureProducerAndConsumerWorks(Producer producer, Consumer consumer)
+            throws PulsarClientException, ExecutionException, InterruptedException {
+        String messageContent = UUID.randomUUID().toString();
+        producer.send(messageContent.getBytes(StandardCharsets.UTF_8));
+        Message message = (Message) consumer.receiveAsync().get();
+        consumer.acknowledgeAsync(message).get();
+        Assert.assertEquals(new String(message.getData(), StandardCharsets.UTF_8), messageContent);
+    }
+
+    /**
+     * Ensure producer and consumer works
+     */
+    protected void ensureProducerAndConsumerWorks(Producer producer_1, Producer producer_2, Consumer consumer)
+            throws PulsarClientException, ExecutionException, InterruptedException {
+        String messageContent_1 = UUID.randomUUID().toString();
+        String messageContent_2 = UUID.randomUUID().toString();
+        HashSet<String> expectReceived = new HashSet<>();
+        expectReceived.add(messageContent_1);
+        expectReceived.add(messageContent_2);
+        producer_1.send(messageContent_1.getBytes(StandardCharsets.UTF_8));
+        producer_2.send(messageContent_2.getBytes(StandardCharsets.UTF_8));
+        Message message_1 = (Message) consumer.receiveAsync().get();
+        consumer.acknowledgeAsync(message_1).get();
+        Message message_2 = (Message) consumer.receiveAsync().get();
+        consumer.acknowledgeAsync(message_2).get();
+        HashSet<String> actualReceived = new HashSet<>();
+        actualReceived.add(new String(message_1.getData(), StandardCharsets.UTF_8));
+        actualReceived.add(new String(message_2.getData(), StandardCharsets.UTF_8));
+        Assert.assertEquals(actualReceived, expectReceived);
+    }
+
+    /**
+     * Ensure transaction works
+     */
+    protected void ensureTransactionWorks(PulsarClientImpl pulsarClient, Producer producer,
+                                          Consumer consumer)
+            throws PulsarClientException, ExecutionException, InterruptedException {
+        String messageContent_before = UUID.randomUUID().toString();
+        String messageContent_tx = UUID.randomUUID().toString();
+
+        Transaction transaction = pulsarClient.newTransaction()
+                .withTransactionTimeout(5, TimeUnit.MINUTES).build().get();
+        // assert producer/consumer work OK
+        producer.send(messageContent_before.getBytes(StandardCharsets.UTF_8));
+        Message message = (Message) consumer.receiveAsync().get();
+        Assert.assertEquals(new String(message.getData(), StandardCharsets.UTF_8), messageContent_before);
+        producer.newMessage(transaction).value(messageContent_tx.getBytes(StandardCharsets.UTF_8)).sendAsync().get();
+        consumer.acknowledgeAsync(message.getMessageId(), transaction);
+        transaction.commit().get();
+        Message message_tx = (Message) consumer.receiveAsync().get();
+        Assert.assertEquals(new String(message_tx.getData(), StandardCharsets.UTF_8), messageContent_tx);
+        consumer.acknowledge(message_tx);
+    }
+}

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/AutoCloseUselessClientConTXTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/AutoCloseUselessClientConTXTest.java
@@ -1,0 +1,160 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.client.impl;
+
+import java.time.Duration;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import org.apache.pulsar.broker.ServiceConfiguration;
+import org.apache.pulsar.client.admin.PulsarAdmin;
+import org.apache.pulsar.client.admin.PulsarAdminException;
+import org.apache.pulsar.client.api.ClientBuilder;
+import org.apache.pulsar.client.api.Consumer;
+import org.apache.pulsar.client.api.Producer;
+import org.apache.pulsar.client.api.PulsarClient;
+import org.apache.pulsar.client.api.PulsarClientException;
+import org.apache.pulsar.common.naming.SystemTopicNames;
+import org.apache.pulsar.common.partition.PartitionedTopicMetadata;
+import org.apache.pulsar.common.policies.data.ClusterData;
+import org.apache.pulsar.common.policies.data.TenantInfo;
+import org.apache.pulsar.metadata.api.MetadataStoreException;
+import org.awaitility.Awaitility;
+import org.testng.Assert;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+public class AutoCloseUselessClientConTXTest extends AutoCloseUselessClientConSupports {
+
+    private static String topicName = UUID.randomUUID().toString().replaceAll("-","");
+    private static String topicFullName = "persistent://public/default/" + topicName;
+
+    @BeforeMethod
+    public void before() throws PulsarAdminException, MetadataStoreException {
+        // Create Topics
+        PulsarAdmin pulsarAdmin_0 = super.getAllAdmins().get(0);
+        List<String> topicList_defaultNamespace = pulsarAdmin_0.topics().getList("public/default");
+        if (!topicList_defaultNamespace.contains(topicName)
+                && !topicList_defaultNamespace.contains(topicFullName + "-partition-0")
+                && !topicList_defaultNamespace.contains(topicFullName)){
+            pulsarAdmin_0.topics().createNonPartitionedTopic(topicFullName);
+        }
+        List<String> topicList_systemNamespace = pulsarAdmin_0.topics().getList("pulsar/system");
+
+        if (!pulsar.getPulsarResources()
+                .getNamespaceResources()
+                .getPartitionedTopicResources().partitionedTopicExists(SystemTopicNames.TRANSACTION_COORDINATOR_ASSIGN)){
+            pulsar.getPulsarResources()
+                    .getNamespaceResources()
+                    .getPartitionedTopicResources()
+                    .createPartitionedTopic(SystemTopicNames.TRANSACTION_COORDINATOR_ASSIGN,
+                            new PartitionedTopicMetadata(2));
+        }
+        if (!pulsar.getPulsarResources()
+                .getNamespaceResources()
+                .getPartitionedTopicResources().partitionedTopicExists(SystemTopicNames.TRANSACTION_COORDINATOR_LOG)){
+            pulsar.getPulsarResources()
+                    .getNamespaceResources()
+                    .getPartitionedTopicResources()
+                    .createPartitionedTopic(SystemTopicNames.TRANSACTION_COORDINATOR_LOG,
+                            new PartitionedTopicMetadata(2));
+        }
+    }
+
+    @Override
+    protected void doInitConf() throws Exception {
+        super.doInitConf();
+        updateConfig(conf, "BROKER-INIT");
+    }
+
+    @Override
+    protected ServiceConfiguration createConfForAdditionalBroker(int additionalBrokerIndex) {
+        ServiceConfiguration conf = super.createConfForAdditionalBroker(additionalBrokerIndex);
+        updateConfig(conf, "BROKER-" + additionalBrokerIndex);
+        return conf;
+    }
+
+    /**
+     * Override for make client enable transaction.
+     */
+    @Override
+    protected PulsarClient createNewPulsarClient(ClientBuilder clientBuilder) throws PulsarClientException {
+        try {
+            if (!admin.clusters().getClusters().contains("test")){
+                admin.clusters().createCluster("test", ClusterData.builder().build());
+            }
+            if (!admin.tenants().getTenants().contains("pulsar")){
+                admin.tenants().createTenant("pulsar",
+                        TenantInfo.builder().allowedClusters(Collections.singleton("test")).build());
+            }
+            if (!admin.namespaces().getNamespaces("pulsar").contains("pulsar/system")) {
+                admin.namespaces().createNamespace("pulsar/system");
+            }
+        }catch (Exception e){
+            e.printStackTrace();
+        }
+        return clientBuilder.enableTransaction(true).build();
+    }
+
+    /**
+     * Override for make broker enable transaction.
+     */
+    private void updateConfig(ServiceConfiguration conf, String advertisedAddress) {
+        this.conf.setTransactionCoordinatorEnabled(true);
+        this.conf.setSystemTopicEnabled(true);
+        this.conf.setTopicLevelPoliciesEnabled(true);
+        conf.setTransactionCoordinatorEnabled(true);
+        conf.setSystemTopicEnabled(true);
+        conf.setTopicLevelPoliciesEnabled(true);
+    }
+
+    @Test
+    public void testConnectionAutoReleaseUnPartitionedTopicWithTransaction() throws Exception {
+        PulsarClientImpl pulsarClient = (PulsarClientImpl) super.getAllClients().get(0);
+        // Init clients
+        Consumer consumer = pulsarClient.newConsumer()
+                .topic(topicName)
+                .subscriptionName("my-subscription-x")
+                .subscribe();
+        Producer producer = pulsarClient.newProducer()
+                .sendTimeout(0, TimeUnit.SECONDS)
+                .topic(topicName)
+                .create();
+        // Ensure transaction works
+        ensureTransactionWorks(pulsarClient, producer, consumer);
+        // Connection to every Broker
+        connectionToEveryBroker(pulsarClient);
+        Assert.assertTrue(pulsarClient.getCnxPool().getPoolSize() >= 5);
+        // Assert "auto release works"
+        trigReleaseConnection(pulsarClient);
+        Awaitility.waitAtMost(Duration.ofSeconds(30)).until(()-> {
+            // Wait for async task done, then assert auto release success
+            return pulsarClient.getCnxPool().getPoolSize() <= 3;
+        });
+        // Verify that the number of connections did not increase after the work was completed
+        Assert.assertTrue(pulsarClient.getCnxPool().getPoolSize() <= 3);
+        // Ensure transaction works
+        ensureTransactionWorks(pulsarClient, producer, consumer);
+        consumer.close();
+        producer.close();
+    }
+
+
+}

--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/ClientBuilder.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/ClientBuilder.java
@@ -127,6 +127,18 @@ public interface ClientBuilder extends Serializable, Cloneable {
     ClientBuilder listenerName(String name);
 
     /**
+     * Release the connection if it is not used for more than {@param connectionMaxIdleSeconds} seconds.
+     * @return the client builder instance
+     */
+    ClientBuilder connectionMaxIdleSeconds(int connectionMaxIdleSeconds);
+
+    /**
+     * Do you want to automatically clean up unused connections.
+     * @return the client builder instance
+     */
+    ClientBuilder autoReleaseIdleConnectionsEnabled(boolean autoReleaseIdleConnectionsEnabled);
+
+    /**
      * Set the authentication provider to use in the Pulsar client instance.
      *
      * <p>Example:

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ClientBuilderImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ClientBuilderImpl.java
@@ -103,6 +103,19 @@ public class ClientBuilderImpl implements ClientBuilder {
     }
 
     @Override
+    public ClientBuilder connectionMaxIdleSeconds(int connectionMaxIdleSeconds) {
+        checkArgument(connectionMaxIdleSeconds >= 0, "Param connectionMaxIdleSeconds at least 1.");
+        conf.setConnectionMaxIdleSeconds(connectionMaxIdleSeconds);
+        return this;
+    }
+
+    @Override
+    public ClientBuilder autoReleaseIdleConnectionsEnabled(boolean autoReleaseIdleConnectionsEnabled) {
+        conf.setAutoReleaseIdleConnectionsEnabled(autoReleaseIdleConnectionsEnabled);
+        return this;
+    }
+
+    @Override
     public ClientBuilder authentication(Authentication authentication) {
         conf.setAuthentication(authentication);
         return this;

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/TransactionMetaStoreHandler.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/TransactionMetaStoreHandler.java
@@ -738,7 +738,7 @@ public class TransactionMetaStoreHandler extends HandlerState
         });
     }
 
-    private ClientCnx cnx() {
+    ClientCnx cnx() {
         return this.connectionHandler.cnx();
     }
 

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ClientConfigurationData.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ClientConfigurationData.java
@@ -125,6 +125,24 @@ public class ClientConfigurationData implements Serializable, Cloneable {
     private int connectionsPerBroker = 1;
 
     @ApiModelProperty(
+            name = "autoReleaseIdleConnectionsEnabled",
+            value = "Do you want to automatically clean up unused connections"
+    )
+    private boolean autoReleaseIdleConnectionsEnabled = true;
+
+    @ApiModelProperty(
+            name = "connectionMaxIdleSeconds",
+            value = "Release the connection if it is not used for more than [connectionMaxIdleSeconds] seconds"
+    )
+    private int connectionMaxIdleSeconds = 180;
+
+    @ApiModelProperty(
+            name = "connectionIdleDetectionIntervalSeconds",
+            value = "How often check idle connections"
+    )
+    private int connectionIdleDetectionIntervalSeconds = 60;
+
+    @ApiModelProperty(
             name = "useTcpNoDelay",
             value = "Whether to use TCP NoDelay option."
     )

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/transaction/TransactionCoordinatorClientImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/transaction/TransactionCoordinatorClientImpl.java
@@ -67,6 +67,13 @@ public class TransactionCoordinatorClientImpl implements TransactionCoordinatorC
         this.pulsarClient = (PulsarClientImpl) pulsarClient;
     }
 
+    public TransactionMetaStoreHandler[] getHandlers() {
+        // To solve problem "may expose internal representation by returning this.handlers", clone one.
+        TransactionMetaStoreHandler[] clone = new TransactionMetaStoreHandler[this.handlers.length];
+        System.arraycopy(handlers, 0, clone, 0, this.handlers.length);
+        return clone;
+    }
+
     @Override
     public void start() throws TransactionCoordinatorClientException {
         try {

--- a/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/ProxyConnection.java
+++ b/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/ProxyConnection.java
@@ -524,6 +524,8 @@ public class ProxyConnection extends PulsarHandler {
 
     ClientConfigurationData createClientConfiguration() {
         ClientConfigurationData clientConf = new ClientConfigurationData();
+        /** The proxy service does not need to automatically clean up invalid connections, so set false. **/
+        clientConf.setAutoReleaseIdleConnectionsEnabled(false);
         clientConf.setServiceUrl(service.getServiceUrl());
         ProxyConfiguration proxyConfig = service.getConfiguration();
         clientConf.setAuthentication(this.getClientAuthentication());

--- a/site2/docs/client-libraries-java.md
+++ b/site2/docs/client-libraries-java.md
@@ -111,6 +111,8 @@ If you create a client, you can use the `loadConf` configuration. The following 
 `authPluginClassName` | String | Name of the authentication plugin | None
  `authParams` | String | Parameters for the authentication plugin <br /><br />**Example**<br /> key1:val1,key2:val2|None
 `operationTimeoutMs`|long|`operationTimeoutMs`|Operation timeout |30000
+`autoReleaseIdleConnectionsEnabled`|boolean|Do you want to automatically clean up unused connections.|true
+`connectionMaxIdleSeconds`|int|Release the connection if it is not used for more than `connectionMaxIdleSeconds` seconds.|180
 `statsIntervalSeconds`|long|Interval between each stats information<br /><br />Stats is activated with positive `statsInterval`<br /><br />Set `statsIntervalSeconds` to 1 second at least. |60
 `numIoThreads`| int| The number of threads used for handling connections to brokers | 1 
 `numListenerThreads`|int|The number of threads used for handling message listeners. The listener thread pool is shared across all the consumers and readers using the "listener" model to get messages. For a given consumer, the listener is always invoked from the same thread to ensure ordering. If you want multiple threads to process a single topic, you need to create a [`shared`](https://pulsar.apache.org/docs/en/next/concepts-messaging/#shared) subscription and multiple consumers for this subscription. This does not ensure ordering.| 1 


### PR DESCRIPTION
### Motivation

Currently, the Pulsar client keeps the connection even if no producers or consumers use this connection.
If a client produces messages to topic A and we have 3 brokers 1, 2, 3. Due to the bundle unloading(loadmanager)
topic ownership will change from A to B and finally to C. For now, the client side will keep 3 connections to all 3 brokers.
We can optimize this part to reduce the broker side connections, the client should close the unused connections.

### Modifications
Add a scheduled task to check for and release unwanted connections

### Verifying this change

- ConnectionPool
  - Add filed : `maxIdleSeconds`
  - After constructor, add A scheduled task at startup

- PulsarClientImpl
  - Provides a function to verify that the connection is still in use

Specific task execution process: 

1. If connection is not still in use, mark it is idle.
2. If A is already marked as idle, release if the free time exceeds `maxIdleSeconds`
3. If A is already marked as idle, the flag will be cleared when it is used again


### Documentation
- [ ] `doc-required` 
  
- [ ] `no-need-doc` 
  
- [ ] `doc` 

- [x] `doc-added`