### PR TITLE
[fix][broker] Fix NPE in MessageDeduplication.

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/MessageDeduplication.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/MessageDeduplication.java
@@ -471,7 +471,7 @@ public class MessageDeduplication {
                 hasInactive = true;
             }
         }
-        if (hasInactive) {
+        if (hasInactive && isEnabled()) {
             takeSnapshot(getManagedCursor().getMarkDeletedPosition());
         }
     }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/MessageDuplicationTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/MessageDuplicationTest.java
@@ -199,6 +199,13 @@ public class MessageDuplicationTest {
         messageDeduplication.purgeInactiveProducers();
         assertEquals(inactiveProducers.size(), 3);
 
+        doReturn(false).when(messageDeduplication).isEnabled();
+        inactiveProducers.put(producerName2, System.currentTimeMillis() - 80000);
+        inactiveProducers.put(producerName3, System.currentTimeMillis() - 80000);
+        messageDeduplication.purgeInactiveProducers();
+        assertFalse(inactiveProducers.containsKey(producerName2));
+        assertFalse(inactiveProducers.containsKey(producerName3));
+        doReturn(true).when(messageDeduplication).isEnabled();
         // Modify the inactive time of produce2 and produce3
         // messageDeduplication.purgeInactiveProducers() will remove producer2 and producer3
         inactiveProducers.put(producerName2, System.currentTimeMillis() - 70000);


### PR DESCRIPTION
### Motivation

When MessageDeduplication#purgeInactiveProducers:
https://github.com/apache/pulsar/blob/d09c6eb26adcaf0aff2c3464e445eb8df5af70a6/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/MessageDeduplication.java#L455-L477

If MessageDeduplication status is not `Enabled`, the cursor will be null. and cause to be NPE at line 475.

See cursor initializes:
https://github.com/apache/pulsar/blob/a43981109a9322d94082ae0d87d0de53b8f237e8/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/MessageDeduplication.java#L272-L292


### StackTrace
```
May 25, 2022 @ 13:39:04.552	2022-05-25T05:39:04,546+0000 [pulsar-inactivity-monitor-22-1] ERROR org.apache.bookkeeper.common.util.SafeRunnable - Unexpected throwable caught 
May 25, 2022 @ 13:39:04.552		at org.apache.pulsar.broker.service.BrokerService.lambda$forEachTopic$78(BrokerService.java:1768) 
May 25, 2022 @ 13:39:04.552		at org.apache.pulsar.broker.service.persistent.MessageDeduplication.purgeInactiveProducers(MessageDeduplication.java:475) 
May 25, 2022 @ 13:39:04.552		at java.util.Optional.ifPresent(Optional.java:183) ~[?:?]
May 25, 2022 @ 13:39:04.552		at org.apache.pulsar.broker.service.BrokerService.checkMessageDeduplicationInfo(BrokerService.java:1735) 
May 25, 2022 @ 13:39:04.552		at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515) [?:?]
May 25, 2022 @ 13:39:04.552		at org.apache.pulsar.common.util.collections.ConcurrentOpenHashMap.forEach(ConcurrentOpenHashMap.java:272) 
May 25, 2022 @ 13:39:04.552		at org.apache.bookkeeper.common.util.SafeRunnable.run(SafeRunnable.java:36) 
May 25, 2022 @ 13:39:04.552	java.lang.NullPointerException: null
May 25, 2022 @ 13:39:04.552		at org.apache.pulsar.broker.service.BrokerService.forEachTopic(BrokerService.java:1766) 
May 25, 2022 @ 13:39:04.552		at org.apache.bookkeeper.mledger.util.SafeRun$1.safeRun(SafeRun.java:32) 
```

### Documentation

- [x] `doc-not-needed` 
(Please explain why)
  