### PR TITLE
Support dlog bookie client configuration via pass through config

### DIFF
--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -950,8 +950,11 @@ managedLedgerDefaultAckQuorum=2
 # in case of lack of enough bookies
 #bookkeeper_opportunisticStriping=false
 
-# you can add other configuration options for the BookKeeper client
-# by prefixing them with bookkeeper_
+# You can add other configuration options for the BookKeeper client
+# by prefixing them with "bookkeeper_". These configurations will be applied
+# to all bookkeeper clients started by the broker (including the managed ledger bookkeeper clients as well as
+# the BookkeeperPackagesStorage bookkeeper client), except the distributed log bookkeeper client.
+# The dlog bookkeeper client is configured in the functions worker configuration file.
 
 # How frequently to flush the cursor positions that were accumulated due to rate limiting. (seconds).
 # Default is 60 seconds
@@ -1428,6 +1431,10 @@ packagesReplicas=1
 
 # The bookkeeper ledger root path
 packagesManagementLedgerRootPath=/ledgers
+
+# When using BookKeeperPackagesStorageProvider, you can configure the
+# bookkeeper client by prefixing configurations with "bookkeeper_".
+# This config will apply to managed ledger bookkeeper clients, as well.
 
 ### --- Packages management service configuration variables (end) --- ###
 

--- a/conf/functions_worker.yml
+++ b/conf/functions_worker.yml
@@ -408,3 +408,17 @@ zooKeeperSessionTimeoutMillis: -1
 # ZooKeeper operation timeout in seconds
 # Deprecated: use metadataStoreOperationTimeoutSeconds
 zooKeeperOperationTimeoutSeconds: -1
+
+### --- Arbitrary Configuration --- ###
+# When a configuration parameter is not explicitly named in the WorkerConfig class, it is only accessible from the
+# properties map. This map can be configured by supplying values to the properties map in this config file.
+
+# Configure the DLog bookkeeper client by prefixing configurations with "bookkeeper_". Because these are arbitrary, they
+# must be added to the properties map to get correctly applied. This configuration applies to the Dlog bookkeeper client
+# in both the standalone function workers and function workers initialized in the broker.
+
+## For example, when using the token authentication provider (AuthenticationProviderToken), you must configure several
+## custom configurations. Here is a sample for configuring one of the necessary configs:
+#properties:
+#    tokenPublicKey: "file:///path/to/my/key"
+#    tokenPublicAlg: "RSA256"

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/common/configuration/PulsarConfigurationUtils.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/common/configuration/PulsarConfigurationUtils.java
@@ -1,0 +1,74 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.common.configuration;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+import org.apache.commons.configuration.AbstractConfiguration;
+import org.apache.distributedlog.DistributedLogConfiguration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Internal utilities for working with {@link Properties} objects.
+ */
+public class PulsarConfigurationUtils {
+
+    private static final String BOOKKEEPER_CLIENT_CONFIG_PREFIX = "bookkeeper_";
+
+    // This configuration must be applied to Distributed Log Configuration keys so that when DLog is initialized,
+    // it applies the configuration to the bookkeeper client configuration.
+    private static final String DLOG_BOOKKEEPER_SECTION_PREFIX = "bkc.";
+
+    private static final Logger LOG = LoggerFactory.getLogger(PulsarConfigurationUtils.class);
+
+    /**
+     * Populates arbitrary configuration into the passed in {@link AbstractConfiguration} by filtering for the
+     * {@link Properties} keys that have the prefix defined here {@link #BOOKKEEPER_CLIENT_CONFIG_PREFIX} and then
+     * applying the key/value pairs after removing the prefix.
+     * @param targetConf - the object to apply the bookkeeper client config
+     * @param srcProps - properties in which to search for arbitrary bookkeeper client config
+     * @param context - string to use when logging about applied configuration
+     */
+    public static void loadPrefixedBookieClientConfiguration(AbstractConfiguration targetConf,
+                                                             Properties srcProps,
+                                                             String context) {
+        Map<String, Object> extraConfigs = getPrefixedProperties(BOOKKEEPER_CLIENT_CONFIG_PREFIX, srcProps, context);
+        if (targetConf instanceof DistributedLogConfiguration) {
+            extraConfigs.forEach((key, value) -> targetConf.setProperty(DLOG_BOOKKEEPER_SECTION_PREFIX + key, value));
+        } else {
+            extraConfigs.forEach(targetConf::setProperty);
+        }
+    }
+
+    private static Map<String, Object> getPrefixedProperties(String prefix, Properties props, String context) {
+        Map<String, Object> extraConfigs = new HashMap<>();
+        int prefixLength = prefix.length();
+        props.forEach((key, value) -> {
+            String sKey = key.toString();
+            if (sKey.startsWith(prefix) && value != null) {
+                String truncatedKey = sKey.substring(prefixLength);
+                LOG.info("Applying {} configuration {}, setting {}={}", context, sKey, truncatedKey, value);
+                extraConfigs.put(truncatedKey, value);
+            }
+        });
+        return extraConfigs;
+    }
+}

