### PR TITLE
[Python] Use async C++ calls to check for Python signals

### DIFF
--- a/pulsar-client-cpp/python/CMakeLists.txt
+++ b/pulsar-client-cpp/python/CMakeLists.txt
@@ -30,7 +30,9 @@ ADD_LIBRARY(_pulsar SHARED src/pulsar.cc
                            src/reader.cc
                            src/schema.cc
                            src/cryptoKeyReader.cc
-                           src/exceptions.cc)
+                           src/exceptions.cc
+                           src/utils.cc
+        )
 
 SET(CMAKE_SHARED_LIBRARY_PREFIX )
 SET(CMAKE_SHARED_LIBRARY_SUFFIX .so)

--- a/pulsar-client-cpp/python/src/client.cc
+++ b/pulsar-client-cpp/python/src/client.cc
@@ -20,78 +20,70 @@
 
 Producer Client_createProducer(Client& client, const std::string& topic, const ProducerConfiguration& conf) {
     Producer producer;
-    Result res;
 
-    Py_BEGIN_ALLOW_THREADS res = client.createProducer(topic, conf, producer);
-    Py_END_ALLOW_THREADS
+    waitForAsyncValue(std::function<void(CreateProducerCallback)>([&](CreateProducerCallback callback) {
+        client.createProducerAsync(topic, conf, callback);
+    }), producer);
 
-        CHECK_RESULT(res);
     return producer;
 }
 
 Consumer Client_subscribe(Client& client, const std::string& topic, const std::string& subscriptionName,
                           const ConsumerConfiguration& conf) {
     Consumer consumer;
-    Result res;
 
-    Py_BEGIN_ALLOW_THREADS res = client.subscribe(topic, subscriptionName, conf, consumer);
-    Py_END_ALLOW_THREADS
+    waitForAsyncValue(std::function<void(SubscribeCallback)>([&](SubscribeCallback callback) {
+        client.subscribeAsync(topic, subscriptionName, conf, callback);
+    }), consumer);
 
-        CHECK_RESULT(res);
     return consumer;
 }
 
 Consumer Client_subscribe_topics(Client& client, boost::python::list& topics,
                                  const std::string& subscriptionName, const ConsumerConfiguration& conf) {
-    Consumer consumer;
-    Result res;
-
     std::vector<std::string> topics_vector;
-
     for (int i = 0; i < len(topics); i++) {
         std::string content = boost::python::extract<std::string>(topics[i]);
         topics_vector.push_back(content);
     }
 
-    Py_BEGIN_ALLOW_THREADS res = client.subscribe(topics_vector, subscriptionName, conf, consumer);
-    Py_END_ALLOW_THREADS
+    Consumer consumer;
 
-        CHECK_RESULT(res);
+    waitForAsyncValue(std::function<void(SubscribeCallback)>([&](SubscribeCallback callback) {
+        client.subscribeAsync(topics_vector, subscriptionName, conf, callback);
+    }), consumer);
+
     return consumer;
 }
 
 Consumer Client_subscribe_pattern(Client& client, const std::string& topic_pattern,
                                   const std::string& subscriptionName, const ConsumerConfiguration& conf) {
     Consumer consumer;
-    Result res;
 
-    Py_BEGIN_ALLOW_THREADS res = client.subscribeWithRegex(topic_pattern, subscriptionName, conf, consumer);
-    Py_END_ALLOW_THREADS
+    waitForAsyncValue(std::function<void(SubscribeCallback)>([&](SubscribeCallback callback) {
+        client.subscribeWithRegexAsync(topic_pattern, subscriptionName, conf, callback);
+    }), consumer);
 
-        CHECK_RESULT(res);
     return consumer;
 }
 
 Reader Client_createReader(Client& client, const std::string& topic, const MessageId& startMessageId,
                            const ReaderConfiguration& conf) {
     Reader reader;
-    Result res;
 
-    Py_BEGIN_ALLOW_THREADS res = client.createReader(topic, startMessageId, conf, reader);
-    Py_END_ALLOW_THREADS
+    waitForAsyncValue(std::function<void(ReaderCallback)>([&](ReaderCallback callback) {
+        client.createReaderAsync(topic, startMessageId, conf, callback);
+    }), reader);
 
-        CHECK_RESULT(res);
     return reader;
 }
 
 boost::python::list Client_getTopicPartitions(Client& client, const std::string& topic) {
     std::vector<std::string> partitions;
-    Result res;
 
-    Py_BEGIN_ALLOW_THREADS res = client.getPartitionsForTopic(topic, partitions);
-    Py_END_ALLOW_THREADS
-
-        CHECK_RESULT(res);
+    waitForAsyncValue(std::function<void(GetPartitionsCallback)>([&](GetPartitionsCallback callback) {
+        client.getPartitionsForTopicAsync(topic, callback);
+    }), partitions);
 
     boost::python::list pyList;
     for (int i = 0; i < partitions.size(); i++) {
@@ -102,12 +94,9 @@ boost::python::list Client_getTopicPartitions(Client& client, const std::string&
 }
 
 void Client_close(Client& client) {
-    Result res;
-
-    Py_BEGIN_ALLOW_THREADS res = client.close();
-    Py_END_ALLOW_THREADS
-
-        CHECK_RESULT(res);
+    waitForAsyncResult([&](ResultCallback callback) {
+        client.closeAsync(callback);
+    });
 }
 
 void export_client() {

--- a/pulsar-client-cpp/python/src/client.cc
+++ b/pulsar-client-cpp/python/src/client.cc
@@ -22,8 +22,9 @@ Producer Client_createProducer(Client& client, const std::string& topic, const P
     Producer producer;
 
     waitForAsyncValue(std::function<void(CreateProducerCallback)>([&](CreateProducerCallback callback) {
-        client.createProducerAsync(topic, conf, callback);
-    }), producer);
+                          client.createProducerAsync(topic, conf, callback);
+                      }),
+                      producer);
 
     return producer;
 }
