### PR TITLE
[fix][broker]Fix topic-level replicator rate limiter not init

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
@@ -2417,7 +2417,7 @@ public class BrokerService implements Closeable {
                         ((AbstractTopic) topic).updateBrokerReplicatorDispatchRate();
                     }
                     topic.getReplicators().forEach((name, persistentReplicator) ->
-                        persistentReplicator.getRateLimiter().ifPresent(DispatchRateLimiter::updateDispatchRate));
+                        persistentReplicator.updateRateLimiter());
                 }
             );
         });

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Replicator.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Replicator.java
@@ -37,8 +37,8 @@ public interface Replicator {
 
     String getRemoteCluster();
 
-    default boolean initializeDispatchRateLimiterIfNeeded() {
-        return false;
+    default void initializeDispatchRateLimiterIfNeeded() {
+        //No-op
     }
 
     default void updateRateLimiter() {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Replicator.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Replicator.java
@@ -37,8 +37,11 @@ public interface Replicator {
 
     String getRemoteCluster();
 
-    default void initializeDispatchRateLimiterIfNeeded() {
-        //No-op
+    default boolean initializeDispatchRateLimiterIfNeeded() {
+        return false;
+    }
+
+    default void updateRateLimiter() {
     }
 
     default Optional<DispatchRateLimiter> getRateLimiter() {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentReplicator.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentReplicator.java
@@ -704,10 +704,19 @@ public class PersistentReplicator extends AbstractReplicator
     }
 
     @Override
-    public void initializeDispatchRateLimiterIfNeeded() {
+    public boolean initializeDispatchRateLimiterIfNeeded() {
         if (!dispatchRateLimiter.isPresent()
             && DispatchRateLimiter.isDispatchRateEnabled(topic.getReplicatorDispatchRate())) {
             this.dispatchRateLimiter = Optional.of(new DispatchRateLimiter(topic, Type.REPLICATOR));
+            return true;
+        }
+        return false;
+    }
+
+    @Override
+    public void updateRateLimiter() {
+        if (!initializeDispatchRateLimiterIfNeeded()) {
+            dispatchRateLimiter.ifPresent(DispatchRateLimiter::updateDispatchRate);
         }
     }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentReplicator.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentReplicator.java
@@ -705,22 +705,19 @@ public class PersistentReplicator extends AbstractReplicator
     }
 
     @Override
-    public boolean initializeDispatchRateLimiterIfNeeded() {
+    public void initializeDispatchRateLimiterIfNeeded() {
         synchronized (dispatchRateLimiterLock) {
             if (!dispatchRateLimiter.isPresent()
                 && DispatchRateLimiter.isDispatchRateEnabled(topic.getReplicatorDispatchRate())) {
                 this.dispatchRateLimiter = Optional.of(new DispatchRateLimiter(topic, Type.REPLICATOR));
-                return true;
             }
-            return false;
         }
     }
 
     @Override
     public void updateRateLimiter() {
-        if (!initializeDispatchRateLimiterIfNeeded()) {
-            dispatchRateLimiter.ifPresent(DispatchRateLimiter::updateDispatchRate);
-        }
+        initializeDispatchRateLimiterIfNeeded();
+        dispatchRateLimiter.ifPresent(DispatchRateLimiter::updateDispatchRate);
     }
 
     private void checkReplicatedSubscriptionMarker(Position position, MessageImpl<?> msg, ByteBuf payload) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentReplicator.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentReplicator.java
@@ -718,10 +718,8 @@ public class PersistentReplicator extends AbstractReplicator
 
     @Override
     public void updateRateLimiter() {
-        synchronized (dispatchRateLimiterLock) {
-            if (!initializeDispatchRateLimiterIfNeeded()) {
-                dispatchRateLimiter.ifPresent(DispatchRateLimiter::updateDispatchRate);
-            }
+        if (!initializeDispatchRateLimiterIfNeeded()) {
+            dispatchRateLimiter.ifPresent(DispatchRateLimiter::updateDispatchRate);
         }
     }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -2398,9 +2398,7 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
 
         return FutureUtil.waitForAll(producerCheckFutures).thenCompose((__) -> {
             return updateSubscriptionsDispatcherRateLimiter().thenCompose((___) -> {
-                replicators.forEach((name, replicator) ->
-                        replicator.getRateLimiter().ifPresent(DispatchRateLimiter::updateDispatchRate)
-                );
+                replicators.forEach((name, replicator) -> replicator.updateRateLimiter());
                 checkMessageExpiry();
                 CompletableFuture<Void> replicationFuture = checkReplicationAndRetryOnFailure();
                 CompletableFuture<Void> dedupFuture = checkDeduplicationStatus();

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -383,10 +383,6 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
                 && DispatchRateLimiter.isDispatchRateEnabled(topicPolicies.getDispatchRate().get())) {
                 this.dispatchRateLimiter = Optional.of(new DispatchRateLimiter(this, Type.TOPIC));
             }
-
-            // dispatch rate limiter for each replicator
-            replicators.forEach((name, replicator) ->
-                replicator.initializeDispatchRateLimiterIfNeeded());
         }
     }
 
@@ -3033,8 +3029,7 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
         updateSubscriptionsDispatcherRateLimiter().thenRun(() -> {
             updatePublishDispatcher();
             updateSubscribeRateLimiter();
-            replicators.forEach((name, replicator) -> replicator.getRateLimiter()
-                    .ifPresent(DispatchRateLimiter::updateDispatchRate));
+            replicators.forEach((name, replicator) -> replicator.updateRateLimiter());
 
             if (policies.getReplicationClusters() != null) {
                 checkReplicationAndRetryOnFailure();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatorRateLimiterTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatorRateLimiterTest.java
@@ -21,6 +21,7 @@ package org.apache.pulsar.broker.service;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
+import static org.testng.AssertJUnit.assertFalse;
 import com.google.common.collect.Sets;
 import java.lang.reflect.Method;
 import java.util.concurrent.TimeUnit;
@@ -74,6 +75,50 @@ public class ReplicatorRateLimiterTest extends ReplicatorTestBase {
     @DataProvider(name = "dispatchRateType")
     public Object[][] dispatchRateProvider() {
         return new Object[][] { { DispatchRateType.messageRate }, { DispatchRateType.byteRate } };
+    }
+
+    @Test
+    public void testReplicatorRateLimiterWithOnlyTopicLevel() throws Exception {
+        cleanup();
+        config1.setDispatchThrottlingRatePerReplicatorInMsg(0); // disable broker level
+        config1.setDispatchThrottlingRatePerReplicatorInByte(0L);
+        setup();
+
+        final String namespace = "pulsar/replicatorchange-" + System.currentTimeMillis();
+        final String topicName = "persistent://" + namespace + "/testReplicatorNamespaceLeveRateLimiter";
+
+        admin1.namespaces().createNamespace(namespace);
+        // set 2 clusters, there will be 1 replicator in each topic
+        admin1.namespaces().setNamespaceReplicationClusters(namespace, Sets.newHashSet("r1", "r2"));
+        @Cleanup
+        PulsarClient client1 = PulsarClient.builder().serviceUrl(url1.toString())
+            .statsInterval(0, TimeUnit.SECONDS).build();
+        client1.newProducer().topic(topicName).create().close();
+        PersistentTopic topic = (PersistentTopic) pulsar1.getBrokerService().getOrCreateTopic(topicName).get();
+
+        // rate limiter disable by default
+        assertFalse(topic.getReplicators().values().get(0).getRateLimiter().isPresent());
+
+        //set topic-level policy, which should take effect
+        DispatchRate topicRate = DispatchRate.builder()
+            .dispatchThrottlingRateInMsg(10)
+            .dispatchThrottlingRateInByte(20)
+            .ratePeriodInSecond(30)
+            .build();
+        admin1.topics().setReplicatorDispatchRate(topicName, topicRate);
+        Awaitility.await().untilAsserted(() ->
+            assertEquals(admin1.topics().getReplicatorDispatchRate(topicName), topicRate));
+        assertTrue(topic.getReplicators().values().get(0).getRateLimiter().isPresent());
+        assertEquals(topic.getReplicators().values().get(0).getRateLimiter().get().getDispatchRateOnMsg(), 10);
+        assertEquals(topic.getReplicators().values().get(0).getRateLimiter().get().getDispatchRateOnByte(), 20L);
+
+        //remove topic-level policy
+        admin1.topics().removeReplicatorDispatchRate(topicName);
+        Awaitility.await().untilAsserted(() ->
+            assertNull(admin1.topics().getReplicatorDispatchRate(topicName)));
+        assertEquals(topic.getReplicators().values().get(0).getRateLimiter().get().getDispatchRateOnMsg(), -1);
+        assertEquals(topic.getReplicators().values().get(0).getRateLimiter().get().getDispatchRateOnByte(),
+            -1L);
     }
 
     @Test

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatorRateLimiterTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatorRateLimiterTest.java
@@ -85,7 +85,7 @@ public class ReplicatorRateLimiterTest extends ReplicatorTestBase {
         setup();
 
         final String namespace = "pulsar/replicatorchange-" + System.currentTimeMillis();
-        final String topicName = "persistent://" + namespace + "/testReplicatorNamespaceLeveRateLimiter";
+        final String topicName = "persistent://" + namespace + "/testReplicatorRateLimiterWithOnlyTopicLevel";
 
         admin1.namespaces().createNamespace(namespace);
         // set 2 clusters, there will be 1 replicator in each topic
@@ -119,6 +119,89 @@ public class ReplicatorRateLimiterTest extends ReplicatorTestBase {
         assertEquals(topic.getReplicators().values().get(0).getRateLimiter().get().getDispatchRateOnMsg(), -1);
         assertEquals(topic.getReplicators().values().get(0).getRateLimiter().get().getDispatchRateOnByte(),
             -1L);
+    }
+
+    @Test
+    public void testReplicatorRateLimiterWithOnlyNamespaceLevel() throws Exception {
+        cleanup();
+        config1.setDispatchThrottlingRatePerReplicatorInMsg(0); // disable broker level
+        config1.setDispatchThrottlingRatePerReplicatorInByte(0L);
+        setup();
+
+        final String namespace = "pulsar/replicatorchange-" + System.currentTimeMillis();
+        final String topicName = "persistent://" + namespace + "/testReplicatorRateLimiterWithOnlyNamespaceLevel";
+
+        admin1.namespaces().createNamespace(namespace);
+        // set 2 clusters, there will be 1 replicator in each topic
+        admin1.namespaces().setNamespaceReplicationClusters(namespace, Sets.newHashSet("r1", "r2"));
+        @Cleanup
+        PulsarClient client1 = PulsarClient.builder().serviceUrl(url1.toString())
+            .statsInterval(0, TimeUnit.SECONDS).build();
+        client1.newProducer().topic(topicName).create().close();
+        PersistentTopic topic = (PersistentTopic) pulsar1.getBrokerService().getOrCreateTopic(topicName).get();
+
+        // rate limiter disable by default
+        assertFalse(topic.getReplicators().values().get(0).getRateLimiter().isPresent());
+
+        //set namespace-level policy, which should take effect
+        DispatchRate topicRate = DispatchRate.builder()
+            .dispatchThrottlingRateInMsg(10)
+            .dispatchThrottlingRateInByte(20)
+            .ratePeriodInSecond(30)
+            .build();
+        admin1.namespaces().setReplicatorDispatchRate(namespace, topicRate);
+        Awaitility.await().untilAsserted(() ->
+            assertEquals(admin1.namespaces().getReplicatorDispatchRate(namespace), topicRate));
+        assertTrue(topic.getReplicators().values().get(0).getRateLimiter().isPresent());
+        assertEquals(topic.getReplicators().values().get(0).getRateLimiter().get().getDispatchRateOnMsg(), 10);
+        assertEquals(topic.getReplicators().values().get(0).getRateLimiter().get().getDispatchRateOnByte(), 20L);
+
+        //remove topic-level policy
+        admin1.namespaces().removeReplicatorDispatchRate(namespace);
+        Awaitility.await().untilAsserted(() ->
+            assertNull(admin1.namespaces().getReplicatorDispatchRate(namespace)));
+        assertEquals(topic.getReplicators().values().get(0).getRateLimiter().get().getDispatchRateOnMsg(), -1);
+        assertEquals(topic.getReplicators().values().get(0).getRateLimiter().get().getDispatchRateOnByte(),
+            -1L);
+    }
+
+    @Test
+    public void testReplicatorRateLimiterWithOnlyBrokerLevel() throws Exception {
+        cleanup();
+        config1.setDispatchThrottlingRatePerReplicatorInMsg(0); // disable broker level when init
+        config1.setDispatchThrottlingRatePerReplicatorInByte(0L);
+        setup();
+
+        final String namespace = "pulsar/replicatorchange-" + System.currentTimeMillis();
+        final String topicName = "persistent://" + namespace + "/testReplicatorRateLimiterWithOnlyBrokerLevel";
+
+        admin1.namespaces().createNamespace(namespace);
+        // set 2 clusters, there will be 1 replicator in each topic
+        admin1.namespaces().setNamespaceReplicationClusters(namespace, Sets.newHashSet("r1", "r2"));
+        @Cleanup
+        PulsarClient client1 = PulsarClient.builder().serviceUrl(url1.toString())
+            .statsInterval(0, TimeUnit.SECONDS).build();
+        client1.newProducer().topic(topicName).create().close();
+        PersistentTopic topic = (PersistentTopic) pulsar1.getBrokerService().getOrCreateTopic(topicName).get();
+
+        // rate limiter disable by default
+        assertFalse(topic.getReplicators().values().get(0).getRateLimiter().isPresent());
+
+        //set broker-level policy, which should take effect
+        admin1.brokers().updateDynamicConfiguration("dispatchThrottlingRatePerReplicatorInMsg", "10");
+        admin1.brokers().updateDynamicConfiguration("dispatchThrottlingRatePerReplicatorInByte", "20");
+        Awaitility.await().untilAsserted(() -> {
+            assertTrue(admin1.brokers()
+                .getAllDynamicConfigurations().containsKey("dispatchThrottlingRatePerReplicatorInByte"));
+            assertEquals(admin1.brokers()
+                .getAllDynamicConfigurations().get("dispatchThrottlingRatePerReplicatorInMsg"), "10");
+            assertEquals(admin1.brokers()
+                .getAllDynamicConfigurations().get("dispatchThrottlingRatePerReplicatorInByte"), "20");
+        });
+
+        assertTrue(topic.getReplicators().values().get(0).getRateLimiter().isPresent());
+        assertEquals(topic.getReplicators().values().get(0).getRateLimiter().get().getDispatchRateOnMsg(), 10);
+        assertEquals(topic.getReplicators().values().get(0).getRateLimiter().get().getDispatchRateOnByte(), 20L);
     }
 
     @Test


### PR DESCRIPTION
### Motivation


* Fix bug: The replicator rate limiter will not be initialized and updated if only topic-level policy is enabled, because  `replicator.getRateLimiter()` is empty for L3067:
https://github.com/apache/pulsar/blob/a43981109a9322d94082ae0d87d0de53b8f237e8/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java#L3063-L3068

### Modifications

*  Add the method `org.apache.pulsar.broker.service.Replicator#updateRateLimiter` to initialize or update  the replicator rate limiter.
*  Use this method to initialize or update all level replicator rate limiter

### Verifying this change

- [x] Make sure that the change passes the CI checks.


This change added tests and can be verified as follows:

  - Added UT `org.apache.pulsar.broker.service.ReplicatorRateLimiterTest#testReplicatorRateLimiterWithOnlyTopicLevel`
  - Added UT `org.apache.pulsar.broker.service.ReplicatorRateLimiterTest#testReplicatorRateLimiterWithOnlyNamespaceLevel`
  - Added UT `org.apache.pulsar.broker.service.ReplicatorRateLimiterTest#testReplicatorRateLimiterWithOnlyBrokerLevel`


### Documentation
- [x] `doc-not-needed` 
  