### PR TITLE
[branch-2.8][broker] Fix can not enable system topic if `AutoUpdateSchemaEnabled=false`.

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractTopic.java
@@ -348,6 +348,9 @@ public abstract class AbstractTopic implements Topic {
     }
 
     private boolean allowAutoUpdateSchema() {
+        if (brokerService.isSystemTopic(topic)) {
+            return true;
+        }
         if (isAllowAutoUpdateSchema == null) {
             return brokerService.pulsar().getConfig().isAllowAutoUpdateSchemaEnabled();
         }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
@@ -2710,7 +2710,7 @@ public class BrokerService implements Closeable, ZooKeeperCacheListener<Policies
         log.debug("No autoSubscriptionCreateOverride policy found for {}", topicName);
         return null;
     }
-    private boolean isSystemTopic(String topic) {
+    public boolean isSystemTopic(String topic) {
         return SystemTopicClient.isSystemTopic(TopicName.get(topic));
     }
 


### PR DESCRIPTION
### Motivation

https://github.com/apache/pulsar/pull/14809 is not cherry-picked to branch-2.7 and branch-2.8, but we support system topic since 2.6, so this issue is also existed in branch-2.8. So we need to cherry-pick it.

### Documentation

- [x] `no-need-doc` 
(Please explain why)
