### PR TITLE
[fix][security] Fix grant all permissions but can't list topic.

### DIFF
--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authorization/PulsarAuthorizationProvider.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authorization/PulsarAuthorizationProvider.java
@@ -480,6 +480,7 @@ public class PulsarAuthorizationProvider implements AuthorizationProvider {
                                         namespaceName, role, authData, AuthAction.packages);
                             case GET_TOPIC:
                             case GET_TOPICS:
+                            case GET_BUNDLE:
                                 return allowConsumeOrProduceOpsAsync(namespaceName, role, authData);
                             case UNSUBSCRIBE:
                             case CLEAR_BACKLOG:
@@ -488,7 +489,6 @@ public class PulsarAuthorizationProvider implements AuthorizationProvider {
                             case CREATE_TOPIC:
                             case DELETE_TOPIC:
                             case ADD_BUNDLE:
-                            case GET_BUNDLE:
                             case DELETE_BUNDLE:
                             case GRANT_PERMISSION:
                             case GET_PERMISSION:

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/AuthorizationTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/AuthorizationTest.java
@@ -19,7 +19,6 @@
 package org.apache.pulsar.broker.auth;
 
 import static org.mockito.Mockito.when;
-import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
@@ -27,7 +26,6 @@ import java.util.EnumSet;
 import org.apache.pulsar.broker.authorization.AuthorizationService;
 import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.admin.PulsarAdminBuilder;
-import org.apache.pulsar.client.admin.PulsarAdminException;
 import org.apache.pulsar.common.naming.TopicDomain;
 import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.policies.data.AuthAction;
@@ -232,7 +230,7 @@ public class AuthorizationTest extends MockedPulsarServiceBaseTest {
     }
 
     @Test
-    public void testGetListWithoutGetBundleOp() throws Exception {
+    public void testGetListWithGetBundleOp() throws Exception {
         String tenant = "p1";
         String namespaceV1 = "p1/global/ns1";
         String namespaceV2 = "p1/ns2";
@@ -248,18 +246,8 @@ public class AuthorizationTest extends MockedPulsarServiceBaseTest {
                 .authentication(new MockAuthentication("pass.pass2"))
                 .build();
         when(pulsar.getAdminClient()).thenReturn(admin2);
-        try {
-            admin2.topics().getList(namespaceV1, TopicDomain.non_persistent);
-        } catch (Exception ex) {
-            assertTrue(ex instanceof PulsarAdminException.NotAuthorizedException);
-            assertEquals(ex.getMessage(), "Unauthorized to validateNamespaceOperation for operation [GET_BUNDLE] on namespace [p1/global/ns1]");
-        }
-        try {
-            admin2.topics().getList(namespaceV2, TopicDomain.non_persistent);
-        } catch (Exception ex) {
-            assertTrue(ex instanceof PulsarAdminException.NotAuthorizedException);
-            assertEquals(ex.getMessage(), "Unauthorized to validateNamespaceOperation for operation [GET_BUNDLE] on namespace [p1/ns2]");
-        }
+        Assert.assertEquals(admin2.topics().getList(namespaceV1, TopicDomain.non_persistent).size(), 0);
+        Assert.assertEquals(admin2.topics().getList(namespaceV2, TopicDomain.non_persistent).size(), 0);
     }
 
     private static void waitForChange() {


### PR DESCRIPTION
Fixes #14191

Master Issue: #14191

### Motivation
As #14191 described, users may get confused about the current permission.
First, we only define the below actions in the grant-permission interface:
```
produce,consume,sources,sinks,functions,packages
```
Though we grant all the actions to some roles like below (`myuser` is not admin, only a normal user):
```
$ pulsar-admin namespaces grant-permission public/default --role myuser --actions produce,consume,sources,sinks,functions,packages
```
But when we list topics under a namespace:
```
$ pulsar-admin --admin-url https://dev.pulsar.xyz.com:8081 --auth-plugin "org.apache.pulsar.client.impl.auth.AuthenticationToken" --auth-params "token:<token>" topics list public/default
```
We will get the below error message :
```
HTTP 403 : Unauthorized to validateNamespaceOperation for operation [GET_BUNDLE] on namespace [mytenant/np1]
```

Because when listing topics, we will search all the topics including non-persistent topics which will validate `GET_BUNDLE` operation, but we don't have this `action` in auth action, and it's not good to add to `AuthAction`, for it's duplicate with `NamespaceOperation`. So we'd better map this to `consume` operation to solve the problem.


### Documentation
  
- [x] `no-need-doc` 
(Please explain why)
  
