### PR TITLE
[fix][managed-ledger] fix calculation in getNumberOfEntriesInStorage

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
@@ -965,7 +965,7 @@ public class ManagedCursorImpl implements ManagedCursor {
     }
 
     public long getNumberOfEntriesInStorage() {
-        return ledger.getNumberOfEntries(Range.openClosed(markDeletePosition, ledger.getLastPosition().getNext()));
+        return ledger.getNumberOfEntries(Range.openClosed(markDeletePosition, ledger.getLastPosition()));
     }
 
     @Override


### PR DESCRIPTION
### Motivation
The number of entries in storage is between `markDeletePosition` and `lastConfirmedEntry`, which the markDeletePosition is excluded, and the `lastConfirmedEntry` in included.
The current algorithm yields 1 more because `ledger.getLastPosition().getNext()` is included.

### Modifications
The right way is to make the algorithm not include `ledger.getLastPosition().getNext()`.

### Verifying this change

- [x]  Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.
### Does this pull request potentially affect one of the following parts:

If `yes` was chosen, please highlight the changes

- Dependencies (does it add or upgrade a dependency): (no)
- The public API: (no)
- The schema: (no)
- The default values of configurations: (no)
- The wire protocol: (no)
- The rest endpoints: (no)
- The admin cli options: (no)
- Anything that affects deployment: (no)

### Documentation
Check the box below and label this PR (if you have committer privilege).

Need to update docs? 
- [x] `no-need-doc` 
