### PR TITLE
[cleanup][metadata] Use TestNG instead of JUnit

### DIFF
--- a/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/bookkeeper/LedgerManagerIteratorTest.java
+++ b/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/bookkeeper/LedgerManagerIteratorTest.java
@@ -18,10 +18,10 @@
  */
 package org.apache.pulsar.metadata.bookkeeper;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
 import com.google.common.collect.Lists;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -114,8 +114,8 @@ public class LedgerManagerIteratorTest extends BaseMetadataStoreTest {
         long last = -1;
         while (lri.hasNext()) {
             LedgerManager.LedgerRange lr = lri.next();
-            assertFalse("ledger range must not be empty", lr.getLedgers().isEmpty());
-            assertTrue("ledger ranges must not overlap", last < lr.start());
+            assertFalse(lr.getLedgers().isEmpty(), "ledger range must not be empty");
+            assertTrue(last < lr.start(), "ledger ranges must not overlap");
             ret.addAll(lr.getLedgers());
             last = lr.end();
         }
@@ -136,7 +136,7 @@ public class LedgerManagerIteratorTest extends BaseMetadataStoreTest {
         }, null, BKException.Code.OK, BKException.Code.ReadException);
 
         latch.await();
-        assertEquals("Final RC of asyncProcessLedgers", BKException.Code.OK, finalRC.get());
+        assertEquals(finalRC.get(), BKException.Code.OK, "Final RC of asyncProcessLedgers");
         return ledgersReadAsync;
     }
 
@@ -154,7 +154,7 @@ public class LedgerManagerIteratorTest extends BaseMetadataStoreTest {
             lri.next();
         }
 
-        assertEquals(false, lri.hasNext());
+        assertEquals(lri.hasNext(), false);
     }
 
     @Test(timeOut = 30000, dataProvider = "impl")
@@ -176,7 +176,7 @@ public class LedgerManagerIteratorTest extends BaseMetadataStoreTest {
         assertEquals(lids.iterator().next().longValue(), id);
 
         Set<Long> ledgersReadAsync = getLedgerIdsByUsingAsyncProcessLedgers(lm);
-        assertEquals("Comparing LedgersIds read asynchronously", lids, ledgersReadAsync);
+        assertEquals(ledgersReadAsync, lids, "Comparing LedgersIds read asynchronously");
     }
 
     @Test(timeOut = 30000, dataProvider = "impl")
@@ -196,10 +196,10 @@ public class LedgerManagerIteratorTest extends BaseMetadataStoreTest {
         LedgerRangeIterator lri = lm.getLedgerRanges(0);
         assertNotNull(lri);
         Set<Long> returnedIds = ledgerRangeToSet(lri);
-        assertEquals(ids, returnedIds);
+        assertEquals(returnedIds, ids);
 
         Set<Long> ledgersReadAsync = getLedgerIdsByUsingAsyncProcessLedgers(lm);
-        assertEquals("Comparing LedgersIds read asynchronously", ids, ledgersReadAsync);
+        assertEquals(ledgersReadAsync, ids, "Comparing LedgersIds read asynchronously");
     }
 
     @Test(timeOut = 240000, dataProvider = "impl")
@@ -223,10 +223,10 @@ public class LedgerManagerIteratorTest extends BaseMetadataStoreTest {
         LedgerRangeIterator lri = lm.getLedgerRanges(0);
         assertNotNull(lri);
         Set<Long> returnedIds = ledgerRangeToSet(lri);
-        assertEquals(ids, returnedIds);
+        assertEquals(returnedIds, ids);
 
         Set<Long> ledgersReadAsync = getLedgerIdsByUsingAsyncProcessLedgers(lm);
-        assertEquals("Comparing LedgersIds read asynchronously", ids, ledgersReadAsync);
+        assertEquals(ledgersReadAsync, ids, "Comparing LedgersIds read asynchronously");
     }
 
     @Test(timeOut = 30000, dataProvider = "impl")
@@ -316,10 +316,10 @@ public class LedgerManagerIteratorTest extends BaseMetadataStoreTest {
         LedgerRangeIterator lri = lm.getLedgerRanges(0);
         assertNotNull(lri);
         Set<Long> returnedIds = ledgerRangeToSet(lri);
-        assertEquals(ids, returnedIds);
+        assertEquals(returnedIds, ids);
 
         Set<Long> ledgersReadAsync = getLedgerIdsByUsingAsyncProcessLedgers(lm);
-        assertEquals("Comparing LedgersIds read asynchronously", ids, ledgersReadAsync);
+        assertEquals(ledgersReadAsync, ids, "Comparing LedgersIds read asynchronously");
 
         lri = lm.getLedgerRanges(0);
         int emptyRanges = 0;
@@ -328,7 +328,7 @@ public class LedgerManagerIteratorTest extends BaseMetadataStoreTest {
                 emptyRanges++;
             }
         }
