### PR TITLE
[fix][security] Add timeout of sync methods and  avoid call sync method for AuthoriationService

### DIFF
--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authorization/AuthorizationService.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authorization/AuthorizationService.java
@@ -357,10 +357,11 @@ public class AuthorizationService {
                                         TenantOperation operation,
                                         String originalRole,
                                         String role,
-                                        AuthenticationDataSource authData) {
+                                        AuthenticationDataSource authData) throws Exception {
         try {
             return allowTenantOperationAsync(
-                    tenantName, operation, originalRole, role, authData).get();
+                    tenantName, operation, originalRole, role, authData).get(
+                            conf.getMetadataStoreOperationTimeoutSeconds(), SECONDS);
         } catch (InterruptedException e) {
             throw new RestException(e);
         } catch (ExecutionException e) {
@@ -455,10 +456,11 @@ public class AuthorizationService {
                                                  PolicyOperation operation,
                                                  String originalRole,
                                                  String role,
-                                                 AuthenticationDataSource authData) {
+                                                 AuthenticationDataSource authData) throws Exception {
         try {
             return allowNamespacePolicyOperationAsync(
-                    namespaceName, policy, operation, originalRole, role, authData).get();
+                    namespaceName, policy, operation, originalRole, role, authData).get(
+                            conf.getMetadataStoreOperationTimeoutSeconds(), SECONDS);
         } catch (InterruptedException e) {
             throw new RestException(e);
         } catch (ExecutionException e) {
@@ -516,10 +518,11 @@ public class AuthorizationService {
                                              PolicyOperation operation,
                                              String originalRole,
                                              String role,
-                                             AuthenticationDataSource authData) {
+                                             AuthenticationDataSource authData) throws Exception {
         try {
             return allowTopicPolicyOperationAsync(
-                    topicName, policy, operation, originalRole, role, authData).get();
+                    topicName, policy, operation, originalRole, role, authData).get(
+                            conf.getMetadataStoreOperationTimeoutSeconds(), SECONDS);
         } catch (InterruptedException e) {
             throw new RestException(e);
         } catch (ExecutionException e) {
@@ -596,9 +599,10 @@ public class AuthorizationService {
                                        TopicOperation operation,
                                        String originalRole,
                                        String role,
-                                       AuthenticationDataSource authData) {
+                                       AuthenticationDataSource authData) throws Exception {
         try {
-            return allowTopicOperationAsync(topicName, operation, originalRole, role, authData).get();
+            return allowTopicOperationAsync(topicName, operation, originalRole, role, authData).get(
+                    conf.getMetadataStoreOperationTimeoutSeconds(), SECONDS);
         } catch (InterruptedException e) {
             throw new RestException(e);
         } catch (ExecutionException e) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
@@ -18,7 +18,6 @@
  */
 package org.apache.pulsar.broker.admin.impl;
 
-import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.apache.pulsar.common.naming.SystemTopicNames.isTransactionCoordinatorAssign;
 import static org.apache.pulsar.common.naming.SystemTopicNames.isTransactionInternalName;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -4035,8 +4034,8 @@ public class PersistentTopicsBase extends AdminResource {
                                     return null;
                                 });
                     } else {
-                        // throw without wrapping to PulsarClientException that considers: unknown error marked as internal
-                        // server error
+                        // throw without wrapping to PulsarClientException that considers: unknown error marked as
+                        // internal server error
                         log.warn("Failed to authorize {} on topic {}", clientAppId, topicName, e);
                         authorizationFuture.completeExceptionally(e);
                     }
@@ -4055,7 +4054,8 @@ public class PersistentTopicsBase extends AdminResource {
                         log.debug("[{}] Total number of partitions for topic {} is {}", clientAppId, topicName,
                                 metadata.partitions);
                     }
-                    metadataFuture.complete(metadata);})
+                    metadataFuture.complete(metadata);
+                })
                 .exceptionally(e -> {
                     metadataFuture.completeExceptionally(e.getCause());
                     return null;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
@@ -4014,46 +4014,52 @@ public class PersistentTopicsBase extends AdminResource {
             PulsarService pulsar, String clientAppId, String originalPrincipal,
             AuthenticationDataSource authenticationData, TopicName topicName) {
         CompletableFuture<PartitionedTopicMetadata> metadataFuture = new CompletableFuture<>();
-        try {
-            // (1) authorize client
-            try {
-                checkAuthorization(pulsar, topicName, clientAppId, authenticationData);
-            } catch (RestException e) {
-                try {
-                    validateAdminAccessForTenant(pulsar,
-                            clientAppId, originalPrincipal, topicName.getTenant(), authenticationData,
-                            pulsar.getConfiguration().getMetadataStoreOperationTimeoutSeconds(), SECONDS);
-                } catch (RestException authException) {
-                    log.warn("Failed to authorize {} on topic {}", clientAppId, topicName);
-                    throw new PulsarClientException(String.format("Authorization failed %s on topic %s with error %s",
-                            clientAppId, topicName, authException.getMessage()));
-                }
-            } catch (Exception ex) {
-                // throw without wrapping to PulsarClientException that considers: unknown error marked as internal
-                // server error
-                log.warn("Failed to authorize {} on topic {}", clientAppId, topicName, ex);
-                throw ex;
-            }
+        CompletableFuture<Void> authorizationFuture = new CompletableFuture<>();
+        checkAuthorizationAsync(pulsar, topicName, clientAppId, authenticationData)
+                .thenRun(() -> authorizationFuture.complete(null))
+                .exceptionally(e -> {
+                    if (e.getCause() instanceof RestException) {
+                        validateAdminAccessForTenantAsync(pulsar,
+                                clientAppId, originalPrincipal, topicName.getTenant(), authenticationData)
+                                .thenRun(() -> {
+                                    authorizationFuture.complete(null);
+                                }).exceptionally(ex -> {
+                                    if (ex.getCause() instanceof RestException) {
+                                        log.warn("Failed to authorize {} on topic {}", clientAppId, topicName);
+                                        authorizationFuture.completeExceptionally(new PulsarClientException(
+                                                String.format("Authorization failed %s on topic %s with error %s",
+                                                clientAppId, topicName, ex.getCause().getMessage())));
+                                    } else {
+                                        authorizationFuture.completeExceptionally(e);
+                                    }
+                                    return null;
+                                });
+                    } else {
+                        // throw without wrapping to PulsarClientException that considers: unknown error marked as internal
+                        // server error
+                        log.warn("Failed to authorize {} on topic {}", clientAppId, topicName, e);
+                        authorizationFuture.completeExceptionally(e);
+                    }
+                    return null;
+                });
 
-            // validates global-namespace contains local/peer cluster: if peer/local cluster present then lookup can
-            // serve/redirect request else fail partitioned-metadata-request so, client fails while creating
-            // producer/consumer
-            checkLocalOrGetPeerReplicationCluster(pulsar, topicName.getNamespaceObject())
-                    .thenCompose(res -> pulsar.getBrokerService()
-                            .fetchPartitionedTopicMetadataCheckAllowAutoCreationAsync(topicName))
-                    .thenAccept(metadata -> {
-                        if (log.isDebugEnabled()) {
-                            log.debug("[{}] Total number of partitions for topic {} is {}", clientAppId, topicName,
-                                    metadata.partitions);
-                        }
-                        metadataFuture.complete(metadata);
-                    }).exceptionally(ex -> {
-                        metadataFuture.completeExceptionally(ex.getCause());
-                        return null;
-                    });
-        } catch (Exception ex) {
-            metadataFuture.completeExceptionally(ex);
-        }
+        // validates global-namespace contains local/peer cluster: if peer/local cluster present then lookup can
+        // serve/redirect request else fail partitioned-metadata-request so, client fails while creating
+        // producer/consumer
+        authorizationFuture.thenCompose(__ ->
+                        checkLocalOrGetPeerReplicationCluster(pulsar, topicName.getNamespaceObject()))
+                .thenCompose(res ->
+                        pulsar.getBrokerService().fetchPartitionedTopicMetadataCheckAllowAutoCreationAsync(topicName))
+                .thenAccept(metadata -> {
+                    if (log.isDebugEnabled()) {
+                        log.debug("[{}] Total number of partitions for topic {} is {}", clientAppId, topicName,
+                                metadata.partitions);
+                    }
+                    metadataFuture.complete(metadata);})
+                .exceptionally(e -> {
+                    metadataFuture.completeExceptionally(e.getCause());
+                    return null;
+                });
         return metadataFuture;
     }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
@@ -4017,13 +4017,13 @@ public class PersistentTopicsBase extends AdminResource {
         checkAuthorizationAsync(pulsar, topicName, clientAppId, authenticationData)
                 .thenRun(() -> authorizationFuture.complete(null))
                 .exceptionally(e -> {
-                    if (e.getCause() instanceof RestException) {
+                    if (FutureUtil.unwrapCompletionException(e) instanceof RestException) {
                         validateAdminAccessForTenantAsync(pulsar,
                                 clientAppId, originalPrincipal, topicName.getTenant(), authenticationData)
                                 .thenRun(() -> {
                                     authorizationFuture.complete(null);
                                 }).exceptionally(ex -> {
-                                    if (ex.getCause() instanceof RestException) {
+                                    if (FutureUtil.unwrapCompletionException(ex) instanceof RestException) {
                                         log.warn("Failed to authorize {} on topic {}", clientAppId, topicName);
                                         authorizationFuture.completeExceptionally(new PulsarClientException(
                                                 String.format("Authorization failed %s on topic %s with error %s",
@@ -4057,7 +4057,7 @@ public class PersistentTopicsBase extends AdminResource {
                     metadataFuture.complete(metadata);
                 })
                 .exceptionally(e -> {
-                    metadataFuture.completeExceptionally(e.getCause());
+                    metadataFuture.completeExceptionally(FutureUtil.unwrapCompletionException(e));
                     return null;
                 });
         return metadataFuture;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/lookup/TopicLookupBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/lookup/TopicLookupBase.java
@@ -261,7 +261,8 @@ public class TopicLookupBase extends PulsarWebResource {
                             false));
                 }).exceptionally(ex -> {
                     validationFuture.complete(
-                            newLookupErrorResponse(ServerError.MetadataError, FutureUtil.unwrapCompletionException(ex).getMessage(), requestId));
+                            newLookupErrorResponse(ServerError.MetadataError,
+                                    FutureUtil.unwrapCompletionException(ex).getMessage(), requestId));
                     return null;
                 });
             }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/lookup/TopicLookupBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/lookup/TopicLookupBase.java
@@ -227,13 +227,14 @@ public class TopicLookupBase extends PulsarWebResource {
                 checkAuthorizationAsync(pulsarService, topicName, clientAppId, authenticationData).thenRun(() ->
                                 validationFuture.complete(null))
                         .exceptionally(e -> {
-                            if (FutureUtil.unwrapCompletionException(e) instanceof RestException) {
+                            Throwable throwable = FutureUtil.unwrapCompletionException(e);
+                            if (throwable instanceof RestException) {
                                 log.warn("Failed to authorized {} on cluster {}", clientAppId, topicName);
                                 validationFuture.complete(newLookupErrorResponse(ServerError.AuthorizationError,
-                                        FutureUtil.unwrapCompletionException(e).getMessage(), requestId));
+                                        throwable.getMessage(), requestId));
                             } else {
                                 log.warn("Unknown error while authorizing {} on cluster {}", clientAppId, topicName);
-                                validationFuture.completeExceptionally(e);
+                                validationFuture.completeExceptionally(throwable);
                             }
                             return null;
                         });

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/lookup/TopicLookupBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/lookup/TopicLookupBase.java
@@ -227,10 +227,10 @@ public class TopicLookupBase extends PulsarWebResource {
                 checkAuthorizationAsync(pulsarService, topicName, clientAppId, authenticationData).thenRun(() ->
                                 validationFuture.complete(null))
                         .exceptionally(e -> {
-                            if (e.getCause() instanceof RestException) {
+                            if (FutureUtil.unwrapCompletionException(e) instanceof RestException) {
                                 log.warn("Failed to authorized {} on cluster {}", clientAppId, topicName);
                                 validationFuture.complete(newLookupErrorResponse(ServerError.AuthorizationError,
-                                        e.getCause().getMessage(), requestId));
+                                        FutureUtil.unwrapCompletionException(e).getMessage(), requestId));
                             } else {
                                 log.warn("Unknown error while authorizing {} on cluster {}", clientAppId, topicName);
                                 validationFuture.completeExceptionally(e);
@@ -260,12 +260,12 @@ public class TopicLookupBase extends PulsarWebResource {
                             false));
                 }).exceptionally(ex -> {
                     validationFuture.complete(
-                            newLookupErrorResponse(ServerError.MetadataError, ex.getCause().getMessage(), requestId));
+                            newLookupErrorResponse(ServerError.MetadataError, FutureUtil.unwrapCompletionException(ex).getMessage(), requestId));
                     return null;
                 });
             }
         }).exceptionally(ex -> {
-            validationFuture.completeExceptionally(ex.getCause());
+            validationFuture.completeExceptionally(FutureUtil.unwrapCompletionException(ex));
             return null;
         });
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/lookup/TopicLookupBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/lookup/TopicLookupBase.java
@@ -220,18 +220,19 @@ public class TopicLookupBase extends PulsarWebResource {
                             cluster);
                 }
                 validationFuture.complete(newLookupResponse(differentClusterData.getBrokerServiceUrl(),
-                        differentClusterData.getBrokerServiceUrlTls(), true, LookupType.Redirect, requestId, false));
+                        differentClusterData.getBrokerServiceUrlTls(), true, LookupType.Redirect,
+                        requestId, false));
             } else {
                 // (2) authorize client
                 checkAuthorizationAsync(pulsarService, topicName, clientAppId, authenticationData).thenRun(() ->
                                 validationFuture.complete(null))
                         .exceptionally(e -> {
                             if (e.getCause() instanceof RestException) {
-                                log.warn("Failed to authorized {} on cluster {}", clientAppId, topicName.toString());
+                                log.warn("Failed to authorized {} on cluster {}", clientAppId, topicName);
                                 validationFuture.complete(newLookupErrorResponse(ServerError.AuthorizationError,
                                         e.getCause().getMessage(), requestId));
                             } else {
-                                log.warn("Unknown error while authorizing {} on cluster {}", clientAppId, topicName.toString());
+                                log.warn("Unknown error while authorizing {} on cluster {}", clientAppId, topicName);
                                 validationFuture.completeExceptionally(e);
                             }
                             return null;
@@ -239,7 +240,8 @@ public class TopicLookupBase extends PulsarWebResource {
 
                 // (3) validate global namespace
                 validationFuture.thenCompose(__ ->
-                        checkLocalOrGetPeerReplicationCluster(pulsarService, topicName.getNamespaceObject())).thenAccept(peerClusterData -> {
+                        checkLocalOrGetPeerReplicationCluster(pulsarService,
+                                topicName.getNamespaceObject())).thenAccept(peerClusterData -> {
                     if (peerClusterData == null) {
                         // (4) all validation passed: initiate lookup
                         validationFuture.complete(null);


### PR DESCRIPTION
### Motivation

Add timeout of sync methods for the AuthoriationService to avoid infinite web thread blocking.

![image](https://user-images.githubusercontent.com/12592133/169628369-cbf84d23-7e7e-4fd2-8350-4dd1a4277e67.png)

![image](https://user-images.githubusercontent.com/12592133/169628373-0993d853-5bb2-4322-af32-c03f70b3e9cc.png)

![image](https://user-images.githubusercontent.com/12592133/169628378-7c17c68f-f522-4649-a398-e01e6adecc93.png)


### Documentation

Check the box below or label this PR directly.

Need to update docs? 
  
- [x] `no-need-doc` 
(Please explain why)