### PR TITLE
fix connect zookeeper slow for getHostName fail

### DIFF
--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/PulsarZooKeeperClient.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/PulsarZooKeeperClient.java
@@ -61,6 +61,7 @@ import org.apache.zookeeper.Watcher;
 import org.apache.zookeeper.Watcher.Event.EventType;
 import org.apache.zookeeper.Watcher.Event.KeeperState;
 import org.apache.zookeeper.ZooKeeper;
+import org.apache.zookeeper.client.ZKClientConfig;
 import org.apache.zookeeper.data.ACL;
 import org.apache.zookeeper.data.Stat;
 
@@ -336,7 +337,9 @@ public class PulsarZooKeeperClient extends ZooKeeper implements Watcher, AutoClo
     }
 
     protected ZooKeeper createZooKeeper() throws IOException {
-        return new ZooKeeper(connectString, sessionTimeoutMs, watcherManager, allowReadOnlyMode);
+        ZooKeeper zkClient = new ZooKeeper(connectString, sessionTimeoutMs, watcherManager, allowReadOnlyMode);
+        zkClient.getClientConfig().setProperty(ZKClientConfig.ZOOKEEPER_SERVER_PRINCIPAL, "zookeeper/" + connectString);
+        return zkClient;
     }
 
     @Override


### PR DESCRIPTION
### Motivation

I met same issue with #14578, broker cannot start due to fail to connect to zookeeper with ConnectionLoss error, and zookeeper shell can connect but cost about 20s to finish the connection. 

After some investigation, I found it's related with zk server host name resolver. 
It happens when zookeeper connection is configed with IP address in broker.conf, and there is no host name configed for the IP address.
in zookeeper client, it will call `InetSocketAddress.getHostName()` when connecting to server and block for 20s in this condition. https://github.com/apache/zookeeper/blob/c94473d2a18b718495225c3497693b58591cd209/zookeeper-server/src/main/java/org/apache/zookeeper/SaslServerPrincipal.java#L59

Maybe it will cause broker got `ConnectionLoss` error.

### Modifications

add Server Principal setting when create zookeeper client to avoid call `InetSocketAddress.getHostName()` 

### Documentation

- [x] `no-need-doc` 