-        assertEquals(0, emptyRanges);
+        assertEquals(emptyRanges, 0);
     }
 
     @Test(timeOut = 30000, dataProvider = "impl")
@@ -367,10 +367,10 @@ public class LedgerManagerIteratorTest extends BaseMetadataStoreTest {
         LedgerRangeIterator lri = lm.getLedgerRanges(0);
         assertNotNull(lri);
         Set<Long> returnedIds = ledgerRangeToSet(lri);
-        assertEquals(ids, returnedIds);
+        assertEquals(returnedIds, ids);
 
         Set<Long> ledgersReadAsync = getLedgerIdsByUsingAsyncProcessLedgers(lm);
-        assertEquals("Comparing LedgersIds read asynchronously", ids, ledgersReadAsync);
+        assertEquals(ledgersReadAsync, ids, "Comparing LedgersIds read asynchronously");
     }
 
     @Test(timeOut = 30000, dataProvider = "impl")
@@ -476,8 +476,8 @@ public class LedgerManagerIteratorTest extends BaseMetadataStoreTest {
             createLedger(lm, ledgerId);
         }
         Set<Long> ledgersReadThroughIterator = ledgerRangeToSet(lri);
-        assertEquals("Comparing LedgersIds read through Iterator", ledgerIds, ledgersReadThroughIterator);
+        assertEquals(ledgersReadThroughIterator, ledgerIds, "Comparing LedgersIds read through Iterator");
         Set<Long> ledgersReadAsync = getLedgerIdsByUsingAsyncProcessLedgers(lm);
-        assertEquals("Comparing LedgersIds read asynchronously", ledgerIds, ledgersReadAsync);
+        assertEquals(ledgersReadAsync, ledgerIds, "Comparing LedgersIds read asynchronously");
     }
 }

--- a/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/bookkeeper/LedgerUnderreplicationManagerTest.java
+++ b/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/bookkeeper/LedgerUnderreplicationManagerTest.java
@@ -18,10 +18,10 @@
  */
 package org.apache.pulsar.metadata.bookkeeper;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
 import com.google.protobuf.TextFormat;
 import java.nio.charset.Charset;
 import java.util.ArrayList;
@@ -172,7 +172,7 @@ public class LedgerUnderreplicationManagerTest extends BaseMetadataStoreTest {
         }
         Long newl = 0xfefefefefefeL;
         lum.markLedgerUnderreplicated(newl, missingReplica);
-        assertEquals("Should have got the one just added", newl, f.get(5, TimeUnit.SECONDS));
+        assertEquals(f.get(5, TimeUnit.SECONDS), newl, "Should have got the one just added");
     }
 
     @Test(timeOut = 60000, dataProvider = "impl")
@@ -196,7 +196,7 @@ public class LedgerUnderreplicationManagerTest extends BaseMetadataStoreTest {
             foundLedgers.add(ul.getLedgerId());
         }
 
