### PR TITLE
[feature][sql] Add support for pulsar authorization

### DIFF
--- a/conf/presto/catalog/pulsar.properties
+++ b/conf/presto/catalog/pulsar.properties
@@ -24,6 +24,8 @@ connector.name=pulsar
 pulsar.broker-service-url=http://localhost:8080
 # the url of Pulsar broker web service
 pulsar.web-service-url=http://localhost:8080
+# the url of Pulsar broker binary service
+pulsar.broker-binary-service-url=pulsar://localhost:6650
 # URI of Zookeeper cluster
 pulsar.zookeeper-uri=127.0.0.1:2181
 # minimum number of entries to read at a single time
@@ -79,6 +81,9 @@ pulsar.rewrite-namespace-delimiter=/
 
 ## Path for the trusted TLS certificate file
 #pulsar.tls-trust-cert-file-path =
+
+## Whether to enable pulsar authorization
+pulsar.authorization-enable=false
 
 ####### BOOKKEEPER CONFIGS #######
 

--- a/pulsar-sql/presto-pulsar/pom.xml
+++ b/pulsar-sql/presto-pulsar/pom.xml
@@ -111,6 +111,13 @@
         </dependency>
 
         <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-impl</artifactId>
+            <version>0.11.1</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>io.prestosql</groupId>
             <artifactId>presto-main</artifactId>
             <version>${presto.version}</version>

--- a/pulsar-sql/presto-pulsar/src/main/java/org/apache/pulsar/sql/presto/PulsarAuth.java
+++ b/pulsar-sql/presto-pulsar/src/main/java/org/apache/pulsar/sql/presto/PulsarAuth.java
@@ -1,0 +1,111 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.sql.presto;
+
+import static io.prestosql.spi.StandardErrorCode.PERMISSION_DENIED;
+import static io.prestosql.spi.StandardErrorCode.QUERY_REJECTED;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.inject.Inject;
+import io.airlift.log.Logger;
+import io.prestosql.spi.PrestoException;
+import io.prestosql.spi.connector.ConnectorSession;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.pulsar.client.api.MessageId;
+import org.apache.pulsar.client.api.PulsarClient;
+import org.apache.pulsar.client.api.PulsarClientException;
+
+public class PulsarAuth {
+
+    private static final Logger log = Logger.get(PulsarAuth.class);
+
+    private final PulsarConnectorConfig pulsarConnectorConfig;
+    private static final String CREDENTIALS_AUTH_PLUGIN = "auth-plugin";
+    private static final String CREDENTIALS_AUTH_PARAMS = "auth-params";
+    @VisibleForTesting
+    final Map<String, Set<String>> authorizedQueryTopicsMap = new ConcurrentHashMap<>();
+
+    @Inject
+    public PulsarAuth(PulsarConnectorConfig pulsarConnectorConfig) {
+        this.pulsarConnectorConfig = pulsarConnectorConfig;
+        if (pulsarConnectorConfig.getAuthorizationEnable() && StringUtils.isEmpty(
+                pulsarConnectorConfig.getBrokerBinaryServiceUrl())) {
+            throw new IllegalArgumentException(
+                    "pulsar.broker-binary-service-url must be presented when the pulsar.authorization-enable is true.");
+        }
+    }
+
+    public void checkTopicAuth(ConnectorSession session, String topic) {
+        Set<String> authorizedTopics =
+                authorizedQueryTopicsMap.computeIfAbsent(session.getQueryId(), query -> new HashSet<>());
+        if (authorizedTopics.contains(topic)) {
+            if (log.isDebugEnabled()) {
+                log.debug("The topic %s is already authorized.", topic);
+            }
+            return;
+        }
+        if (log.isDebugEnabled()) {
+            log.debug("Checking the authorization for the topic: %s", topic);
+        }
+        Map<String, String> extraCredentials = session.getIdentity().getExtraCredentials();
+        if (extraCredentials.isEmpty()) {
+            throw new PrestoException(QUERY_REJECTED,
+                    String.format(
+                            "Failed to check the authorization for topic %s: The credential information is empty.",
+                            topic));
+        }
+        String authMethod = extraCredentials.get(CREDENTIALS_AUTH_PLUGIN);
+        String authParams = extraCredentials.get(CREDENTIALS_AUTH_PARAMS);
+        if (StringUtils.isEmpty(authMethod) || StringUtils.isEmpty(authParams)) {
+            throw new PrestoException(QUERY_REJECTED,
+                    String.format(
+                            "Failed to check the authorization for topic %s: Required credential parameters are "
+                                    + "missing. Please specify the auth-method and auth-params in the extra "
+                                    + "credentials.",
+                            topic));
+        }
+        try {
+            PulsarClient client = PulsarClient.builder()
+                    .serviceUrl(pulsarConnectorConfig.getBrokerBinaryServiceUrl())
+                    .authentication(authMethod, authParams)
+                    .build();
+            client.newReader().topic(topic).startMessageId(MessageId.earliest).create();
+            authorizedQueryTopicsMap.computeIfPresent(session.getQueryId(), (query, topics) -> {
+                topics.add(topic);
+                return topics;
+            });
+            if (log.isDebugEnabled()) {
+                log.debug("Check the authorization for the topic %s successfully.", topic);
+            }
+        } catch (PulsarClientException.AuthenticationException | PulsarClientException.AuthorizationException e) {
+            throw new PrestoException(PERMISSION_DENIED,
+                    String.format("Failed to access topic %s: %s", topic, e.getLocalizedMessage()));
+        } catch (PulsarClientException e) {
+            throw new PrestoException(QUERY_REJECTED,
+                    String.format("Failed to check authorization for topic %s: %s", topic, e.getLocalizedMessage()));
+        }
+    }
+
+    public void cleanSession(ConnectorSession session) {
+        authorizedQueryTopicsMap.remove(session.getQueryId());
+    }
+}

