### PR TITLE
[cleanup][broker] Delete duplicate method definitions

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentDispatcher.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentDispatcher.java
@@ -19,35 +19,14 @@
 package org.apache.pulsar.broker.service.nonpersistent;
 
 import java.util.List;
-import java.util.concurrent.CompletableFuture;
 import org.apache.bookkeeper.mledger.Entry;
 import org.apache.bookkeeper.mledger.impl.PositionImpl;
-import org.apache.pulsar.broker.service.BrokerServiceException;
 import org.apache.pulsar.broker.service.Consumer;
 import org.apache.pulsar.broker.service.Dispatcher;
-import org.apache.pulsar.common.api.proto.CommandSubscribe.SubType;
 import org.apache.pulsar.common.stats.Rate;
 
 
 public interface NonPersistentDispatcher extends Dispatcher {
-
-    void addConsumer(Consumer consumer) throws BrokerServiceException;
-
-    void removeConsumer(Consumer consumer) throws BrokerServiceException;
-
-    boolean isConsumerConnected();
-
-    List<Consumer> getConsumers();
-
-    boolean canUnsubscribe(Consumer consumer);
-
-    CompletableFuture<Void> close();
-
-    CompletableFuture<Void> disconnectAllConsumers(boolean isResetCursor);
-
-    void reset();
-
-    SubType getType();
 
     void sendMessages(List<Entry> entries);
 


### PR DESCRIPTION
### Motivation

`NonPersistentDispatcher`'s superclass `Dispatcher` already declares exactly the same methods, so definitions of those methods are completely unnecessary.

https://github.com/apache/pulsar/blob/b6351f73481fc78d8ba13f7355194c9c51dc59c4/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentDispatcher.java#L34-L50

### Modifications

Delete these methods



Need to update docs? 

- [ ] `doc-required` 
- [x] `no-need-doc` 
- [ ] `doc` 
- [ ] `doc-added`