-        assertEquals(foundLedgers, ledgers);
+        assertEquals(ledgers, foundLedgers);
     }
 
     /**
@@ -221,7 +221,7 @@ public class LedgerUnderreplicationManagerTest extends BaseMetadataStoreTest {
         m1.markLedgerUnderreplicated(ledger, missingReplica);
         Future<Long> f = getLedgerToReplicate(m1);
         Long l = f.get(5, TimeUnit.SECONDS);
-        assertEquals("Should be the ledger I just marked", ledger, l);
+        assertEquals(l, ledger, "Should be the ledger I just marked");
 
         f = getLedgerToReplicate(m2);
         try {
@@ -235,7 +235,7 @@ public class LedgerUnderreplicationManagerTest extends BaseMetadataStoreTest {
         m1.close();
 
         l = f.get(5, TimeUnit.SECONDS);
-        assertEquals("Should be the ledger I marked", ledger, l);
+        assertEquals(l, ledger, "Should be the ledger I marked");
     }
 
 
@@ -274,9 +274,8 @@ public class LedgerUnderreplicationManagerTest extends BaseMetadataStoreTest {
             Long a = fA.get(5, TimeUnit.SECONDS);
             Long b = fB.get(5, TimeUnit.SECONDS);
 
-            assertTrue("Should be the ledgers I just marked",
-                    (a.equals(ledgerA) && b.equals(ledgerB))
-                            || (a.equals(ledgerB) && b.equals(ledgerA)));
+            assertTrue((a.equals(ledgerA) && b.equals(ledgerB)) || (a.equals(ledgerB) && b.equals(ledgerA)),
+                    "Should be the ledgers I just marked");
             lA.set(a);
             lB.set(b);
         });
@@ -293,7 +292,7 @@ public class LedgerUnderreplicationManagerTest extends BaseMetadataStoreTest {
         m1.close();
 
         Long l = f.get(5, TimeUnit.SECONDS);
-        assertEquals("Should be the ledger I marked", lB.get(), l);
+        assertEquals(l, lB.get(), "Should be the ledger I marked");
     }
 
     /**
@@ -326,9 +325,8 @@ public class LedgerUnderreplicationManagerTest extends BaseMetadataStoreTest {
         Long lA = fA.get(5, TimeUnit.SECONDS);
         Long lB = fB.get(5, TimeUnit.SECONDS);
 
-        assertTrue("Should be the ledgers I just marked",
-                (lA.equals(ledgerA) && lB.equals(ledgerB))
-                        || (lA.equals(ledgerB) && lB.equals(ledgerA)));
+        assertTrue((lA.equals(ledgerA) && lB.equals(ledgerB)) || (lA.equals(ledgerB) && lB.equals(ledgerA)),
+                "Should be the ledgers I just marked");
 
         Future<Long> f = getLedgerToReplicate(m2);
         try {
@@ -341,7 +339,7 @@ public class LedgerUnderreplicationManagerTest extends BaseMetadataStoreTest {
         m1.releaseUnderreplicatedLedger(lB);
 
         Long l = f.get(5, TimeUnit.SECONDS);
-        assertEquals("Should be the ledger I marked", lB, l);
+        assertEquals(l, lB, "Should be the ledger I marked");
     }
 
     /**
@@ -365,14 +363,12 @@ public class LedgerUnderreplicationManagerTest extends BaseMetadataStoreTest {
 
         lum.markLedgerUnderreplicated(ledgerA, missingReplica2);
 
-        assertEquals("Should be the ledger I just marked",
-                lA, ledgerA);
+        assertEquals(lA, ledgerA, "Should be the ledger I just marked");
         lum.markLedgerReplicated(lA);
 
         Future<Long> f = getLedgerToReplicate(lum);
         lA = f.get(5, TimeUnit.SECONDS);
-        assertEquals("Should be the ledger I had marked previously",
-                lA, ledgerA);
+        assertEquals(lA, ledgerA, "Should be the ledger I had marked previously");
     }
 
     /**
@@ -397,23 +393,23 @@ public class LedgerUnderreplicationManagerTest extends BaseMetadataStoreTest {
 
         // lock is not yet acquired so replicationWorkerIdRereplicatingLedger
         // should
-        assertEquals("ReplicationWorkerId of the lock", null, lum.getReplicationWorkerIdRereplicatingLedger(ledgerA));
+        assertEquals(lum.getReplicationWorkerIdRereplicatingLedger(ledgerA), null, "ReplicationWorkerId of the lock");
 
         Future<Long> fA = getLedgerToReplicate(lum);
         Long lA = fA.get(5, TimeUnit.SECONDS);
-        assertEquals("Should be the ledger that was just marked", lA, ledgerA);
+        assertEquals(lA, ledgerA, "Should be the ledger that was just marked");
 
         /*
          * ZkLedgerUnderreplicationManager.getLockData uses
          * DNS.getDefaultHost("default") as the bookieId.
          *
          */
-        assertEquals("ReplicationWorkerId of the lock", DNS.getDefaultHost("default"),
-                lum.getReplicationWorkerIdRereplicatingLedger(ledgerA));
+        assertEquals(lum.getReplicationWorkerIdRereplicatingLedger(ledgerA), DNS.getDefaultHost("default"),
+                "ReplicationWorkerId of the lock");
 
         lum.markLedgerReplicated(lA);
 
