### PR TITLE
[Tests] Fix resource leaks in Pulsar IO integration tests

### DIFF
--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/RabbitMQSinkTester.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/RabbitMQSinkTester.java
@@ -106,4 +106,9 @@ public class RabbitMQSinkTester extends SinkTester<RabbitMQContainer> {
         private final String key;
         private final byte[] body;
     }
+
+    @Override
+    public void close() throws Exception {
+
+    }
 }

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/RabbitMQSourceTester.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/RabbitMQSourceTester.java
@@ -89,4 +89,9 @@ public class RabbitMQSourceTester extends SourceTester<RabbitMQContainer> {
             return values;
         }
     }
+
+    @Override
+    public void close() throws Exception {
+
+    }
 }

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/sinks/CassandraSinkTester.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/sinks/CassandraSinkTester.java
@@ -133,4 +133,16 @@ public class CassandraSinkTester extends SinkTester<CassandraContainer> {
             assertEquals(expectedValue, value);
         }
     }
+
+    @Override
+    public void close() throws Exception {
+        if (session != null) {
+            session.close();
+            session = null;
+        }
+        if (cluster != null) {
+            cluster.close();
+            cluster = null;
+        }
+    }
 }

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/sinks/ElasticSearchSinkTester.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/sinks/ElasticSearchSinkTester.java
@@ -176,4 +176,11 @@ public abstract class ElasticSearchSinkTester extends SinkTester<ElasticsearchCo
         }
     }
 
+    @Override
+    public void close() throws Exception {
+        if (elasticClient != null) {
+            elasticClient._transport().close();
+            elasticClient = null;
+        }
+    }
 }

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/sinks/HdfsSinkTester.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/sinks/HdfsSinkTester.java
@@ -56,4 +56,8 @@ public class HdfsSinkTester extends SinkTester<HdfsContainer> {
 
 	}
 
+	@Override
+	public void close() throws Exception {
+
+	}
 }

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/sinks/JdbcPostgresSinkTester.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/sinks/JdbcPostgresSinkTester.java
@@ -191,4 +191,12 @@ public class JdbcPostgresSinkTester extends SinkTester<PostgreSQLContainer> {
     public boolean isKeyValueSchema() {
         return keyValueSchema;
     }
+
+    @Override
+    public void close() throws Exception {
+        if (connection != null) {
+            connection.close();
+            connection = null;
+        }
+    }
 }

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/sinks/KafkaSinkTester.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/sinks/KafkaSinkTester.java
@@ -21,7 +21,6 @@ package org.apache.pulsar.tests.integration.io.sinks;
 import static org.apache.pulsar.tests.integration.topologies.PulsarTestBase.randomName;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
-
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.Iterator;
@@ -32,7 +31,6 @@ import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.common.serialization.StringDeserializer;
-import org.apache.pulsar.tests.integration.io.sinks.SinkTester.SinkType;
 import org.apache.pulsar.tests.integration.topologies.PulsarCluster;
 import org.testcontainers.containers.Container.ExecResult;
 import org.testcontainers.containers.KafkaContainer;
