### PR TITLE
[improve] Upgrade BookKeeper to 4.14.5 (2.8, 2.9, 2.10 branches)

### DIFF
--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -397,31 +397,31 @@ The Apache Software License, Version 2.0
     - org.apache.logging.log4j-log4j-1.2-api-2.17.1.jar
  * Java Native Access JNA -- net.java.dev.jna-jna-4.2.0.jar
  * BookKeeper
-    - org.apache.bookkeeper-bookkeeper-common-4.14.4.jar
-    - org.apache.bookkeeper-bookkeeper-common-allocator-4.14.4.jar
-    - org.apache.bookkeeper-bookkeeper-proto-4.14.4.jar
-    - org.apache.bookkeeper-bookkeeper-server-4.14.4.jar
-    - org.apache.bookkeeper-bookkeeper-tools-framework-4.14.4.jar
-    - org.apache.bookkeeper-circe-checksum-4.14.4.jar
-    - org.apache.bookkeeper-cpu-affinity-4.14.4.jar
-    - org.apache.bookkeeper-statelib-4.14.4.jar
-    - org.apache.bookkeeper-stream-storage-api-4.14.4.jar
-    - org.apache.bookkeeper-stream-storage-common-4.14.4.jar
-    - org.apache.bookkeeper-stream-storage-java-client-4.14.4.jar
-    - org.apache.bookkeeper-stream-storage-java-client-base-4.14.4.jar
-    - org.apache.bookkeeper-stream-storage-proto-4.14.4.jar
-    - org.apache.bookkeeper-stream-storage-server-4.14.4.jar
-    - org.apache.bookkeeper-stream-storage-service-api-4.14.4.jar
-    - org.apache.bookkeeper-stream-storage-service-impl-4.14.4.jar
-    - org.apache.bookkeeper.http-http-server-4.14.4.jar
-    - org.apache.bookkeeper.http-vertx-http-server-4.14.4.jar
-    - org.apache.bookkeeper.stats-bookkeeper-stats-api-4.14.4.jar
-    - org.apache.bookkeeper.stats-prometheus-metrics-provider-4.14.4.jar
-    - org.apache.distributedlog-distributedlog-common-4.14.4.jar
-    - org.apache.distributedlog-distributedlog-core-4.14.4-tests.jar
-    - org.apache.distributedlog-distributedlog-core-4.14.4.jar
-    - org.apache.distributedlog-distributedlog-protocol-4.14.4.jar
-    - org.apache.bookkeeper.stats-codahale-metrics-provider-4.14.4.jar
+    - org.apache.bookkeeper-bookkeeper-common-4.14.5.jar
+    - org.apache.bookkeeper-bookkeeper-common-allocator-4.14.5.jar
+    - org.apache.bookkeeper-bookkeeper-proto-4.14.5.jar
+    - org.apache.bookkeeper-bookkeeper-server-4.14.5.jar
+    - org.apache.bookkeeper-bookkeeper-tools-framework-4.14.5.jar
+    - org.apache.bookkeeper-circe-checksum-4.14.5.jar
+    - org.apache.bookkeeper-cpu-affinity-4.14.5.jar
+    - org.apache.bookkeeper-statelib-4.14.5.jar
+    - org.apache.bookkeeper-stream-storage-api-4.14.5.jar
+    - org.apache.bookkeeper-stream-storage-common-4.14.5.jar
+    - org.apache.bookkeeper-stream-storage-java-client-4.14.5.jar
+    - org.apache.bookkeeper-stream-storage-java-client-base-4.14.5.jar
+    - org.apache.bookkeeper-stream-storage-proto-4.14.5.jar
+    - org.apache.bookkeeper-stream-storage-server-4.14.5.jar
+    - org.apache.bookkeeper-stream-storage-service-api-4.14.5.jar
+    - org.apache.bookkeeper-stream-storage-service-impl-4.14.5.jar
+    - org.apache.bookkeeper.http-http-server-4.14.5.jar
+    - org.apache.bookkeeper.http-vertx-http-server-4.14.5.jar
+    - org.apache.bookkeeper.stats-bookkeeper-stats-api-4.14.5.jar
+    - org.apache.bookkeeper.stats-prometheus-metrics-provider-4.14.5.jar
+    - org.apache.distributedlog-distributedlog-common-4.14.5.jar
+    - org.apache.distributedlog-distributedlog-core-4.14.5-tests.jar
+    - org.apache.distributedlog-distributedlog-core-4.14.5.jar
+    - org.apache.distributedlog-distributedlog-protocol-4.14.5.jar
+    - org.apache.bookkeeper.stats-codahale-metrics-provider-4.14.5.jar
   * Apache HTTP Client
     - org.apache.httpcomponents-httpclient-4.5.13.jar
     - org.apache.httpcomponents-httpcore-4.4.13.jar

--- a/pom.xml
+++ b/pom.xml
@@ -104,7 +104,7 @@ flexible messaging model and an intuitive client API.</description>
     <!-- apache commons -->
     <commons-compress.version>1.21</commons-compress.version>
 
-    <bookkeeper.version>4.14.4</bookkeeper.version>
+    <bookkeeper.version>4.14.5</bookkeeper.version>
     <zookeeper.version>3.6.3</zookeeper.version>
     <commons-cli.version>1.5.0</commons-cli.version>
     <snappy.version>1.1.7</snappy.version> <!-- ZooKeeper server -->

--- a/pulsar-sql/presto-distribution/LICENSE
+++ b/pulsar-sql/presto-distribution/LICENSE
@@ -435,18 +435,18 @@ The Apache Software License, Version 2.0
     - async-http-client-2.12.1.jar
     - async-http-client-netty-utils-2.12.1.jar
   * Apache Bookkeeper
-    - bookkeeper-common-4.14.4.jar
-    - bookkeeper-common-allocator-4.14.4.jar
-    - bookkeeper-proto-4.14.4.jar
-    - bookkeeper-server-4.14.4.jar
-    - bookkeeper-stats-api-4.14.4.jar
-    - bookkeeper-tools-framework-4.14.4.jar
-    - circe-checksum-4.14.4.jar
-    - codahale-metrics-provider-4.14.4.jar
-    - cpu-affinity-4.14.4.jar
-    - http-server-4.14.4.jar
-    - prometheus-metrics-provider-4.14.4.jar
-    - codahale-metrics-provider-4.14.4.jar
+    - bookkeeper-common-4.14.5.jar
+    - bookkeeper-common-allocator-4.14.5.jar
+    - bookkeeper-proto-4.14.5.jar
+    - bookkeeper-server-4.14.5.jar
+    - bookkeeper-stats-api-4.14.5.jar
+    - bookkeeper-tools-framework-4.14.5.jar
+    - circe-checksum-4.14.5.jar
+    - codahale-metrics-provider-4.14.5.jar
+    - cpu-affinity-4.14.5.jar
+    - http-server-4.14.5.jar
+    - prometheus-metrics-provider-4.14.5.jar
+    - codahale-metrics-provider-4.14.5.jar
   * Apache Commons
     - commons-cli-1.5.0.jar
     - commons-codec-1.15.jar


### PR DESCRIPTION
### Motivation

BookKeeper 4.14.5 has been released. It contains a crucial fix identified in Pulsar (https://github.com/apache/pulsar/issues/14436)

Release notes: https://bookkeeper.apache.org/release-notes/#4145

### Modifications

* Upgrade BK dependency 

- [x] `no-need-doc` 