### PR TITLE
[fix][connector] KCA Sink: org.apache.kafka.connect.errors.DataException: Invalid Java object for schema with type ..

### DIFF
--- a/pulsar-io/kafka-connect-adaptor/src/test/java/org/apache/pulsar/io/kafka/connect/KafkaConnectSinkTest.java
+++ b/pulsar-io/kafka-connect-adaptor/src/test/java/org/apache/pulsar/io/kafka/connect/KafkaConnectSinkTest.java
@@ -337,8 +337,28 @@ public class KafkaConnectSinkTest extends ProducerConsumerBase  {
         assertEquals(expectedKeySchema, result.get("keySchema"));
         assertEquals(expectedSchema, result.get("valueSchema"));
 
-        SinkRecord sinkRecord = sink.toSinkRecord(record);
-        return sinkRecord;
+        if (schema.getSchemaInfo().getType().isPrimitive()) {
+            // to test cast of primitive values
+            Message msgOut = mock(MessageImpl.class);
+            when(msgOut.getValue()).thenReturn(getGenericRecord(result.get("value"), schema));
+            when(msgOut.getKey()).thenReturn(result.get("key").toString());
+            when(msgOut.hasKey()).thenReturn(true);
+            when(msgOut.getMessageId()).thenReturn(new MessageIdImpl(1, 0, 0));
+
+            Record<GenericObject> recordOut = PulsarRecord.<String>builder()
+                    .topicName("fake-topic")
+                    .message(msgOut)
+                    .schema(schema)
+                    .ackFunction(status::incrementAndGet)
+                    .failFunction(status::decrementAndGet)
+                    .build();
+
+            SinkRecord sinkRecord = sink.toSinkRecord(recordOut);
+            return sinkRecord;
+        } else {
+            SinkRecord sinkRecord = sink.toSinkRecord(record);
+            return sinkRecord;
+        }
     }
 
     private GenericRecord getGenericRecord(Object value, Schema schema) {
@@ -364,71 +384,135 @@ public class KafkaConnectSinkTest extends ProducerConsumerBase  {
         return rec;
     }
 
+
+    @Test
+    public void genericRecordCastTest() throws Exception {
+        props.put("kafkaConnectorSinkClass", SchemaedFileStreamSinkConnector.class.getCanonicalName());
+
+        KafkaConnectSink sink = new KafkaConnectSink();
+        sink.open(props, context);
+
+        AvroSchema<PulsarSchemaToKafkaSchemaTest.StructWithAnnotations> pulsarAvroSchema
+                = AvroSchema.of(PulsarSchemaToKafkaSchemaTest.StructWithAnnotations.class);
+
+        final GenericData.Record obj = new GenericData.Record(pulsarAvroSchema.getAvroSchema());
+        // schema type INT32
+        obj.put("field1", (byte)10);
+        // schema type STRING
+        obj.put("field2", "test");
+        // schema type INT64
+        obj.put("field3", (short)100);
+
+        final GenericRecord rec = getGenericRecord(obj, pulsarAvroSchema);
+        Message msg = mock(MessageImpl.class);
+        when(msg.getValue()).thenReturn(rec);
+        when(msg.getKey()).thenReturn("key");
+        when(msg.hasKey()).thenReturn(true);
+        when(msg.getMessageId()).thenReturn(new MessageIdImpl(1, 0, 0));
+
+        final AtomicInteger status = new AtomicInteger(0);
+        Record<GenericObject> record = PulsarRecord.<String>builder()
+                .topicName("fake-topic")
+                .message(msg)
+                .schema(pulsarAvroSchema)
+                .ackFunction(status::incrementAndGet)
+                .failFunction(status::decrementAndGet)
+                .build();
+
+        SinkRecord sinkRecord = sink.toSinkRecord(record);
+
+        Struct out = (Struct) sinkRecord.value();
+        Assert.assertEquals(out.get("field1").getClass(), Integer.class);
+        Assert.assertEquals(out.get("field2").getClass(), String.class);
+        Assert.assertEquals(out.get("field3").getClass(), Long.class);
+
+        Assert.assertEquals(out.get("field1"), 10);
+        Assert.assertEquals(out.get("field2"), "test");
+        Assert.assertEquals(out.get("field3"), 100L);
+
+        sink.close();
+    }
+
     @Test
     public void bytesRecordSchemaTest() throws Exception {
         byte[] in = "val".getBytes(StandardCharsets.US_ASCII);
         SinkRecord sinkRecord = recordSchemaTest(in, Schema.BYTES, "val", "BYTES");
-        byte[] out = (byte[]) sinkRecord.value();
-        Assert.assertEquals(out, in);
+        // test/mock writes it as string
+        Assert.assertEquals(sinkRecord.value(), "val");
     }
 
     @Test
     public void stringRecordSchemaTest() throws Exception {
         SinkRecord sinkRecord = recordSchemaTest("val", Schema.STRING, "val", "STRING");
-        String out = (String) sinkRecord.value();
-        Assert.assertEquals(out, "val");
+        Assert.assertEquals(sinkRecord.value().getClass(), String.class);
+        Assert.assertEquals(sinkRecord.value(), "val");
     }
 
     @Test
     public void booleanRecordSchemaTest() throws Exception {
         SinkRecord sinkRecord = recordSchemaTest(true, Schema.BOOL, true, "BOOLEAN");
-        boolean out = (boolean) sinkRecord.value();
-        Assert.assertEquals(out, true);
+        Assert.assertEquals(sinkRecord.value().getClass(), Boolean.class);
+        Assert.assertEquals(sinkRecord.value(), true);
     }
 
     @Test
     public void byteRecordSchemaTest() throws Exception {
         // int 1 is coming back from ObjectMapper
         SinkRecord sinkRecord = recordSchemaTest((byte)1, Schema.INT8, 1, "INT8");
-        byte out = (byte) sinkRecord.value();
-        Assert.assertEquals(out, 1);
+        Assert.assertEquals(sinkRecord.value().getClass(), Byte.class);
+        Assert.assertEquals(sinkRecord.value(), (byte)1);
     }
 
     @Test
     public void shortRecordSchemaTest() throws Exception {
         // int 1 is coming back from ObjectMapper
         SinkRecord sinkRecord = recordSchemaTest((short)1, Schema.INT16, 1, "INT16");
-        short out = (short) sinkRecord.value();
-        Assert.assertEquals(out, 1);
+        Assert.assertEquals(sinkRecord.value().getClass(), Short.class);
+        Assert.assertEquals(sinkRecord.value(), (short)1);
     }
 
     @Test
     public void integerRecordSchemaTest() throws Exception {
         SinkRecord sinkRecord = recordSchemaTest(Integer.MAX_VALUE, Schema.INT32, Integer.MAX_VALUE, "INT32");
-        int out = (int) sinkRecord.value();
-        Assert.assertEquals(out, Integer.MAX_VALUE);
+        Assert.assertEquals(sinkRecord.value().getClass(), Integer.class);
+        Assert.assertEquals(sinkRecord.value(), Integer.MAX_VALUE);
     }
 
     @Test
     public void longRecordSchemaTest() throws Exception {
         SinkRecord sinkRecord = recordSchemaTest(Long.MAX_VALUE, Schema.INT64, Long.MAX_VALUE, "INT64");
-        long out = (long) sinkRecord.value();
-        Assert.assertEquals(out, Long.MAX_VALUE);
+        Assert.assertEquals(sinkRecord.value().getClass(), Long.class);
+        Assert.assertEquals(sinkRecord.value(), Long.MAX_VALUE);
+    }
+
+    @Test
+    public void longRecordSchemaTestCast() throws Exception {
+        // int 1 is coming from ObjectMapper, expect Long (as in schema) from sinkRecord
+        SinkRecord sinkRecord = recordSchemaTest(1L, Schema.INT64, 1, "INT64");
+        Assert.assertEquals(sinkRecord.value().getClass(), Long.class);
+        Assert.assertEquals(sinkRecord.value(), 1L);
     }
 
     @Test
     public void floatRecordSchemaTest() throws Exception {
-        // 1.0d is coming back from ObjectMapper
+        // 1.0d is coming back from ObjectMapper, expect Float (as in schema) from sinkRecord
         SinkRecord sinkRecord = recordSchemaTest(1.0f, Schema.FLOAT, 1.0d, "FLOAT32");
-        float out = (float) sinkRecord.value();
-        Assert.assertEquals(out, 1.0d);
+        Assert.assertEquals(sinkRecord.value().getClass(), Float.class);
+        Assert.assertEquals(sinkRecord.value(), 1.0f);
     }
 
     @Test
     public void doubleRecordSchemaTest() throws Exception {
         SinkRecord sinkRecord = recordSchemaTest(Double.MAX_VALUE, Schema.DOUBLE, Double.MAX_VALUE, "FLOAT64");
-        double out = (double) sinkRecord.value();
-        Assert.assertEquals(out, Double.MAX_VALUE);
+        Assert.assertEquals(sinkRecord.value().getClass(), Double.class);
+        Assert.assertEquals(sinkRecord.value(), Double.MAX_VALUE);
+    }
+
+    @Test
+    public void doubleRecordSchemaTestCast() throws Exception {
+        SinkRecord sinkRecord = recordSchemaTest(1.0d, Schema.DOUBLE, 1.0d, "FLOAT64");
+        Assert.assertEquals(sinkRecord.value().getClass(), Double.class);
+        Assert.assertEquals(sinkRecord.value(), 1.0d);
     }
 
     @Test
@@ -455,9 +539,12 @@ public class KafkaConnectSinkTest extends ProducerConsumerBase  {
         SinkRecord sinkRecord = recordSchemaTest(jsonNode, jsonSchema, expected, "STRUCT");
 
         Struct out = (Struct) sinkRecord.value();
-        Assert.assertEquals((int)out.get("field1"), 10);
-        Assert.assertEquals((String)out.get("field2"), "test");
-        Assert.assertEquals((long)out.get("field3"), 100L);
+        Assert.assertEquals(out.get("field1").getClass(), Integer.class);
+        Assert.assertEquals(out.get("field1"), 10);
+        Assert.assertEquals(out.get("field2").getClass(), String.class);
+        Assert.assertEquals(out.get("field2"), "test");
+        Assert.assertEquals(out.get("field3").getClass(), Long.class);
+        Assert.assertEquals(out.get("field3"), 100L);
     }
 
     @Test
@@ -479,9 +566,9 @@ public class KafkaConnectSinkTest extends ProducerConsumerBase  {
         SinkRecord sinkRecord = recordSchemaTest(obj, pulsarAvroSchema, expected, "STRUCT");
 
         Struct out = (Struct) sinkRecord.value();
-        Assert.assertEquals((int)out.get("field1"), 10);
-        Assert.assertEquals((String)out.get("field2"), "test");
-        Assert.assertEquals((long)out.get("field3"), 100L);
+        Assert.assertEquals(out.get("field1"), 10);
+        Assert.assertEquals(out.get("field2"), "test");
+        Assert.assertEquals(out.get("field3"), 100L);
     }
 
     @Test

--- a/pulsar-io/kafka-connect-adaptor/src/test/java/org/apache/pulsar/io/kafka/connect/PulsarSchemaToKafkaSchemaTest.java
+++ b/pulsar-io/kafka-connect-adaptor/src/test/java/org/apache/pulsar/io/kafka/connect/PulsarSchemaToKafkaSchemaTest.java
@@ -29,9 +29,11 @@ import org.apache.pulsar.client.api.schema.SchemaDefinition;
 import org.apache.pulsar.client.impl.schema.AvroSchema;
 import org.apache.pulsar.client.impl.schema.JSONSchema;
 import org.apache.pulsar.client.impl.schema.KeyValueSchemaImpl;
+import org.apache.pulsar.io.kafka.connect.schema.KafkaConnectData;
 import org.apache.pulsar.io.kafka.connect.schema.PulsarSchemaToKafkaSchema;
 import org.testng.annotations.Test;
 
+import java.math.BigInteger;
 import java.util.List;
 
 import static org.testng.Assert.assertEquals;
@@ -165,6 +167,37 @@ public class PulsarSchemaToKafkaSchemaTest {
         for (String name: STRUCT_FIELDS) {
             assertEquals(kafkaSchema.field(name).name(), name);
         }
+    }
+
+    @Test
+    public void castToKafkaSchemaTest() {
+        assertEquals(Byte.class,
+                KafkaConnectData.castToKafkaSchema(100L,
+                        org.apache.kafka.connect.data.Schema.INT8_SCHEMA).getClass());
+
+        assertEquals(Short.class,
+                KafkaConnectData.castToKafkaSchema(100.0d,
+                        org.apache.kafka.connect.data.Schema.INT16_SCHEMA).getClass());
+
+        assertEquals(Integer.class,
+                KafkaConnectData.castToKafkaSchema((byte)5,
+                        org.apache.kafka.connect.data.Schema.INT32_SCHEMA).getClass());
+
+        assertEquals(Long.class,
+                KafkaConnectData.castToKafkaSchema((short)5,
+                        org.apache.kafka.connect.data.Schema.INT64_SCHEMA).getClass());
+
+        assertEquals(Float.class,
+                KafkaConnectData.castToKafkaSchema(1.0d,
+                        org.apache.kafka.connect.data.Schema.FLOAT32_SCHEMA).getClass());
+
+        assertEquals(Double.class,
+                KafkaConnectData.castToKafkaSchema(1.5f,
+                        org.apache.kafka.connect.data.Schema.FLOAT64_SCHEMA).getClass());
+
+        assertEquals(Double.class,
+                KafkaConnectData.castToKafkaSchema(new BigInteger("100"),
+                        org.apache.kafka.connect.data.Schema.FLOAT64_SCHEMA).getClass());
     }
 
     @Test


### PR DESCRIPTION
### Motivation

Kafka Connect Adaptor Sink may fail with 

```
ERROR org.apache.pulsar.io.kafka.connect.KafkaConnectSink - Error sending the record SinkRecord(sourceRecord=PulsarRecord(topicName=Optional[persistent://pexpipelinetest/connectors/cbart-pex-text.public.links], partition=0, message=Optional[org.apache.pulsar.client.impl.MessageImpl@528e9a52], schema=AUTO_CONSUME({schemaVersion=,schemaType=BYTES}{schemaVersion=\x00\x00\x00\x00\x00\x00\x00\x06,schemaType=KEY_VALUE}{schemaVersion=org.apache.pulsar.common.protocol.schema.LatestVersion@1ec80826,schemaType=KEY_VALUE}), failFunction=org.apache.pulsar.functions.source.PulsarSource$$Lambda$303/0x0000000100728040@4bcce14b, ackFunction=org.apache.pulsar.functions.source.PulsarSource$$Lambda$302/0x0000000100709c40@24de2714), value=(key = "org.apache.pulsar.client.impl.schema.generic.GenericJsonRecord@6ffabd48", value = "org.apache.pulsar.client.impl.schema.generic.GenericJsonRecord@4900f6ef"))
org.apache.kafka.connect.errors.DataException: Invalid Java object for schema with type INT64: class java.lang.Integer for field: "txId"
	at org.apache.kafka.connect.data.ConnectSchema.validateValue(ConnectSchema.java:246) ~[connect-api-2.7.2.jar:?]
	at org.apache.kafka.connect.data.Struct.put(Struct.java:216) ~[connect-api-2.7.2.jar:?]
	at org.apache.pulsar.io.kafka.connect.schema.KafkaConnectData.pulsarGenericRecordAsConnectData(KafkaConnectData.java:88) ~[pulsar-io-kafka-connect-adaptor-2.8.0.1.1.35.jar:2.8.0.1.1.35]
	at org.apache.pulsar.io.kafka.connect.schema.KafkaConnectData.getKafkaConnectData(KafkaConnectData.java:57) ~[pulsar-io-kafka-connect-adaptor-2.8.0.1.1.35.jar:2.8.0.1.1.35]
	at org.apache.pulsar.io.kafka.connect.schema.KafkaConnectData.pulsarGenericRecordAsConnectData(KafkaConnectData.java:88) ~[pulsar-io-kafka-connect-adaptor-2.8.0.1.1.35.jar:2.8.0.1.1.35]
	at org.apache.pulsar.io.kafka.connect.schema.KafkaConnectData.getKafkaConnectData(KafkaConnectData.java:57) ~[pulsar-io-kafka-connect-adaptor-2.8.0.1.1.35.jar:2.8.0.1.1.35]
	at org.apache.pulsar.io.kafka.connect.KafkaConnectSink.toSinkRecord(KafkaConnectSink.java:267) ~[pulsar-io-kafka-connect-adaptor-2.8.0.1.1.35.jar:2.8.0.1.1.35]
	at org.apache.pulsar.io.kafka.connect.KafkaConnectSink.write(KafkaConnectSink.java:112) [pulsar-io-kafka-connect-adaptor-2.8.0.1.1.35.jar:2.8.0.1.1.35]
	at org.apache.pulsar.functions.instance.JavaInstanceRunnable.sendOutputMessage(JavaInstanceRunnable.java:363) [com.datastax.oss-pulsar-functions-instance-2.8.0.1.1.42.jar:2.8.0.1.1.42]
	at org.apache.pulsar.functions.instance.JavaInstanceRunnable.handleResult(JavaInstanceRunnable.java:346) [com.datastax.oss-pulsar-functions-instance-2.8.0.1.1.42.jar:2.8.0.1.1.42]
	at org.apache.pulsar.functions.instance.JavaInstanceRunnable.run(JavaInstanceRunnable.java:295) [com.datastax.oss-pulsar-functions-instance-2.8.0.1.1.42.jar:2.8.0.1.1.42]
	at java.lang.Thread.run(Thread.java:829) [?:?]
```

Usecase:
Postgres -> debezium connector -> Pulsar -> KCA-based Sink connector

The rootcause:
* json is written with schema of int64 (Long) for field
* when read, the schema is int64 but actual value we get (genericRecord.getField()) is an Integer
* Kafka's [ConnectSchema validation](https://github.com/apache/kafka/blob/6ab4d047d563e0fe42a7c0ed6f10ddecda135595/connect/api/src/main/java/org/apache/kafka/connect/data/ConnectSchema.java#L47-L71) wants exact type (Long) and won't accept Integer/won't cast

Fixing this in KCA in case there are similar quirks in the GenericAvroRecord etc + to avoid redeployment of Pulsar when only the connector can be rebuilt + to avoid potentially breaking changes.

It is discussable whether fixing it in GenericJsonRecord/Generic<Whatever>Record is needed (not in this change). 
I haven't seen it affecting anything outside of KCA yet.
https://github.com/apache/pulsar/blob/b2678be0a97580d69da0b543a499efb3d9adbd5e/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/generic/GenericJsonRecord.java#L61-L102

As one can see, the type returned is not related to SchemaInfo, e.g. binary can be returned as a String, a number (BigInteger) as a String even if the schema type is DOUBLE, and so on.
These cases are out of the scope of this PR, here I want to address situations when e.g. a Long/INT64 is written as json but post-read it becomes Integer and fails kafka's data validation. 

### Modifications

*Describe the modifications you've done.*

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

  -  Added unit tests, modified existing tests (new test reproed the error prior to the fix)

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

NO

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API: (yes / no)
  - The schema: (yes / no / don't know)
  - The default values of configurations: (yes / no)
  - The wire protocol: (yes / no)
  - The rest endpoints: (yes / no)
  - The admin cli options: (yes / no)
  - Anything that affects deployment: (yes / no / don't know)

### Documentation

Check the box below or label this PR directly.

Need to update docs? 

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)
  
- [x] `no-need-doc` 
(Please explain why)
  
- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-added`
(Docs have been already added)