### PR TITLE
[cleanup][broker]Cleanup DispatchRateLimiter isDispatchRateNeeded()

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/DispatchRateLimiter.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/DispatchRateLimiter.java
@@ -24,12 +24,10 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 import org.apache.pulsar.broker.ServiceConfiguration;
 import org.apache.pulsar.broker.service.BrokerService;
-import org.apache.pulsar.broker.service.BrokerServiceException;
 import org.apache.pulsar.common.naming.NamespaceName;
 import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.policies.data.DispatchRate;
 import org.apache.pulsar.common.policies.data.Policies;
-import org.apache.pulsar.common.policies.data.TopicPolicies;
 import org.apache.pulsar.common.policies.data.impl.DispatchRateImpl;
 import org.apache.pulsar.common.util.RateLimiter;
 import org.slf4j.Logger;
@@ -201,79 +199,6 @@ public class DispatchRateLimiter {
                 this.topicName, type, dispatchRate);
         }
         updateDispatchRate(dispatchRate);
-    }
-
-    public static boolean isDispatchRateNeeded(BrokerService brokerService, Optional<Policies> policies,
-            String topicName, Type type) {
-        final ServiceConfiguration serviceConfig = brokerService.pulsar().getConfiguration();
-        if (type == Type.BROKER) {
-            return brokerService.getBrokerDispatchRateLimiter().isDispatchRateLimitingEnabled();
-        }
-
-        Optional<DispatchRate> dispatchRate = getTopicPolicyDispatchRate(brokerService, topicName, type);
-        if (dispatchRate.isPresent()) {
-            return true;
-        }
-
-        policies = policies.isPresent() ? policies : getPolicies(brokerService, topicName);
-        return isDispatchRateNeeded(serviceConfig, policies, topicName, type);
-    }
-
-    public static Optional<DispatchRate> getTopicPolicyDispatchRate(BrokerService brokerService,
-                                                                    String topicName, Type type) {
-        Optional<DispatchRate> dispatchRate = Optional.empty();
-        final ServiceConfiguration serviceConfiguration = brokerService.pulsar().getConfiguration();
-        if (serviceConfiguration.isSystemTopicEnabled() && serviceConfiguration.isTopicLevelPoliciesEnabled()) {
-            try {
-                switch (type) {
-                    case TOPIC:
-                        dispatchRate = Optional.ofNullable(brokerService.pulsar().getTopicPoliciesService()
-                                .getTopicPolicies(TopicName.get(topicName)))
-                                .map(TopicPolicies::getDispatchRate);
-                        break;
-                    case SUBSCRIPTION:
-                        dispatchRate = Optional.ofNullable(brokerService.pulsar().getTopicPoliciesService()
-                                .getTopicPolicies(TopicName.get(topicName)))
-                                .map(TopicPolicies::getSubscriptionDispatchRate);
-                        break;
-                    case REPLICATOR:
-                        dispatchRate = Optional.ofNullable(brokerService.pulsar().getTopicPoliciesService()
-                                .getTopicPolicies(TopicName.get(topicName)))
-                                .map(TopicPolicies::getReplicatorDispatchRate);
-                        break;
-                    default:
-                        break;
-                }
-            } catch (BrokerServiceException.TopicPoliciesCacheNotInitException e) {
-                log.debug("Topic {} policies have not been initialized yet.", topicName);
-            } catch (Exception e) {
-                log.debug("[{}] Failed to get topic dispatch rate. ", topicName, e);
-            }
-        }
-
-        return dispatchRate;
-    }
-
-    public static boolean isDispatchRateNeeded(final ServiceConfiguration serviceConfig,
-            final Optional<Policies> policies, final String topicName, final Type type) {
-        DispatchRate dispatchRate = getPoliciesDispatchRate(serviceConfig.getClusterName(), policies, type);
-        if (dispatchRate == null) {
-            switch (type) {
-                case TOPIC:
-                    return serviceConfig.getDispatchThrottlingRatePerTopicInMsg() > 0
-                        || serviceConfig.getDispatchThrottlingRatePerTopicInByte() > 0;
-                case SUBSCRIPTION:
-                    return serviceConfig.getDispatchThrottlingRatePerSubscriptionInMsg() > 0
-                        || serviceConfig.getDispatchThrottlingRatePerSubscriptionInByte() > 0;
-                case REPLICATOR:
-                    return serviceConfig.getDispatchThrottlingRatePerReplicatorInMsg() > 0
-                        || serviceConfig.getDispatchThrottlingRatePerReplicatorInByte() > 0;
-                default:
-                    log.error("error DispatchRateLimiter type: {} ", type);
-                    return false;
-            }
-        }
-        return true;
     }
 
     @SuppressWarnings("deprecation")

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentStickyKeyDispatcherMultipleConsumersTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentStickyKeyDispatcherMultipleConsumersTest.java
@@ -23,12 +23,10 @@ import static org.apache.pulsar.common.protocol.Commands.serializeMetadataAndPay
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -39,7 +37,6 @@ import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelPromise;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 import org.apache.bookkeeper.mledger.Entry;
 import org.apache.bookkeeper.mledger.impl.EntryImpl;
 import org.apache.pulsar.broker.PulsarService;
@@ -50,11 +47,9 @@ import org.apache.pulsar.broker.service.Consumer;
 import org.apache.pulsar.broker.service.EntryBatchSizes;
 import org.apache.pulsar.broker.service.HashRangeAutoSplitStickyKeyConsumerSelector;
 import org.apache.pulsar.broker.service.RedeliveryTracker;
-import org.apache.pulsar.broker.service.persistent.DispatchRateLimiter;
 import org.apache.pulsar.common.api.proto.MessageMetadata;
 import org.apache.pulsar.common.policies.data.HierarchyTopicPolicies;
 import org.apache.pulsar.common.protocol.Commands;
-import org.mockito.MockedStatic;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
@@ -94,17 +89,9 @@ public class NonPersistentStickyKeyDispatcherMultipleConsumersTest {
 
         subscriptionMock = mock(NonPersistentSubscription.class);
 
-        try (MockedStatic<DispatchRateLimiter> rateLimiterMockedStatic = mockStatic(DispatchRateLimiter.class);) {
-            rateLimiterMockedStatic.when(() -> DispatchRateLimiter.isDispatchRateNeeded(
-                            any(BrokerService.class),
-                            any(Optional.class),
-                            anyString(),
-                            any(DispatchRateLimiter.Type.class)))
-                    .thenReturn(false);
-            nonpersistentDispatcher = new NonPersistentStickyKeyDispatcherMultipleConsumers(
-                    topicMock, subscriptionMock,
-                    new HashRangeAutoSplitStickyKeyConsumerSelector());
-        }
+        nonpersistentDispatcher = new NonPersistentStickyKeyDispatcherMultipleConsumers(
+            topicMock, subscriptionMock,
+            new HashRangeAutoSplitStickyKeyConsumerSelector());
     }
 
     @Test(timeOut = 10000)


### PR DESCRIPTION
### Motivation


* Remove `isDispatchRateNeeded()` and `getTopicPolicyDispatchRate()` and `isDispatchRateNeeded()` in `DispatchRateLimiter`, because it is only invoked by UT to mock. 

### Modifications

* Remove `isDispatchRateNeeded()` and `getTopicPolicyDispatchRate()` and `isDispatchRateNeeded()`  in  `DispatchRateLimiter`

### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Documentation

  
- [x] `doc-not-needed` 
