### PR TITLE
[fix][client] `ZeroQueueConsumer` may not increase the permit after unloading the topic.

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/ZeroQueueSizeTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/ZeroQueueSizeTest.java
@@ -32,8 +32,6 @@ import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ZeroQueueConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ZeroQueueConsumerImpl.java
@@ -84,12 +84,6 @@ public class ZeroQueueConsumerImpl<T> extends ConsumerImpl<T> {
 
     @Override
     protected CompletableFuture<Message<T>> internalReceiveAsync() {
-        // Just being cautious
-        if (incomingMessages.size() > 0) {
-            log.error("The incoming message queue should never be greater than 0 when Queue size is 0");
-            incomingMessages.forEach(Message::release);
-            incomingMessages.clear();
-        }
         CompletableFuture<Message<T>> future = super.internalReceiveAsync();
         waitingOnReceiveForZeroQueueSize = true;
         if (!future.isDone()) {

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ZeroQueueConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ZeroQueueConsumerImpl.java
@@ -95,10 +95,12 @@ public class ZeroQueueConsumerImpl<T> extends ConsumerImpl<T> {
         if (!future.isDone()) {
             increaseAvailablePermits(cnx());
         }
-        future.whenComplete((message,e) -> {
-            synchronized (this) {
-                if (((MessageImpl<?>) message).getCnx() == cnx()) {
-                    waitingOnReceiveForZeroQueueSize = false;
+        future.whenComplete((message, ex) -> {
+            if (message != null) {
+                synchronized (this) {
+                    if (((MessageImpl<?>) message).getCnx() == cnx()) {
+                        waitingOnReceiveForZeroQueueSize = false;
+                    }
                 }
             }
         });

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ZeroQueueConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ZeroQueueConsumerImpl.java
@@ -96,13 +96,7 @@ public class ZeroQueueConsumerImpl<T> extends ConsumerImpl<T> {
             increaseAvailablePermits(cnx());
         }
         future.whenComplete((message, ex) -> {
-            if (message != null) {
-                synchronized (this) {
-                    if (((MessageImpl<?>) message).getCnx() == cnx()) {
-                        waitingOnReceiveForZeroQueueSize = false;
-                    }
-                }
-            }
+            waitingOnReceiveForZeroQueueSize = false;
         });
 
         return future;


### PR DESCRIPTION
Fixes #15679 

Master Issue: #15679

### Motivation

`ZeroQueueConsumer` may not increase the permit after unloading the topic. because `internalReceiveAsync` is an async method. when it invokes `increaseAvailablePermits(cnx());` the cnx may not be the new cnx.

https://github.com/apache/pulsar/blob/c642731562205261e5bc9bcba16b42df354e745c/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ZeroQueueConsumerImpl.java#L85-L94

### Modifications

- re-send permit when connection reconnected.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Documentation

- [x] `doc-not-needed` 
