### PR TITLE
[improve][broker] Avoid using synchronous operations in the async method to block metadata threads.

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
@@ -18,7 +18,6 @@
  */
 package org.apache.pulsar.broker.admin.impl;
 
-import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.apache.pulsar.common.naming.SystemTopicNames.isTransactionCoordinatorAssign;
 import static org.apache.pulsar.common.naming.SystemTopicNames.isTransactionInternalName;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -3908,9 +3907,9 @@ public class PersistentTopicsBase extends AdminResource {
                     }
                     return CompletableFuture.completedFuture(null);
                 }).thenCompose(__ ->
-                    // validates global-namespace contains local/peer cluster: if peer/local cluster present then lookup can
-                    // serve/redirect request else fail partitioned-metadata-request so, client fails while creating
-                    // producer/consumer
+                    // validates global-namespace contains local/peer cluster: if peer/local cluster present
+                    // then lookup can serve/redirect request else fail partitioned-metadata-request
+                    // so, client fails while creating producer/consumer.
                     checkLocalOrGetPeerReplicationCluster(pulsar, topicName.getNamespaceObject())
                     .thenCompose(res ->
                             pulsar.getBrokerService()

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
@@ -3882,7 +3882,7 @@ public class PersistentTopicsBase extends AdminResource {
         return validateTopicOperationAsync(pulsar, topicName, clientAppId, TopicOperation.LOOKUP, authenticationData)
                 .handle((__, ex) -> {
                     if (ex != null) {
-                        if (isSpecificRestException(FutureUtil.unwrapCompletionException(ex), Status.UNAUTHORIZED)) {
+                        if (FutureUtil.unwrapCompletionException(ex) instanceof RestException) {
                             return false; // Operational verification failed.
                         }
                         // throw without wrapping to PulsarClientException that considers:
@@ -3897,12 +3897,11 @@ public class PersistentTopicsBase extends AdminResource {
                         return validateAdminAccessForTenantAsync(pulsar,
                                 clientAppId, originalPrincipal, topicName.getTenant(), authenticationData)
                                 .exceptionally(ex -> {
-                                    Throwable realCause = FutureUtil.unwrapCompletionException(ex);
-                                    if (realCause instanceof RestException) {
+                                    if (FutureUtil.unwrapCompletionException(ex) instanceof RestException) {
                                         log.warn("Failed to authorize {} on topic {}", clientAppId, topicName);
                                         throw FutureUtil.wrapToCompletionException(new PulsarClientException(
                                                 String.format("Authorization failed %s on topic %s with error %s",
-                                                clientAppId, topicName, realCause.getMessage())));
+                                                clientAppId, topicName, ex.getMessage())));
                                     }
                                     return null;
                                 });

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/lookup/TopicLookupBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/lookup/TopicLookupBase.java
@@ -26,7 +26,6 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionException;
 import javax.ws.rs.Encoded;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.container.AsyncResponse;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/PulsarWebResource.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/PulsarWebResource.java
@@ -1205,8 +1205,8 @@ public abstract class PulsarWebResource {
     }
 
     public static boolean isSpecificRestException(Throwable ex, Status status) {
-        return ex instanceof WebApplicationException &&
-                ((WebApplicationException) ex).getResponse().getStatus() == status.getStatusCode();
+        return ex instanceof WebApplicationException
+                && ((WebApplicationException) ex).getResponse().getStatus() == status.getStatusCode();
     }
 
     protected static void resumeAsyncResponseExceptionally(AsyncResponse asyncResponse, Throwable exception) {


### PR DESCRIPTION
Fixes #15549

Master Issue: #15549

### Motivation

See #15549 

### Modifications

- Use `validateTopicOperationAsync` instead of `checkAuthorization` method and make it pure async.
- Refactor code to make it more readable.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Documentation

- [x] `no-need-doc` 