### PR TITLE
[improve][client]Remove unnecessary bitset set and clear operation

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PersistentAcknowledgmentsGroupingTracker.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PersistentAcknowledgmentsGroupingTracker.java
@@ -403,8 +403,6 @@ public class PersistentAcknowledgmentsGroupingTracker implements Acknowledgments
                     batchMessageId.getBatchSize(), AckType.Cumulative, properties);
         } else {
             BitSetRecyclable bitSet = BitSetRecyclable.create();
-            bitSet.set(0, batchMessageId.getBatchSize());
-            bitSet.clear(0, batchMessageId.getBatchIndex() + 1);
             return doCumulativeAck(batchMessageId, null, bitSet);
         }
     }


### PR DESCRIPTION

### Motivation
A new bit set is created with all bits are initially set false.
There is no need to set then clear bitset index when doing doCumulativeBatchIndexAck



### Modifications

Remove unnecessary bitset operation



### Documentation

Check the box below or label this PR directly.

Need to update docs? 

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)
  
- [x] `doc-not-needed` 
(Please explain why)
  
- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)