### PR TITLE
Modify IllegalException to ParameterException in CmdFunctions

### DIFF
--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdFunctions.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdFunctions.java
@@ -646,7 +646,7 @@ public class CmdFunctions extends CmdBase {
             if (functionConfig.getRuntime() == FunctionConfig.Runtime.PYTHON
                     || functionConfig.getRuntime() == FunctionConfig.Runtime.JAVA){
                 if (StringUtils.isEmpty(functionConfig.getClassName())) {
-                    throw new IllegalArgumentException("No Function Classname specified");
+                    throw new ParameterException("No Function Classname specified");
                 }
             }
             if (StringUtils.isEmpty(functionConfig.getName())) {
@@ -960,7 +960,7 @@ public class CmdFunctions extends CmdBase {
         protected void validateFunctionConfigs(FunctionConfig functionConfig) {
             if (StringUtils.isEmpty(functionConfig.getClassName())) {
                 if (StringUtils.isEmpty(functionConfig.getName())) {
-                    throw new IllegalArgumentException("Function Name not provided");
+                    throw new ParameterException("Function Name not provided");
                 }
             } else if (StringUtils.isEmpty(functionConfig.getName())) {
                 org.apache.pulsar.common.functions.Utils.inferMissingFunctionName(functionConfig);


### PR DESCRIPTION
### Motivation
This PR is to modify IllegalException to ParameterException in CmdFunctions.

### Modifications

pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdFunctions.java

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API: (yes / no)
  - The schema: (yes / no / don't know)
  - The default values of configurations: (yes / no)
  - The wire protocol: (yes / no)
  - The rest endpoints: (yes / no)
  - The admin cli options: (yes / no)
  - Anything that affects deployment: (yes / no / don't know)

### Documentation



Need to update docs? 


  
- [x] `no-need-doc` 
(Please explain why)
  
