### PR TITLE
[feature][Doc] Add doc for `CommandAckResponse`

### DIFF
--- a/site2/docs/developing-binary-protocol.md
+++ b/site2/docs/developing-binary-protocol.md
@@ -419,11 +419,11 @@ Parameters:
    `txnid_most_bits` and `txnid_least_bits`uniquely identify a transaction.
  * `request_id` -> *(optional)* ID for handling response and timeout.
 
-##### Command CommandAckResponse
+##### Command AckResponse
 
-This is the broker's response to ack request by the client. It contains the `consumer_id` sent in the request. 
-If transaction is used, it will also contain the transactionId and requestID sent in the request.
-The client will process the specific request according to the request ID.
+An `AckResponse` is the broker’s response to acknowledge a request sent by the client. It contains the `consumer_id` sent in the request.
+If a transaction is used, it contains both Transaction ID and Request ID that are sent in the request.
+The client finishes the specific request according to the Request ID.
 If the `error` field is set, it indicates that the request has failed.
 
 Example of ack response with redirection:
@@ -433,7 +433,7 @@ message CommandAckResponse {
     "consumer_id" : 1,
     "txnid_least_bits" = 0,
     "txnid_most_bits" = 1,
-    “request_id” = 5
+    "request_id" = 5
 }
 ```
 

--- a/site2/docs/developing-binary-protocol.md
+++ b/site2/docs/developing-binary-protocol.md
@@ -433,7 +433,7 @@ message CommandAckResponse {
     "consumer_id" : 1,
     "txnid_least_bits" = 0,
     "txnid_most_bits" = 1,
-    request_id = 5
+    “request_id” = 5
 }
 ```
 

--- a/site2/docs/developing-binary-protocol.md
+++ b/site2/docs/developing-binary-protocol.md
@@ -418,7 +418,24 @@ Parameters:
  * `txnid_least_bits` -> *(optional)* The ID of the transaction opened in a TC,
    `txnid_most_bits` and `txnid_least_bits`uniquely identify a transaction.
  * `request_id` -> *(optional)* ID for handling response and timeout.
-   
+
+##### Command CommandAckResponse
+
+This is the broker's response to ack request by the client. It contains the `consumer_id` sent in the request. 
+If transaction is used, it will also contain the transactionId and requestID sent in the request.
+The client will process the specific request according to the request ID.
+If the `error` field is set, it indicates that the request has failed.
+
+Example of ack response with redirection:
+
+```protobuf
+message CommandAckResponse {
+    "consumer_id" : 1,
+    "txnid_least_bits" = 0,
+    "txnid_most_bits" = 1,
+    request_id = 5
+}
+```
 
 ##### Command CloseConsumer
 


### PR DESCRIPTION
### Motivation
Now, the website do not have related doc of `CommandAckResponse` in https://github.com/apache/pulsar/pull/8996.
### Modification
Add the doc for `CommandAckResponse`.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API: (yes / no)
  - The schema: (yes / no / don't know)
  - The default values of configurations: (yes / no)
  - The wire protocol: (yes / no)
  - The rest endpoints: (yes / no)
  - The admin cli options: (yes / no)
  - Anything that affects deployment: (yes / no / don't know)

### Documentation

Check the box below or label this PR directly.

Need to update docs? 

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)
  
- [ ] `no-need-doc` 
(Please explain why)
  
- [x] `doc` 
(Your PR contains doc changes)

- [ ] `doc-added`
(Docs have been already added)