### PR TITLE
[cleanup][managed-ledger] Use TestNG instead of JUnit

### DIFF
--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedCursorInfoMetadataTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedCursorInfoMetadataTest.java
@@ -18,7 +18,7 @@
  */
 package org.apache.bookkeeper.mledger.impl;
 
-import static org.junit.Assert.assertEquals;
+import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.expectThrows;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -26,7 +26,6 @@ import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.bookkeeper.mledger.proto.MLDataFormats;
 import org.apache.pulsar.common.api.proto.CompressionType;
-import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
@@ -73,8 +72,9 @@ public class ManagedCursorInfoMetadataTest {
             IllegalArgumentException compressionTypeEx = expectThrows(IllegalArgumentException.class, () -> {
                 new MetaStoreImpl(null, null, null, compressionType);
             });
-            assertEquals("No enum constant org.apache.bookkeeper.mledger.proto.MLDataFormats.CompressionType."
-                    + compressionType, compressionTypeEx.getMessage());
+            assertEquals(compressionTypeEx.getMessage(),
+                    "No enum constant org.apache.bookkeeper.mledger.proto.MLDataFormats.CompressionType."
+                            + compressionType);
             return;
         } else {
             metaStore = new MetaStoreImpl(null, null, null, compressionType);
@@ -85,12 +85,12 @@ public class ManagedCursorInfoMetadataTest {
         log.info("[{}] Uncompressed data size: {}, compressed data size: {}",
                 compressionType, managedCursorInfo.getSerializedSize(), compressionBytes.length);
         if (compressionType == null || compressionType.equals(CompressionType.NONE.name())) {
-            Assert.assertEquals(compressionBytes.length, managedCursorInfo.getSerializedSize());
+            assertEquals(compressionBytes.length, managedCursorInfo.getSerializedSize());
         }
 
         // parse compression data and unCompression data, check their results.
         MLDataFormats.ManagedCursorInfo info1 = metaStore.parseManagedCursorInfo(compressionBytes);
         MLDataFormats.ManagedCursorInfo info2 = metaStore.parseManagedCursorInfo(managedCursorInfo.toByteArray());
-        Assert.assertEquals(info1, info2);
+        assertEquals(info1, info2);
     }
 }

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/test/BookKeeperClusterTestCase.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/test/BookKeeperClusterTestCase.java
@@ -24,7 +24,7 @@
 package org.apache.bookkeeper.test;
 
 import static org.apache.bookkeeper.util.BookKeeperConstants.AVAILABLE_NODE;
-import static org.junit.Assert.assertFalse;
+import static org.testng.Assert.assertFalse;
 
 import com.google.common.base.Stopwatch;
 import java.io.File;
@@ -191,7 +191,7 @@ public abstract class BookKeeperClusterTestCase {
             LOG.error("Got async exception: ", e);
             failed = true;
         }
-        assertFalse("Async failure", failed);
+        assertFalse(failed, "Async failure");
         Stopwatch sw = Stopwatch.createStarted();
         LOG.info("TearDown");
         Exception tearDownException = null;

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/test/ZooKeeperUtil.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/test/ZooKeeperUtil.java
@@ -23,8 +23,7 @@
 
 package org.apache.bookkeeper.test;
 
-import static org.junit.Assert.assertTrue;
-
+import static org.testng.Assert.assertTrue;
 import java.io.File;
 import java.io.IOException;
 import java.net.InetAddress;
@@ -199,9 +198,8 @@ public class ZooKeeperUtil implements ZooKeeperCluster {
         // shutdown ZK server
         if (serverFactory != null) {
             serverFactory.shutdown();
-            assertTrue("waiting for server down",
-                    ClientBase.waitForServerDown(getZooKeeperConnectString(),
-                            ClientBase.CONNECTION_TIMEOUT));
+            assertTrue(ClientBase.waitForServerDown(getZooKeeperConnectString(), ClientBase.CONNECTION_TIMEOUT),
+                    "waiting for server down");
         }
         if (zks != null) {
             zks.getTxnLogFactory().close();


### PR DESCRIPTION
### Motivation

The codebase has two unit test frameworks: JUnit and TestNG, which always make us confused about which one to use. I check the git commits and found that #1032 does this thing, but still has some tests using JUnit. We need to remove the JUnit, use the TestNG as the unit test framework in the codebase.

### Modifications

- Use TestNG instead of JUnit

### Documentation

Need to update docs? 

- [x] `no-need-doc` 
(Please explain why)
