### PR TITLE
[fix][dependency] Add OWASP suppression for openstack-keystone-2.5.0 and openstack-swift-2.5.0

### DIFF
--- a/src/owasp-dependency-check-suppressions.xml
+++ b/src/owasp-dependency-check-suppressions.xml
@@ -296,21 +296,21 @@
     <!-- jclouds/openswift misdetections -->
     <suppress>
         <notes><![CDATA[
-       file name: openstack-swift-2.4.0.jar
+       file name: openstack-swift-2.5.0.jar
        ]]></notes>
         <sha1>3f8f54bbcb73608ac8b66f186a824b75065eb413</sha1>
         <cve>CVE-2016-0738</cve>
     </suppress>
     <suppress>
         <notes><![CDATA[
-       file name: openstack-swift-2.4.0.jar
+       file name: openstack-swift-2.5.0.jar
        ]]></notes>
         <sha1>3f8f54bbcb73608ac8b66f186a824b75065eb413</sha1>
         <cve>CVE-2017-16613</cve>
     </suppress>
     <suppress>
         <notes><![CDATA[
-       file name: openstack-swift-2.4.0.jar
+       file name: openstack-swift-2.5.0.jar
        ]]></notes>
         <sha1>3f8f54bbcb73608ac8b66f186a824b75065eb413</sha1>
         <cve>CVE-2017-8761</cve>
@@ -318,42 +318,42 @@
     
     <suppress>
         <notes><![CDATA[
-       file name: openstack-keystone-2.4.0.jar
+       file name: openstack-keystone-2.5.0.jar
        ]]></notes>
         <sha1>4f47a6b485371d357827b6a517ba54d073dc7b8b</sha1>
         <cve>CVE-2018-14432</cve>
     </suppress>
     <suppress>
         <notes><![CDATA[
-       file name: openstack-keystone-2.4.0.jar
+       file name: openstack-keystone-2.5.0.jar
        ]]></notes>
         <sha1>4f47a6b485371d357827b6a517ba54d073dc7b8b</sha1>
         <cve>CVE-2018-20170</cve>
     </suppress>
     <suppress>
         <notes><![CDATA[
-       file name: openstack-keystone-2.4.0.jar
+       file name: openstack-keystone-2.5.0.jar
        ]]></notes>
         <sha1>4f47a6b485371d357827b6a517ba54d073dc7b8b</sha1>
         <cve>CVE-2020-12689</cve>
     </suppress>
     <suppress>
         <notes><![CDATA[
-       file name: openstack-keystone-2.4.0.jar
+       file name: openstack-keystone-2.5.0.jar
        ]]></notes>
         <sha1>4f47a6b485371d357827b6a517ba54d073dc7b8b</sha1>
         <cve>CVE-2020-12690</cve>
     </suppress>
     <suppress>
         <notes><![CDATA[
-       file name: openstack-keystone-2.4.0.jar
+       file name: openstack-keystone-2.5.0.jar
        ]]></notes>
         <sha1>4f47a6b485371d357827b6a517ba54d073dc7b8b</sha1>
         <cve>CVE-2020-12691</cve>
     </suppress>
     <suppress>
         <notes><![CDATA[
-       file name: openstack-keystone-2.4.0.jar
+       file name: openstack-keystone-2.5.0.jar
        ]]></notes>
         <sha1>4f47a6b485371d357827b6a517ba54d073dc7b8b</sha1>
         <cve>CVE-2020-12692</cve>

--- a/src/owasp-dependency-check-suppressions.xml
+++ b/src/owasp-dependency-check-suppressions.xml
@@ -298,64 +298,56 @@
         <notes><![CDATA[
        file name: openstack-swift-2.5.0.jar
        ]]></notes>
-        <sha1>3f8f54bbcb73608ac8b66f186a824b75065eb413</sha1>
+        <sha1>d99d0eab2e01d69d8a326fc152427fbd759af88a</sha1>
         <cve>CVE-2016-0738</cve>
     </suppress>
     <suppress>
         <notes><![CDATA[
        file name: openstack-swift-2.5.0.jar
        ]]></notes>
