### PR TITLE
[branch-2.7][broker] Fix can not enable system topic if `AutoUpdateSchemaEnabled=false`

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractTopic.java
@@ -266,7 +266,7 @@ public abstract class AbstractTopic implements Topic {
         String base = TopicName.get(getName()).getPartitionedTopicName();
         String id = TopicName.get(base).getSchemaName();
         SchemaRegistryService schemaRegistryService = brokerService.pulsar().getSchemaRegistryService();
-        return isAllowAutoUpdateSchema ? schemaRegistryService
+        return allowAutoUpdateSchema() ? schemaRegistryService
                 .putSchemaIfAbsent(id, schema, schemaCompatibilityStrategy)
                 : schemaRegistryService.trimDeletedSchemaAndGetList(id).thenCompose(schemaAndMetadataList ->
                 schemaRegistryService.getSchemaVersionBySchemaData(schemaAndMetadataList, schema)
@@ -603,5 +603,12 @@ public abstract class AbstractTopic implements Topic {
             this.topicPublishRateLimiter = PublishRateLimiter.DISABLED_RATE_LIMITER;
             enableProducerReadForPublishRateLimiting();
         }
+    }
+
+    private boolean allowAutoUpdateSchema() {
+        if (brokerService.isSystemTopic(topic)) {
+            return true;
+        }
+        return isAllowAutoUpdateSchema;
     }
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
@@ -2463,7 +2463,7 @@ public class BrokerService implements Closeable, ZooKeeperCacheListener<Policies
         log.debug("No autoSubscriptionCreateOverride policy found for {}", topicName);
         return null;
     }
-    private boolean isSystemTopic(String topic) {
+    public boolean isSystemTopic(String topic) {
         return SystemTopicClient.isSystemTopic(TopicName.get(topic));
     }
 


### PR DESCRIPTION
### Motivation

https://github.com/apache/pulsar/pull/14809 is not cherry-picked to branch-2.7 and branch-2.8, but we support system topic since 2.6, so this issue is also existed in branch-2.7 and branch-2.8. So we need to cherry-pick them.

Some users face the same issue of branch-2.7:
<img width="1152" alt="image" src="https://user-images.githubusercontent.com/6297296/169998868-3ce203fa-594e-4011-845c-106bb018ad7f.png">



### Documentation

- [x] `no-need-doc` 
(Please explain why)
