### PR TITLE
[docs] Fix broken contributing guide link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,5 +22,5 @@
 ## Contributing to Apache Pulsar
 
 We would love for you to contribute to Apache Pulsar and make it even better!
-Please check the [Contributing to Apache Pulsar](https://pulsar.apache.org/en/contributing/) 
+Please check the [Contributing to Apache Pulsar](https://pulsar.apache.org/contributing/)
 page before starting to work on the project.


### PR DESCRIPTION
### Motivation

The current link to the contributor's guide is broken and results in a 404. Replace it with the new link.

### Modifications

* Update the `CONTRIBUTING.md` link.