### PR TITLE
[cleanup][ledger] Remove unnecessary code in ManagedLedgerImpl

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
@@ -329,9 +329,6 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
         this.maximumRolloverTimeMs = getMaximumRolloverTimeMs(config);
         this.mlOwnershipChecker = mlOwnershipChecker;
         this.propertiesMap = Maps.newHashMap();
-        if (config.getManagedLedgerInterceptor() != null) {
-            this.managedLedgerInterceptor = config.getManagedLedgerInterceptor();
-        }
         this.inactiveLedgerRollOverTimeMs = config.getInactiveLedgerRollOverTimeMs();
     }
 


### PR DESCRIPTION
### Motivation

The managedLedgerInterceptor member variable is initialized twice within the same method.

https://github.com/apache/pulsar/blob/b155d84c2ee397fe8003f452f04ae6cedf229b5c/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java#L319-L321

https://github.com/apache/pulsar/blob/b155d84c2ee397fe8003f452f04ae6cedf229b5c/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java#L332-L334

### Modifications

Remove unnecessary code

### Documentation

- [ ] `doc-required` 
  
- [x] `no-need-doc` 
  
- [ ] `doc` 

- [ ] `doc-added`