### PR TITLE
[improve][connector] Sink support custom acknowledge type

### DIFF
--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/SinkRecord.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/SinkRecord.java
@@ -85,13 +85,23 @@ public class SinkRecord<T> implements Record<T> {
 
     /**
      * Some sink sometimes wants to control the ack type.
-     *
-     * @param cumulative
      */
-    public void ack(boolean cumulative) {
+    public void cumulativeAck() {
         if (sourceRecord instanceof PulsarRecord) {
             PulsarRecord pulsarRecord = (PulsarRecord) sourceRecord;
-            pulsarRecord.ack(cumulative);
+            pulsarRecord.cumulativeAck();
+        } else {
+            throw new RuntimeException("SourceRecord class type must be PulsarRecord");
+        }
+    }
+
+    /**
+     * Some sink sometimes wants to control the ack type.
+     */
+    public void individualAck() {
+        if (sourceRecord instanceof PulsarRecord) {
+            PulsarRecord pulsarRecord = (PulsarRecord) sourceRecord;
+            pulsarRecord.individualAck();
         } else {
             throw new RuntimeException("SourceRecord class type must be PulsarRecord");
         }

--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/SinkRecord.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/SinkRecord.java
@@ -93,7 +93,7 @@ public class SinkRecord<T> implements Record<T> {
             PulsarRecord pulsarRecord = (PulsarRecord) sourceRecord;
             pulsarRecord.ack(cumulative);
         } else {
-            throw new RuntimeException("SourceRecord class type must equals PulsarRecord");
+            throw new RuntimeException("SourceRecord class type must be PulsarRecord");
         }
     }
 

--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/SinkRecord.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/SinkRecord.java
@@ -29,6 +29,7 @@ import org.apache.pulsar.client.impl.schema.AutoConsumeSchema;
 import org.apache.pulsar.client.impl.schema.KeyValueSchemaImpl;
 import org.apache.pulsar.functions.api.KVRecord;
 import org.apache.pulsar.functions.api.Record;
+import org.apache.pulsar.functions.source.PulsarRecord;
 
 @Slf4j
 @Data
@@ -80,6 +81,20 @@ public class SinkRecord<T> implements Record<T> {
     @Override
     public void ack() {
         sourceRecord.ack();
+    }
+
+    /**
+     * Some sink sometimes wants to control the ack type.
+     *
+     * @param cumulative
+     */
+    public void ack(boolean cumulative) {
+        if (sourceRecord instanceof PulsarRecord) {
+            PulsarRecord pulsarRecord = (PulsarRecord) sourceRecord;
+            pulsarRecord.ack(cumulative);
+        } else {
+            throw new RuntimeException("SourceRecord class type must equals PulsarRecord");
+        }
     }
 
     @Override

--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/source/PulsarRecord.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/source/PulsarRecord.java
@@ -97,11 +97,16 @@ public class PulsarRecord<T> implements RecordWithEncryptionContext<T> {
 
     /**
      * Some sink sometimes wants to control the ack type.
-     *
-     * @param cumulative
      */
-    public void ack(boolean cumulative) {
-        this.customAckFunction.accept(cumulative);
+    public void cumulativeAck() {
+        this.customAckFunction.accept(true);
+    }
+
+    /**
+     * Some sink sometimes wants to control the ack type.
+     */
+    public void individualAck() {
+        this.customAckFunction.accept(false);
     }
 
     @Override

--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/source/PulsarRecord.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/source/PulsarRecord.java
@@ -20,6 +20,7 @@ package org.apache.pulsar.functions.source;
 
 import java.util.Map;
 import java.util.Optional;
+import java.util.function.Consumer;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -44,6 +45,7 @@ public class PulsarRecord<T> implements RecordWithEncryptionContext<T> {
 
     private final Runnable failFunction;
     private final Runnable ackFunction;
+    private final Consumer<Boolean> customAckFunction;
 
     @Override
     public Optional<String> getKey() {
@@ -93,6 +95,15 @@ public class PulsarRecord<T> implements RecordWithEncryptionContext<T> {
         }
     }
 
+    /**
+     * Some sink sometimes wants to control the ack type.
+     *
+     * @param cumulative
+     */
+    public void ack(boolean cumulative) {
+        this.customAckFunction.accept(cumulative);
+    }
+
     @Override
     public Optional<EncryptionContext> getEncryptionCtx() {
         return message.getEncryptionCtx();
@@ -121,4 +132,5 @@ public class PulsarRecord<T> implements RecordWithEncryptionContext<T> {
     public Optional<Message<T>> getMessage() {
         return Optional.of(message);
     }
+
 }

--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/source/PulsarSource.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/source/PulsarSource.java
@@ -132,6 +132,17 @@ public abstract class PulsarSource<T> implements Source<T> {
                 .message(message)
                 .schema(schema)
                 .topicName(message.getTopicName())
+                .customAckFunction(cumulative -> {
+                    try {
+                        if (cumulative) {
+                            consumer.acknowledgeCumulativeAsync(message);
+                        } else {
+                            consumer.acknowledgeAsync(message);
+                        }
+                    } finally {
+                        message.release();
+                    }
+                })
                 .ackFunction(() -> {
                     try {
                         if (pulsarSourceConfig

--- a/pulsar-functions/instance/src/test/java/org/apache/pulsar/functions/instance/SinkRecordTest.java
+++ b/pulsar-functions/instance/src/test/java/org/apache/pulsar/functions/instance/SinkRecordTest.java
@@ -41,7 +41,7 @@ public class SinkRecordTest {
             Assert.fail("Should throw runtime exception");
         } catch (Exception e) {
             Assert.assertTrue(e instanceof RuntimeException);
-            Assert.assertEquals(e.getMessage(), "SourceRecord class type must equals PulsarRecord");
+            Assert.assertEquals(e.getMessage(), "SourceRecord class type must be PulsarRecord");
         }
     }
 }

--- a/pulsar-functions/instance/src/test/java/org/apache/pulsar/functions/instance/SinkRecordTest.java
+++ b/pulsar-functions/instance/src/test/java/org/apache/pulsar/functions/instance/SinkRecordTest.java
@@ -32,12 +32,12 @@ public class SinkRecordTest {
         PulsarRecord pulsarRecord = Mockito.mock(PulsarRecord.class);
         SinkRecord sinkRecord = new SinkRecord<>(pulsarRecord, new Object());
 
-        sinkRecord.ack(true);
-        Mockito.verify(pulsarRecord, Mockito.times(1)).ack(true);
+        sinkRecord.cumulativeAck();
+        Mockito.verify(pulsarRecord, Mockito.times(1)).cumulativeAck();
 
         sinkRecord = new SinkRecord(Mockito.mock(Record.class), new Object());
         try {
-            sinkRecord.ack(true);
+            sinkRecord.individualAck();
             Assert.fail("Should throw runtime exception");
         } catch (Exception e) {
             Assert.assertTrue(e instanceof RuntimeException);

--- a/pulsar-functions/instance/src/test/java/org/apache/pulsar/functions/instance/SinkRecordTest.java
+++ b/pulsar-functions/instance/src/test/java/org/apache/pulsar/functions/instance/SinkRecordTest.java
@@ -1,0 +1,47 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.functions.instance;
+
+import org.apache.pulsar.functions.api.Record;
+import org.apache.pulsar.functions.source.PulsarRecord;
+import org.junit.Assert;
+import org.mockito.Mockito;
+import org.testng.annotations.Test;
+
+public class SinkRecordTest {
+
+    @Test
+    public void testCustomAck() {
+
+        PulsarRecord pulsarRecord = Mockito.mock(PulsarRecord.class);
+        SinkRecord sinkRecord = new SinkRecord<>(pulsarRecord, new Object());
+
+        sinkRecord.ack(true);
+        Mockito.verify(pulsarRecord, Mockito.times(1)).ack(true);
+
+        sinkRecord = new SinkRecord(Mockito.mock(Record.class), new Object());
+        try {
+            sinkRecord.ack(true);
+            Assert.fail("Should throw runtime exception");
+        } catch (Exception e) {
+            Assert.assertTrue(e instanceof RuntimeException);
+            Assert.assertEquals(e.getMessage(), "SourceRecord class type must equals PulsarRecord");
+        }
+    }
+}

--- a/pulsar-functions/instance/src/test/java/org/apache/pulsar/functions/source/PulsarSourceTest.java
+++ b/pulsar-functions/instance/src/test/java/org/apache/pulsar/functions/source/PulsarSourceTest.java
@@ -374,10 +374,10 @@ public class PulsarSourceTest {
 
         PulsarRecord record = (PulsarRecord) pulsarSource.buildRecord(consumer, message);
 
-        record.ack(true);
+        record.cumulativeAck();
         Mockito.verify(consumer, Mockito.times(1)).acknowledgeCumulativeAsync(message);
 
-        record.ack(false);
+        record.individualAck();
         Mockito.verify(consumer, Mockito.times(1)).acknowledgeAsync(message);
     }
 

--- a/pulsar-functions/instance/src/test/java/org/apache/pulsar/functions/source/PulsarSourceTest.java
+++ b/pulsar-functions/instance/src/test/java/org/apache/pulsar/functions/source/PulsarSourceTest.java
@@ -369,6 +369,9 @@ public class PulsarSourceTest {
         PulsarSource pulsarSource = getPulsarSource(pulsarSourceConfig);
         Message message = Mockito.mock(Message.class);
         Consumer consumer = Mockito.mock(Consumer.class);
+        Mockito.when(consumer.acknowledgeAsync(message)).thenReturn(CompletableFuture.completedFuture(null));
+        Mockito.when(consumer.acknowledgeCumulativeAsync(message)).thenReturn(CompletableFuture.completedFuture(null));
+
         PulsarRecord record = (PulsarRecord) pulsarSource.buildRecord(consumer, message);
 
         record.ack(true);

--- a/pulsar-functions/instance/src/test/java/org/apache/pulsar/functions/source/PulsarSourceTest.java
+++ b/pulsar-functions/instance/src/test/java/org/apache/pulsar/functions/source/PulsarSourceTest.java
@@ -38,6 +38,7 @@ import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.client.api.Consumer;
 import org.apache.pulsar.client.api.ConsumerBuilder;
+import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.client.api.SubscriptionInitialPosition;
@@ -360,4 +361,21 @@ public class PulsarSourceTest {
 
         fail("Unknown config type");
     }
+
+
+    @Test(dataProvider = "sourceImpls")
+    public void testPulsarRecordCustomAck(PulsarSourceConfig pulsarSourceConfig) throws Exception {
+
+        PulsarSource pulsarSource = getPulsarSource(pulsarSourceConfig);
+        Message message = Mockito.mock(Message.class);
+        Consumer consumer = Mockito.mock(Consumer.class);
+        PulsarRecord record = (PulsarRecord) pulsarSource.buildRecord(consumer, message);
+
+        record.ack(true);
+        Mockito.verify(consumer, Mockito.times(1)).acknowledgeCumulativeAsync(message);
+
+        record.ack(false);
+        Mockito.verify(consumer, Mockito.times(1)).acknowledgeAsync(message);
+    }
+
 }

--- a/pulsar-io/cassandra/src/main/java/org/apache/pulsar/io/cassandra/CassandraAbstractSink.java
+++ b/pulsar-io/cassandra/src/main/java/org/apache/pulsar/io/cassandra/CassandraAbstractSink.java
@@ -71,7 +71,6 @@ public abstract class CassandraAbstractSink<K, V> implements Sink<byte[]> {
 
     @Override
     public void write(Record<byte[]> record) {
-        Optional<Message<byte[]>> message = record.getMessage();
         KeyValue<K, V> keyValue = extractKeyValue(record);
         BoundStatement bound = statement.bind(keyValue.getKey(), keyValue.getValue());
         ResultSetFuture future = session.executeAsync(bound);

--- a/pulsar-io/cassandra/src/main/java/org/apache/pulsar/io/cassandra/CassandraAbstractSink.java
+++ b/pulsar-io/cassandra/src/main/java/org/apache/pulsar/io/cassandra/CassandraAbstractSink.java
@@ -29,6 +29,8 @@ import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.MoreExecutors;
 import java.util.Map;
+import java.util.Optional;
+import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.functions.api.Record;
 import org.apache.pulsar.io.core.KeyValue;
 import org.apache.pulsar.io.core.Sink;
@@ -69,6 +71,7 @@ public abstract class CassandraAbstractSink<K, V> implements Sink<byte[]> {
 
     @Override
     public void write(Record<byte[]> record) {
+        Optional<Message<byte[]>> message = record.getMessage();
         KeyValue<K, V> keyValue = extractKeyValue(record);
         BoundStatement bound = statement.bind(keyValue.getKey(), keyValue.getValue());
         ResultSetFuture future = session.executeAsync(bound);

--- a/pulsar-io/cassandra/src/main/java/org/apache/pulsar/io/cassandra/CassandraAbstractSink.java
+++ b/pulsar-io/cassandra/src/main/java/org/apache/pulsar/io/cassandra/CassandraAbstractSink.java
@@ -29,8 +29,6 @@ import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.MoreExecutors;
 import java.util.Map;
-import java.util.Optional;
-import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.functions.api.Record;
 import org.apache.pulsar.io.core.KeyValue;
 import org.apache.pulsar.io.core.Sink;


### PR DESCRIPTION
### Motivation

The current source  ack type and `ProcessingGuarantees` are forcibly bound together, This is not flexible for implementing a new sink. If sink is Guarantees equals `ATMOST_ONCE`,  it can't be use `acknowledgeCumulative`

https://github.com/apache/pulsar/blob/a0dcab679b1842a2efee4df2f31bf41ef5ab1dd0/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/source/PulsarSource.java#L136-L142


### Modifications
- Provide an `ack(boolean cumulative)` method to support the sink to select the ack type

### Documentation
- [x] `no-need-doc` 
