### PR TITLE
[pulsar-broker] Fix create invalid partitioned topic when allowAutoTopicCreationType=partitioned

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
@@ -2616,6 +2616,12 @@ public class BrokerService implements Closeable {
                                             && !topicName.isPartitioned()
                                             && pulsar.getBrokerService().isAllowAutoTopicCreation(topicName)
                                             && pulsar.getBrokerService().isDefaultTopicTypePartitioned(topicName)) {
+                                        if (topicName.toString().contains(TopicName.PARTITIONED_TOPIC_SUFFIX)) {
+                                            String msg = "Partitioned Topic Name should not contain '-partition-'";
+                                            future.completeExceptionally(
+                                                    new PulsarServerException.InvalidTopicNameException(msg));
+                                            return;
+                                        }
 
                                         pulsar.getBrokerService().createDefaultPartitionedTopicAsync(topicName)
                                                 .thenAccept(md -> future.complete(md))

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/utils/ClientChannelHelper.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/utils/ClientChannelHelper.java
@@ -21,6 +21,7 @@ package org.apache.pulsar.broker.service.utils;
 import java.util.Queue;
 
 import org.apache.pulsar.common.api.proto.CommandGetTopicsOfNamespaceResponse;
+import org.apache.pulsar.common.api.proto.CommandPartitionedTopicMetadataResponse;
 import org.apache.pulsar.common.protocol.PulsarDecoder;
 import org.apache.pulsar.common.api.proto.CommandAck;
 import org.apache.pulsar.common.api.proto.CommandCloseConsumer;
@@ -155,6 +156,11 @@ public class ClientChannelHelper {
         @Override
         protected void handleGetTopicsOfNamespaceSuccess(CommandGetTopicsOfNamespaceResponse response) {
             queue.offer(new CommandGetTopicsOfNamespaceResponse().copyFrom(response));
+        }
+
+        @Override
+        protected void handlePartitionResponse(CommandPartitionedTopicMetadataResponse response) {
+            queue.offer(new CommandPartitionedTopicMetadataResponse().copyFrom(response));
         }
     };
 

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ClientCnx.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ClientCnx.java
@@ -1185,6 +1185,8 @@ public class ClientCnx extends PulsarHandler {
             return new PulsarClientException.IncompatibleSchemaException(errorMsg);
         case TopicNotFound:
             return new PulsarClientException.TopicDoesNotExistException(errorMsg);
+        case InvalidTopicName:
+            return new PulsarClientException.InvalidTopicNameException(errorMsg);
         case ConsumerAssignError:
             return new PulsarClientException.ConsumerAssignException(errorMsg);
         case NotAllowedError:


### PR DESCRIPTION
### Motivation

In certain circumstance (allowAutoTopicCreation=true, allowAutoTopicCreationType=partitioned), client use default deadLetterPolicy may create invalid partitioned topic that topicName contains `-partition-`.

### Modifications

- Prevent create partitioned topic which topicName contains `-partition-` on broker side
- Use topicNameWithoutPartition in default deadLetterTopic and retryLetterTopic on client side

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change added tests and can be verified as follows:

*(example:)*
  - BrokerServiceTest#testShouldFailIfGetPartitionsForNotExistInvalidTopic

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (**yes**) It use topicNameWithoutPartition instead of original topic as part of default deadLetterTopic.
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

Check the box below or label this PR directly.

Need to update docs? 
  
- [x] `no-need-doc` 
bugfix