### PR TITLE
[enh] Broker: make max size of Consumer metadata configurable

### DIFF
--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -781,6 +781,10 @@ public class ServiceConfiguration implements PulsarConfiguration {
     private double maxUnackedMessagesPerSubscriptionOnBrokerBlocked = 0.16;
     @FieldContext(
             category = CATEGORY_POLICIES,
+            doc = "Maximum size of Consumer metadata")
+    private int maxConsumerMetadataSize = 1024;
+    @FieldContext(
+            category = CATEGORY_POLICIES,
             dynamic = true,
             doc = "Broker periodically checks if subscription is stuck and unblock if flag is enabled. "
                     + "(Default is disabled)"

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
@@ -992,7 +992,8 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
 
                 log.info("[{}] Subscribing on topic {} / {}", remoteAddress, topicName, subscriptionName);
                 try {
-                    Metadata.validateMetadata(metadata);
+                    Metadata.validateMetadata(metadata,
+                            service.getPulsar().getConfiguration().getMaxConsumerMetadataSize());
                 } catch (IllegalArgumentException iae) {
                     final String msg = iae.getMessage();
                     consumers.remove(consumerId, consumerFuture);

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/naming/Metadata.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/naming/Metadata.java
@@ -25,11 +25,9 @@ import java.util.Map;
  */
 public class Metadata {
 
-    private static final int MAX_METADATA_SIZE = 1024; // 1 Kb
-
     private Metadata() {}
 
-    public static void validateMetadata(Map<String, String> metadata) throws IllegalArgumentException {
+    public static void validateMetadata(Map<String, String> metadata, int maxConsumerMetadataSize) throws IllegalArgumentException {
         if (metadata == null) {
             return;
         }
@@ -37,13 +35,13 @@ public class Metadata {
         int size = 0;
         for (Map.Entry<String, String> e : metadata.entrySet()) {
             size += (e.getKey().length() + e.getValue().length());
-            if (size > MAX_METADATA_SIZE) {
-                throw new IllegalArgumentException(getErrorMessage());
+            if (size > maxConsumerMetadataSize) {
+                throw new IllegalArgumentException(getErrorMessage(maxConsumerMetadataSize));
             }
         }
     }
 
-    private static String getErrorMessage() {
-        return "metadata has a max size of 1 Kb";
+    private static String getErrorMessage(int maxConsumerMetadataSize) {
+        return "metadata has a max size of " + maxConsumerMetadataSize + " bytes";
     }
 }

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/naming/Metadata.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/naming/Metadata.java
@@ -27,7 +27,8 @@ public class Metadata {
 
     private Metadata() {}
 
-    public static void validateMetadata(Map<String, String> metadata, int maxConsumerMetadataSize) throws IllegalArgumentException {
+    public static void validateMetadata(Map<String, String> metadata,
+                                        int maxConsumerMetadataSize) throws IllegalArgumentException {
         if (metadata == null) {
             return;
         }

--- a/pulsar-common/src/test/java/org/apache/pulsar/common/naming/MetadataTests.java
+++ b/pulsar-common/src/test/java/org/apache/pulsar/common/naming/MetadataTests.java
@@ -32,21 +32,21 @@ public class MetadataTests {
         Map<String, String> metadata = new HashMap<>();
 
         metadata.put(generateKey(1, 512), generateKey(1, 512));
-        Assert.assertTrue(validateMetadata(metadata));
+        Assert.assertTrue(validateMetadata(metadata, 1024));
 
         metadata.clear();
         metadata.put(generateKey(1, 512), generateKey(1, 511));
-        Assert.assertTrue(validateMetadata(metadata));
+        Assert.assertTrue(validateMetadata(metadata, 1024));
 
         metadata.clear();
         metadata.put(generateKey(1, 256), generateKey(1, 256));
         metadata.put(generateKey(2, 256), generateKey(2, 256));
-        Assert.assertTrue(validateMetadata(metadata));
+        Assert.assertTrue(validateMetadata(metadata, 1024));
 
         metadata.clear();
         metadata.put(generateKey(1, 256), generateKey(1, 256));
         metadata.put(generateKey(2, 256), generateKey(2, 255));
-        Assert.assertTrue(validateMetadata(metadata));
+        Assert.assertTrue(validateMetadata(metadata, 1024));
     }
 
     @Test
@@ -54,24 +54,27 @@ public class MetadataTests {
         Map<String, String> metadata = new HashMap<>();
 
         metadata.put(generateKey(1, 512), generateKey(1, 513));
-        Assert.assertFalse(validateMetadata(metadata));
+        Assert.assertFalse(validateMetadata(metadata, 1024));
 
         metadata.clear();
         metadata.put(generateKey(1, 256), generateKey(1, 256));
         metadata.put(generateKey(2, 256), generateKey(2, 257));
-        Assert.assertFalse(validateMetadata(metadata));
+        Assert.assertFalse(validateMetadata(metadata, 1024));
 
 
         metadata.clear();
         metadata.put(generateKey(1, 256), generateKey(1, 256));
         metadata.put(generateKey(2, 256), generateKey(2, 256));
         metadata.put(generateKey(3, 1), generateKey(3, 1));
-        Assert.assertFalse(validateMetadata(metadata));
+        Assert.assertFalse(validateMetadata(metadata, 1024));
+
+        // set bigger maxConsumerMetadataSize, now validation should pass
+        Assert.assertTrue(validateMetadata(metadata, 1024 * 10));
     }
 
-    private static boolean validateMetadata(Map<String, String> metadata) {
+    private static boolean validateMetadata(Map<String, String> metadata, int maxSize) {
         try {
-            Metadata.validateMetadata(metadata);
+            Metadata.validateMetadata(metadata, maxSize);
             return true;
         } catch (IllegalArgumentException ignore) {
             return false;


### PR DESCRIPTION
### Motivation

There is a hard coded limit of 1k for the Consumer Metadata, it may happen that a Consumer fails to subscribe due to this limit.
Consumer metadata are often used to provide information about the Consumer.
It may happen that such pieces of information are collected from the local environment of the Consumer and they could be slightly bigger than 1kb. 

We should make this limit configurable, to unblock such usercases.

### Modifications

Add `maxConsumerMetadataSize` configuration parameter, defaults to 1k as in previous Pulsar versions

### Verifying this change

This change is already covered by existing tests and I have added some new tests
