### PR TITLE
[feature][doc] Add docs about how to use basic authentication

### DIFF
--- a/site2/docs/security-basic-auth.md
+++ b/site2/docs/security-basic-auth.md
@@ -1,0 +1,127 @@
+---
+id: security-basic-auth
+title: Authentication using HTTP basic
+sidebar_label: "Authentication using HTTP basic"
+---
+
+````mdx-code-block
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+````
+
+[Basic authentication](https://en.wikipedia.org/wiki/Basic_access_authentication) is a simple authentication scheme built into the HTTP protocol, which uses base64-encoded username and password pairs as credentials.
+
+## Prerequisites
+
+Install [`htpasswd`](https://httpd.apache.org/docs/2.4/programs/htpasswd.html) in your environment to create a password file for storing username-password pairs.
+
+* For Ubuntu/Debian, run the following command to install `htpasswd`.
+   
+   ```
+   apt install apache2-utils
+   ```
+ 
+* For CentOS/RHEL, run the following command to install `htpasswd`.
+
+   ```
+   yum install httpd-tools
+   ```
+
+## Create your authentication file
+
+:::note
+Currently, you can use MD5 (recommended) and CRYPT encryption to authenticate your password.
+:::
+
+Create a password file named `.htpasswd` with a user account `superuser/admin`:
+* Use MD5 encryption (recommended):
+
+   ```
+   htpasswd -cmb .htpasswd superuser admin
+   ```
+
+* Use CRYPT encryption:
+
+   ```
+   htpasswd -cdb .htpasswd superuser admin
+   ```
+
+You can preview the content of your password file by running the following command:
+
+```
+cat .htpasswd
+superuser:$apr1$GBIYZYFZ$MzLcPrvoUky16mLcK6UtX/
+```
+
+## Enable basic authentication on brokers
+
+To configure brokers to authenticate clients, complete the following steps.
+
+1. Add the following parameters to the `conf/broker.conf` file. If you use a standalone Pulsar, you need to add these parameters to the `conf/standalone.conf` file.
+
+   ```
+   # Configuration to enable Basic authentication
+   authenticationEnabled=true
+   authenticationProviders=org.apache.pulsar.broker.authentication.AuthenticationProviderBasic
+
+   # Authentication settings of the broker itself. Used when the broker connects to other brokers, either in same or other clusters
+   brokerClientAuthenticationPlugin=org.apache.pulsar.client.impl.auth.AuthenticationBasic
+   brokerClientAuthenticationParameters={"userId":"superuser","password":"admin"}
+
+   # If this flag is set then the broker authenticates the original Auth data
+   # else it just accepts the originalPrincipal and authorizes it (if required).
+   authenticateOriginalAuthData=true
+   ```
+
+2. Set an environment variable named `pulsar.auth.basic.conf` and the value is `.htpasswd`. Pulsar reads this environment variable to implement HTTP basic authentication.
+
+## Enable basic authentication on proxies
+
+To configure proxies to authenticate clients, complete the following steps.
+
+1. Add the following parameters to the `conf/proxy.conf` file:
+
+   ```
+   # For clients connecting to the proxy
+   authenticationEnabled=true
+   authenticationProviders=org.apache.pulsar.broker.authentication.AuthenticationProviderBasic
+
+   # For the proxy to connect to brokers
+   brokerClientAuthenticationPlugin=org.apache.pulsar.client.impl.auth.AuthenticationBasic
+   brokerClientAuthenticationParameters={"userId":"superuser","password":"admin"}
+
+   # Whether client authorization credentials are forwarded to the broker for re-authorization.
+   # Authentication must be enabled via authenticationEnabled=true for this to take effect.
+   forwardAuthorizationCredentials=true
+   ```
+
+2. Set an environment variable named `pulsar.auth.basic.conf` and the value is `.htpasswd`. Pulsar reads this environment variable to implement HTTP basic authentication.
+
+## Configure basic authentication through CLI tools
+
+[Command-line tools](https://pulsar.apache.org/docs/next/reference-cli-tools), such as [Pulsar-admin](https://pulsar.apache.org/tools/pulsar-admin/), [Pulsar-perf](https://pulsar.apache.org/tools/pulsar-perf/) and [Pulsar-client](https://pulsar.apache.org/tools/pulsar-client/), use the `conf/client.conf` file in your Pulsar installation. To use basic authentication through Pulsar CLI tools, you need to add the following parameters to the `conf/client.conf` file.
+
+```
+authPlugin=org.apache.pulsar.client.impl.auth.AuthenticationBasic
+authParams={"userId":"superuser","password":"admin"}
+```
+
+
+## Configure basic authentication in Pulsar clients
+
+The following example shows how to configure basic authentication when using Pulsar clients.
+
+<Tabs>
+  <TabItem value="Java" label="Java" default>
+
+   ```java
+   AuthenticationBasic auth = new AuthenticationBasic();
+   auth.configure("{\"userId\":\"superuser\",\"password\":\"admin\"}");
+   PulsarClient client = PulsarClient.builder()
+      .serviceUrl("pulsar://broker.example.com:6650")
+      .authentication(auth)
+      .build();
+   ```
+
+  </TabItem>
+</Tabs>

--- a/site2/docs/security-basic-auth.md
+++ b/site2/docs/security-basic-auth.md
@@ -97,9 +97,9 @@ To configure proxies to authenticate clients, complete the following steps.
 
 2. Set an environment variable named `PULSAR_EXTRA_OPTS` and the value is `-Dpulsar.auth.basic.conf=/path/to/.htpasswd`. Pulsar reads this environment variable to implement HTTP basic authentication.
 
-## Configure basic authentication through CLI tools
+## Configure basic authentication in CLI tools
 
-[Command-line tools](/docs/next/reference-cli-tools), such as [Pulsar-admin](/tools/pulsar-admin/), [Pulsar-perf](/tools/pulsar-perf/) and [Pulsar-client](/tools/pulsar-client/), use the `conf/client.conf` file in your Pulsar installation. To use basic authentication through Pulsar CLI tools, you need to add the following parameters to the `conf/client.conf` file.
+[Command-line tools](/docs/next/reference-cli-tools), such as [Pulsar-admin](/tools/pulsar-admin/), [Pulsar-perf](/tools/pulsar-perf/) and [Pulsar-client](/tools/pulsar-client/), use the `conf/client.conf` file in your Pulsar installation. To configure basic authentication in Pulsar CLI tools, you need to add the following parameters to the `conf/client.conf` file.
 
 ```
 authPlugin=org.apache.pulsar.client.impl.auth.AuthenticationBasic

--- a/site2/docs/security-basic-auth.md
+++ b/site2/docs/security-basic-auth.md
@@ -37,19 +37,19 @@ Create a password file named `.htpasswd` with a user account `superuser/admin`:
 * Use MD5 encryption (recommended):
 
    ```
-   htpasswd -cmb .htpasswd superuser admin
+   htpasswd -cmb /path/to/.htpasswd superuser admin
    ```
 
 * Use CRYPT encryption:
 
    ```
-   htpasswd -cdb .htpasswd superuser admin
+   htpasswd -cdb /path/to/.htpasswd superuser admin
    ```
 
 You can preview the content of your password file by running the following command:
 
 ```
-cat .htpasswd
+cat path/to/.htpasswd
 superuser:$apr1$GBIYZYFZ$MzLcPrvoUky16mLcK6UtX/
 ```
 
@@ -73,7 +73,7 @@ To configure brokers to authenticate clients, complete the following steps.
    authenticateOriginalAuthData=true
    ```
 
-2. Set an environment variable named `pulsar.auth.basic.conf` and the value is `.htpasswd`. Pulsar reads this environment variable to implement HTTP basic authentication.
+2. Set an environment variable named `PULSAR_EXTRA_OPTS` and the value is `-Dpulsar.auth.basic.conf=/path/to/.htpasswd`. Pulsar reads this environment variable to implement HTTP basic authentication.
 
 ## Enable basic authentication on proxies
 
@@ -95,11 +95,11 @@ To configure proxies to authenticate clients, complete the following steps.
    forwardAuthorizationCredentials=true
    ```
 
-2. Set an environment variable named `pulsar.auth.basic.conf` and the value is `.htpasswd`. Pulsar reads this environment variable to implement HTTP basic authentication.
+2. Set an environment variable named `PULSAR_EXTRA_OPTS` and the value is `-Dpulsar.auth.basic.conf=/path/to/.htpasswd`. Pulsar reads this environment variable to implement HTTP basic authentication.
 
 ## Configure basic authentication through CLI tools
 
-[Command-line tools](https://pulsar.apache.org/docs/next/reference-cli-tools), such as [Pulsar-admin](https://pulsar.apache.org/tools/pulsar-admin/), [Pulsar-perf](https://pulsar.apache.org/tools/pulsar-perf/) and [Pulsar-client](https://pulsar.apache.org/tools/pulsar-client/), use the `conf/client.conf` file in your Pulsar installation. To use basic authentication through Pulsar CLI tools, you need to add the following parameters to the `conf/client.conf` file.
+[Command-line tools](/docs/next/reference-cli-tools), such as [Pulsar-admin](/tools/pulsar-admin/), [Pulsar-perf](/tools/pulsar-perf/) and [Pulsar-client](/tools/pulsar-client/), use the `conf/client.conf` file in your Pulsar installation. To use basic authentication through Pulsar CLI tools, you need to add the following parameters to the `conf/client.conf` file.
 
 ```
 authPlugin=org.apache.pulsar.client.impl.auth.AuthenticationBasic

--- a/site2/docs/security-overview.md
+++ b/site2/docs/security-overview.md
@@ -31,6 +31,6 @@ Currently Pulsar supports the following authentication providers:
 - [Kerberos authentication](security-kerberos)
 - [JSON Web Token (JWT) authentication](security-jwt)
 - [OAuth 2.0 authentication](security-oauth2)
-- Basic authentication
+- [HTTP basic authentication](security-basic-auth)
 
 

--- a/site2/website/sidebars.json
+++ b/site2/website/sidebars.json
@@ -146,6 +146,7 @@
         "security-athenz",
         "security-kerberos",
         "security-oauth2",
+        "security-basic-auth",
         "security-authorization",
         "security-encryption",
         "security-extending",

--- a/site2/website/versioned_docs/version-2.10.0/security-basic-auth.md
+++ b/site2/website/versioned_docs/version-2.10.0/security-basic-auth.md
@@ -1,0 +1,127 @@
+---
+id: security-basic-auth
+title: Authentication using HTTP basic
+sidebar_label: "Authentication using HTTP basic"
+---
+
+````mdx-code-block
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+````
+
+[Basic authentication](https://en.wikipedia.org/wiki/Basic_access_authentication) is a simple authentication scheme built into the HTTP protocol, which uses base64-encoded username and password pairs as credentials.
+
+## Prerequisites
+
+Install [`htpasswd`](https://httpd.apache.org/docs/2.4/programs/htpasswd.html) in your environment to create a password file for storing username-password pairs.
+
+* For Ubuntu/Debian, run the following command to install `htpasswd`.
+   
+   ```
+   apt install apache2-utils
+   ```
+ 
+* For CentOS/RHEL, run the following command to install `htpasswd`.
+
+   ```
+   yum install httpd-tools
+   ```
+
+## Create your authentication file
+
+:::note
+Currently, you can use MD5 (recommended) and CRYPT encryption to authenticate your password.
+:::
+
+Create a password file named `.htpasswd` with a user account `superuser/admin`:
+* Use MD5 encryption (recommended):
+
+   ```
+   htpasswd -cmb /path/to/.htpasswd superuser admin
+   ```
+
+* Use CRYPT encryption:
+
+   ```
+   htpasswd -cdb /path/to/.htpasswd superuser admin
+   ```
+
+You can preview the content of your password file by running the following command:
+
+```
+cat path/to/.htpasswd
+superuser:$apr1$GBIYZYFZ$MzLcPrvoUky16mLcK6UtX/
+```
+
+## Enable basic authentication on brokers
+
+To configure brokers to authenticate clients, complete the following steps.
+
+1. Add the following parameters to the `conf/broker.conf` file. If you use a standalone Pulsar, you need to add these parameters to the `conf/standalone.conf` file.
+
+   ```
+   # Configuration to enable Basic authentication
+   authenticationEnabled=true
+   authenticationProviders=org.apache.pulsar.broker.authentication.AuthenticationProviderBasic
+
+   # Authentication settings of the broker itself. Used when the broker connects to other brokers, either in same or other clusters
+   brokerClientAuthenticationPlugin=org.apache.pulsar.client.impl.auth.AuthenticationBasic
+   brokerClientAuthenticationParameters={"userId":"superuser","password":"admin"}
+
+   # If this flag is set then the broker authenticates the original Auth data
+   # else it just accepts the originalPrincipal and authorizes it (if required).
+   authenticateOriginalAuthData=true
+   ```
+
+2. Set an environment variable named `PULSAR_EXTRA_OPTS` and the value is `-Dpulsar.auth.basic.conf=/path/to/.htpasswd`. Pulsar reads this environment variable to implement HTTP basic authentication.
+
+## Enable basic authentication on proxies
+
+To configure proxies to authenticate clients, complete the following steps.
+
+1. Add the following parameters to the `conf/proxy.conf` file:
+
+   ```
+   # For clients connecting to the proxy
+   authenticationEnabled=true
+   authenticationProviders=org.apache.pulsar.broker.authentication.AuthenticationProviderBasic
+
+   # For the proxy to connect to brokers
+   brokerClientAuthenticationPlugin=org.apache.pulsar.client.impl.auth.AuthenticationBasic
+   brokerClientAuthenticationParameters={"userId":"superuser","password":"admin"}
+
+   # Whether client authorization credentials are forwarded to the broker for re-authorization.
+   # Authentication must be enabled via authenticationEnabled=true for this to take effect.
+   forwardAuthorizationCredentials=true
+   ```
+
+2. Set an environment variable named `PULSAR_EXTRA_OPTS` and the value is `-Dpulsar.auth.basic.conf=/path/to/.htpasswd`. Pulsar reads this environment variable to implement HTTP basic authentication.
+
+## Configure basic authentication in CLI tools
+
+[Command-line tools](/docs/next/reference-cli-tools), such as [Pulsar-admin](/tools/pulsar-admin/), [Pulsar-perf](/tools/pulsar-perf/) and [Pulsar-client](/tools/pulsar-client/), use the `conf/client.conf` file in your Pulsar installation. To configure basic authentication in Pulsar CLI tools, you need to add the following parameters to the `conf/client.conf` file.
+
+```
+authPlugin=org.apache.pulsar.client.impl.auth.AuthenticationBasic
+authParams={"userId":"superuser","password":"admin"}
+```
+
+
+## Configure basic authentication in Pulsar clients
+
+The following example shows how to configure basic authentication when using Pulsar clients.
+
+<Tabs>
+  <TabItem value="Java" label="Java" default>
+
+   ```java
+   AuthenticationBasic auth = new AuthenticationBasic();
+   auth.configure("{\"userId\":\"superuser\",\"password\":\"admin\"}");
+   PulsarClient client = PulsarClient.builder()
+      .serviceUrl("pulsar://broker.example.com:6650")
+      .authentication(auth)
+      .build();
+   ```
+
+  </TabItem>
+</Tabs>

--- a/site2/website/versioned_docs/version-2.10.0/security-overview.md
+++ b/site2/website/versioned_docs/version-2.10.0/security-overview.md
@@ -32,6 +32,6 @@ Currently Pulsar supports the following authentication providers:
 - [Kerberos authentication](security-kerberos)
 - [JSON Web Token (JWT) authentication](security-jwt)
 - [OAuth 2.0 authentication](security-oauth2)
-- Basic authentication
+- [HTTP basic authentication](security-basic-auth)
 
 

--- a/site2/website/versioned_docs/version-2.8.0/security-basic-auth.md
+++ b/site2/website/versioned_docs/version-2.8.0/security-basic-auth.md
@@ -1,0 +1,127 @@
+---
+id: security-basic-auth
+title: Authentication using HTTP basic
+sidebar_label: "Authentication using HTTP basic"
+---
+
+````mdx-code-block
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+````
+
+[Basic authentication](https://en.wikipedia.org/wiki/Basic_access_authentication) is a simple authentication scheme built into the HTTP protocol, which uses base64-encoded username and password pairs as credentials.
+
+## Prerequisites
+
+Install [`htpasswd`](https://httpd.apache.org/docs/2.4/programs/htpasswd.html) in your environment to create a password file for storing username-password pairs.
+
+* For Ubuntu/Debian, run the following command to install `htpasswd`.
+   
+   ```
+   apt install apache2-utils
+   ```
+ 
+* For CentOS/RHEL, run the following command to install `htpasswd`.
+
+   ```
+   yum install httpd-tools
+   ```
+
+## Create your authentication file
+
+:::note
+Currently, you can use MD5 (recommended) and CRYPT encryption to authenticate your password.
+:::
+
+Create a password file named `.htpasswd` with a user account `superuser/admin`:
+* Use MD5 encryption (recommended):
+
+   ```
+   htpasswd -cmb /path/to/.htpasswd superuser admin
+   ```
+
+* Use CRYPT encryption:
+
+   ```
+   htpasswd -cdb /path/to/.htpasswd superuser admin
+   ```
+
+You can preview the content of your password file by running the following command:
+
+```
+cat path/to/.htpasswd
+superuser:$apr1$GBIYZYFZ$MzLcPrvoUky16mLcK6UtX/
+```
+
+## Enable basic authentication on brokers
+
+To configure brokers to authenticate clients, complete the following steps.
+
+1. Add the following parameters to the `conf/broker.conf` file. If you use a standalone Pulsar, you need to add these parameters to the `conf/standalone.conf` file.
+
+   ```
+   # Configuration to enable Basic authentication
+   authenticationEnabled=true
+   authenticationProviders=org.apache.pulsar.broker.authentication.AuthenticationProviderBasic
+
+   # Authentication settings of the broker itself. Used when the broker connects to other brokers, either in same or other clusters
+   brokerClientAuthenticationPlugin=org.apache.pulsar.client.impl.auth.AuthenticationBasic
+   brokerClientAuthenticationParameters={"userId":"superuser","password":"admin"}
+
+   # If this flag is set then the broker authenticates the original Auth data
+   # else it just accepts the originalPrincipal and authorizes it (if required).
+   authenticateOriginalAuthData=true
+   ```
+
+2. Set an environment variable named `PULSAR_EXTRA_OPTS` and the value is `-Dpulsar.auth.basic.conf=/path/to/.htpasswd`. Pulsar reads this environment variable to implement HTTP basic authentication.
+
+## Enable basic authentication on proxies
+
+To configure proxies to authenticate clients, complete the following steps.
+
+1. Add the following parameters to the `conf/proxy.conf` file:
+
+   ```
+   # For clients connecting to the proxy
+   authenticationEnabled=true
+   authenticationProviders=org.apache.pulsar.broker.authentication.AuthenticationProviderBasic
+
+   # For the proxy to connect to brokers
+   brokerClientAuthenticationPlugin=org.apache.pulsar.client.impl.auth.AuthenticationBasic
+   brokerClientAuthenticationParameters={"userId":"superuser","password":"admin"}
+
+   # Whether client authorization credentials are forwarded to the broker for re-authorization.
+   # Authentication must be enabled via authenticationEnabled=true for this to take effect.
+   forwardAuthorizationCredentials=true
+   ```
+
+2. Set an environment variable named `PULSAR_EXTRA_OPTS` and the value is `-Dpulsar.auth.basic.conf=/path/to/.htpasswd`. Pulsar reads this environment variable to implement HTTP basic authentication.
+
+## Configure basic authentication in CLI tools
+
+[Command-line tools](/docs/next/reference-cli-tools), such as [Pulsar-admin](/tools/pulsar-admin/), [Pulsar-perf](/tools/pulsar-perf/) and [Pulsar-client](/tools/pulsar-client/), use the `conf/client.conf` file in your Pulsar installation. To configure basic authentication in Pulsar CLI tools, you need to add the following parameters to the `conf/client.conf` file.
+
+```
+authPlugin=org.apache.pulsar.client.impl.auth.AuthenticationBasic
+authParams={"userId":"superuser","password":"admin"}
+```
+
+
+## Configure basic authentication in Pulsar clients
+
+The following example shows how to configure basic authentication when using Pulsar clients.
+
+<Tabs>
+  <TabItem value="Java" label="Java" default>
+
+   ```java
+   AuthenticationBasic auth = new AuthenticationBasic();
+   auth.configure("{\"userId\":\"superuser\",\"password\":\"admin\"}");
+   PulsarClient client = PulsarClient.builder()
+      .serviceUrl("pulsar://broker.example.com:6650")
+      .authentication(auth)
+      .build();
+   ```
+
+  </TabItem>
+</Tabs>

--- a/site2/website/versioned_docs/version-2.8.0/security-overview.md
+++ b/site2/website/versioned_docs/version-2.8.0/security-overview.md
@@ -31,5 +31,6 @@ Currently Pulsar supports the following authentication providers:
 - [Athenz](security-athenz)
 - [Kerberos](security-kerberos)
 - [JSON Web Token Authentication](security-jwt)
-
+- [OAuth 2.0 authentication](security-oauth2)
+- [HTTP basic authentication](security-basic-auth)
 

--- a/site2/website/versioned_docs/version-2.8.1/security-basic-auth.md
+++ b/site2/website/versioned_docs/version-2.8.1/security-basic-auth.md
@@ -1,0 +1,127 @@
+---
+id: security-basic-auth
+title: Authentication using HTTP basic
+sidebar_label: "Authentication using HTTP basic"
+---
+
+````mdx-code-block
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+````
+
+[Basic authentication](https://en.wikipedia.org/wiki/Basic_access_authentication) is a simple authentication scheme built into the HTTP protocol, which uses base64-encoded username and password pairs as credentials.
+
+## Prerequisites
+
+Install [`htpasswd`](https://httpd.apache.org/docs/2.4/programs/htpasswd.html) in your environment to create a password file for storing username-password pairs.
+
+* For Ubuntu/Debian, run the following command to install `htpasswd`.
+   
+   ```
+   apt install apache2-utils
+   ```
+ 
+* For CentOS/RHEL, run the following command to install `htpasswd`.
+
+   ```
+   yum install httpd-tools
+   ```
+
+## Create your authentication file
+
+:::note
+Currently, you can use MD5 (recommended) and CRYPT encryption to authenticate your password.
+:::
+
+Create a password file named `.htpasswd` with a user account `superuser/admin`:
+* Use MD5 encryption (recommended):
+
+   ```
+   htpasswd -cmb /path/to/.htpasswd superuser admin
+   ```
+
+* Use CRYPT encryption:
+
+   ```
+   htpasswd -cdb /path/to/.htpasswd superuser admin
+   ```
+
+You can preview the content of your password file by running the following command:
+
+```
+cat path/to/.htpasswd
+superuser:$apr1$GBIYZYFZ$MzLcPrvoUky16mLcK6UtX/
+```
+
+## Enable basic authentication on brokers
+
+To configure brokers to authenticate clients, complete the following steps.
+
+1. Add the following parameters to the `conf/broker.conf` file. If you use a standalone Pulsar, you need to add these parameters to the `conf/standalone.conf` file.
+
+   ```
+   # Configuration to enable Basic authentication
+   authenticationEnabled=true
+   authenticationProviders=org.apache.pulsar.broker.authentication.AuthenticationProviderBasic
+
+   # Authentication settings of the broker itself. Used when the broker connects to other brokers, either in same or other clusters
+   brokerClientAuthenticationPlugin=org.apache.pulsar.client.impl.auth.AuthenticationBasic
+   brokerClientAuthenticationParameters={"userId":"superuser","password":"admin"}
+
+   # If this flag is set then the broker authenticates the original Auth data
+   # else it just accepts the originalPrincipal and authorizes it (if required).
+   authenticateOriginalAuthData=true
+   ```
+
+2. Set an environment variable named `PULSAR_EXTRA_OPTS` and the value is `-Dpulsar.auth.basic.conf=/path/to/.htpasswd`. Pulsar reads this environment variable to implement HTTP basic authentication.
+
+## Enable basic authentication on proxies
+
+To configure proxies to authenticate clients, complete the following steps.
+
+1. Add the following parameters to the `conf/proxy.conf` file:
+
+   ```
+   # For clients connecting to the proxy
+   authenticationEnabled=true
+   authenticationProviders=org.apache.pulsar.broker.authentication.AuthenticationProviderBasic
+
+   # For the proxy to connect to brokers
+   brokerClientAuthenticationPlugin=org.apache.pulsar.client.impl.auth.AuthenticationBasic
+   brokerClientAuthenticationParameters={"userId":"superuser","password":"admin"}
+
+   # Whether client authorization credentials are forwarded to the broker for re-authorization.
+   # Authentication must be enabled via authenticationEnabled=true for this to take effect.
+   forwardAuthorizationCredentials=true
+   ```
+
+2. Set an environment variable named `PULSAR_EXTRA_OPTS` and the value is `-Dpulsar.auth.basic.conf=/path/to/.htpasswd`. Pulsar reads this environment variable to implement HTTP basic authentication.
+
+## Configure basic authentication in CLI tools
+
+[Command-line tools](/docs/next/reference-cli-tools), such as [Pulsar-admin](/tools/pulsar-admin/), [Pulsar-perf](/tools/pulsar-perf/) and [Pulsar-client](/tools/pulsar-client/), use the `conf/client.conf` file in your Pulsar installation. To configure basic authentication in Pulsar CLI tools, you need to add the following parameters to the `conf/client.conf` file.
+
+```
+authPlugin=org.apache.pulsar.client.impl.auth.AuthenticationBasic
+authParams={"userId":"superuser","password":"admin"}
+```
+
+
+## Configure basic authentication in Pulsar clients
+
+The following example shows how to configure basic authentication when using Pulsar clients.
+
+<Tabs>
+  <TabItem value="Java" label="Java" default>
+
+   ```java
+   AuthenticationBasic auth = new AuthenticationBasic();
+   auth.configure("{\"userId\":\"superuser\",\"password\":\"admin\"}");
+   PulsarClient client = PulsarClient.builder()
+      .serviceUrl("pulsar://broker.example.com:6650")
+      .authentication(auth)
+      .build();
+   ```
+
+  </TabItem>
+</Tabs>

--- a/site2/website/versioned_docs/version-2.8.1/security-overview.md
+++ b/site2/website/versioned_docs/version-2.8.1/security-overview.md
@@ -31,5 +31,6 @@ Currently Pulsar supports the following authentication providers:
 - [Athenz](security-athenz)
 - [Kerberos](security-kerberos)
 - [JSON Web Token Authentication](security-jwt)
-
+- [OAuth 2.0 authentication](security-oauth2)
+- [HTTP basic authentication](security-basic-auth)
 

--- a/site2/website/versioned_docs/version-2.8.2/security-basic-auth.md
+++ b/site2/website/versioned_docs/version-2.8.2/security-basic-auth.md
@@ -1,0 +1,127 @@
+---
+id: security-basic-auth
+title: Authentication using HTTP basic
+sidebar_label: "Authentication using HTTP basic"
+---
+
+````mdx-code-block
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+````
+
+[Basic authentication](https://en.wikipedia.org/wiki/Basic_access_authentication) is a simple authentication scheme built into the HTTP protocol, which uses base64-encoded username and password pairs as credentials.
+
+## Prerequisites
+
+Install [`htpasswd`](https://httpd.apache.org/docs/2.4/programs/htpasswd.html) in your environment to create a password file for storing username-password pairs.
+
+* For Ubuntu/Debian, run the following command to install `htpasswd`.
+   
+   ```
+   apt install apache2-utils
+   ```
+ 
+* For CentOS/RHEL, run the following command to install `htpasswd`.
+
+   ```
+   yum install httpd-tools
+   ```
+
+## Create your authentication file
+
+:::note
+Currently, you can use MD5 (recommended) and CRYPT encryption to authenticate your password.
+:::
+
+Create a password file named `.htpasswd` with a user account `superuser/admin`:
+* Use MD5 encryption (recommended):
+
+   ```
+   htpasswd -cmb /path/to/.htpasswd superuser admin
+   ```
+
+* Use CRYPT encryption:
+
+   ```
+   htpasswd -cdb /path/to/.htpasswd superuser admin
+   ```
+
+You can preview the content of your password file by running the following command:
+
+```
+cat path/to/.htpasswd
+superuser:$apr1$GBIYZYFZ$MzLcPrvoUky16mLcK6UtX/
+```
+
+## Enable basic authentication on brokers
+
+To configure brokers to authenticate clients, complete the following steps.
+
+1. Add the following parameters to the `conf/broker.conf` file. If you use a standalone Pulsar, you need to add these parameters to the `conf/standalone.conf` file.
+
+   ```
+   # Configuration to enable Basic authentication
+   authenticationEnabled=true
+   authenticationProviders=org.apache.pulsar.broker.authentication.AuthenticationProviderBasic
+
+   # Authentication settings of the broker itself. Used when the broker connects to other brokers, either in same or other clusters
+   brokerClientAuthenticationPlugin=org.apache.pulsar.client.impl.auth.AuthenticationBasic
+   brokerClientAuthenticationParameters={"userId":"superuser","password":"admin"}
+
+   # If this flag is set then the broker authenticates the original Auth data
+   # else it just accepts the originalPrincipal and authorizes it (if required).
+   authenticateOriginalAuthData=true
+   ```
+
+2. Set an environment variable named `PULSAR_EXTRA_OPTS` and the value is `-Dpulsar.auth.basic.conf=/path/to/.htpasswd`. Pulsar reads this environment variable to implement HTTP basic authentication.
+
+## Enable basic authentication on proxies
+
+To configure proxies to authenticate clients, complete the following steps.
+
+1. Add the following parameters to the `conf/proxy.conf` file:
+
+   ```
+   # For clients connecting to the proxy
+   authenticationEnabled=true
+   authenticationProviders=org.apache.pulsar.broker.authentication.AuthenticationProviderBasic
+
+   # For the proxy to connect to brokers
+   brokerClientAuthenticationPlugin=org.apache.pulsar.client.impl.auth.AuthenticationBasic
+   brokerClientAuthenticationParameters={"userId":"superuser","password":"admin"}
+
+   # Whether client authorization credentials are forwarded to the broker for re-authorization.
+   # Authentication must be enabled via authenticationEnabled=true for this to take effect.
+   forwardAuthorizationCredentials=true
+   ```
+
+2. Set an environment variable named `PULSAR_EXTRA_OPTS` and the value is `-Dpulsar.auth.basic.conf=/path/to/.htpasswd`. Pulsar reads this environment variable to implement HTTP basic authentication.
+
+## Configure basic authentication in CLI tools
+
+[Command-line tools](/docs/next/reference-cli-tools), such as [Pulsar-admin](/tools/pulsar-admin/), [Pulsar-perf](/tools/pulsar-perf/) and [Pulsar-client](/tools/pulsar-client/), use the `conf/client.conf` file in your Pulsar installation. To configure basic authentication in Pulsar CLI tools, you need to add the following parameters to the `conf/client.conf` file.
+
+```
+authPlugin=org.apache.pulsar.client.impl.auth.AuthenticationBasic
+authParams={"userId":"superuser","password":"admin"}
+```
+
+
+## Configure basic authentication in Pulsar clients
+
+The following example shows how to configure basic authentication when using Pulsar clients.
+
+<Tabs>
+  <TabItem value="Java" label="Java" default>
+
+   ```java
+   AuthenticationBasic auth = new AuthenticationBasic();
+   auth.configure("{\"userId\":\"superuser\",\"password\":\"admin\"}");
+   PulsarClient client = PulsarClient.builder()
+      .serviceUrl("pulsar://broker.example.com:6650")
+      .authentication(auth)
+      .build();
+   ```
+
+  </TabItem>
+</Tabs>

--- a/site2/website/versioned_docs/version-2.8.2/security-overview.md
+++ b/site2/website/versioned_docs/version-2.8.2/security-overview.md
@@ -31,5 +31,6 @@ Currently Pulsar supports the following authentication providers:
 - [Athenz](security-athenz)
 - [Kerberos](security-kerberos)
 - [JSON Web Token Authentication](security-jwt)
-
+- [OAuth 2.0 authentication](security-oauth2)
+- [HTTP basic authentication](security-basic-auth)
 

--- a/site2/website/versioned_docs/version-2.8.3/security-basic-auth.md
+++ b/site2/website/versioned_docs/version-2.8.3/security-basic-auth.md
@@ -1,0 +1,127 @@
+---
+id: security-basic-auth
+title: Authentication using HTTP basic
+sidebar_label: "Authentication using HTTP basic"
+---
+
+````mdx-code-block
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+````
+
+[Basic authentication](https://en.wikipedia.org/wiki/Basic_access_authentication) is a simple authentication scheme built into the HTTP protocol, which uses base64-encoded username and password pairs as credentials.
+
+## Prerequisites
+
+Install [`htpasswd`](https://httpd.apache.org/docs/2.4/programs/htpasswd.html) in your environment to create a password file for storing username-password pairs.
+
+* For Ubuntu/Debian, run the following command to install `htpasswd`.
+   
+   ```
+   apt install apache2-utils
+   ```
+ 
+* For CentOS/RHEL, run the following command to install `htpasswd`.
+
+   ```
+   yum install httpd-tools
+   ```
+
+## Create your authentication file
+
+:::note
+Currently, you can use MD5 (recommended) and CRYPT encryption to authenticate your password.
+:::
+
+Create a password file named `.htpasswd` with a user account `superuser/admin`:
+* Use MD5 encryption (recommended):
+
+   ```
+   htpasswd -cmb /path/to/.htpasswd superuser admin
+   ```
+
+* Use CRYPT encryption:
+
+   ```
+   htpasswd -cdb /path/to/.htpasswd superuser admin
+   ```
+
+You can preview the content of your password file by running the following command:
+
+```
+cat path/to/.htpasswd
+superuser:$apr1$GBIYZYFZ$MzLcPrvoUky16mLcK6UtX/
+```
+
+## Enable basic authentication on brokers
+
+To configure brokers to authenticate clients, complete the following steps.
+
+1. Add the following parameters to the `conf/broker.conf` file. If you use a standalone Pulsar, you need to add these parameters to the `conf/standalone.conf` file.
+
+   ```
+   # Configuration to enable Basic authentication
+   authenticationEnabled=true
+   authenticationProviders=org.apache.pulsar.broker.authentication.AuthenticationProviderBasic
+
+   # Authentication settings of the broker itself. Used when the broker connects to other brokers, either in same or other clusters
+   brokerClientAuthenticationPlugin=org.apache.pulsar.client.impl.auth.AuthenticationBasic
+   brokerClientAuthenticationParameters={"userId":"superuser","password":"admin"}
+
+   # If this flag is set then the broker authenticates the original Auth data
+   # else it just accepts the originalPrincipal and authorizes it (if required).
+   authenticateOriginalAuthData=true
+   ```
+
+2. Set an environment variable named `PULSAR_EXTRA_OPTS` and the value is `-Dpulsar.auth.basic.conf=/path/to/.htpasswd`. Pulsar reads this environment variable to implement HTTP basic authentication.
+
+## Enable basic authentication on proxies
+
+To configure proxies to authenticate clients, complete the following steps.
+
+1. Add the following parameters to the `conf/proxy.conf` file:
+
+   ```
+   # For clients connecting to the proxy
+   authenticationEnabled=true
+   authenticationProviders=org.apache.pulsar.broker.authentication.AuthenticationProviderBasic
+
+   # For the proxy to connect to brokers
+   brokerClientAuthenticationPlugin=org.apache.pulsar.client.impl.auth.AuthenticationBasic
+   brokerClientAuthenticationParameters={"userId":"superuser","password":"admin"}
+
+   # Whether client authorization credentials are forwarded to the broker for re-authorization.
+   # Authentication must be enabled via authenticationEnabled=true for this to take effect.
+   forwardAuthorizationCredentials=true
+   ```
+
+2. Set an environment variable named `PULSAR_EXTRA_OPTS` and the value is `-Dpulsar.auth.basic.conf=/path/to/.htpasswd`. Pulsar reads this environment variable to implement HTTP basic authentication.
+
+## Configure basic authentication in CLI tools
+
+[Command-line tools](/docs/next/reference-cli-tools), such as [Pulsar-admin](/tools/pulsar-admin/), [Pulsar-perf](/tools/pulsar-perf/) and [Pulsar-client](/tools/pulsar-client/), use the `conf/client.conf` file in your Pulsar installation. To configure basic authentication in Pulsar CLI tools, you need to add the following parameters to the `conf/client.conf` file.
+
+```
+authPlugin=org.apache.pulsar.client.impl.auth.AuthenticationBasic
+authParams={"userId":"superuser","password":"admin"}
+```
+
+
+## Configure basic authentication in Pulsar clients
+
+The following example shows how to configure basic authentication when using Pulsar clients.
+
+<Tabs>
+  <TabItem value="Java" label="Java" default>
+
+   ```java
+   AuthenticationBasic auth = new AuthenticationBasic();
+   auth.configure("{\"userId\":\"superuser\",\"password\":\"admin\"}");
+   PulsarClient client = PulsarClient.builder()
+      .serviceUrl("pulsar://broker.example.com:6650")
+      .authentication(auth)
+      .build();
+   ```
+
+  </TabItem>
+</Tabs>

--- a/site2/website/versioned_docs/version-2.8.3/security-overview.md
+++ b/site2/website/versioned_docs/version-2.8.3/security-overview.md
@@ -31,5 +31,6 @@ Currently Pulsar supports the following authentication providers:
 - [Athenz](security-athenz)
 - [Kerberos](security-kerberos)
 - [JSON Web Token Authentication](security-jwt)
-
+- [OAuth 2.0 authentication](security-oauth2)
+- [HTTP basic authentication](security-basic-auth)
 

--- a/site2/website/versioned_docs/version-2.9.0/security-basic-auth.md
+++ b/site2/website/versioned_docs/version-2.9.0/security-basic-auth.md
@@ -1,0 +1,127 @@
+---
+id: security-basic-auth
+title: Authentication using HTTP basic
+sidebar_label: "Authentication using HTTP basic"
+---
+
+````mdx-code-block
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+````
+
+[Basic authentication](https://en.wikipedia.org/wiki/Basic_access_authentication) is a simple authentication scheme built into the HTTP protocol, which uses base64-encoded username and password pairs as credentials.
+
+## Prerequisites
+
+Install [`htpasswd`](https://httpd.apache.org/docs/2.4/programs/htpasswd.html) in your environment to create a password file for storing username-password pairs.
+
+* For Ubuntu/Debian, run the following command to install `htpasswd`.
+   
+   ```
+   apt install apache2-utils
+   ```
+ 
+* For CentOS/RHEL, run the following command to install `htpasswd`.
+
+   ```
+   yum install httpd-tools
+   ```
+
+## Create your authentication file
+
+:::note
+Currently, you can use MD5 (recommended) and CRYPT encryption to authenticate your password.
+:::
+
+Create a password file named `.htpasswd` with a user account `superuser/admin`:
+* Use MD5 encryption (recommended):
+
+   ```
+   htpasswd -cmb /path/to/.htpasswd superuser admin
+   ```
+
+* Use CRYPT encryption:
+
+   ```
+   htpasswd -cdb /path/to/.htpasswd superuser admin
+   ```
+
+You can preview the content of your password file by running the following command:
+
+```
+cat path/to/.htpasswd
+superuser:$apr1$GBIYZYFZ$MzLcPrvoUky16mLcK6UtX/
+```
+
+## Enable basic authentication on brokers
+
+To configure brokers to authenticate clients, complete the following steps.
+
+1. Add the following parameters to the `conf/broker.conf` file. If you use a standalone Pulsar, you need to add these parameters to the `conf/standalone.conf` file.
+
+   ```
+   # Configuration to enable Basic authentication
+   authenticationEnabled=true
+   authenticationProviders=org.apache.pulsar.broker.authentication.AuthenticationProviderBasic
+
+   # Authentication settings of the broker itself. Used when the broker connects to other brokers, either in same or other clusters
+   brokerClientAuthenticationPlugin=org.apache.pulsar.client.impl.auth.AuthenticationBasic
+   brokerClientAuthenticationParameters={"userId":"superuser","password":"admin"}
+
+   # If this flag is set then the broker authenticates the original Auth data
+   # else it just accepts the originalPrincipal and authorizes it (if required).
+   authenticateOriginalAuthData=true
+   ```
+
+2. Set an environment variable named `PULSAR_EXTRA_OPTS` and the value is `-Dpulsar.auth.basic.conf=/path/to/.htpasswd`. Pulsar reads this environment variable to implement HTTP basic authentication.
+
+## Enable basic authentication on proxies
+
+To configure proxies to authenticate clients, complete the following steps.
+
+1. Add the following parameters to the `conf/proxy.conf` file:
+
+   ```
+   # For clients connecting to the proxy
+   authenticationEnabled=true
+   authenticationProviders=org.apache.pulsar.broker.authentication.AuthenticationProviderBasic
+
+   # For the proxy to connect to brokers
+   brokerClientAuthenticationPlugin=org.apache.pulsar.client.impl.auth.AuthenticationBasic
+   brokerClientAuthenticationParameters={"userId":"superuser","password":"admin"}
+
+   # Whether client authorization credentials are forwarded to the broker for re-authorization.
+   # Authentication must be enabled via authenticationEnabled=true for this to take effect.
+   forwardAuthorizationCredentials=true
+   ```
+
+2. Set an environment variable named `PULSAR_EXTRA_OPTS` and the value is `-Dpulsar.auth.basic.conf=/path/to/.htpasswd`. Pulsar reads this environment variable to implement HTTP basic authentication.
+
+## Configure basic authentication in CLI tools
+
+[Command-line tools](/docs/next/reference-cli-tools), such as [Pulsar-admin](/tools/pulsar-admin/), [Pulsar-perf](/tools/pulsar-perf/) and [Pulsar-client](/tools/pulsar-client/), use the `conf/client.conf` file in your Pulsar installation. To configure basic authentication in Pulsar CLI tools, you need to add the following parameters to the `conf/client.conf` file.
+
+```
+authPlugin=org.apache.pulsar.client.impl.auth.AuthenticationBasic
+authParams={"userId":"superuser","password":"admin"}
+```
+
+
+## Configure basic authentication in Pulsar clients
+
+The following example shows how to configure basic authentication when using Pulsar clients.
+
+<Tabs>
+  <TabItem value="Java" label="Java" default>
+
+   ```java
+   AuthenticationBasic auth = new AuthenticationBasic();
+   auth.configure("{\"userId\":\"superuser\",\"password\":\"admin\"}");
+   PulsarClient client = PulsarClient.builder()
+      .serviceUrl("pulsar://broker.example.com:6650")
+      .authentication(auth)
+      .build();
+   ```
+
+  </TabItem>
+</Tabs>

--- a/site2/website/versioned_docs/version-2.9.0/security-overview.md
+++ b/site2/website/versioned_docs/version-2.9.0/security-overview.md
@@ -31,5 +31,6 @@ Currently Pulsar supports the following authentication providers:
 - [Athenz](security-athenz)
 - [Kerberos](security-kerberos)
 - [JSON Web Token Authentication](security-jwt)
-
+- [OAuth 2.0 authentication](security-oauth2)
+- [HTTP basic authentication](security-basic-auth)
 

--- a/site2/website/versioned_docs/version-2.9.1/security-basic-auth.md
+++ b/site2/website/versioned_docs/version-2.9.1/security-basic-auth.md
@@ -1,0 +1,127 @@
+---
+id: security-basic-auth
+title: Authentication using HTTP basic
+sidebar_label: "Authentication using HTTP basic"
+---
+
+````mdx-code-block
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+````
+
+[Basic authentication](https://en.wikipedia.org/wiki/Basic_access_authentication) is a simple authentication scheme built into the HTTP protocol, which uses base64-encoded username and password pairs as credentials.
+
+## Prerequisites
+
+Install [`htpasswd`](https://httpd.apache.org/docs/2.4/programs/htpasswd.html) in your environment to create a password file for storing username-password pairs.
+
+* For Ubuntu/Debian, run the following command to install `htpasswd`.
+   
+   ```
+   apt install apache2-utils
+   ```
+ 
+* For CentOS/RHEL, run the following command to install `htpasswd`.
+
+   ```
+   yum install httpd-tools
+   ```
+
+## Create your authentication file
+
+:::note
+Currently, you can use MD5 (recommended) and CRYPT encryption to authenticate your password.
+:::
+
+Create a password file named `.htpasswd` with a user account `superuser/admin`:
+* Use MD5 encryption (recommended):
+
+   ```
+   htpasswd -cmb /path/to/.htpasswd superuser admin
+   ```
+
+* Use CRYPT encryption:
+
+   ```
+   htpasswd -cdb /path/to/.htpasswd superuser admin
+   ```
+
+You can preview the content of your password file by running the following command:
+
+```
+cat path/to/.htpasswd
+superuser:$apr1$GBIYZYFZ$MzLcPrvoUky16mLcK6UtX/
+```
+
+## Enable basic authentication on brokers
+
+To configure brokers to authenticate clients, complete the following steps.
+
+1. Add the following parameters to the `conf/broker.conf` file. If you use a standalone Pulsar, you need to add these parameters to the `conf/standalone.conf` file.
+
+   ```
+   # Configuration to enable Basic authentication
+   authenticationEnabled=true
+   authenticationProviders=org.apache.pulsar.broker.authentication.AuthenticationProviderBasic
+
+   # Authentication settings of the broker itself. Used when the broker connects to other brokers, either in same or other clusters
+   brokerClientAuthenticationPlugin=org.apache.pulsar.client.impl.auth.AuthenticationBasic
+   brokerClientAuthenticationParameters={"userId":"superuser","password":"admin"}
+
+   # If this flag is set then the broker authenticates the original Auth data
+   # else it just accepts the originalPrincipal and authorizes it (if required).
+   authenticateOriginalAuthData=true
+   ```
+
+2. Set an environment variable named `PULSAR_EXTRA_OPTS` and the value is `-Dpulsar.auth.basic.conf=/path/to/.htpasswd`. Pulsar reads this environment variable to implement HTTP basic authentication.
+
+## Enable basic authentication on proxies
+
+To configure proxies to authenticate clients, complete the following steps.
+
+1. Add the following parameters to the `conf/proxy.conf` file:
+
+   ```
+   # For clients connecting to the proxy
+   authenticationEnabled=true
+   authenticationProviders=org.apache.pulsar.broker.authentication.AuthenticationProviderBasic
+
+   # For the proxy to connect to brokers
+   brokerClientAuthenticationPlugin=org.apache.pulsar.client.impl.auth.AuthenticationBasic
+   brokerClientAuthenticationParameters={"userId":"superuser","password":"admin"}
+
+   # Whether client authorization credentials are forwarded to the broker for re-authorization.
+   # Authentication must be enabled via authenticationEnabled=true for this to take effect.
+   forwardAuthorizationCredentials=true
+   ```
+
+2. Set an environment variable named `PULSAR_EXTRA_OPTS` and the value is `-Dpulsar.auth.basic.conf=/path/to/.htpasswd`. Pulsar reads this environment variable to implement HTTP basic authentication.
+
+## Configure basic authentication in CLI tools
+
+[Command-line tools](/docs/next/reference-cli-tools), such as [Pulsar-admin](/tools/pulsar-admin/), [Pulsar-perf](/tools/pulsar-perf/) and [Pulsar-client](/tools/pulsar-client/), use the `conf/client.conf` file in your Pulsar installation. To configure basic authentication in Pulsar CLI tools, you need to add the following parameters to the `conf/client.conf` file.
+
+```
+authPlugin=org.apache.pulsar.client.impl.auth.AuthenticationBasic
+authParams={"userId":"superuser","password":"admin"}
+```
+
+
+## Configure basic authentication in Pulsar clients
+
+The following example shows how to configure basic authentication when using Pulsar clients.
+
+<Tabs>
+  <TabItem value="Java" label="Java" default>
+
+   ```java
+   AuthenticationBasic auth = new AuthenticationBasic();
+   auth.configure("{\"userId\":\"superuser\",\"password\":\"admin\"}");
+   PulsarClient client = PulsarClient.builder()
+      .serviceUrl("pulsar://broker.example.com:6650")
+      .authentication(auth)
+      .build();
+   ```
+
+  </TabItem>
+</Tabs>

--- a/site2/website/versioned_docs/version-2.9.1/security-overview.md
+++ b/site2/website/versioned_docs/version-2.9.1/security-overview.md
@@ -31,5 +31,6 @@ Currently Pulsar supports the following authentication providers:
 - [Athenz](security-athenz)
 - [Kerberos](security-kerberos)
 - [JSON Web Token Authentication](security-jwt)
-
+- [OAuth 2.0 authentication](security-oauth2)
+- [HTTP basic authentication](security-basic-auth)
 

--- a/site2/website/versioned_docs/version-2.9.2/security-basic-auth.md
+++ b/site2/website/versioned_docs/version-2.9.2/security-basic-auth.md
@@ -1,0 +1,127 @@
+---
+id: security-basic-auth
+title: Authentication using HTTP basic
+sidebar_label: "Authentication using HTTP basic"
+---
+
+````mdx-code-block
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+````
+
+[Basic authentication](https://en.wikipedia.org/wiki/Basic_access_authentication) is a simple authentication scheme built into the HTTP protocol, which uses base64-encoded username and password pairs as credentials.
+
+## Prerequisites
+
+Install [`htpasswd`](https://httpd.apache.org/docs/2.4/programs/htpasswd.html) in your environment to create a password file for storing username-password pairs.
+
+* For Ubuntu/Debian, run the following command to install `htpasswd`.
+   
+   ```
+   apt install apache2-utils
+   ```
+ 
+* For CentOS/RHEL, run the following command to install `htpasswd`.
+
+   ```
+   yum install httpd-tools
+   ```
+
+## Create your authentication file
+
+:::note
+Currently, you can use MD5 (recommended) and CRYPT encryption to authenticate your password.
+:::
+
+Create a password file named `.htpasswd` with a user account `superuser/admin`:
+* Use MD5 encryption (recommended):
+
+   ```
+   htpasswd -cmb /path/to/.htpasswd superuser admin
+   ```
+
+* Use CRYPT encryption:
+
+   ```
+   htpasswd -cdb /path/to/.htpasswd superuser admin
+   ```
+
+You can preview the content of your password file by running the following command:
+
+```
+cat path/to/.htpasswd
+superuser:$apr1$GBIYZYFZ$MzLcPrvoUky16mLcK6UtX/
+```
+
+## Enable basic authentication on brokers
+
+To configure brokers to authenticate clients, complete the following steps.
+
+1. Add the following parameters to the `conf/broker.conf` file. If you use a standalone Pulsar, you need to add these parameters to the `conf/standalone.conf` file.
+
+   ```
+   # Configuration to enable Basic authentication
+   authenticationEnabled=true
+   authenticationProviders=org.apache.pulsar.broker.authentication.AuthenticationProviderBasic
+
+   # Authentication settings of the broker itself. Used when the broker connects to other brokers, either in same or other clusters
+   brokerClientAuthenticationPlugin=org.apache.pulsar.client.impl.auth.AuthenticationBasic
+   brokerClientAuthenticationParameters={"userId":"superuser","password":"admin"}
+
+   # If this flag is set then the broker authenticates the original Auth data
+   # else it just accepts the originalPrincipal and authorizes it (if required).
+   authenticateOriginalAuthData=true
+   ```
+
+2. Set an environment variable named `PULSAR_EXTRA_OPTS` and the value is `-Dpulsar.auth.basic.conf=/path/to/.htpasswd`. Pulsar reads this environment variable to implement HTTP basic authentication.
+
+## Enable basic authentication on proxies
+
+To configure proxies to authenticate clients, complete the following steps.
+
+1. Add the following parameters to the `conf/proxy.conf` file:
+
+   ```
+   # For clients connecting to the proxy
+   authenticationEnabled=true
+   authenticationProviders=org.apache.pulsar.broker.authentication.AuthenticationProviderBasic
+
+   # For the proxy to connect to brokers
+   brokerClientAuthenticationPlugin=org.apache.pulsar.client.impl.auth.AuthenticationBasic
+   brokerClientAuthenticationParameters={"userId":"superuser","password":"admin"}
+
+   # Whether client authorization credentials are forwarded to the broker for re-authorization.
+   # Authentication must be enabled via authenticationEnabled=true for this to take effect.
+   forwardAuthorizationCredentials=true
+   ```
+
+2. Set an environment variable named `PULSAR_EXTRA_OPTS` and the value is `-Dpulsar.auth.basic.conf=/path/to/.htpasswd`. Pulsar reads this environment variable to implement HTTP basic authentication.
+
+## Configure basic authentication in CLI tools
+
+[Command-line tools](/docs/next/reference-cli-tools), such as [Pulsar-admin](/tools/pulsar-admin/), [Pulsar-perf](/tools/pulsar-perf/) and [Pulsar-client](/tools/pulsar-client/), use the `conf/client.conf` file in your Pulsar installation. To configure basic authentication in Pulsar CLI tools, you need to add the following parameters to the `conf/client.conf` file.
+
+```
+authPlugin=org.apache.pulsar.client.impl.auth.AuthenticationBasic
+authParams={"userId":"superuser","password":"admin"}
+```
+
+
+## Configure basic authentication in Pulsar clients
+
+The following example shows how to configure basic authentication when using Pulsar clients.
+
+<Tabs>
+  <TabItem value="Java" label="Java" default>
+
+   ```java
+   AuthenticationBasic auth = new AuthenticationBasic();
+   auth.configure("{\"userId\":\"superuser\",\"password\":\"admin\"}");
+   PulsarClient client = PulsarClient.builder()
+      .serviceUrl("pulsar://broker.example.com:6650")
+      .authentication(auth)
+      .build();
+   ```
+
+  </TabItem>
+</Tabs>

--- a/site2/website/versioned_docs/version-2.9.2/security-overview.md
+++ b/site2/website/versioned_docs/version-2.9.2/security-overview.md
@@ -31,5 +31,7 @@ Currently Pulsar supports the following authentication providers:
 - [Athenz](security-athenz)
 - [Kerberos](security-kerberos)
 - [JSON Web Token Authentication](security-jwt)
+- [OAuth 2.0 authentication](security-oauth2)
+- [HTTP basic authentication](security-basic-auth)
 
 

--- a/site2/website/versioned_sidebars/version-2.10.0-sidebars.json
+++ b/site2/website/versioned_sidebars/version-2.10.0-sidebars.json
@@ -392,6 +392,10 @@
         },
         {
           "type": "doc",
+          "id": "version-2.10.0/security-basic-auth"
+        },
+        {
+          "type": "doc",
           "id": "version-2.10.0/security-authorization"
         },
         {

--- a/site2/website/versioned_sidebars/version-2.8.0-sidebars.json
+++ b/site2/website/versioned_sidebars/version-2.8.0-sidebars.json
@@ -384,6 +384,10 @@
         },
         {
           "type": "doc",
+          "id": "version-2.8.0/security-basic-auth"
+        },
+        {
+          "type": "doc",
           "id": "version-2.8.0/security-authorization"
         },
         {

--- a/site2/website/versioned_sidebars/version-2.8.1-sidebars.json
+++ b/site2/website/versioned_sidebars/version-2.8.1-sidebars.json
@@ -384,6 +384,10 @@
         },
         {
           "type": "doc",
+          "id": "version-2.8.1/security-basic-auth"
+        },
+        {
+          "type": "doc",
           "id": "version-2.8.1/security-authorization"
         },
         {

--- a/site2/website/versioned_sidebars/version-2.8.2-sidebars.json
+++ b/site2/website/versioned_sidebars/version-2.8.2-sidebars.json
@@ -384,6 +384,10 @@
         },
         {
           "type": "doc",
+          "id": "version-2.8.2/security-basic-auth"
+        },
+        {
+          "type": "doc",
           "id": "version-2.8.2/security-authorization"
         },
         {

--- a/site2/website/versioned_sidebars/version-2.8.3-sidebars.json
+++ b/site2/website/versioned_sidebars/version-2.8.3-sidebars.json
@@ -384,6 +384,10 @@
         },
         {
           "type": "doc",
+          "id": "version-2.8.2/security-basic-auth"
+        },
+        {
+          "type": "doc",
           "id": "version-2.8.3/security-authorization"
         },
         {

--- a/site2/website/versioned_sidebars/version-2.9.0-sidebars.json
+++ b/site2/website/versioned_sidebars/version-2.9.0-sidebars.json
@@ -384,6 +384,10 @@
         },
         {
           "type": "doc",
+          "id": "version-2.9.0/security-basic-auth"
+        },
+        {
+          "type": "doc",
           "id": "version-2.9.0/security-authorization"
         },
         {

--- a/site2/website/versioned_sidebars/version-2.9.1-sidebars.json
+++ b/site2/website/versioned_sidebars/version-2.9.1-sidebars.json
@@ -384,6 +384,10 @@
         },
         {
           "type": "doc",
+          "id": "version-2.9.1/security-basic-auth"
+        },
+        {
+          "type": "doc",
           "id": "version-2.9.1/security-authorization"
         },
         {

--- a/site2/website/versioned_sidebars/version-2.9.2-sidebars.json
+++ b/site2/website/versioned_sidebars/version-2.9.2-sidebars.json
@@ -384,6 +384,10 @@
         },
         {
           "type": "doc",
+          "id": "version-2.9.2/security-basic-auth"
+        },
+        {
+          "type": "doc",
           "id": "version-2.9.2/security-authorization"
         },
         {


### PR DESCRIPTION
Fixes #14661 

### Modifications

1. Add a new topic about how to use basic authentication
2. Sync the topic in the left navigation and security overview

The preview looks good.
<img width="1771" alt="image" src="https://user-images.githubusercontent.com/60642177/169942966-0e62fa1d-4656-4ad9-9ce4-05b91081e40e.png">
<img width="1702" alt="image" src="https://user-images.githubusercontent.com/60642177/169978047-ab5ce8b4-6193-4248-8136-2785dc4bd1c0.png">
<img width="1713" alt="image" src="https://user-images.githubusercontent.com/60642177/169978143-1b030053-d5fa-492b-9180-ae639ab5d711.png">
<img width="1717" alt="image" src="https://user-images.githubusercontent.com/60642177/169978259-db0250e6-2c15-4213-8b75-70fb276c1f9a.png">



Note that the changes need to be applied to more historical versions since 2.8 as soon as it gets approved.

### Documentation
  
- [x] `doc` 
