### PR TITLE
Revert #15524: do not redeliver message when txn is not opened

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/TransactionEndToEndTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/TransactionEndToEndTest.java
@@ -1052,67 +1052,13 @@ public class TransactionEndToEndTest extends TransactionTestBase {
             Assert.assertTrue(e.getCause().getCause() instanceof TransactionCoordinatorClientException
                     .InvalidTxnStatusException);
         }
-        Message<String> message = null;
         try {
-            message = consumer.receive();
+            Message<String> message = consumer.receive();
             consumer.acknowledgeAsync(message.getMessageId(), transaction).get();
             Assert.fail();
         } catch (Exception e) {
             Assert.assertTrue(e.getCause() instanceof TransactionCoordinatorClientException
                     .InvalidTxnStatusException);
         }
-        Message<String> message1 = consumer.receive(5, TimeUnit.SECONDS);
-        Assert.assertEquals(message.getMessageId(), message1.getMessageId());
-    }
-
-    @Test
-    public void testTxnTimeRedeliverForShareSub() throws Exception{
-        String topic = NAMESPACE1 + "/testTxnTimeOutInClient";
-        @Cleanup
-        Producer<String> producer = pulsarClient.newProducer(Schema.STRING).producerName("testTxnTimeOut_producer")
-                .topic(topic).sendTimeout(0, TimeUnit.SECONDS).enableBatching(false).create();
-        @Cleanup
-        Consumer<String> consumer1 = pulsarClient.newConsumer(Schema.STRING)
-                .consumerName("testTxnTimeOut_consumer1")
-                .topic(topic)
-                .subscriptionName("testTxnTimeOut_sub1")
-                .subscriptionType(SubscriptionType.Shared)
-                .subscribe();
-
-        @Cleanup
-        Consumer<String> consumer2 = pulsarClient.newConsumer(Schema.STRING)
-                .consumerName("testTxnTimeOut_consumer2")
-                .topic(topic)
-                .subscriptionName("testTxnTimeOut_sub2")
-                .subscriptionType(SubscriptionType.Shared)
-                .subscribe();
-
-        Transaction transaction = pulsarClient.newTransaction().withTransactionTimeout(1, TimeUnit.SECONDS)
-                .build().get();
-        for (int i = 0; i < 5; i++) {
-            producer.newMessage().send();
-        }
-
-        Awaitility.await().untilAsserted(() -> {
-            Assert.assertEquals(((TransactionImpl)transaction).getState(), TransactionImpl.State.TIMEOUT);
-        });
-
-
-        Message<String> message = null;
-        try {
-            message = consumer1.receive();
-            consumer1.acknowledgeAsync(message.getMessageId(), transaction).get();
-            Assert.fail();
-        } catch (Exception e) {
-            Assert.assertTrue(e.getCause() instanceof TransactionCoordinatorClientException
-                    .InvalidTxnStatusException);
-        }
-
-        Message<String> message1 = consumer1.receive(5, TimeUnit.SECONDS);
-        Message<String> message2 = consumer2.receive(5, TimeUnit.SECONDS);
-        Assert.assertTrue(message1.getMessageId().equals(message.getMessageId())
-                && !message2.getMessageId().equals(message.getMessageId())
-                || message2.getMessageId().equals(message.getMessageId())
-                && !message1.getMessageId().equals(message.getMessageId()));
     }
 }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBase.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBase.java
@@ -571,7 +571,6 @@ public abstract class ConsumerBase<T> extends HandlerState implements Consumer<T
             txnImpl = (TransactionImpl) txn;
             CompletableFuture<Void> completableFuture = new CompletableFuture<>();
            if (!txnImpl.checkIfOpen(completableFuture)) {
-               redeliverUnacknowledgedMessages(Collections.singleton(messageId));
                return completableFuture;
            }
         }


### PR DESCRIPTION
Revert https://github.com/apache/pulsar/pull/15524

### Motivation
In the previous implementation, if the user confirmed the message with the transaction that the supermarket has timed out, an exception will be reported to the user and the message will be redeliver. But after our discussion, we think that it may be a better choice to hand over whether to resend the message to the users.
### Modification
Recover the previous implementation.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API: (yes / no)
  - The schema: (yes / no / don't know)
  - The default values of configurations: (yes / no)
  - The wire protocol: (yes / no)
  - The rest endpoints: (yes / no)
  - The admin cli options: (yes / no)
  - Anything that affects deployment: (yes / no / don't know)

### Documentation

Check the box below or label this PR directly.

Need to update docs? 

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)
  
- [x] `no-need-doc` 
(Please explain why)
  
- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-added`
(Docs have been already added)