### PR TITLE
[fix][python client] Fixed reserved keys is not removed when JsonSchema being encoded

### DIFF
--- a/pulsar-client-cpp/python/pulsar/schema/schema.py
+++ b/pulsar-client-cpp/python/pulsar/schema/schema.py
@@ -77,6 +77,14 @@ class StringSchema(Schema):
         return 'StringSchema'
 
 
+def remove_reserved_key(data):
+    if '_default' in data:
+        del data['_default']
+    if '_required' in data:
+        del data['_required']
+    if '_required_default' in data:
+        del data['_required_default']
+
 
 class JsonSchema(Schema):
 
@@ -88,19 +96,15 @@ class JsonSchema(Schema):
         if isinstance(o, enum.Enum):
             return o.value
         else:
-            return o.__dict__
+            data = o.__dict__.copy()
+            remove_reserved_key(data)
+            return data
 
     def encode(self, obj):
         self._validate_object_type(obj)
         # Copy the dict of the object as to not modify the provided object via the reference provided
         data = obj.__dict__.copy()
-        if '_default' in data:
-            del data['_default']
-        if '_required' in data:
-            del data['_required']
-        if '_required_default' in data:
-            del data['_required_default']
-
+        remove_reserved_key(data)
         return json.dumps(data, default=self._get_serialized_value, indent=True).encode('utf-8')
 
     def decode(self, data):

--- a/pulsar-client-cpp/python/schema_test.py
+++ b/pulsar-client-cpp/python/schema_test.py
@@ -1266,5 +1266,18 @@ class SchemaTest(TestCase):
 
         client.close()
 
+    def test_json_schema_encode_remove_reserved_key(self):
+        class SchemaB(Record):
+            field = String(required=True)
+
+        class SchemaA(Record):
+            field = SchemaB()
+
+        a = SchemaA(field=SchemaB(field="something"))
+        b = JsonSchema(SchemaA).encode(a)
+        # reserved field should not be in the encoded json
+        self.assertTrue(b'_default' not in b)
+        self.assertTrue(b'_required' not in b)
+        self.assertTrue(b'_required_default' not in b)
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
Fixes #15844

### Motivation

JsonSchema doesn't remove reserved keys(`_default`,`_required`,`_required_default`) when being encoded. Resulting in confusing encoding output.

### Modifications

Extract a common method to remove reserved keys when JsonSchema is being encoded, and this common method will be called when JsonSchema::encode method is called.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change added tests and can be verified as follows:

  - *Added a unit test method named test_json_schema_encode_remove_reserved_key, see pulsar-client-cpp/python/schema_test.py*

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API: (yes / **no**)
  - The schema: (yes / **no** / don't know)
  - The default values of configurations: (yes / **no**)
  - The wire protocol: (yes / **no**)
  - The rest endpoints: (yes / **no**)
  - The admin cli options: (yes / **no**)
  - Anything that affects deployment: (yes / **no** / don't know)

### Documentation

Check the box below or label this PR directly.

Need to update docs? 

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)
  
- [x] `doc-not-needed` 
(Please explain why)
  
- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)