-        assertEquals("ReplicationWorkerId of the lock", null, lum.getReplicationWorkerIdRereplicatingLedger(ledgerA));
+        assertEquals(lum.getReplicationWorkerIdRereplicatingLedger(ledgerA), null, "ReplicationWorkerId of the lock");
     }
 
     /**
@@ -440,16 +436,13 @@ public class LedgerUnderreplicationManagerTest extends BaseMetadataStoreTest {
         byte[] data = store.get(getUrLedgerZnode(ledgerA)).join().get().getValue();
         TextFormat.merge(new String(data, Charset.forName("UTF-8")), builderA);
         List<String> replicaList = builderA.getReplicaList();
-        assertEquals("Published duplicate missing replica : " + replicaList, 1,
-                replicaList.size());
-        assertTrue("Published duplicate missing replica : " + replicaList,
-                replicaList.contains(missingReplica1));
+        assertEquals(replicaList.size(), 1, "Published duplicate missing replica : " + replicaList);
+        assertTrue(replicaList.contains(missingReplica1), "Published duplicate missing replica : " + replicaList);
 
         Future<Long> fA = getLedgerToReplicate(m1);
         Long lA = fA.get(5, TimeUnit.SECONDS);
 
-        assertEquals("Should be the ledger I just marked",
-                lA, ledgerA);
+        assertEquals(lA, ledgerA, "Should be the ledger I just marked");
         m1.markLedgerReplicated(lA);
 
         Future<Long> f = getLedgerToReplicate(m2);
@@ -612,8 +605,7 @@ public class LedgerUnderreplicationManagerTest extends BaseMetadataStoreTest {
         Thread thread1 = new Thread(() -> {
             try {
                 Long lA = lum.getLedgerToRereplicate();
-                assertEquals("Should be the ledger I just marked", lA,
-                        ledgerA);
+                assertEquals(lA, ledgerA, "Should be the ledger I just marked");
                 znodeLatch.countDown();
             } catch (UnavailableException e) {
                 e.printStackTrace();
@@ -622,15 +614,13 @@ public class LedgerUnderreplicationManagerTest extends BaseMetadataStoreTest {
         thread1.start();
 
         try {
-            assertFalse("shouldn't complete", znodeLatch.await(1, TimeUnit.SECONDS));
-            assertEquals("Failed to disable ledger replication!", 2, znodeLatch
-                    .getCount());
+            assertFalse(znodeLatch.await(1, TimeUnit.SECONDS), "shouldn't complete");
+            assertEquals(znodeLatch.getCount(), 2, "Failed to disable ledger replication!");
 
             lum.enableLedgerReplication();
             znodeLatch.await(5, TimeUnit.SECONDS);
             log.debug("Enabled Ledeger Replication");
-            assertEquals("Failed to disable ledger replication!", 0, znodeLatch
-                    .getCount());
+            assertEquals(znodeLatch.getCount(), 0, "Failed to disable ledger replication!");
         } finally {
             thread1.interrupt();
         }
@@ -644,13 +634,13 @@ public class LedgerUnderreplicationManagerTest extends BaseMetadataStoreTest {
         LedgerUnderreplicationManager underReplicaMgr1 = lmf.newLedgerUnderreplicationManager();
         @Cleanup
         LedgerUnderreplicationManager underReplicaMgr2 = lmf.newLedgerUnderreplicationManager();
-        assertEquals(-1, underReplicaMgr1.getCheckAllLedgersCTime());
+        assertEquals(underReplicaMgr1.getCheckAllLedgersCTime(), -1);
         long curTime = System.currentTimeMillis();
         underReplicaMgr2.setCheckAllLedgersCTime(curTime);
-        assertEquals(curTime, underReplicaMgr1.getCheckAllLedgersCTime());
+        assertEquals(underReplicaMgr1.getCheckAllLedgersCTime(), curTime);
         curTime = System.currentTimeMillis();
         underReplicaMgr2.setCheckAllLedgersCTime(curTime);
-        assertEquals(curTime, underReplicaMgr1.getCheckAllLedgersCTime());
+        assertEquals(underReplicaMgr1.getCheckAllLedgersCTime(), curTime);
     }
 
     @Test(timeOut = 60000, dataProvider = "impl")
@@ -663,15 +653,15 @@ public class LedgerUnderreplicationManagerTest extends BaseMetadataStoreTest {
         @Cleanup
         LedgerUnderreplicationManager underReplicaMgr2 = lmf.newLedgerUnderreplicationManager();
 
-        assertEquals(-1, underReplicaMgr1.getPlacementPolicyCheckCTime());
+        assertEquals(underReplicaMgr1.getPlacementPolicyCheckCTime(), -1);
         long curTime = System.currentTimeMillis();
         underReplicaMgr2.setPlacementPolicyCheckCTime(curTime);
 
-        assertEquals(curTime, underReplicaMgr1.getPlacementPolicyCheckCTime());
+        assertEquals(underReplicaMgr1.getPlacementPolicyCheckCTime(), curTime);
         curTime = System.currentTimeMillis();
         underReplicaMgr2.setPlacementPolicyCheckCTime(curTime);
 
-        assertEquals(curTime, underReplicaMgr1.getPlacementPolicyCheckCTime());
+        assertEquals(underReplicaMgr1.getPlacementPolicyCheckCTime(), curTime);
     }
 
     @Test(timeOut = 60000, dataProvider = "impl")
@@ -683,13 +673,13 @@ public class LedgerUnderreplicationManagerTest extends BaseMetadataStoreTest {
         LedgerUnderreplicationManager underReplicaMgr1 = lmf.newLedgerUnderreplicationManager();
         @Cleanup
         LedgerUnderreplicationManager underReplicaMgr2 = lmf.newLedgerUnderreplicationManager();
-        assertEquals(-1, underReplicaMgr1.getReplicasCheckCTime());
+        assertEquals(underReplicaMgr1.getReplicasCheckCTime(), -1);
         long curTime = System.currentTimeMillis();
         underReplicaMgr2.setReplicasCheckCTime(curTime);
-        assertEquals(curTime, underReplicaMgr1.getReplicasCheckCTime());
+        assertEquals(underReplicaMgr1.getReplicasCheckCTime(), curTime);
         curTime = System.currentTimeMillis();
         underReplicaMgr2.setReplicasCheckCTime(curTime);
-        assertEquals(curTime, underReplicaMgr1.getReplicasCheckCTime());
+        assertEquals(underReplicaMgr1.getReplicasCheckCTime(), curTime);
     }
 
     private void verifyMarkLedgerUnderreplicated(Collection<String> missingReplica) throws Exception {
@@ -708,9 +698,8 @@ public class LedgerUnderreplicationManagerTest extends BaseMetadataStoreTest {
         List<String> replicaList = builderA.getReplicaList();
 
         for (String replica : missingReplica) {
-            assertTrue("UrLedger:" + urLedgerA
-                    + " doesn't contain failed bookie :" + replica, replicaList
-                    .contains(replica));
+            assertTrue(replicaList.contains(replica),
+                    "UrLedger:" + urLedgerA + " doesn't contain failed bookie :" + replica);
         }
     }
 

--- a/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/bookkeeper/LedgerUnderreplicationManagerTest.java
+++ b/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/bookkeeper/LedgerUnderreplicationManagerTest.java
@@ -196,7 +196,7 @@ public class LedgerUnderreplicationManagerTest extends BaseMetadataStoreTest {
             foundLedgers.add(ul.getLedgerId());
         }
 
-        assertEquals(ledgers, foundLedgers);
+        assertEquals(foundLedgers, ledgers);
     }
 
     /**

--- a/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/bookkeeper/PulsarLayoutManagerTest.java
+++ b/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/bookkeeper/PulsarLayoutManagerTest.java
@@ -18,9 +18,9 @@
  */
 package org.apache.pulsar.metadata.bookkeeper;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
 import java.io.IOException;
 import java.util.UUID;
 import java.util.function.Supplier;
