### PR TITLE
Support shrink for TripleLongPriorityQueue

### DIFF
--- a/pulsar-common/src/main/java/org/apache/pulsar/common/util/collections/TripleLongPriorityQueue.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/util/collections/TripleLongPriorityQueue.java
@@ -179,10 +179,14 @@ public class TripleLongPriorityQueue implements AutoCloseable {
     private void shrinkCapacity() {
         if (capacity > initialCapacity &&  size < capacity * shrinkFactor) {
             int decreasingSize = (int) (capacity * shrinkFactor * RESERVATION_FACTOR);
-            if (decreasingSize <= 0 || capacity - decreasingSize <= DEFAULT_INITIAL_CAPACITY) {
+            if (decreasingSize <= 0) {
                 return;
             }
-            this.capacity = capacity - decreasingSize;
+            if (capacity - decreasingSize <= initialCapacity) {
+                this.capacity = initialCapacity;
+            } else {
+                this.capacity = capacity - decreasingSize;
+            }
             buffer.capacity(this.capacity * TUPLE_SIZE);
         }
     }

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/util/collections/TripleLongPriorityQueue.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/util/collections/TripleLongPriorityQueue.java
@@ -51,7 +51,7 @@ public class TripleLongPriorityQueue implements AutoCloseable {
     private int capacity;
     private int size;
     /**
-     * When size < capacity * shrinkFactor, may trigger shrinking
+     * When size < capacity * shrinkFactor, may trigger shrinking.
      */
     private final float shrinkFactor;
 

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/util/collections/TripleLongPriorityQueue.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/util/collections/TripleLongPriorityQueue.java
@@ -97,8 +97,6 @@ public class TripleLongPriorityQueue implements AutoCloseable {
     public void add(long n1, long n2, long n3) {
         if (size == capacity) {
             increaseCapacity();
-        } else {
-            shrinkCapacity();
         }
 
         put(size, n1, n2, n3);

--- a/pulsar-common/src/test/java/org/apache/pulsar/common/util/collections/TripleLongPriorityQueueTest.java
+++ b/pulsar-common/src/test/java/org/apache/pulsar/common/util/collections/TripleLongPriorityQueueTest.java
@@ -135,4 +135,40 @@ public class TripleLongPriorityQueueTest {
 
         pq.close();
     }
+
+    @Test
+    public void testShrink() throws Exception {
+        int initialCapacity = 20;
+        int tupleSize = 3 * 8;
+        TripleLongPriorityQueue pq = new TripleLongPriorityQueue(initialCapacity, 0.5f);
+        triggerScaleOut(initialCapacity, pq);
+
+        assertEquals(pq.size(), initialCapacity);
+        assertEquals(pq.getBuffer().capacity(), initialCapacity * tupleSize);
+
+        pq.add(0, 0, 0);
+        // Scale out to capacity * 2
+        int scaleCapacity = initialCapacity * 2;
+        assertEquals(pq.getBuffer().capacity(), scaleCapacity * tupleSize);
+        // Trigger shrinking
+        for (int i = 0; i < initialCapacity / 2 + 1; i++) {
+             pq.pop();
+        }
+        int capacity = scaleCapacity - (int)(scaleCapacity * 0.5f * 0.9f);
+        assertEquals(pq.getBuffer().capacity(), capacity * tupleSize);
+        // Scale out to capacity * 2
+        triggerScaleOut(initialCapacity, pq);
+        scaleCapacity = capacity * 2;
+        assertEquals(pq.getBuffer().capacity(), scaleCapacity * tupleSize);
+        // Trigger shrinking
+        pq.clear();
+        capacity = scaleCapacity - (int)(scaleCapacity * 0.5f * 0.9f);
+        assertEquals(pq.getBuffer().capacity(), capacity * tupleSize);
+    }
+
+    private void triggerScaleOut(int initialCapacity, TripleLongPriorityQueue pq) {
+        for (long i = 0; i < initialCapacity; i++) {
+            pq.add(i, i, i);
+        }
+    }
 }

--- a/pulsar-common/src/test/java/org/apache/pulsar/common/util/collections/TripleLongPriorityQueueTest.java
+++ b/pulsar-common/src/test/java/org/apache/pulsar/common/util/collections/TripleLongPriorityQueueTest.java
@@ -141,13 +141,12 @@ public class TripleLongPriorityQueueTest {
         int initialCapacity = 20;
         int tupleSize = 3 * 8;
         TripleLongPriorityQueue pq = new TripleLongPriorityQueue(initialCapacity, 0.5f);
-        triggerScaleOut(initialCapacity, pq);
-
-        assertEquals(pq.size(), initialCapacity);
+        pq.add(0, 0, 0);
+        assertEquals(pq.size(), 1);
         assertEquals(pq.getBuffer().capacity(), initialCapacity * tupleSize);
 
-        pq.add(0, 0, 0);
         // Scale out to capacity * 2
+        triggerScaleOut(initialCapacity, pq);
         int scaleCapacity = initialCapacity * 2;
         assertEquals(pq.getBuffer().capacity(), scaleCapacity * tupleSize);
         // Trigger shrinking
@@ -167,7 +166,7 @@ public class TripleLongPriorityQueueTest {
     }
 
     private void triggerScaleOut(int initialCapacity, TripleLongPriorityQueue pq) {
-        for (long i = 0; i < initialCapacity; i++) {
+        for (long i = 0; i < initialCapacity + 1; i++) {
             pq.add(i, i, i);
         }
     }


### PR DESCRIPTION
### Motivation
Support shrinkage in TripleLongPriorityQueue. Avoid memory waste.

### Modifications
When the actual memory usage is less than the threshold, scale down.
Since the thresholds for expansion and contraction may be the same, in order to avoid frequent expansion and contraction, a 10% buffer is reserved.

### Verifying this change
Verify that it can shrink normally

### Documentation
- [ x ] `doc-not-needed`   
  It is a internal class