### PR TITLE
[ci] Owasp check: add branch-2.10 and fix JDK version for each branch

### DIFF
--- a/.github/workflows/ci-owasp-dependency-check.yaml
+++ b/.github/workflows/ci-owasp-dependency-check.yaml
@@ -37,6 +37,8 @@ jobs:
         include:
           - name: master
             checkout_branch: 'master'
+          - name: branch-2.10
+            checkout_branch: 'branch-2.10'
           - name: branch-2.9
             checkout_branch: 'branch-2.9'
           - name: branch-2.8
@@ -64,10 +66,18 @@ jobs:
             ${{ runner.os }}-m2-dependencies-core-modules-
 
       - name: Set up JDK 17
+        if: ${{ matrix.name != "branch-2.8" && matrix.name != "branch-2.9" && matrix.name != "branch-2.10" }}
         uses: actions/setup-java@v2
         with:
           distribution: 'temurin'
           java-version: 17
+
+      - name: Set up JDK 11
+        if: ${{ matrix.name == "branch-2.8" || matrix.name == "branch-2.9" || matrix.name == "branch-2.10" }}
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'temurin'
+          java-version: 11
 
       - name: run install by skip tests
         run: mvn -q -B -ntp clean install -DskipTests


### PR DESCRIPTION
### Motivation

Owasp check doesn't work with branch-2.9 and branch-2.8 because now it uses JDK 17. They have to run with JDK 11.
Also branch-2.10 is missing

### Modifications
- Added explicit exception in the job to use JDK 11 for branch 2.8, 2.9 and 2.10, leave master and future release branches to use JDK 17
- Add 2.10 to the matrix 
  
- [x] `no-need-doc` 
