### PR TITLE
[fix][c++ client] avoid race condition causing double callback on close

### DIFF
--- a/pulsar-client-cpp/lib/ClientImpl.cc
+++ b/pulsar-client-cpp/lib/ClientImpl.cc
@@ -536,8 +536,13 @@ void ClientImpl::handleClose(Result result, SharedInt numberOfOpenHandlers, Resu
     }
     if (*numberOfOpenHandlers == 0) {
         Lock lock(mutex_);
-        state_ = Closed;
-        lock.unlock();
+        if (state_ == Closed) {
+            LOG_DEBUG("Client is already shutting down, possible race condition in handleClose");
+            return lock.unlock();
+        } else {
+            state_ = Closed;
+            lock.unlock();
+        }
 
         LOG_DEBUG("Shutting down producers and consumers for client");
         // handleClose() is called in ExecutorService's event loop, while shutdown() tried to wait the event

--- a/pulsar-client-cpp/lib/ClientImpl.cc
+++ b/pulsar-client-cpp/lib/ClientImpl.cc
@@ -538,7 +538,7 @@ void ClientImpl::handleClose(Result result, SharedInt numberOfOpenHandlers, Resu
         Lock lock(mutex_);
         if (state_ == Closed) {
             LOG_DEBUG("Client is already shutting down, possible race condition in handleClose");
-            return lock.unlock();
+            return;
         } else {
             state_ = Closed;
             lock.unlock();


### PR DESCRIPTION
### Motivation

The pulsar-client-node library uses the c api to interact with the pulsar client. The model for the c api is to pass in a `void *ctx` to async functions with a callback. Typically, these callbacks free the context and rely heavily on the fact that the callback is called once. I was able to reproducibly trigger the close callback to call twice, resulting in a double free error in pulsar-client-node.

### Modifications

My running theory is that the cause for this is a race condition in the decrementing of `numberOfOpenHandlers` shared pointer. It is possible for two threads to decrement the number in parallel, and to both end up with `*numberOfOpenHandlers == 0`. This fix assumes this can happen and synchronizes on the state, so even if this does happen, only one thread will be able to set the state to `Closed` and create the subsequent shutdown task.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.
- [ ] Run reproduction steps with pulsar-client-node using the new version

This change is already covered by existing tests, such as all of the tests in ClientTest.cc. Given that this is a race condition it's not possible to reproduce consistently for tests. I will run reproduction steps with pulsar-client-node.


### Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API: no
  - The schema: no
  - The default values of configurations: no
  - The wire protocol: no
  - The rest endpoints: no
  - The admin cli options: no
  - Anything that affects deployment: no

### Documentation

- [ ] `doc-required`
  
- [x] `no-need-doc` 
  
- [ ] `doc`

- [ ] `doc-added`