### PR TITLE
[branch-2.9][fix][broker] Fix jdk API compatibility issues.

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/ModularLoadManagerWrapper.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/ModularLoadManagerWrapper.java
@@ -18,6 +18,8 @@
  */
 package org.apache.pulsar.broker.loadbalance.impl;
 
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -68,8 +70,10 @@ public class ModularLoadManagerWrapper implements LoadManager {
         return leastLoadedBroker.map(s -> {
             String webServiceUrl = getBrokerWebServiceUrl(s);
             String brokerZnodeName = getBrokerZnodeName(s, webServiceUrl);
+            Map<String, String> map = new HashMap<>();
+            map.put(ResourceUnit.PROPERTY_KEY_BROKER_ZNODE_NAME, brokerZnodeName);
             return new SimpleResourceUnit(webServiceUrl,
-                new PulsarResourceDescription(), Map.of(ResourceUnit.PROPERTY_KEY_BROKER_ZNODE_NAME, brokerZnodeName));
+                new PulsarResourceDescription(), Collections.unmodifiableMap(map));
         });
     }
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/TopicTransactionBufferRecoverTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/TopicTransactionBufferRecoverTest.java
@@ -495,7 +495,7 @@ public class TopicTransactionBufferRecoverTest extends TransactionTestBase {
         doThrow(new RuntimeException("test")).when(reader).hasMoreEvents();
         // check reader close topic
         checkCloseTopic(pulsarClient, transactionBufferSnapshotServiceOriginal,
-                transactionBufferSnapshotService, originalTopic, field, producer);
+                transactionBufferSnapshotService, originalTopic, field);
         doReturn(true).when(reader).hasMoreEvents();
 
         // mock reader can't read snapshot fail throw PulsarClientException


### PR DESCRIPTION
### Motivation

PR #15633 uses the API `Map.of()` introduced in JDK 9, but branch-2.9 needs to be compiled in JDK 8.

### Modification

- Use `Collections.unmodifiableMap(map)` to instead of `Map.of()`