@@ -33,8 +34,9 @@ Consumer Client_subscribe(Client& client, const std::string& topic, const std::s
     Consumer consumer;
 
     waitForAsyncValue(std::function<void(SubscribeCallback)>([&](SubscribeCallback callback) {
-        client.subscribeAsync(topic, subscriptionName, conf, callback);
-    }), consumer);
+                          client.subscribeAsync(topic, subscriptionName, conf, callback);
+                      }),
+                      consumer);
 
     return consumer;
 }
@@ -50,8 +52,9 @@ Consumer Client_subscribe_topics(Client& client, boost::python::list& topics,
     Consumer consumer;
 
     waitForAsyncValue(std::function<void(SubscribeCallback)>([&](SubscribeCallback callback) {
-        client.subscribeAsync(topics_vector, subscriptionName, conf, callback);
-    }), consumer);
+                          client.subscribeAsync(topics_vector, subscriptionName, conf, callback);
+                      }),
+                      consumer);
 
     return consumer;
 }
@@ -61,8 +64,9 @@ Consumer Client_subscribe_pattern(Client& client, const std::string& topic_patte
     Consumer consumer;
 
     waitForAsyncValue(std::function<void(SubscribeCallback)>([&](SubscribeCallback callback) {
-        client.subscribeWithRegexAsync(topic_pattern, subscriptionName, conf, callback);
-    }), consumer);
+                          client.subscribeWithRegexAsync(topic_pattern, subscriptionName, conf, callback);
+                      }),
+                      consumer);
 
     return consumer;
 }
@@ -72,8 +76,9 @@ Reader Client_createReader(Client& client, const std::string& topic, const Messa
     Reader reader;
 
     waitForAsyncValue(std::function<void(ReaderCallback)>([&](ReaderCallback callback) {
-        client.createReaderAsync(topic, startMessageId, conf, callback);
-    }), reader);
+                          client.createReaderAsync(topic, startMessageId, conf, callback);
+                      }),
+                      reader);
 
     return reader;
 }
