### PR TITLE
[Broker] Close transactionBufferClient before closing the internal Pulsar client

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
@@ -487,6 +487,10 @@ public class PulsarService implements AutoCloseable, ShutdownService {
                 transactionBufferSnapshotService = null;
             }
 
+            if (transactionBufferClient != null) {
+                transactionBufferClient.close();
+            }
+
             if (client != null) {
                 client.close();
                 client = null;
@@ -517,10 +521,6 @@ public class PulsarService implements AutoCloseable, ShutdownService {
             if (protocolHandlers != null) {
                 protocolHandlers.close();
                 protocolHandlers = null;
-            }
-
-            if (transactionBufferClient != null) {
-                transactionBufferClient.close();
             }
 
             if (coordinationService != null) {


### PR DESCRIPTION
### Motivation

- `transactionBufferClient` uses the internal Pulsar client and therefore it should be closed before the internal Pulsar client.

### Modifications

- close `transactionsBufferClient` before the internal Pulsar client in `PulsarService`

### Additional context

I noticed the shutdown order inconsistency while investigating the flaky test failure #15920 .