### PR TITLE
[improve][connector] JDBC sinks: support Avro specific datatypes

### DIFF
--- a/pulsar-io/jdbc/core/src/main/java/org/apache/pulsar/io/jdbc/BaseJdbcAutoSchemaSink.java
+++ b/pulsar-io/jdbc/core/src/main/java/org/apache/pulsar/io/jdbc/BaseJdbcAutoSchemaSink.java
@@ -20,8 +20,6 @@
 package org.apache.pulsar.io.jdbc;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.collect.Lists;
 import java.sql.PreparedStatement;
 import java.util.HashMap;
@@ -31,7 +29,6 @@ import java.util.Map;
 import java.util.function.Function;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.avro.Schema;
-import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericFixed;
 import org.apache.pulsar.client.api.schema.GenericObject;
 import org.apache.pulsar.client.api.schema.GenericRecord;

--- a/pulsar-io/jdbc/sqlite/src/test/java/org/apache/pulsar/io/jdbc/SqliteJdbcSinkTest.java
+++ b/pulsar-io/jdbc/sqlite/src/test/java/org/apache/pulsar/io/jdbc/SqliteJdbcSinkTest.java
@@ -23,7 +23,6 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 import lombok.Data;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.avro.LogicalTypes;
 import org.apache.avro.util.Utf8;
 import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.Schema;

--- a/pulsar-io/jdbc/sqlite/src/test/java/org/apache/pulsar/io/jdbc/SqliteJdbcSinkTest.java
+++ b/pulsar-io/jdbc/sqlite/src/test/java/org/apache/pulsar/io/jdbc/SqliteJdbcSinkTest.java
@@ -23,6 +23,8 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 import lombok.Data;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.avro.LogicalTypes;
+import org.apache.avro.util.Utf8;
 import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.client.api.schema.GenericObject;
@@ -425,6 +427,7 @@ public class SqliteJdbcSinkTest {
 
         RecordSchemaBuilder valueSchemaBuilder = org.apache.pulsar.client.api.schema.SchemaBuilder.record("value");
         valueSchemaBuilder.field("string").type(SchemaType.STRING).optional().defaultValue(null);
+        valueSchemaBuilder.field("stringutf8").type(SchemaType.STRING).optional().defaultValue(null);
         valueSchemaBuilder.field("int").type(SchemaType.INT32).optional().defaultValue(null);
         valueSchemaBuilder.field("bool").type(SchemaType.BOOLEAN).optional().defaultValue(null);
         valueSchemaBuilder.field("double").type(SchemaType.DOUBLE).optional().defaultValue(null);
@@ -434,6 +437,7 @@ public class SqliteJdbcSinkTest {
 
         GenericRecord valueGenericRecord = valueSchema.newRecordBuilder()
                 .set("string", "thestring")
+                .set("stringutf8", schemaType == SchemaType.AVRO ? new Utf8("thestringutf8"): "thestringutf8")
                 .set("int", Integer.MAX_VALUE)
                 .set("bool", true)
                 .set("double", Double.MAX_VALUE)
@@ -475,6 +479,8 @@ public class SqliteJdbcSinkTest {
                 "CREATE TABLE kvtable (" +
                         "    key  TEXT," +
                         "    int  INTEGER," +
+                        "    string TEXT," +
+                        "    stringutf8 TEXT," +
                         "    nulltext  TEXT," +
                         "    bool  NUMERIC," +
                         "    double NUMERIC," +
@@ -488,7 +494,7 @@ public class SqliteJdbcSinkTest {
         conf.put("jdbcUrl", jdbcUrl);
         conf.put("tableName", "kvtable");
         conf.put("key", "key");
-        conf.put("nonKey", "long,int,double,float,bool,nulltext");
+        conf.put("nonKey", "long,int,double,float,bool,nulltext,string,stringutf8");
         // change batchSize to 1, to flush on each write.
         conf.put("batchSize", 1);
         try (SqliteJdbcAutoSchemaSink kvSchemaJdbcSink = new SqliteJdbcAutoSchemaSink();) {
@@ -496,9 +502,12 @@ public class SqliteJdbcSinkTest {
             kvSchemaJdbcSink.write(genericObjectRecord);
 
             Awaitility.await().untilAsserted(() -> {
-                final int count = sqliteUtils.select("select int,bool,double,float,long,nulltext from kvtable where key='mykey'", (resultSet) -> {
+                final int count = sqliteUtils.select("select int,string,stringutf8,bool,double,float," +
+                        "long,nulltext from kvtable where key='mykey'", (resultSet) -> {
                     int index = 1;
                     Assert.assertEquals(resultSet.getInt(index++), Integer.MAX_VALUE);
+                    Assert.assertEquals(resultSet.getString(index++), "thestring");
+                    Assert.assertEquals(resultSet.getString(index++), "thestringutf8");
                     Assert.assertEquals(resultSet.getBoolean(index++), true);
                     Assert.assertEquals(resultSet.getDouble(index++), Double.MAX_VALUE);
                     Assert.assertEquals(resultSet.getFloat(index++), Float.MAX_VALUE);


### PR DESCRIPTION
### Motivation
JDBC sinks doesn't support Avro datatypes like Utf8.

```
2022-05-30T16:16:35,850+0000 [pool-5-thread-1] ERROR org.apache.pulsar.io.jdbc.JdbcAbstractSink - Got exception 
java.lang.Exception: Not support value type, need to add it. class org.apache.avro.util.Utf8
	at org.apache.pulsar.io.jdbc.BaseJdbcAutoSchemaSink.setColumnValue(BaseJdbcAutoSchemaSink.java:134) ~[pulsar-io-jdbc-core-2.10.0.5-SNAPSHOT.jar:?]
	at org.apache.pulsar.io.jdbc.BaseJdbcAutoSchemaSink.bindValue(BaseJdbcAutoSchemaSink.java:89) ~[pulsar-io-jdbc-core-2.10.0.5-SNAPSHOT.jar:?]
	at org.apache.pulsar.io.jdbc.JdbcAbstractSink.flush(JdbcAbstractSink.java:206) ~[pulsar-io-jdbc-core-2.10.0.5-SNAPSHOT.jar:?]
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515) [?:?]
	at java.util.concurrent.FutureTask.run(FutureTask.java:264) [?:?]
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:304) [?:?]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128) [?:?]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628) [?:?]
	at java.lang.Thread.run(Thread.java:829) [?:?]
```
### Modifications

Added converted (inspired by the ElasticSearch one) to do proper conversion of data, from Avro generic record to JDBC compatible type.

- [x] `doc-not-needed` 