### PR TITLE
[improve][doc] numFunctionPackageReplicas explanation

### DIFF
--- a/site2/docs/functions-worker.md
+++ b/site2/docs/functions-worker.md
@@ -38,7 +38,7 @@ In this mode, most of the settings are already inherited from your broker config
 
 Pay attention to the following required settings when configuring functions-worker in this mode.
 
-- `numFunctionPackageReplicas`: The number of replicas to store function packages. The default value is `1`, which is good for standalone deployment. For production deployment, to ensure high availability, set it to be larger than `2`.
+- `numFunctionPackageReplicas`: The number of replicas to store function packages. The FunctionPackage is stored in bookkeeper fully in one bookie. The default value is `1`, which is good for standalone deployment. For production deployment, set it to be larger than `2` so the function package will be stored in more than 2 bookies. In case one bookie die the others will have a copy and the function can be recovered.
 - `initializedDlogMetadata`: Whether to initialize distributed log metadata in runtime. If it is set to `true`, you must ensure that it has been initialized by `bin/pulsar initialize-cluster-metadata` command.
 
 If authentication is enabled on the BookKeeper cluster, configure the following BookKeeper authentication settings.


### PR DESCRIPTION
Removed mention to HA in numFunctionPackage replicas that can lead to a misunderstanding where that value is related to High Availability in functions. 

As it is just a way to store the function packages in Bookkeeper, and default value stores it only once in a bookie so it is dangerous in case we lose that bookie

### Motivation

The explanation about HA distract me about the importance of the parameter.

### Modifications

Clarify the parameter meaning.

### Verifying this change

- [ X ] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: ( no )
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: ( no )

### Documentation

Check the box below or label this PR directly.

Need to update docs? 

- [ ] `doc-required` 
  
- [ ] `doc-not-needed` 

  
- [X] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)