### PR TITLE
[CI] Add "CI - Integration - Shade on Java *" builds as required

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -64,6 +64,9 @@ github:
           - CI - Integration - Backwards Compatibility
           - CI - Integration - Cli
           - CI - Integration - Messaging
+          - CI - Integration - Shade on Java 8
+          - CI - Integration - Shade on Java 11
+          - CI - Integration - Shade on Java 17
           - CI - Integration - Standalone
           - CI - Integration - Transaction
           - Build Pulsar docker image


### PR DESCRIPTION
### Motivation

PIP-156 PR #15264 added new build jobs which should be required checks.
Since required checks are changed, it was first necessary to remove the existing required checks that are were removed in #15264 . This was done in #15496 .  
This PR finally adds the new build jobs as required checks.

### Modifications

Add `CI - Integration - Shade on Java 8`, `CI - Integration - Shade on Java 11` and `CI - Integration - Shade on Java 17` to required checks in `.asf.yaml`.

### Additional details

- This PR shouldn't be merged before the in-progress PRs are processed, since they might have completed the build using the previous version of the GitHub Actions workflow. Merging this PR will require that the new build version has been used for all PRs.