### PR TITLE
[fix][doc] Binary protocol spec: perform topic lookup before creating/connecting a producer/consumer

### DIFF
--- a/site2/docs/develop-binary-protocol.md
+++ b/site2/docs/develop-binary-protocol.md
@@ -4,6 +4,14 @@ title: Pulsar binary protocol specification
 sidebar_label: "Binary protocol"
 ---
 
+:::note
+
+**Important**
+
+This page is deprecated and not updated anymore. For the latest and complete information about Pulsar binary protocol specification, see [Pulsar admin doc](developing-binary-protocol.md).
+
+:::
+
 Pulsar uses a custom binary protocol for communications between producers/consumers and brokers. This protocol is designed to support required features, such as acknowledgements and flow control, while ensuring maximum transport and implementation efficiency.
 
 Clients and brokers exchange *commands* with each other. Commands are formatted as binary [protocol buffer](https://developers.google.com/protocol-buffers/) (aka *protobuf*) messages. The format of protobuf commands is specified in the [`PulsarApi.proto`](https://github.com/apache/pulsar/blob/master/pulsar-common/src/main/proto/PulsarApi.proto) file and also documented in the [Protobuf interface](#protobuf-interface) section below.

--- a/site2/docs/develop-binary-protocol.md
+++ b/site2/docs/develop-binary-protocol.md
@@ -8,7 +8,7 @@ sidebar_label: "Binary protocol"
 
 **Important**
 
-This page is deprecated and not updated anymore. For the latest and complete information about Pulsar binary protocol specification, see [Pulsar admin doc](developing-binary-protocol.md).
+This page is deprecated and not updated anymore. For the latest and complete information, see [Pulsar binary protocol specification](developing-binary-protocol.md).
 
 :::
 

--- a/site2/docs/developing-binary-protocol.md
+++ b/site2/docs/developing-binary-protocol.md
@@ -191,6 +191,12 @@ If the client does not receive a response indicating producer creation success o
 the client should first send a command to close the original producer before sending a
 command to re-attempt producer creation.
 
+:::note
+
+Before creating or connecting a producer, you need to perform [topic lookup](#topic-lookup) first.
+
+:::
+
 ##### Command Producer
 
 ```protobuf
@@ -284,7 +290,7 @@ Fields:
  * `sequence_id`: The sequence ID of the published message.
  * `message_id`: The message ID assigned by the system to the published message
    Unique within a single cluster. Message ID is composed of 2 longs, `ledgerId`
-   and `entryId`, that reflect that this unique ID is assigned when appending
+   and `entryId`, which reflects that this unique ID is assigned when appending
    to a BookKeeper ledger.
 
 
@@ -320,6 +326,12 @@ After every reconnection, a client needs to subscribe to the topic. If a
 subscription is not already there, a new one will be created.
 
 ![Consumer](/assets/binary-protocol-consumer.png)
+
+:::note
+
+Before creating or connecting a consumer, you need to perform [topic lookup](#topic-lookup) first.
+
+:::
 
 #### Flow control
 


### PR DESCRIPTION

Fixes #15690 

### Modifications

1. Add a note for performing topic lookup before creating/connecting a producer/consumer.
<img width="1460" alt="image" src="https://user-images.githubusercontent.com/60642177/169798916-dbfaa8d9-0454-4ba6-8f80-258aa36f0be6.png">

2. Add deprecation notice to an outdated doc page.


### Documentation
  
- [x] `doc` 
