### PR TITLE
[C++] Unblock all threads when Pulsar client is closed

### DIFF
--- a/pulsar-client-cpp/include/pulsar/Result.h
+++ b/pulsar-client-cpp/include/pulsar/Result.h
@@ -89,7 +89,7 @@ enum Result
 
     ResultMemoryBufferIsFull,  /// Client-wide memory limit has been reached
 
-    ResultInterrupted, // Interrupted while waiting to dequeue
+    ResultInterrupted,  // Interrupted while waiting to dequeue
 };
 
 // Return string representation of result code

--- a/pulsar-client-cpp/include/pulsar/Result.h
+++ b/pulsar-client-cpp/include/pulsar/Result.h
@@ -89,7 +89,7 @@ enum Result
 
     ResultMemoryBufferIsFull,  /// Client-wide memory limit has been reached
 
-    ResultInterrupted,  // Interrupted while waiting to dequeue
+    ResultInterrupted,  /// Interrupted while waiting to dequeue
 };
 
 // Return string representation of result code

--- a/pulsar-client-cpp/include/pulsar/Result.h
+++ b/pulsar-client-cpp/include/pulsar/Result.h
@@ -88,6 +88,8 @@ enum Result
     ResultProducerFenced,                            /// Producer was fenced by broker
 
     ResultMemoryBufferIsFull,  /// Client-wide memory limit has been reached
+
+    ResultInterrupted, // Interrupted while waiting to dequeue
 };
 
 // Return string representation of result code

--- a/pulsar-client-cpp/include/pulsar/c/result.h
+++ b/pulsar-client-cpp/include/pulsar/c/result.h
@@ -90,7 +90,8 @@ typedef enum
     pulsar_result_TransactionNotFound,                  /// Transaction not found
     pulsar_result_ProducerFenced,                       /// Producer was fenced by broker
 
-    pulsar_result_MemoryBufferIsFull  /// Client-wide memory limit has been reached
+    pulsar_result_MemoryBufferIsFull,  /// Client-wide memory limit has been reached
+    pulsar_result_Interrupted,  /// Interrupted while waiting to dequeue
 } pulsar_result;
 
 // Return string representation of result code

--- a/pulsar-client-cpp/include/pulsar/c/result.h
+++ b/pulsar-client-cpp/include/pulsar/c/result.h
@@ -91,7 +91,7 @@ typedef enum
     pulsar_result_ProducerFenced,                       /// Producer was fenced by broker
 
     pulsar_result_MemoryBufferIsFull,  /// Client-wide memory limit has been reached
-    pulsar_result_Interrupted,  /// Interrupted while waiting to dequeue
+    pulsar_result_Interrupted,         /// Interrupted while waiting to dequeue
 } pulsar_result;
 
 // Return string representation of result code

