### PR TITLE
[PIP-150][improve][broker] Support read the message of startMessageId position on the broker side

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedLedger.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedLedger.java
@@ -250,6 +250,32 @@ public interface ManagedLedger {
             throws InterruptedException, ManagedLedgerException;
 
     /**
+     * Open a ManagedCursor in this ManagedLedger.
+     * <p>
+     * If the cursors doesn't exist, a new one will be created and its position will be at the end of the ManagedLedger.
+     *
+     * @param name
+     *            the name associated with the ManagedCursor
+     * @param initialPosition
+     *            the cursor will be set at latest position or not when first created
+     *            default is <b>true</b>
+     * @param properties
+     *             user defined properties that will be attached to the first position of the cursor, if the open
+     *             operation will trigger the creation of the cursor.
+     * @param cursorProperties
+     *            the properties for the Cursor
+     * @param inclusive
+     *            whether to start read from the specified position
+     * @return the ManagedCursor
+     * @throws ManagedLedgerException
+     */
+    default ManagedCursor openCursor(String name, InitialPosition initialPosition, Map<String, Long> properties,
+                                     Map<String, String> cursorProperties, boolean inclusive)
+            throws InterruptedException, ManagedLedgerException {
+        return openCursor(name, initialPosition, properties, cursorProperties);
+    }
+
+    /**
      * Creates a new cursor whose metadata is not backed by durable storage. A caller can treat the non-durable cursor
      * exactly like a normal cursor, with the only difference in that after restart it will not remember which entries
      * were deleted. Also it does not prevent data from being deleted.
@@ -268,6 +294,12 @@ public interface ManagedLedger {
     ManagedCursor newNonDurableCursor(Position startPosition, String subscriptionName) throws ManagedLedgerException;
     ManagedCursor newNonDurableCursor(Position startPosition, String subscriptionName, InitialPosition initialPosition,
                                       boolean isReadCompacted) throws ManagedLedgerException;
+
+    default ManagedCursor newNonDurableCursor(Position startPosition, String subscriptionName,
+                                              InitialPosition initialPosition, boolean isReadCompacted,
+                                              boolean inclusive) throws ManagedLedgerException {
+        return newNonDurableCursor(startPosition, subscriptionName, initialPosition, isReadCompacted);
+    }
 
     /**
      * Delete a ManagedCursor asynchronously.
@@ -348,7 +380,32 @@ public interface ManagedLedger {
      *            opaque context
      */
     void asyncOpenCursor(String name, InitialPosition initialPosition, Map<String, Long> properties,
-                         Map<String, String> cursorProperties, OpenCursorCallback callback, Object ctx);
+                         Map<String, String> cursorProperties, OpenCursorCallback callback,
+                         Object ctx);
+
+    /**
+     * Open a ManagedCursor asynchronously.
+     *
+     * @see #openCursor(String)
+     * @param name
+     *            the name associated with the ManagedCursor
+     * @param initialPosition
+     *            the cursor will be set at lastest position or not when first created
+     *            default is <b>true</b>
+     * @param cursorProperties
+     *            the properties for the Cursor
+     * @param inclusive
+     *            whether to read from the specified position
+     * @param callback
+     *            callback object
+     * @param ctx
+     *            opaque context
+     */
+    default void asyncOpenCursor(String name, InitialPosition initialPosition, Map<String, Long> properties,
+                                 Map<String, String> cursorProperties, boolean inclusive, OpenCursorCallback callback,
+                                 Object ctx) {
+        asyncOpenCursor(name, initialPosition, properties, cursorProperties, callback, ctx);
+    }
 
     /**
      * Get a list of all the cursors reading from this ManagedLedger.

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
@@ -976,6 +976,7 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
         final KeySharedMeta keySharedMeta = subscribe.hasKeySharedMeta()
               ? new KeySharedMeta().copyFrom(subscribe.getKeySharedMeta())
               : emptyKeySharedMeta;
+        final boolean startMessageIdInclusive = subscribe.isStartMessageIdInclusive();
 
         if (log.isDebugEnabled()) {
             log.debug("Topic name = {}, subscription name = {}, schema is {}", topicName, subscriptionName,
@@ -1083,6 +1084,7 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
                                     .replicatedSubscriptionStateArg(isReplicated).keySharedMeta(keySharedMeta)
                                     .subscriptionProperties(subscriptionProperties)
                                     .consumerEpoch(consumerEpoch)
+                                    .startMessageIdInclusive(startMessageIdInclusive)
                                     .build();
                             if (schema != null) {
                                 return topic.addSchemaIfIdleOrCheckCompatible(schema)

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/SubscriptionOption.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/SubscriptionOption.java
@@ -49,6 +49,7 @@ public class SubscriptionOption {
     private KeySharedMeta keySharedMeta;
     private Optional<Map<String, String>> subscriptionProperties;
     private long consumerEpoch;
+    private boolean startMessageIdInclusive;
 
     public static Optional<Map<String, String>> getPropertiesMap(List<KeyValue> list) {
         if (list == null) {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentTopicTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentTopicTest.java
@@ -1562,11 +1562,11 @@ public class PersistentTopicTest extends MockedBookKeeperTestCase {
         doAnswer(new Answer<Object>() {
             @Override
             public Object answer(InvocationOnMock invocationOnMock) throws Throwable {
-                ((OpenCursorCallback) invocationOnMock.getArguments()[4]).openCursorComplete(cursorMock, null);
+                ((OpenCursorCallback) invocationOnMock.getArguments()[5]).openCursorComplete(cursorMock, null);
                 return null;
             }
         }).when(ledgerMock).asyncOpenCursor(matches(".*success.*"), any(InitialPosition.class), any(Map.class),
-                any(Map.class), any(OpenCursorCallback.class), any());
+                any(Map.class), anyBoolean(), any(OpenCursorCallback.class), any());
 
         doAnswer(new Answer<Object>() {
             @Override
@@ -2215,9 +2215,9 @@ public class PersistentTopicTest extends MockedBookKeeperTestCase {
             return null;
         }).when(mockLedger).asyncDeleteCursor(matches(".*success.*"), any(DeleteCursorCallback.class), any());
         doAnswer((Answer<Object>) invocationOnMock -> {
-            ((OpenCursorCallback) invocationOnMock.getArguments()[4]).openCursorComplete(mockCursor, null);
+            ((OpenCursorCallback) invocationOnMock.getArguments()[5]).openCursorComplete(mockCursor, null);
             return null;
-        }).when(mockLedger).asyncOpenCursor(any(), any(), any(), any(), any(), any());
+        }).when(mockLedger).asyncOpenCursor(any(), any(), any(), any(), anyBoolean(), any(), any());
         PersistentTopic topic = new PersistentTopic(successTopicName, mockLedger, brokerService);
 
         CommandSubscribe cmd = new CommandSubscribe()

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ServerCnxTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ServerCnxTest.java
@@ -22,6 +22,7 @@ import static org.apache.pulsar.broker.BrokerTestUtil.spyWithClassAndConstructor
 import static org.apache.pulsar.broker.auth.MockedPulsarServiceBaseTest.createMockBookKeeper;
 import static org.apache.pulsar.broker.auth.MockedPulsarServiceBaseTest.createMockZooKeeper;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doReturn;
@@ -1701,25 +1702,25 @@ public class ServerCnxTest {
 
         doAnswer((Answer<Object>) invocationOnMock -> {
             Thread.sleep(300);
-            ((OpenCursorCallback) invocationOnMock.getArguments()[4]).openCursorComplete(cursorMock, null);
+            ((OpenCursorCallback) invocationOnMock.getArguments()[5]).openCursorComplete(cursorMock, null);
             return null;
         }).when(ledgerMock).asyncOpenCursor(matches(".*success.*"), any(InitialPosition.class), any(Map.class), any(Map.class),
-                any(OpenCursorCallback.class), any());
+                anyBoolean(), any(OpenCursorCallback.class), any());
 
         doAnswer((Answer<Object>) invocationOnMock -> {
             Thread.sleep(300);
-            ((OpenCursorCallback) invocationOnMock.getArguments()[3])
+            ((OpenCursorCallback) invocationOnMock.getArguments()[2])
                     .openCursorFailed(new ManagedLedgerException("Managed ledger failure"), null);
             return null;
         }).when(ledgerMock).asyncOpenCursor(matches(".*fail.*"), any(InitialPosition.class), any(OpenCursorCallback.class), any());
 
         doAnswer((Answer<Object>) invocationOnMock -> {
             Thread.sleep(300);
-            ((OpenCursorCallback) invocationOnMock.getArguments()[3])
+            ((OpenCursorCallback) invocationOnMock.getArguments()[4])
                     .openCursorFailed(new ManagedLedgerException("Managed ledger failure"), null);
             return null;
         }).when(ledgerMock).asyncOpenCursor(matches(".*fail.*"), any(InitialPosition.class), any(Map.class), any(Map.class),
-                any(OpenCursorCallback.class), any());
+                anyBoolean(), any(OpenCursorCallback.class), any());
 
         doAnswer((Answer<Object>) invocationOnMock -> {
             ((DeleteCursorCallback) invocationOnMock.getArguments()[1]).deleteCursorComplete(null);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/StartMessageIdInclusiveTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/StartMessageIdInclusiveTest.java
@@ -1,0 +1,203 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.client.impl;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+import com.google.common.collect.Sets;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.TimeUnit;
+import lombok.Cleanup;
+import org.apache.pulsar.broker.auth.MockedPulsarServiceBaseTest;
+import org.apache.pulsar.client.api.Consumer;
+import org.apache.pulsar.client.api.Message;
+import org.apache.pulsar.client.api.MessageId;
+import org.apache.pulsar.client.api.Producer;
+import org.apache.pulsar.client.api.Reader;
+import org.apache.pulsar.client.api.SubscriptionInitialPosition;
+import org.apache.pulsar.client.api.SubscriptionMode;
+import org.apache.pulsar.common.policies.data.ClusterData;
+import org.apache.pulsar.common.policies.data.TenantInfoImpl;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+@Test(groups = "broker-impl")
+public class StartMessageIdInclusiveTest extends MockedPulsarServiceBaseTest {
+
+    @BeforeMethod(alwaysRun = true)
+    @Override
+    protected void setup() throws Exception {
+        super.internalSetup();
+
+        admin.clusters().createCluster("test",
+                ClusterData.builder().serviceUrl(pulsar.getWebServiceAddress()).build());
+        admin.tenants().createTenant("my-property",
+                new TenantInfoImpl(Sets.newHashSet("appid1", "appid2"), Sets.newHashSet("test")));
+        admin.namespaces().createNamespace("my-property/my-ns", Sets.newHashSet("test"));
+    }
+
+    @AfterMethod(alwaysRun = true)
+    @Override
+    protected void cleanup() throws Exception {
+        super.internalCleanup();
+    }
+
+    @DataProvider(name = "subscriptionMode")
+    public Object[] subscriptionModeProvider() {
+        return new Object[]{SubscriptionMode.Durable, SubscriptionMode.NonDurable};
+    }
+
+    @Test
+    public void testReaderLatestMessage() throws Exception {
+        final String topic = "persistent://my-property/my-ns/my-topic";
+
+        @Cleanup
+        Producer<byte[]> producer = pulsarClient.newProducer().topic(topic).create();
+        for (int i = 0; i < 10; i++) {
+            producer.send(String.valueOf(i).getBytes(StandardCharsets.UTF_8));
+        }
+
+        @Cleanup
+        Reader<byte[]> readerWithInclusive = pulsarClient.newReader()
+                .topic(topic)
+                .startMessageId(MessageId.latest)
+                .startMessageIdInclusive()
+                .create();
+
+        Message<byte[]> m = readerWithInclusive.readNext(3, TimeUnit.SECONDS);
+        assertNotNull(m);
+        assertEquals(m.getData(), "9".getBytes(StandardCharsets.UTF_8));
+
+        @Cleanup
+        Reader<byte[]> readerWithoutInclusive = pulsarClient.newReader()
+                .topic(topic)
+                .startMessageId(MessageId.latest)
+                .create();
+
+        m = readerWithoutInclusive.readNext(3, TimeUnit.SECONDS);
+        assertNull(m);
+    }
+
+    @Test
+    public void testReaderEarliestMessage() throws Exception {
+        final String topic = "persistent://my-property/my-ns/my-topic";
+
+        @Cleanup
+        Producer<byte[]> producer = pulsarClient.newProducer().topic(topic).create();
+        for (int i = 0; i < 10; i++) {
+            producer.send(String.valueOf(i).getBytes(StandardCharsets.UTF_8));
+        }
+
+        @Cleanup
+        Reader<byte[]> readerWithInclusive = pulsarClient.newReader()
+                .topic(topic)
+                .startMessageId(MessageId.earliest)
+                .startMessageIdInclusive()
+                .create();
+
+        Message<byte[]> m = readerWithInclusive.readNext(3, TimeUnit.SECONDS);
+        assertNotNull(m);
+        assertEquals(m.getData(), "0".getBytes(StandardCharsets.UTF_8));
+
+        @Cleanup
+        Reader<byte[]> readerWithoutInclusive = pulsarClient.newReader()
+                .topic(topic)
+                .startMessageId(MessageId.earliest)
+                .startMessageIdInclusive()
+                .create();
+
+        m = readerWithoutInclusive.readNext(3, TimeUnit.SECONDS);
+        assertNotNull(m);
+        assertEquals(m.getData(), "0".getBytes(StandardCharsets.UTF_8));
+    }
+
+    @Test(dataProvider = "subscriptionMode")
+    public void testConsumerLatestMessage(SubscriptionMode subscriptionMode) throws Exception {
+        final String topic = "persistent://my-property/my-ns/my-topic";
+
+        @Cleanup
+        Producer<byte[]> producer = pulsarClient.newProducer().topic(topic).create();
+        for (int i = 0; i < 10; i++) {
+            producer.send(String.valueOf(i).getBytes(StandardCharsets.UTF_8));
+        }
+
+        @Cleanup
+        Consumer<byte[]> consumerWithInclusive = pulsarClient.newConsumer()
+                .topic(topic)
+                .subscriptionInitialPosition(SubscriptionInitialPosition.Latest)
+                .subscriptionName("consumerWithInclusive")
+                .subscriptionMode(subscriptionMode)
+                .startMessageIdInclusive()
+                .subscribe();
+
+        Message<byte[]> m = consumerWithInclusive.receive(3, TimeUnit.SECONDS);
+        assertNotNull(m);
+        assertEquals(m.getData(), "9".getBytes(StandardCharsets.UTF_8));
+
+        @Cleanup
+        Consumer<byte[]> consumerWithoutInclusive = pulsarClient.newConsumer()
+                .topic(topic)
+                .subscriptionInitialPosition(SubscriptionInitialPosition.Latest)
+                .subscriptionName("consumerWithoutInclusive")
+                .subscriptionMode(subscriptionMode)
+                .subscribe();
+
+        m = consumerWithoutInclusive.receive(3, TimeUnit.SECONDS);
+        assertNull(m);
+    }
+
+    @Test(dataProvider = "subscriptionMode")
+    public void testConsumerEarliestMessage(SubscriptionMode subscriptionMode) throws Exception {
+        final String topic = "persistent://my-property/my-ns/my-topic";
+
+        @Cleanup
+        Producer<byte[]> producer = pulsarClient.newProducer().topic(topic).create();
+        for (int i = 0; i < 10; i++) {
+            producer.send(String.valueOf(i).getBytes(StandardCharsets.UTF_8));
+        }
+
+        @Cleanup
+        Consumer<byte[]> consumerWithInclusive = pulsarClient.newConsumer()
+                .topic(topic)
+                .subscriptionInitialPosition(SubscriptionInitialPosition.Earliest)
+                .subscriptionName("consumerWithInclusive")
+                .startMessageIdInclusive()
+                .subscriptionMode(subscriptionMode)
+                .subscribe();
+
+        Message<byte[]> m = consumerWithInclusive.receive(3, TimeUnit.SECONDS);
+        assertNotNull(m);
+        assertEquals(m.getData(), "0".getBytes(StandardCharsets.UTF_8));
+
+        @Cleanup
+        Consumer<byte[]> consumerWithoutInclusive = pulsarClient.newConsumer()
+                .topic(topic)
+                .subscriptionInitialPosition(SubscriptionInitialPosition.Earliest)
+                .subscriptionName("consumerWithoutInclusive")
+                .subscriptionMode(subscriptionMode)
+                .subscribe();
+
+        m = consumerWithoutInclusive.receive(3, TimeUnit.SECONDS);
+        assertNotNull(m);
+        assertEquals(m.getData(), "0".getBytes(StandardCharsets.UTF_8));
+    }
+}

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
@@ -865,7 +865,7 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
                     InitialPosition.valueOf(subscriptionInitialPosition.getValue()),
                     startMessageRollbackDuration, si, createTopicIfDoesNotExist, conf.getKeySharedPolicy(),
                     // Use the current epoch to subscribe.
-                    conf.getSubscriptionProperties(), CONSUMER_EPOCH.get(this));
+                    conf.getSubscriptionProperties(), CONSUMER_EPOCH.get(this), conf.isResetIncludeHead());
 
             cnx.sendRequestWithId(request, requestId).thenRun(() -> {
                 synchronized (ConsumerImpl.this) {

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/protocol/Commands.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/protocol/Commands.java
@@ -559,7 +559,7 @@ public class Commands {
         return newSubscribe(topic, subscription, consumerId, requestId, subType, priorityLevel, consumerName,
                 isDurable, startMessageId, metadata, readCompacted, isReplicated, subscriptionInitialPosition,
                 startMessageRollbackDurationInSec, schemaInfo, createTopicIfDoesNotExist, null,
-                Collections.emptyMap(), DEFAULT_CONSUMER_EPOCH);
+                Collections.emptyMap(), DEFAULT_CONSUMER_EPOCH, false);
     }
 
     public static ByteBuf newSubscribe(String topic, String subscription, long consumerId, long requestId,
@@ -567,7 +567,7 @@ public class Commands {
                Map<String, String> metadata, boolean readCompacted, boolean isReplicated,
                InitialPosition subscriptionInitialPosition, long startMessageRollbackDurationInSec,
                SchemaInfo schemaInfo, boolean createTopicIfDoesNotExist, KeySharedPolicy keySharedPolicy,
-               Map<String, String> subscriptionProperties, long consumerEpoch) {
+               Map<String, String> subscriptionProperties, long consumerEpoch, boolean startMessageIdInclusive) {
         BaseCommand cmd = localCmd(Type.SUBSCRIBE);
         CommandSubscribe subscribe = cmd.setSubscribe()
                 .setTopic(topic)
@@ -582,7 +582,8 @@ public class Commands {
                 .setInitialPosition(subscriptionInitialPosition)
                 .setReplicateSubscriptionState(isReplicated)
                 .setForceTopicCreation(createTopicIfDoesNotExist)
-                .setConsumerEpoch(consumerEpoch);
+                .setConsumerEpoch(consumerEpoch)
+                .setStartMessageIdInclusive(startMessageIdInclusive);
 
         if (subscriptionProperties != null && !subscriptionProperties.isEmpty()) {
             List<KeyValue> keyValues = new ArrayList<>();

--- a/pulsar-common/src/main/proto/PulsarApi.proto
+++ b/pulsar-common/src/main/proto/PulsarApi.proto
@@ -394,6 +394,9 @@ message CommandSubscribe {
 
     // The consumer epoch, when exclusive and failover consumer redeliver unack message will increase the epoch
     optional uint64 consumer_epoch = 19;
+
+    // If specified, the subscription will read the message from start message id position.
+    optional bool start_message_id_inclusive = 20 [default = false];
 }
 
 message CommandPartitionedTopicMetadata {


### PR DESCRIPTION
Fixes #14883 

### Motivation

See #14883

### Modifications

- In broker side, add a `start_message_id_inclusive` field to `CommandSubscribe` message
- Client supports set the `start_message_id_inclusive` value of `CommandSubscribe` message
- Improve `NonDurableCursorImpl.java` and `ManagedCursorImpl.java` supports reading the message of startMessageId position 

### Verifying this change

- [x] Make sure that the change passes the CI checks.
- Added tests

### Documentation

Need to update docs? 

- [x] `no-need-doc` 

- [x] `doc-not-needed`
