### PR TITLE
[fix][client] Fix NPE when TableView handles null value message

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/TableViewTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/TableViewTest.java
@@ -18,6 +18,9 @@
  */
 package org.apache.pulsar.client.impl;
 
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.fail;
+
 import com.google.common.collect.Sets;
 import java.time.Duration;
 import java.util.HashSet;
@@ -40,7 +43,6 @@ import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
-import static org.testng.Assert.fail;
 
 /**
  * Unit test for {@link org.apache.pulsar.client.impl.TableViewImpl}.
@@ -113,18 +115,18 @@ public class TableViewTest extends MockedPulsarServiceBaseTest {
         tv.forEachAndListen((k, v) -> log.info("{} -> {}", k, new String(v)));
         Awaitility.await().untilAsserted(() -> {
             log.info("Current tv size: {}", tv.size());
-            Assert.assertEquals(tv.size(), count);
+            assertEquals(tv.size(), count);
         });
-        Assert.assertEquals(tv.keySet(), keys);
+        assertEquals(tv.keySet(), keys);
         tv.forEachAndListen((k, v) -> log.info("checkpoint {} -> {}", k, new String(v)));
 
         // Send more data
         Set<String> keys2 = this.publishMessages(topic, count * 2, false);
         Awaitility.await().untilAsserted(() -> {
             log.info("Current tv size: {}", tv.size());
-            Assert.assertEquals(tv.size(), count * 2);
+            assertEquals(tv.size(), count * 2);
         });
-        Assert.assertEquals(tv.keySet(), keys2);
+        assertEquals(tv.keySet(), keys2);
         // Test collection
         try {
             tv.keySet().clear();
@@ -161,9 +163,9 @@ public class TableViewTest extends MockedPulsarServiceBaseTest {
         tv.forEachAndListen((k, v) -> log.info("{} -> {}", k, new String(v)));
         Awaitility.await().untilAsserted(() -> {
             log.info("Current tv size: {}", tv.size());
-            Assert.assertEquals(tv.size(), count);
+            assertEquals(tv.size(), count);
         });
-        Assert.assertEquals(tv.keySet(), keys);
+        assertEquals(tv.keySet(), keys);
         tv.forEachAndListen((k, v) -> log.info("checkpoint {} -> {}", k, new String(v)));
 
         admin.topics().updatePartitionedTopic(topic, 4);
@@ -174,8 +176,45 @@ public class TableViewTest extends MockedPulsarServiceBaseTest {
                 this.publishMessages(topicName.getPartition(3).toString(), count * 2, false);
         Awaitility.await().atMost(Duration.ofSeconds(10)).untilAsserted(() -> {
             log.info("Current tv size: {}", tv.size());
-            Assert.assertEquals(tv.size(), count * 2);
+            assertEquals(tv.size(), count * 2);
         });
-        Assert.assertEquals(tv.keySet(), keys2);
+        assertEquals(tv.keySet(), keys2);
+    }
+
+    @Test(timeOut = 30 * 1000)
+    public void testPublishNullValue() throws Exception {
+        String topic = "persistent://public/default/tableview-test-publish-null-value";
+        admin.topics().createPartitionedTopic(topic, 3);
+
+        final TableView<String> tv = pulsarClient.newTableViewBuilder(Schema.STRING)
+                .topic(topic)
+                .autoUpdatePartitionsInterval(5, TimeUnit.SECONDS)
+                .create();
+        @Cleanup
+        Producer<String> producer = pulsarClient.newProducer(Schema.STRING).topic(topic).create();
+
+        producer.newMessage().key("key1").value("value1").send();
+
+        Awaitility.await().untilAsserted(() -> assertEquals(tv.get("key1"), "value1"));
+        assertEquals(tv.size(), 1);
+
+        // Try to remove key1 by publishing the tombstones message.
+        producer.newMessage().key("key1").value(null).send();
+        Awaitility.await().untilAsserted(() -> assertEquals(tv.size(), 0));
+
+        producer.newMessage().key("key2").value("value2").send();
+        Awaitility.await().untilAsserted(() -> assertEquals(tv.get("key2"), "value2"));
+        assertEquals(tv.size(), 1);
+
+        tv.close();
+
+        @Cleanup
+        TableView<String> tv1 = pulsarClient.newTableViewBuilder(Schema.STRING)
+                .topic(topic)
+                .autoUpdatePartitionsInterval(5, TimeUnit.SECONDS)
+                .create();
+
+        assertEquals(tv1.size(), 1);
+        assertEquals(tv.get("key2"), "value2");
     }
 }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/TableViewImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/TableViewImpl.java
@@ -155,7 +155,11 @@ public class TableViewImpl<T> implements TableView<T> {
 
                 try {
                     listenersMutex.lock();
-                    data.put(msg.getKey(), msg.getValue());
+                    if (null == msg.getValue()){
+                        data.remove(msg.getKey());
+                    } else {
+                        data.put(msg.getKey(), msg.getValue());
+                    }
 
                     for (BiConsumer<String, T> listener : listeners) {
                         try {


### PR DESCRIPTION
### Motivation

Currently, when we publish a null value message([tombstones](https://en.wikipedia.org/wiki/Tombstone_(data_store))) to a compacted topic used to `TableView`, the `TableView` should remove this key, but in the current implementation will throw an NPE and the `TableView` will stop reading the message.

ConcurrentHashMap:
```java
    final V putVal(K key, V value, boolean onlyIfAbsent) {
        if (key == null || value == null) throw new NullPointerException();
```

### Modifications

* Fix TableView handles null value messages.
* Add unit test to cover this case.

### Documentation

Check the box below or label this PR directly.

Need to update docs? 

- [x] `doc-not-needed` 
