### PR TITLE
[fix][doc] Fix security-oauth2 docs curl example OAuth URL

### DIFF
--- a/site2/docs/security-oauth2.md
+++ b/site2/docs/security-oauth2.md
@@ -57,7 +57,7 @@ The following shows a typical original OAuth2 request, which is used to obtain t
 ```bash
 
 curl --request POST \
-  --url https://dev-kt-aa9ne.us.auth0.com \
+  --url https://dev-kt-aa9ne.us.auth0.com/oauth/token \
   --header 'content-type: application/json' \
   --data '{
   "client_id":"Xd23RHsUnvUlP7wchjNYOaIfazgeHd9x",

--- a/site2/website/versioned_docs/version-2.10.0/security-oauth2.md
+++ b/site2/website/versioned_docs/version-2.10.0/security-oauth2.md
@@ -58,7 +58,7 @@ The following shows a typical original OAuth2 request, which is used to obtain t
 ```bash
 
 curl --request POST \
-  --url https://dev-kt-aa9ne.us.auth0.com \
+  --url https://dev-kt-aa9ne.us.auth0.com/oauth/token \
   --header 'content-type: application/json' \
   --data '{
   "client_id":"Xd23RHsUnvUlP7wchjNYOaIfazgeHd9x",

--- a/site2/website/versioned_docs/version-2.7.0/security-oauth2.md
+++ b/site2/website/versioned_docs/version-2.7.0/security-oauth2.md
@@ -54,7 +54,7 @@ The following shows a typical original OAuth2 request, which is used to obtain t
 ```bash
 
 curl --request POST \
-  --url https://dev-kt-aa9ne.us.auth0.com \
+  --url https://dev-kt-aa9ne.us.auth0.com/oauth/token \
   --header 'content-type: application/json' \
   --data '{
   "client_id":"Xd23RHsUnvUlP7wchjNYOaIfazgeHd9x",

--- a/site2/website/versioned_docs/version-2.7.1/security-oauth2.md
+++ b/site2/website/versioned_docs/version-2.7.1/security-oauth2.md
@@ -54,7 +54,7 @@ The following shows a typical original OAuth2 request, which is used to obtain t
 ```bash
 
 curl --request POST \
-  --url https://dev-kt-aa9ne.us.auth0.com \
+  --url https://dev-kt-aa9ne.us.auth0.com/oauth/token \
   --header 'content-type: application/json' \
   --data '{
   "client_id":"Xd23RHsUnvUlP7wchjNYOaIfazgeHd9x",

--- a/site2/website/versioned_docs/version-2.7.2/security-oauth2.md
+++ b/site2/website/versioned_docs/version-2.7.2/security-oauth2.md
@@ -54,7 +54,7 @@ The following shows a typical original OAuth2 request, which is used to obtain t
 ```bash
 
 curl --request POST \
-  --url https://dev-kt-aa9ne.us.auth0.com \
+  --url https://dev-kt-aa9ne.us.auth0.com/oauth/token \
   --header 'content-type: application/json' \
   --data '{
   "client_id":"Xd23RHsUnvUlP7wchjNYOaIfazgeHd9x",

--- a/site2/website/versioned_docs/version-2.7.3/security-oauth2.md
+++ b/site2/website/versioned_docs/version-2.7.3/security-oauth2.md
@@ -54,7 +54,7 @@ The following shows a typical original OAuth2 request, which is used to obtain t
 ```bash
 
 curl --request POST \
-  --url https://dev-kt-aa9ne.us.auth0.com \
+  --url https://dev-kt-aa9ne.us.auth0.com/oauth/token \
   --header 'content-type: application/json' \
   --data '{
   "client_id":"Xd23RHsUnvUlP7wchjNYOaIfazgeHd9x",

--- a/site2/website/versioned_docs/version-2.7.4/security-oauth2.md
+++ b/site2/website/versioned_docs/version-2.7.4/security-oauth2.md
@@ -54,7 +54,7 @@ The following shows a typical original OAuth2 request, which is used to obtain t
 ```bash
 
 curl --request POST \
-  --url https://dev-kt-aa9ne.us.auth0.com \
+  --url https://dev-kt-aa9ne.us.auth0.com/oauth/token \
   --header 'content-type: application/json' \
   --data '{
   "client_id":"Xd23RHsUnvUlP7wchjNYOaIfazgeHd9x",

--- a/site2/website/versioned_docs/version-2.8.0/security-oauth2.md
+++ b/site2/website/versioned_docs/version-2.8.0/security-oauth2.md
@@ -54,7 +54,7 @@ The following shows a typical original OAuth2 request, which is used to obtain t
 ```bash
 
 curl --request POST \
-  --url https://dev-kt-aa9ne.us.auth0.com \
+  --url https://dev-kt-aa9ne.us.auth0.com/oauth/token \
   --header 'content-type: application/json' \
   --data '{
   "client_id":"Xd23RHsUnvUlP7wchjNYOaIfazgeHd9x",