--- a/pulsar-client-cpp/lib/ClientImpl.cc
+++ b/pulsar-client-cpp/lib/ClientImpl.cc
@@ -493,6 +493,8 @@ void ClientImpl::closeAsync(CloseCallback callback) {
     state_ = Closing;
     lock.unlock();
 
+    memoryLimitController_.close();
+
     SharedInt numberOfOpenHandlers = std::make_shared<int>(producers.size() + consumers.size());
     LOG_INFO("Closing Pulsar client with " << producers.size() << " producers and " << consumers.size()
                                            << " consumers");

--- a/pulsar-client-cpp/lib/ConsumerImpl.cc
+++ b/pulsar-client-cpp/lib/ConsumerImpl.cc
@@ -722,11 +722,14 @@ Result ConsumerImpl::fetchSingleMessageFromBroker(Message& msg) {
     sendFlowPermitsToBroker(currentCnx, 1);
 
     while (true) {
-        incomingMessages_.pop(msg);
+        if (!incomingMessages_.pop(msg)) {
+            return ResultInterrupted;
+        }
+
         {
             // Lock needed to prevent race between connectionOpened and the check "msg.impl_->cnx_ ==
             // currentCnx.get())"
-            Lock localLock(mutex_);
+            Lock localLock1(mutex_);
             // if message received due to an old flow - discard it and wait for the message from the
             // latest flow command
             if (msg.impl_->cnx_ == currentCnx.get()) {
@@ -787,7 +790,10 @@ Result ConsumerImpl::receiveHelper(Message& msg) {
         return fetchSingleMessageFromBroker(msg);
     }
 
-    incomingMessages_.pop(msg);
+    if (!incomingMessages_.pop(msg)) {
+        return ResultInterrupted;
+    }
+
     messageProcessed(msg);
     return ResultOk;
 }
@@ -998,6 +1004,7 @@ void ConsumerImpl::closeAsync(ResultCallback callback) {
 
     LOG_INFO(getName() << "Closing consumer for topic " << topic_);
     state_ = Closing;
+    incomingMessages_.close();
 
     // Flush pending grouped ACK requests.
     if (ackGroupingTrackerPtr_) {

--- a/pulsar-client-cpp/lib/ConsumerImpl.cc
+++ b/pulsar-client-cpp/lib/ConsumerImpl.cc
@@ -729,7 +729,7 @@ Result ConsumerImpl::fetchSingleMessageFromBroker(Message& msg) {
         {
             // Lock needed to prevent race between connectionOpened and the check "msg.impl_->cnx_ ==
             // currentCnx.get())"
-            Lock localLock1(mutex_);
+            Lock localLock(mutex_);
             // if message received due to an old flow - discard it and wait for the message from the
             // latest flow command
             if (msg.impl_->cnx_ == currentCnx.get()) {

--- a/pulsar-client-cpp/lib/ExecutorService.cc
+++ b/pulsar-client-cpp/lib/ExecutorService.cc
@@ -38,13 +38,13 @@ void ExecutorService::start() {
         if (self->isClosed()) {
             return;
         }
-        LOG_INFO("Run io_service in a single thread");
+        LOG_DEBUG("Run io_service in a single thread");
         boost::system::error_code ec;
         self->getIOService().run(ec);
         if (ec) {
             LOG_ERROR("Failed to run io_service: " << ec.message());
         } else {
-            LOG_INFO("Event loop of ExecutorService exits successfully");
+            LOG_DEBUG("Event loop of ExecutorService exits successfully");
         }
         self->ioServiceDone_ = true;
         self->cond_.notify_all();

--- a/pulsar-client-cpp/lib/MemoryLimitController.cc
+++ b/pulsar-client-cpp/lib/MemoryLimitController.cc
@@ -45,16 +45,23 @@ bool MemoryLimitController::tryReserveMemory(uint64_t size) {
     }
 }
 
-void MemoryLimitController::reserveMemory(uint64_t size) {
+bool MemoryLimitController::reserveMemory(uint64_t size) {
     if (!tryReserveMemory(size)) {
         std::unique_lock<std::mutex> lock(mutex_);
 
         // Check again, while holding the lock, to ensure we reserve attempt and the waiting for the condition
         // are synchronized.
         while (!tryReserveMemory(size)) {
+            if (isClosed_) {
+                // Interrupt the waiting if the client is closing
+                return false;
+            }
+
             condition_.wait(lock);
         }
     }
+
+    return true;
 }
 
 void MemoryLimitController::releaseMemory(uint64_t size) {
@@ -69,5 +76,11 @@ void MemoryLimitController::releaseMemory(uint64_t size) {
 }
 
 uint64_t MemoryLimitController::currentUsage() const { return currentUsage_; }
+
+void MemoryLimitController::close() {
+    std::unique_lock<std::mutex> lock(mutex_);
+    isClosed_ = true;
+    condition_.notify_all();
+}
 
 }  // namespace pulsar

--- a/pulsar-client-cpp/lib/MemoryLimitController.h
+++ b/pulsar-client-cpp/lib/MemoryLimitController.h
@@ -30,15 +30,18 @@ class MemoryLimitController {
    public:
     explicit MemoryLimitController(uint64_t memoryLimit);
     bool tryReserveMemory(uint64_t size);
-    void reserveMemory(uint64_t size);
+    bool reserveMemory(uint64_t size);
     void releaseMemory(uint64_t size);
     uint64_t currentUsage() const;
+
+    void close();
 
    private:
     const uint64_t memoryLimit_;
     std::atomic<uint64_t> currentUsage_;
     std::mutex mutex_;
     std::condition_variable condition_;
+    bool isClosed_ = false;
 };
 
 }  // namespace pulsar

--- a/pulsar-client-cpp/lib/PartitionedConsumerImpl.cc
+++ b/pulsar-client-cpp/lib/PartitionedConsumerImpl.cc
@@ -417,8 +417,7 @@ void PartitionedConsumerImpl::messageReceived(Consumer consumer, const Message& 
         if (messages_.full()) {
             lock.unlock();
         }
-        messages_.push(msg);
-        if (messageListener_) {
+        if (messages_.push(msg) && messageListener_) {
             unAckedMessageTrackerPtr_->add(msg.getMessageId());
             listenerExecutor_->postWork(
                 std::bind(&PartitionedConsumerImpl::internalListener, shared_from_this(), consumer));

--- a/pulsar-client-cpp/lib/ProducerImpl.cc
+++ b/pulsar-client-cpp/lib/ProducerImpl.cc
@@ -525,20 +525,16 @@ int ProducerImpl::getNumOfChunks(uint32_t size, uint32_t maxMessageSize) {
 
 Result ProducerImpl::canEnqueueRequest(uint32_t payloadSize) {
     if (conf_.getBlockIfQueueFull()) {
-        if (semaphore_) {
-            if (!semaphore_->acquire()) {
-                return ResultInterrupted;
-            }
+        if (semaphore_ && !semaphore_->acquire()) {
+            return ResultInterrupted;
         }
         if (!memoryLimitController_.reserveMemory(payloadSize)) {
             return ResultInterrupted;
         }
         return ResultOk;
     } else {
-        if (semaphore_) {
-            if (!semaphore_->tryAcquire()) {
-                return ResultProducerQueueIsFull;
-            }
+        if (semaphore_ && !semaphore_->tryAcquire()) {
+            return ResultProducerQueueIsFull;
         }
 
         if (!memoryLimitController_.tryReserveMemory(payloadSize)) {

--- a/pulsar-client-cpp/lib/Result.cc
+++ b/pulsar-client-cpp/lib/Result.cc
@@ -159,6 +159,9 @@ const char* strResult(Result result) {
 
         case ResultMemoryBufferIsFull:
             return "ResultMemoryBufferIsFull";
+
+        case ResultInterrupted:
+            return "ResultInterrupted";
     };
     // NOTE : Do not add default case in the switch above. In future if we get new cases for
     // ServerError and miss them in the switch above we would like to get notified. Adding

--- a/pulsar-client-cpp/lib/Semaphore.h
+++ b/pulsar-client-cpp/lib/Semaphore.h
@@ -31,15 +31,18 @@ class Semaphore {
     explicit Semaphore(uint32_t limit);
 
     bool tryAcquire(int n = 1);
-    void acquire(int n = 1);
+    bool acquire(int n = 1);
     void release(int n = 1);
     uint32_t currentUsage() const;
+
+    void close();
 
    private:
     const uint32_t limit_;
     uint32_t currentUsage_;
     mutable std::mutex mutex_;
     std::condition_variable condition_;
+    bool isClosed_ = false;
 };
 
 }  // namespace pulsar

--- a/pulsar-client-cpp/python/src/enums.cc
+++ b/pulsar-client-cpp/python/src/enums.cc
@@ -84,7 +84,8 @@ void export_enums() {
         .value("TransactionConflict", ResultTransactionConflict)
         .value("TransactionNotFound", ResultTransactionNotFound)
         .value("ProducerFenced", ResultProducerFenced)
-        .value("MemoryBufferIsFull", ResultMemoryBufferIsFull);
+        .value("MemoryBufferIsFull", ResultMemoryBufferIsFull)
+        .value("Interrupted", pulsar::ResultInterrupted);
 
     enum_<SchemaType>("SchemaType", "Supported schema types")
         .value("NONE", pulsar::NONE)

--- a/pulsar-client-cpp/python/src/exceptions.cc
+++ b/pulsar-client-cpp/python/src/exceptions.cc
@@ -100,4 +100,5 @@ void export_exceptions() {
     exceptions[ResultTransactionNotFound] = createExceptionClass("TransactionNotFound", basePulsarException);
     exceptions[ResultProducerFenced] = createExceptionClass("ProducerFenced", basePulsarException);
     exceptions[ResultMemoryBufferIsFull] = createExceptionClass("MemoryBufferIsFull", basePulsarException);
+    exceptions[ResultInterrupted] = createExceptionClass("Interrupted", basePulsarException);
 }

--- a/pulsar-client-cpp/tests/BlockingQueueTest.cc
+++ b/pulsar-client-cpp/tests/BlockingQueueTest.cc
@@ -18,6 +18,7 @@
  */
 #include <gtest/gtest.h>
 #include <lib/BlockingQueue.h>
+#include <lib/Latch.h>
 
 #include <future>
 #include <iostream>
@@ -152,71 +153,6 @@ TEST(BlockingQueueTest, testTimeout) {
     ASSERT_FALSE(popReturn);
 }
 
-TEST(BlockingQueueTest, testReservedSpot) {
-    size_t size = 3;
-    BlockingQueue<int> queue(size);
-
-    ASSERT_TRUE(queue.empty());
-    ASSERT_FALSE(queue.full());
-    ASSERT_EQ(0, queue.size());
-
-    queue.push(1);
-    ASSERT_FALSE(queue.empty());
-    ASSERT_FALSE(queue.full());
-    ASSERT_EQ(1, queue.size());
-
-    BlockingQueue<int>::ReservedSpot spot1 = queue.reserve();
-    ASSERT_FALSE(queue.empty());
-    ASSERT_FALSE(queue.full());
-    ASSERT_EQ(1, queue.size());
-
-    queue.push(2, spot1);
-
-    ASSERT_FALSE(queue.empty());
-    ASSERT_FALSE(queue.full());
-    ASSERT_EQ(2, queue.size());
-
-    {
-        BlockingQueue<int>::ReservedSpot spot2 = queue.reserve();
-
-        ASSERT_FALSE(queue.empty());
-        ASSERT_TRUE(queue.full());
-        ASSERT_EQ(2, queue.size());
-    }
-
-    ASSERT_FALSE(queue.empty());
-    ASSERT_FALSE(queue.full());
-    ASSERT_EQ(2, queue.size());
-
-    BlockingQueue<int>::ReservedSpot spot3 = queue.reserve();
-
-    int res;
-    queue.pop(res);
-    ASSERT_EQ(1, res);
-
-    ASSERT_FALSE(queue.empty());
-    ASSERT_FALSE(queue.full());
-    ASSERT_EQ(1, queue.size());
-
-    queue.pop(res);
-    ASSERT_EQ(2, res);
-
-    ASSERT_TRUE(queue.empty());
-    ASSERT_FALSE(queue.full());
-    ASSERT_EQ(0, queue.size());
-
-    spot3.release();
-
-    {
-        BlockingQueue<int>::ReservedSpot spot1 = queue.reserve();
-        BlockingQueue<int>::ReservedSpot spot2 = queue.reserve();
-        BlockingQueue<int>::ReservedSpot spot3 = queue.reserve();
-
-        ASSERT_TRUE(queue.empty());
-        ASSERT_TRUE(queue.full());
-        ASSERT_EQ(0, queue.size());
-    }
-}
 
 TEST(BlockingQueueTest, testPushPopRace) {
     auto test_logic = []() {
@@ -253,4 +189,50 @@ TEST(BlockingQueueTest, testPushPopRace) {
     };
 
     ASSERT_EXIT(test_logic(), ::testing::ExitedWithCode(0), "Exiting");
+}
+
+TEST(BlockingQueueTest, testCloseInterruptOnEmpty) {
+    BlockingQueue<int> queue(10);
+    pulsar::Latch latch(1);
+
+    auto thread = std::thread([&]() {
+        int v;
+        bool res = queue.pop(v);
+        ASSERT_FALSE(res);
+        latch.countdown();
+    });
+
+    // Sleep to allow for background thread to call pop and be blocked there
+    std::this_thread::sleep_for(std::chrono::seconds(1));
+
+    queue.close();
+    bool wasUnblocked = latch.wait(std::chrono::seconds(5));
+
+    ASSERT_TRUE(wasUnblocked);
+    thread.join();
+}
+
+TEST(BlockingQueueTest, testCloseInterruptOnFull) {
+    BlockingQueue<int> queue(10);
+    pulsar::Latch latch(1);
+
+    auto thread = std::thread([&]() {
+        int i = 0;
+        while (true) {
+            bool res = queue.push(i++);
+            if (!res) {
+                latch.countdown();
+                return;
+            }
+        }
+    });
+
+    // Sleep to allow for background thread to fill the queue and be blocked there
+    std::this_thread::sleep_for(std::chrono::seconds(1));
+
+    queue.close();
+    bool wasUnblocked = latch.wait(std::chrono::seconds(5));
+
+    ASSERT_TRUE(wasUnblocked);
+    thread.join();
 }

--- a/pulsar-client-cpp/tests/BlockingQueueTest.cc
+++ b/pulsar-client-cpp/tests/BlockingQueueTest.cc
@@ -153,7 +153,6 @@ TEST(BlockingQueueTest, testTimeout) {
     ASSERT_FALSE(popReturn);
 }
 
-
 TEST(BlockingQueueTest, testPushPopRace) {
     auto test_logic = []() {
         size_t size = 5;

--- a/pulsar-client-cpp/tests/UnboundedBlockingQueueTest.cc
+++ b/pulsar-client-cpp/tests/UnboundedBlockingQueueTest.cc
@@ -1,0 +1,178 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+#include <gtest/gtest.h>
+#include <lib/UnboundedBlockingQueue.h>
+#include <lib/Latch.h>
+
+#include <future>
+#include <thread>
+
+class UnboundedProducerWorker {
+   private:
+    std::thread producerThread_;
+    UnboundedBlockingQueue<int>& queue_;
+
+   public:
+    UnboundedProducerWorker(UnboundedBlockingQueue<int>& queue) : queue_(queue) {}
+
+    void produce(int number) {
+        producerThread_ = std::thread(&UnboundedProducerWorker::pushNumbers, this, number);
+    }
+
+    void pushNumbers(int number) {
+        for (int i = 1; i <= number; i++) {
+            queue_.push(i);
+        }
+    }
+
+    void join() { producerThread_.join(); }
+};
+
+class UnboundedConsumerWorker {
+   private:
+    std::thread consumerThread_;
+    UnboundedBlockingQueue<int>& queue_;
+
+   public:
+    UnboundedConsumerWorker(UnboundedBlockingQueue<int>& queue) : queue_(queue) {}
+
+    void consume(int number) {
+        consumerThread_ = std::thread(&UnboundedConsumerWorker::popNumbers, this, number);
+    }
+
+    void popNumbers(int number) {
+        for (int i = 1; i <= number; i++) {
+            int poppedElement;
+            queue_.pop(poppedElement);
+        }
+    }
+
+    void join() { consumerThread_.join(); }
+};
+
+TEST(UnboundedBlockingQueueTest, testBasic) {
+    size_t size = 5;
+    UnboundedBlockingQueue<int> queue(size);
+
+    UnboundedProducerWorker producerWorker(queue);
+    producerWorker.produce(5);
+
+    UnboundedConsumerWorker consumerWorker(queue);
+    consumerWorker.consume(5);
+
+    producerWorker.join();
+    consumerWorker.join();
+
+    size_t zero = 0;
+    ASSERT_EQ(zero, queue.size());
+}
+
+TEST(UnboundedBlockingQueueTest, testQueueOperations) {
+    size_t size = 5;
+    UnboundedBlockingQueue<int> queue(size);
+    for (size_t i = 1; i <= size; i++) {
+        queue.push(i);
+    }
+    ASSERT_EQ(queue.size(), size);
+
+    int cnt = 1;
+    for (BlockingQueue<int>::const_iterator it = queue.begin(); it != queue.end(); it++) {
+        ASSERT_EQ(cnt, *it);
+        ++cnt;
+    }
+
+    cnt = 1;
+    for (BlockingQueue<int>::iterator it = queue.begin(); it != queue.end(); it++) {
+        ASSERT_EQ(cnt, *it);
+        ++cnt;
+    }
+
+    int poppedElement;
+    for (size_t i = 1; i <= size; i++) {
+        queue.pop(poppedElement);
+    }
+
+    ASSERT_FALSE(queue.peek(poppedElement));
+}
+
+TEST(UnboundedBlockingQueueTest, testBlockingProducer) {
+    size_t size = 5;
+    UnboundedBlockingQueue<int> queue(size);
+
+    UnboundedProducerWorker producerWorker(queue);
+    producerWorker.produce(8);
+
+    UnboundedConsumerWorker consumerWorker(queue);
+    consumerWorker.consume(5);
+
+    producerWorker.join();
+    consumerWorker.join();
+
+    size_t three = 3;
+    ASSERT_EQ(three, queue.size());
+}
+
+TEST(UnboundedBlockingQueueTest, testBlockingConsumer) {
+    size_t size = 5;
+    UnboundedBlockingQueue<int> queue(size);
+
+    UnboundedProducerWorker producerWorker(queue);
+    producerWorker.produce(5);
+
+    UnboundedConsumerWorker consumerWorker(queue);
+    consumerWorker.consume(8);
+
+    producerWorker.pushNumbers(3);
+
+    producerWorker.join();
+    consumerWorker.join();
+
+    size_t zero = 0;
+    ASSERT_EQ(zero, queue.size());
+}
+
+TEST(UnboundedBlockingQueueTest, testTimeout) {
+    size_t size = 5;
+    UnboundedBlockingQueue<int> queue(size);
+    int value;
+    bool popReturn = queue.pop(value, std::chrono::seconds(1));
+    std::this_thread::sleep_for(std::chrono::seconds(2));
+    ASSERT_FALSE(popReturn);
+}
+
+TEST(UnboundedBlockingQueueTest, testCloseInterruptOnEmpty) {
+    UnboundedBlockingQueue<int> queue(10);
+    pulsar::Latch latch(1);
+
+    auto thread = std::thread([&]() {
+        int v;
+        bool res = queue.pop(v);
+        ASSERT_FALSE(res);
+        latch.countdown();
+    });
+
+    // Sleep to allow for background thread to call pop and be blocked there
+    std::this_thread::sleep_for(std::chrono::seconds(1));
+
+    queue.close();
+    bool wasUnblocked = latch.wait(std::chrono::seconds(5));
+
+    ASSERT_TRUE(wasUnblocked);
+    thread.join();
+}


### PR DESCRIPTION
### Motivation

All the blocking operations on the C++ client are currently not unblocked when the producer/consumer/client are closed. 

### Modifications

Introduced new error `ResultInterrupted` which is triggered when client is closed while we're waiting on some conditions.