### PR TITLE
[fix][broker] ensure new line added before appending new keys from env

### DIFF
--- a/docker/pulsar/scripts/apply-config-from-env-with-prefix.py
+++ b/docker/pulsar/scripts/apply-config-from-env-with-prefix.py
@@ -73,6 +73,10 @@ for conf_filename in conf_files:
             lines[idx] = '%s=%s\n' % (k, v)
 
 
+    # Ensure we have a new-line at the end of the file, to avoid issue
+    # when appending more lines to the config
+    lines.append('\n')
+
     # Add new keys from Env
     for k in sorted(os.environ.keys()):
         v = os.environ[k]


### PR DESCRIPTION
### Motivation

Copying change from `apply-config-from-env.py` to ensure new line included before appending 

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API: ( no)
  - The schema: ( no)
  - The default values of configurations: ( no)
  - The wire protocol: ( no)
  - The rest endpoints: ( no)
  - The admin cli options: ( no)
  - Anything that affects deployment: ( no )

### Documentation
Need to update docs? 

- [X] `no-need-doc` 
(Please explain why)
  