### PR TITLE
[fix][python]Fix generated Python protobuf code not compatible with latest protobuf package

### DIFF
--- a/pulsar-client-cpp/python/setup.py
+++ b/pulsar-client-cpp/python/setup.py
@@ -82,7 +82,7 @@ extras_require = {}
 # functions dependencies
 extras_require["functions"] = sorted(
     {
-      "protobuf>=3.6.1",
+      "protobuf>=3.6.1,<=3.20.*",
       "grpcio<1.28,>=1.8.2",
       "apache-bookkeeper-client>=4.9.2",
       "prometheus_client",

--- a/pulsar-functions/instance/src/scripts/run_python_instance_tests.sh
+++ b/pulsar-functions/instance/src/scripts/run_python_instance_tests.sh
@@ -21,7 +21,7 @@
 
 # Make sure dependencies are installed
 pip3 install mock --user
-pip3 install protobuf --user
+pip3 install protobuf==3.20.1 --user
 pip3 install fastavro --user
 
 CUR_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"


### PR DESCRIPTION
### Motivation
Protobuf latest 4.21 version broke compatibility with files generated with protoc < 3.19
As a result all current CI tests fail.
See https://developers.google.com/protocol-buffers/docs/news/2022-05-06

### Modifications
This fix downgrades protobuf python package to 3.20.1.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

no

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API: (yes / no)
  - The schema: (yes / no / don't know)
  - The default values of configurations: (yes / no)
  - The wire protocol: (yes / no)
  - The rest endpoints: (yes / no)
  - The admin cli options: (yes / no)
  - Anything that affects deployment: (yes / no / don't know)

### Documentation

Check the box below or label this PR directly.

Need to update docs? 

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)
  
- [x] `doc-not-needed` 
fix
  
- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)