### PR TITLE
[fix][owasp] Suppress CVE-2016-1000027 detection in Spring dependencies

### DIFF
--- a/src/owasp-dependency-check-suppressions.xml
+++ b/src/owasp-dependency-check-suppressions.xml
@@ -169,32 +169,9 @@
         <cpe>cpe:/a:apache:rocketmq</cpe>
     </suppress>
     <suppress>
-        <notes><![CDATA[
-     file name: spring-core-3.2.18.RELEASE.jar
-     ]]></notes>
-        <sha1>0e2bd9c162280cd79c2ea0f67f174ee5d7b84ddd</sha1>
-        <cpe>cpe:/a:pivotal_software:spring_framework</cpe>
-    </suppress>
-    <suppress>
-        <notes><![CDATA[
-     file name: spring-core-3.2.18.RELEASE.jar
-     ]]></notes>
-        <sha1>0e2bd9c162280cd79c2ea0f67f174ee5d7b84ddd</sha1>
-        <cpe>cpe:/a:springsource:spring_framework</cpe>
-    </suppress>
-    <suppress>
-        <notes><![CDATA[
-     file name: spring-core-3.2.18.RELEASE.jar
-     ]]></notes>
-        <sha1>0e2bd9c162280cd79c2ea0f67f174ee5d7b84ddd</sha1>
-        <cpe>cpe:/a:vmware:spring_framework</cpe>
-    </suppress>
-    <suppress>
-        <notes><![CDATA[
-     file name: spring-core-3.2.18.RELEASE.jar
-     ]]></notes>
-        <sha1>0e2bd9c162280cd79c2ea0f67f174ee5d7b84ddd</sha1>
-        <cpe>cpe:/a:vmware:springsource_spring_framework</cpe>
+        <notes><![CDATA[Ignored since we are not vulnerable]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.springframework/spring.*$</packageUrl>
+        <cve>CVE-2016-1000027</cve>
     </suppress>
     <suppress>
         <notes><![CDATA[


### PR DESCRIPTION
### Motivation
Fix OWASP scan as CVE-2016-1000027 is a false positive for Spring
See https://github.com/spring-projects/spring-framework/issues/24434#issuecomment-1132113566

### Modifications
* Added CVE-2016-1000027 to OWASP suppressions fiile
* Removed old suppressions not used anymore

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

no

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API: (yes / no)
  - The schema: (yes / no / don't know)
  - The default values of configurations: (yes / no)
  - The wire protocol: (yes / no)
  - The rest endpoints: (yes / no)
  - The admin cli options: (yes / no)
  - Anything that affects deployment: (yes / no / don't know)

### Documentation

Check the box below or label this PR directly.

Need to update docs? 

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)
  
- [x] `doc-not-needed` 
fix
  
- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)