--- a/pulsar-broker-common/src/test/java/org/apache/pulsar/common/configuration/PulsarConfigurationUtilsTest.java
+++ b/pulsar-broker-common/src/test/java/org/apache/pulsar/common/configuration/PulsarConfigurationUtilsTest.java
@@ -1,0 +1,65 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.common.configuration;
+
+import org.apache.bookkeeper.conf.ClientConfiguration;
+import org.apache.distributedlog.DistributedLogConfiguration;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.util.NoSuchElementException;
+import java.util.Properties;
+
+public class PulsarConfigurationUtilsTest {
+    @Test
+    public void testLoadArbitraryBookieConfiguration() {
+        ClientConfiguration bkConf = new ClientConfiguration();
+        Properties props = new Properties();
+        // Use a config that will only get applied with the correct prefix and that
+        props.setProperty("bookkeeper_addEntryTimeoutSec", "200");
+        props.setProperty("addEntryTimeoutSec", "100");
+
+        Assert.assertNotEquals(bkConf.getAddEntryTimeout(), 200, "Should get the BK default");
+
+        // Submit conf to get updated
+        PulsarConfigurationUtils.loadPrefixedBookieClientConfiguration(bkConf, props, "test");
+
+        Assert.assertEquals(bkConf.getAddEntryTimeout(), 200, "Only the prefixed value should apply");
+    }
+    @Test
+    public void testLoadArbitraryBookieConfigurationDLog() {
+        DistributedLogConfiguration conf = new DistributedLogConfiguration();
+        Properties props = new Properties();
+        // Use a config that will only get applied with the correct prefix and that
+        props.setProperty("bookkeeper_addEntryTimeoutSec", "200");
+        props.setProperty("addEntryTimeoutSec", "100");
+
+        // Assert none of the configs are set yet.
+        Assert.assertThrows(NoSuchElementException.class, () -> conf.getInt("addEntryTimeoutSec"));
+        Assert.assertThrows(NoSuchElementException.class, () -> conf.getInt("bkc.addEntryTimeoutSec"));
+
+        // Submit conf to get updated
+        PulsarConfigurationUtils.loadPrefixedBookieClientConfiguration(conf, props, "test");
+
+        // Ensure the configuration is set using the proper distributed log prefix for bookkeeper configs.
+        Assert.assertThrows(NoSuchElementException.class, () -> conf.getInt("addEntryTimeoutSec"));
+        Assert.assertEquals(conf.getInt("bkc.addEntryTimeoutSec"), 200,
+                "Only the prefixed value should apply");
+    }
+}

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/BookKeeperClientFactoryImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/BookKeeperClientFactoryImpl.java
@@ -44,6 +44,7 @@ import org.apache.bookkeeper.stats.StatsLogger;
 import org.apache.pulsar.bookie.rackawareness.BookieRackAffinityMapping;
 import org.apache.pulsar.bookie.rackawareness.IsolatedBookieEnsemblePlacementPolicy;
 import org.apache.pulsar.common.allocator.PulsarByteBufAllocator;
+import org.apache.pulsar.common.configuration.PulsarConfigurationUtils;
 import org.apache.pulsar.common.protocol.Commands;
 import org.apache.pulsar.metadata.api.MetadataStore;
 import org.apache.pulsar.metadata.api.extended.MetadataStoreExtended;
@@ -151,14 +152,7 @@ public class BookKeeperClientFactoryImpl implements BookKeeperClientFactory {
         bkConf.setGetBookieInfoRetryIntervalSeconds(
                 conf.getBookkeeperClientGetBookieInfoRetryIntervalSeconds(), TimeUnit.SECONDS);
         Properties allProps = conf.getProperties();
-        allProps.forEach((key, value) -> {
-            String sKey = key.toString();
-            if (sKey.startsWith("bookkeeper_") && value != null) {
-                String bkExtraConfigKey = sKey.substring(11);
-                log.info("Extra BookKeeper client configuration {}, setting {}={}", sKey, bkExtraConfigKey, value);
-                bkConf.setProperty(bkExtraConfigKey, value);
-            }
-        });
+        PulsarConfigurationUtils.loadPrefixedBookieClientConfiguration(bkConf, allProps, "BookKeeper client");
         return bkConf;
     }
 

--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/WorkerUtils.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/WorkerUtils.java
@@ -55,6 +55,7 @@ import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.api.Reader;
 import org.apache.pulsar.client.api.ReaderBuilder;
 import org.apache.pulsar.common.conf.InternalConfigurationData;
