### PR TITLE
[Build] Remove obsolete jdk11 and errorprone-jdk11 maven profiles

### DIFF
--- a/build/run_integration_group.sh
+++ b/build/run_integration_group.sh
@@ -103,9 +103,7 @@ test_group_shade_build() {
 
 test_group_shade_run() {
   local additional_args
-  if [[ $JAVA_MAJOR_VERSION == "8" ]]; then
-    additional_args="-Dmaven.compiler.source=8 -Dmaven.compiler.target=8 -Dmaven.compiler.release= -Dtest.additional.args="
-  elif [[ $JAVA_MAJOR_VERSION -lt 17 ]]; then
+  if [[ $JAVA_MAJOR_VERSION -gt 8 && $JAVA_MAJOR_VERSION -lt 17 ]]; then
     additional_args="-Dmaven.compiler.source=$JAVA_MAJOR_VERSION -Dmaven.compiler.target=$JAVA_MAJOR_VERSION"
   fi
   mvn_run_integration_test --skip-build-deps --clean "$@" -Denforcer.skip=true -DShadeTests -DtestForkCount=1 -DtestReuseFork=false $additional_args

--- a/build/run_integration_group.sh
+++ b/build/run_integration_group.sh
@@ -95,7 +95,7 @@ test_group_shade_build() {
 }
 
 test_group_shade_run() {
-  mvn_run_integration_test --skip-build-deps "$@" -DShadeTests -DtestForkCount=1 -DtestReuseFork=false -Dmaven.compiler.source=8 -Dmaven.compiler.target=8
+  mvn_run_integration_test --skip-build-deps "$@" -Denforcer.skip=true -DShadeTests -DtestForkCount=1 -DtestReuseFork=false -Dmaven.compiler.source=8 -Dmaven.compiler.target=8
 }
 
 test_group_backwards_compat() {

--- a/buildtools/pom.xml
+++ b/buildtools/pom.xml
@@ -50,7 +50,11 @@
     <guava.version>31.0.1-jre</guava.version>
     <ant.version>1.10.12</ant.version>
     <snakeyaml.version>1.30</snakeyaml.version>
-    <test.additional.args></test.additional.args>
+    <!-- required for running tests on JDK11+ -->
+    <test.additional.args>
+      --add-opens java.base/jdk.internal.loader=ALL-UNNAMED
+      --add-opens java.base/java.lang=ALL-UNNAMED <!--Mockito-->
+    </test.additional.args>
   </properties>
 
   <dependencyManagement>
@@ -242,19 +246,4 @@
       </extension>
     </extensions>
   </build>
-  <profiles>
-    <profile>
-      <id>jdk11</id>
-      <activation>
-        <jdk>[11,)</jdk>
-      </activation>
-      <properties>
-        <!-- required for running tests on JDK11+ -->
-        <test.additional.args>
-          --add-opens java.base/jdk.internal.loader=ALL-UNNAMED
-          --add-opens java.base/java.lang=ALL-UNNAMED <!--Mockito-->
-        </test.additional.args>
-      </properties>
-    </profile>
-  </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -244,7 +244,7 @@ flexible messaging model and an intuitive client API.</description>
     <exec-maven-plugin.version>3.0.0</exec-maven-plugin.version>
     <license-maven-plugin.version>4.0.rc2</license-maven-plugin.version>
     <directory-maven-plugin.version>1.0</directory-maven-plugin.version>
-    <maven-enforcer-plugin.version>3.0.0-M3</maven-enforcer-plugin.version>
+    <maven-enforcer-plugin.version>3.0.0</maven-enforcer-plugin.version>
     <!-- surefire.version is defined in apache parent pom -->
     <!-- it is used for surefire, failsafe and surefire-report plugins -->
     <!-- do not upgrade surefire.version to 3.0.0-M5 since it runs slowly and breaks tests. -->
@@ -1371,27 +1371,6 @@ flexible messaging model and an intuitive client API.</description>
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-enforcer-plugin</artifactId>
-        <version>3.0.0</version>
-        <executions>
-          <execution>
-            <id>enforce-versions</id>
-            <goals>
-              <goal>enforce</goal>
-            </goals>
-            <configuration>
-              <rules>
-                <requireJavaVersion>
-                  <version>17</version>
-                  <message>Java 17+ is required to build Pulsar.</message>
-                </requireJavaVersion>
-              </rules>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-checkstyle-plugin</artifactId>
         <dependencies>
           <dependency>
@@ -1730,10 +1709,11 @@ flexible messaging model and an intuitive client API.</description>
               <configuration>
                 <rules>
                   <requireJavaVersion>
-                    <version>[1.8.0,)</version>
+                    <version>17</version>
+                    <message>Java 17+ is required to build Pulsar.</message>
                   </requireJavaVersion>
                   <requireMavenVersion>
-                    <version>[3.3.9,)</version>
+                    <version>3.6.1</version>
                   </requireMavenVersion>
                 </rules>
               </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -79,7 +79,7 @@ flexible messaging model and an intuitive client API.</description>
   <properties>
     <maven.compiler.source>17</maven.compiler.source>
     <maven.compiler.target>17</maven.compiler.target>
-    <maven.compiler.release>${maven.compiler.target}</maven.compiler.release>
+    <pulsar.broker.compiler.release>${maven.compiler.target}</pulsar.broker.compiler.release>
     <pulsar.client.compiler.release>8</pulsar.client.compiler.release>
 
     <!--config keys to configure test selection -->
@@ -1757,8 +1757,7 @@ flexible messaging model and an intuitive client API.</description>
           <artifactId>maven-compiler-plugin</artifactId>
           <version>${maven-compiler-plugin.version}</version>
           <configuration>
-            <!-- for some reason, setting maven.compiler.release property alone doesn't work -->
-            <release>${maven.compiler.release}</release>
+            <release>${pulsar.broker.compiler.release}</release>
           </configuration>
         </plugin>
         <plugin>
@@ -1888,6 +1887,20 @@ flexible messaging model and an intuitive client API.</description>
   </build>
 
   <profiles>
+    <profile>
+      <!-- used for running integration tests on Java 8 -->
+      <id>integration-test-java8</id>
+      <activation>
+        <jdk>1.8</jdk>
+      </activation>
+      <properties>
+        <test.additional.args/>
+        <maven.compiler.source>8</maven.compiler.source>
+        <maven.compiler.target>8</maven.compiler.target>
+        <pulsar.broker.compiler.release></pulsar.broker.compiler.release>
+        <pulsar.client.compiler.release></pulsar.client.compiler.release>
+      </properties>
+    </profile>
     <profile>
       <id>coverage</id>
       <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -79,6 +79,7 @@ flexible messaging model and an intuitive client API.</description>
   <properties>
     <maven.compiler.source>17</maven.compiler.source>
     <maven.compiler.target>17</maven.compiler.target>
+    <maven.compiler.release>${maven.compiler.target}</maven.compiler.release>
     <pulsar.client.compiler.release>8</pulsar.client.compiler.release>
 
     <!--config keys to configure test selection -->
@@ -90,7 +91,12 @@ flexible messaging model and an intuitive client API.</description>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <redirectTestOutputToFile>true</redirectTestOutputToFile>
-    <test.additional.args></test.additional.args>
+    <!-- required for running tests on JDK11+ -->
+    <test.additional.args>
+      --add-opens java.base/jdk.internal.loader=ALL-UNNAMED
+      --add-opens java.base/java.lang=ALL-UNNAMED <!--Mockito-->
+      --add-opens java.base/java.io=ALL-UNNAMED <!--Bookkeeper NativeIO -->
+    </test.additional.args>
     <testReuseFork>true</testReuseFork>
     <testForkCount>4</testForkCount>
     <testRealAWS>false</testRealAWS>
@@ -1749,6 +1755,10 @@ flexible messaging model and an intuitive client API.</description>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-compiler-plugin</artifactId>
           <version>${maven-compiler-plugin.version}</version>
+          <configuration>
+            <!-- for some reason, setting maven.compiler.release property alone doesn't work -->
+            <release>${maven.compiler.release}</release>
+          </configuration>
         </plugin>
         <plugin>
           <groupId>org.gaul</groupId>
@@ -1877,37 +1887,6 @@ flexible messaging model and an intuitive client API.</description>
   </build>
 
   <profiles>
-    <profile>
-      <id>jdk11</id>
-      <activation>
-        <jdk>[11,)</jdk>
-      </activation>
-      <properties>
-        <!-- prevents silent NoSuchMethodErrors that happen at runtime on Java 8 -->
-        <!-- see https://github.com/apache/pulsar/issues/8445 -->
-        <maven.compiler.release>${maven.compiler.target}</maven.compiler.release>
-        <!-- required for running tests on JDK11+ -->
-        <test.additional.args>
-          --add-opens java.base/jdk.internal.loader=ALL-UNNAMED
-          --add-opens java.base/java.lang=ALL-UNNAMED <!--Mockito-->
-          --add-opens java.base/java.io=ALL-UNNAMED <!--Bookkeeper NativeIO -->
-        </test.additional.args>
-      </properties>
-      <build>
-        <pluginManagement>
-          <plugins>
-            <plugin>
-              <groupId>org.apache.maven.plugins</groupId>
-              <artifactId>maven-compiler-plugin</artifactId>
-              <configuration>
-                <!-- for some reason, setting maven.compiler.release property alone doesn't work -->
-                <release>${maven.compiler.release}</release>
-              </configuration>
-            </plugin>
-          </plugins>
-        </pluginManagement>
-      </build>
-    </profile>
     <profile>
       <id>coverage</id>
       <properties>
@@ -2169,21 +2148,18 @@ flexible messaging model and an intuitive client API.</description>
     <!--
          Configure Google Error Prone static code analyser, http://errorprone.info
 
-         consists of 3 maven profiles: errorprone, errorprone-jdk8 and errorprone-jdk11
-
          usage:
-         activate profiles "errorprone" and either "errorprone-jdk8" or "errorprone-jdk11"
-         depending on the JVM version
+         activate profile "errorprone"
 
          It is required to add "lombok.addJavaxGeneratedAnnotation = true" to lombok.config
          temporarily before running the analysis.
 
          usage example:
          echo lombok.addJavaxGeneratedAnnotation=true >> lombok.config
-         mvn -Perrorprone,errorprone-jdk11,main compile
+         mvn -Perrorprone,main compile
 
          Revisiting warnings and errors is possible in IntelliJ after activating
-         errorprone, errorprone-jdk11 and main in "Maven->Profiles" and choosing
+         errorprone and main in "Maven->Profiles" and choosing
          "Build->Rebuild Project"
          Compiling all Pulsar projects in IntelliJ requires some manual tweaks to get the
          shaded projects to pass compilation. In some cases, it's better to mark the project
@@ -2208,7 +2184,7 @@ flexible messaging model and an intuitive client API.</description>
                 <arg>-Xlint:-options</arg>
                 <!-- configure Error Prone . Disable some checks that crash the compiler or are annoying -->
                 <!-- the following argument must be kept on one line when building with JDK8 -->
-                <arg>-Xplugin:ErrorProne -XepExcludedPaths:.*/target/generated-sources/.* -XepDisableWarningsInGeneratedCode -Xep:UnusedVariable:OFF -Xep:FallThrough:OFF -Xep:OverrideThrowableToString:OFF -Xep:UnusedMethod:OFF -Xep:StringSplitter:OFF -Xep:CanonicalDuration:OFF ${errorprone.arguments.jdk11}</arg>
+                <arg>-Xplugin:ErrorProne -XepExcludedPaths:.*/target/generated-sources/.* -XepDisableWarningsInGeneratedCode -Xep:UnusedVariable:OFF -Xep:FallThrough:OFF -Xep:OverrideThrowableToString:OFF -Xep:UnusedMethod:OFF -Xep:StringSplitter:OFF -Xep:CanonicalDuration:OFF -Xep:Slf4jDoNotLogMessageOfExceptionExplicitly:WARN -Xep:Slf4jSignOnlyFormat:WARN -Xep:Slf4jFormatShouldBeConst:WARN -Xep:Slf4jLoggerShouldBePrivate:WARN -Xep:Slf4jLoggerShouldBeNonStatic:OFF</arg>
               </compilerArgs>
               <annotationProcessorPaths combine.children="append">
                 <path>
@@ -2221,53 +2197,8 @@ flexible messaging model and an intuitive client API.</description>
                   <artifactId>mockito-errorprone</artifactId>
                   <version>${mockito.version}</version>
                 </path>
-              </annotationProcessorPaths>
-            </configuration>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-    <!-- running errorprone on JDK 8 requires special javac configuration -->
-    <profile>
-      <id>errorprone-jdk8</id>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-compiler-plugin</artifactId>
-            <configuration>
-              <compilerArgs combine.children="append">
-                <arg>
-                  -J-Xbootclasspath/p:${settings.localRepository}/com/google/errorprone/javac/${errorprone.javac.version}/javac-${errorprone.javac.version}.jar</arg>
-              </compilerArgs>
-              <annotationProcessorPaths combine.children="append">
-                <path>
-                  <groupId>com.google.errorprone</groupId>
-                  <artifactId>javac</artifactId>
-                  <version>${errorprone.javac.version}</version>
-                </path>
-              </annotationProcessorPaths>
-            </configuration>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-    <profile>
-      <id>errorprone-jdk11</id>
-      <properties>
-        <!-- pass the additional properties to -Xplugin:ErrorProne argument defined in errorprone profile -->
-        <!-- change configuration of slf4j checks to be more permissive -->
-        <errorprone.arguments.jdk11>-Xep:Slf4jDoNotLogMessageOfExceptionExplicitly:WARN -Xep:Slf4jSignOnlyFormat:WARN -Xep:Slf4jFormatShouldBeConst:WARN -Xep:Slf4jLoggerShouldBePrivate:WARN -Xep:Slf4jLoggerShouldBeNonStatic:OFF</errorprone.arguments.jdk11>
-      </properties>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-compiler-plugin</artifactId>
-            <configuration>
-              <annotationProcessorPaths combine.children="append">
                 <!-- add https://github.com/KengoTODA/errorprone-slf4j Error Prone plugin -->
-                <!-- detects slf4j misusage. Doesn't run on Java 8, so this is why it's in the errorprone-jdk11 profile -->
+                <!-- detects slf4j misusage. -->
                 <path>
                   <groupId>jp.skypencil.errorprone.slf4j</groupId>
                   <artifactId>errorprone-slf4j</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -250,7 +250,7 @@ flexible messaging model and an intuitive client API.</description>
     <!-- do not upgrade surefire.version to 3.0.0-M5 since it runs slowly and breaks tests. -->
     <surefire.version>3.0.0-M3</surefire.version>
     <maven-assembly-plugin.version>3.3.0</maven-assembly-plugin.version>
-    <maven-compiler-plugin.version>3.9.0</maven-compiler-plugin.version>
+    <maven-compiler-plugin.version>3.10.1</maven-compiler-plugin.version>
     <maven-dependency-plugin.version>3.1.2</maven-dependency-plugin.version>
     <maven-modernizer-plugin.version>2.3.0</maven-modernizer-plugin.version>
     <maven-shade-plugin>3.3.0</maven-shade-plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -1371,6 +1371,27 @@ flexible messaging model and an intuitive client API.</description>
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <version>3.0.0</version>
+        <executions>
+          <execution>
+            <id>enforce-versions</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <configuration>
+              <rules>
+                <requireJavaVersion>
+                  <version>17</version>
+                  <message>Java 17+ is required to build Pulsar.</message>
+                </requireJavaVersion>
+              </rules>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-checkstyle-plugin</artifactId>
         <dependencies>
           <dependency>


### PR DESCRIPTION
### Motivation

After PIP-156 PR #15264 changes, Java JDK 17 is required for building Pulsar.
The previous solution to support building with Java 8 and Java 11 had added jdk11 profile. This can be removed now.

### Modifications

- remove obsolete jdk11, errorprone-jdk8 and errorprone-jdk11 profiles
- add Maven Enforcer plugin to stop the build when JDK is not Java 17+