### PR TITLE
Bump snappy zstd version to fix CompressorCodecBackwardCompatTest on Apple M1

### DIFF
--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -528,7 +528,7 @@ The Apache Software License, Version 2.0
     - org.apache.zookeeper-zookeeper-jute-3.8.0.jar
     - org.apache.zookeeper-zookeeper-prometheus-metrics-3.8.0.jar
   * Snappy Java
-    - org.xerial.snappy-snappy-java-1.1.7.jar
+    - org.xerial.snappy-snappy-java-1.1.8.4.jar
   * Google HTTP Client
     - com.google.http-client-google-http-client-gson-1.41.0.jar
     - com.google.http-client-google-http-client-1.41.0.jar

--- a/pom.xml
+++ b/pom.xml
@@ -116,7 +116,7 @@ flexible messaging model and an intuitive client API.</description>
     <bookkeeper.version>4.15.0</bookkeeper.version>
     <zookeeper.version>3.8.0</zookeeper.version>
     <commons-cli.version>1.5.0</commons-cli.version>
-    <snappy.version>1.1.7</snappy.version> <!-- ZooKeeper server -->
+    <snappy.version>1.1.8.4</snappy.version> <!-- ZooKeeper server -->
     <dropwizardmetrics.version>4.1.12.1</dropwizardmetrics.version> <!-- ZooKeeper server -->
     <curator.version>5.1.0</curator.version>
     <netty.version>4.1.77.Final</netty.version>
@@ -223,7 +223,7 @@ flexible messaging model and an intuitive client API.</description>
     <ant.version>1.10.12</ant.version>
     <seancfoley.ipaddress.version>5.3.3</seancfoley.ipaddress.version>
     <disruptor.version>3.4.3</disruptor.version>
-
+    <zstd-jni.version>1.5.2-3</zstd-jni.version>
 
     <!-- test dependencies -->
     <cassandra.version>3.6.0</cassandra.version>
@@ -1282,6 +1282,12 @@ flexible messaging model and an intuitive client API.</description>
         <groupId>org.jetbrains.kotlin</groupId>
         <artifactId>kotlin-stdlib-jdk8</artifactId>
         <version>${kotlin-stdlib.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>com.github.luben</groupId>
+        <artifactId>zstd-jni</artifactId>
+        <version>${zstd-jni.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/pulsar-common/pom.xml
+++ b/pulsar-common/pom.xml
@@ -181,14 +181,12 @@
     <dependency>
       <groupId>com.github.luben</groupId>
       <artifactId>zstd-jni</artifactId>
-      <version>1.3.7-3</version>
       <scope>test</scope>
     </dependency>
 
     <dependency>
       <groupId>org.xerial.snappy</groupId>
       <artifactId>snappy-java</artifactId>
-      <version>1.1.7.5</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/pulsar-sql/presto-distribution/LICENSE
+++ b/pulsar-sql/presto-distribution/LICENSE
@@ -452,7 +452,7 @@ The Apache Software License, Version 2.0
   * GSON
     - gson-2.8.9.jar
   * Snappy
-    - snappy-java-1.1.7.jar
+    - snappy-java-1.1.8.4.jar
   * Jackson
     - jackson-module-parameter-names-2.13.2.jar
   * Java Assist


### PR DESCRIPTION
### Motivation
Make `CompressorCodecBackwardCompatTest` paas on Apple M1

### Modifications
- Bump snappy from 1.1.7 to 1.1.8.4
- Bump zstd version from 1.3.7-3 to 1.1.8.4
