### PR TITLE
[fix][doc] Deprecate io-cli page and update occurrences referenced elsewhere

### DIFF
--- a/site2/docs/io-cli.md
+++ b/site2/docs/io-cli.md
@@ -4,6 +4,14 @@ title: Connector Admin CLI
 sidebar_label: "CLI"
 ---
 
+:::note
+
+**Important**
+
+This page is deprecated and not updated anymore. For the latest and complete information about `Pulsar-admin`, including commands, flags, descriptions, and more, see [Pulsar admin docs](https://pulsar.apache.org/tools/pulsar-admin/).
+
+:::
+
 The `pulsar-admin` tool helps you manage Pulsar connectors.
   
 ## `sources`

--- a/site2/docs/io-overview.md
+++ b/site2/docs/io-overview.md
@@ -157,7 +157,7 @@ For more information about the options of `pulsar-admin sinks update`, see [here
 
 ## Work with connector
 
-You can manage Pulsar connectors (for example, create, update, start, stop, restart, reload, delete and perform other operations on connectors) via the [Connector Admin CLI](reference-connector-admin) with [sources](io-cli.md#sources) and [sinks](io-cli.md#sinks) subcommands.
+You can manage Pulsar connectors (for example, create, update, start, stop, restart, reload, delete and perform other operations on connectors) via the `Connector Admin CLI` with sources and sinks subcommands. For the latest and complete information, see [Pulsar admin docs](https://pulsar.apache.org/tools/pulsar-admin/).
 
-Connectors (sources and sinks) and Functions are components of instances, and they all run on Functions workers. When managing a source, sink or function via [Connector Admin CLI](reference-connector-admin.md) or [Functions Admin CLI](functions-cli), an instance is started on a worker. For more information, see [Functions worker](functions-worker.md#run-functions-worker-separately).
+Connectors (sources and sinks) and Functions are components of instances, and they all run on Functions workers. When managing a source, sink or function via the `Connector Admin CLI` or [Functions Admin CLI](functions-cli), an instance is started on a worker. For more information, see [Functions worker](functions-worker.md#run-functions-worker-separately).
 

--- a/site2/docs/io-quickstart.md
+++ b/site2/docs/io-quickstart.md
@@ -17,7 +17,7 @@ At the end of this tutorial, you are able to:
 :::tip
 
 * These instructions assume you are running Pulsar in [standalone mode](getting-started-standalone). However, all
-the commands used in this tutorial can be used in a multi-nodes Pulsar cluster without any changes.
+the commands used in this tutorial can be used in a multi-node Pulsar cluster without any changes.
 * All the instructions are assumed to run at the root directory of a Pulsar binary distribution.
 
 :::
@@ -38,9 +38,9 @@ For more information about **how to install a standalone Pulsar and built-in con
    
    ```
 
-   All the components of a Pulsar service are start in order. 
+   All the components of a Pulsar service are started in order. 
    
-   You can curl those pulsar service endpoints to make sure Pulsar service is up running correctly.
+   You can curl those pulsar service endpoints to make sure Pulsar service is up and running correctly.
 
 2. Check Pulsar binary protocol port.
 
@@ -239,7 +239,7 @@ For more information, see [Cassandra sink connector](io-cassandra-sink).
 
 ### Create a Cassandra sink
 
-You can use the [Connector Admin CLI](io-cli) 
+You can use the [Connector Admin CLI](https://pulsar.apache.org/tools/pulsar-admin/) 
 to create a sink connector and perform other operations on them.
 
 Run the following command to create a Cassandra sink connector with sink type _cassandra_ and the config file _examples/cassandra-sink.yml_ created previously.
@@ -266,7 +266,7 @@ as a Pulsar Function and writes the messages produced in the topic _test_cassand
 
 ### Inspect a Cassandra sink
 
-You can use the [Connector Admin CLI](io-cli) 
+You can use the [Connector Admin CLI](https://pulsar.apache.org/tools/pulsar-admin/) 
 to monitor a connector and perform other operations on it.
 
 * Get the information of a Cassandra sink. 
@@ -430,7 +430,7 @@ to monitor a connector and perform other operations on it.
 
 ### Delete a Cassandra Sink
 
-You can use the [Connector Admin CLI](io-cli) 
+You can use the [Connector Admin CLI](https://pulsar.apache.org/tools/pulsar-admin/) 
 to delete a connector and perform other operations on it.
 
 ```bash
@@ -552,7 +552,7 @@ In this section, you need to configure a JDBC sink connector.
    
    To run a JDBC sink connector, you need to prepare a YAML configuration file including the information that Pulsar connector runtime needs to know. 
    
-   For example, how Pulsar connector can find the PostgreSQL cluster, what is the JDBC URL and the table that Pulsar connector uses for writing messages to.
+   For example, how Pulsar connector can find the PostgreSQL cluster, what is the JDBC URL and the table that Pulsar connector uses for writing messages.
 
    Create a _pulsar-postgres-jdbc-sink.yaml_ file, copy the following contents to this file, and place the file in the `pulsar/connectors` folder.
 
@@ -614,7 +614,7 @@ In this section, you need to configure a JDBC sink connector.
 
 ### Create a JDBC sink
 
-You can use the [Connector Admin CLI](io-cli) 
+You can use the [Connector Admin CLI](https://pulsar.apache.org/tools/pulsar-admin/) 
 to create a sink connector and perform other operations on it.
 
 This example creates a sink connector and specifies the desired information.
@@ -646,7 +646,7 @@ This sink connector runs as a Pulsar Function and writes the messages produced i
 
 :::tip
 
-For more information about `pulsar-admin sinks create options`, see [here](io-cli.md#sinks).
+For more information about `pulsar-admin sinks create options`, see [Pulsar admin docs](https://pulsar.apache.org/tools/pulsar-admin/).
 
 :::
 
@@ -660,7 +660,7 @@ Created successfully
 
 ### Inspect a JDBC sink
 
-You can use the [Connector Admin CLI](io-cli) 
+You can use the [Connector Admin CLI](https://pulsar.apache.org/tools/pulsar-admin/) 
 to monitor a connector and perform other operations on it.
 
 * List all running JDBC sink(s).
@@ -675,7 +675,7 @@ to monitor a connector and perform other operations on it.
 
   :::tip
 
-  For more information about `pulsar-admin sinks list options`, see [here](io-cli.md/#list-1).
+  For more information about `pulsar-admin sinks list options`, see [Pulsar admin docs](https://pulsar.apache.org/tools/pulsar-admin/).
 
   :::
 
@@ -702,7 +702,7 @@ to monitor a connector and perform other operations on it.
 
   :::tip
 
-  For more information about `pulsar-admin sinks get options`, see [here](io-cli.md/#get-1).
+  For more information about `pulsar-admin sinks get options`, see [Pulsar admin docs](https://pulsar.apache.org/tools/pulsar-admin/).
 
   :::
 
@@ -747,11 +747,11 @@ to monitor a connector and perform other operations on it.
 
   :::tip
 
-  For more information about `pulsar-admin sinks status options`, see [here](io-cli.md/#status-1).
+  For more information about `pulsar-admin sinks status options`, see [Pulsar admin docs](https://pulsar.apache.org/tools/pulsar-admin/).
 
   :::
 
-  The result shows the current status of sink connector, including the number of instance, running status, worker ID and so on.
+  The result shows the current status of sink connector, including the number of instances, running status, worker ID and so on.
 
   ```json
   
@@ -780,7 +780,7 @@ to monitor a connector and perform other operations on it.
 
 ### Stop a JDBC sink
 
-You can use the [Connector Admin CLI](io-cli) 
+You can use the [Connector Admin CLI](https://pulsar.apache.org/tools/pulsar-admin/) 
 to stop a connector and perform other operations on it.
 
 ```bash
@@ -794,7 +794,7 @@ $ bin/pulsar-admin sinks stop \
 
 :::tip
 
-For more information about `pulsar-admin sinks stop options`, see [here](io-cli.md/#stop-1).
+For more information about `pulsar-admin sinks stop options`, see [Pulsar admin docs](https://pulsar.apache.org/tools/pulsar-admin/).
 
 :::
 
@@ -808,7 +808,7 @@ Stopped successfully
 
 ### Restart a JDBC sink
 
-You can use the [Connector Admin CLI](io-cli) 
+You can use the [Connector Admin CLI](https://pulsar.apache.org/tools/pulsar-admin/) 
 to restart a connector and perform other operations on it.
 
 ```bash
@@ -822,7 +822,7 @@ $ bin/pulsar-admin sinks restart \
 
 :::tip
 
-For more information about `pulsar-admin sinks restart options`, see [here](io-cli.md/#restart-1).
+For more information about `pulsar-admin sinks restart options`, see [Pulsar admin docs](https://pulsar.apache.org/tools/pulsar-admin/).
 
 :::
 
@@ -838,13 +838,13 @@ Started successfully
 
 * Optionally, you can run a standalone sink connector using `pulsar-admin sinks localrun options`. 
 Note that `pulsar-admin sinks localrun options` **runs a sink connector locally**, while `pulsar-admin sinks start options` **starts a sink connector in a cluster**.
-* For more information about `pulsar-admin sinks localrun options`, see [here](io-cli.md#localrun-1).
+* For more information about `pulsar-admin sinks localrun options`, see [Pulsar admin docs](https://pulsar.apache.org/tools/pulsar-admin/).
 
 :::
 
 ### Update a JDBC sink
 
-You can use the [Connector Admin CLI](io-cli) 
+You can use the [Connector Admin CLI](https://pulsar.apache.org/tools/pulsar-admin/) 
 to update a connector and perform other operations on it.
 
 This example updates the parallelism of the _pulsar-postgres-jdbc-sink_ sink connector to 2.
@@ -859,7 +859,7 @@ $ bin/pulsar-admin sinks update \
 
 :::tip
 
-For more information about `pulsar-admin sinks update options`, see [here](io-cli.md/#update-1).
+For more information about `pulsar-admin sinks update options`, see [Pulsar admin docs](https://pulsar.apache.org/tools/pulsar-admin/).
 
 :::
 
@@ -912,7 +912,7 @@ The result shows that the parallelism is 2.
 
 ### Delete a JDBC sink
 
-You can use the [Connector Admin CLI](io-cli) 
+You can use the [Connector Admin CLI](https://pulsar.apache.org/tools/pulsar-admin/) 
 to delete a connector and perform other operations on it.
 
 This example deletes the _pulsar-postgres-jdbc-sink_ sink connector.
@@ -928,7 +928,7 @@ $ bin/pulsar-admin sinks delete \
 
 :::tip
 
-For more information about `pulsar-admin sinks delete options`, see [here](io-cli.md/#delete-1).
+For more information about `pulsar-admin sinks delete options`, see [Pulsar admin docs](https://pulsar.apache.org/tools/pulsar-admin/).
 
 :::
 

--- a/site2/docs/io-use.md
+++ b/site2/docs/io-use.md
@@ -18,7 +18,7 @@ Pulsar bundles several [builtin connectors](io-connectors) used to move data in 
 
 :::note
 
-When using a non-builtin connector, you need to specify the path of a archive file for the connector.
+When using a non-builtin connector, you need to specify the path of an archive file for the connector.
 
 :::
 
@@ -136,7 +136,7 @@ $ pulsar-admin sources reload
 
 ```
 
-For more information, see [`here`](io-cli.md#reload).
+For the latest and complete information, see [Pulsar admin docs](https://pulsar.apache.org/tools/pulsar-admin/).
 
 #### Sink
 
@@ -148,7 +148,7 @@ $ pulsar-admin sinks reload
 
 ```
 
-For more information, see [`here`](io-cli.md#reload-1).
+For the latest and complete information, see [Pulsar admin docs](https://pulsar.apache.org/tools/pulsar-admin/).
 
 ### `available`
 
@@ -207,7 +207,7 @@ $ pulsar-admin sources create options
 
 ```
 
-For more information, see [here](io-cli.md#create).
+For the latest and complete information, see [Pulsar admin docs](https://pulsar.apache.org/tools/pulsar-admin/).
 
 </TabItem>
 <TabItem value="REST API">
@@ -298,7 +298,7 @@ $ pulsar-admin sinks create options
 
 ```
 
-For more information, see [here](io-cli.md#create-1).
+For the latest and complete information, see [Pulsar admin docs](https://pulsar.apache.org/tools/pulsar-admin/).
 
 </TabItem>
 <TabItem value="REST API">
@@ -393,7 +393,7 @@ $ pulsar-admin sources start options
 
 ```
 
-For more information, see [here](io-cli.md#start).
+For the latest and complete information, see [Pulsar admin docs](https://pulsar.apache.org/tools/pulsar-admin/).
 
 </TabItem>
 <TabItem value="REST API">
@@ -430,7 +430,7 @@ $ pulsar-admin sinks start options
 
 ```
 
-For more information, see [here](io-cli.md#start-1).
+For the latest and complete information, see [Pulsar admin docs](https://pulsar.apache.org/tools/pulsar-admin/).
 
 </TabItem>
 <TabItem value="REST API">
@@ -471,7 +471,7 @@ $ pulsar-admin sources localrun options
 
 ```
 
-For more information, see [here](io-cli.md#localrun).
+For the latest and complete information, see [Pulsar admin docs](https://pulsar.apache.org/tools/pulsar-admin/).
 
 </TabItem>
 
@@ -497,8 +497,7 @@ $ pulsar-admin sinks localrun options
 
 ```
 
-For more information, see [here](io-cli.md#localrun-1).
-
+For the latest and complete information, see [Pulsar admin docs](https://pulsar.apache.org/tools/pulsar-admin/).
 </TabItem>
 
 </Tabs>
@@ -537,7 +536,7 @@ $ pulsar-admin sources get options
 
 ```
 
-For more information, see [here](io-cli.md#get).
+For the latest and complete information, see [Pulsar admin docs](https://pulsar.apache.org/tools/pulsar-admin/).
 
 </TabItem>
 <TabItem value="REST API">
@@ -650,7 +649,7 @@ $ pulsar-admin sinks get options
 
 ```
 
-For more information, see [here](io-cli.md#get-1).
+For the latest and complete information, see [Pulsar admin docs](https://pulsar.apache.org/tools/pulsar-admin/).
 
 </TabItem>
 <TabItem value="REST API">
@@ -760,7 +759,7 @@ $ pulsar-admin sources list options
 
 ```
 
-For more information, see [here](io-cli.md#list).
+For the latest and complete information, see [Pulsar admin docs](https://pulsar.apache.org/tools/pulsar-admin/).
 
 </TabItem>
 <TabItem value="REST API">
@@ -819,7 +818,7 @@ $ pulsar-admin sinks list options
 
 ```
 
-For more information, see [here](io-cli.md#list-1).
+For the latest and complete information, see [Pulsar admin docs](https://pulsar.apache.org/tools/pulsar-admin/).
 
 </TabItem>
 <TabItem value="REST API">
@@ -882,7 +881,7 @@ $ pulsar-admin sources status options
 
 ```
 
-For more information, see [here](io-cli.md#status).
+For the latest and complete information, see [Pulsar admin docs](https://pulsar.apache.org/tools/pulsar-admin/).
 
 </TabItem>
 <TabItem value="REST API">
@@ -978,7 +977,7 @@ $ pulsar-admin sinks status options
 
 ```
 
-For more information, see [here](io-cli.md#status-1).
+For the latest and complete information, see [Pulsar admin docs](https://pulsar.apache.org/tools/pulsar-admin/).
 
 </TabItem>
 <TabItem value="REST API">
@@ -1080,7 +1079,7 @@ $ pulsar-admin sources update options
 
 ```
 
-For more information, see [here](io-cli.md#update).
+For the latest and complete information, see [Pulsar admin docs](https://pulsar.apache.org/tools/pulsar-admin/).
 
 </TabItem>
 <TabItem value="REST API">
@@ -1175,7 +1174,7 @@ $ pulsar-admin sinks update options
 
 ```
 
-For more information, see [here](io-cli.md#update-1).
+For the latest and complete information, see [Pulsar admin docs](https://pulsar.apache.org/tools/pulsar-admin/).
 
 </TabItem>
 <TabItem value="REST API">
@@ -1276,7 +1275,7 @@ $ pulsar-admin sources stop options
 
 ```
 
-For more information, see [here](io-cli.md#stop).
+For the latest and complete information, see [Pulsar admin docs](https://pulsar.apache.org/tools/pulsar-admin/).
 
 </TabItem>
 <TabItem value="REST API">
@@ -1372,7 +1371,7 @@ $ pulsar-admin sinks stop options
 
 ```
 
-For more information, see [here](io-cli.md#stop-1).
+For the latest and complete information, see [Pulsar admin docs](https://pulsar.apache.org/tools/pulsar-admin/).
 
 </TabItem>
 <TabItem value="REST API">
@@ -1474,7 +1473,7 @@ $ pulsar-admin sources restart options
 
 ```
 
-For more information, see [here](io-cli.md#restart).
+For the latest and complete information, see [Pulsar admin docs](https://pulsar.apache.org/tools/pulsar-admin/).
 
 </TabItem>
 <TabItem value="REST API">
@@ -1570,7 +1569,7 @@ $ pulsar-admin sinks restart options
 
 ```
 
-For more information, see [here](io-cli.md#restart-1).
+For the latest and complete information, see [Pulsar admin docs](https://pulsar.apache.org/tools/pulsar-admin/).
 
 </TabItem>
 <TabItem value="REST API">
@@ -1672,7 +1671,7 @@ $ pulsar-admin sources delete options
 
 ```
 
-For more information, see [here](io-cli.md#delete).
+For the latest and complete information, see [Pulsar admin docs](https://pulsar.apache.org/tools/pulsar-admin/).
 
 </TabItem>
 <TabItem value="REST API">
@@ -1738,7 +1737,7 @@ $ pulsar-admin sinks delete options
 
 ```
 
-For more information, see [here](io-cli.md#delete-1).
+For the latest and complete information, see [Pulsar admin docs](https://pulsar.apache.org/tools/pulsar-admin/).
 
 </TabItem>
 <TabItem value="REST API">

--- a/site2/website/sidebars.json
+++ b/site2/website/sidebars.json
@@ -64,8 +64,7 @@
         "io-debug",
         "io-connectors",
         "io-cdc",
-        "io-develop",
-        "io-cli"
+        "io-develop"
       ]
     },
     {

--- a/site2/website/versioned_docs/version-2.10.0/io-cli.md
+++ b/site2/website/versioned_docs/version-2.10.0/io-cli.md
@@ -5,6 +5,14 @@ sidebar_label: "CLI"
 original_id: io-cli
 ---
 
+:::note
+
+**Important**
+
+This page is deprecated and not updated anymore. For the latest and complete information about `Pulsar-admin`, including commands, flags, descriptions, and more, see [Pulsar admin docs](https://pulsar.apache.org/tools/pulsar-admin/).
+
+:::
+
 The `pulsar-admin` tool helps you manage Pulsar connectors.
   
 ## `sources`

--- a/site2/website/versioned_docs/version-2.10.0/io-overview.md
+++ b/site2/website/versioned_docs/version-2.10.0/io-overview.md
@@ -158,7 +158,6 @@ For more information about the options of `pulsar-admin sinks update`, see [here
 
 ## Work with connector
 
-You can manage Pulsar connectors (for example, create, update, start, stop, restart, reload, delete and perform other operations on connectors) via the [Connector Admin CLI](reference-connector-admin) with [sources](io-cli.md#sources) and [sinks](io-cli.md#sinks) subcommands.
+You can manage Pulsar connectors (for example, create, update, start, stop, restart, reload, delete and perform other operations on connectors) via the `Connector Admin CLI` with sources and sinks subcommands. For the latest and complete information, see [Pulsar admin docs](https://pulsar.apache.org/tools/pulsar-admin/).
 
-Connectors (sources and sinks) and Functions are components of instances, and they all run on Functions workers. When managing a source, sink or function via [Connector Admin CLI](reference-connector-admin.md) or [Functions Admin CLI](functions-cli), an instance is started on a worker. For more information, see [Functions worker](functions-worker.md#run-functions-worker-separately).
-
+Connectors (sources and sinks) and Functions are components of instances, and they all run on Functions workers. When managing a source, sink or function via the `Connector Admin CLI` or [Functions Admin CLI](functions-cli), an instance is started on a worker. For more information, see [Functions worker](functions-worker.md#run-functions-worker-separately).

--- a/site2/website/versioned_docs/version-2.10.0/io-quickstart.md
+++ b/site2/website/versioned_docs/version-2.10.0/io-quickstart.md
@@ -18,7 +18,7 @@ At the end of this tutorial, you are able to:
 :::tip
 
 * These instructions assume you are running Pulsar in [standalone mode](getting-started-standalone). However, all
-the commands used in this tutorial can be used in a multi-nodes Pulsar cluster without any changes.
+the commands used in this tutorial can be used in a multi-node Pulsar cluster without any changes.
 * All the instructions are assumed to run at the root directory of a Pulsar binary distribution.
 
 :::
@@ -39,9 +39,9 @@ For more information about **how to install a standalone Pulsar and built-in con
    
    ```
 
-   All the components of a Pulsar service are start in order. 
+   All the components of a Pulsar service are started in order. 
    
-   You can curl those pulsar service endpoints to make sure Pulsar service is up running correctly.
+   You can curl those pulsar service endpoints to make sure Pulsar service is up and running correctly.
 
 2. Check Pulsar binary protocol port.
 
@@ -240,7 +240,7 @@ For more information, see [Cassandra sink connector](io-cassandra-sink).
 
 ### Create a Cassandra sink
 
-You can use the [Connector Admin CLI](io-cli) 
+You can use the [Connector Admin CLI](https://pulsar.apache.org/tools/pulsar-admin/) 
 to create a sink connector and perform other operations on them.
 
 Run the following command to create a Cassandra sink connector with sink type _cassandra_ and the config file _examples/cassandra-sink.yml_ created previously.
@@ -267,7 +267,7 @@ as a Pulsar Function and writes the messages produced in the topic _test_cassand
 
 ### Inspect a Cassandra sink
 
-You can use the [Connector Admin CLI](io-cli) 
+You can use the [Connector Admin CLI](https://pulsar.apache.org/tools/pulsar-admin/) 
 to monitor a connector and perform other operations on it.
 
 * Get the information of a Cassandra sink. 
@@ -431,7 +431,7 @@ to monitor a connector and perform other operations on it.
 
 ### Delete a Cassandra Sink
 
-You can use the [Connector Admin CLI](io-cli) 
+You can use the [Connector Admin CLI](https://pulsar.apache.org/tools/pulsar-admin/) 
 to delete a connector and perform other operations on it.
 
 ```bash
@@ -553,7 +553,7 @@ In this section, you need to configure a JDBC sink connector.
    
    To run a JDBC sink connector, you need to prepare a YAML configuration file including the information that Pulsar connector runtime needs to know. 
    
-   For example, how Pulsar connector can find the PostgreSQL cluster, what is the JDBC URL and the table that Pulsar connector uses for writing messages to.
+   For example, how Pulsar connector can find the PostgreSQL cluster, what is the JDBC URL and the table that Pulsar connector uses for writing messages.
 
    Create a _pulsar-postgres-jdbc-sink.yaml_ file, copy the following contents to this file, and place the file in the `pulsar/connectors` folder.
 
@@ -615,7 +615,7 @@ In this section, you need to configure a JDBC sink connector.
 
 ### Create a JDBC sink
 
-You can use the [Connector Admin CLI](io-cli) 
+You can use the [Connector Admin CLI](https://pulsar.apache.org/tools/pulsar-admin/) 
 to create a sink connector and perform other operations on it.
 
 This example creates a sink connector and specifies the desired information.
@@ -647,7 +647,7 @@ This sink connector runs as a Pulsar Function and writes the messages produced i
 
 :::tip
 
-For more information about `pulsar-admin sinks create options`, see [here](io-cli.md#sinks).
+For more information about `pulsar-admin sinks create options`, see [Pulsar admin docs](https://pulsar.apache.org/tools/pulsar-admin/).
 
 :::
 
@@ -661,7 +661,7 @@ Created successfully
 
 ### Inspect a JDBC sink
 
-You can use the [Connector Admin CLI](io-cli) 
+You can use the [Connector Admin CLI](https://pulsar.apache.org/tools/pulsar-admin/) 
 to monitor a connector and perform other operations on it.
 
 * List all running JDBC sink(s).
@@ -676,7 +676,7 @@ to monitor a connector and perform other operations on it.
 
   :::tip
 
-  For more information about `pulsar-admin sinks list options`, see [here](io-cli.md/#list-1).
+  For more information about `pulsar-admin sinks list options`, see [Pulsar admin docs](https://pulsar.apache.org/tools/pulsar-admin/).
 
   :::
 
@@ -703,7 +703,7 @@ to monitor a connector and perform other operations on it.
 
   :::tip
 
-  For more information about `pulsar-admin sinks get options`, see [here](io-cli.md/#get-1).
+  For more information about `pulsar-admin sinks get options`, see [Pulsar admin docs](https://pulsar.apache.org/tools/pulsar-admin/).
 
   :::
 
@@ -748,11 +748,11 @@ to monitor a connector and perform other operations on it.
 
   :::tip
 
-  For more information about `pulsar-admin sinks status options`, see [here](io-cli.md/#status-1).
+  For more information about `pulsar-admin sinks status options`, see [Pulsar admin docs](https://pulsar.apache.org/tools/pulsar-admin/).
 
   :::
 
-  The result shows the current status of sink connector, including the number of instance, running status, worker ID and so on.
+  The result shows the current status of sink connector, including the number of instances, running status, worker ID and so on.
 
   ```json
   
@@ -781,7 +781,7 @@ to monitor a connector and perform other operations on it.
 
 ### Stop a JDBC sink
 
-You can use the [Connector Admin CLI](io-cli) 
+You can use the [Connector Admin CLI](https://pulsar.apache.org/tools/pulsar-admin/) 
 to stop a connector and perform other operations on it.
 
 ```bash
@@ -795,7 +795,7 @@ $ bin/pulsar-admin sinks stop \
 
 :::tip
 
-For more information about `pulsar-admin sinks stop options`, see [here](io-cli.md/#stop-1).
+For more information about `pulsar-admin sinks stop options`, see [Pulsar admin docs](https://pulsar.apache.org/tools/pulsar-admin/).
 
 :::
 
@@ -809,7 +809,7 @@ Stopped successfully
 
 ### Restart a JDBC sink
 
-You can use the [Connector Admin CLI](io-cli) 
+You can use the [Connector Admin CLI](https://pulsar.apache.org/tools/pulsar-admin/) 
 to restart a connector and perform other operations on it.
 
 ```bash
@@ -823,7 +823,7 @@ $ bin/pulsar-admin sinks restart \
 
 :::tip
 
-For more information about `pulsar-admin sinks restart options`, see [here](io-cli.md/#restart-1).
+For more information about `pulsar-admin sinks restart options`, see [Pulsar admin docs](https://pulsar.apache.org/tools/pulsar-admin/).
 
 :::
 
@@ -839,13 +839,13 @@ Started successfully
 
 * Optionally, you can run a standalone sink connector using `pulsar-admin sinks localrun options`. 
 Note that `pulsar-admin sinks localrun options` **runs a sink connector locally**, while `pulsar-admin sinks start options` **starts a sink connector in a cluster**.
-* For more information about `pulsar-admin sinks localrun options`, see [here](io-cli.md#localrun-1).
+* For more information about `pulsar-admin sinks localrun options`, see [Pulsar admin docs](https://pulsar.apache.org/tools/pulsar-admin/).
 
 :::
 
 ### Update a JDBC sink
 
-You can use the [Connector Admin CLI](io-cli) 
+You can use the [Connector Admin CLI](https://pulsar.apache.org/tools/pulsar-admin/) 
 to update a connector and perform other operations on it.
 
 This example updates the parallelism of the _pulsar-postgres-jdbc-sink_ sink connector to 2.
@@ -860,7 +860,7 @@ $ bin/pulsar-admin sinks update \
 
 :::tip
 
-For more information about `pulsar-admin sinks update options`, see [here](io-cli.md/#update-1).
+For more information about `pulsar-admin sinks update options`, see [Pulsar admin docs](https://pulsar.apache.org/tools/pulsar-admin/).
 
 :::
 
@@ -913,7 +913,7 @@ The result shows that the parallelism is 2.
 
 ### Delete a JDBC sink
 
-You can use the [Connector Admin CLI](io-cli) 
+You can use the [Connector Admin CLI](https://pulsar.apache.org/tools/pulsar-admin/) 
 to delete a connector and perform other operations on it.
 
 This example deletes the _pulsar-postgres-jdbc-sink_ sink connector.
@@ -929,7 +929,7 @@ $ bin/pulsar-admin sinks delete \
 
 :::tip
 
-For more information about `pulsar-admin sinks delete options`, see [here](io-cli.md/#delete-1).
+For more information about `pulsar-admin sinks delete options`, see [Pulsar admin docs](https://pulsar.apache.org/tools/pulsar-admin/).
 
 :::
 

--- a/site2/website/versioned_docs/version-2.10.0/io-use.md
+++ b/site2/website/versioned_docs/version-2.10.0/io-use.md
@@ -19,7 +19,7 @@ Pulsar bundles several [builtin connectors](io-connectors) used to move data in 
 
 :::note
 
-When using a non-builtin connector, you need to specify the path of a archive file for the connector.
+When using a non-builtin connector, you need to specify the path of an archive file for the connector.
 
 :::
 
@@ -137,7 +137,7 @@ $ pulsar-admin sources reload
 
 ```
 
-For more information, see [`here`](io-cli.md#reload).
+For the latest and complete information, see [Pulsar admin docs](https://pulsar.apache.org/tools/pulsar-admin/).
 
 #### Sink
 
@@ -149,7 +149,7 @@ $ pulsar-admin sinks reload
 
 ```
 
-For more information, see [`here`](io-cli.md#reload-1).
+For the latest and complete information, see [Pulsar admin docs](https://pulsar.apache.org/tools/pulsar-admin/).
 
 ### `available`
 
@@ -208,7 +208,7 @@ $ pulsar-admin sources create options
 
 ```
 
-For more information, see [here](io-cli.md#create).
+For the latest and complete information, see [Pulsar admin docs](https://pulsar.apache.org/tools/pulsar-admin/).
 
 </TabItem>
 <TabItem value="REST API">
@@ -299,7 +299,7 @@ $ pulsar-admin sinks create options
 
 ```
 
-For more information, see [here](io-cli.md#create-1).
+For the latest and complete information, see [Pulsar admin docs](https://pulsar.apache.org/tools/pulsar-admin/).
 
 </TabItem>
 <TabItem value="REST API">
@@ -394,7 +394,7 @@ $ pulsar-admin sources start options
 
 ```
 
-For more information, see [here](io-cli.md#start).
+For the latest and complete information, see [Pulsar admin docs](https://pulsar.apache.org/tools/pulsar-admin/).
 
 </TabItem>
 <TabItem value="REST API">
@@ -431,7 +431,7 @@ $ pulsar-admin sinks start options
 
 ```
 
-For more information, see [here](io-cli.md#start-1).
+For the latest and complete information, see [Pulsar admin docs](https://pulsar.apache.org/tools/pulsar-admin/).
 
 </TabItem>
 <TabItem value="REST API">
@@ -472,7 +472,7 @@ $ pulsar-admin sources localrun options
 
 ```
 
-For more information, see [here](io-cli.md#localrun).
+For the latest and complete information, see [Pulsar admin docs](https://pulsar.apache.org/tools/pulsar-admin/).
 
 </TabItem>
 
@@ -498,7 +498,7 @@ $ pulsar-admin sinks localrun options
 
 ```
 
-For more information, see [here](io-cli.md#localrun-1).
+For the latest and complete information, see [Pulsar admin docs](https://pulsar.apache.org/tools/pulsar-admin/).
 
 </TabItem>
 
@@ -538,7 +538,7 @@ $ pulsar-admin sources get options
 
 ```
 
-For more information, see [here](io-cli.md#get).
+For the latest and complete information, see [Pulsar admin docs](https://pulsar.apache.org/tools/pulsar-admin/).
 
 </TabItem>
 <TabItem value="REST API">
@@ -651,7 +651,7 @@ $ pulsar-admin sinks get options
 
 ```
 
-For more information, see [here](io-cli.md#get-1).
+For the latest and complete information, see [Pulsar admin docs](https://pulsar.apache.org/tools/pulsar-admin/).
 
 </TabItem>
 <TabItem value="REST API">
@@ -761,7 +761,7 @@ $ pulsar-admin sources list options
 
 ```
 
-For more information, see [here](io-cli.md#list).
+For the latest and complete information, see [Pulsar admin docs](https://pulsar.apache.org/tools/pulsar-admin/).
 
 </TabItem>
 <TabItem value="REST API">
@@ -820,7 +820,7 @@ $ pulsar-admin sinks list options
 
 ```
 
-For more information, see [here](io-cli.md#list-1).
+For the latest and complete information, see [Pulsar admin docs](https://pulsar.apache.org/tools/pulsar-admin/).
 
 </TabItem>
 <TabItem value="REST API">
@@ -883,7 +883,7 @@ $ pulsar-admin sources status options
 
 ```
 
-For more information, see [here](io-cli.md#status).
+For the latest and complete information, see [Pulsar admin docs](https://pulsar.apache.org/tools/pulsar-admin/).
 
 </TabItem>
 <TabItem value="REST API">
@@ -979,7 +979,7 @@ $ pulsar-admin sinks status options
 
 ```
 
-For more information, see [here](io-cli.md#status-1).
+For the latest and complete information, see [Pulsar admin docs](https://pulsar.apache.org/tools/pulsar-admin/).
 
 </TabItem>
 <TabItem value="REST API">
@@ -1081,7 +1081,7 @@ $ pulsar-admin sources update options
 
 ```
 
-For more information, see [here](io-cli.md#update).
+For the latest and complete information, see [Pulsar admin docs](https://pulsar.apache.org/tools/pulsar-admin/).
 
 </TabItem>
 <TabItem value="REST API">
@@ -1176,7 +1176,7 @@ $ pulsar-admin sinks update options
 
 ```
 
-For more information, see [here](io-cli.md#update-1).
+For the latest and complete information, see [Pulsar admin docs](https://pulsar.apache.org/tools/pulsar-admin/).
 
 </TabItem>
 <TabItem value="REST API">
@@ -1277,7 +1277,7 @@ $ pulsar-admin sources stop options
 
 ```
 
-For more information, see [here](io-cli.md#stop).
+For the latest and complete information, see [Pulsar admin docs](https://pulsar.apache.org/tools/pulsar-admin/).
 
 </TabItem>
 <TabItem value="REST API">
@@ -1373,7 +1373,7 @@ $ pulsar-admin sinks stop options
 
 ```
 
-For more information, see [here](io-cli.md#stop-1).
+For the latest and complete information, see [Pulsar admin docs](https://pulsar.apache.org/tools/pulsar-admin/).
 
 </TabItem>
 <TabItem value="REST API">
@@ -1475,7 +1475,7 @@ $ pulsar-admin sources restart options
 
 ```
 
-For more information, see [here](io-cli.md#restart).
+For the latest and complete information, see [Pulsar admin docs](https://pulsar.apache.org/tools/pulsar-admin/).
 
 </TabItem>
 <TabItem value="REST API">
@@ -1571,7 +1571,7 @@ $ pulsar-admin sinks restart options
 
 ```
 
-For more information, see [here](io-cli.md#restart-1).
+For the latest and complete information, see [Pulsar admin docs](https://pulsar.apache.org/tools/pulsar-admin/).
 
 </TabItem>
 <TabItem value="REST API">
@@ -1673,7 +1673,7 @@ $ pulsar-admin sources delete options
 
 ```
 
-For more information, see [here](io-cli.md#delete).
+For the latest and complete information, see [Pulsar admin docs](https://pulsar.apache.org/tools/pulsar-admin/).
 
 </TabItem>
 <TabItem value="REST API">
@@ -1739,7 +1739,7 @@ $ pulsar-admin sinks delete options
 
 ```
 
-For more information, see [here](io-cli.md#delete-1).
+For the latest and complete information, see [Pulsar admin docs](https://pulsar.apache.org/tools/pulsar-admin/).
 
 </TabItem>
 <TabItem value="REST API">

--- a/site2/website/versioned_sidebars/version-2.10.0-sidebars.json
+++ b/site2/website/versioned_sidebars/version-2.10.0-sidebars.json
@@ -163,10 +163,6 @@
         {
           "type": "doc",
           "id": "version-2.10.0/io-develop"
-        },
-        {
-          "type": "doc",
-          "id": "version-2.10.0/io-cli"
         }
       ]
     },


### PR DESCRIPTION
### Motivation

Both version 2.10 and the next version docs have broken links and fail to redirect to the io-cli page.
However, this io-cli page (https://pulsar.apache.org/docs/next/io-cli/) is no longer maintained.
This fix is to make https://pulsar.apache.org/tools/pulsar-admin/ the single source of truth for Pulsar admin docs and for i/o connector admin docs as well.


### Modifications

1. Add a deprecation notice in the `io-cli.md` file and hide it from left navigation.
2. Update occurrences that have referenced `io-cli.md` in other files.
3. Minor typo fixes.

The preview looks good.
<img width="1461" alt="image" src="https://user-images.githubusercontent.com/60642177/170030052-3c3e3be9-5171-428f-8b3a-ac55a20c31ef.png">

### Documentation
  
- [x] `doc` 
