### PR TITLE
[Fix][Docker] Add write permissions to /pulsar subdirectories to enable running as non-root user

### DIFF
--- a/docker/pulsar/Dockerfile
+++ b/docker/pulsar/Dockerfile
@@ -33,10 +33,14 @@ COPY scripts/pulsar-zookeeper-ruok.sh /pulsar/bin
 COPY scripts/watch-znode.py /pulsar/bin
 COPY scripts/install-pulsar-client.sh /pulsar/bin
 
-# In order to support running this docker image as a container on OpenShift
-# the final image needs to give the root group sufficient permission.
+# The final image needs to give the root group sufficient permission for Pulsar components
+# to write to specific directories within /pulsar
 # The file permissions are preserved when copying files from this builder image to the target image.
-RUN chmod -R g+w /pulsar/conf
+RUN for SUBDIRECTORY in conf data download logs; do \
+     [ -d /pulsar/$SUBDIRECTORY ] || mkdir /pulsar/$SUBDIRECTORY; \
+     chmod -R g+w /pulsar/$SUBDIRECTORY; \
+     done
+
 # Presto writes logs to this directory (at least during tests), so we need to give the process permission
 # to create those log directories. This should be removed when presto is removed.
 RUN chmod g+w /pulsar/lib/presto


### PR DESCRIPTION
Fixes #15230

### Motivation

The Quickstart/[Getting Started in Docker](https://pulsar.apache.org/docs/next/getting-started-docker) example does not work with Pulsar 2.10.0:
```shell
docker run -it -p 6650:6650  -p 8080:8080 --mount source=pulsardata,target=/pulsar/data --mount source=pulsarconf,target=/pulsar/conf apachepulsar/pulsar:2.10.0 bin/pulsar standalone
```
When you run the command, you get a permissions error:
```
ERROR org.apache.pulsar.PulsarStandaloneStarter - Failed to start pulsar service.
java.nio.file.AccessDeniedException: /pulsar/data/standalone
```

This is because the Docker image is running as a non-root user but does not have permissions to write to the volume being mounted at `/pulsar/data`

I think this issue is an important concern because it frustrates prospective/new Pulsar users (like me!) with their first impression of trying the project

### Modifications
- Previously the Docker image was adding write permissions (for the root group) to the `/pulsar/conf` directory
- This PR updates that RUN instruction with a shell script loop that creates and sets write permissions on the following directories:
  - `/pulsar/conf`
  - `/pulsar/data`
  - `/pulsar/download`
  - `/pulsar/logs`

### Verifying this change

This change is a trivial rework / code cleanup without any test coverage.
- It can be verified by running the Getting Started in Docker example code listed above, which currently fails with Pulsar 2.10.0

### Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API: no
  - The schema: no
  - The default values of configurations: no
  - The wire protocol: no
  - The rest endpoints: no
  - The admin cli options: no
  - Anything that affects deployment: yes
    - This PR updates the Docker image by creating empty, writeable subdirectories (`data`, `download`, `logs`) inside of `/pulsar` that did not previously exist to enable mounting of volumes that will be writeable by a non-root user at run-time. Potentially this may affect users who were relying on these directories not existing, however I'd contend that the image is broken for new users who are trying out Pulsar for the first time.

### Documentation

Check the box below or label this PR directly.

Need to update docs? 
- [ ] `doc-required` 
- [X] `no-need-doc` 
  - This PR fixes an issue that is already covered by existing "Getting Started in Docker" documentation, it does not require any updates to the existing documentation.
- [ ] `doc` 
- [ ] `doc-added`
