### PR TITLE
[Improve][Doc] Unnecessary warning removal

### DIFF
--- a/site2/docs/deploy-bare-metal.md
+++ b/site2/docs/deploy-bare-metal.md
@@ -430,8 +430,6 @@ $ bin/pulsar-client produce \
   -m "Hello Pulsar"
 ```
 
-> You may need to use a different cluster name in the topic if you specify a cluster name other than `pulsar-cluster-1`.
-
 This command publishes a single message to the Pulsar topic. In addition, you can subscribe to the Pulsar topic in a different terminal before publishing messages as below:
 
 ```bash


### PR DESCRIPTION


Fixes # 15071

### Motivation

Previous command doesn't need the cluster name for the execution of the command

### Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: ( no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

Need to update docs? 

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)
  
- [ X] `no-need-doc` 
(Please explain why)
  
- [ X] `doc` 
(Your PR contains doc changes)

- [ ] `doc-added`
(Docs have been already added)