### PR TITLE
[fix][broker] Fix NPE when set `AutoTopicCreationOverride`

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/NamespacesBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/NamespacesBase.java
@@ -97,6 +97,7 @@ import org.apache.pulsar.common.policies.data.SubscribeRate;
 import org.apache.pulsar.common.policies.data.SubscriptionAuthMode;
 import org.apache.pulsar.common.policies.data.TenantOperation;
 import org.apache.pulsar.common.policies.data.TopicHashPositions;
+import org.apache.pulsar.common.policies.data.TopicType;
 import org.apache.pulsar.common.policies.data.ValidateResult;
 import org.apache.pulsar.common.policies.data.impl.AutoTopicCreationOverrideImpl;
 import org.apache.pulsar.common.policies.data.impl.DispatchRateImpl;
@@ -834,9 +835,11 @@ public abstract class NamespacesBase extends AdminResource {
                         "Invalid configuration for autoTopicCreationOverride. the detail is "
                                 + validateResult.getErrorInfo());
             }
-            if (maxPartitions > 0 && autoTopicCreationOverride.getDefaultNumPartitions() > maxPartitions) {
-                throw new RestException(Status.NOT_ACCEPTABLE,
-                        "Number of partitions should be less than or equal to " + maxPartitions);
+            if (Objects.equals(autoTopicCreationOverride.getTopicType(), TopicType.PARTITIONED.toString())) {
+                if (maxPartitions > 0 && autoTopicCreationOverride.getDefaultNumPartitions() > maxPartitions) {
+                    throw new RestException(Status.NOT_ACCEPTABLE,
+                            "Number of partitions should be less than or equal to " + maxPartitions);
+                }
             }
         }
         // Force to read the data s.t. the watch to the cache content is setup.


### PR DESCRIPTION
### Motivation

When the user wants to set the `AutoTopicCreationOverride` policy with `non-partitioned` type, the correct request body is as below. 

```json
{
    "allowAutoTopicCreation": true,
    "topicType": "non-partitioned"
}
```
On the broker side, the request body entity field `defaultNumPartitions` is `null`. the NPE will occur when the user sets config `maxNumPartitionsPerPartitionedTopic` greater than 0.

https://github.com/apache/pulsar/blob/3c60063716d3cdd561bf1e956a551a2297869fd9/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/NamespacesBase.java#L839-L842


### Modifications

- Check `maxNumPartitionsPerPartitionedTopic` just `topicType` is `partitioned`

### Verifying this change

- [x] Make sure that the change passes the CI checks.

Add a test `testAutoTopicCreationOverrideWithMaxNumPartitionsLimit` to verify this change.


### Documentation

- [x] `no-need-doc` 