### PR TITLE
[fix][broker] fix npe when doCacheEviction

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
@@ -2162,17 +2162,22 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
         }
     }
 
-    void doCacheEviction(long maxTimestamp) {
-        if (entryCache.getSize() <= 0) {
-            return;
-        }
+    public PositionImpl getEvictionPosition(){
         PositionImpl evictionPos;
         if (config.isCacheEvictionByMarkDeletedPosition()) {
-            evictionPos = getEarlierMarkDeletedPositionForActiveCursors().getNext();
+            PositionImpl earlierMarkDeletedPosition = getEarlierMarkDeletedPositionForActiveCursors();
+            evictionPos = earlierMarkDeletedPosition != null ? earlierMarkDeletedPosition.getNext() : null;
         } else {
             // Always remove all entries already read by active cursors
             evictionPos = getEarlierReadPositionForActiveCursors();
         }
+        return evictionPos;
+    }
+    void doCacheEviction(long maxTimestamp) {
+        if (entryCache.getSize() <= 0) {
+            return;
+        }
+        PositionImpl evictionPos = getEvictionPosition();
         if (evictionPos != null) {
             entryCache.invalidateEntries(evictionPos);
         }

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerTest.java
@@ -292,6 +292,71 @@ public class ManagedLedgerTest extends MockedBookKeeperTestCase {
     }
 
     @Test
+    public void testDoCacheEviction() throws Throwable {
+        CompletableFuture<Boolean> result = new CompletableFuture<>();
+        ManagedLedgerConfig config = new ManagedLedgerConfig();
+        config.setCacheEvictionByMarkDeletedPosition(true);
+        factory.updateCacheEvictionTimeThreshold(TimeUnit.MILLISECONDS
+                .toNanos(30000));
+        factory.asyncOpen("my_test_ledger", config, new OpenLedgerCallback() {
+            @Override
+            public void openLedgerComplete(ManagedLedger ledger, Object ctx) {
+                ledger.asyncOpenCursor("test-cursor", new OpenCursorCallback() {
+                    @Override
+                    public void openCursorComplete(ManagedCursor cursor, Object ctx) {
+                        ManagedLedger ledger = (ManagedLedger) ctx;
+                        String message1 = "test";
+                        ledger.asyncAddEntry(message1.getBytes(Encoding), new AddEntryCallback() {
+                            @Override
+                            public void addComplete(Position position, ByteBuf entryData, Object ctx) {
+                                try {
+                                    @SuppressWarnings("unchecked")
+                                    Pair<ManagedLedger, ManagedCursor> pair = (Pair<ManagedLedger, ManagedCursor>) ctx;
+                                    ManagedLedger ledger = pair.getLeft();
+                                    ManagedCursor cursor = pair.getRight();
+                                    if (((ManagedLedgerImpl) ledger).getCacheSize() != message1.getBytes(Encoding).length) {
+                                        result.complete(false);
+                                        return;
+                                    }
+
+                                    ManagedLedgerImpl ledgerImpl = (ManagedLedgerImpl) ledger;
+                                    ledgerImpl.getActiveCursors().removeCursor(cursor.getName());
+                                    assertNull(ledgerImpl.getEvictionPosition());
+                                    assertTrue(ledgerImpl.getCacheSize() == message1.getBytes(Encoding).length);
+                                    ledgerImpl.doCacheEviction(
+                                            System.nanoTime() - TimeUnit.MILLISECONDS.toNanos(1));
+                                    assertTrue(ledgerImpl.getCacheSize() == 0);
+                                    result.complete(true);
+                                } catch (Throwable e) {
+                                    result.completeExceptionally(e);
+                                }
+                            }
+
+                            @Override
+                            public void addFailed(ManagedLedgerException exception, Object ctx) {
+                                result.completeExceptionally(exception);
+                            }
+                        }, Pair.of(ledger, cursor));
+                    }
+
+                    @Override
+                    public void openCursorFailed(ManagedLedgerException exception, Object ctx) {
+                        result.completeExceptionally(exception);
+                    }
+                }, ledger);
+            }
+
+            @Override
+            public void openLedgerFailed(ManagedLedgerException exception, Object ctx) {
+                result.completeExceptionally(exception);
+            }
+        }, null, null);
+        assertTrue(result.get());
+
+        log.info("Test completed");
+    }
+
+    @Test
     public void testCacheEvictionByMarkDeletedPosition() throws Throwable {
         CompletableFuture<Boolean> result = new CompletableFuture<>();
         ManagedLedgerConfig config = new ManagedLedgerConfig();


### PR DESCRIPTION
### Motivation
**I reopened a PR based on the latest code, the original PR was: https://github.com/apache/pulsar/pull/15184**



fix npe when doCacheEviction:
<img width="1391" alt="image" src="https://user-images.githubusercontent.com/19296967/163565355-62230abb-612b-4ba7-b2f9-65de3c6bd6fc.png">


### Documentation

Check the box below or label this PR directly.

Need to update docs? 

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)
  
- [x] `no-need-doc` 
(Please explain why)
  
- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-added`
(Docs have been already added)