### PR TITLE
Add bk rack info setting in cluster metadata setup 

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/PulsarClusterMetadataSetup.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/PulsarClusterMetadataSetup.java
@@ -384,7 +384,8 @@ public class PulsarClusterMetadataSetup {
         return rackConfiguration;
     }
 
-    static void createRackInfo(PulsarResources resources, String rackInfo) throws ExecutionException, InterruptedException {
+    static void createRackInfo(PulsarResources resources, String rackInfo) throws ExecutionException,
+            InterruptedException {
         if (rackInfo != null) {
             BookiesRackConfiguration rackConfiguration = parseRackInfo(rackInfo);
             resources.getBookieResources().update(optionalBookiesRackConfiguration -> rackConfiguration).get();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/zookeeper/ClusterMetadataSetupTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/zookeeper/ClusterMetadataSetupTest.java
@@ -291,6 +291,33 @@ public class ClusterMetadataSetupTest {
     }
 
     @Test
+    public void testSetupWithBkRackInfo() throws Exception {
+        String zkConnection = "127.0.0.1:" + localZkS.getZookeeperPort();
+        String[] args = {
+                "--cluster", "testReSetupClusterMetadata-cluster",
+                "--zookeeper", zkConnection,
+                "--configuration-store", zkConnection,
+                "--web-service-url", "http://127.0.0.1:8080",
+                "--web-service-url-tls", "https://127.0.0.1:8443",
+                "--broker-service-url", "pulsar://127.0.0.1:6650",
+                "--broker-service-url-tls","pulsar+ssl://127.0.0.1:6651",
+                "--rack-info","address:127.0.0.1:3181,rack:/rack1;address:127.0.0.2:3181,rack:/rack2"
+        };
+
+        PulsarClusterMetadataSetup.main(args);
+
+        try (MetadataStoreExtended localStore = PulsarClusterMetadataSetup
+                .initMetadataStore(zkConnection, 30000)) {
+            // expected exist
+            assertTrue(localStore.exists("/bookies").get());
+            byte[] res = localStore.get("/bookies").join().get().getValue();
+            String result = new String(res);
+            assertEquals(result, "{\"default\":{\"127.0.0.1:3181\":{\"rack\":\"/rack1\"}," +
+                    "\"127.0.0.2:3181\":{\"rack\":\"/rack2\"}}}");
+        }
+    }
+
+    @Test
     public void testInitialNamespaceSetup() throws Exception {
         // missing arguments
         assertEquals(PulsarInitialNamespaceSetup.doMain(new String[]{}), 1);


### PR DESCRIPTION
### Motivation

Currently we have only Admin API  `Bookies.updateBookieRackInfo()` to config rack info. 
If we want to setup up a pulsar cluster with some rack info config, we need to start brokers first,  wait for brokers start, then call Admin API.
It's better to provide a way to do the config before start brokers to make the deployment more easier.

### Modifications

Add rack info setting in cluster metadata setup like:
```
bin/pulsar initialize-cluster-metadata \
                --cluster clusterName \
                --zookeeper 127.0.0.1:2181 \
                --configuration-store 127.0.0.1:2181 \
                --web-service-url http://127.0.0.1:8080 \
                --broker-service-url pulsar://127.0.0.1:6650 \
                --rack-info address:127.0.0.1:3181,rack:/rack1;address:127.0.0.2:3181,rack:/rack2
```

### Verifying this change
This change added tests and can be verified as follows:
ClusterMetadataSetupTest.testSetupWithBkRackInfo

### Documentation

- [x] `doc-required` 
(Your PR needs to update docs and you will update later)
  