### PR TITLE
[fix][test] Fix schema not found check on unit test

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiSchemaValidationEnforcedTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiSchemaValidationEnforcedTest.java
@@ -36,17 +36,15 @@ import org.apache.pulsar.common.policies.data.TenantInfoImpl;
 import org.apache.pulsar.common.protocol.schema.PostSchemaPayload;
 import org.apache.pulsar.common.schema.SchemaInfo;
 import org.apache.pulsar.common.schema.SchemaType;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
+import org.testng.collections.Maps;
+import java.util.Map;
 
 @Slf4j
 @Test(groups = "broker-admin")
-public class AdminApiSchemaValidationEnforced extends MockedPulsarServiceBaseTest {
-
-    private static final Logger LOG = LoggerFactory.getLogger(AdminApiSchemaValidationEnforced.class);
+public class AdminApiSchemaValidationEnforcedTest extends MockedPulsarServiceBaseTest {
 
     @BeforeMethod
     @Override
@@ -83,7 +81,7 @@ public class AdminApiSchemaValidationEnforced extends MockedPulsarServiceBaseTes
         try {
             admin.schemas().getSchemaInfo(topicName);
         } catch (PulsarAdminException.NotFoundException e) {
-            assertTrue(e.getMessage().contains("HTTP 404 Not Found"));
+            assertTrue(e.getMessage().contains("Schema not found"));
         }
         try (Producer p = pulsarClient.newProducer().topic(topicName).create()) {
             p.send("test schemaValidationEnforced".getBytes());
@@ -100,7 +98,7 @@ public class AdminApiSchemaValidationEnforced extends MockedPulsarServiceBaseTes
         try {
             admin.schemas().getSchemaInfo(topicName);
         } catch (PulsarAdminException.NotFoundException e) {
-            assertTrue(e.getMessage().contains("HTTP 404 Not Found"));
+            assertTrue(e.getMessage().contains("Schema not found"));
         }
         Map<String, String> properties = new HashMap<>();
         SchemaInfo schemaInfo = SchemaInfo.builder()
@@ -128,7 +126,7 @@ public class AdminApiSchemaValidationEnforced extends MockedPulsarServiceBaseTes
         try {
             admin.schemas().getSchemaInfo(topicName);
         } catch (PulsarAdminException.NotFoundException e) {
-            assertTrue(e.getMessage().contains("HTTP 404 Not Found"));
+            assertTrue(e.getMessage().contains("Schema not found"));
         }
         try (Producer p = pulsarClient.newProducer().topic(topicName).create()) {
             p.send("test schemaValidationEnforced".getBytes());
@@ -148,7 +146,7 @@ public class AdminApiSchemaValidationEnforced extends MockedPulsarServiceBaseTes
         try {
             admin.schemas().getSchemaInfo(topicName);
         } catch (PulsarAdminException.NotFoundException e) {
-            assertTrue(e.getMessage().contains("HTTP 404 Not Found"));
+            assertTrue(e.getMessage().contains("Schema not found"));
         }
         Map<String, String> properties = new HashMap<>();
         properties.put("key1", "value1");
@@ -178,7 +176,7 @@ public class AdminApiSchemaValidationEnforced extends MockedPulsarServiceBaseTes
         try {
             admin.schemas().getSchemaInfo(topicName);
         } catch (PulsarAdminException.NotFoundException e) {
-            assertTrue(e.getMessage().contains("HTTP 404 Not Found"));
+            assertTrue(e.getMessage().contains("Schema not found"));
         }
         admin.namespaces().setSchemaValidationEnforced(namespace,true);
         Map<String, String> properties = new HashMap<>();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiSchemaValidationEnforcedTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiSchemaValidationEnforcedTest.java
@@ -39,8 +39,6 @@ import org.apache.pulsar.common.schema.SchemaType;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
-import org.testng.collections.Maps;
-import java.util.Map;
 
 @Slf4j
 @Test(groups = "broker-admin")
@@ -112,7 +110,12 @@ public class AdminApiSchemaValidationEnforcedTest extends MockedPulsarServiceBas
         try (Producer p = pulsarClient.newProducer().topic(topicName).create()) {
             p.send("test schemaValidationEnforced".getBytes());
         }
-        assertEquals(admin.schemas().getSchemaInfo(topicName), schemaInfo);
+        SchemaInfo schemaInfo1 = admin.schemas().getSchemaInfo(topicName);
+        assertEquals(schemaInfo1.getSchema(), schemaInfo.getSchema());
+        assertEquals(schemaInfo1.getName(), schemaInfo.getName());
+        assertEquals(schemaInfo1.getType(), schemaInfo.getType());
+        assertEquals(schemaInfo1.getSchemaDefinition(), schemaInfo.getSchemaDefinition());
+        assertEquals(schemaInfo1.getProperties(), schemaInfo.getProperties());
     }
 
 


### PR DESCRIPTION
### Motivation

After #12647, the schema not found exception message is replaced by `Schema not found`, so the `AdminApiSchemaValidationEnforced` test will always fail.
```
java.lang.AssertionError: 
Expected :true
Actual   :false
<Click to see difference>


  at org.testng.Assert.fail(Assert.java:99)
  at org.testng.Assert.failNotEquals(Assert.java:1037)
  at org.testng.Assert.assertTrue(Assert.java:45)
  at org.testng.Assert.assertTrue(Assert.java:55)
  at org.apache.pulsar.broker.admin.AdminApiSchemaValidationEnforced.testDisableSchemaValidationEnforcedHasSchema(AdminApiSchemaValidationEnforced.java:105)
// ...
```

### Documentation

Check the box below or label this PR directly.

Need to update docs? 

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)
  
- [x] `doc-not-needed` 
(Please explain why)
  
- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)