### PR TITLE
[fix][broker-common] expose configurationMetadataStore and localMetadataStore

### DIFF
--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/resources/PulsarResources.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/resources/PulsarResources.java
@@ -47,8 +47,9 @@ public class PulsarResources {
     private final BookieResources bookieResources;
     @Getter
     private final TopicResources topicResources;
-
+    @Getter
     private final Optional<MetadataStore> localMetadataStore;
+    @Getter
     private final Optional<MetadataStore> configurationMetadataStore;
 
     public PulsarResources(MetadataStore localMetadataStore, MetadataStore configurationMetadataStore) {


### PR DESCRIPTION
### Motivation

In old version, the `configurationMetadataStore` and `localMetadataStore` are exposed.

This behavior broke by [#12078](https://github.com/apache/pulsar/pull/12078/files#diff-2784063a9101df0581a149ff4129b18623c01ca4638a91e3fdd58c380e75dd2cL31).

Affected version: 2.9.x, 2.10.x

### Modifications

- expose the `configurationMetadataStore` and `localMetadataStore` in `PulsarResources`

### Documentation

Check the box below or label this PR directly.

Need to update docs? 

- [x] `no-need-doc` 
(Please explain why)