### PR TITLE
[improve][pulsar-functions] Make Pulsar Admin Client accessible in source and sink functions

### DIFF
--- a/pulsar-functions/api-java/src/main/java/org/apache/pulsar/functions/api/BaseContext.java
+++ b/pulsar-functions/api-java/src/main/java/org/apache/pulsar/functions/api/BaseContext.java
@@ -20,6 +20,7 @@ package org.apache.pulsar.functions.api;
 
 import java.nio.ByteBuffer;
 import java.util.concurrent.CompletableFuture;
+import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.api.ClientBuilder;
 import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.common.classification.InterfaceAudience;
@@ -216,5 +217,12 @@ public interface BaseContext {
     default ClientBuilder getPulsarClientBuilder() {
         throw new UnsupportedOperationException("not implemented");
     }
+
+    /**
+     * Get the pulsar admin client.
+     *
+     * @return The instance of pulsar admin client
+     */
+    PulsarAdmin getPulsarAdmin();
 
 }

--- a/pulsar-functions/api-java/src/main/java/org/apache/pulsar/functions/api/Context.java
+++ b/pulsar-functions/api-java/src/main/java/org/apache/pulsar/functions/api/Context.java
@@ -22,7 +22,6 @@ import java.util.Collection;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
-import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.api.ConsumerBuilder;
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.api.Schema;
@@ -111,13 +110,6 @@ public interface Context extends BaseContext {
      * @return Either the user config value associated with a given key or a supplied default value
      */
     Object getUserConfigValueOrDefault(String key, Object defaultValue);
-
-    /**
-     * Get the pulsar admin client.
-     *
-     * @return The instance of pulsar admin client
-     */
-    PulsarAdmin getPulsarAdmin();
 
     /**
      * Publish an object using serDe or schema class for serializing to the topic.

--- a/pulsar-io/common/src/test/java/org/apache/pulsar/io/common/IOConfigUtilsTest.java
+++ b/pulsar-io/common/src/test/java/org/apache/pulsar/io/common/IOConfigUtilsTest.java
@@ -21,6 +21,7 @@ package org.apache.pulsar.io.common;
 import lombok.Data;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.client.api.ConsumerBuilder;
+import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.api.Schema;
@@ -210,6 +211,11 @@ public class IOConfigUtilsTest {
         public PulsarClient getPulsarClient() {
             return null;
         }
+
+        @Override
+        public PulsarAdmin getPulsarAdmin() {
+            return null;
+        }
     }
 
     @Test
@@ -366,6 +372,11 @@ public class IOConfigUtilsTest {
 
         @Override
         public PulsarClient getPulsarClient() {
+            return null;
+        }
+
+        @Override
+        public PulsarAdmin getPulsarAdmin() {
             return null;
         }
     }

--- a/pulsar-io/kafka/src/test/java/org/apache/pulsar/io/kafka/sink/KafkaAbstractSinkTest.java
+++ b/pulsar-io/kafka/src/test/java/org/apache/pulsar/io/kafka/sink/KafkaAbstractSinkTest.java
@@ -22,6 +22,7 @@ package org.apache.pulsar.io.kafka.sink;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.security.auth.SecurityProtocol;
+import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.common.io.SinkConfig;
 import org.apache.pulsar.functions.api.Record;
@@ -178,6 +179,11 @@ public class KafkaAbstractSinkTest {
 
             @Override
             public PulsarClient getPulsarClient() {
+                return null;
+            }
+
+            @Override
+            public PulsarAdmin getPulsarAdmin() {
                 return null;
             }
         };


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://docs.google.com/document/d/1d8Pw6ZbWk-_pCKdOmdvx9rnhPiyuxwq60_TrD68d7BA/edit#heading=h.trs9rsex3xom)*. 

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.

**(The sections below can be removed for hotfixes of typos)**
-->
### Motivation
Currently Pulsar functions using `Context` have access to PulsarAdmin client instance. By moving the `getPulsarAdmin` method from `Context` to the parent interface `BaseContext` we can provide the same access to source and sink functions as well. This would provide sources and sinks access to topic stats in order for them to make decisions with regards to scale and load handling, throttling, etc.

### Modifications

The `getPulsarAdmin` method from `Context` to the parent interface `BaseContext`.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change is already covered by existing tests, such as `ContextImplTest`.

### Does this pull request potentially affect one of the following parts:
  - Dependencies (does it add or upgrade a dependency): no
  - The public API: no
  - The schema: no
  - The default values of configurations: no
  - The wire protocol: no
  - The rest endpoints: no
  - The admin cli options: no
  - Anything that affects deployment: no

### Documentation

Check the box below or label this PR directly.

Need to update docs? 

- [x] `no-need-doc` 
The method already has Javadoc