### PR TITLE
[cleanup][client] Use TestNG instead of JUnit

### DIFF
--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/AutoClusterFailoverTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/AutoClusterFailoverTest.java
@@ -18,6 +18,10 @@
  */
 package org.apache.pulsar.client.impl;
 
+import static org.mockito.Mockito.mock;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.HashMap;
@@ -30,11 +34,7 @@ import org.apache.pulsar.client.api.ServiceUrlProvider;
 import org.apache.pulsar.client.impl.conf.ClientConfigurationData;
 import org.awaitility.Awaitility;
 import org.mockito.Mockito;
-import org.testng.Assert;
 import org.testng.annotations.Test;
-
-import static org.junit.Assert.assertEquals;
-import static org.mockito.Mockito.mock;
 
 @Test(groups = "broker-impl")
 public class AutoClusterFailoverTest {
@@ -53,18 +53,18 @@ public class AutoClusterFailoverTest {
                 .checkInterval(checkInterval, TimeUnit.MILLISECONDS)
                 .build();
 
+        assertTrue(provider instanceof AutoClusterFailover);
         AutoClusterFailover autoClusterFailover = (AutoClusterFailover) provider;
-        Assert.assertTrue(provider instanceof AutoClusterFailover);
-        Assert.assertEquals(primary, provider.getServiceUrl());
-        Assert.assertEquals(primary, autoClusterFailover.getPrimary());
-        Assert.assertEquals(secondary, autoClusterFailover.getSecondary().get(0));
-        Assert.assertEquals(TimeUnit.SECONDS.toNanos(failoverDelay), autoClusterFailover.getFailoverDelayNs());
-        Assert.assertEquals(TimeUnit.SECONDS.toNanos(switchBackDelay), autoClusterFailover.getSwitchBackDelayNs());
-        Assert.assertEquals(checkInterval, autoClusterFailover.getIntervalMs());
-        Assert.assertNull(autoClusterFailover.getPrimaryTlsTrustCertsFilePath());
-        Assert.assertNull(autoClusterFailover.getPrimaryAuthentication());
-        Assert.assertNull(autoClusterFailover.getSecondaryAuthentications());
-        Assert.assertNull(autoClusterFailover.getSecondaryTlsTrustCertsFilePaths());
+        assertEquals(provider.getServiceUrl(), primary);
+        assertEquals(autoClusterFailover.getPrimary(), primary);
+        assertEquals(autoClusterFailover.getSecondary().get(0), secondary);
+        assertEquals(autoClusterFailover.getFailoverDelayNs(), TimeUnit.SECONDS.toNanos(failoverDelay));
+        assertEquals(autoClusterFailover.getSwitchBackDelayNs(), TimeUnit.SECONDS.toNanos(switchBackDelay));
+        assertEquals(autoClusterFailover.getIntervalMs(), checkInterval);
+        assertNull(autoClusterFailover.getPrimaryTlsTrustCertsFilePath());
+        assertNull(autoClusterFailover.getPrimaryAuthentication());
+        assertNull(autoClusterFailover.getSecondaryAuthentications());
+        assertNull(autoClusterFailover.getSecondaryTlsTrustCertsFilePaths());
 
         String primaryTlsTrustCertsFilePath = "primary/path";
         String secondaryTlsTrustCertsFilePath = "primary/path";
@@ -94,9 +94,9 @@ public class AutoClusterFailoverTest {
                 .build();
 
         AutoClusterFailover autoClusterFailover1 = (AutoClusterFailover) provider1;
-        Assert.assertEquals(secondaryTlsTrustCertsFilePath,
-                autoClusterFailover1.getSecondaryTlsTrustCertsFilePaths().get(secondary));
-        Assert.assertEquals(secondaryAuthentication, autoClusterFailover1.getSecondaryAuthentications().get(secondary));
+        assertEquals(autoClusterFailover1.getSecondaryTlsTrustCertsFilePaths().get(secondary),
+                secondaryTlsTrustCertsFilePath);
+        assertEquals(autoClusterFailover1.getSecondaryAuthentications().get(secondary), secondaryAuthentication);
     }
 
     @Test
@@ -127,15 +127,15 @@ public class AutoClusterFailoverTest {
 
         for (int i = 0; i < 2; i++) {
             Awaitility.await().untilAsserted(() ->
-                    Assert.assertEquals(secondary, autoClusterFailover.getServiceUrl()));
-            assertEquals(-1, autoClusterFailover.getFailedTimestamp());
+                    assertEquals(autoClusterFailover.getServiceUrl(), secondary));
+            assertEquals(autoClusterFailover.getFailedTimestamp(), -1);
 
             // primary cluster came back
             Mockito.doReturn(true).when(autoClusterFailover).probeAvailable(primary);
             Awaitility.await().untilAsserted(() ->
-                    Assert.assertEquals(primary, autoClusterFailover.getServiceUrl()));
-            assertEquals(-1, autoClusterFailover.getRecoverTimestamp());
-            assertEquals(-1, autoClusterFailover.getFailedTimestamp());
+                    assertEquals(autoClusterFailover.getServiceUrl(), primary));
+            assertEquals(autoClusterFailover.getRecoverTimestamp(), -1);
+            assertEquals(autoClusterFailover.getFailedTimestamp(), -1);
 
             Mockito.doReturn(false).when(autoClusterFailover).probeAvailable(primary);
         }
@@ -167,13 +167,11 @@ public class AutoClusterFailoverTest {
 
         autoClusterFailover.initialize(pulsarClient);
 
-        Awaitility.await().untilAsserted(() ->
-                Assert.assertEquals(secondary, autoClusterFailover.getServiceUrl()));
+        Awaitility.await().untilAsserted(() -> assertEquals(autoClusterFailover.getServiceUrl(), secondary));
 
         // primary cluster came back
         Mockito.doReturn(true).when(autoClusterFailover).probeAvailable(primary);
-        Awaitility.await().untilAsserted(() ->
-                Assert.assertEquals(primary, autoClusterFailover.getServiceUrl()));
+        Awaitility.await().untilAsserted(() -> assertEquals(autoClusterFailover.getServiceUrl(), primary));
     }
 
     @Test
@@ -223,15 +221,13 @@ public class AutoClusterFailoverTest {
 
         autoClusterFailover.initialize(pulsarClient);
 
-        Awaitility.await().untilAsserted(() ->
-                Assert.assertEquals(secondary, autoClusterFailover.getServiceUrl()));
+        Awaitility.await().untilAsserted(() -> assertEquals(autoClusterFailover.getServiceUrl(), secondary));
         Mockito.verify(pulsarClient, Mockito.atLeastOnce()).updateTlsTrustCertsFilePath(secondaryTlsTrustCertsFilePath);
         Mockito.verify(pulsarClient, Mockito.atLeastOnce()).updateAuthentication(secondaryAuthentication);
 
         // primary cluster came back
         Mockito.doReturn(true).when(autoClusterFailover).probeAvailable(primary);
-        Awaitility.await().untilAsserted(() ->
-                Assert.assertEquals(primary, autoClusterFailover.getServiceUrl()));
+        Awaitility.await().untilAsserted(() -> assertEquals(autoClusterFailover.getServiceUrl(), primary));
         Mockito.verify(pulsarClient, Mockito.atLeastOnce()).updateTlsTrustCertsFilePath(primaryTlsTrustCertsFilePath);
         Mockito.verify(pulsarClient, Mockito.atLeastOnce()).updateAuthentication(primaryAuthentication);
 
@@ -276,15 +272,13 @@ public class AutoClusterFailoverTest {
 
         autoClusterFailover.initialize(pulsarClient);
 
-        Awaitility.await().untilAsserted(() ->
-                Assert.assertEquals(secondary, autoClusterFailover.getServiceUrl()));
+        Awaitility.await().untilAsserted(() -> assertEquals(autoClusterFailover.getServiceUrl(), secondary));
         Mockito.verify(pulsarClient, Mockito.atLeastOnce())
                 .updateTlsTrustStorePathAndPassword(secondaryTlsTrustStorePath, secondaryTlsTrustStorePassword);
 
         // primary cluster came back
         Mockito.doReturn(true).when(autoClusterFailover).probeAvailable(primary);
-        Awaitility.await().untilAsserted(() ->
-                Assert.assertEquals(primary, autoClusterFailover.getServiceUrl()));
+        Awaitility.await().untilAsserted(() -> assertEquals(autoClusterFailover.getServiceUrl(), primary));
         Mockito.verify(pulsarClient, Mockito.atLeastOnce())
                 .updateTlsTrustStorePathAndPassword(primaryTlsTrustStorePath, primaryTlsTrustStorePassword);
 

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/ProducerImplTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/ProducerImplTest.java
@@ -18,11 +18,12 @@
  */
 package org.apache.pulsar.client.impl;
 
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
 import java.nio.ByteBuffer;
 import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.common.api.proto.MessageMetadata;
-import org.junit.Assert;
-import org.junit.Test;
+import org.testng.annotations.Test;
 
 public class ProducerImplTest {
     @Test
@@ -39,11 +40,11 @@ public class ProducerImplTest {
                             null, 0, null);
             opSendMsg.chunkedMessageCtx = ctx;
             // check the ctx hasn't been deallocated.
-            Assert.assertEquals(testMessageId, ctx.firstChunkMessageId);
+            assertEquals(ctx.firstChunkMessageId, testMessageId);
             opSendMsg.recycle();
         }
 
         // check if the ctx is deallocated successfully.
-        Assert.assertNull(ctx.firstChunkMessageId);
+        assertNull(ctx.firstChunkMessageId);
     }
 }

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/auth/oauth2/protocol/TokenClientTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/auth/oauth2/protocol/TokenClientTest.java
@@ -18,20 +18,18 @@
  */
 package org.apache.pulsar.client.impl.auth.oauth2.protocol;
 
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertNotNull;
 import com.google.gson.Gson;
+import java.io.IOException;
+import java.net.URL;
+import java.util.concurrent.ExecutionException;
 import org.asynchttpclient.BoundRequestBuilder;
 import org.asynchttpclient.DefaultAsyncHttpClient;
 import org.asynchttpclient.ListenableFuture;
 import org.asynchttpclient.Response;
-import org.junit.Assert;
-import org.junit.Test;
-
-import java.io.IOException;
-import java.net.URL;
-import java.util.concurrent.ExecutionException;
-
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import org.testng.annotations.Test;
 
 /**
  * Token client exchange token mock test.
@@ -67,7 +65,7 @@ public class TokenClientTest {
         tokenResult.setIdToken("test-id");
         when(response.getResponseBodyAsBytes()).thenReturn(new Gson().toJson(tokenResult).getBytes());
         TokenResult tr = tokenClient.exchangeClientCredentials(request);
-        Assert.assertNotNull(tr);
+        assertNotNull(tr);
     }
 
     @Test
@@ -97,6 +95,6 @@ public class TokenClientTest {
         tokenResult.setIdToken("test-id");
         when(response.getResponseBodyAsBytes()).thenReturn(new Gson().toJson(tokenResult).getBytes());
         TokenResult tr = tokenClient.exchangeClientCredentials(request);
-        Assert.assertNotNull(tr);
+        assertNotNull(tr);
     }
 }


### PR DESCRIPTION
### Motivation

The codebase has two unit test frameworks: JUnit and TestNG, which always make us confused about which one to use. I check the git commits and found that #1032 does this thing, but still has some tests using JUnit. We need to remove the JUnit, use the TestNG as the unit test framework in the codebase.

### Modifications

- Use TestNG instead of JUnit

### Documentation

Need to update docs? 

- [x] `no-need-doc` 
(Please explain why)
