### PR TITLE
[fix][broker] Fix deadlock in broker after race condition in topic creation failure

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
@@ -1400,9 +1400,10 @@ public class BrokerService implements Closeable {
                                             if (topicFuture.isCompletedExceptionally()) {
                                                 log.warn("{} future is already completed with failure {}, closing the"
                                                         + " topic", topic, FutureUtil.getException(topicFuture));
-                                                persistentTopic.stopReplProducers().whenCompleteAsync((v, exception) -> {
-                                                    topics.remove(topic, topicFuture);
-                                                }, executor());
+                                                persistentTopic.stopReplProducers()
+                                                        .whenCompleteAsync((v, exception) -> {
+                                                            topics.remove(topic, topicFuture);
+                                                        }, executor());
                                             } else {
                                                 addTopicToStatsMaps(topicName, persistentTopic);
                                                 topicFuture.complete(Optional.of(persistentTopic));

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
@@ -1400,9 +1400,9 @@ public class BrokerService implements Closeable {
                                             if (topicFuture.isCompletedExceptionally()) {
                                                 log.warn("{} future is already completed with failure {}, closing the"
                                                         + " topic", topic, FutureUtil.getException(topicFuture));
-                                                persistentTopic.stopReplProducers().whenComplete((v, exception) -> {
+                                                persistentTopic.stopReplProducers().whenCompleteAsync((v, exception) -> {
                                                     topics.remove(topic, topicFuture);
-                                                });
+                                                }, executor());
                                             } else {
                                                 addTopicToStatsMaps(topicName, persistentTopic);
                                                 topicFuture.complete(Optional.of(persistentTopic));
@@ -1411,10 +1411,10 @@ public class BrokerService implements Closeable {
                                         .exceptionally((ex) -> {
                                             log.warn("Replication or dedup check failed."
                                                     + " Removing topic from topics list {}, {}", topic, ex);
-                                            persistentTopic.stopReplProducers().whenComplete((v, exception) -> {
+                                            persistentTopic.stopReplProducers().whenCompleteAsync((v, exception) -> {
                                                 topics.remove(topic, topicFuture);
                                                 topicFuture.completeExceptionally(ex);
-                                            });
+                                            }, executor());
                                             return null;
                                         });
                             } catch (PulsarServerException e) {


### PR DESCRIPTION
### Motivation

We need to make sure to trigger the removal from the map in a different thread, otherwise we can deadlock ourselves by trying to re-acquire the same StampedLock from the same thread when removing. This can happen if all the operation in the topic creation path are completing immediately and ultimately with a failure in the dedup or geo-replication check.

```
"pulsar-web-42-1" #109 prio=5 os_prio=0 cpu=3026.59ms elapsed=225914.89s tid=0x00007f7be6bf0000 nid=0x2d78 waiting on condition  [0x00007f7b268b4000]
   java.lang.Thread.State: WAITING (parking)
	at jdk.internal.misc.Unsafe.park(java.base@11.0.14.1/Native Method)
	- parking to wait for  <0x0000000687b6a410> (a org.apache.pulsar.common.util.collections.ConcurrentOpenHashMap$Section)
	at java.util.concurrent.locks.LockSupport.park(java.base@11.0.14.1/LockSupport.java:194)
	at java.util.concurrent.locks.StampedLock.acquireWrite(java.base@11.0.14.1/StampedLock.java:1315)
	at java.util.concurrent.locks.StampedLock.writeLock(java.base@11.0.14.1/StampedLock.java:461)
	at org.apache.pulsar.common.util.collections.ConcurrentOpenHashMap$Section.remove(ConcurrentOpenHashMap.java:332)
	at org.apache.pulsar.common.util.collections.ConcurrentOpenHashMap$Section.access$200(ConcurrentOpenHashMap.java:206)
	at org.apache.pulsar.common.util.collections.ConcurrentOpenHashMap.remove(ConcurrentOpenHashMap.java:164)
    
    
	at org.apache.pulsar.broker.service.BrokerService$2.lambda$null$4(BrokerService.java:1363)
	at org.apache.pulsar.broker.service.BrokerService$2$$Lambda$1102/0x00000008408a1440.accept(Unknown Source)
	at java.util.concurrent.CompletableFuture.uniWhenComplete(java.base@11.0.14.1/CompletableFuture.java:859)
	at java.util.concurrent.CompletableFuture.uniWhenCompleteStage(java.base@11.0.14.1/CompletableFuture.java:883)
	at java.util.concurrent.CompletableFuture.whenComplete(java.base@11.0.14.1/CompletableFuture.java:2251)
	at org.apache.pulsar.broker.service.BrokerService$2.lambda$openLedgerComplete$5(BrokerService.java:1362)
	at org.apache.pulsar.broker.service.BrokerService$2$$Lambda$893/0x000000084081a440.apply(Unknown Source)
	at java.util.concurrent.CompletableFuture.uniExceptionally(java.base@11.0.14.1/CompletableFuture.java:986)
	at java.util.concurrent.CompletableFuture.uniExceptionallyStage(java.base@11.0.14.1/CompletableFuture.java:1004)
	at java.util.concurrent.CompletableFuture.exceptionally(java.base@11.0.14.1/CompletableFuture.java:2307)
	at org.apache.pulsar.broker.service.BrokerService$2.openLedgerComplete(BrokerService.java:1357)
	at org.apache.bookkeeper.mledger.impl.ManagedLedgerFactoryImpl.lambda$asyncOpen$7(ManagedLedgerFactoryImpl.java:425)
	at org.apache.bookkeeper.mledger.impl.ManagedLedgerFactoryImpl$$Lambda$808/0x00000008407b6440.accept(Unknown Source)
	at java.util.concurrent.CompletableFuture.uniAcceptNow(java.base@11.0.14.1/CompletableFuture.java:753)
	at java.util.concurrent.CompletableFuture.uniAcceptStage(java.base@11.0.14.1/CompletableFuture.java:731)
	at java.util.concurrent.CompletableFuture.thenAccept(java.base@11.0.14.1/CompletableFuture.java:2108)
	at org.apache.bookkeeper.mledger.impl.ManagedLedgerFactoryImpl.asyncOpen(ManagedLedgerFactoryImpl.java:425)
	at org.apache.pulsar.broker.service.BrokerService.lambda$createPersistentTopic$58(BrokerService.java:1322)
	at org.apache.pulsar.broker.service.BrokerService$$Lambda$800/0x00000008407b1040.accept(Unknown Source)
	at java.util.concurrent.CompletableFuture.uniAcceptNow(java.base@11.0.14.1/CompletableFuture.java:753)
	at java.util.concurrent.CompletableFuture.uniAcceptStage(java.base@11.0.14.1/CompletableFuture.java:731)
	at java.util.concurrent.CompletableFuture.thenAccept(java.base@11.0.14.1/CompletableFuture.java:2108)
	at org.apache.pulsar.broker.service.BrokerService.createPersistentTopic(BrokerService.java:1304)
	at org.apache.pulsar.broker.service.BrokerService.lambda$loadOrCreatePersistentTopic$52(BrokerService.java:1257)
	at org.apache.pulsar.broker.service.BrokerService$$Lambda$791/0x00000008407a2c40.run(Unknown Source)
	at java.util.concurrent.CompletableFuture.uniRunNow(java.base@11.0.14.1/CompletableFuture.java:815)
	at java.util.concurrent.CompletableFuture.uniRunStage(java.base@11.0.14.1/CompletableFuture.java:799)
	at java.util.concurrent.CompletableFuture.thenRun(java.base@11.0.14.1/CompletableFuture.java:2121)
	at org.apache.pulsar.broker.service.BrokerService.loadOrCreatePersistentTopic(BrokerService.java:1253)
	at org.apache.pulsar.broker.service.BrokerService.lambda$getTopic$26(BrokerService.java:896)
	at org.apache.pulsar.broker.service.BrokerService$$Lambda$786/0x00000008407a3840.apply(Unknown Source)
	at org.apache.pulsar.common.util.collections.ConcurrentOpenHashMap$Section.put(ConcurrentOpenHashMap.java:302)
	at org.apache.pulsar.common.util.collections.ConcurrentOpenHashMap.computeIfAbsent(ConcurrentOpenHashMap.java:151)
    
	at org.apache.pulsar.broker.service.BrokerService.getTopic(BrokerService.java:895)
	at org.apache.pulsar.broker.service.BrokerService.getTopicIfExists(BrokerService.java:857)
	at org.apache.pulsar.broker.admin.impl.PersistentTopicsBase.getTopicReference(PersistentTopicsBase.java:3637)
	at org.apache.pulsar.broker.admin.impl.PersistentTopicsBase.internalGetStats(PersistentTopicsBase.java:1156)
	at org.apache.pulsar.broker.admin.v2.PersistentTopics.getStats(PersistentTopics.java:955)
```