### PR TITLE
[broker]Use HierarchyTopicPolicies to update topic-level subscribeRate

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -3050,7 +3050,7 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
 
         FutureUtil.waitForAll(consumerCheckFutures).thenRun(() -> {
             updatePublishDispatcher();
-            initializeTopicSubscribeRateLimiterIfNeeded(Optional.ofNullable(policies));
+            updateSubscribeRateLimiter();
             if (this.subscribeRateLimiter.isPresent()) {
                 subscribeRateLimiter.ifPresent(subscribeRateLimiter ->
                         subscribeRateLimiter.onSubscribeRateUpdate(getSubscribeRate()));
@@ -3079,23 +3079,6 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
         synchronized (dispatchRateLimiter) {
             if (!dispatchRateLimiter.isPresent() && policies.getDispatchRate() != null) {
                 this.dispatchRateLimiter = Optional.of(new DispatchRateLimiter(this, Type.TOPIC));
-            }
-        }
-    }
-
-    private void initializeTopicSubscribeRateLimiterIfNeeded(Optional<TopicPolicies> policies) {
-        if (!policies.isPresent()) {
-            return;
-        }
-        synchronized (subscribeRateLimiter) {
-            if (!subscribeRateLimiter.isPresent()
-                    && policies.get().getSubscribeRate() != null
-                    && policies.get().getSubscribeRate().subscribeThrottlingRatePerConsumer > 0) {
-                this.subscribeRateLimiter = Optional.of(new SubscribeRateLimiter(this));
-            } else if (!policies.get().isSubscribeRateSet()
-                    || policies.get().getSubscribeRate().subscribeThrottlingRatePerConsumer <= 0) {
-                subscribeRateLimiter.ifPresent(SubscribeRateLimiter::close);
-                this.subscribeRateLimiter = Optional.empty();
             }
         }
     }


### PR DESCRIPTION
### Motivation

Use HierarchyTopicPolicies to update topic-level subscribeRate

### Modifications

Use `updateSubscribeRateLimiter()` to update topic-level subscribeRate, instead of `initializeTopicSubscribeRateLimiterIfNeeded`.   After this Modification,  broker-level, ns-level and topic-level subscribeRate updating all use the same method `updateSubscribeRateLimiter()`

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change is already covered by existing tests, such as *(please describe tests)*.

* org.apache.pulsar.broker.admin.TopicPoliciesTest#testDisableSubscribeRate

### Documentation
  
- [x] `no-need-doc` 
(Please explain why)