### PR TITLE
[improve][client] Throw more meaningful derived exception instead of PulsarClientException

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
@@ -4301,8 +4301,8 @@ public class PersistentTopicsBase extends AdminResource {
                                 }).exceptionally(ex -> {
                                     Throwable throwable2 = FutureUtil.unwrapCompletionException(ex);
                                     if (throwable2 instanceof RestException) {
-                                        String errorMessage = String.format("Authorization failed %s on topic %s " +
-                                         "with error %s", clientAppId, topicName, throwable2.getMessage());
+                                        String errorMessage = String.format("Authorization failed %s on topic %s "
+                                                + "with error %s", clientAppId, topicName, throwable2.getMessage());
                                         log.warn(errorMessage);
                                         authorizationFuture.completeExceptionally(
                                                 new PulsarClientException.AuthorizationException(errorMessage));

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
@@ -4301,10 +4301,11 @@ public class PersistentTopicsBase extends AdminResource {
                                 }).exceptionally(ex -> {
                                     Throwable throwable2 = FutureUtil.unwrapCompletionException(ex);
                                     if (throwable2 instanceof RestException) {
-                                        log.warn("Failed to authorize {} on topic {}", clientAppId, topicName);
-                                        authorizationFuture.completeExceptionally(new PulsarClientException(
-                                                String.format("Authorization failed %s on topic %s with error %s",
-                                                clientAppId, topicName, throwable2.getMessage())));
+                                        String errorMessage = String.format("Authorization failed %s on topic %s " +
+                                         "with error %s", clientAppId, topicName, throwable2.getMessage());
+                                        log.warn(errorMessage);
+                                        authorizationFuture.completeExceptionally(
+                                                new PulsarClientException.AuthorizationException(errorMessage));
                                     } else {
                                         authorizationFuture.completeExceptionally(throwable2);
                                     }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/SubscriptionSeekTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/SubscriptionSeekTest.java
@@ -778,7 +778,7 @@ public class SubscriptionSeekTest extends BrokerTestBase {
             assertNull(consumer.seekAsync((topic)-> new Object()).get());
             fail("should fail");
         } catch (Exception e) {
-            assertTrue(e.getCause() instanceof PulsarClientException);
+            assertTrue(e.getCause() instanceof PulsarClientException.NotSupportedException);
             assertTrue(e.getCause().getMessage().contains("Only support seek by messageId or timestamp"));
         }
     }

--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/PulsarClientException.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/PulsarClientException.java
@@ -148,6 +148,17 @@ public class PulsarClientException extends IOException {
      */
     public static class InvalidServiceURL extends PulsarClientException {
         /**
+         * Constructs an {@code InvalidServiceURL} with the specified detail message.
+         *
+         * @param msg
+         *        The detail message (which is saved for later retrieval
+         *        by the {@link #getMessage()} method)
+         */
+        public InvalidServiceURL(String msg) {
+            super(msg);
+        }
+
+        /**
          * Constructs an {@code InvalidServiceURL} with the specified cause.
          *
          * @param t
@@ -642,6 +653,10 @@ public class PulsarClientException extends IOException {
         public NotConnectedException(long sequenceId) {
             super("Not connected to broker", sequenceId);
         }
+
+        public NotConnectedException(String msg) {
+            super(msg);
+        }
     }
 
     /**
@@ -964,11 +979,13 @@ public class PulsarClientException extends IOException {
         } else if (t instanceof ConsumerBusyException) {
             return new ConsumerBusyException(msg);
         } else if (t instanceof NotConnectedException) {
-            return new NotConnectedException();
+            return new NotConnectedException(msg);
         } else if (t instanceof InvalidMessageException) {
             return new InvalidMessageException(msg);
         } else if (t instanceof InvalidTopicNameException) {
             return new InvalidTopicNameException(msg);
+        } else if (t instanceof InvalidServiceURL) {
+            return new InvalidServiceURL(msg);
         } else if (t instanceof NotSupportedException) {
             return new NotSupportedException(msg);
         } else if (t instanceof NotAllowedException) {
@@ -1056,11 +1073,13 @@ public class PulsarClientException extends IOException {
         } else if (cause instanceof ConsumerBusyException) {
             newException = new ConsumerBusyException(msg);
         } else if (cause instanceof NotConnectedException) {
-            newException = new NotConnectedException();
+            newException = new NotConnectedException(msg);
         } else if (cause instanceof InvalidMessageException) {
             newException = new InvalidMessageException(msg);
         } else if (cause instanceof InvalidTopicNameException) {
             newException = new InvalidTopicNameException(msg);
+        } else if (cause instanceof InvalidServiceURL) {
+            newException = new InvalidServiceURL(msg);
         } else if (cause instanceof NotSupportedException) {
             newException = new NotSupportedException(msg);
         } else if (cause instanceof NotAllowedException) {

--- a/pulsar-client-auth-sasl/src/main/java/org/apache/pulsar/client/impl/auth/AuthenticationSasl.java
+++ b/pulsar-client-auth-sasl/src/main/java/org/apache/pulsar/client/impl/auth/AuthenticationSasl.java
@@ -314,8 +314,8 @@ public class AuthenticationSasl implements Authentication, EncodedAuthentication
 
                 if (response.getStatus() != HttpURLConnection.HTTP_OK) {
                     log.warn("HTTP get request failed: {}", response.getStatusInfo());
-                    authFuture.completeExceptionally(new PulsarClientException("Sasl Auth request failed: "
-                            + response.getStatus()));
+                    String errorMessage = "Sasl Auth request failed: " + response.getStatus();
+                    authFuture.completeExceptionally(new PulsarClientException.AuthenticationException(errorMessage));
                     return;
                 } else {
                     if (response.getHeaderString(SASL_AUTH_ROLE_TOKEN) != null) {

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ClientCnx.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ClientCnx.java
@@ -287,7 +287,8 @@ public class ClientCnx extends PulsarHandler {
         lastDisconnectedTimestamp = System.currentTimeMillis();
         log.info("{} Disconnected", ctx.channel());
         if (!connectionFuture.isDone()) {
-            connectionFuture.completeExceptionally(new PulsarClientException("Connection already closed"));
+            connectionFuture.completeExceptionally(
+                    new PulsarClientException.AlreadyClosedException("Connection already closed"));
         }
 
         ConnectException e = new ConnectException(

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBase.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBase.java
@@ -417,7 +417,7 @@ public abstract class ConsumerBase<T> extends HandlerState implements Consumer<T
     public void reconsumeLater(Message<?> message, Map<String, String> customProperties, long delayTime, TimeUnit unit)
             throws PulsarClientException {
         if (!conf.isRetryEnable()) {
-            throw new PulsarClientException(RECONSUME_LATER_ERROR_MSG);
+            throw new PulsarClientException.NotSupportedException(RECONSUME_LATER_ERROR_MSG);
         }
         try {
             reconsumeLaterAsync(message, customProperties, delayTime, unit).get();
@@ -525,7 +525,8 @@ public abstract class ConsumerBase<T> extends HandlerState implements Consumer<T
     public CompletableFuture<Void> reconsumeLaterAsync(
             Message<?> message, Map<String, String> customProperties, long delayTime, TimeUnit unit) {
         if (!conf.isRetryEnable()) {
-            return FutureUtil.failedFuture(new PulsarClientException(RECONSUME_LATER_ERROR_MSG));
+            return FutureUtil.failedFuture(new PulsarClientException.NotSupportedException(
+                    RECONSUME_LATER_ERROR_MSG));
         }
         try {
             validateMessageId(message);
@@ -567,7 +568,7 @@ public abstract class ConsumerBase<T> extends HandlerState implements Consumer<T
     public CompletableFuture<Void> reconsumeLaterCumulativeAsync(
             Message<?> message, Map<String, String> customProperties, long delayTime, TimeUnit unit) {
         if (!conf.isRetryEnable()) {
-            return FutureUtil.failedFuture(new PulsarClientException(RECONSUME_LATER_ERROR_MSG));
+            return FutureUtil.failedFuture(new PulsarClientException.NotSupportedException(RECONSUME_LATER_ERROR_MSG));
         }
         if (!isCumulativeAcknowledgementAllowed(conf.getSubscriptionType())) {
             return FutureUtil.failedFuture(new PulsarClientException.InvalidConfigurationException(

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
@@ -428,7 +428,7 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
             });
         } else {
             unsubscribeFuture.completeExceptionally(
-                new PulsarClientException(
+                new PulsarClientException.NotConnectedException(
                     String.format("The client is not connected to the broker when unsubscribing the "
                             + "subscription %s of the topic %s", subscription, topicName.toString())));
         }
@@ -2122,7 +2122,7 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
             return seekAsync((long) seekPosition);
         }
         return FutureUtil.failedFuture(
-                new PulsarClientException("Only support seek by messageId or timestamp"));
+                new PulsarClientException.NotSupportedException("Only support seek by messageId or timestamp"));
     }
 
     private Optional<CompletableFuture<Void>> seekAsyncCheckState(String seekBy) {
@@ -2134,7 +2134,7 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
         }
 
         if (!isConnected()) {
-            return Optional.of(FutureUtil.failedFuture(new PulsarClientException(
+            return Optional.of(FutureUtil.failedFuture(new PulsarClientException.NotConnectedException(
                     String.format("The client is not connected to the broker when seeking the subscription %s of the "
                             + "topic %s to %s", subscription, topicName.toString(), seekBy))));
         }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiTopicsConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiTopicsConsumerImpl.java
@@ -448,7 +448,7 @@ public class MultiTopicsConsumerImpl<T> extends ConsumerBase<T> {
         TopicMessageIdImpl topicMessageId = (TopicMessageIdImpl) messageId;
 
         if (getState() != State.Ready) {
-            return FutureUtil.failedFuture(new PulsarClientException("Consumer already closed"));
+            return FutureUtil.failedFuture(new PulsarClientException.AlreadyClosedException("Consumer already closed"));
         }
 
         if (ackType == AckType.Cumulative) {
@@ -480,7 +480,8 @@ public class MultiTopicsConsumerImpl<T> extends ConsumerBase<T> {
             return CompletableFuture.allOf(resultFutures.toArray(new CompletableFuture[0]));
         } else {
             if (getState() != State.Ready) {
-                return FutureUtil.failedFuture(new PulsarClientException("Consumer already closed"));
+                return FutureUtil.failedFuture(
+                        new PulsarClientException.AlreadyClosedException("Consumer already closed"));
             }
             Map<String, List<MessageId>> topicToMessageIdMap = new HashMap<>();
             for (MessageId messageId : messageIdList) {
@@ -514,7 +515,7 @@ public class MultiTopicsConsumerImpl<T> extends ConsumerBase<T> {
         checkArgument(messageId instanceof TopicMessageIdImpl);
         TopicMessageIdImpl topicMessageId = (TopicMessageIdImpl) messageId;
         if (getState() != State.Ready) {
-            return FutureUtil.failedFuture(new PulsarClientException("Consumer already closed"));
+            return FutureUtil.failedFuture(new PulsarClientException.AlreadyClosedException("Consumer already closed"));
         }
 
         if (ackType == AckType.Cumulative) {

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PulsarChannelInitializer.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PulsarChannelInitializer.java
@@ -79,8 +79,8 @@ public class PulsarChannelInitializer extends ChannelInitializer<SocketChannel> 
             if (tlsEnabledWithKeyStore) {
                 AuthenticationDataProvider authData1 = conf.getAuthentication().getAuthData();
                 if (StringUtils.isBlank(conf.getTlsTrustStorePath())) {
-                    throw new PulsarClientException("Failed to create TLS context, the tlsTrustStorePath"
-                            + " need to be configured if useKeyStoreTls enabled");
+                    throw new PulsarClientException.AuthenticationException("Failed to create TLS context, "
+                            + "the tlsTrustStorePath need to be configured if useKeyStoreTls enabled");
                 }
                 nettySSLContextAutoRefreshBuilder = new NettySSLContextAutoRefreshBuilder(
                             conf.getSslProvider(),

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/ConsumerImplTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/ConsumerImplTest.java
@@ -35,6 +35,7 @@ import java.util.concurrent.TimeUnit;
 
 import org.apache.pulsar.client.api.Consumer;
 import org.apache.pulsar.client.api.Message;
+import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.client.api.Messages;
 import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.client.api.PulsarClientException;
@@ -256,5 +257,17 @@ public class ConsumerImplTest {
         createConsumer(consumerConf);
 
         assertThat(consumer.getPriorityLevel()).isEqualTo(1);
+    }
+
+    @Test(expectedExceptions = PulsarClientException.NotConnectedException.class)
+    public void testUnsubscribeWhenDisconnected() throws PulsarClientException {
+        Assert.assertFalse(consumer.isConnected());
+        consumer.unsubscribe();
+    }
+
+    @Test(expectedExceptions = PulsarClientException.NotConnectedException.class)
+    public void testSeekWhenDisconnected() throws PulsarClientException {
+        Assert.assertFalse(consumer.isConnected());
+        consumer.seek(MessageId.latest);
     }
 }

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/MultiTopicsConsumerImplTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/MultiTopicsConsumerImplTest.java
@@ -28,7 +28,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
-import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.expectThrows;
 import static org.testng.Assert.fail;

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/MultiTopicsConsumerImplTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/MultiTopicsConsumerImplTest.java
@@ -31,6 +31,7 @@ import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.expectThrows;
+import static org.testng.Assert.fail;
 import com.google.common.collect.Sets;
 import io.netty.channel.EventLoopGroup;
 import io.netty.util.HashedWheelTimer;
@@ -258,14 +259,13 @@ public class MultiTopicsConsumerImplTest {
         ByteBuffer payload = ByteBuffer.wrap(new byte[0]);
         MessageImpl<?> msg = MessageImpl.create(new MessageMetadata(), payload, Schema.BYTES, null);
         msg.setMessageId(messageId);
-        Throwable cause1 = null;
         try {
             consumer.reconsumeLater(msg, null, 1, TimeUnit.MINUTES);
+            fail("Should failed with PulsarClientException.NotSupportedException");
+        } catch (PulsarClientException.NotSupportedException ignore) {
         } catch (PulsarClientException e) {
-            cause1 = e;
+            fail("Should failed with PulsarClientException.NotSupportedException");
         }
-        assertNotNull(cause1);
-        assertEquals(cause1.getClass(), PulsarClientException.NotSupportedException.class);
 
         CompletableFuture<Void> future2 = consumer.reconsumeLaterAsync(msg, null, 1, TimeUnit.MINUTES);
         Throwable cause2 = getExceptionallyFutureCause(future2);

--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/ContextImpl.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/ContextImpl.java
@@ -803,7 +803,7 @@ class ContextImpl implements Context, SinkContext, SourceContext, AutoCloseable 
     @VisibleForTesting
     Consumer<?> getConsumer(String topic, int partition) throws PulsarClientException {
         if (inputConsumers == null) {
-            throw new PulsarClientException("Getting consumer is not supported");
+            throw new PulsarClientException.NotSupportedException("Getting consumer is not supported");
         }
 
         Consumer<?> consumer = tryGetConsumer(topic, partition);
@@ -818,7 +818,7 @@ class ContextImpl implements Context, SinkContext, SourceContext, AutoCloseable 
         if (consumer != null) {
             return consumer;
         }
-        throw new PulsarClientException("Consumer for topic " + topic
+        throw new PulsarClientException.NotFoundException("Consumer for topic " + topic
                 + " partition " + partition + " is not found");
     }
 }

--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/InstanceUtils.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/InstanceUtils.java
@@ -177,7 +177,7 @@ public class InstanceUtils {
             clientBuilder.ioThreads(Runtime.getRuntime().availableProcessors());
             return clientBuilder;
         }
-        throw new PulsarClientException("pulsarServiceUrl cannot be null");
+        throw new PulsarClientException.InvalidServiceURL("pulsarServiceUrl cannot be null");
     }
 
     public static PulsarClient createPulsarClient(String pulsarServiceUrl, AuthenticationConfig authConfig)
@@ -210,6 +210,6 @@ public class InstanceUtils {
             }
             return pulsarAdminBuilder.build();
         }
-        throw new PulsarClientException("pulsarWebServiceUrl cannot be null");
+        throw new PulsarClientException.InvalidServiceURL("pulsarWebServiceUrl cannot be null");
     }
 }

--- a/pulsar-functions/instance/src/test/java/org/apache/pulsar/functions/instance/ContextImplTest.java
+++ b/pulsar-functions/instance/src/test/java/org/apache/pulsar/functions/instance/ContextImplTest.java
@@ -309,6 +309,14 @@ public class ContextImplTest {
                 new String[0],
                 FunctionDetails.ComponentType.FUNCTION, null, new InstanceStateManager(),
                 pulsarAdmin, clientBuilder);
+
+        try {
+            context.getConsumer("z", 1);
+            Assert.fail("Expected exception");
+        } catch (PulsarClientException.NotSupportedException e) {
+            // pass
+        }
+
         Consumer<?> mockConsumer = Mockito.mock(Consumer.class);
         when(mockConsumer.getTopic()).thenReturn(TopicName.get("z").toString());
         context.setInputConsumers(Lists.newArrayList(mockConsumer));
@@ -317,7 +325,7 @@ public class ContextImplTest {
         try {
             context.getConsumer("z", 1);
             Assert.fail("Expected exception");
-        } catch (PulsarClientException e) {
+        } catch (PulsarClientException.NotFoundException e) {
             // pass
         }
     }

--- a/pulsar-functions/instance/src/test/java/org/apache/pulsar/functions/instance/InstanceUtilsTest.java
+++ b/pulsar-functions/instance/src/test/java/org/apache/pulsar/functions/instance/InstanceUtilsTest.java
@@ -19,6 +19,7 @@
 package org.apache.pulsar.functions.instance;
 
 import static org.testng.Assert.assertEquals;
+import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.functions.proto.Function;
 import org.apache.pulsar.functions.proto.Function.FunctionDetails;
 import org.testng.annotations.Test;
@@ -76,5 +77,10 @@ public class InstanceUtilsTest {
         assertEquals(InstanceUtils.calculateSubjectType(builder.build()), FunctionDetails.ComponentType.SOURCE);
         builder.setComponentType(FunctionDetails.ComponentType.FUNCTION);
         assertEquals(InstanceUtils.calculateSubjectType(builder.build()), FunctionDetails.ComponentType.FUNCTION);
+    }
+
+    @Test(expectedExceptions = PulsarClientException.InvalidServiceURL.class)
+    public void testInvalidServiceURL() throws PulsarClientException {
+        InstanceUtils.createPulsarClient("an-invalid-pulsar-service-url", AuthenticationConfig.builder().build());
     }
 }


### PR DESCRIPTION
### Motivation

Currently we are abuse `PulsarClientException`, I think we could use a more meaningful derived exception instead. For example, call `acknowledge` on an already closed consumer throws PulsarClientException with message `Consumer already closed`, it's hard for caller to determine what kind of exception they catch.

### Modifications

It's safe to use a derived exception instead of PulsarClientException.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

Check the box below or label this PR directly.

Need to update docs? 

- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->

### Matching PR in forked repository

PR in forked repository: https://github.com/Shawyeok/pulsar/pull/3