@@ -49,7 +47,7 @@ public class KafkaSinkTester extends SinkTester<KafkaContainer> {
 
     private final String containerName;
 
-      public KafkaSinkTester(String containerName) {
+    public KafkaSinkTester(String containerName) {
         super(containerName, SinkType.KAFKA);
         this.containerName = containerName;
         String suffix = randomName(8) + "_" + System.currentTimeMillis();
@@ -68,35 +66,35 @@ public class KafkaSinkTester extends SinkTester<KafkaContainer> {
                 .withEmbeddedZookeeper()
                 .withNetworkAliases(containerName)
                 .withCreateContainerCmdModifier(createContainerCmd -> createContainerCmd
-                    .withName(containerName)
-                    .withHostName(cluster.getClusterName() + "-" + containerName));
+                        .withName(containerName)
+                        .withHostName(cluster.getClusterName() + "-" + containerName));
     }
 
     @Override
     public void prepareSink() throws Exception {
         ExecResult execResult = serviceContainer.execInContainer(
-            "/usr/bin/kafka-topics",
-            "--create",
-            "--zookeeper",
-            "localhost:2181",
-            "--partitions",
-            "1",
-            "--replication-factor",
-            "1",
-            "--topic",
-            kafkaTopicName);
+                "/usr/bin/kafka-topics",
+                "--create",
+                "--zookeeper",
+                "localhost:2181",
+                "--partitions",
+                "1",
+                "--replication-factor",
+                "1",
+                "--topic",
+                kafkaTopicName);
         assertTrue(
-            execResult.getStdout().contains("Created topic"),
-            execResult.getStdout());
+                execResult.getStdout().contains("Created topic"),
+                execResult.getStdout());
 
         kafkaConsumer = new KafkaConsumer<>(
-            ImmutableMap.of(
-                ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, serviceContainer.getBootstrapServers(),
-                ConsumerConfig.GROUP_ID_CONFIG, "sink-test-" + randomName(8),
-                ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest"
-            ),
-            new StringDeserializer(),
-            new StringDeserializer()
+                ImmutableMap.of(
+                        ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, serviceContainer.getBootstrapServers(),
+                        ConsumerConfig.GROUP_ID_CONFIG, "sink-test-" + randomName(8),
+                        ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest"
+                ),
+                new StringDeserializer(),
+                new StringDeserializer()
         );
         kafkaConsumer.subscribe(Arrays.asList(kafkaTopicName));
         log.info("Successfully subscribe to kafka topic {}", kafkaTopicName);
@@ -108,7 +106,7 @@ public class KafkaSinkTester extends SinkTester<KafkaContainer> {
         while (kvIter.hasNext()) {
             ConsumerRecords<String, String> records = kafkaConsumer.poll(Duration.ofSeconds(1L));
             log.info("Received {} records from kafka topic {}",
-                records.count(), kafkaTopicName);
+                    records.count(), kafkaTopicName);
             if (records.isEmpty()) {
                 continue;
             }
@@ -120,6 +118,14 @@ public class KafkaSinkTester extends SinkTester<KafkaContainer> {
                 assertEquals(expectedRecord.getKey(), consumerRecord.key());
                 assertEquals(expectedRecord.getValue(), consumerRecord.value());
             }
+        }
+    }
+
+    @Override
+    public void close() throws Exception {
+        if (kafkaConsumer != null) {
+            kafkaConsumer.close();
+            kafkaConsumer = null;
         }
     }
 }

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/sinks/KinesisSinkTester.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/sinks/KinesisSinkTester.java
@@ -270,4 +270,12 @@ public class KinesisSinkTester extends SinkTester<LocalStackContainer> {
         private Set<Long> set1;
         private Map<String, String> map1;
     }
+
+    @Override
+    public void close() throws Exception {
+        if (client != null) {
+            client.close();
+            client = null;
+        }
+    }
 }

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/sinks/OpenSearchSinkTester.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/sinks/OpenSearchSinkTester.java
@@ -73,5 +73,12 @@ public class OpenSearchSinkTester extends ElasticSearchSinkTester {
         });
     }
 
-
+    @Override
+    public void close() throws Exception {
+        super.close();
+        if (elasticClient != null) {
+            elasticClient.close();
+            elasticClient = null;
+        }
+    }
 }

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/sinks/SinkTester.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/sinks/SinkTester.java
@@ -34,7 +34,7 @@ import org.testng.collections.Maps;
  * A tester used for testing a specific sink.
  */
 @Getter
-public abstract class SinkTester<ServiceContainerT extends GenericContainer> {
+public abstract class SinkTester<ServiceContainerT extends GenericContainer> implements AutoCloseable {
 
     @Getter
     public enum SinkType {
@@ -127,6 +127,4 @@ public abstract class SinkTester<ServiceContainerT extends GenericContainer> {
                     .send();
         }
     }
-
-
 }

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/sources/KafkaSourceTester.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/sources/KafkaSourceTester.java
@@ -142,4 +142,12 @@ public class KafkaSourceTester extends SourceTester<KafkaContainer> {
         log.info("Successfully produced {} messages to kafka topic {}", numMessages, kafkaTopicName);
         return kvs;
     }
+
+    @Override
+    public void close() throws Exception {
+        if (kafkaConsumer != null) {
+            kafkaConsumer.close();
+            kafkaConsumer = null;
+        }
+    }
 }

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/sources/SourceTester.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/sources/SourceTester.java
@@ -39,7 +39,7 @@ import org.testng.collections.Maps;
  */
 @Getter
 @Slf4j
