### PR TITLE
[fix][doc] Remove inappropriate content caused by website migration

### DIFF
--- a/site2/website/versioned_docs/version-2.1.1-incubating/administration-geo.md
+++ b/site2/website/versioned_docs/version-2.1.1-incubating/administration-geo.md
@@ -129,23 +129,6 @@ $ bin/pulsar-admin namespaces set-clusters my-tenant/my-namespace \
 
 ```
 
-#### Enable geo-replication at topic level
-
-You can set geo-replication at topic level using the command `pulsar-admin topics set-replication-clusters`. For the latest and complete information about `Pulsar admin`, including commands, flags, descriptions, and more information, see [Pulsar admin doc](https://pulsar.apache.org/tools/pulsar-admin/).
-
-```shell
-
-$ bin/pulsar-admin topics set-replication-clusters --clusters us-west,us-east,us-cent my-tenant/my-namespace/my-topic
-
-```
-
-:::tip
-
-- You can change the replication clusters for a namespace at any time, without disruption to ongoing traffic. Replication channels are immediately set up or stopped in all clusters as soon as the configuration changes.
-- Once you create a geo-replication namespace, any topics that producers or consumers create within that namespace are replicated across clusters. Typically, each application uses the `serviceUrl` for the local cluster.
-
-:::
-
 ### Use topics with geo-replication
 
 #### Selective replication

--- a/site2/website/versioned_docs/version-2.10.0/tiered-storage-filesystem.md
+++ b/site2/website/versioned_docs/version-2.10.0/tiered-storage-filesystem.md
@@ -123,6 +123,7 @@ You can configure the filesystem offloader driver in the `broker.conf` or `stand
 <TabItem value="NFS">
 
 - **Required** configurations are as below. 
+  
   Parameter | Description | Example value
   |---|---|---
   `managedLedgerOffloadDriver` | Offloader driver name, which is case-insensitive. | filesystem

--- a/site2/website/versioned_docs/version-2.2.0/administration-geo.md
+++ b/site2/website/versioned_docs/version-2.2.0/administration-geo.md
@@ -129,23 +129,6 @@ $ bin/pulsar-admin namespaces set-clusters my-tenant/my-namespace \
 
 ```
 
-#### Enable geo-replication at topic level
-
-You can set geo-replication at topic level using the command `pulsar-admin topics set-replication-clusters`. For the latest and complete information about `Pulsar admin`, including commands, flags, descriptions, and more information, see [Pulsar admin doc](https://pulsar.apache.org/tools/pulsar-admin/).
-
-```shell
-
-$ bin/pulsar-admin topics set-replication-clusters --clusters us-west,us-east,us-cent my-tenant/my-namespace/my-topic
-
-```
-
-:::tip
-
-- You can change the replication clusters for a namespace at any time, without disruption to ongoing traffic. Replication channels are immediately set up or stopped in all clusters as soon as the configuration changes.
-- Once you create a geo-replication namespace, any topics that producers or consumers create within that namespace are replicated across clusters. Typically, each application uses the `serviceUrl` for the local cluster.
-
-:::
-
 ### Use topics with geo-replication
 
 #### Selective replication

--- a/site2/website/versioned_docs/version-2.2.1/administration-geo.md
+++ b/site2/website/versioned_docs/version-2.2.1/administration-geo.md
@@ -129,23 +129,6 @@ $ bin/pulsar-admin namespaces set-clusters my-tenant/my-namespace \
 
 ```
 