@@ -82,8 +87,9 @@ boost::python::list Client_getTopicPartitions(Client& client, const std::string&
     std::vector<std::string> partitions;
 
     waitForAsyncValue(std::function<void(GetPartitionsCallback)>([&](GetPartitionsCallback callback) {
-        client.getPartitionsForTopicAsync(topic, callback);
-    }), partitions);
+                          client.getPartitionsForTopicAsync(topic, callback);
+                      }),
+                      partitions);
 
     boost::python::list pyList;
     for (int i = 0; i < partitions.size(); i++) {
@@ -94,9 +100,7 @@ boost::python::list Client_getTopicPartitions(Client& client, const std::string&
 }
 
 void Client_close(Client& client) {
-    waitForAsyncResult([&](ResultCallback callback) {
-        client.closeAsync(callback);
-    });
+    waitForAsyncResult([&](ResultCallback callback) { client.closeAsync(callback); });
 }
 
 void export_client() {

--- a/pulsar-client-cpp/python/src/consumer.cc
+++ b/pulsar-client-cpp/python/src/consumer.cc
@@ -19,35 +19,18 @@
 #include "utils.h"
 
 void Consumer_unsubscribe(Consumer& consumer) {
-    Result res;
-    Py_BEGIN_ALLOW_THREADS res = consumer.unsubscribe();
-    Py_END_ALLOW_THREADS
-
-        CHECK_RESULT(res);
+    waitForAsyncResult([&consumer](ResultCallback callback) {
+       consumer.unsubscribeAsync(callback);
+    });
 }
 
 Message Consumer_receive(Consumer& consumer) {
     Message msg;
-    Result res;
 
-    while (true) {
-        Py_BEGIN_ALLOW_THREADS res = consumer.receive(msg);
-        Py_END_ALLOW_THREADS
+    waitForAsyncValue(std::function<void(ReceiveCallback)>([&consumer](ReceiveCallback callback) {
+        consumer.receiveAsync(callback);
+    }), msg);
 
-            if (res != ResultTimeout) {
-            // In case of timeout we keep calling receive() to simulate a
-            // blocking call until a message is available, while breaking
-            // every once in a while to check the Python signal status
-            break;
-        }
-
-        if (PyErr_CheckSignals() == -1) {
-            PyErr_SetInterrupt();
-            return msg;
-        }
-    }
-
-    CHECK_RESULT(res);
     return msg;
 }
 
@@ -57,7 +40,7 @@ Message Consumer_receive_timeout(Consumer& consumer, int timeoutMs) {
     Py_BEGIN_ALLOW_THREADS res = consumer.receive(msg, timeoutMs);
     Py_END_ALLOW_THREADS
 
-        CHECK_RESULT(res);
+    CHECK_RESULT(res);
     return msg;
 }
 
@@ -84,11 +67,9 @@ void Consumer_acknowledge_cumulative_message_id(Consumer& consumer, const Messag
 }
 
 void Consumer_close(Consumer& consumer) {
-    Result res;
-    Py_BEGIN_ALLOW_THREADS res = consumer.close();
-    Py_END_ALLOW_THREADS
-
-        CHECK_RESULT(res);
+    waitForAsyncResult([&consumer](ResultCallback callback) {
+        consumer.closeAsync(callback);
+    });
 }
 
 void Consumer_pauseMessageListener(Consumer& consumer) { CHECK_RESULT(consumer.pauseMessageListener()); }
@@ -96,19 +77,15 @@ void Consumer_pauseMessageListener(Consumer& consumer) { CHECK_RESULT(consumer.p
 void Consumer_resumeMessageListener(Consumer& consumer) { CHECK_RESULT(consumer.resumeMessageListener()); }
 
 void Consumer_seek(Consumer& consumer, const MessageId& msgId) {
-    Result res;
-    Py_BEGIN_ALLOW_THREADS res = consumer.seek(msgId);
-    Py_END_ALLOW_THREADS
-
-        CHECK_RESULT(res);
+    waitForAsyncResult([msgId, &consumer](ResultCallback callback) {
+        consumer.seekAsync(msgId, callback);
+    });
 }
 
 void Consumer_seek_timestamp(Consumer& consumer, uint64_t timestamp) {
-    Result res;
-    Py_BEGIN_ALLOW_THREADS res = consumer.seek(timestamp);
-    Py_END_ALLOW_THREADS
-
-        CHECK_RESULT(res);
+    waitForAsyncResult([timestamp, &consumer](ResultCallback callback) {
+        consumer.seekAsync(timestamp, callback);
+    });
 }
 
 bool Consumer_is_connected(Consumer& consumer) { return consumer.isConnected(); }

--- a/pulsar-client-cpp/python/src/consumer.cc
+++ b/pulsar-client-cpp/python/src/consumer.cc
@@ -19,17 +19,15 @@
 #include "utils.h"
 
 void Consumer_unsubscribe(Consumer& consumer) {
-    waitForAsyncResult([&consumer](ResultCallback callback) {
-       consumer.unsubscribeAsync(callback);
-    });
+    waitForAsyncResult([&consumer](ResultCallback callback) { consumer.unsubscribeAsync(callback); });
 }
 
 Message Consumer_receive(Consumer& consumer) {
     Message msg;
 
-    waitForAsyncValue(std::function<void(ReceiveCallback)>([&consumer](ReceiveCallback callback) {
-        consumer.receiveAsync(callback);
-    }), msg);
+    waitForAsyncValue(std::function<void(ReceiveCallback)>(
+                          [&consumer](ReceiveCallback callback) { consumer.receiveAsync(callback); }),
+                      msg);
 
     return msg;
 }
@@ -40,7 +38,7 @@ Message Consumer_receive_timeout(Consumer& consumer, int timeoutMs) {
     Py_BEGIN_ALLOW_THREADS res = consumer.receive(msg, timeoutMs);
     Py_END_ALLOW_THREADS
 
-    CHECK_RESULT(res);
+        CHECK_RESULT(res);
     return msg;
 }
 
@@ -67,9 +65,7 @@ void Consumer_acknowledge_cumulative_message_id(Consumer& consumer, const Messag
 }
 
 void Consumer_close(Consumer& consumer) {
-    waitForAsyncResult([&consumer](ResultCallback callback) {
-        consumer.closeAsync(callback);
-    });
+    waitForAsyncResult([&consumer](ResultCallback callback) { consumer.closeAsync(callback); });
 }
 
 void Consumer_pauseMessageListener(Consumer& consumer) { CHECK_RESULT(consumer.pauseMessageListener()); }
@@ -77,15 +73,12 @@ void Consumer_pauseMessageListener(Consumer& consumer) { CHECK_RESULT(consumer.p
 void Consumer_resumeMessageListener(Consumer& consumer) { CHECK_RESULT(consumer.resumeMessageListener()); }
 
 void Consumer_seek(Consumer& consumer, const MessageId& msgId) {
-    waitForAsyncResult([msgId, &consumer](ResultCallback callback) {
-        consumer.seekAsync(msgId, callback);
-    });
+    waitForAsyncResult([msgId, &consumer](ResultCallback callback) { consumer.seekAsync(msgId, callback); });
 }
 
 void Consumer_seek_timestamp(Consumer& consumer, uint64_t timestamp) {
-    waitForAsyncResult([timestamp, &consumer](ResultCallback callback) {
-        consumer.seekAsync(timestamp, callback);
-    });
+    waitForAsyncResult(
+        [timestamp, &consumer](ResultCallback callback) { consumer.seekAsync(timestamp, callback); });
 }
 
 bool Consumer_is_connected(Consumer& consumer) { return consumer.isConnected(); }

--- a/pulsar-client-cpp/python/src/exceptions.cc
+++ b/pulsar-client-cpp/python/src/exceptions.cc
@@ -35,7 +35,15 @@ PyObject* createExceptionClass(const char* name, PyObject* baseTypeObj = PyExc_E
     return typeObj;
 }
 
-PyObject* get_exception_class(Result result) { return exceptions[result]; }
+PyObject* get_exception_class(Result result) {
+    auto it = exceptions.find(result);
+    if (it != exceptions.end()) {
+        return it->second;
+    } else {
+        std::cerr << "Error result exception not found: " << result << std::endl;
+        abort();
+    }
+}
 
 void export_exceptions() {
     using namespace boost::python;

--- a/pulsar-client-cpp/python/src/producer.cc
+++ b/pulsar-client-cpp/python/src/producer.cc
@@ -23,12 +23,12 @@
 extern boost::python::object MessageId_serialize(const MessageId& msgId);
 
 boost::python::object Producer_send(Producer& producer, const Message& message) {
-    Result res;
     MessageId messageId;
-    Py_BEGIN_ALLOW_THREADS res = producer.send(message, messageId);
-    Py_END_ALLOW_THREADS
 
-        CHECK_RESULT(res);
+    waitForAsyncValue(std::function<void(SendCallback)>([&](SendCallback callback) {
+        producer.sendAsync(message, callback);
+    }), messageId);
+
     return MessageId_serialize(messageId);
 }
 
@@ -60,19 +60,15 @@ void Producer_sendAsync(Producer& producer, const Message& message, py::object c
 }
 
 void Producer_flush(Producer& producer) {
-    Result res;
-    Py_BEGIN_ALLOW_THREADS res = producer.flush();
-    Py_END_ALLOW_THREADS
-
-        CHECK_RESULT(res);
+    waitForAsyncResult([&](ResultCallback callback) {
+        producer.flushAsync(callback);
+    });
 }
 
 void Producer_close(Producer& producer) {
-    Result res;
-    Py_BEGIN_ALLOW_THREADS res = producer.close();
-    Py_END_ALLOW_THREADS
-
-        CHECK_RESULT(res);
+    waitForAsyncResult([&](ResultCallback callback) {
+        producer.closeAsync(callback);
+    });
 }
 
 bool Producer_is_connected(Producer& producer) { return producer.isConnected(); }

--- a/pulsar-client-cpp/python/src/producer.cc
+++ b/pulsar-client-cpp/python/src/producer.cc
@@ -25,9 +25,9 @@ extern boost::python::object MessageId_serialize(const MessageId& msgId);
 boost::python::object Producer_send(Producer& producer, const Message& message) {
     MessageId messageId;
 
-    waitForAsyncValue(std::function<void(SendCallback)>([&](SendCallback callback) {
-        producer.sendAsync(message, callback);
-    }), messageId);
+    waitForAsyncValue(std::function<void(SendCallback)>(
+                          [&](SendCallback callback) { producer.sendAsync(message, callback); }),
+                      messageId);
 
     return MessageId_serialize(messageId);
 }
@@ -60,15 +60,11 @@ void Producer_sendAsync(Producer& producer, const Message& message, py::object c
 }
 
 void Producer_flush(Producer& producer) {
-    waitForAsyncResult([&](ResultCallback callback) {
-        producer.flushAsync(callback);
-    });
+    waitForAsyncResult([&](ResultCallback callback) { producer.flushAsync(callback); });
 }
 
 void Producer_close(Producer& producer) {
-    waitForAsyncResult([&](ResultCallback callback) {
-        producer.closeAsync(callback);
-    });
+    waitForAsyncResult([&](ResultCallback callback) { producer.closeAsync(callback); });
 }
 
 bool Producer_is_connected(Producer& producer) { return producer.isConnected(); }

--- a/pulsar-client-cpp/python/src/pulsar.cc
+++ b/pulsar-client-cpp/python/src/pulsar.cc
@@ -35,7 +35,6 @@ PyObject* get_exception_class(Result result);
 static void translateException(const PulsarException& ex) {
     std::string err = "Pulsar error: ";
     err += strResult(ex._result);
-
     PyErr_SetString(get_exception_class(ex._result), err.c_str());
 }
 

--- a/pulsar-client-cpp/python/src/reader.cc
+++ b/pulsar-client-cpp/python/src/reader.cc
@@ -61,29 +61,24 @@ Message Reader_readNextTimeout(Reader& reader, int timeoutMs) {
 bool Reader_hasMessageAvailable(Reader& reader) {
     bool available = false;
 
-    waitForAsyncValue(std::function<void(HasMessageAvailableCallback)>([&](HasMessageAvailableCallback callback) {
-        reader.hasMessageAvailableAsync(callback);
-    }), available);
+    waitForAsyncValue(
+        std::function<void(HasMessageAvailableCallback)>(
+            [&](HasMessageAvailableCallback callback) { reader.hasMessageAvailableAsync(callback); }),
+        available);
 
     return available;
 }
 
 void Reader_close(Reader& reader) {
-    waitForAsyncResult([&](ResultCallback callback) {
-        reader.closeAsync(callback);
-    });
+    waitForAsyncResult([&](ResultCallback callback) { reader.closeAsync(callback); });
 }
 
 void Reader_seek(Reader& reader, const MessageId& msgId) {
-    waitForAsyncResult([&](ResultCallback callback) {
-        reader.seekAsync(msgId, callback);
-    });
+    waitForAsyncResult([&](ResultCallback callback) { reader.seekAsync(msgId, callback); });
 }
 
 void Reader_seek_timestamp(Reader& reader, uint64_t timestamp) {
-    waitForAsyncResult([&](ResultCallback callback) {
-        reader.seekAsync(timestamp, callback);
-    });
+    waitForAsyncResult([&](ResultCallback callback) { reader.seekAsync(timestamp, callback); });
 }
 
 bool Reader_is_connected(Reader& reader) { return reader.isConnected(); }

--- a/pulsar-client-cpp/python/src/reader.cc
+++ b/pulsar-client-cpp/python/src/reader.cc
@@ -22,6 +22,8 @@ Message Reader_readNext(Reader& reader) {
     Message msg;
     Result res;
 
+    // TODO: There is currently no readNextAsync() version for the Reader.
+    // Once that's available, we should also convert these ad-hoc loops.
     while (true) {
         Py_BEGIN_ALLOW_THREADS
             // Use 100ms timeout to periodically check whether the
@@ -58,36 +60,30 @@ Message Reader_readNextTimeout(Reader& reader, int timeoutMs) {
 
 bool Reader_hasMessageAvailable(Reader& reader) {
     bool available = false;
-    Result res;
-    Py_BEGIN_ALLOW_THREADS res = reader.hasMessageAvailable(available);
-    Py_END_ALLOW_THREADS
 
-        CHECK_RESULT(res);
+    waitForAsyncValue(std::function<void(HasMessageAvailableCallback)>([&](HasMessageAvailableCallback callback) {
+        reader.hasMessageAvailableAsync(callback);
+    }), available);
+
     return available;
 }
 
 void Reader_close(Reader& reader) {
-    Result res;
-    Py_BEGIN_ALLOW_THREADS res = reader.close();
-    Py_END_ALLOW_THREADS
-
-        CHECK_RESULT(res);
+    waitForAsyncResult([&](ResultCallback callback) {
+        reader.closeAsync(callback);
+    });
 }
 
 void Reader_seek(Reader& reader, const MessageId& msgId) {
-    Result res;
-    Py_BEGIN_ALLOW_THREADS res = reader.seek(msgId);
-    Py_END_ALLOW_THREADS
-
-        CHECK_RESULT(res);
+    waitForAsyncResult([&](ResultCallback callback) {
+        reader.seekAsync(msgId, callback);
+    });
 }
 
 void Reader_seek_timestamp(Reader& reader, uint64_t timestamp) {
-    Result res;
-    Py_BEGIN_ALLOW_THREADS res = reader.seek(timestamp);
-    Py_END_ALLOW_THREADS
-
-        CHECK_RESULT(res);
+    waitForAsyncResult([&](ResultCallback callback) {
+        reader.seekAsync(timestamp, callback);
+    });
 }
 
 bool Reader_is_connected(Reader& reader) { return reader.isConnected(); }

--- a/pulsar-client-cpp/python/src/utils.cc
+++ b/pulsar-client-cpp/python/src/utils.cc
@@ -20,7 +20,7 @@
 #include "utils.h"
 
 void waitForAsyncResult(std::function<void(ResultCallback)> func) {
-    Result res;
+    Result res = ResultOk;
     bool b;
     Promise<bool, Result> promise;
     Future<bool, Result> future = promise.getFuture();

--- a/pulsar-client-cpp/python/src/utils.cc
+++ b/pulsar-client-cpp/python/src/utils.cc
@@ -25,18 +25,16 @@ void waitForAsyncResult(std::function<void(ResultCallback)> func) {
     Promise<bool, Result> promise;
     Future<bool, Result> future = promise.getFuture();
 
-    Py_BEGIN_ALLOW_THREADS
-    func(WaitForCallback(promise));
+    Py_BEGIN_ALLOW_THREADS func(WaitForCallback(promise));
     Py_END_ALLOW_THREADS
 
-    bool isComplete;
+        bool isComplete;
     while (true) {
         // Check periodically for Python signals
-        Py_BEGIN_ALLOW_THREADS
-            isComplete = future.get(b, std::ref(res), std::chrono::milliseconds(100));
+        Py_BEGIN_ALLOW_THREADS isComplete = future.get(b, std::ref(res), std::chrono::milliseconds(100));
         Py_END_ALLOW_THREADS
 
-        if (isComplete) {
+            if (isComplete) {
             CHECK_RESULT(res);
             return;
         }

--- a/pulsar-client-cpp/python/src/utils.h
+++ b/pulsar-client-cpp/python/src/utils.h
@@ -42,24 +42,22 @@ inline void CHECK_RESULT(Result res) {
 
 void waitForAsyncResult(std::function<void(ResultCallback)> func);
 
-template<typename T, typename Callback>
+template <typename T, typename Callback>
 inline void waitForAsyncValue(std::function<void(Callback)> func, T& value) {
     Result res;
     Promise<Result, T> promise;
     Future<Result, T> future = promise.getFuture();
 
-    Py_BEGIN_ALLOW_THREADS
-        func(WaitForCallbackValue<T>(promise));
+    Py_BEGIN_ALLOW_THREADS func(WaitForCallbackValue<T>(promise));
     Py_END_ALLOW_THREADS
 
-    bool isComplete;
+        bool isComplete;
     while (true) {
         // Check periodically for Python signals
-        Py_BEGIN_ALLOW_THREADS
-            isComplete = future.get(res, std::ref(value), std::chrono::milliseconds(100));
+        Py_BEGIN_ALLOW_THREADS isComplete = future.get(res, std::ref(value), std::chrono::milliseconds(100));
         Py_END_ALLOW_THREADS
 
-        if (isComplete) {
+            if (isComplete) {
             CHECK_RESULT(res);
             return;
         }

--- a/pulsar-client-cpp/python/src/utils.h
+++ b/pulsar-client-cpp/python/src/utils.h
@@ -44,7 +44,7 @@ void waitForAsyncResult(std::function<void(ResultCallback)> func);
 
 template <typename T, typename Callback>
 inline void waitForAsyncValue(std::function<void(Callback)> func, T& value) {
-    Result res;
+    Result res = ResultOk;
     Promise<Result, T> promise;
     Future<Result, T> future = promise.getFuture();
 


### PR DESCRIPTION
Fix #6477

### Motivation

Currently the Python wrapper is calling blocking methods in the C++ API. That means that the Python interpreter thread is stuck in the blocking call (even if other Python threads are allowed to run), but it will prevent the interpreter to process any OS signals.

Instead, we should use C++ async methods and check periodically for Python signals, so that we can unblock the interpreter when needed.

### Modifications

Added wrapper functions to handle the logic of checking for the future completion and for the Python signal handling.