### PR TITLE
[feature][client] Support creating a reader in the paused state

### DIFF
--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/Reader.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/Reader.java
@@ -215,4 +215,15 @@ public interface Reader<T> extends Closeable {
      * @return a future to track the completion of the seek operation
      */
     CompletableFuture<Void> seekAsync(long timestamp);
+
+    /**
+     * Stop requesting new messages from the broker until {@link #resume()} is called. Note that this might cause
+     * {@link #readNext()} to block until {@link #resume()} is called and new messages are pushed by the broker.
+     */
+    void pause();
+
+    /**
+     * Resume requesting messages from the broker.
+     */
+    void resume();
 }

--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/ReaderBuilder.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/ReaderBuilder.java
@@ -367,4 +367,15 @@ public interface ReaderBuilder<T> extends Cloneable {
      */
     ReaderBuilder<T> expireTimeOfIncompleteChunkedMessage(long duration, TimeUnit unit);
 
+    /**
+     * Start the reader in a paused state. When enabled, the reader does not immediately fetch messages when
+     * {@link #create()} is called. Instead, the reader waits to fetch messages until {@link Reader#resume()} is
+     * called.
+     * <p/>
+     * See also {@link Reader#pause()}.
+     *
+     * @default false
+     */
+    ReaderBuilder<T> startPaused(boolean paused);
+
 }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiTopicsReaderImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiTopicsReaderImpl.java
@@ -67,6 +67,7 @@ public class MultiTopicsReaderImpl<T> implements Reader<T> {
         consumerConfiguration.setReceiverQueueSize(readerConfiguration.getReceiverQueueSize());
         consumerConfiguration.setReadCompacted(readerConfiguration.isReadCompacted());
         consumerConfiguration.setPoolMessages(readerConfiguration.isPoolMessages());
+        consumerConfiguration.setStartPaused(readerConfiguration.isStartPaused());
 
         // chunking configuration
         consumerConfiguration.setMaxPendingChunkedMessage(readerConfiguration.getMaxPendingChunkedMessage());
@@ -205,6 +206,16 @@ public class MultiTopicsReaderImpl<T> implements Reader<T> {
     @Override
     public CompletableFuture<Void> seekAsync(long timestamp) {
         return multiTopicsConsumer.seekAsync(timestamp);
+    }
+
+    @Override
+    public void pause() {
+        multiTopicsConsumer.pause();
+    }
+
+    @Override
+    public void resume() {
+        multiTopicsConsumer.resume();
     }
 
     @Override

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ReaderBuilderImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ReaderBuilderImpl.java
@@ -271,4 +271,9 @@ public class ReaderBuilderImpl<T> implements ReaderBuilder<T> {
         return this;
     }
 
+    @Override
+    public ReaderBuilder<T> startPaused(boolean paused) {
+        conf.setStartPaused(paused);
+        return this;
+    }
 }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ReaderImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ReaderImpl.java
@@ -72,6 +72,7 @@ public class ReaderImpl<T> implements Reader<T> {
         consumerConfiguration.setReceiverQueueSize(readerConfiguration.getReceiverQueueSize());
         consumerConfiguration.setReadCompacted(readerConfiguration.isReadCompacted());
         consumerConfiguration.setPoolMessages(readerConfiguration.isPoolMessages());
+        consumerConfiguration.setStartPaused(readerConfiguration.isStartPaused());
 
         // chunking configuration
         consumerConfiguration.setMaxPendingChunkedMessage(readerConfiguration.getMaxPendingChunkedMessage());
@@ -243,5 +244,15 @@ public class ReaderImpl<T> implements Reader<T> {
     @Override
     public CompletableFuture<Void> seekAsync(long timestamp) {
         return consumer.seekAsync(timestamp);
+    }
+
+    @Override
+    public void pause() {
+        consumer.pause();
+    }
+
+    @Override
+    public void resume() {
+        consumer.resume();
     }
 }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ReaderConfigurationData.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ReaderConfigurationData.java
@@ -75,6 +75,8 @@ public class ReaderConfigurationData<T> implements Serializable, Cloneable {
 
     private long expireTimeOfIncompleteChunkedMessageMillis = TimeUnit.MINUTES.toMillis(1);
 
+    private boolean startPaused = false;
+
     @JsonIgnore
     public String getTopicName() {
         if (topicNames.size() > 1) {

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/ReaderImplTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/ReaderImplTest.java
@@ -77,4 +77,29 @@ public class ReaderImplTest {
         // then
         assertFalse(reader.getConsumer().hasNextPendingReceive());
     }
+
+    @Test
+    public void testReaderCreatedWhilePaused() {
+        PulsarClientImpl client = ClientTestFixtures.createPulsarClientMock(executorProvider, internalExecutor);
+        String topic = "non-persistent://tenant/ns1/my-topic";
+
+        ReaderConfigurationData<byte[]> readerConf = new ReaderConfigurationData<>();
+
+        readerConf.setStartPaused(true);
+        readerConf.setTopicName(topic);
+
+        ReaderImpl<byte[]> reader =
+                new ReaderImpl<>(client, readerConf, ClientTestFixtures.createMockedExecutorProvider(),
+                        new CompletableFuture<>(), Schema.BYTES);
+
+        assertTrue(reader.getConsumer().paused);
+
+        MultiTopicsReaderImpl<byte[]> multiTopicsReader =
+                new MultiTopicsReaderImpl<>(client, readerConf, ClientTestFixtures.createMockedExecutorProvider(),
+                        new CompletableFuture<>(), Schema.BYTES);
+
+        for (ConsumerImpl<byte[]> consumer : multiTopicsReader.getMultiTopicsConsumer().getConsumers()) {
+            assertTrue(consumer.paused);
+        }
+    }
 }

--- a/pulsar-websocket/src/test/java/org/apache/pulsar/websocket/ReaderHandlerTest.java
+++ b/pulsar-websocket/src/test/java/org/apache/pulsar/websocket/ReaderHandlerTest.java
@@ -211,6 +211,16 @@ public class ReaderHandlerTest {
         }
 
         @Override
+        public void pause() {
+
+        }
+
+        @Override
+        public void resume() {
+
+        }
+
+        @Override
         public void close() throws IOException {
 
         }


### PR DESCRIPTION

### Motivation

https://github.com/apache/pulsar/pull/11974 added support for creating a consumer in the paused state. This PR adds this support for the reader.

### Modifications

* Add new parameter `startPaused` in the ReaderBuilder and ReaderConfigurationData
* Add `pause` and `resume` support for the Reader.

### Verifying this change

This change added tests

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (yes)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

Check the box below or label this PR directly.

Need to update docs? 

- [x] `no-need-doc` 

  