### PR TITLE
[fix][ci] Fix tests memory leak due to mockito-inline

### DIFF
--- a/buildtools/pom.xml
+++ b/buildtools/pom.xml
@@ -50,6 +50,7 @@
     <guava.version>31.0.1-jre</guava.version>
     <ant.version>1.10.12</ant.version>
     <snakeyaml.version>1.30</snakeyaml.version>
+    <mockito.version>3.12.4</mockito.version>
     <!-- required for running tests on JDK11+ -->
     <test.additional.args>
       --add-opens java.base/jdk.internal.loader=ALL-UNNAMED
@@ -140,6 +141,16 @@
       <artifactId>netty-common</artifactId>
       <version>4.1.76.Final</version>
       <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>${mockito.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-inline</artifactId>
+      <version>${mockito.version}</version>
     </dependency>
   </dependencies>
 

--- a/buildtools/src/main/java/org/apache/pulsar/tests/MockitoCleanupListener.java
+++ b/buildtools/src/main/java/org/apache/pulsar/tests/MockitoCleanupListener.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pulsar.tests;
 
+import org.mockito.Mockito;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -36,10 +37,22 @@ public class MockitoCleanupListener extends BetweenTestClassesListenerAdapter {
 
     @Override
     protected void onBetweenTestClasses(Class<?> endedTestClass, Class<?> startedTestClass) {
-        if (MOCKITO_CLEANUP_ENABLED && MockitoThreadLocalStateCleaner.INSTANCE.isEnabled()) {
-            LOG.info("Cleaning up Mockito's ThreadSafeMockingProgress.MOCKING_PROGRESS_PROVIDER thread local state.");
-            MockitoThreadLocalStateCleaner.INSTANCE.cleanup();
+        if (MOCKITO_CLEANUP_ENABLED) {
+            if (MockitoThreadLocalStateCleaner.INSTANCE.isEnabled()) {
+                LOG.info("Cleaning up Mockito's ThreadSafeMockingProgress.MOCKING_PROGRESS_PROVIDER thread local state.");
+                MockitoThreadLocalStateCleaner.INSTANCE.cleanup();
+            }
+            cleanupMockitoInline();
         }
+    }
+
+    /**
+     * Mockito-inline can leak mocked objects, we need to clean up the inline mocks after every test.
+     * See <a href="https://javadoc.io/doc/org.mockito/mockito-core/latest/org/mockito/Mockito.html#47"}>
+     *     mockito docs</a>.
+     */
+    private void cleanupMockitoInline() {
+        Mockito.framework().clearInlineMocks();
     }
 
 }


### PR DESCRIPTION
### Motivation
I noticed an increased memory usage in long-running process which run the unit broker tests. After investigating I found out the introduction of mockito-inline is the culprit.

In the documentation is specified that it this behaviour is possible and [there's a way to fix it](https://javadoc.io/doc/org.mockito/mockito-core/latest/org/mockito/Mockito.html#47)


### Modifications

* Added the inline mocks cleanup between tests along with other mockito cleanups

 
- [x] `no-need-doc` 
