### PR TITLE
[fix][ci] Fix Owasp dependency check: Unexpected symbol: branch-2

### DIFF
--- a/.github/workflows/ci-owasp-dependency-check.yaml
+++ b/.github/workflows/ci-owasp-dependency-check.yaml
@@ -66,14 +66,14 @@ jobs:
             ${{ runner.os }}-m2-dependencies-core-modules-
 
       - name: Set up JDK 17
-        if: ${{ matrix.name != "branch-2.8" && matrix.name != "branch-2.9" && matrix.name != "branch-2.10" }}
+        if: ${{ matrix.name != 'branch-2.8' && matrix.name != 'branch-2.9' && matrix.name != 'branch-2.10' }}
         uses: actions/setup-java@v2
         with:
           distribution: 'temurin'
           java-version: 17
 
       - name: Set up JDK 11
-        if: ${{ matrix.name == "branch-2.8" || matrix.name == "branch-2.9" || matrix.name == "branch-2.10" }}
+        if: ${{ matrix.name == 'branch-2.8' || matrix.name == 'branch-2.9' || matrix.name == 'branch-2.10' }}
         uses: actions/setup-java@v2
         with:
           distribution: 'temurin'


### PR DESCRIPTION
### Motivation
Owasp regular checks is now failing with this error
```
Invalid workflow file
The workflow is not valid. .github/workflows/ci-owasp-dependency-check.yaml (Line: 69, Col: 13): Unexpected symbol: '"branch-2'. Located at position 16 within expression: matrix.name != "branch-2.8" && matrix.name != "branch-2.9" && matrix.name != "branch-2.10" .github/workflows/ci-owasp-dependency-check.yaml (Line: 76, Col: 13): Unexpected symbol: '"branch-2'. Located at position 16 within expression: matrix.name == "branch-2.8" || matrix.name == "branch-2.9" || matrix.name == "branch-2.10"
```
That is because single quote must be used with strings.

### Modifications

* Use single quote for strings

- [x] `no-need-doc` 
