### PR TITLE
[improve][test] Reduce LedgerUnderreplicationManagerTest flakyness

### DIFF
--- a/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/bookkeeper/LedgerUnderreplicationManagerTest.java
+++ b/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/bookkeeper/LedgerUnderreplicationManagerTest.java
@@ -33,6 +33,8 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -74,7 +76,7 @@ public class LedgerUnderreplicationManagerTest extends BaseMetadataStoreTest {
                 log.error("Error getting ledger id", e);
                 return -1L;
             }
-        });
+        }, executor);
     }
 
     private MetadataStoreExtended store;
@@ -84,8 +86,10 @@ public class LedgerUnderreplicationManagerTest extends BaseMetadataStoreTest {
 
     private String basePath;
     private String urLedgerPath;
+    private Executor executor;
 
     private void methodSetup(Supplier<String> urlSupplier) throws Exception {
+        this.executor = Executors.newSingleThreadExecutor();
         String ledgersRoot = "/ledgers-" + UUID.randomUUID();
         this.store = MetadataStoreExtended.create(urlSupplier.get(), MetadataStoreConfig.builder().build());
         this.layoutManager = new PulsarLayoutManager(store, ledgersRoot);

--- a/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/bookkeeper/LedgerUnderreplicationManagerTest.java
+++ b/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/bookkeeper/LedgerUnderreplicationManagerTest.java
@@ -33,7 +33,7 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
@@ -86,7 +86,7 @@ public class LedgerUnderreplicationManagerTest extends BaseMetadataStoreTest {
 
     private String basePath;
     private String urLedgerPath;
-    private Executor executor;
+    private ExecutorService executor;
 
     private void methodSetup(Supplier<String> urlSupplier) throws Exception {
         this.executor = Executors.newSingleThreadExecutor();
@@ -116,6 +116,15 @@ public class LedgerUnderreplicationManagerTest extends BaseMetadataStoreTest {
         }
         if (store != null) {
             store.close();
+        }
+        if (executor != null) {
+            try {
+                executor.shutdownNow();
+                executor.awaitTermination(5, TimeUnit.SECONDS);
+            } catch (InterruptedException ex) {
+                Thread.currentThread().interrupt();
+            }
+            executor = null;
         }
     }
 


### PR DESCRIPTION
### Motivation

In our CI environment we've seen many times that the test `LedgerUnderreplicationManagerTest` fails in this way:
```
java.util.concurrent.TimeoutException
	at java.base/java.util.concurrent.CompletableFuture.timedGet(CompletableFuture.java:1886)
	at java.base/java.util.concurrent.CompletableFuture.get(CompletableFuture.java:2021)
	at org.apache.pulsar.metadata.bookkeeper.LedgerUnderreplicationManagerTest.test2reportSame(LedgerUnderreplicationManagerTest.java:428)
```

All of the tests then fail. The reason behind the timeout is that the method `LedgerUnderreplicationManagerTest#getLedgerToReplicate` uses the common thread pool and it causes deadlock in some way. Using a dedicated thread pool solves the issue.

Note that I haven't ever seen this failure in the OSS pulsar CI so I believe is related to the way we run the tests in our CI but the fix is still a good solution

### Modifications
* Use a dedicated thread pool for the method `getLedgerToReplicate`. This is a test method so the production code is not affected at all.
  
- [x] `no-need-doc` 