### PR TITLE
[cleanup][tests] Use TestNG instead of JUnit

### DIFF
--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/sources/debezium/DebeziumMsSqlSourceTester.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/sources/debezium/DebeziumMsSqlSourceTester.java
@@ -26,8 +26,8 @@ import org.apache.pulsar.tests.integration.containers.PulsarContainer;
 import org.apache.pulsar.tests.integration.docker.ContainerExecResult;
 import org.apache.pulsar.tests.integration.io.sources.SourceTester;
 import org.apache.pulsar.tests.integration.topologies.PulsarCluster;
-import org.junit.Assert;
 import org.testcontainers.shaded.com.google.common.base.Preconditions;
+import org.testng.Assert;
 import org.testng.util.Strings;
 
 import java.io.Closeable;

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/sources/debezium/DebeziumPostgreSqlSourceTester.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/sources/debezium/DebeziumPostgreSqlSourceTester.java
@@ -139,7 +139,7 @@ public class DebeziumPostgreSqlSourceTester extends SourceTester<DebeziumPostgre
             String lastConfirmedFlushLsn = res.getStdout();
             log.info("Current confirmedFlushLsn: \n{} \nLast confirmedFlushLsn: \n{}",
                     confirmedFlushLsn.get(), lastConfirmedFlushLsn);
-            org.junit.Assert.assertNotEquals(confirmedFlushLsn.get(), lastConfirmedFlushLsn);
+            Assert.assertNotEquals(confirmedFlushLsn.get(), lastConfirmedFlushLsn);
             confirmedFlushLsn.set(lastConfirmedFlushLsn);
         } catch (Exception e) {
             Assert.fail("failed to get flush lsn", e);


### PR DESCRIPTION
### Motivation

The codebase has two unit test frameworks: JUnit and TestNG, which always make us confused about which one to use. I check the git commits and found that #1032 does this thing, but still has some tests using JUnit. We need to remove the JUnit, use the TestNG as the unit test framework in the codebase.

### Modifications

- Use TestNG instead of JUnit

### Documentation

Need to update docs? 

- [x] `no-need-doc` 
(Please explain why)
