### PR TITLE
[fix][auth] Generate correct well-known OpenID configuration URL

### DIFF
--- a/pulsar-client-cpp/lib/auth/AuthOauth2.cc
+++ b/pulsar-client-cpp/lib/auth/AuthOauth2.cc
@@ -143,16 +143,8 @@ ClientCredentialFlow::ClientCredentialFlow(ParamMap& params)
       audience_(params["audience"]),
       scope_(params["scope"]) {}
 
-const std::string ClientCredentialFlow::getWellKnownOpenIdConfigurationUrl() {
-    if (issuerUrl_.empty()) {
-        LOG_ERROR("Failed to get well known openid configuration: issuer_url is not set");
-        return "";
-    }
-    std::string configurationUrl = issuerUrl_;
-    if (configurationUrl.back() == '/') {
-        configurationUrl.pop_back();
-    }
-    return configurationUrl.append("/.well-known/openid-configuration");
+std::string ClientCredentialFlow::getTokenEndPoint() const {
+    return tokenEndPoint_;
 }
 
 static size_t curlWriteCallback(void* contents, size_t size, size_t nmemb, void* responseDataPtr) {
@@ -180,7 +172,12 @@ void ClientCredentialFlow::initialize() {
     curl_easy_setopt(handle, CURLOPT_CUSTOMREQUEST, "GET");
 
     // set URL: well-know endpoint
-    curl_easy_setopt(handle, CURLOPT_URL, getWellKnownOpenIdConfigurationUrl().c_str());
+    std::string wellKnownUrl = issuerUrl_;
+    if (wellKnownUrl.back() == '/') {
+        wellKnownUrl.pop_back();
+    }
+    wellKnownUrl.append("/.well-known/openid-configuration");
+    curl_easy_setopt(handle, CURLOPT_URL,wellKnownUrl.c_str());
 
     // Write callback
     curl_easy_setopt(handle, CURLOPT_WRITEFUNCTION, curlWriteCallback);

--- a/pulsar-client-cpp/lib/auth/AuthOauth2.cc
+++ b/pulsar-client-cpp/lib/auth/AuthOauth2.cc
@@ -143,6 +143,18 @@ ClientCredentialFlow::ClientCredentialFlow(ParamMap& params)
       audience_(params["audience"]),
       scope_(params["scope"]) {}
 
+const std::string ClientCredentialFlow::getWellKnownOpenIdConfigurationUrl() {
+    if (issuerUrl_.empty()) {
+        LOG_ERROR("Failed to get well known openid configuration: issuer_url is not set");
+        return "";
+    }
+    std::string configurationUrl = issuerUrl_;
+    if (configurationUrl.back() == '/') {
+        configurationUrl.pop_back();
+    }
+    return configurationUrl.append("/.well-known/openid-configuration");
+}
+
 static size_t curlWriteCallback(void* contents, size_t size, size_t nmemb, void* responseDataPtr) {
     ((std::string*)responseDataPtr)->append((char*)contents, size * nmemb);
     return size * nmemb;
@@ -168,7 +180,7 @@ void ClientCredentialFlow::initialize() {
     curl_easy_setopt(handle, CURLOPT_CUSTOMREQUEST, "GET");
 
     // set URL: well-know endpoint
-    curl_easy_setopt(handle, CURLOPT_URL, (issuerUrl_ + "/.well-known/openid-configuration").c_str());
+    curl_easy_setopt(handle, CURLOPT_URL, getWellKnownOpenIdConfigurationUrl().c_str());
 
     // Write callback
     curl_easy_setopt(handle, CURLOPT_WRITEFUNCTION, curlWriteCallback);

--- a/pulsar-client-cpp/lib/auth/AuthOauth2.cc
+++ b/pulsar-client-cpp/lib/auth/AuthOauth2.cc
@@ -143,9 +143,7 @@ ClientCredentialFlow::ClientCredentialFlow(ParamMap& params)
       audience_(params["audience"]),
       scope_(params["scope"]) {}
 
-std::string ClientCredentialFlow::getTokenEndPoint() const {
-    return tokenEndPoint_;
-}
+std::string ClientCredentialFlow::getTokenEndPoint() const { return tokenEndPoint_; }
 
 static size_t curlWriteCallback(void* contents, size_t size, size_t nmemb, void* responseDataPtr) {
     ((std::string*)responseDataPtr)->append((char*)contents, size * nmemb);
@@ -177,7 +175,7 @@ void ClientCredentialFlow::initialize() {
         wellKnownUrl.pop_back();
     }
     wellKnownUrl.append("/.well-known/openid-configuration");
-    curl_easy_setopt(handle, CURLOPT_URL,wellKnownUrl.c_str());
+    curl_easy_setopt(handle, CURLOPT_URL, wellKnownUrl.c_str());
 
     // Write callback
     curl_easy_setopt(handle, CURLOPT_WRITEFUNCTION, curlWriteCallback);

--- a/pulsar-client-cpp/lib/auth/AuthOauth2.h
+++ b/pulsar-client-cpp/lib/auth/AuthOauth2.h
@@ -58,6 +58,7 @@ class ClientCredentialFlow : public Oauth2Flow {
     void close();
 
     ParamMap generateParamMap() const;
+    const std::string getWellKnownOpenIdConfigurationUrl();
 
    private:
     std::string tokenEndPoint_;

--- a/pulsar-client-cpp/lib/auth/AuthOauth2.h
+++ b/pulsar-client-cpp/lib/auth/AuthOauth2.h
@@ -58,7 +58,7 @@ class ClientCredentialFlow : public Oauth2Flow {
     void close();
 
     ParamMap generateParamMap() const;
-    const std::string getWellKnownOpenIdConfigurationUrl();
+    std::string getTokenEndPoint() const;
 
    private:
     std::string tokenEndPoint_;

--- a/pulsar-client-cpp/tests/AuthPluginTest.cc
+++ b/pulsar-client-cpp/tests/AuthPluginTest.cc
@@ -412,6 +412,20 @@ TEST(AuthPluginTest, testOauth2RequestBody) {
     ASSERT_EQ(flow2.generateParamMap(), expectedResult2);
 }
 
+TEST(AuthPluginTest, getWellKnownOpenIdConfigurationUrl) {
+    std::string issuerUrl = "https://dev-kt-aa9ne.us.auth0.com";
+    std::string configurationUrl = "https://dev-kt-aa9ne.us.auth0.com/.well-known/openid-configuration";
+
+    ParamMap params;
+    params["issuer_url"] = issuerUrl;
+    ClientCredentialFlow flow1(params);
+    ASSERT_EQ(flow1.getWellKnownOpenIdConfigurationUrl(), configurationUrl);
+
+    params["issuer_url"] = issuerUrl.append("/");
+    ClientCredentialFlow flow2(params);
+    ASSERT_EQ(flow2.getWellKnownOpenIdConfigurationUrl(), configurationUrl);
+}
+
 TEST(AuthPluginTest, testOauth2Failure) {
     ParamMap params;
     auto addKeyValue = [&](const std::string& key, const std::string& value) {

--- a/pulsar-client-cpp/tests/AuthPluginTest.cc
+++ b/pulsar-client-cpp/tests/AuthPluginTest.cc
@@ -412,18 +412,24 @@ TEST(AuthPluginTest, testOauth2RequestBody) {
     ASSERT_EQ(flow2.generateParamMap(), expectedResult2);
 }
 
-TEST(AuthPluginTest, getWellKnownOpenIdConfigurationUrl) {
+TEST(AuthPluginTest, testInitialize) {
     std::string issuerUrl = "https://dev-kt-aa9ne.us.auth0.com";
-    std::string configurationUrl = "https://dev-kt-aa9ne.us.auth0.com/.well-known/openid-configuration";
+    std::string expectedTokenEndPoint = issuerUrl + "/oauth/token";
 
     ParamMap params;
     params["issuer_url"] = issuerUrl;
-    ClientCredentialFlow flow1(params);
-    ASSERT_EQ(flow1.getWellKnownOpenIdConfigurationUrl(), configurationUrl);
+    params["client_id"] = "Xd23RHsUnvUlP7wchjNYOaIfazgeHd9x";
+    params["client_secret"] = "rT7ps7WY8uhdVuBTKWZkttwLdQotmdEliaM5rLfmgNibvqziZ-g07ZH52N_poGAb";
+    params["audience"] = "https://dev-kt-aa9ne.us.auth0.com/api/v2/";
 
-    params["issuer_url"] = issuerUrl.append("/");
+    ClientCredentialFlow flow1(params);
+    flow1.initialize();
+    ASSERT_EQ(flow1.getTokenEndPoint(), expectedTokenEndPoint);
+
+    params["issuer_url"] = issuerUrl + "/";
     ClientCredentialFlow flow2(params);
-    ASSERT_EQ(flow2.getWellKnownOpenIdConfigurationUrl(), configurationUrl);
+    flow2.initialize();
+    ASSERT_EQ(flow2.getTokenEndPoint(), expectedTokenEndPoint);
 }
 
 TEST(AuthPluginTest, testOauth2Failure) {


### PR DESCRIPTION
### Motivation

Currently, the well-known OpenID configuration URL generated by issuer_url and suffix (/.well-known/openid-configuration), if the issurer_url end with a slash, the well-known OpenID configuration URL will be not correct.

#### Demo
```
issuer_url: https://dev-kt-aa9ne.us.auth0.com/
openid_url: https://dev-kt-aa9ne.us.auth0.com//.well-known/openid-configuration
```

Making the issuer_url as below could work well.
```
issuer_url: https://dev-kt-aa9ne.us.auth0.com/
issuer_url: https://dev-kt-aa9ne.us.auth0.com
```

### Modifications

Trim the slash if the issuer_url end with a slash.

### Verifying this change

Add a unit test to verify the method `ClientCredentialFlow::initialize`.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

Check the box below or label this PR directly.

Need to update docs? 

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)
  
- [x] `doc-not-needed` 
(Please explain why)
  
- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)