### PR TITLE
Fix schema stats prometheus summary memory leak

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/SchemaRegistryServiceImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/SchemaRegistryServiceImpl.java
@@ -249,6 +249,7 @@ public class SchemaRegistryServiceImpl implements SchemaRegistryService {
                             log.debug("[{}] User {} delete schema finished", schemaId, user);
                         }
                         this.stats.recordDelLatency(schemaId, this.clock.millis() - start);
+                        this.stats.unRecordSchema(schemaId);
                     }
                 });
     }
@@ -267,11 +268,13 @@ public class SchemaRegistryServiceImpl implements SchemaRegistryService {
                     if (t != null) {
                         this.stats.recordDelFailed(schemaId);
                         log.error("[{}] Delete schema storage failed", schemaId);
+                        this.stats.unRecordSchema(schemaId);
                     } else {
                         this.stats.recordDelLatency(schemaId, this.clock.millis() - start);
                         if (log.isDebugEnabled()) {
                             log.debug("[{}] Delete schema storage finished", schemaId);
                         }
+                        this.stats.unRecordSchema(schemaId);
                     }
                 });
     }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/SchemaRegistryStats.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/SchemaRegistryStats.java
@@ -109,6 +109,12 @@ class SchemaRegistryStats implements AutoCloseable {
         this.compatibleCounter.labels(schemaId).inc();
     }
 
+    void unRecordSchema(String schemaId) {
+        this.deleteOpsLatency.remove(schemaId);
+        this.getOpsLatency.remove(schemaId);
+        this.putOpsLatency.remove(schemaId);
+    }
+
     @Override
     public void close() throws Exception {
         if (CLOSED.compareAndSet(false, true)) {


### PR DESCRIPTION
### Motivation
#14723 introduces `schemaId` label metrics.
Prometheus summary maintains a map to record label and value, `summary` will not auto-release the label. Which will leads to memory leak.

We missed to unRecord label when schemaId were deleted.

### Modifications
unRecord schema when schemaId deleted