### PR TITLE
[WebSocket] Fix MultiTopicReader#getConsumer ClassCastException

### DIFF
--- a/pulsar-websocket/src/test/java/org/apache/pulsar/websocket/ReaderHandlerTest.java
+++ b/pulsar-websocket/src/test/java/org/apache/pulsar/websocket/ReaderHandlerTest.java
@@ -74,6 +74,8 @@ public class ReaderHandlerTest {
         ReaderHandler readerHandler = new ReaderHandler(wss, request, servletUpgradeResponse);
         // verify success
         Assert.assertEquals(readerHandler.getSubscription(), subName);
+        // Verify consumer is returned
+        readerHandler.getConsumer();
     }
 
     @Test
@@ -102,6 +104,8 @@ public class ReaderHandlerTest {
         ReaderHandler readerHandler = new ReaderHandler(wss, request, servletUpgradeResponse);
         // verify success
         Assert.assertEquals(readerHandler.getSubscription(), subName);
+        // Verify consumer is successfully returned
+        readerHandler.getConsumer();
     }
 
     @Test


### PR DESCRIPTION
### Motivation

This fixes an issue similar to the one solved in https://github.com/apache/pulsar/pull/14316. When the `reader` is a `MultiTopicReader`, the `getConsumer()` method currently throws a `ClassCastException`.

### Modifications

* Update `MultiTopicReader#getConsumer` so that it safely casts the `reader`.
* Update the `ReaderHandler` constructor to use the `getConsumer` method.

### Verifying this change

I expanded existing tests to cover the scenario that would have previously failed.

### Does this pull request potentially affect one of the following parts:

No, this is not a breaking change.