### PR TITLE
[CI] Run pulsar-io unit tests in separate build job

### DIFF
--- a/.github/workflows/pulsar-ci.yaml
+++ b/.github/workflows/pulsar-ci.yaml
@@ -159,6 +159,8 @@ jobs:
             timeout: 75
           - name: Proxy
             group: PROXY
+          - name: Pulsar IO
+            group: PULSAR_IO
 
     steps:
       - name: checkout

--- a/build/run_unit_group.sh
+++ b/build/run_unit_group.sh
@@ -129,17 +129,14 @@ function test_group_proxy() {
 }
 
 function test_group_other() {
-  mvn_test --install -PskipTestsForUnitGroupOther -DdisableIoMainProfile=true \
+  mvn_test --install -PskipTestsForUnitGroupOther -DdisableIoMainProfile=true -DdisableSqlMainProfile=true \
            -Dexclude='**/ManagedLedgerTest.java,
                    **/OffloadersCacheTest.java
-                  **/TestPulsarKeyValueSchemaHandler.java,
                   **/PrimitiveSchemaTest.java,
                   BlobStoreManagedLedgerOffloaderTest.java'
 
   mvn_test -pl managed-ledger -Dinclude='**/ManagedLedgerTest.java,
                                                   **/OffloadersCacheTest.java'
-
-  mvn_test -pl pulsar-sql/presto-pulsar-plugin -Dinclude='**/TestPulsarKeyValueSchemaHandler.java'
 
   mvn_test -pl pulsar-client -Dinclude='**/PrimitiveSchemaTest.java'
 
@@ -147,7 +144,7 @@ function test_group_other() {
 
   echo "::endgroup::"
   local modules_with_quarantined_tests=$(git grep -l '@Test.*"quarantine"' | grep '/src/test/java/' | \
-    awk -F '/src/test/java/' '{ print $1 }' | grep -v -E 'pulsar-broker|pulsar-proxy|pulsar-io' | sort | uniq | \
+    awk -F '/src/test/java/' '{ print $1 }' | grep -v -E 'pulsar-broker|pulsar-proxy|pulsar-io|pulsar-sql' | sort | uniq | \
     perl -0777 -p -e 's/\n(\S)/,$1/g')
   if [ -n "${modules_with_quarantined_tests}" ]; then
     echo "::group::Running quarantined tests outside of pulsar-broker & pulsar-proxy (if any)"
@@ -162,6 +159,10 @@ function test_group_pulsar_io() {
     $MVN_TEST_OPTIONS -pl kafka-connect-avro-converter-shaded clean install
     echo "::group::Running pulsar-io tests"
     mvn_test --install -Ppulsar-io-tests,-main
+    echo "::endgroup::"
+
+    echo "::group::Running pulsar-sql tests"
+    mvn_test --install -Ppulsar-sql-tests,-main
     echo "::endgroup::"
 }
 

--- a/build/run_unit_group.sh
+++ b/build/run_unit_group.sh
@@ -34,6 +34,11 @@ function mvn_test() {
       RETRY=""
       shift
     fi
+    local clean_arg=""
+    if [[ "$1" == "--clean" ]]; then
+        clean_arg="clean"
+        shift
+    fi
     TARGET=verify
     if [[ "$1" == "--install" ]]; then
       TARGET="install"
@@ -42,7 +47,7 @@ function mvn_test() {
     echo "::group::Run tests for " "$@"
     # use "verify" instead of "test" to workaround MDEP-187 issue in pulsar-functions-worker and pulsar-broker projects with the maven-dependency-plugin's copy goal
     # Error message was "Artifact has not been packaged yet. When used on reactor artifact, copy should be executed after packaging: see MDEP-187"
-    $RETRY $MVN_TEST_OPTIONS $TARGET "$@" "${COMMANDLINE_ARGS[@]}"
+    $RETRY $MVN_TEST_OPTIONS $clean_arg $TARGET "$@" "${COMMANDLINE_ARGS[@]}"
     echo "::endgroup::"
     set +x
     "$SCRIPT_DIR/pulsar_ci_tool.sh" move_test_reports
@@ -129,7 +134,7 @@ function test_group_proxy() {
 }
 
 function test_group_other() {
-  mvn_test --install -PskipTestsForUnitGroupOther -DdisableIoMainProfile=true -DdisableSqlMainProfile=true \
+  mvn_test --clean --install -PskipTestsForUnitGroupOther -DdisableIoMainProfile=true -DdisableSqlMainProfile=true \
            -Dexclude='**/ManagedLedgerTest.java,
                    **/OffloadersCacheTest.java
                   **/PrimitiveSchemaTest.java,

--- a/build/run_unit_group.sh
+++ b/build/run_unit_group.sh
@@ -136,7 +136,7 @@ function test_group_proxy() {
 function test_group_other() {
   mvn_test --clean --install \
            -pl '!org.apache.pulsar:distribution,!org.apache.pulsar:pulsar-offloader-distribution,!org.apache.pulsar:pulsar-server-distribution,!org.apache.pulsar:pulsar-io-distribution' \
-           -PskipTestsForUnitGroupOther -DdisableIoMainProfile=true -DdisableSqlMainProfile=true \
+           -PskipTestsForUnitGroupOther -DdisableIoMainProfile=true -DdisableSqlMainProfile=true -DskipIntegrationTests \
            -Dexclude='**/ManagedLedgerTest.java,
                    **/OffloadersCacheTest.java
                   **/PrimitiveSchemaTest.java,

--- a/build/run_unit_group.sh
+++ b/build/run_unit_group.sh
@@ -134,7 +134,9 @@ function test_group_proxy() {
 }
 
 function test_group_other() {
-  mvn_test --clean --install -PskipTestsForUnitGroupOther -DdisableIoMainProfile=true -DdisableSqlMainProfile=true \
+  mvn_test --clean --install \
+           -pl '!org.apache.pulsar:distribution,!org.apache.pulsar:pulsar-offloader-distribution,!org.apache.pulsar:pulsar-server-distribution,!org.apache.pulsar:pulsar-io-distribution' \
+           -PskipTestsForUnitGroupOther -DdisableIoMainProfile=true -DdisableSqlMainProfile=true \
            -Dexclude='**/ManagedLedgerTest.java,
                    **/OffloadersCacheTest.java
                   **/PrimitiveSchemaTest.java,

--- a/pom.xml
+++ b/pom.xml
@@ -2360,6 +2360,13 @@ flexible messaging model and an intuitive client API.</description>
         <module>pulsar-io</module>
       </modules>
     </profile>
+
+    <profile>
+      <id>pulsar-sql-tests</id>
+      <modules>
+        <module>pulsar-sql</module>
+      </modules>
+    </profile>
   </profiles>
 
   <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -2353,6 +2353,13 @@ flexible messaging model and an intuitive client API.</description>
         <os.detected.classifier>osx-x86_64</os.detected.classifier>
       </properties>
     </profile>
+
+    <profile>
+      <id>pulsar-io-tests</id>
+      <modules>
+        <module>pulsar-io</module>
+      </modules>
+    </profile>
   </profiles>
 
   <repositories>

--- a/pulsar-broker/pom.xml
+++ b/pulsar-broker/pom.xml
@@ -773,7 +773,7 @@
       </build>
     </profile>
     <profile>
-      <id>brokerSkipTest</id>
+      <id>skipTestsForUnitGroupOther</id>
       <build>
         <plugins>
           <plugin>

--- a/pulsar-io/pom.xml
+++ b/pulsar-io/pom.xml
@@ -77,6 +77,43 @@
     </profile>
 
     <profile>
+      <id>pulsar-io-tests</id>
+      <modules>
+        <module>core</module>
+        <module>batch-discovery-triggerers</module>
+        <module>batch-data-generator</module>
+        <module>common</module>
+        <module>docs</module>
+        <module>aws</module>
+        <module>twitter</module>
+        <module>cassandra</module>
+        <module>aerospike</module>
+        <module>kafka</module>
+        <module>rabbitmq</module>
+        <module>kinesis</module>
+        <module>hdfs3</module>
+        <module>jdbc</module>
+        <module>data-generator</module>
+        <module>elastic-search</module>
+        <module>kafka-connect-adaptor</module>
+        <module>kafka-connect-adaptor-nar</module>
+        <module>debezium</module>
+        <module>hdfs2</module>
+        <module>canal</module>
+        <module>file</module>
+        <module>netty</module>
+        <module>hbase</module>
+        <module>mongo</module>
+        <module>flume</module>
+        <module>redis</module>
+        <module>solr</module>
+        <module>influxdb</module>
+        <module>dynamodb</module>
+        <module>nsq</module>
+      </modules>
+    </profile>
+
+    <profile>
       <id>core-modules</id>
       <modules>
         <module>core</module>

--- a/pulsar-proxy/pom.xml
+++ b/pulsar-proxy/pom.xml
@@ -262,6 +262,20 @@
         </dependency>
       </dependencies>
     </profile>
+    <profile>
+      <id>skipTestsForUnitGroupOther</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <configuration>
+              <skipTests>true</skipTests>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
   </profiles>
 
 </project>

--- a/pulsar-sql/pom.xml
+++ b/pulsar-sql/pom.xml
@@ -31,13 +31,6 @@
     <artifactId>pulsar-sql</artifactId>
     <name>Pulsar SQL :: Parent</name>
 
-    <modules>
-        <module>presto-pulsar</module>
-        <module>presto-pulsar-plugin</module>
-        <module>java-version-trim-agent</module>
-        <module>presto-distribution</module>
-    </modules>
-
     <properties>
         <!-- keep using okhttp3 3.x for Presto -->
         <okhttp3.version>3.14.9</okhttp3.version>
@@ -178,6 +171,31 @@
     </build>
 
     <profiles>
+        <profile>
+            <id>main</id>
+            <activation>
+                <property>
+                    <name>disableSqlMainProfile</name>
+                    <!-- always active unless true is passed as a value -->
+                    <value>!true</value>
+                </property>
+            </activation>
+            <modules>
+                <module>presto-pulsar</module>
+                <module>presto-pulsar-plugin</module>
+                <module>java-version-trim-agent</module>
+                <module>presto-distribution</module>
+            </modules>
+        </profile>
+        <profile>
+            <id>pulsar-sql-tests</id>
+            <modules>
+                <module>presto-pulsar</module>
+                <module>presto-pulsar-plugin</module>
+                <module>java-version-trim-agent</module>
+                <module>presto-distribution</module>
+            </modules>
+        </profile>
         <!--
         The only working way for OWASP dependency checker plugin
         to exclude module when failBuildOnCVSS is used


### PR DESCRIPTION
### Motivation

About 15 minutes of "CI - Unit - Other" build job is spent running pulsar-io unit tests.
It would be an improvement to run pulsar-io tests in a separate build job.
When "CI - Unit - Other" build job fails, it will be quicker to re-run the build job when pulsar-io tests aren't part of it.

### Modifications

- Add new build job "CI - Unit - Pulsar IO"
- add support for group "PULSAR_IO" in `build/run_unit_group.sh` script
- rename `brokerSkipTest` Maven profile to `skipTestsForUnitGroupOther` and use this Maven profile for excluding tests from the OTHER group
- add new profile `pulsar-io-tests` to select pulsar-io modules