-public abstract class SourceTester<ServiceContainerT extends GenericContainer> {
+public abstract class SourceTester<ServiceContainerT extends GenericContainer> implements AutoCloseable {
 
     public static final String INSERT = "INSERT";
 

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/sources/debezium/DebeziumMongoDbSourceTester.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/sources/debezium/DebeziumMongoDbSourceTester.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pulsar.tests.integration.io.sources.debezium;
 
+import java.util.Map;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.tests.integration.containers.DebeziumMongoDbContainer;
@@ -25,11 +26,8 @@ import org.apache.pulsar.tests.integration.containers.PulsarContainer;
 import org.apache.pulsar.tests.integration.io.sources.SourceTester;
 import org.apache.pulsar.tests.integration.topologies.PulsarCluster;
 
-import java.io.Closeable;
-import java.util.Map;
-
 @Slf4j
-public class DebeziumMongoDbSourceTester extends SourceTester<DebeziumMongoDbContainer> implements Closeable {
+public class DebeziumMongoDbSourceTester extends SourceTester<DebeziumMongoDbContainer> {
 
     private static final String NAME = "debezium-mongodb";
 
@@ -118,7 +116,10 @@ public class DebeziumMongoDbSourceTester extends SourceTester<DebeziumMongoDbCon
     @Override
     public void close() {
         if (pulsarCluster != null) {
-            pulsarCluster.stopService(DebeziumMongoDbContainer.NAME, debeziumMongoDbContainer);
+            if (debeziumMongoDbContainer != null) {
+                pulsarCluster.stopService(DebeziumMongoDbContainer.NAME, debeziumMongoDbContainer);
+                debeziumMongoDbContainer = null;
+            }
         }
     }
 }

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/sources/debezium/DebeziumMsSqlSourceTester.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/sources/debezium/DebeziumMsSqlSourceTester.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pulsar.tests.integration.io.sources.debezium;
 
+import java.util.Map;
 import lombok.Getter;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
@@ -29,9 +30,6 @@ import org.apache.pulsar.tests.integration.topologies.PulsarCluster;
 import org.testcontainers.shaded.com.google.common.base.Preconditions;
 import org.testng.Assert;
 import org.testng.util.Strings;
-
-import java.io.Closeable;
-import java.util.Map;
 
 /**
  * A tester for testing Debezium Microsoft SQl Server source.

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/sources/debezium/DebeziumMsSqlSourceTester.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/sources/debezium/DebeziumMsSqlSourceTester.java
@@ -37,7 +37,7 @@ import java.util.Map;
  * A tester for testing Debezium Microsoft SQl Server source.
  */
 @Slf4j
-public class DebeziumMsSqlSourceTester extends SourceTester<DebeziumMsSqlContainer> implements Closeable {
+public class DebeziumMsSqlSourceTester extends SourceTester<DebeziumMsSqlContainer> {
 
     private static final String NAME = "debezium-mssql";
 
@@ -158,7 +158,10 @@ public class DebeziumMsSqlSourceTester extends SourceTester<DebeziumMsSqlContain
     @Override
     public void close() {
         if (pulsarCluster != null) {
-            PulsarCluster.stopService(DebeziumMsSqlContainer.NAME, debeziumMsSqlContainer);
+            if (debeziumMsSqlContainer != null) {
+                PulsarCluster.stopService(DebeziumMsSqlContainer.NAME, debeziumMsSqlContainer);
+                debeziumMsSqlContainer = null;
+            }
         }
     }
 

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/sources/debezium/DebeziumMySqlSourceTester.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/sources/debezium/DebeziumMySqlSourceTester.java
@@ -38,7 +38,7 @@ import org.apache.pulsar.tests.integration.topologies.PulsarCluster;
  * which is a MySQL database server preconfigured with an inventory database.
  */
 @Slf4j
-public class DebeziumMySqlSourceTester extends SourceTester<DebeziumMySQLContainer> implements Closeable {
+public class DebeziumMySqlSourceTester extends SourceTester<DebeziumMySQLContainer> {
 
     private static final String NAME = "debezium-mysql";
 
@@ -128,7 +128,10 @@ public class DebeziumMySqlSourceTester extends SourceTester<DebeziumMySQLContain
     @Override
     public void close() {
         if (pulsarCluster != null) {
-            pulsarCluster.stopService(DebeziumMySQLContainer.NAME, debeziumMySqlContainer);
+            if (debeziumMySqlContainer != null) {
+                pulsarCluster.stopService(DebeziumMySQLContainer.NAME, debeziumMySqlContainer);
+                debeziumMySqlContainer = null;
+            }
         }
     }
 

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/sources/debezium/DebeziumMySqlSourceTester.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/sources/debezium/DebeziumMySqlSourceTester.java
@@ -18,9 +18,7 @@
  */
 package org.apache.pulsar.tests.integration.io.sources.debezium;
 
-import java.io.Closeable;
 import java.util.Map;
-
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.tests.integration.containers.DebeziumMySQLContainer;

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/sources/debezium/DebeziumOracleDbSourceTester.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/sources/debezium/DebeziumOracleDbSourceTester.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pulsar.tests.integration.io.sources.debezium;
 
+import java.util.Map;
 import lombok.Getter;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
@@ -29,14 +30,11 @@ import org.apache.pulsar.tests.integration.topologies.PulsarCluster;
 import org.testcontainers.shaded.com.google.common.base.Preconditions;
 import org.testng.util.Strings;
 
-import java.io.Closeable;
-import java.util.Map;
-
 /**
  * A tester for testing Debezium OracleDb source.
  */
 @Slf4j
-public class DebeziumOracleDbSourceTester extends SourceTester<DebeziumOracleDbContainer> implements Closeable {
+public class DebeziumOracleDbSourceTester extends SourceTester<DebeziumOracleDbContainer> {
 
     private static final String NAME = "debezium-oracle";
     private static final long SLEEP_AFTER_COMMAND_MS = 30_000;
@@ -247,7 +245,10 @@ public class DebeziumOracleDbSourceTester extends SourceTester<DebeziumOracleDbC
     @Override
     public void close() {
         if (pulsarCluster != null) {
-            PulsarCluster.stopService(DebeziumOracleDbContainer.NAME, debeziumOracleDbContainer);
+            if (debeziumOracleDbContainer != null) {
+                PulsarCluster.stopService(DebeziumOracleDbContainer.NAME, debeziumOracleDbContainer);
+                debeziumOracleDbContainer = null;
+            }
         }
     }
 

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/sources/debezium/DebeziumPostgreSqlSourceTester.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/sources/debezium/DebeziumPostgreSqlSourceTester.java
@@ -18,6 +18,8 @@
  */
 package org.apache.pulsar.tests.integration.io.sources.debezium;
 
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.tests.integration.containers.DebeziumPostgreSqlContainer;
@@ -26,10 +28,6 @@ import org.apache.pulsar.tests.integration.docker.ContainerExecResult;
 import org.apache.pulsar.tests.integration.io.sources.SourceTester;
 import org.apache.pulsar.tests.integration.topologies.PulsarCluster;
 import org.testng.Assert;
-
-import java.io.Closeable;
-import java.util.Map;
-import java.util.concurrent.atomic.AtomicReference;
 
 /**
  * A tester for testing Debezium Postgresql source.
@@ -41,7 +39,7 @@ import java.util.concurrent.atomic.AtomicReference;
  * which is a Postgresql database server preconfigured with an inventory database.
  */
 @Slf4j
-public class DebeziumPostgreSqlSourceTester extends SourceTester<DebeziumPostgreSqlContainer> implements Closeable {
+public class DebeziumPostgreSqlSourceTester extends SourceTester<DebeziumPostgreSqlContainer> {
 
     private static final String NAME = "debezium-postgres";
 
@@ -155,7 +153,10 @@ public class DebeziumPostgreSqlSourceTester extends SourceTester<DebeziumPostgre
     @Override
     public void close() {
         if (pulsarCluster != null) {
-            PulsarCluster.stopService(DebeziumPostgreSqlContainer.NAME, debeziumPostgresqlContainer);
+            if (debeziumPostgresqlContainer != null) {
+                PulsarCluster.stopService(DebeziumPostgreSqlContainer.NAME, debeziumPostgresqlContainer);
+                debeziumPostgresqlContainer = null;
+            }
         }
     }
 

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/sources/debezium/PulsarIODebeziumSourceRunner.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/sources/debezium/PulsarIODebeziumSourceRunner.java
@@ -19,6 +19,9 @@
 package org.apache.pulsar.tests.integration.io.sources.debezium;
 
 import com.google.common.base.Preconditions;
+import lombok.Cleanup;
+import lombok.extern.slf4j.Slf4j;
+import net.jodah.failsafe.Failsafe;
 import org.apache.pulsar.client.api.Consumer;
 import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.client.api.SubscriptionInitialPosition;
@@ -27,10 +30,6 @@ import org.apache.pulsar.tests.integration.io.sources.PulsarIOSourceRunner;
 import org.apache.pulsar.tests.integration.io.sources.SourceTester;
 import org.apache.pulsar.tests.integration.topologies.PulsarCluster;
 import org.testcontainers.containers.GenericContainer;
-
-import lombok.Cleanup;
-import lombok.extern.slf4j.Slf4j;
-import net.jodah.failsafe.Failsafe;
 
 @Slf4j
 public class PulsarIODebeziumSourceRunner extends PulsarIOSourceRunner {
@@ -63,7 +62,16 @@ public class PulsarIODebeziumSourceRunner extends PulsarIOSourceRunner {
     @Override
     @SuppressWarnings({ "rawtypes", "unchecked" })
     public <T extends GenericContainer> void testSource(SourceTester<T> sourceTester)  throws Exception {
-           // prepare the testing environment for source
+        try {
+            internalTestSource(sourceTester);
+        } finally {
+            sourceTester.close();
+        }
+    }
+
+    private <T extends GenericContainer> void internalTestSource
+            (SourceTester<T> sourceTester) throws Exception {
+        // prepare the testing environment for source
         prepareSource(sourceTester);
 
         // submit the source connector


### PR DESCRIPTION
Fixes #15853

### Motivation

See #15853 

### Modifications

Fix resources leaks by making SinkTester and SourceTester to implement AutoClosable and handling this in the framework.