### PR TITLE
[broker] Make ServiceConfiguration#brokerInterceptors configure dynamic

### DIFF
--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -1201,6 +1201,7 @@ public class ServiceConfiguration implements PulsarConfiguration {
     private String brokerInterceptorsDirectory = "./interceptors";
 
     @FieldContext(
+            dynamic = true,
             category = CATEGORY_SERVER,
             doc = "List of broker interceptor to load, which is a list of broker interceptor names"
     )

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/intercept/BrokerInterceptorDelegator.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/intercept/BrokerInterceptorDelegator.java
@@ -1,0 +1,131 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.intercept;
+
+import io.netty.buffer.ByteBuf;
+import org.apache.bookkeeper.mledger.Entry;
+import org.apache.pulsar.broker.PulsarService;
+import org.apache.pulsar.broker.service.*;
+import org.apache.pulsar.common.api.proto.BaseCommand;
+import org.apache.pulsar.common.api.proto.CommandAck;
+import org.apache.pulsar.common.api.proto.MessageMetadata;
+import org.apache.pulsar.common.intercept.InterceptException;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import java.io.IOException;
+import java.util.Map;
+
+public class BrokerInterceptorDelegator implements BrokerInterceptor {
+
+    private final BrokerInterceptor interceptor;
+
+    BrokerInterceptorDelegator(BrokerInterceptor interceptor) {
+        if (null == interceptor)
+            throw new IllegalArgumentException("Argument [interceptor] is required");
+
+        this.interceptor = interceptor;
+    }
+
+    public static BrokerInterceptor create(BrokerInterceptor interceptor) {
+        return new BrokerInterceptorDelegator(interceptor);
+    }
+
+    @Override
+    public void beforeSendMessage(Subscription subscription, Entry entry, long[] ackSet, MessageMetadata msgMetadata) {
+        this.interceptor.beforeSendMessage(subscription, entry, ackSet, msgMetadata);
+    }
+
+    @Override
+    public void onConnectionCreated(ServerCnx cnx) {
+        this.interceptor.onConnectionCreated(cnx);
+    }
+
+    @Override
+    public void producerCreated(ServerCnx cnx, Producer producer, Map<String, String> metadata) {
+        this.interceptor.producerCreated(cnx, producer, metadata);
+    }
+
+    @Override
+    public void consumerCreated(ServerCnx cnx, Consumer consumer, Map<String, String> metadata) {
+        this.interceptor.consumerCreated(cnx, consumer, metadata);
+    }
+
+    @Override
+    public void messageProduced(ServerCnx cnx, Producer producer, long startTimeNs, long ledgerId, long entryId, Topic.PublishContext publishContext) {
+        this.interceptor.messageProduced(cnx, producer, startTimeNs, ledgerId, entryId, publishContext);
+    }
+
+    @Override
+    public void messageDispatched(ServerCnx cnx, Consumer consumer, long ledgerId, long entryId, ByteBuf headersAndPayload) {
+        this.interceptor.messageDispatched(cnx, consumer, ledgerId, entryId, headersAndPayload);
+    }
+
+    @Override
+    public void messageAcked(ServerCnx cnx, Consumer consumer, CommandAck ackCmd) {
+        this.interceptor.messageAcked(cnx, consumer, ackCmd);
+    }
+
+    @Override
+    public void txnOpened(long tcId, String txnID) {
+        this.interceptor.txnOpened(tcId, txnID);
+    }
+
+    @Override
+    public void txnEnded(String txnID, long txnAction) {
+        this.interceptor.txnEnded(txnID, txnAction);
+    }
+
+    @Override
+    public void onPulsarCommand(BaseCommand command, ServerCnx cnx) throws InterceptException {
+        this.interceptor.onPulsarCommand(command, cnx);
+    }
+
+    @Override
+    public void onConnectionClosed(ServerCnx cnx) {
+        this.interceptor.onConnectionClosed(cnx);
+    }
+
+    @Override
+    public void onWebserviceRequest(ServletRequest request) throws IOException, ServletException, InterceptException {
+        this.interceptor.onWebserviceRequest(request);
+    }
+
+    @Override
+    public void onWebserviceResponse(ServletRequest request, ServletResponse response) throws IOException, ServletException {
+        this.interceptor.onWebserviceResponse(request, response);
+    }
+
+    @Override
+    public void onFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
+        this.interceptor.onFilter(request, response, chain);
+    }
+
+    @Override
+    public void initialize(PulsarService pulsarService) throws Exception {
+        this.interceptor.initialize(pulsarService);
+    }
+
+    @Override
+    public void close() {
+        this.interceptor.close();
+    }
+}

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/intercept/BrokerInterceptorDelegator.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/intercept/BrokerInterceptorDelegator.java
@@ -21,7 +21,11 @@ package org.apache.pulsar.broker.intercept;
 import io.netty.buffer.ByteBuf;
 import org.apache.bookkeeper.mledger.Entry;
 import org.apache.pulsar.broker.PulsarService;
