### PR TITLE
[blog] renamed blog post file to have `.md` extension

### DIFF
--- a/site2/website/blog/2022-05-11-apache-pulsar-community-welcomes-500th-contributor.md
+++ b/site2/website/blog/2022-05-11-apache-pulsar-community-welcomes-500th-contributor.md
@@ -1,6 +1,6 @@
 ---
 title: "The Apache Pulsar Community Welcomes 500th Contributor!"
-date: 2022-02-24
+date: 2022-05-11
 author: "Matteo Merli", "Karin Landers", "Alice Bi"
 ---
 


### PR DESCRIPTION
### Motivation

The blog post added in #14464 was missing the `.md` extension and therefore it never made it to the website. Fixed naming and changed the date since the original one was back in February.