### PR TITLE
[fix] [proxy] empty metaStore is set even though it has been configured in proxy.conf

### DIFF
--- a/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/ProxyServiceStarter.java
+++ b/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/ProxyServiceStarter.java
@@ -143,12 +143,14 @@ public class ProxyServiceStarter {
             // load config file
             config = PulsarConfigurationLoader.create(configFile, ProxyConfiguration.class);
 
-            if (isBlank(metadataStoreUrl)) {
+            if (!isBlank(metadataStoreUrl)) {
+                // Use metadataStoreUrl from command line
+                config.setMetadataStoreUrl(metadataStoreUrl);
+            } else if (!isBlank(zookeeperServers)){
                 // Use zookeeperServers from command line if metadataStoreUrl is empty;
                 config.setMetadataStoreUrl(zookeeperServers);
             } else {
-                // Use metadataStoreUrl from command line
-                config.setMetadataStoreUrl(metadataStoreUrl);
+                // use "metadataStoreUrl" property in "proxy.conf".
             }
 
             if (!isBlank(globalZookeeperServers)) {


### PR DESCRIPTION
### Motivation

When there is no configuration in the command line, empty metaStore is set even though it has been configured in proxy.conf

https://github.com/apache/pulsar/blob/67361e8db632b0cd4c23198c5c569f3f2193fc70/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/ProxyServiceStarter.java#L146-L152

### Modifications

Set the read priority to Command line `metadataStoreUrl `, Command line `zookeeperServers , and Proxy conf `metadataStoreUrl`


### Documentation

- [ ] `doc-required` 
  
- [x] `doc-not-needed` 
  
- [ ] `doc` 

- [ ] `doc-complete`