### PR TITLE
[improve][doc] Add support for chained authentication providers with the same auth method name

### DIFF
--- a/site2/docs/security-extending.md
+++ b/site2/docs/security-extending.md
@@ -54,9 +54,9 @@ authenticationProviders=
 
 :::tip
 
-Pulsar supports chained authentication providers with the same authentication method name. 
+Pulsar supports an authentication provider chain that contains multiple authentication providers with the same authentication method name. 
 
-For example, your Pulsar cluster uses JSON Web Token (JWT) authentication and you want to upgrade it to use OAuth2.0 authentication. Both JWT and OAuth2.0 share the same authentication method name. In this case, you can chain their class names in `conf/broker.conf` and separate them by using a comma.
+For example, your Pulsar cluster uses JSON Web Token (JWT) authentication and you want to upgrade it to use OAuth2.0 authentication. Both JWT and OAuth2.0 share the same authentication method name. In this case, you can chain the two class names in `authenticationProviders` and separate them by using a comma.
 
 ```properties
 authenticationProviders=org.apache.pulsar.broker.authentication.AuthenticationProviderJWT,org.apache.pulsar.broker.authentication.AuthenticationProviderOAuth2

--- a/site2/docs/security-extending.md
+++ b/site2/docs/security-extending.md
@@ -62,6 +62,8 @@ For example, your Pulsar cluster uses JSON Web Token (JWT) authentication (with 
 authenticationProviders=org.apache.pulsar.broker.authentication.AuthenticationProviderToken,org.apache.pulsar.broker.authentication.AuthenticationProviderOAuth2
 ```
 
+As a result, brokers look up the authentication providers with the `token` authentication method (JWT and OAuth2.0 authentication) when receiving the requests to use the `token` authentication method. If a client cannot be authenticated via JWT authentication, OAuth2.0 authentication is used.
+
 :::
 
 For the implementation of the `org.apache.pulsar.broker.authentication.AuthenticationProvider` interface, refer to [code](https://github.com/apache/pulsar/blob/master/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authentication/AuthenticationProvider.java).

--- a/site2/docs/security-extending.md
+++ b/site2/docs/security-extending.md
@@ -56,10 +56,10 @@ authenticationProviders=
 
 Pulsar supports an authentication provider chain that contains multiple authentication providers with the same authentication method name. 
 
-For example, your Pulsar cluster uses JSON Web Token (JWT) authentication and you want to upgrade it to use OAuth2.0 authentication. Both JWT and OAuth2.0 share the same authentication method name. In this case, you can chain the two class names in `authenticationProviders` and separate them by using a comma.
+For example, your Pulsar cluster uses JSON Web Token (JWT) authentication (with an authentication method named `token`) and you want to upgrade it to use OAuth2.0 authentication with the same authentication name. In this case, you can implement your own authentication provider `AuthenticationProviderOAuth2` and configure `authenticationProviders` as follows.
 
 ```properties
-authenticationProviders=org.apache.pulsar.broker.authentication.AuthenticationProviderJWT,org.apache.pulsar.broker.authentication.AuthenticationProviderOAuth2
+authenticationProviders=org.apache.pulsar.broker.authentication.AuthenticationProviderToken,org.apache.pulsar.broker.authentication.AuthenticationProviderOAuth2
 ```
 
 :::

--- a/site2/docs/security-extending.md
+++ b/site2/docs/security-extending.md
@@ -52,7 +52,19 @@ authenticationProviders=
 
 ```
 
-For the implementation of the `org.apache.pulsar.broker.authentication.AuthenticationProvider` interface, refer to [here](https://github.com/apache/pulsar/blob/master/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authentication/AuthenticationProvider.java).
+:::tip
+
+Pulsar supports chained authentication providers with the same authentication method name. 
+
+For example, your Pulsar cluster uses JSON Web Token (JWT) authentication and you want to upgrade it to use OAuth2.0 authentication. Both JWT and OAuth2.0 share the same authentication method name. In this case, you can chain their class names in `conf/broker.conf` and separate them by using a comma.
+
+```properties
+authenticationProviders=org.apache.pulsar.broker.authentication.AuthenticationProviderJWT,org.apache.pulsar.broker.authentication.AuthenticationProviderOAuth2
+```
+
+:::
+
+For the implementation of the `org.apache.pulsar.broker.authentication.AuthenticationProvider` interface, refer to [code](https://github.com/apache/pulsar/blob/master/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authentication/AuthenticationProvider.java).
 
 You can find the following examples for different broker authentication plugins:
 
@@ -79,4 +91,4 @@ To provide a custom authorization provider, you need to implement the `org.apach
  
  ```
 
-For the implementation of the `org.apache.pulsar.broker.authorization.AuthorizationProvider` interface, refer to [here](https://github.com/apache/pulsar/blob/master/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authorization/AuthorizationProvider.java).
+For the implementation of the `org.apache.pulsar.broker.authorization.AuthorizationProvider` interface, refer to [code](https://github.com/apache/pulsar/blob/master/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authorization/AuthorizationProvider.java).

--- a/site2/docs/security-overview.md
+++ b/site2/docs/security-overview.md
@@ -20,7 +20,7 @@ You had better secure the service components in your Apache Pulsar deployment.
 
 In Pulsar, a *role* is a string, like `admin` or `app1`, which can represent a single client or multiple clients. You can use roles to control permission for clients to produce or consume from certain topics, administer the configuration for tenants, and so on.
 
-Apache Pulsar uses a [Authentication Provider](#authentication-providers) to establish the identity of a client and then assign a *role token* to that client. This role token is then used for [Authorization and ACLs](security-authorization) to determine what the client is authorized to do.
+Apache Pulsar uses a [Authentication Provider](#authentication-providers) or a [Authentication Provider Chain](security-extending.md/#proxybroker-authentication-plugin) to establish the identity of a client and then assign a *role token* to that client. This role token is then used for [Authorization and ACLs](security-authorization) to determine what the client is authorized to do.
 
 ## Authentication providers
 


### PR DESCRIPTION
Fix #15055 

### Modifications

Add information for chained authentication providers.

The preview looks good.
<img width="1701" alt="image" src="https://user-images.githubusercontent.com/60642177/171008535-928246e7-aac1-4060-a032-3a9083207ecf.png">


### Documentation

- [x] `doc` 
