### PR TITLE
Fix malformed page for kafka-sink

### DIFF
--- a/site2/docs/io-kafka-sink.md
+++ b/site2/docs/io-kafka-sink.md
@@ -54,9 +54,7 @@ Before using the Kafka sink connector, you need to create a configuration file t
 
 * YAML
   
-  ```
-
-yaml
+  ```yaml
   configs:
       bootstrapServers: "localhost:6667"
       topic: "test"


### PR DESCRIPTION
Fixes #15783 

### Motivation

YAML config is malformed

- [x] `doc` 