### PR TITLE
[improve][functions] Sinks: allow to reset --timeout-ms to zero

### DIFF
--- a/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/SinkConfigUtils.java
+++ b/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/SinkConfigUtils.java
@@ -404,7 +404,7 @@ public class SinkConfigUtils {
             ResourceConfigUtils.validate(sinkConfig.getResources());
         }
 
-        if (sinkConfig.getTimeoutMs() != null && sinkConfig.getTimeoutMs() <= 0) {
+        if (sinkConfig.getTimeoutMs() != null && sinkConfig.getTimeoutMs() < 0) {
             throw new IllegalArgumentException("Sink timeout must be a positive number");
         }
 

--- a/pulsar-functions/utils/src/test/java/org/apache/pulsar/functions/utils/SinkConfigUtilsTest.java
+++ b/pulsar-functions/utils/src/test/java/org/apache/pulsar/functions/utils/SinkConfigUtilsTest.java
@@ -482,4 +482,19 @@ public class SinkConfigUtilsTest {
         convertedConfig = SinkConfigUtils.convertFromDetails(functionDetails);
         assertTrue(convertedConfig.getInputSpecs().get("test-input").isPoolMessages());
     }
+
+    @Test
+    public void testAllowDisableSinkTimeout() {
+        SinkConfig sinkConfig = createSinkConfig();
+        sinkConfig.setInputSpecs(null);
+        sinkConfig.setTopicsPattern("my-topic-*");
+        SinkConfigUtils.validateAndExtractDetails(sinkConfig, this.getClass().getClassLoader(),
+                true);
+        sinkConfig.setTimeoutMs(null);
+        SinkConfigUtils.validateAndExtractDetails(sinkConfig, this.getClass().getClassLoader(),
+                true);
+        sinkConfig.setTimeoutMs(0L);
+        SinkConfigUtils.validateAndExtractDetails(sinkConfig, this.getClass().getClassLoader(),
+                true);
+    }
 }


### PR DESCRIPTION
### Motivation

Currently there's no way to remove the timeout from a running sink. You get a error like `Sink timeout must be a positive number`. 

### Modifications

- Allow to set timeout=0 when creating/updating a sink

- [x] `no-need-doc` 
