### PR TITLE
[improve][client] improve exception messages in setMessageRoutingMode

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerBuilderImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerBuilderImpl.java
@@ -351,10 +351,12 @@ public class ProducerBuilderImpl<T> implements ProducerBuilder<T> {
             messageRoutingMode(MessageRoutingMode.RoundRobinPartition);
         } else if (conf.getMessageRoutingMode() == null && conf.getCustomMessageRouter() != null) {
             messageRoutingMode(MessageRoutingMode.CustomPartition);
-        } else if ((conf.getMessageRoutingMode() == MessageRoutingMode.CustomPartition
-                && conf.getCustomMessageRouter() == null)
-                || (conf.getMessageRoutingMode() != MessageRoutingMode.CustomPartition
-                && conf.getCustomMessageRouter() != null)) {
+        } else if (conf.getMessageRoutingMode() == MessageRoutingMode.CustomPartition
+                && conf.getCustomMessageRouter() == null) {
+            throw new PulsarClientException("When 'messageRoutingMode' is " + MessageRoutingMode.CustomPartition
+                + ", 'messageRouter' should be set");
+        } else if (conf.getMessageRoutingMode() != MessageRoutingMode.CustomPartition
+                && conf.getCustomMessageRouter() != null) {
             throw new PulsarClientException("When 'messageRouter' is set, 'messageRoutingMode' "
                     + "should be set as " + MessageRoutingMode.CustomPartition);
         }

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/ProducerBuilderImplTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/ProducerBuilderImplTest.java
@@ -123,6 +123,17 @@ public class ProducerBuilderImplTest {
         assertNotNull(producer);
     }
 
+    @Test(expectedExceptions = PulsarClientException.class,
+        expectedExceptionsMessageRegExp =
+            ".*When 'messageRoutingMode' is CustomPartition, 'messageRouter' should be set")
+    public void testProducerBuilderImplWhenMessageRoutingIsCustomPartitionAndMessageRouterNotSet()
+        throws PulsarClientException {
+        producerBuilderImpl = new ProducerBuilderImpl(client, Schema.BYTES);
+        producerBuilderImpl.topic(TOPIC_NAME)
+            .messageRoutingMode(MessageRoutingMode.CustomPartition)
+            .create();
+    }
+
     @Test(expectedExceptions = PulsarClientException.class)
     public void testProducerBuilderImplWhenMessageRoutingModeIsSinglePartitionAndMessageRouterIsSet()
             throws PulsarClientException {


### PR DESCRIPTION
### Motivation


 when `messageRoutingMode` is set `CustomPartition` and `messageRouter` is  not set,  the exception message is :
```
When 'messageRouter' is set, 'messageRoutingMode' should be set as CustomPartition
```
which will confuse the users

### Modifications

Correct the exceptions message

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change added tests and can be verified as follows:
  -  `org.apache.pulsar.client.impl.ProducerBuilderImplTest#testProducerBuilderImplWhenMessageRoutingIsCustomPartitionAndMessageRouterNotSet`
  


### Documentation
  
- [x] `no-need-doc` 
