### PR TITLE
[fix][broker] Make `deleteTopicPolicies` serialized is executed when close topic.

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
@@ -2936,7 +2936,7 @@ public class BrokerService implements Closeable {
                 .getPoliciesAsync(topicName.getNamespaceObject())
                 .thenComposeAsync(optPolicies -> {
                     if (optPolicies.isPresent() && optPolicies.get().deleted) {
-                        // If the namespace is deleted, we can return directly.
+                        // We can return the completed future directly if the namespace is already deleted.
                         return CompletableFuture.completedFuture(null);
                     }
                     TopicName cloneTopicName = TopicName.get(topicName.getPartitionedTopicName());

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -1179,7 +1179,7 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
                     brokerService.deleteTopicAuthenticationWithRetry(topic, deleteTopicAuthenticationFuture, 5);
 
                     deleteTopicAuthenticationFuture.thenCompose(__ -> deleteSchema())
-                            .thenAccept(__ -> deleteTopicPolicies())
+                            .thenCompose(__ -> deleteTopicPolicies())
                             .thenCompose(__ -> transactionBufferCleanupAndClose())
                             .whenComplete((v, ex) -> {
                         if (ex != null) {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/AuthenticatedProducerConsumerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/AuthenticatedProducerConsumerTest.java
@@ -80,6 +80,7 @@ public class AuthenticatedProducerConsumerTest extends ProducerConsumerBase {
         conf.setTlsCertificateFilePath(TLS_SERVER_CERT_FILE_PATH);
         conf.setTlsKeyFilePath(TLS_SERVER_KEY_FILE_PATH);
         conf.setTlsAllowInsecureConnection(true);
+        conf.setTopicLevelPoliciesEnabled(false);
 
         Set<String> superUserRoles = new HashSet<>();
         superUserRoles.add("localhost");


### PR DESCRIPTION
### Motivation

In the current implementation, when closing the topic we use `thenAccept` to delete topic policies. It will ignore the exception and do not waiting for the inner `CompletableFuture`.

### Modifications

- Use `thenCompose` to instead of `thenAccept`
- When namespace is marked `deleted`, we don't need to delete topic policies.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Documentation

- [x] `doc-not-needed` 
(Please explain why)