### PR TITLE
[cleanup][broker] Use TestNG instead of JUnit

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiClusterTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiClusterTest.java
@@ -18,9 +18,8 @@
  */
 package org.apache.pulsar.broker.admin;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThrows;
-
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertThrows;
 import com.google.common.collect.Sets;
 import java.util.UUID;
 import lombok.extern.slf4j.Slf4j;

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiDynamicConfigurationsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiDynamicConfigurationsTest.java
@@ -18,9 +18,9 @@
  */
 package org.apache.pulsar.broker.admin;
 
-import static org.junit.Assert.fail;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.fail;
 import java.util.Map;
 import javax.ws.rs.core.Response;
 import lombok.extern.slf4j.Slf4j;

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiHealthCheckTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiHealthCheckTest.java
@@ -18,6 +18,9 @@
  */
 package org.apache.pulsar.broker.admin;
 
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
 import com.google.common.collect.Sets;
 import java.lang.management.ManagementFactory;
 import java.lang.management.ThreadMXBean;
@@ -35,7 +38,6 @@ import org.apache.pulsar.common.policies.data.ClusterData;
 import org.apache.pulsar.common.policies.data.TenantInfoImpl;
 import org.apache.pulsar.compaction.Compactor;
 import org.awaitility.Awaitility;
-import org.junit.Assert;
 import org.springframework.util.CollectionUtils;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
