### PR TITLE
[CI] Collect heap dumps when OutOfMemoryError happens in unit tests

### DIFF
--- a/.github/workflows/pulsar-ci.yaml
+++ b/.github/workflows/pulsar-ci.yaml
@@ -244,6 +244,15 @@ jobs:
           path: surefire-reports
           retention-days: 7
 
+      - name: Upload possible heap dump
+        uses: actions/upload-artifact@v3
+        if: ${{ always() && needs.changed_files_job.outputs.docs_only != 'true' }}
+        with:
+          name: Unit-${{ matrix.group }}-heapdump
+          path: /tmp/*.hprof
+          retention-days: 7
+          if-no-files-found: ignore
+
       - name: Wait for ssh connection when build fails
         # ssh access is enabled for builds in own forks
         uses: ./.github/actions/ssh-access

--- a/pom.xml
+++ b/pom.xml
@@ -104,6 +104,7 @@ flexible messaging model and an intuitive client API.</description>
     <testRealAWS>false</testRealAWS>
     <testRetryCount>1</testRetryCount>
     <testJacocoAgentArgument></testJacocoAgentArgument>
+    <testHeapDumpPath>/tmp</testHeapDumpPath>
     <docker.organization>apachepulsar</docker.organization>
     <skipSourceReleaseAssembly>false</skipSourceReleaseAssembly>
     <skipBuildDistribution>false</skipBuildDistribution>
@@ -1420,7 +1421,7 @@ flexible messaging model and an intuitive client API.</description>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
-          <argLine>${testJacocoAgentArgument} -XX:+ExitOnOutOfMemoryError -Xmx1G -XX:+UseG1GC
+          <argLine>${testJacocoAgentArgument} -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=${testHeapDumpPath} -XX:+ExitOnOutOfMemoryError -Xmx1G -XX:+UseG1GC
             -Dpulsar.allocator.pooled=true
             -Dpulsar.allocator.leak_detection=Advanced
             -Dpulsar.allocator.exit_on_oom=false


### PR DESCRIPTION
### Motivation

Whenever an OutOfMemoryError happens in a unit test, it's very hard to diagnose without a heap dump.
This PR makes changes in the build and CI to collect heap dumps when OutOfMemoryError happens in unit tests.

### Modifications

- Add `XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/tmp` to test JVM args
- Upload `/tmp/*.hprof` files to GitHub Actions artifacts