### PR TITLE
[improve][Doc] Update hyperlink for Apache BookKeeper Upgrade guide #15542

### DIFF
--- a/site2/docs/administration-upgrade.md
+++ b/site2/docs/administration-upgrade.md
@@ -74,7 +74,7 @@ You can upgrade all ZooKeeper servers one by one by following steps in canary te
 ## Upgrade bookies
 
 While you upgrade bookies, you can do canary test first, and then upgrade all bookies in the cluster.
-For more details, you can read Apache BookKeeper [Upgrade guide](http://bookkeeper.apache.org/docs/next/admin/upgrade).
+For more details, you can read Apache BookKeeper [Upgrade guide](https://bookkeeper.apache.org/docs/next/admin/upgrade).
 
 ### Canary test
 

--- a/site2/docs/administration-upgrade.md
+++ b/site2/docs/administration-upgrade.md
@@ -74,7 +74,7 @@ You can upgrade all ZooKeeper servers one by one by following steps in canary te
 ## Upgrade bookies
 
 While you upgrade bookies, you can do canary test first, and then upgrade all bookies in the cluster.
-For more details, you can read Apache BookKeeper [Upgrade guide](http://bookkeeper.apache.org/docs/latest/admin/upgrade).
+For more details, you can read Apache BookKeeper [Upgrade guide](http://bookkeeper.apache.org/docs/next/admin/upgrade).
 
 ### Canary test
 


### PR DESCRIPTION
Update hyperlink for Apache BookKeeper Upgrade guide

Fixes #15542 

Master Issue: #15542 

### Motivation
The hyperlink to the Apache BookKeeper Upgrade guide is out of date

### Modifications

Update hyperlink for Apache BookKeeper Upgrade guide
http://bookkeeper.apache.org/docs/next/admin/upgrade/

### Documentation
- [√ ] `no-need-doc` 