@@ -89,10 +91,10 @@ public class AdminApiHealthCheckTest extends MockedPulsarServiceBaseTest {
         final String testHealthCheckTopic = String.format("persistent://pulsar/test/localhost:%s/healthcheck",
                 pulsar.getConfig().getWebServicePort().get());
         Awaitility.await().untilAsserted(() -> {
-            Assert.assertFalse(future.isCompletedExceptionally());
+            assertFalse(future.isCompletedExceptionally());
         });
         Awaitility.await().untilAsserted(() ->
-                Assert.assertTrue(CollectionUtils.isEmpty(admin.topics()
+                assertTrue(CollectionUtils.isEmpty(admin.topics()
                         .getSubscriptions(testHealthCheckTopic).stream()
                         // All system topics are using compaction, even though is not explicitly set in the policies.
                         .filter(v -> !v.equals(Compactor.COMPACTION_SUBSCRIPTION))
@@ -166,7 +168,7 @@ public class AdminApiHealthCheckTest extends MockedPulsarServiceBaseTest {
         for (int i=0; i < 1000; i++) {
             long[] threadIds = threadBean.findDeadlockedThreads();
             // assert that there's no deadlock
-            Assert.assertNull(threadIds);
+            assertNull(threadIds);
         }
     }
 
@@ -190,11 +192,11 @@ public class AdminApiHealthCheckTest extends MockedPulsarServiceBaseTest {
         final String testHealthCheckTopic = String.format("persistent://pulsar/test/localhost:%s/healthcheck",
                 pulsar.getConfig().getWebServicePort().get());
         Awaitility.await().untilAsserted(() -> {
-            Assert.assertFalse(future.isCompletedExceptionally());
+            assertFalse(future.isCompletedExceptionally());
         });
         // To ensure we don't have any subscription
         Awaitility.await().untilAsserted(() ->
-                Assert.assertTrue(CollectionUtils.isEmpty(admin.topics()
+                assertTrue(CollectionUtils.isEmpty(admin.topics()
                         .getSubscriptions(testHealthCheckTopic).stream()
                         // All system topics are using compaction, even though is not explicitly set in the policies.
                         .filter(v -> !v.equals(Compactor.COMPACTION_SUBSCRIPTION))
@@ -223,11 +225,11 @@ public class AdminApiHealthCheckTest extends MockedPulsarServiceBaseTest {
         final String testHealthCheckTopic = String.format("persistent://pulsar/localhost:%s/healthcheck",
                 pulsar.getConfig().getWebServicePort().get());
         Awaitility.await().untilAsserted(() -> {
-            Assert.assertFalse(future.isCompletedExceptionally());
+            assertFalse(future.isCompletedExceptionally());
         });
         // To ensure we don't have any subscription
         Awaitility.await().untilAsserted(() ->
-                Assert.assertTrue(CollectionUtils.isEmpty(admin.topics()
+                assertTrue(CollectionUtils.isEmpty(admin.topics()
                         .getSubscriptions(testHealthCheckTopic).stream()
                         // All system topics are using compaction, even though is not explicitly set in the policies.
                         .filter(v -> !v.equals(Compactor.COMPACTION_SUBSCRIPTION))

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiSchemaTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiSchemaTest.java
@@ -20,10 +20,10 @@ package org.apache.pulsar.broker.admin;
 
 import static java.lang.String.format;
 import static java.nio.charset.StandardCharsets.US_ASCII;
-import static org.junit.Assert.assertNull;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.doReturn;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 import com.google.common.collect.Sets;

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/SimpleBrokerStartTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/SimpleBrokerStartTest.java
@@ -19,6 +19,8 @@
 package org.apache.pulsar.broker.loadbalance;
 
 import static org.mockito.Mockito.spy;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
 import java.util.Optional;
 import lombok.Cleanup;
 import lombok.extern.slf4j.Slf4j;
@@ -27,7 +29,6 @@ import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.broker.ServiceConfiguration;
 import org.apache.pulsar.broker.loadbalance.impl.SimpleLoadManagerImpl;
 import org.apache.pulsar.zookeeper.LocalBookkeeperEnsemble;
-import org.junit.Assert;
 import org.testng.annotations.Test;
 
 @Slf4j
@@ -88,9 +89,9 @@ public class SimpleBrokerStartTest {
             PulsarService pulsarService = new PulsarService(config);
             try {
                 pulsarService.start();
-                Assert.fail("unexpected behaviour");
+                fail("unexpected behaviour");
             } catch (PulsarServerException ex) {
-                Assert.assertTrue(ex.getCause() instanceof IllegalStateException);
+                assertTrue(ex.getCause() instanceof IllegalStateException);
             }
         }
     }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/namespace/NamespaceServiceTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/namespace/NamespaceServiceTest.java
@@ -18,7 +18,6 @@
  */
 package org.apache.pulsar.broker.namespace;
 
-import static org.junit.Assert.assertNotEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doReturn;
@@ -27,6 +26,7 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/AbstractBaseDispatcherTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/AbstractBaseDispatcherTest.java
@@ -20,10 +20,10 @@ package org.apache.pulsar.broker.service;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.pulsar.common.protocol.Commands.serializeMetadataAndPayload;
-import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
 import com.google.common.collect.ImmutableMap;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/PersistentTopicTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/PersistentTopicTest.java
@@ -29,6 +29,7 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNull;
+import static org.testng.Assert.fail;
 import java.lang.reflect.Field;
 import java.net.URI;
 import java.util.ArrayList;
@@ -53,7 +54,6 @@ import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.policies.data.Policies;
 import org.apache.pulsar.common.policies.data.TopicStats;
 import org.awaitility.Awaitility;
-import org.junit.Assert;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -285,12 +285,12 @@ public class PersistentTopicTest extends BrokerTestBase {
             @Cleanup
             Producer<byte[]> producer = pulsarClient.newProducer().topic(topicName)
                     .create();
-            Assert.fail("unexpected operation");
+            fail("unexpected operation");
         } catch (PulsarClientException ex) {
-            Assert.assertTrue(ex.getMessage()
+           assertTrue(ex.getMessage()
                     .contains("Invalid topic name"));
         }
-        Assert.assertEquals(admin.topics().getList(ns).size(), 0);
+        assertEquals(admin.topics().getList(ns).size(), 0);
         URI tcpLookupUrl = new URI(pulsar.getBrokerServiceUrl());
         PulsarClient client = PulsarClient.builder()
                 .serviceUrl(tcpLookupUrl.toString())
@@ -300,12 +300,12 @@ public class PersistentTopicTest extends BrokerTestBase {
             Producer<byte[]> producer = client.newProducer()
                     .topic(topicName)
                     .create();
-            Assert.fail("unexpected operation");
+            fail("unexpected operation");
         } catch (PulsarClientException ex) {
-            Assert.assertTrue(ex.getMessage()
+            assertTrue(ex.getMessage()
                     .contains("Invalid topic name"));
         }
-        Assert.assertEquals(admin.topics().getList(ns).size(), 0);
+        assertEquals(admin.topics().getList(ns).size(), 0);
         pulsar.getConfiguration().setAllowAutoTopicCreationType("non-partitioned");
     }
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/LedgerOffloaderMetricsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/LedgerOffloaderMetricsTest.java
@@ -20,6 +20,8 @@ package org.apache.pulsar.broker.stats;
 
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.spy;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.LinkedList;
@@ -38,7 +40,6 @@ import org.apache.pulsar.broker.service.BrokerService;
 import org.apache.pulsar.broker.service.BrokerTestBase;
 import org.apache.pulsar.broker.service.Topic;
 import org.apache.pulsar.broker.service.persistent.PersistentTopic;
-import org.junit.Assert;
 import org.mockito.Mockito;
 import org.mockito.stubbing.Answer;
 import org.testng.annotations.AfterMethod;
@@ -82,7 +83,7 @@ public class LedgerOffloaderMetricsTest  extends BrokerTestBase {
             admin.topics().createNonPartitionedTopic(topicName);
 
             doReturn(topicFuture).when(brokerService).getTopicIfExists(topicName);
-            Assert.assertTrue(topic instanceof PersistentTopic);
+            assertTrue(topic instanceof PersistentTopic);
 
             ManagedLedger ledgerM = Mockito.mock(ManagedLedger.class);
             doReturn(ledgerM).when(((PersistentTopic) topic)).getManagedLedger();
@@ -103,13 +104,13 @@ public class LedgerOffloaderMetricsTest  extends BrokerTestBase {
         }
 
         for (String topicName : topics) {
-            Assert.assertEquals(offloaderStats.getOffloadError(topicName), 2);
-            Assert.assertEquals(offloaderStats.getOffloadBytes(topicName) , 100);
-            Assert.assertEquals((long) offloaderStats.getReadLedgerLatency(topicName).sum, 1);
-            Assert.assertEquals(offloaderStats.getReadOffloadError(topicName), 2);
-            Assert.assertEquals((long) offloaderStats.getReadOffloadIndexLatency(topicName).sum ,1000);
-            Assert.assertEquals(offloaderStats.getReadOffloadBytes(topicName), 100000);
-            Assert.assertEquals(offloaderStats.getWriteStorageError(topicName), 2);
+            assertEquals(offloaderStats.getOffloadError(topicName), 2);
+            assertEquals(offloaderStats.getOffloadBytes(topicName) , 100);
+            assertEquals((long) offloaderStats.getReadLedgerLatency(topicName).sum, 1);
+            assertEquals(offloaderStats.getReadOffloadError(topicName), 2);
+            assertEquals((long) offloaderStats.getReadOffloadIndexLatency(topicName).sum ,1000);
+            assertEquals(offloaderStats.getReadOffloadBytes(topicName), 100000);
+            assertEquals(offloaderStats.getWriteStorageError(topicName), 2);
         }
     }
 
@@ -149,7 +150,7 @@ public class LedgerOffloaderMetricsTest  extends BrokerTestBase {
                 queue.add(topicName);
                 admin.topics().createNonPartitionedTopic(topicName);
                 doReturn(topicFuture).when(brokerService).getTopicIfExists(topicName);
-                Assert.assertTrue(topic instanceof PersistentTopic);
+                assertTrue(topic instanceof PersistentTopic);
 
 
                 ManagedLedger ledgerM = Mockito.mock(ManagedLedger.class);
@@ -174,13 +175,13 @@ public class LedgerOffloaderMetricsTest  extends BrokerTestBase {
             List<String> topics = entry.getValue();
             String topicName = topics.get(0);
 
-            Assert.assertTrue(offloaderStats.getOffloadError(topicName) >= 1);
-            Assert.assertTrue(offloaderStats.getOffloadBytes(topicName) >= 100);
-            Assert.assertTrue((long) offloaderStats.getReadLedgerLatency(topicName).sum >= 1);
-            Assert.assertTrue(offloaderStats.getReadOffloadError(topicName) >= 1);
-            Assert.assertTrue((long) offloaderStats.getReadOffloadIndexLatency(topicName).sum >= 1000);
-            Assert.assertTrue(offloaderStats.getReadOffloadBytes(topicName) >= 100000);
-            Assert.assertTrue(offloaderStats.getWriteStorageError(topicName) >= 1);
+            assertTrue(offloaderStats.getOffloadError(topicName) >= 1);
+            assertTrue(offloaderStats.getOffloadBytes(topicName) >= 100);
+            assertTrue((long) offloaderStats.getReadLedgerLatency(topicName).sum >= 1);
+            assertTrue(offloaderStats.getReadOffloadError(topicName) >= 1);
+            assertTrue((long) offloaderStats.getReadOffloadIndexLatency(topicName).sum >= 1000);
+            assertTrue(offloaderStats.getReadOffloadBytes(topicName) >= 100000);
+            assertTrue(offloaderStats.getWriteStorageError(topicName) >= 1);
         }
     }
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/TimeWindowTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/TimeWindowTest.java
@@ -18,8 +18,9 @@
  */
 package org.apache.pulsar.broker.stats;
 
-import org.junit.Test;
-import org.testng.Assert;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import org.testng.annotations.Test;
 
 public class TimeWindowTest {
 
@@ -31,52 +32,52 @@ public class TimeWindowTest {
 
         WindowWrap<Integer> expect1 = timeWindow.current(oldValue -> 1);
         WindowWrap<Integer> expect2 = timeWindow.current(oldValue -> null);
-        Assert.assertNotNull(expect1);
-        Assert.assertNotNull(expect2);
+        assertNotNull(expect1);
+        assertNotNull(expect2);
 
         if (expect1.start() == expect2.start()) {
-            Assert.assertEquals((int) expect1.value(), 1);
-            Assert.assertEquals(expect1, expect2);
-            Assert.assertEquals(expect1.value(), expect2.value());
+            assertEquals((int) expect1.value(), 1);
+            assertEquals(expect1, expect2);
+            assertEquals(expect1.value(), expect2.value());
         }
 
         Thread.sleep(intervalInMs);
 
         WindowWrap<Integer> expect3 = timeWindow.current(oldValue -> 2);
         WindowWrap<Integer> expect4 = timeWindow.current(oldValue -> null);
-        Assert.assertNotNull(expect3);
-        Assert.assertNotNull(expect4);
+        assertNotNull(expect3);
+        assertNotNull(expect4);
 
         if (expect3.start() == expect4.start()) {
-            Assert.assertEquals((int) expect3.value(), 2);
-            Assert.assertEquals(expect3, expect4);
-            Assert.assertEquals(expect3.value(), expect4.value());
+            assertEquals((int) expect3.value(), 2);
+            assertEquals(expect3, expect4);
+            assertEquals(expect3.value(), expect4.value());
         }
 
         Thread.sleep(intervalInMs);
 
         WindowWrap<Integer> expect5 = timeWindow.current(oldValue -> 3);
         WindowWrap<Integer> expect6 = timeWindow.current(oldValue -> null);
-        Assert.assertNotNull(expect5);
-        Assert.assertNotNull(expect6);
+        assertNotNull(expect5);
+        assertNotNull(expect6);
 
         if (expect5.start() == expect6.start()) {
-            Assert.assertEquals((int) expect5.value(), 3);
-            Assert.assertEquals(expect5, expect6);
-            Assert.assertEquals(expect5.value(), expect6.value());
+            assertEquals((int) expect5.value(), 3);
+            assertEquals(expect5, expect6);
+            assertEquals(expect5.value(), expect6.value());
         }
 
         Thread.sleep(intervalInMs);
 
         WindowWrap<Integer> expect7 = timeWindow.current(oldValue -> 4);
         WindowWrap<Integer> expect8 = timeWindow.current(oldValue -> null);
-        Assert.assertNotNull(expect7);
-        Assert.assertNotNull(expect8);
+        assertNotNull(expect7);
+        assertNotNull(expect8);
 
         if (expect7.start() == expect8.start()) {
-            Assert.assertEquals((int) expect7.value(), 4);
-            Assert.assertEquals(expect7, expect8);
-            Assert.assertEquals(expect7.value(), expect8.value());
+            assertEquals((int) expect7.value(), 4);
+            assertEquals(expect7, expect8);
+            assertEquals(expect7.value(), expect8.value());
         }
     }
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/TransactionClientConnectTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/TransactionClientConnectTest.java
@@ -18,9 +18,17 @@
  */
 package org.apache.pulsar.client.impl;
 
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.bookkeeper.mledger.impl.ManagedLedgerImpl;
@@ -35,20 +43,9 @@ import org.apache.pulsar.transaction.coordinator.TransactionMetadataStore;
 import org.apache.pulsar.transaction.coordinator.TransactionMetadataStoreState;
 import org.apache.pulsar.transaction.coordinator.impl.MLTransactionMetadataStore;
 import org.awaitility.Awaitility;
-import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
-
-import java.lang.reflect.Field;
-import java.lang.reflect.Method;
-import java.util.Collections;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
-
-import static org.junit.Assert.assertFalse;
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertTrue;
 
 @Slf4j
 public class TransactionClientConnectTest extends TransactionTestBase {
@@ -97,7 +94,7 @@ public class TransactionClientConnectTest extends TransactionTestBase {
             completableFuture.get(3, TimeUnit.SECONDS);
         } catch (TimeoutException ignore) {
         } catch (ExecutionException e) {
-            Assert.assertFalse(e.getCause()
+            assertFalse(e.getCause()
                     instanceof TransactionCoordinatorClientException.CoordinatorNotFoundException);
         }
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/compaction/CompactorMXBeanImplTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/compaction/CompactorMXBeanImplTest.java
@@ -18,12 +18,11 @@
  */
 package org.apache.pulsar.compaction;
 
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
 import org.testng.annotations.Test;
 
 import java.util.concurrent.TimeUnit;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 
 @Test(groups = "broker-compaction")
 public class CompactorMXBeanImplTest {
@@ -59,7 +58,7 @@ public class CompactorMXBeanImplTest {
         mxBean.addCompactionWriteOp(topic, 33);
         assertTrue(compaction.getCompactionWriteThroughput() > 0L);
         mxBean.addCompactionLatencyOp(topic, 10, TimeUnit.NANOSECONDS);
-        assertTrue(compaction.getCompactionLatencyBuckets()[0] > 0l);
+        assertTrue(compaction.getCompactionLatencyBuckets()[0] > 0L);
         mxBean.reset();
         assertEquals(compaction.getCompactionRemovedEventCount(), 0, 0);
         assertEquals(compaction.getCompactionSucceedCount(), 0, 0);


### PR DESCRIPTION
### Motivation

The codebase has two unit test frameworks: JUnit and TestNG, which always make us confused about which one to use. I check the git commits and found that #1032 does this thing, but still has some tests using JUnit. We need to remove the JUnit, use the TestNG as the unit test framework in the codebase.

### Modifications

- Use TestNG instead of JUnit

### Documentation

Need to update docs? 

- [x] `no-need-doc` 
(Please explain why)
