### PR TITLE
[fix] [admin] Enhanced verification for retention policy

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/PersistentTopics.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/PersistentTopics.java
@@ -2158,6 +2158,7 @@ public class PersistentTopics extends PersistentTopicsBase {
             @QueryParam("isGlobal") @DefaultValue("false") boolean isGlobal,
             @ApiParam(value = "Retention policies for the specified namespace") RetentionPolicies retention) {
         validateTopicName(tenant, namespace, encodedTopic);
+        validateRetentionPolicies(retention);
         preValidation(authoritative)
             .thenCompose(__ -> internalSetRetention(retention, isGlobal))
             .thenRun(() -> {
@@ -4000,4 +4001,10 @@ public class PersistentTopics extends PersistentTopicsBase {
     }
 
     private static final Logger log = LoggerFactory.getLogger(PersistentTopics.class);
+
+    protected void validateRetentionPolicies(RetentionPolicies retention) {
+        checkNotNull(retention, "retention policies should not be null");
+        checkArgument(!retention.allGatesNotSet(), "Not set any retention gate."
+                + "If you want remove retention policy, suggest the delete api");
+    }
 }

--- a/pulsar-client-admin-api/src/main/java/org/apache/pulsar/common/policies/data/RetentionPolicies.java
+++ b/pulsar-client-admin-api/src/main/java/org/apache/pulsar/common/policies/data/RetentionPolicies.java
@@ -28,24 +28,33 @@ package org.apache.pulsar.common.policies.data;
  * Infinite retention can be achieved by setting both time and size limits to `-1`.
  */
 public class RetentionPolicies {
-    private int retentionTimeInMinutes;
-    private long retentionSizeInMB;
+
+    public static final int DEFAULT_RETENTION_TIME_IN_MINUTES = 0;
+
+    public static final long DEFAULT_RETENTION_SIZE_IN_MB = 0;
+
+    private Integer retentionTimeInMinutes;
+    private Long retentionSizeInMB;
 
     public RetentionPolicies() {
-        this(0, 0);
+        this(null, null);
     }
 
-    public RetentionPolicies(int retentionTimeInMinutes, int retentionSizeInMB) {
-        this.retentionSizeInMB = retentionSizeInMB;
+    public RetentionPolicies(Integer retentionTimeInMinutes, Integer retentionSizeInMB) {
+        this.retentionSizeInMB = retentionSizeInMB == null ? null : retentionSizeInMB.longValue();
         this.retentionTimeInMinutes = retentionTimeInMinutes;
     }
 
+    public boolean allGatesNotSet(){
+        return retentionTimeInMinutes == null && retentionSizeInMB == null;
+    }
+
     public int getRetentionTimeInMinutes() {
-        return retentionTimeInMinutes;
+        return retentionTimeInMinutes == null ? DEFAULT_RETENTION_TIME_IN_MINUTES : retentionTimeInMinutes;
     }
 
     public long getRetentionSizeInMB() {
-        return retentionSizeInMB;
+        return retentionSizeInMB == null ? DEFAULT_RETENTION_SIZE_IN_MB : retentionSizeInMB;
     }
 
     @Override
@@ -58,23 +67,23 @@ public class RetentionPolicies {
         }
         RetentionPolicies that = (RetentionPolicies) o;
 
-        if (retentionTimeInMinutes != that.retentionTimeInMinutes) {
+        if (getRetentionTimeInMinutes() != that.getRetentionTimeInMinutes()) {
             return false;
         }
 
-        return retentionSizeInMB == that.retentionSizeInMB;
+        return getRetentionSizeInMB() == that.getRetentionSizeInMB();
     }
 
     @Override
     public int hashCode() {
-        long result = retentionTimeInMinutes;
-        result = 31 * result + retentionSizeInMB;
+        long result = getRetentionTimeInMinutes();
+        result = 31 * result + getRetentionSizeInMB();
         return Long.hashCode(result);
     }
 
     @Override
     public String toString() {
-        return "RetentionPolicies{" + "retentionTimeInMinutes=" + retentionTimeInMinutes + ", retentionSizeInMB="
-                + retentionSizeInMB + '}';
+        return "RetentionPolicies{" + "retentionTimeInMinutes=" + getRetentionTimeInMinutes() + ", retentionSizeInMB="
+                + getRetentionSizeInMB() + '}';
     }
 }


### PR DESCRIPTION
### Motivation

Lego ran into an issue where they would call the /admin/v2/persistent/{tenant}/{namespace}/{topic}/retention endpoint after creating a topic, but the call appeared to have no effect, despite returning HTTP 204.

After some initial debugging, they determined that the root cause was related to the casing of the parameters in their JSON payload. They initially provided this:

```
{"RetentionSizeInMb":-1,"RetentionTimeInMinutes":40320}
```

Which should have been this:

```
{"retentionSizeInMB":-1,"retentionTimeInMinutes":40320}
```

This will trick the user into thinking the setup succeeded when it didn't

#### Observed behavior
When an empty config is submitted, /admin/v2/persistent/{tenant}/{namespace}/{topic}/retention returns HTTP 204

#### Expected behavior
When an empty config is submitted, /admin/v2/persistent/{tenant}/{namespace}/{topic}/retention returns HTTP 400




### Modifications

Enhanced verification



### Documentation



- [ ] `doc-required` 

  
- [x] `doc-not-needed` 

  
- [ ] `doc` 


- [ ] `doc-complete`