-#### Enable geo-replication at topic level
-
-You can set geo-replication at topic level using the command `pulsar-admin topics set-replication-clusters`. For the latest and complete information about `Pulsar admin`, including commands, flags, descriptions, and more information, see [Pulsar admin doc](https://pulsar.apache.org/tools/pulsar-admin/).
-
-```shell
-
-$ bin/pulsar-admin topics set-replication-clusters --clusters us-west,us-east,us-cent my-tenant/my-namespace/my-topic
-
-```
-
-:::tip
-
-- You can change the replication clusters for a namespace at any time, without disruption to ongoing traffic. Replication channels are immediately set up or stopped in all clusters as soon as the configuration changes.
-- Once you create a geo-replication namespace, any topics that producers or consumers create within that namespace are replicated across clusters. Typically, each application uses the `serviceUrl` for the local cluster.
-
-:::
-
 ### Use topics with geo-replication
 
 #### Selective replication

--- a/site2/website/versioned_docs/version-2.3.0/administration-geo.md
+++ b/site2/website/versioned_docs/version-2.3.0/administration-geo.md
@@ -129,23 +129,6 @@ $ bin/pulsar-admin namespaces set-clusters my-tenant/my-namespace \
 
 ```
 
-#### Enable geo-replication at topic level
-
-You can set geo-replication at topic level using the command `pulsar-admin topics set-replication-clusters`. For the latest and complete information about `Pulsar admin`, including commands, flags, descriptions, and more information, see [Pulsar admin doc](https://pulsar.apache.org/tools/pulsar-admin/).
-
-```shell
-
-$ bin/pulsar-admin topics set-replication-clusters --clusters us-west,us-east,us-cent my-tenant/my-namespace/my-topic
-
-```
-
-:::tip
-
-- You can change the replication clusters for a namespace at any time, without disruption to ongoing traffic. Replication channels are immediately set up or stopped in all clusters as soon as the configuration changes.
-- Once you create a geo-replication namespace, any topics that producers or consumers create within that namespace are replicated across clusters. Typically, each application uses the `serviceUrl` for the local cluster.
-
-:::
-
 ### Use topics with geo-replication
 
 #### Selective replication

--- a/site2/website/versioned_docs/version-2.3.1/administration-geo.md
+++ b/site2/website/versioned_docs/version-2.3.1/administration-geo.md
@@ -129,23 +129,6 @@ $ bin/pulsar-admin namespaces set-clusters my-tenant/my-namespace \
 
 ```
 
-#### Enable geo-replication at topic level
-
-You can set geo-replication at topic level using the command `pulsar-admin topics set-replication-clusters`. For the latest and complete information about `Pulsar admin`, including commands, flags, descriptions, and more information, see [Pulsar admin doc](https://pulsar.apache.org/tools/pulsar-admin/).
-
-```shell
-
-$ bin/pulsar-admin topics set-replication-clusters --clusters us-west,us-east,us-cent my-tenant/my-namespace/my-topic
-
-```
-
-:::tip
-
-- You can change the replication clusters for a namespace at any time, without disruption to ongoing traffic. Replication channels are immediately set up or stopped in all clusters as soon as the configuration changes.
-- Once you create a geo-replication namespace, any topics that producers or consumers create within that namespace are replicated across clusters. Typically, each application uses the `serviceUrl` for the local cluster.
-
-:::
-
 ### Use topics with geo-replication
 
 #### Selective replication

--- a/site2/website/versioned_docs/version-2.9.1/administration-geo.md
+++ b/site2/website/versioned_docs/version-2.9.1/administration-geo.md
@@ -134,23 +134,6 @@ $ bin/pulsar-admin namespaces set-clusters my-tenant/my-namespace \
 
 ```
 
-#### Enable geo-replication at topic level
-
-You can set geo-replication at topic level using the command `pulsar-admin topics set-replication-clusters`. For the latest and complete information about `Pulsar admin`, including commands, flags, descriptions, and more information, see [Pulsar admin doc](https://pulsar.apache.org/tools/pulsar-admin/).
-
-```shell
-
-$ bin/pulsar-admin topics set-replication-clusters --clusters us-west,us-east,us-cent my-tenant/my-namespace/my-topic
-
-```
-
-:::tip
-
-- You can change the replication clusters for a namespace at any time, without disruption to ongoing traffic. Replication channels are immediately set up or stopped in all clusters as soon as the configuration changes.
-- Once you create a geo-replication namespace, any topics that producers or consumers create within that namespace are replicated across clusters. Typically, each application uses the `serviceUrl` for the local cluster.
-
-:::
-
 ### Use topics with geo-replication
 
 Once you create a geo-replication namespace, any topics that producers or consumers create within that namespace is replicated across clusters. Typically, each application uses the `serviceUrl` for the local cluster.

--- a/site2/website/versioned_docs/version-2.9.2/administration-geo.md
+++ b/site2/website/versioned_docs/version-2.9.2/administration-geo.md
@@ -134,23 +134,6 @@ $ bin/pulsar-admin namespaces set-clusters my-tenant/my-namespace \
 
 ```
 
-#### Enable geo-replication at topic level
-
-You can set geo-replication at topic level using the command `pulsar-admin topics set-replication-clusters`. For the latest and complete information about `Pulsar admin`, including commands, flags, descriptions, and more information, see [Pulsar admin doc](https://pulsar.apache.org/tools/pulsar-admin/).
-
-```shell
-
-$ bin/pulsar-admin topics set-replication-clusters --clusters us-west,us-east,us-cent my-tenant/my-namespace/my-topic
-
-```
-
-:::tip
-
-- You can change the replication clusters for a namespace at any time, without disruption to ongoing traffic. Replication channels are immediately set up or stopped in all clusters as soon as the configuration changes.
-- Once you create a geo-replication namespace, any topics that producers or consumers create within that namespace are replicated across clusters. Typically, each application uses the `serviceUrl` for the local cluster.
-
-:::
-
 ### Use topics with geo-replication
 
 Once you create a geo-replication namespace, any topics that producers or consumers create within that namespace is replicated across clusters. Typically, each application uses the `serviceUrl` for the local cluster.


### PR DESCRIPTION
When fixing https://github.com/streamnative/platform-support-tickets/issues/576, I find that the doc of `explanations for setting geo-replication at topic level` is added to several doc versions during the website migration. This PR removes them. That doc is suitable for 2.10 and later versions.

![image](https://user-images.githubusercontent.com/50226895/169474236-bd5d2f1a-30c6-403b-8ed7-8003f3d70696.png)
