### PR TITLE
[Broker] Fix logging in shutdown when broker shutdown

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/PulsarBrokerStarter.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/PulsarBrokerStarter.java
@@ -338,6 +338,8 @@ public class PulsarBrokerStarter {
                     starter.shutdown();
                 } catch (Throwable t) {
                     log.error("Error while shutting down Pulsar service", t);
+                } finally {
+                    LogManager.shutdown();
                 }
             }, "pulsar-service-shutdown")
         );

--- a/pulsar-broker/src/main/java/org/apache/pulsar/PulsarStandaloneStarter.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/PulsarStandaloneStarter.java
@@ -123,10 +123,10 @@ public class PulsarStandaloneStarter extends PulsarStandalone {
                 if (bkEnsemble != null) {
                     bkEnsemble.stop();
                 }
-
-                LogManager.shutdown();
             } catch (Exception e) {
                 log.error("Shutdown failed: {}", e.getMessage(), e);
+            } finally {
+                LogManager.shutdown();
             }
         }));
     }


### PR DESCRIPTION
Fixes #15625

### Motivation
There's an issue  reported about problems in broker shutdown. This PR will help print log fully when we shut down broker;

After this PR fixed, the broker shutdown log printed as follow:
![image](https://user-images.githubusercontent.com/84127069/168623650-c9d594ec-2695-4ed6-b4be-3a03d10c543b.png)


### Modifications
We have set `log4j.shutdownHookEnabled=false`, so we need add finally `LogManager.shutdown()` invoke in `PulsarBrokerStarter` and `PulsarStandaloneStarter` Runtime ShutdownHook.


### Documentation
- [X] `no-need-doc` 