--- a/pulsar-sql/presto-pulsar/src/main/java/org/apache/pulsar/sql/presto/PulsarConnectorConfig.java
+++ b/pulsar-sql/presto-pulsar/src/main/java/org/apache/pulsar/sql/presto/PulsarConnectorConfig.java
@@ -43,6 +43,7 @@ import org.apache.pulsar.common.protocol.Commands;
 public class PulsarConnectorConfig implements AutoCloseable {
 
     private String brokerServiceUrl = "http://localhost:8080";
+    private String brokerBinaryServiceUrl = "pulsar://localhost:6650/";
     private String webServiceUrl = ""; //leave empty
     private String zookeeperUri = "localhost:2181";
     private int entryReadBatchSize = 100;
@@ -62,6 +63,8 @@ public class PulsarConnectorConfig implements AutoCloseable {
 
     private boolean namespaceDelimiterRewriteEnable = false;
     private String rewriteNamespaceDelimiter = "/";
+
+    private boolean authorizationEnable = false;
 
     // --- Ledger Offloading ---
     private String managedLedgerOffloadDriver = null;
@@ -101,6 +104,14 @@ public class PulsarConnectorConfig implements AutoCloseable {
     @Config("pulsar.broker-service-url")
     public PulsarConnectorConfig setBrokerServiceUrl(String brokerServiceUrl) {
         this.brokerServiceUrl = brokerServiceUrl;
+        return this;
+    }
+    public String getBrokerBinaryServiceUrl() {
+        return this.brokerBinaryServiceUrl;
+    }
+    @Config("pulsar.broker-binary-service-url")
+    public PulsarConnectorConfig setBrokerBinaryServiceUrl(String brokerBinaryServiceUrl) {
+        this.brokerBinaryServiceUrl = brokerBinaryServiceUrl;
         return this;
     }
     @Config("pulsar.web-service-url")
@@ -235,6 +246,16 @@ public class PulsarConnectorConfig implements AutoCloseable {
     @Config("pulsar.namespace-delimiter-rewrite-enable")
     public PulsarConnectorConfig setNamespaceDelimiterRewriteEnable(boolean namespaceDelimiterRewriteEnable) {
         this.namespaceDelimiterRewriteEnable = namespaceDelimiterRewriteEnable;
+        return this;
+    }
+
+    public boolean getAuthorizationEnable() {
+        return authorizationEnable;
+    }
+
+    @Config("pulsar.authorization-enable")
+    public PulsarConnectorConfig setAuthorizationEnable(boolean authorizationEnable) {
+        this.authorizationEnable = authorizationEnable;
         return this;
     }
 

--- a/pulsar-sql/presto-pulsar/src/main/java/org/apache/pulsar/sql/presto/PulsarConnectorModule.java
+++ b/pulsar-sql/presto-pulsar/src/main/java/org/apache/pulsar/sql/presto/PulsarConnectorModule.java
@@ -55,6 +55,7 @@ public class PulsarConnectorModule implements Module {
         binder.bind(PulsarMetadata.class).in(Scopes.SINGLETON);
         binder.bind(PulsarSplitManager.class).in(Scopes.SINGLETON);
         binder.bind(PulsarRecordSetProvider.class).in(Scopes.SINGLETON);
+        binder.bind(PulsarAuth.class).in(Scopes.SINGLETON);
 
         binder.bind(PulsarDispatchingRowDecoderFactory.class).in(Scopes.SINGLETON);
 

--- a/pulsar-sql/presto-pulsar/src/test/java/org/apache/pulsar/sql/presto/TestPulsarAuth.java
+++ b/pulsar-sql/presto-pulsar/src/test/java/org/apache/pulsar/sql/presto/TestPulsarAuth.java
@@ -1,0 +1,172 @@
+package org.apache.pulsar.sql.presto;
+
+import static io.prestosql.spi.StandardErrorCode.PERMISSION_DENIED;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import com.google.common.collect.Sets;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.prestosql.spi.PrestoException;
+import io.prestosql.spi.connector.ConnectorSession;
+import io.prestosql.spi.security.ConnectorIdentity;
+import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.Optional;
+import java.util.Properties;
+import javax.crypto.SecretKey;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.apache.pulsar.broker.auth.MockedPulsarServiceBaseTest;
+import org.apache.pulsar.broker.authentication.utils.AuthTokenUtils;
+import org.apache.pulsar.client.admin.PulsarAdminBuilder;
+import org.apache.pulsar.client.admin.PulsarAdminException;
+import org.apache.pulsar.client.api.AuthenticationFactory;
+import org.apache.pulsar.common.policies.data.AuthAction;
+import org.apache.pulsar.common.policies.data.ClusterData;
+import org.apache.pulsar.common.policies.data.TenantInfoImpl;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+public class TestPulsarAuth extends MockedPulsarServiceBaseTest {
+    private SecretKey secretKey;
+    private final String SUPER_USER_ROLE = "admin";
+
+    @BeforeClass
+    @Override
+    protected void setup() throws Exception {
+        conf.setAuthenticationEnabled(true);
+        conf.setAuthenticationProviders(
+                Sets.newHashSet("org.apache.pulsar.broker.authentication.AuthenticationProviderToken"));
+        conf.setAuthorizationEnabled(true);
+        secretKey = AuthTokenUtils.createSecretKey(SignatureAlgorithm.HS256);
+        Properties properties = new Properties();
+        properties.setProperty("tokenSecretKey", AuthTokenUtils.encodeKeyBase64(secretKey));
+        conf.setProperties(properties);
+        conf.setSuperUserRoles(Sets.newHashSet(SUPER_USER_ROLE));
+        conf.setClusterName("c1");
+        internalSetup();
+
+        admin.clusters().createCluster("c1", ClusterData.builder().build());
+        admin.tenants().createTenant("p1", new TenantInfoImpl(Sets.newHashSet(SUPER_USER_ROLE), Sets.newHashSet("c1")));
+        waitForChange();
+        admin.namespaces().createNamespace("p1/c1/ns1");
+        waitForChange();
+    }
+
+    @Override
+    protected void customizeNewPulsarAdminBuilder(PulsarAdminBuilder pulsarAdminBuilder) {
+        pulsarAdminBuilder.authentication(
+                AuthenticationFactory.token(AuthTokenUtils.createToken(secretKey, SUPER_USER_ROLE, Optional.empty())));
+    }
+
+    @AfterClass
+    @Override
+    protected void cleanup() throws Exception {
+        internalCleanup();
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testConfigCheck() {
+        PulsarConnectorConfig pulsarConnectorConfig = new PulsarConnectorConfig();
+        pulsarConnectorConfig.setAuthorizationEnable(true);
+        pulsarConnectorConfig.setBrokerBinaryServiceUrl("");
+
+        new PulsarAuth(pulsarConnectorConfig);
+    }
+
+    @Test
+    public void testPulsarSqlAuth() throws PulsarAdminException {
+        String passRole = RandomStringUtils.randomAlphabetic(4) + "-pass";
+        String deniedRole = RandomStringUtils.randomAlphabetic(4) + "-denied";
+        String topic = "persistent://p1/c1/ns1/" + RandomStringUtils.randomAlphabetic(4);
+        String otherTopic = "persistent://p1/c1/ns1/" + RandomStringUtils.randomAlphabetic(4) + "-other";
+        String passToken = AuthTokenUtils.createToken(secretKey, passRole, Optional.empty());
+        String deniedToken = AuthTokenUtils.createToken(secretKey, deniedRole, Optional.empty());
+
+        admin.topics().grantPermission(topic, passRole, EnumSet.of(AuthAction.consume));
+        waitForChange();
+
+        ConnectorSession session = mock(ConnectorSession.class);
+        ConnectorIdentity identity = mock(ConnectorIdentity.class);
+        PulsarConnectorConfig pulsarConnectorConfig = mock(PulsarConnectorConfig.class);
+
+        doReturn(true).when(pulsarConnectorConfig).getAuthorizationEnable();
+        doReturn(pulsar.getBrokerServiceUrl()).when(pulsarConnectorConfig).getBrokerBinaryServiceUrl();
+
+        doReturn("query-1").when(session).getQueryId();
+        doReturn(identity).when(session).getIdentity();
+
+        doReturn(new HashMap<String, String>() {{
+            put("auth-plugin", "org.apache.pulsar.client.impl.auth.AuthenticationToken");
+            put("auth-params", passToken);
+        }}).when(identity).getExtraCredentials();
+
+        PulsarAuth pulsarAuth = new PulsarAuth(pulsarConnectorConfig);
+
+        pulsarAuth.checkTopicAuth(session, topic); // should pass
+
+        // authorizedQueryTopicPairs should contain the authorized query and topic.
+        Assert.assertTrue(
+                pulsarAuth.authorizedQueryTopicsMap.containsKey(session.getQueryId()));
+        Assert.assertTrue(pulsarAuth.authorizedQueryTopicsMap.get(session.getQueryId()).contains(topic));
+
+        // Using the authorized query but not authorized topic should fail.
+        // This part of the test case is for the case where a query accesses multiple topics but only some of them
+        // have permission.
+        try {
+            pulsarAuth.checkTopicAuth(session, otherTopic);
+            Assert.fail(); // should fail
+        } catch (PrestoException e){
+            Assert.assertEquals(PERMISSION_DENIED.toErrorCode(), e.getErrorCode());
+            Assert.assertTrue(e.getMessage().contains("not authorized"));
+        }
+
+        // test clean session
+        pulsarAuth.cleanSession(session);
+
+        Assert.assertFalse(pulsarAuth.authorizedQueryTopicsMap.containsKey(session.getQueryId()));
+
+        doReturn("test-fail").when(session).getQueryId();
+
+        doReturn("query-2").when(session).getQueryId();
+
+        try{
+            doReturn(new HashMap<String, String>() {{
+                put("auth-plugin", "org.apache.pulsar.client.impl.auth.AuthenticationToken");
+                put("auth-params", "invalid-token");
+            }}).when(identity).getExtraCredentials();
+            pulsarAuth.checkTopicAuth(session, topic);
+            Assert.fail(); // should fail
+        } catch (PrestoException e){
+            Assert.assertEquals(PERMISSION_DENIED.toErrorCode(), e.getErrorCode());
+            Assert.assertTrue(e.getMessage().contains("Unable to authenticate"));
+        }
+
+        pulsarAuth.cleanSession(session);
+        Assert.assertTrue(pulsarAuth.authorizedQueryTopicsMap.isEmpty());
+
+        doReturn("query-3").when(session).getQueryId();
+
+        try{
+            doReturn(new HashMap<String, String>() {{
+                put("auth-plugin", "org.apache.pulsar.client.impl.auth.AuthenticationToken");
+                put("auth-params", deniedToken);
+            }}).when(identity).getExtraCredentials();
+            pulsarAuth.checkTopicAuth(session, topic);
+            Assert.fail(); // should fail
+        } catch (PrestoException e){
+            Assert.assertEquals(PERMISSION_DENIED.toErrorCode(), e.getErrorCode());
+            Assert.assertTrue(e.getMessage().contains("not authorized"));
+        }
+
+        pulsarAuth.cleanSession(session);
+        Assert.assertTrue(pulsarAuth.authorizedQueryTopicsMap.isEmpty());
+    }
+
+    private static void waitForChange() {
+        try {
+            Thread.sleep(100);
+        } catch (InterruptedException ignored) {
+        }
+    }
+}

--- a/pulsar-sql/presto-pulsar/src/test/java/org/apache/pulsar/sql/presto/TestPulsarConnector.java
+++ b/pulsar-sql/presto-pulsar/src/test/java/org/apache/pulsar/sql/presto/TestPulsarConnector.java
@@ -97,6 +97,8 @@ public abstract class TestPulsarConnector {
 
     protected PulsarMetadata pulsarMetadata;
 
+    protected PulsarAuth pulsarAuth;
+
     protected PulsarAdmin pulsarAdmin;
 
     protected Schemas schemas;
@@ -367,7 +369,9 @@ public abstract class TestPulsarConnector {
         pulsarConnectorConfig.setMaxSplitMessageQueueSize(100);
         PulsarDispatchingRowDecoderFactory dispatchingRowDecoderFactory =
                 new PulsarDispatchingRowDecoderFactory(prestoConnectorContext.getTypeManager());
-        PulsarMetadata pulsarMetadata = new PulsarMetadata(pulsarConnectorId, pulsarConnectorConfig, dispatchingRowDecoderFactory);
+        PulsarAuth pulsarAuth = new PulsarAuth(pulsarConnectorConfig);
+        PulsarMetadata pulsarMetadata =
+                new PulsarMetadata(pulsarConnectorId, pulsarConnectorConfig, dispatchingRowDecoderFactory, pulsarAuth);
         return pulsarMetadata;
     }
 
@@ -539,7 +543,11 @@ public abstract class TestPulsarConnector {
         doReturn(schemas).when(pulsarAdmin).schemas();
         doReturn(pulsarAdmin).when(this.pulsarConnectorConfig).getPulsarAdmin();
 
-        this.pulsarMetadata = new PulsarMetadata(pulsarConnectorId, this.pulsarConnectorConfig, dispatchingRowDecoderFactory);
+        this.pulsarAuth = mock(PulsarAuth.class);
+
+        this.pulsarMetadata =
+                new PulsarMetadata(pulsarConnectorId, this.pulsarConnectorConfig, dispatchingRowDecoderFactory,
+                        this.pulsarAuth);
         this.pulsarSplitManager = Mockito.spy(new PulsarSplitManager(pulsarConnectorId, this.pulsarConnectorConfig));
 
         ManagedLedgerFactory managedLedgerFactory = mock(ManagedLedgerFactory.class);

--- a/pulsar-sql/presto-pulsar/src/test/java/org/apache/pulsar/sql/presto/TestPulsarMetadata.java
+++ b/pulsar-sql/presto-pulsar/src/test/java/org/apache/pulsar/sql/presto/TestPulsarMetadata.java
@@ -26,6 +26,8 @@ import org.apache.pulsar.client.admin.PulsarAdminException;
 import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.schema.SchemaInfo;
 import org.apache.pulsar.common.schema.SchemaType;
+import org.mockito.Mockito;
+import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import javax.ws.rs.ClientErrorException;
@@ -35,6 +37,7 @@ import java.util.stream.Collectors;
 
 import static io.prestosql.spi.StandardErrorCode.NOT_FOUND;
 import static io.prestosql.spi.StandardErrorCode.NOT_SUPPORTED;
+import static io.prestosql.spi.StandardErrorCode.PERMISSION_DENIED;
 import static org.mockito.Mockito.*;
 import static org.testng.Assert.*;
 
@@ -376,5 +379,60 @@ public class TestPulsarMetadata extends TestPulsarConnector {
         }
 
         assertTrue(fieldNames.isEmpty());
+    }
+
+    @Test
+    public void testPulsarAuthCheck() {
+        this.pulsarConnectorConfig.setAuthorizationEnable(true);
+        doNothing().when(this.pulsarAuth).checkTopicAuth(isA(ConnectorSession.class), isA(String.class));
+
+        // Test getTableHandle should pass the auth check
+        SchemaTableName schemaTableName = new SchemaTableName(TOPIC_1.getNamespace(), TOPIC_1.getLocalName());
+        this.pulsarMetadata.getTableHandle(mock(ConnectorSession.class), schemaTableName);
+
+        // Test getTableMetadata should pass the auth check
+        TopicName topic = TOPIC_1;
+        PulsarTableHandle pulsarTableHandle = new PulsarTableHandle(
+                topic.toString(),
+                topic.getNamespace(),
+                topic.getLocalName(),
+                topic.getLocalName()
+        );
+        this.pulsarMetadata.getTableMetadata(mock(ConnectorSession.class),
+                pulsarTableHandle);
+
+        // Test getColumnHandles should pass the auth check
+        this.pulsarMetadata.getColumnHandles(mock(ConnectorSession.class), pulsarTableHandle);
+
+        doThrow(new PrestoException(PERMISSION_DENIED, "not authorized")).when(this.pulsarAuth)
+                .checkTopicAuth(isA(ConnectorSession.class), isA(String.class));
+
+        // Test getTableHandle should fail the auth check
+        try {
+            this.pulsarMetadata.getTableHandle(mock(ConnectorSession.class), schemaTableName);
+            Assert.fail(); // should fail
+        } catch (PrestoException e) {
+            Assert.assertEquals(PERMISSION_DENIED.toErrorCode(), e.getErrorCode());
+        }
+
+        // Test getTableMetadata should fail the auth check
+        try {
+            this.pulsarMetadata.getTableMetadata(mock(ConnectorSession.class),
+                    pulsarTableHandle);
+            Assert.fail(); // should fail
+        } catch (PrestoException e) {
+            Assert.assertEquals(PERMISSION_DENIED.toErrorCode(), e.getErrorCode());
+        }
+
+        // Test getColumnHandles should fail the auth check
+        try {
+            this.pulsarMetadata.getColumnHandles(mock(ConnectorSession.class), pulsarTableHandle);
+            Assert.fail(); // should fail
+        } catch (PrestoException e) {
+            Assert.assertEquals(PERMISSION_DENIED.toErrorCode(), e.getErrorCode());
+        }
+
+        this.pulsarMetadata.cleanupQuery(mock(ConnectorSession.class));
+        Mockito.verify(this.pulsarAuth, Mockito.times(1)).cleanSession(isA(ConnectorSession.class));
     }
 }

--- a/pulsar-sql/presto-pulsar/src/test/java/org/apache/pulsar/sql/presto/decoder/AbstractDecoderTester.java
+++ b/pulsar-sql/presto-pulsar/src/test/java/org/apache/pulsar/sql/presto/decoder/AbstractDecoderTester.java
@@ -30,6 +30,7 @@ import java.math.BigDecimal;
 import org.apache.pulsar.common.naming.NamespaceName;
 import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.schema.SchemaInfo;
+import org.apache.pulsar.sql.presto.PulsarAuth;
 import org.apache.pulsar.sql.presto.PulsarColumnHandle;
 import org.apache.pulsar.sql.presto.PulsarColumnMetadata;
 import org.apache.pulsar.sql.presto.PulsarConnectorConfig;
@@ -67,7 +68,8 @@ public abstract class AbstractDecoderTester {
         this.pulsarConnectorConfig.setMaxEntryReadBatchSize(1);
         this.pulsarConnectorConfig.setMaxSplitEntryQueueSize(10);
         this.pulsarConnectorConfig.setMaxSplitMessageQueueSize(100);
-        this.pulsarMetadata = new PulsarMetadata(pulsarConnectorId, this.pulsarConnectorConfig, decoderFactory);
+        this.pulsarMetadata = new PulsarMetadata(pulsarConnectorId, this.pulsarConnectorConfig, decoderFactory,
+                new PulsarAuth(this.pulsarConnectorConfig));
         this.topicName = TopicName.get("persistent", NamespaceName.get("tenant-1", "ns-1"), "topic-1");
     }
 


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://docs.google.com/document/d/1d8Pw6ZbWk-_pCKdOmdvx9rnhPiyuxwq60_TrD68d7BA/edit#heading=h.trs9rsex3xom)*. 

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.

**(The sections below can be removed for hotfixes of typos)**
-->

*(If this PR fixes a github issue, please add `Fixes #<xyz>`.)*


### Motivation

Currently, pulsar SQL does not compatible with the authentication and authorization from the pulsar broker. We don't have any security-related integration between Pulsar and Presto.

Although we can implement a presto access control plugin to interface with the pulsar broker's authorization module. But this method does not handle authentication well.

### Modifications

This PR adds authentication and authorization support between Pulsar and Pulsar SQL by using the extra credentials properties. The request from the pulsar SQL client can have auth-related parameters(like `auth-plugin` and `auth-params`) attached to the extra credentials. The pulsar SQL worker can therefore obtain auth information and use PulsarClient to initiate an auth verification request to the broker. In this way, we can call the broker's authentication and authentication directly on the pulsar SQL worker.

This PR adds a new module `PulsarAuth` to the SQL worker. 

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API: (yes / no)
  - The schema: (yes / no / don't know)
  - The default values of configurations: (yes / no)
  - The wire protocol: (yes / no)
  - The rest endpoints: (yes / no)
  - The admin cli options: (yes / no)
  - Anything that affects deployment: (yes / no / don't know)

### Documentation

Check the box below or label this PR directly.

Need to update docs? 

- [x] `doc-required` 