### PR TITLE
Upgrade Netty to 4.1.77.Final and netty-tcnative to 2.0.52.Final

### DIFF
--- a/buildtools/pom.xml
+++ b/buildtools/pom.xml
@@ -138,7 +138,7 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-common</artifactId>
-      <version>4.1.76.Final</version>
+      <version>4.1.77.Final</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -352,31 +352,31 @@ The Apache Software License, Version 2.0
     - org.apache.commons-commons-compress-1.21.jar
     - org.apache.commons-commons-lang3-3.11.jar
  * Netty
-    - io.netty-netty-buffer-4.1.76.Final.jar
-    - io.netty-netty-codec-4.1.76.Final.jar
-    - io.netty-netty-codec-dns-4.1.76.Final.jar
-    - io.netty-netty-codec-http-4.1.76.Final.jar
-    - io.netty-netty-codec-http2-4.1.76.Final.jar
-    - io.netty-netty-codec-socks-4.1.76.Final.jar
-    - io.netty-netty-codec-haproxy-4.1.76.Final.jar
-    - io.netty-netty-common-4.1.76.Final.jar
-    - io.netty-netty-handler-4.1.76.Final.jar
-    - io.netty-netty-handler-proxy-4.1.76.Final.jar
-    - io.netty-netty-resolver-4.1.76.Final.jar
-    - io.netty-netty-resolver-dns-4.1.76.Final.jar
-    - io.netty-netty-transport-4.1.76.Final.jar
-    - io.netty-netty-transport-classes-epoll-4.1.76.Final.jar
-    - io.netty-netty-transport-native-epoll-4.1.76.Final-linux-x86_64.jar
-    - io.netty-netty-transport-native-epoll-4.1.76.Final.jar
-    - io.netty-netty-transport-native-unix-common-4.1.76.Final.jar
-    - io.netty-netty-transport-native-unix-common-4.1.76.Final-linux-x86_64.jar
-    - io.netty-netty-tcnative-boringssl-static-2.0.51.Final.jar
-    - io.netty-netty-tcnative-boringssl-static-2.0.51.Final-linux-aarch_64.jar
-    - io.netty-netty-tcnative-boringssl-static-2.0.51.Final-linux-x86_64.jar
-    - io.netty-netty-tcnative-boringssl-static-2.0.51.Final-osx-aarch_64.jar
-    - io.netty-netty-tcnative-boringssl-static-2.0.51.Final-osx-x86_64.jar
-    - io.netty-netty-tcnative-boringssl-static-2.0.51.Final-windows-x86_64.jar
-    - io.netty-netty-tcnative-classes-2.0.51.Final.jar
+    - io.netty-netty-buffer-4.1.77.Final.jar
+    - io.netty-netty-codec-4.1.77.Final.jar
+    - io.netty-netty-codec-dns-4.1.77.Final.jar
+    - io.netty-netty-codec-http-4.1.77.Final.jar
+    - io.netty-netty-codec-http2-4.1.77.Final.jar
+    - io.netty-netty-codec-socks-4.1.77.Final.jar
+    - io.netty-netty-codec-haproxy-4.1.77.Final.jar
+    - io.netty-netty-common-4.1.77.Final.jar
+    - io.netty-netty-handler-4.1.77.Final.jar
+    - io.netty-netty-handler-proxy-4.1.77.Final.jar
+    - io.netty-netty-resolver-4.1.77.Final.jar
+    - io.netty-netty-resolver-dns-4.1.77.Final.jar
+    - io.netty-netty-transport-4.1.77.Final.jar
+    - io.netty-netty-transport-classes-epoll-4.1.77.Final.jar
+    - io.netty-netty-transport-native-epoll-4.1.77.Final-linux-x86_64.jar
+    - io.netty-netty-transport-native-epoll-4.1.77.Final.jar
+    - io.netty-netty-transport-native-unix-common-4.1.77.Final.jar
+    - io.netty-netty-transport-native-unix-common-4.1.77.Final-linux-x86_64.jar
+    - io.netty-netty-tcnative-boringssl-static-2.0.52.Final.jar
+    - io.netty-netty-tcnative-boringssl-static-2.0.52.Final-linux-aarch_64.jar
+    - io.netty-netty-tcnative-boringssl-static-2.0.52.Final-linux-x86_64.jar
+    - io.netty-netty-tcnative-boringssl-static-2.0.52.Final-osx-aarch_64.jar
+    - io.netty-netty-tcnative-boringssl-static-2.0.52.Final-osx-x86_64.jar
+    - io.netty-netty-tcnative-boringssl-static-2.0.52.Final-windows-x86_64.jar
+    - io.netty-netty-tcnative-classes-2.0.52.Final.jar
  * Prometheus client
     - io.prometheus-simpleclient-0.5.0.jar
     - io.prometheus-simpleclient_common-0.5.0.jar

