### PR TITLE
[fix][doc] Code highlight not working on some pages

### DIFF
--- a/site2/docs/admin-api-topics.md
+++ b/site2/docs/admin-api-topics.md
@@ -1255,7 +1255,7 @@ pulsar-admin topics last-message-id topic-name
 </TabItem>
 <TabItem value="Java">
 
-```Java
+```java
 
 String topic = "persistent://my-tenant/my-namespace/my-topic";
 admin.topics().getLastMessage(topic);

--- a/site2/docs/client-libraries-node.md
+++ b/site2/docs/client-libraries-node.md
@@ -79,7 +79,7 @@ In order to interact with Pulsar, you first need a client object. You can create
 
 Here is an example:
 
-```JavaScript
+```javascript
 
 const Pulsar = require('pulsar-client');
 
@@ -117,7 +117,7 @@ Pulsar producers publish messages to Pulsar topics. You can [configure](#produce
 
 Here is an example:
 
-```JavaScript
+```javascript
 
 const producer = await client.createProducer({
   topic: 'my-topic', // or 'my-tenant/my-namespace/my-topic' to specify topic's tenant and namespace 
@@ -170,7 +170,7 @@ Pulsar Node.js producers have the following methods available:
 
 This example creates a Node.js producer for the `my-topic` topic and sends 10 messages to that topic:
 
-```JavaScript
+```javascript
 
 const Pulsar = require('pulsar-client');
 
@@ -207,7 +207,7 @@ Pulsar consumers subscribe to one or more Pulsar topics and listen for incoming 
 
 Here is an example:
 
-```JavaScript
+```javascript
 
 const consumer = await client.subscribe({
   topic: 'my-topic',
@@ -266,7 +266,7 @@ Pulsar Node.js consumers have the following methods available:
 
 This example creates a Node.js consumer with the `my-subscription` subscription on the `my-topic` topic, receives messages, prints the content that arrive, and acknowledges each message to the Pulsar broker for 10 times:
 
-```JavaScript
+```javascript
 
 const Pulsar = require('pulsar-client');
 
@@ -298,7 +298,7 @@ const Pulsar = require('pulsar-client');
 
 Instead a consumer can be created with `listener` to process messages.
 
-```JavaScript
+```javascript
 
 // Create a consumer
 const consumer = await client.subscribe({
@@ -328,7 +328,7 @@ Pulsar readers process messages from Pulsar topics. Readers are different from c
 
 Here is an example:
 
-```JavaScript
+```javascript
 
 const reader = await client.createReader({
   topic: 'my-topic',
@@ -369,7 +369,7 @@ Pulsar Node.js readers have the following methods available:
 
 This example creates a Node.js reader with the `my-topic` topic, reads messages, and prints the content that arrive for 10 times:
 
-```JavaScript
+```javascript
 
 const Pulsar = require('pulsar-client');
 
@@ -404,7 +404,7 @@ In Pulsar Node.js client, you have to construct producer message object for prod
 
 Here is an example message:
 
-```JavaScript
+```javascript
 
 const msg = {
   data: Buffer.from('Hello, Pulsar'),

--- a/site2/docs/functions-develop.md
+++ b/site2/docs/functions-develop.md
@@ -30,7 +30,7 @@ The language-native function, which adds an exclamation point to all incoming st
   values={[{"label":"Java","value":"Java"},{"label":"Python","value":"Python"}]}>
 <TabItem value="Java">
 
-```Java
+```java
 
 import java.util.function.Function;
 
@@ -85,7 +85,7 @@ The following example uses Pulsar Functions SDK.
   values={[{"label":"Java","value":"Java"},{"label":"Python","value":"Python"},{"label":"Go","value":"Go"}]}>
 <TabItem value="Java">
 
-```Java
+```java
 
 import org.apache.pulsar.functions.api.Context;
 import org.apache.pulsar.functions.api.Function;
@@ -122,7 +122,7 @@ For complete code, see [here](https://github.com/apache/pulsar/blob/master/pulsa
 </TabItem>
 <TabItem value="Go">
 
-```Go
+```go
 
 package main
 
@@ -171,7 +171,7 @@ The following example uses the extended interface of Pulsar Function SDK for Jav
   values={[{"label":"Java","value":"Java"}]}>
 <TabItem value="Java">
 
-```Java
+```java
 
 import org.apache.pulsar.functions.api.Context;
 import org.apache.pulsar.functions.api.Function;

--- a/site2/docs/functions-package.md
+++ b/site2/docs/functions-package.md
@@ -30,7 +30,7 @@ To package a function in Java, complete the following steps.
 
 1. Create a new maven project with a pom file. In the following code sample, the value of `mainClass` is your package name.
 
-   ```Java
+   ```java
    
    <?xml version="1.0" encoding="UTF-8"?>
    <project xmlns="http://maven.apache.org/POM/4.0.0"

--- a/site2/docs/functions-runtime.md
+++ b/site2/docs/functions-runtime.md
@@ -245,7 +245,7 @@ In order to safely distribute secrets, Pulasr Functions can reference Kubernetes
 
 You can create a secret in the namespace where your functions are deployed. For example, you deploy functions to the `pulsar-func` Kubernetes namespace, and you have a secret named `database-creds` with a field name `password`, which you want to mount in the pod as an environment variable called `DATABASE_PASSWORD`. The following functions configuration enables you to reference that secret and mount the value as an environment variable in the pod.
 
-```Yaml
+```yaml
 
 tenant: "mytenant"
 namespace: "mynamespace"
@@ -269,7 +269,7 @@ The `org.apache.pulsar.functions.auth.KubernetesFunctionAuthProvider` interface 
 
 Pulsar includes an implementation of this interface for token authentication, and distributes the certificate authority via the same implementation. The configuration is similar as follows:
 
-```Yaml
+```yaml
 
 functionAuthProviderClassName: org.apache.pulsar.functions.auth.KubernetesSecretsTokenAuthProvider
 
@@ -291,7 +291,7 @@ When you run a functions worker in a standalone process (that is, not embedded i
 
 For example, if you use token authentication, you need to configure the following properties in the `function-worker.yml` file.
 
-```Yaml
+```yaml
 
 clientAuthenticationPlugin: org.apache.pulsar.client.impl.auth.AuthenticationToken
 clientAuthenticationParameters: file:///etc/pulsar/token/admin-token.txt
@@ -368,14 +368,14 @@ If you run multiple clusters tied together with geo-replication, it is important
 
 For example, if you have two clusters: `east-1` and `west-1`, you can configure the functions workers for `east-1` and `west-1` perspectively as follows.
 
-```Yaml
+```yaml
 
 pulsarFunctionsCluster: east-1
 pulsarFunctionsNamespace: public/functions-east-1
 
 ```
 
-```Yaml
+```yaml
 
 pulsarFunctionsCluster: west-1
 pulsarFunctionsNamespace: public/functions-west-1
@@ -390,7 +390,7 @@ When configuring a standalone functions worker, you need to configure properties
 
 You need to configure the following required properties.
 
-```Yaml
+```yaml
 
 workerPort: 8080
 workerPortTls: 8443 # when using TLS

--- a/site2/docs/security-oauth2.md
+++ b/site2/docs/security-oauth2.md
@@ -175,7 +175,7 @@ client = Client("pulsar://my-cluster:6650", authentication=AuthenticationOauth2(
 To enable OAuth2 authentication in Node.js client, you need to configure OAuth2 authentication.
 This example shows how to configure OAuth2 authentication in Node.js client.
 
-```JavaScript
+```javascript
 
     const Pulsar = require('pulsar-client');
     const issuer_url = process.env.ISSUER_URL;

--- a/site2/docs/security-tls-authentication.md
+++ b/site2/docs/security-tls-authentication.md
@@ -189,7 +189,7 @@ pulsar::Client client("pulsar+ssl://broker.example.com:6651/", config);
 
 ### Node.js client
 
-```JavaScript
+```javascript
 
 const Pulsar = require('pulsar-client');
 

--- a/site2/docs/security-tls-transport.md
+++ b/site2/docs/security-tls-transport.md
@@ -280,7 +280,7 @@ config.setValidateHostName(false);
 
 #### Node.js client
 
-```JavaScript
+```javascript
 
 const Pulsar = require('pulsar-client');
 


### PR DESCRIPTION
Fixes #15854 

### Motivation

Code highlighting does not work on some pages like https://pulsar.apache.org/docs/functions-develop because notations like <code>\`\`\`Java</code> instead of <code>\`\`\`java</code> are used in Markdown.

### Modifications

Correct the Markdown syntax.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API: no
  - The schema: no
  - The default values of configurations: no
  - The wire protocol: no
  - The rest endpoints: no
  - The admin cli options: no
  - Anything that affects deployment: no

### Documentation

Check the box below or label this PR directly.

Need to update docs? 

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)
  
- [ ] `doc-not-needed` 
(Please explain why)
  
- [x] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)