### PR TITLE
Enable TCP/IP keepalive for all ZK client connections in all components started with bin/pulsar

### DIFF
--- a/bin/pulsar
+++ b/bin/pulsar
@@ -270,6 +270,8 @@ OPTS="$OPTS -Dlog4j.configurationFile=`basename $PULSAR_LOG_CONF`"
 # rarely needed when trying to list many z-nodes under a
 # directory)
 OPTS="$OPTS -Djute.maxbuffer=10485760 -Djava.net.preferIPv4Stack=true"
+# Enable TCP keepalive for all Zookeeper client connections
+OPTS="$OPTS -Dzookeeper.clientTcpKeepAlive=true"
 
 # Allow Netty to use reflection access
 OPTS="$OPTS -Dio.netty.tryReflectionSetAccessible=true"
@@ -328,7 +330,7 @@ OPTS="$OPTS -Dpulsar.functions.extra.dependencies.dir=${FUNCTIONS_EXTRA_DEPS_DIR
 OPTS="$OPTS -Dpulsar.functions.instance.classpath=${PULSAR_CLASSPATH}"
 OPTS="$OPTS -Dpulsar.functions.log.conf=${FUNCTIONS_LOG_CONF}"
 
-ZK_OPTS=" -Dzookeeper.4lw.commands.whitelist=* -Dzookeeper.snapshot.trust.empty=true -Dzookeeper.tcpKeepAlive=true -Dzookeeper.clientTcpKeepAlive=true"
+ZK_OPTS=" -Dzookeeper.4lw.commands.whitelist=* -Dzookeeper.snapshot.trust.empty=true -Dzookeeper.tcpKeepAlive=true"
 
 LOG4J2_SHUTDOWN_HOOK_DISABLED="-Dlog4j.shutdownHookEnabled=false"
 


### PR DESCRIPTION
### Motivation

This is a follow-up on #12982 which enabled TCP/IP keepalive for ZK server side.
This PR enables TCP/IP keepalive for all ZK client connections in all components

- Enable TCP keepAlive flag on the sockets used for client connections
  - see https://issues.apache.org/jira/browse/ZOOKEEPER-3712 for details
    - "Some broken network infrastructure may lose the FIN packet that is sent from closing client.
        These never closed client sockets cause OS resource leak. Enabling this option terminates
        these zombie sockets by idle check. ... Currently this option is only available
        when default NIOServerCnxnFactory is used."

### Modifications

add `-Dzookeeper.clientTcpKeepAlive=true` to `OPTS` in `bin/pulsar` script so that the setting is passed to all components that are started using `bin/pulsar` script.