### PR TITLE
[fix][tests] Add alwaysRun=true in some @Before* TestNG annotations

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentTopicTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentTopicTest.java
@@ -167,13 +167,12 @@ public class PersistentTopicTest extends MockedBookKeeperTestCase {
     final String failTopicName = "persistent://prop/use/ns-abc/failTopic";
     final String successSubName = "successSub";
     final String successSubName2 = "successSub2";
-    final String successSubName3 = "successSub3";
     private static final Logger log = LoggerFactory.getLogger(PersistentTopicTest.class);
 
     private OrderedExecutor executor;
     private EventLoopGroup eventLoopGroup;
 
-    @BeforeMethod
+    @BeforeMethod(alwaysRun = true)
     public void setup() throws Exception {
         eventLoopGroup = new NioEventLoopGroup();
         executor = OrderedExecutor.newBuilder().numThreads(1).build();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ServerCnxTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ServerCnxTest.java
@@ -157,12 +157,12 @@ public class ServerCnxTest {
             "persistent://use/ns-abc/topic-2",
             "persistent://use/ns-abc/topic");
 
-    private final ManagedLedger ledgerMock = mock(ManagedLedger.class);
-    private final ManagedCursor cursorMock = mock(ManagedCursor.class);
+    private ManagedLedger ledgerMock;
+    private ManagedCursor cursorMock;
     private OrderedExecutor executor;
     private EventLoopGroup eventLoopGroup;
 
-    @BeforeMethod
+    @BeforeMethod(alwaysRun = true)
     public void setup() throws Exception {
         eventLoopGroup = new NioEventLoopGroup();
         executor = OrderedExecutor.newBuilder().numThreads(1).build();
@@ -223,8 +223,12 @@ public class ServerCnxTest {
 
     @AfterMethod(alwaysRun = true)
     public void teardown() throws Exception {
-        serverCnx.close();
-        channel.close();
+        if (serverCnx != null) {
+            serverCnx.close();
+        }
+        if (channel != null) {
+            channel.close();
+        }
         pulsar.close();
         brokerService.close();
         executor.shutdownNow();
@@ -1636,6 +1640,8 @@ public class ServerCnxTest {
     }
 
     private void setupMLAsyncCallbackMocks() {
+        ledgerMock = mock(ManagedLedger.class);
+        cursorMock = mock(ManagedCursor.class);
         doReturn(new ArrayList<Object>()).when(ledgerMock).getCursors();
 
         // call openLedgerComplete with ledgerMock on ML factory asyncOpen

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/ConsumerAckResponseTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/ConsumerAckResponseTest.java
@@ -42,12 +42,13 @@ import org.testng.annotations.Test;
 @Test(groups = "broker-impl")
 public class ConsumerAckResponseTest extends ProducerConsumerBase {
 
-    private static final TransactionImpl transaction = mock(TransactionImpl.class);
+    private TransactionImpl transaction;
 
-    @BeforeClass
+    @BeforeClass(alwaysRun = true)
     public void setup() throws Exception {
         super.internalSetup();
         super.producerBaseSetup();
+        transaction = mock(TransactionImpl.class);
         doReturn(1L).when(transaction).getTxnIdLeastBits();
         doReturn(1L).when(transaction).getTxnIdMostBits();
         doReturn(TransactionImpl.State.OPEN).when(transaction).getState();

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/ConsumerBuilderImplTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/ConsumerBuilderImplTest.java
@@ -37,7 +37,7 @@ import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.client.api.SubscriptionInitialPosition;
 import org.apache.pulsar.client.api.SubscriptionMode;
 import org.apache.pulsar.client.impl.conf.ConsumerConfigurationData;
-import org.testng.annotations.BeforeTest;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 /**
@@ -48,7 +48,7 @@ public class ConsumerBuilderImplTest {
     private static final String TOPIC_NAME = "testTopicName";
     private ConsumerBuilderImpl consumerBuilderImpl;
 
-    @BeforeTest
+    @BeforeMethod(alwaysRun = true)
     public void setup() {
         PulsarClientImpl client = mock(PulsarClientImpl.class);
         ConsumerConfigurationData consumerConfigurationData = mock(ConsumerConfigurationData.class);

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/PartitionedProducerImplTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/PartitionedProducerImplTest.java
@@ -52,7 +52,7 @@ import org.apache.pulsar.client.impl.customroute.PartialRoundRobinMessageRouterI
 import org.apache.pulsar.common.api.proto.MessageMetadata;
 import org.apache.pulsar.common.util.netty.EventLoopUtil;
 import org.assertj.core.util.Sets;
-import org.testng.annotations.BeforeTest;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 /**
@@ -67,7 +67,7 @@ public class PartitionedProducerImplTest {
     private ProducerInterceptors producerInterceptors;
     private CompletableFuture<Producer> producerCreatedFuture;
 
-    @BeforeTest
+    @BeforeMethod(alwaysRun = true)
     public void setup() {
         client = mock(PulsarClientImpl.class);
         schema = mock(Schema.class);

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/ProducerBuilderImplTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/ProducerBuilderImplTest.java
@@ -49,7 +49,7 @@ public class ProducerBuilderImplTest {
     private PulsarClientImpl client;
     private ProducerBuilderImpl producerBuilderImpl;
 
-    @BeforeTest
+    @BeforeTest(alwaysRun = true)
     public void setup() {
         Producer producer = mock(Producer.class);
         client = mock(PulsarClientImpl.class);

--- a/pulsar-functions/instance/src/test/java/org/apache/pulsar/functions/instance/ContextImplTest.java
+++ b/pulsar-functions/instance/src/test/java/org/apache/pulsar/functions/instance/ContextImplTest.java
@@ -76,9 +76,9 @@ public class ContextImplTest {
     private PulsarClientImpl client;
     private PulsarAdmin pulsarAdmin;
     private ContextImpl context;
-    private Producer producer = mock(Producer.class);
+    private Producer producer;
 
-    @BeforeMethod
+    @BeforeMethod(alwaysRun = true)
     public void setup() throws PulsarClientException {
         config = new InstanceConfig();
         config.setExposePulsarAdminClientEnabled(true);
@@ -89,6 +89,7 @@ public class ContextImplTest {
         logger = mock(Logger.class);
         pulsarAdmin = mock(PulsarAdmin.class);
 
+        producer = mock(Producer.class);
         client = mock(PulsarClientImpl.class);
         when(client.newProducer()).thenReturn(new ProducerBuilderImpl(client, Schema.BYTES));
         when(client.createProducerAsync(any(ProducerConfigurationData.class), any(), any()))

--- a/pulsar-functions/worker/src/test/java/org/apache/pulsar/functions/worker/FunctionMetaDataTopicTailerTest.java
+++ b/pulsar-functions/worker/src/test/java/org/apache/pulsar/functions/worker/FunctionMetaDataTopicTailerTest.java
@@ -36,6 +36,7 @@ import org.apache.pulsar.functions.proto.Function.FunctionMetaData;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 /**
@@ -44,14 +45,13 @@ import org.testng.annotations.Test;
 @Slf4j
 public class FunctionMetaDataTopicTailerTest {
 
-    private static final String TEST_NAME = "test-fmt";
+    private Reader reader;
+    private ReaderBuilder readerBuilder;
+    private FunctionMetaDataManager fsm;
+    private FunctionMetaDataTopicTailer fsc;
 
-    private final Reader reader;
-    private final ReaderBuilder readerBuilder;
-    private final FunctionMetaDataManager fsm;
-    private final FunctionMetaDataTopicTailer fsc;
-
-    public FunctionMetaDataTopicTailerTest() throws Exception {
+    @BeforeMethod(alwaysRun = true)
+    public void before() throws Exception {
         this.reader = mock(Reader.class);
         this.readerBuilder = mock(ReaderBuilder.class);
         when(readerBuilder.topic(anyString())).thenReturn(readerBuilder);


### PR DESCRIPTION
### Motivation
I found out some test classes which don't set `alwaysRun=true` in the @BeforeTests and @BeforeMethod annotation.
This can cause the test setup to not run, depending on the way the maven command is specified. (for example if you don't specify the `groups` option)

### Modifications

* Add `alwaysRun=true`

- [x] `no-need-doc` 