+import org.apache.pulsar.common.configuration.PulsarConfigurationUtils;
 import org.apache.pulsar.common.functions.WorkerInfo;
 import org.apache.pulsar.common.policies.data.FunctionInstanceStatsDataImpl;
 import org.apache.pulsar.common.policies.data.FunctionInstanceStatsImpl;
@@ -160,6 +161,9 @@ public final class WorkerUtils {
                         workerConfig.getBookkeeperClientAuthenticationParameters());
             }
         }
+        // Map arbitrary bookkeeper client configuration into DLog Config.
+        PulsarConfigurationUtils.loadPrefixedBookieClientConfiguration(conf, workerConfig.getProperties(),
+                "DLog BookKeeper client");
         return conf;
     }
 

--- a/pulsar-package-management/bookkeeper-storage/src/main/java/org/apache/pulsar/packages/management/storage/bookkeeper/BookKeeperPackagesStorage.java
+++ b/pulsar-package-management/bookkeeper-storage/src/main/java/org/apache/pulsar/packages/management/storage/bookkeeper/BookKeeperPackagesStorage.java
@@ -74,6 +74,15 @@ public class BookKeeperPackagesStorage implements PackagesStorage {
                     configuration.getBookkeeperClientAuthenticationParameters());
             }
         }
+        // Map arbitrary bookkeeper client configuration into DLog Config.
+        configuration.getProperties().forEach((key, value) -> {
+            String sKey = key.toString();
+            if (sKey.startsWith("bookkeeper_") && value != null) {
+                String bkConfigKey = "bkc." + sKey.substring(11);
+                log.info("Applying DLog BookKeeper client configuration {}, setting {}={}", sKey, bkConfigKey, value);
+                conf.setProperty(bkConfigKey, value);
+            }
+        });
         try {
             this.namespace = NamespaceBuilder.newBuilder()
                 .conf(conf).clientId(NS_CLIENT_ID).uri(initializeDlogNamespace()).build();

--- a/pulsar-package-management/bookkeeper-storage/src/main/java/org/apache/pulsar/packages/management/storage/bookkeeper/BookKeeperPackagesStorageConfiguration.java
+++ b/pulsar-package-management/bookkeeper-storage/src/main/java/org/apache/pulsar/packages/management/storage/bookkeeper/BookKeeperPackagesStorageConfiguration.java
@@ -62,6 +62,10 @@ public class BookKeeperPackagesStorageConfiguration implements PackagesStorageCo
         return getProperty("bookkeeperClientAuthenticationParameters");
     }
 
+    @Override
+    public Properties getProperties() {
+        return configuration.getProperties();
+    }
 
     @Override
     public String getProperty(String key) {

--- a/pulsar-package-management/core/src/main/java/org/apache/pulsar/packages/management/core/PackagesStorageConfiguration.java
+++ b/pulsar-package-management/core/src/main/java/org/apache/pulsar/packages/management/core/PackagesStorageConfiguration.java
@@ -50,4 +50,10 @@ public interface PackagesStorageConfiguration {
      *          a group of the property
      */
     void setProperty(Properties properties);
+
+    /**
+     * Get all properties for the configuration.
+     * @return all properties for the configuration
+     */
+    Properties getProperties();
 }

--- a/pulsar-package-management/core/src/main/java/org/apache/pulsar/packages/management/core/impl/DefaultPackagesStorageConfiguration.java
+++ b/pulsar-package-management/core/src/main/java/org/apache/pulsar/packages/management/core/impl/DefaultPackagesStorageConfiguration.java
@@ -39,4 +39,9 @@ public class DefaultPackagesStorageConfiguration implements PackagesStorageConfi
     public void setProperty(Properties properties) {
         this.properties = properties;
     }
+
+    @Override
+    public Properties getProperties() {
+        return this.properties;
+    }
 }


### PR DESCRIPTION
### Motivation

Enable pass through configuration support for the bookkeeper clients created by `DistributedLog` and `BookKeeperPackagesStorage`. This support is already present for the managed ledger bookkeeper client, which takes all `bookkeeper_` prefixed configs. In order to simplify configuration, I reused the `bookkeeper_` prefix since it's reasonable to assume that these configs will be the same.

### Modifications

* Create `PulsarConfigurationUtils` class to reduce code duplication for mapping prefixed config classes into other config classes. This class is not available in the `pulsar-package-management` module, so the code is copied. I don't think we should expose this code in the client jars.
* Update the `BookKeeperPackagesStorageConfiguration` to expose the underlying `properties` object.
* Add documentation to the `broker.conf` and the `functions_worker.yml` files.

### Verifying this change

I added tests to ensure that the new methods work as expected.

### Does this pull request potentially affect one of the following parts:

This is a backwards compatible change. The only nuance is that the package management dlog bookie client will inherit the same configs that the broker already uses for the bookie client. I think this is preferable.