### PR TITLE
[Tests] Dump function logs when testJavaLoggingFunction test fails

### DIFF
--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/functions/PulsarFunctionsTest.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/functions/PulsarFunctionsTest.java
@@ -1502,8 +1502,13 @@ public abstract class PulsarFunctionsTest extends PulsarFunctionsTestBase {
         // get function stats
         getFunctionStatsEmpty(functionName);
 
-        // publish and consume result
-        publishAndConsumeMessages(inputTopicName, logTopicName, numMessages, "-log");
+        try {
+            // publish and consume result
+            publishAndConsumeMessages(inputTopicName, logTopicName, numMessages, "-log");
+        } finally {
+            // dump function logs so that it's easier to investigate failures
+            pulsarCluster.dumpFunctionLogs(functionName);
+        }
 
         // get function status
         getFunctionStatus(functionName, numMessages, true);


### PR DESCRIPTION
### Motivation

Related to #15392

- the test is currently the most flaky test and it would be useful to add this logging
  so the the problem could be investigated