-import org.apache.pulsar.broker.service.*;
+import org.apache.pulsar.broker.service.Consumer;
+import org.apache.pulsar.broker.service.Producer;
+import org.apache.pulsar.broker.service.ServerCnx;
+import org.apache.pulsar.broker.service.Subscription;
+import org.apache.pulsar.broker.service.Topic;
 import org.apache.pulsar.common.api.proto.BaseCommand;
 import org.apache.pulsar.common.api.proto.CommandAck;
 import org.apache.pulsar.common.api.proto.MessageMetadata;
@@ -36,7 +40,7 @@ import java.util.Map;
 
 public class BrokerInterceptorDelegator implements BrokerInterceptor {
 
-    private final BrokerInterceptor interceptor;
+    private volatile BrokerInterceptor interceptor;
 
     BrokerInterceptorDelegator(BrokerInterceptor interceptor) {
         if (null == interceptor)
@@ -127,5 +131,14 @@ public class BrokerInterceptorDelegator implements BrokerInterceptor {
     @Override
     public void close() {
         this.interceptor.close();
+    }
+
+
+    public void updateBrokerInterceptor(BrokerInterceptor interceptor) {
+        this.interceptor = interceptor;
+    }
+
+    public BrokerInterceptor getBrokerInterceptor() {
+        return this.interceptor;
     }
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
@@ -2285,6 +2285,10 @@ public class BrokerService implements Closeable {
         // add listener to notify topic subscriptionTypesEnabled changed.
         registerConfigurationListener("subscriptionTypesEnabled", this::updateBrokerSubscriptionTypesEnabled);
 
+        //add listener to notify pulsarservice update broker-interceptors
+        registerConfigurationListener("interceptors",
+                interceptors -> this.pulsar().updateBrokerInterceptor(interceptors));
+
         // add more listeners here
     }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/ProcessHandlerFilter.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/ProcessHandlerFilter.java
@@ -28,21 +28,23 @@ import javax.servlet.ServletResponse;
 import javax.ws.rs.core.MediaType;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.pulsar.broker.PulsarService;
+import org.apache.pulsar.broker.ServiceConfiguration;
 import org.apache.pulsar.broker.intercept.BrokerInterceptor;
 
 public class ProcessHandlerFilter implements Filter {
 
     private final BrokerInterceptor interceptor;
-    private final boolean interceptorEnabled;
+    private final ServiceConfiguration configuration;
 
     public ProcessHandlerFilter(PulsarService pulsar) {
         this.interceptor = pulsar.getBrokerInterceptor();
-        this.interceptorEnabled = !pulsar.getConfig().getBrokerInterceptors().isEmpty();
+        this.configuration = pulsar.getConfiguration();
     }
 
     @Override
     public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
             throws IOException, ServletException {
+        boolean interceptorEnabled = !this.configuration.getBrokerInterceptors().isEmpty();
         if (interceptorEnabled
                 && !StringUtils.containsIgnoreCase(request.getContentType(), MediaType.MULTIPART_FORM_DATA)
                 && !StringUtils.containsIgnoreCase(request.getContentType(), MediaType.APPLICATION_OCTET_STREAM)) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/ResponseHandlerFilter.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/ResponseHandlerFilter.java
@@ -33,6 +33,7 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response.Status;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.pulsar.broker.PulsarService;
+import org.apache.pulsar.broker.ServiceConfiguration;
 import org.apache.pulsar.broker.intercept.BrokerInterceptor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -46,12 +47,12 @@ public class ResponseHandlerFilter implements Filter {
 
     private final String brokerAddress;
     private final BrokerInterceptor interceptor;
-    private final boolean interceptorEnabled;
+    private final ServiceConfiguration configuration;
 
     public ResponseHandlerFilter(PulsarService pulsar) {
         this.brokerAddress = pulsar.getAdvertisedAddress();
         this.interceptor = pulsar.getBrokerInterceptor();
-        this.interceptorEnabled = !pulsar.getConfig().getBrokerInterceptors().isEmpty();
+        this.configuration = pulsar.getConfiguration();
     }
 
     @Override
@@ -104,6 +105,7 @@ public class ResponseHandlerFilter implements Filter {
     }
 
     private void handleInterceptor(ServletRequest request, ServletResponse response) {
+        boolean interceptorEnabled = !this.configuration.getBrokerInterceptors().isEmpty();
         if (interceptorEnabled
                 && !StringUtils.containsIgnoreCase(request.getContentType(), MediaType.MULTIPART_FORM_DATA)
                 && !StringUtils.containsIgnoreCase(request.getContentType(), MediaType.APPLICATION_OCTET_STREAM)) {


### PR DESCRIPTION
### Motivation

Make ServiceConfiguration#brokerInterceptors configure dynamic, so that we can config broker interceptors by dynamic config api and without broker restart. 

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

Check the box below or label this PR directly.

Need to update docs? 

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)
  
- [x] `no-need-doc` 
(Please explain why)
  
- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-added`
(Docs have been already added)