### PR TITLE
[improve][doc] add explanations for loadBalancerSheddingGracePeriodMinutes and loadBalancerResourceQuotaUpdateIntervalMinutes

### DIFF
--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -2000,7 +2000,8 @@ public class ServiceConfiguration implements PulsarConfiguration {
     @FieldContext(
         category = CATEGORY_LOAD_BALANCER,
         deprecated = true,
-        doc = "Usage threshold to determine a broker as under-loaded (only used by SimpleLoadManagerImpl)"
+        doc = "Usage threshold to determine a broker as under-loaded (used by SimpleLoadManagerImpl and "
+                + "ModularLoadManagerImpl)"
     )
     @Deprecated
     private int loadBalancerBrokerUnderloadedThresholdPercentage = 50;
@@ -2103,7 +2104,7 @@ public class ServiceConfiguration implements PulsarConfiguration {
         category = CATEGORY_LOAD_BALANCER,
         deprecated = true,
         doc = "Usage threshold to determine a broker is having just right level of load"
-            + " (only used by SimpleLoadManagerImpl)"
+            + " (used by SimpleLoadManagerImpl and ModularLoadManagerImpl)"
     )
     private int loadBalancerBrokerComfortLoadLevelPercentage = 65;
     @FieldContext(


### PR DESCRIPTION
### Motivation
Both of ` loadBalancerSheddingGracePeriodMinutes` and `loadBalancerResourceQuotaUpdateIntervalMinutes` are configurable for `ModularLoadManagerImpl` strategy . But the explanation is incorrect.
The explanation about  `loadBalancerSheddingGracePeriodMinutes` and `loadBalancerResourceQuotaUpdateIntervalMinutes`  distract me to config the `ModularLoadManagerImpl` strategy.

### Modifications
Clarify the parameter meaning.

### Verifying this change

- [x]  Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.
### Does this pull request potentially affect one of the following parts:

If `yes` was chosen, please highlight the changes

- Dependencies (does it add or upgrade a dependency): (no)
- The public API: (no)
- The schema: (no)
- The default values of configurations: (no)
- The wire protocol: (no)
- The rest endpoints: (no)
- The admin cli options: (no)
- Anything that affects deployment: (no)

### Documentation

Check the box below or label this PR directly.

Need to update docs?

- [ ] `doc-required`

- [ ] `doc-not-needed`

- [x] `doc`
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)
