### PR TITLE
[fix][test] Fix test AuthorizationTest#getListWithoutGetBundleOp - Unauthorized to validateNamespaceOperation for operation [GET_BUNDLE] on namespace [p1/global/ns1]

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/AuthorizationTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/AuthorizationTest.java
@@ -24,6 +24,8 @@ import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 import java.util.EnumSet;
+
+import lombok.SneakyThrows;
 import org.apache.pulsar.broker.authorization.AuthorizationService;
 import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.admin.PulsarAdminBuilder;
@@ -248,18 +250,35 @@ public class AuthorizationTest extends MockedPulsarServiceBaseTest {
                 .authentication(new MockAuthentication("pass.pass2"))
                 .build();
         when(pulsar.getAdminClient()).thenReturn(admin2);
+        checkNotAuthorizedException(() -> admin2.topics().getList(namespaceV1, TopicDomain.non_persistent),
+                "GET_TOPICS",
+                "p1/global/ns1");
+
+        checkNotAuthorizedException(() -> admin2.topics().getList(namespaceV2, TopicDomain.non_persistent),
+                "GET_TOPICS",
+                "p1/ns2");
+
+        checkNotAuthorizedException(() -> admin2.topics().getListInBundle(namespaceV1, "0x00000000_0xffffffff"),
+                "GET_BUNDLE",
+                "p1/global/ns1");
+
+        checkNotAuthorizedException(() -> admin2.topics().getListInBundle(namespaceV2, "0x00000000_0xffffffff"),
+                "GET_BUNDLE",
+                "p1/ns2");
+    }
+
+    @SneakyThrows
+    private void checkNotAuthorizedException(Assert.ThrowingRunnable throwingRunnable,
+                                             String expectedNamespaceOperation,
+                                             String namespace) {
         try {
-            admin2.topics().getList(namespaceV1, TopicDomain.non_persistent);
-        } catch (Exception ex) {
+            throwingRunnable.run();
+        } catch (PulsarAdminException.NotAuthorizedException ex) {
             assertTrue(ex instanceof PulsarAdminException.NotAuthorizedException);
-            assertEquals(ex.getMessage(), "Unauthorized to validateNamespaceOperation for operation [GET_BUNDLE] on namespace [p1/global/ns1]");
+            assertEquals(ex.getMessage(), "Unauthorized to validateNamespaceOperation for operation ["
+                    + expectedNamespaceOperation + "] on namespace [" + namespace + "]");
         }
-        try {
-            admin2.topics().getList(namespaceV2, TopicDomain.non_persistent);
-        } catch (Exception ex) {
-            assertTrue(ex instanceof PulsarAdminException.NotAuthorizedException);
-            assertEquals(ex.getMessage(), "Unauthorized to validateNamespaceOperation for operation [GET_BUNDLE] on namespace [p1/ns2]");
-        }
+
     }
 
     private static void waitForChange() {


### PR DESCRIPTION
### Motivation
Locally this test fails in this way (both on master and branch-2.10).
```
java.lang.AssertionError: expected [Unauthorized to validateNamespaceOperation for operation [GET_BUNDLE] on namespace [p1/global/ns1]] but found [Unauthorized to validateNamespaceOperation for operation [GET_TOPICS] on namespace [p1/global/ns1]]
	at org.testng.Assert.fail(Assert.java:99)
	at org.testng.Assert.failNotEquals(Assert.java:1037)
	at org.testng.Assert.assertEqualsImpl(Assert.java:140)
	at org.testng.Assert.assertEquals(Assert.java:122)
	at org.testng.Assert.assertEquals(Assert.java:629)
	at org.testng.Assert.assertEquals(Assert.java:639)
	at org.apache.pulsar.broker.auth.AuthorizationTest.testGetListWithoutGetBundleOp(AuthorizationTest.java:255)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at org.testng.internal.MethodInvocationHelper.invokeMethod(MethodInvocationHelper.java:132)
	at org.testng.internal.InvokeMethodRunnable.runOne(InvokeMethodRunnable.java:45)
	at org.testng.internal.InvokeMethodRunnable.call(InvokeMethodRunnable.java:73)
	at org.testng.internal.InvokeMethodRunnable.call(InvokeMethodRunnable.java:11)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:829)
```

I didn't get how this could be mergeable when we merged the related pull (https://github.com/apache/pulsar/pull/14638) or if it is failing on CI since it is under the flaky group.


### Modifications

* Added the right error message check

- [x] `no-need-doc` 