--- a/pom.xml
+++ b/pom.xml
@@ -119,8 +119,8 @@ flexible messaging model and an intuitive client API.</description>
     <snappy.version>1.1.7</snappy.version> <!-- ZooKeeper server -->
     <dropwizardmetrics.version>4.1.12.1</dropwizardmetrics.version> <!-- ZooKeeper server -->
     <curator.version>5.1.0</curator.version>
-    <netty.version>4.1.76.Final</netty.version>
-    <netty-tc-native.version>2.0.51.Final</netty-tc-native.version>
+    <netty.version>4.1.77.Final</netty.version>
+    <netty-tc-native.version>2.0.52.Final</netty-tc-native.version>
     <jetty.version>9.4.44.v20210927</jetty.version>
     <conscrypt.version>2.5.2</conscrypt.version>
     <jersey.version>2.34</jersey.version>

--- a/pulsar-sql/presto-distribution/LICENSE
+++ b/pulsar-sql/presto-distribution/LICENSE
@@ -232,31 +232,31 @@ The Apache Software License, Version 2.0
     - commons-lang3-3.11.jar
  * Netty
     - netty-3.10.6.Final.jar
-    - netty-buffer-4.1.76.Final.jar
-    - netty-codec-4.1.76.Final.jar
-    - netty-codec-dns-4.1.76.Final.jar
-    - netty-codec-http-4.1.76.Final.jar
-    - netty-codec-haproxy-4.1.76.Final.jar
-    - netty-codec-socks-4.1.76.Final.jar
-    - netty-handler-proxy-4.1.76.Final.jar
-    - netty-common-4.1.76.Final.jar
-    - netty-handler-4.1.76.Final.jar
+    - netty-buffer-4.1.77.Final.jar
+    - netty-codec-4.1.77.Final.jar
+    - netty-codec-dns-4.1.77.Final.jar
+    - netty-codec-http-4.1.77.Final.jar
+    - netty-codec-haproxy-4.1.77.Final.jar
+    - netty-codec-socks-4.1.77.Final.jar
+    - netty-handler-proxy-4.1.77.Final.jar
+    - netty-common-4.1.77.Final.jar
+    - netty-handler-4.1.77.Final.jar
     - netty-reactive-streams-2.0.4.jar
-    - netty-resolver-4.1.76.Final.jar
-    - netty-resolver-dns-4.1.76.Final.jar
-    - netty-tcnative-boringssl-static-2.0.51.Final.jar
-    - netty-tcnative-boringssl-static-2.0.51.Final-linux-aarch_64.jar
-    - netty-tcnative-boringssl-static-2.0.51.Final-linux-x86_64.jar
-    - netty-tcnative-boringssl-static-2.0.51.Final-osx-aarch_64.jar
-    - netty-tcnative-boringssl-static-2.0.51.Final-osx-x86_64.jar
-    - netty-tcnative-boringssl-static-2.0.51.Final-windows-x86_64.jar
-    - netty-tcnative-classes-2.0.51.Final.jar
-    - netty-transport-4.1.76.Final.jar
-    - netty-transport-classes-epoll-4.1.76.Final.jar
-    - netty-transport-native-epoll-4.1.76.Final-linux-x86_64.jar
-    - netty-transport-native-unix-common-4.1.76.Final.jar
-    - netty-transport-native-unix-common-4.1.76.Final-linux-x86_64.jar
-    - netty-codec-http2-4.1.76.Final.jar
+    - netty-resolver-4.1.77.Final.jar
+    - netty-resolver-dns-4.1.77.Final.jar
+    - netty-tcnative-boringssl-static-2.0.52.Final.jar
+    - netty-tcnative-boringssl-static-2.0.52.Final-linux-aarch_64.jar
+    - netty-tcnative-boringssl-static-2.0.52.Final-linux-x86_64.jar
+    - netty-tcnative-boringssl-static-2.0.52.Final-osx-aarch_64.jar
+    - netty-tcnative-boringssl-static-2.0.52.Final-osx-x86_64.jar
+    - netty-tcnative-boringssl-static-2.0.52.Final-windows-x86_64.jar
+    - netty-tcnative-classes-2.0.52.Final.jar
+    - netty-transport-4.1.77.Final.jar
+    - netty-transport-classes-epoll-4.1.77.Final.jar
+    - netty-transport-native-epoll-4.1.77.Final-linux-x86_64.jar
+    - netty-transport-native-unix-common-4.1.77.Final.jar
+    - netty-transport-native-unix-common-4.1.77.Final-linux-x86_64.jar
+    - netty-codec-http2-4.1.77.Final.jar
  * GRPC
     - grpc-api-1.45.1.jar
     - grpc-context-1.45.1.jar


### PR DESCRIPTION
### Motivation

- release notes https://netty.io/news/2022/05/06/2-1-77-Final.html
- some highlights:
  - improves Alpine / musl compatibility
    - could help issues such as #14534 #11415 #11224 #10798
  - improves shading compatibility
  - fixes a bug related to the native epoll transport and epoll_pwait2

### Modifications

Upgrade Netty to 4.1.77.Final and netty-tcnative to 2.0.52.Final