### PR TITLE
[feature][website] Remove .asf.yaml as website content is moving to repos/pulsar-site

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -1,3 +1,0 @@
-publish:
-  whoami: asf-site
-  source: github


### PR DESCRIPTION
Master Issue: #12637

### Motivation

We are ready to switch over website publishing to the pulsar-site repository.

### Modifications

Remove the .asf.yaml file which stops publishing of the website from the `asf-site` branch.

### Verifying this change

This change is a trivial rework / code cleanup without any test coverage.


### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API: (yes / no)
  - The schema: (yes / no / don't know)
  - The default values of configurations: (yes / no)
  - The wire protocol: (yes / no)
  - The rest endpoints: (yes / no)
  - The admin cli options: (yes / no)
  - Anything that affects deployment: (yes / no / don't know)

### Documentation

Check the box below or label this PR directly.

Need to update docs? 

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)
  
- [x] `no-need-doc` 
(Please explain why)
  
- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-added`
(Docs have been already added)