--- a/site2/website/versioned_docs/version-2.8.1/security-oauth2.md
+++ b/site2/website/versioned_docs/version-2.8.1/security-oauth2.md
@@ -54,7 +54,7 @@ The following shows a typical original OAuth2 request, which is used to obtain t
 ```bash
 
 curl --request POST \
-  --url https://dev-kt-aa9ne.us.auth0.com \
+  --url https://dev-kt-aa9ne.us.auth0.com/oauth/token \
   --header 'content-type: application/json' \
   --data '{
   "client_id":"Xd23RHsUnvUlP7wchjNYOaIfazgeHd9x",

--- a/site2/website/versioned_docs/version-2.8.2/security-oauth2.md
+++ b/site2/website/versioned_docs/version-2.8.2/security-oauth2.md
@@ -54,7 +54,7 @@ The following shows a typical original OAuth2 request, which is used to obtain t
 ```bash
 
 curl --request POST \
-  --url https://dev-kt-aa9ne.us.auth0.com \
+  --url https://dev-kt-aa9ne.us.auth0.com/oauth/token \
   --header 'content-type: application/json' \
   --data '{
   "client_id":"Xd23RHsUnvUlP7wchjNYOaIfazgeHd9x",

--- a/site2/website/versioned_docs/version-2.8.3/security-oauth2.md
+++ b/site2/website/versioned_docs/version-2.8.3/security-oauth2.md
@@ -54,7 +54,7 @@ The following shows a typical original OAuth2 request, which is used to obtain t
 ```bash
 
 curl --request POST \
-  --url https://dev-kt-aa9ne.us.auth0.com \
+  --url https://dev-kt-aa9ne.us.auth0.com/oauth/token \
   --header 'content-type: application/json' \
   --data '{
   "client_id":"Xd23RHsUnvUlP7wchjNYOaIfazgeHd9x",

--- a/site2/website/versioned_docs/version-2.9.0/security-oauth2.md
+++ b/site2/website/versioned_docs/version-2.9.0/security-oauth2.md
@@ -54,7 +54,7 @@ The following shows a typical original OAuth2 request, which is used to obtain t
 ```bash
 
 curl --request POST \
-  --url https://dev-kt-aa9ne.us.auth0.com \
+  --url https://dev-kt-aa9ne.us.auth0.com/oauth/token \
   --header 'content-type: application/json' \
   --data '{
   "client_id":"Xd23RHsUnvUlP7wchjNYOaIfazgeHd9x",

--- a/site2/website/versioned_docs/version-2.9.1/security-oauth2.md
+++ b/site2/website/versioned_docs/version-2.9.1/security-oauth2.md
@@ -54,7 +54,7 @@ The following shows a typical original OAuth2 request, which is used to obtain t
 ```bash
 
 curl --request POST \
-  --url https://dev-kt-aa9ne.us.auth0.com \
+  --url https://dev-kt-aa9ne.us.auth0.com/oauth/token \
   --header 'content-type: application/json' \
   --data '{
   "client_id":"Xd23RHsUnvUlP7wchjNYOaIfazgeHd9x",

--- a/site2/website/versioned_docs/version-2.9.2/security-oauth2.md
+++ b/site2/website/versioned_docs/version-2.9.2/security-oauth2.md
@@ -54,7 +54,7 @@ The following shows a typical original OAuth2 request, which is used to obtain t
 ```bash
 
 curl --request POST \
-  --url https://dev-kt-aa9ne.us.auth0.com \
+  --url https://dev-kt-aa9ne.us.auth0.com/oauth/token \
   --header 'content-type: application/json' \
   --data '{
   "client_id":"Xd23RHsUnvUlP7wchjNYOaIfazgeHd9x",


### PR DESCRIPTION
### Motivation

Currently, the oauth2 curl example doc has the wrong URL, if we use the command, we will get error code 1020.

```shell
curl --request POST \
  --url https://dev-kt-aa9ne.us.auth0.com \
  --header 'content-type: application/json' \
  --data '{
  "client_id":"Xd23RHsUnvUlP7wchjNYOaIfazgeHd9x",
  "client_secret":"rT7ps7WY8uhdVuBTKWZkttwLdQotmdEliaM5rLfmgNibvqziZ-g07ZH52N_poGAb",
  "audience":"https://dev-kt-aa9ne.us.auth0.com/api/v2/",
  "grant_type":"client_credentials"}'
error code: 1020
```

### Modifications
Fix security-oauth2 docs curl example OAuth URL

### Documentation

Check the box below or label this PR directly.

Need to update docs? 

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)
  
- [ ] `no-need-doc` 
(Please explain why)
  
- [x] `doc` 
(Your PR contains doc changes)

- [ ] `doc-added`
(Docs have been already added)