### PR TITLE
[fix][test] Fix flaky test PersistentTopicsTest#testTriggerCompactionTopic

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/PersistentTopicsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/PersistentTopicsTest.java
@@ -901,9 +901,13 @@ public class PersistentTopicsTest extends MockedPulsarServiceBaseTest {
 
         // create non partitioned topic and compaction on it
         response = mock(AsyncResponse.class);
-        persistentTopics.createNonPartitionedTopic(response, testTenant, testNamespace, nonPartitionTopicName, true, null);
-        persistentTopics.compact(response, testTenant, testNamespace, nonPartitionTopicName, true);
         ArgumentCaptor<Response> responseCaptor = ArgumentCaptor.forClass(Response.class);
+        persistentTopics.createNonPartitionedTopic(response, testTenant, testNamespace, nonPartitionTopicName, true, null);
+        verify(response, timeout(5000).times(1)).resume(responseCaptor.capture());
+        Assert.assertEquals(responseCaptor.getValue().getStatus(), Response.Status.NO_CONTENT.getStatusCode());
+        response = mock(AsyncResponse.class);
+        responseCaptor = ArgumentCaptor.forClass(Response.class);
+        persistentTopics.compact(response, testTenant, testNamespace, nonPartitionTopicName, true);
         verify(response, timeout(5000).times(1)).resume(responseCaptor.capture());
         Assert.assertEquals(responseCaptor.getValue().getStatus(), Response.Status.NO_CONTENT.getStatusCode());
 


### PR DESCRIPTION
Fixes #15894
### Motivation

`testTriggerCompactionTopic` is flaky, because `createNonPartitionedTopic ` and `compact` use the same response: 

https://github.com/apache/pulsar/blob/ecd275dc21f33483a649e5b872990771257b1d45/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/PersistentTopicsTest.java#L902-L908

they are both return `Status.NO_CONTENT`, so the test fails sporadically with below error:
```
But was 2 times:
-> at org.apache.pulsar.broker.admin.impl.PersistentTopicsBase.lambda$internalTriggerCompactionNonPartitionedTopic$309(PersistentTopicsBase.java:3804)
-> at org.apache.pulsar.broker.admin.v2.PersistentTopics.lambda$createNonPartitionedTopic$2(PersistentTopics.java:352)
```

### Documentation

- [x] `doc-not-needed` 