@@ -80,7 +80,7 @@ public class PulsarLayoutManagerTest extends BaseMetadataStoreTest {
 
         // read the layout
         LedgerLayout readLayout = layoutManager.readLedgerLayout();
-        assertEquals(layout, readLayout);
+        assertEquals(readLayout, layout);
 
         // attempts to create the layout again and it should fail
         LedgerLayout newLayout = new LedgerLayout(

--- a/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/bookkeeper/PulsarLedgerAuditorManagerTest.java
+++ b/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/bookkeeper/PulsarLedgerAuditorManagerTest.java
@@ -18,10 +18,10 @@
  */
 package org.apache.pulsar.metadata.bookkeeper;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
 import java.util.UUID;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
@@ -84,13 +84,13 @@ public class PulsarLedgerAuditorManagerTest extends BaseMetadataStoreTest {
             log.info("---- LAM-1 - Received auditor event: {}", auditorEvent);
         });
 
-        assertEquals(BookieId.parse("bookie-1:3181"), lam1.getCurrentAuditor());
+        assertEquals(lam1.getCurrentAuditor(), BookieId.parse("bookie-1:3181"));
 
         @Cleanup("shutdownNow")
         ExecutorService executor = Executors.newCachedThreadPool();
 
         LedgerAuditorManager lam2 = new PulsarLedgerAuditorManager(store2, ledgersRootPath);
-        assertEquals(BookieId.parse("bookie-1:3181"), lam2.getCurrentAuditor());
+        assertEquals(lam2.getCurrentAuditor(), BookieId.parse("bookie-1:3181"));
 
         CountDownLatch latch = new CountDownLatch(1);
         executor.execute(() -> {
@@ -109,14 +109,14 @@ public class PulsarLedgerAuditorManagerTest extends BaseMetadataStoreTest {
         // LAM2 will be kept waiting until LAM1 goes away
         assertFalse(latch.await(1, TimeUnit.SECONDS));
 
-        assertEquals(BookieId.parse("bookie-1:3181"), lam1.getCurrentAuditor());
-        assertEquals(BookieId.parse("bookie-1:3181"), lam2.getCurrentAuditor());
+        assertEquals(lam1.getCurrentAuditor(), BookieId.parse("bookie-1:3181"));
+        assertEquals(lam2.getCurrentAuditor(), BookieId.parse("bookie-1:3181"));
 
         lam1.close();
 
         // Now LAM2 will take over
         assertTrue(latch.await(10, TimeUnit.SECONDS));
-        assertEquals(BookieId.parse("bookie-2:3181"), lam2.getCurrentAuditor());
+        assertEquals(lam2.getCurrentAuditor(), BookieId.parse("bookie-2:3181"));
     }
 
 }

--- a/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/bookkeeper/PulsarMetadataDriverBaseStaticTest.java
+++ b/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/bookkeeper/PulsarMetadataDriverBaseStaticTest.java
@@ -18,7 +18,7 @@
  */
 package org.apache.pulsar.metadata.bookkeeper;
 
-import static org.junit.Assert.assertEquals;
+import static org.testng.Assert.assertEquals;
 import java.net.URI;
 import org.apache.bookkeeper.meta.HierarchicalLedgerManagerFactory;
 import org.apache.bookkeeper.meta.LongHierarchicalLedgerManagerFactory;
@@ -36,16 +36,12 @@ public class PulsarMetadataDriverBaseStaticTest {
         URI uri = URI.create(uriStr);
 
         String zkServers = ZKMetadataDriverBase.getZKServersFromServiceUri(uri);
-        assertEquals(
-            "server1,server2,server3",
-            zkServers);
+        assertEquals(zkServers, "server1,server2,server3");
 
         uriStr = "zk://server1,server2,server3/ledgers";
         uri = URI.create(uriStr);
         zkServers = ZKMetadataDriverBase.getZKServersFromServiceUri(uri);
-        assertEquals(
-            "server1,server2,server3",
-            zkServers);
+        assertEquals(zkServers, "server1,server2,server3");
     }
 
     @Test(expectedExceptions = NullPointerException.class)
@@ -65,57 +61,40 @@ public class PulsarMetadataDriverBaseStaticTest {
 
     @Test
     public void testResolveLedgerManagerFactoryUnspecifiedLayout() {
-        assertEquals(
-            null,
-            ZKMetadataDriverBase.resolveLedgerManagerFactory(
-                        URI.create("zk://127.0.0.1/ledgers"))
-        );
+        assertEquals(ZKMetadataDriverBase.resolveLedgerManagerFactory(URI.create("zk://127.0.0.1/ledgers")), null);
     }
 
     @Test
     public void testResolveLedgerManagerFactoryNullLayout() {
-        assertEquals(
-                null,
-                ZKMetadataDriverBase.resolveLedgerManagerFactory(
-                        URI.create("zk+null://127.0.0.1/ledgers"))
-        );
+        assertEquals(ZKMetadataDriverBase.resolveLedgerManagerFactory(URI.create("zk+null://127.0.0.1/ledgers")), null);
     }
 
     @SuppressWarnings("deprecation")
     @Test
     public void testResolveLedgerManagerFactoryFlat() {
-        assertEquals(
-            org.apache.bookkeeper.meta.FlatLedgerManagerFactory.class,
-            ZKMetadataDriverBase.resolveLedgerManagerFactory(
-                URI.create("zk+flat://127.0.0.1/ledgers"))
-        );
+        assertEquals(ZKMetadataDriverBase.resolveLedgerManagerFactory(URI.create("zk+flat://127.0.0.1/ledgers")),
+                org.apache.bookkeeper.meta.FlatLedgerManagerFactory.class);
     }
 
     @SuppressWarnings("deprecation")
     @Test
     public void testResolveLedgerManagerFactoryMs() {
-        assertEquals(
-            org.apache.bookkeeper.meta.MSLedgerManagerFactory.class,
-            ZKMetadataDriverBase.resolveLedgerManagerFactory(
-                URI.create("zk+ms://127.0.0.1/ledgers"))
-        );
+        assertEquals(ZKMetadataDriverBase.resolveLedgerManagerFactory(URI.create("zk+ms://127.0.0.1/ledgers")),
+                org.apache.bookkeeper.meta.MSLedgerManagerFactory.class);
     }
 
     @Test
     public void testResolveLedgerManagerFactoryHierarchical() {
         assertEquals(
-            HierarchicalLedgerManagerFactory.class,
-            ZKMetadataDriverBase.resolveLedgerManagerFactory(
-                URI.create("zk+hierarchical://127.0.0.1/ledgers"))
-        );
+                ZKMetadataDriverBase.resolveLedgerManagerFactory(URI.create("zk+hierarchical://127.0.0.1/ledgers")),
+                HierarchicalLedgerManagerFactory.class);
     }
 
     @Test
     public void testResolveLedgerManagerFactoryLongHierarchical() {
         assertEquals(
-            LongHierarchicalLedgerManagerFactory.class,
-            ZKMetadataDriverBase.resolveLedgerManagerFactory(
-                URI.create("zk+longhierarchical://127.0.0.1/ledgers"))
+                ZKMetadataDriverBase.resolveLedgerManagerFactory(URI.create("zk+longhierarchical://127.0.0.1/ledgers")),
+                LongHierarchicalLedgerManagerFactory.class
         );
     }
 

--- a/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/bookkeeper/PulsarRegistrationClientTest.java
+++ b/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/bookkeeper/PulsarRegistrationClientTest.java
@@ -19,8 +19,8 @@
 package org.apache.pulsar.metadata.bookkeeper;
 
 import static org.apache.bookkeeper.common.concurrent.FutureUtils.result;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
 import static org.mockito.Mockito.mock;
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -84,7 +84,7 @@ public class PulsarRegistrationClientTest extends BaseMetadataStoreTest {
 
         Versioned<Set<BookieId>> result = result(rc.getWritableBookies());
 
-        assertEquals(addresses.size(), result.getValue().size());
+        assertEquals(result.getValue().size(), addresses.size());
     }
 
 
@@ -111,7 +111,7 @@ public class PulsarRegistrationClientTest extends BaseMetadataStoreTest {
 
         Versioned<Set<BookieId>> result = result(rc.getReadOnlyBookies());
 
-        assertEquals(addresses.size(), result.getValue().size());
+        assertEquals(result.getValue().size(), addresses.size());
     }
 
     @Test(dataProvider = "impl")
@@ -137,7 +137,7 @@ public class PulsarRegistrationClientTest extends BaseMetadataStoreTest {
         }
 
         Versioned<Set<BookieId>> result = result(rc.getAllBookies());
-        assertEquals(addresses.size(), result.getValue().size());
+        assertEquals(result.getValue().size(), addresses.size());
     }
 
     @Test(dataProvider = "impl")
@@ -190,7 +190,7 @@ public class PulsarRegistrationClientTest extends BaseMetadataStoreTest {
 
         Awaitility.await().untilAsserted(() -> {
             assertFalse(updates.isEmpty());
-            assertEquals(BOOKIES, bookies.size());
+            assertEquals(bookies.size(), BOOKIES);
         });
     }
 


### PR DESCRIPTION
### Motivation

The codebase has two unit test frameworks: JUnit and TestNG, which always make us confused about which one to use. I check the git commits and found that #1032 does this thing, but still has some tests using JUnit. We need to remove the JUnit, use the TestNG as the unit test framework in the codebase.

### Modifications

- Use TestNG instead of JUnit

### Documentation

Need to update docs? 

- [x] `no-need-doc` 
(Please explain why)