-        <sha1>3f8f54bbcb73608ac8b66f186a824b75065eb413</sha1>
+        <sha1>d99d0eab2e01d69d8a326fc152427fbd759af88a</sha1>
         <cve>CVE-2017-16613</cve>
     </suppress>
     <suppress>
         <notes><![CDATA[
-       file name: openstack-swift-2.5.0.jar
-       ]]></notes>
-        <sha1>3f8f54bbcb73608ac8b66f186a824b75065eb413</sha1>
-        <cve>CVE-2017-8761</cve>
-    </suppress>
-    
-    <suppress>
-        <notes><![CDATA[
        file name: openstack-keystone-2.5.0.jar
        ]]></notes>
-        <sha1>4f47a6b485371d357827b6a517ba54d073dc7b8b</sha1>
+        <sha1>a7e89bd278fa8be9fa604dda66d1606de5530797</sha1>
         <cve>CVE-2018-14432</cve>
     </suppress>
     <suppress>
         <notes><![CDATA[
        file name: openstack-keystone-2.5.0.jar
        ]]></notes>
-        <sha1>4f47a6b485371d357827b6a517ba54d073dc7b8b</sha1>
+        <sha1>a7e89bd278fa8be9fa604dda66d1606de5530797</sha1>
         <cve>CVE-2018-20170</cve>
     </suppress>
     <suppress>
         <notes><![CDATA[
        file name: openstack-keystone-2.5.0.jar
        ]]></notes>
-        <sha1>4f47a6b485371d357827b6a517ba54d073dc7b8b</sha1>
+        <sha1>a7e89bd278fa8be9fa604dda66d1606de5530797</sha1>
         <cve>CVE-2020-12689</cve>
     </suppress>
     <suppress>
         <notes><![CDATA[
        file name: openstack-keystone-2.5.0.jar
        ]]></notes>
-        <sha1>4f47a6b485371d357827b6a517ba54d073dc7b8b</sha1>
+        <sha1>a7e89bd278fa8be9fa604dda66d1606de5530797</sha1>
         <cve>CVE-2020-12690</cve>
     </suppress>
     <suppress>
         <notes><![CDATA[
        file name: openstack-keystone-2.5.0.jar
        ]]></notes>
-        <sha1>4f47a6b485371d357827b6a517ba54d073dc7b8b</sha1>
+        <sha1>a7e89bd278fa8be9fa604dda66d1606de5530797</sha1>
         <cve>CVE-2020-12691</cve>
     </suppress>
     <suppress>
         <notes><![CDATA[
        file name: openstack-keystone-2.5.0.jar
        ]]></notes>
-        <sha1>4f47a6b485371d357827b6a517ba54d073dc7b8b</sha1>
+        <sha1>a7e89bd278fa8be9fa604dda66d1606de5530797</sha1>
         <cve>CVE-2020-12692</cve>
     </suppress>
 


### PR DESCRIPTION

<!--
### Contribution Checklist
  
  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://docs.google.com/document/d/1d8Pw6ZbWk-_pCKdOmdvx9rnhPiyuxwq60_TrD68d7BA/edit#heading=h.trs9rsex3xom)*. 

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.

**(The sections below can be removed for hotfixes of typos)**
-->



### Motivation

Currently, there is a failure in the OWASP dependency check in the CI: https://github.com/apache/pulsar/runs/6648112388?check_suite_focus=true

The openstack-keystone and openstack-swift have been suppressed in https://github.com/apache/pulsar/pull/13926 .

The root cause is that the PR https://github.com/apache/pulsar/pull/15649 had updated the jcloud version but didn't update the version of openstack-keystone and openstack-swift included in jcloud in the file `owasp-dependency-check-suppressions.xml`.

### Modifications

* Add OWASP suppression for openstack-keystone-2.5.0 and openstack-swift-2.5.0.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API: (yes / no)
  - The schema: (yes / no / don't know)
  - The default values of configurations: (yes / no)
  - The wire protocol: (yes / no)
  - The rest endpoints: (yes / no)
  - The admin cli options: (yes / no)
  - Anything that affects deployment: (yes / no / don't know)

### Documentation

Check the box below or label this PR directly.

Need to update docs? 

- [x] `doc-not-needed` 
This is a small fix for CI.
  