### PR TITLE
Allow Pulsar Broker and Functions to run on JDK11 (PIP-156 related)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,8 +77,8 @@ flexible messaging model and an intuitive client API.</description>
   </issueManagement>
 
   <properties>
-    <maven.compiler.source>17</maven.compiler.source>
-    <maven.compiler.target>17</maven.compiler.target>
+    <maven.compiler.source>11</maven.compiler.source>
+    <maven.compiler.target>11</maven.compiler.target>
     <pulsar.client.compiler.release>8</pulsar.client.compiler.release>
 
     <!--config keys to configure test selection -->

--- a/site2/docs/functions-package.md
+++ b/site2/docs/functions-package.md
@@ -73,7 +73,8 @@ To package a function in Java, complete the following steps.
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
                     <configuration>
-                        <release>17</release>
+                        <source>11</source>
+                        <target>11</target>
                     </configuration>
                 </plugin>
             </plugins>


### PR DESCRIPTION
PIP-156 with commit a742eb53cfc5aaaaf5896be04de11df5d5e0ef40 added the requirement to run the Pulsar Broker and build Pulsar Functions on JDK17.

This patch relaxes this requirement by setting JDK11 as target JDK for the Broker and for Pulsar IO/Functions framework.