### PR TITLE
[modify][admin] Change the permissions of the schema API from Admin to normal produce/consume

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/AdminResource.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/AdminResource.java
@@ -55,8 +55,6 @@ import org.apache.pulsar.common.policies.data.BundlesData;
 import org.apache.pulsar.common.policies.data.NamespaceOperation;
 import org.apache.pulsar.common.policies.data.PersistencePolicies;
 import org.apache.pulsar.common.policies.data.Policies;
-import org.apache.pulsar.common.policies.data.PolicyName;
-import org.apache.pulsar.common.policies.data.PolicyOperation;
 import org.apache.pulsar.common.policies.data.RetentionPolicies;
 import org.apache.pulsar.common.policies.data.SchemaCompatibilityStrategy;
 import org.apache.pulsar.common.policies.data.SubscribeRate;
@@ -749,9 +747,7 @@ public abstract class AdminResource extends PulsarWebResource {
     }
 
     protected CompletableFuture<SchemaCompatibilityStrategy> getSchemaCompatibilityStrategyAsync() {
-        return validateTopicPolicyOperationAsync(topicName,
-                PolicyName.SCHEMA_COMPATIBILITY_STRATEGY,
-                PolicyOperation.READ)
+        return validateTopicOperationAsync(topicName, TopicOperation.CONSUME)
                 .thenCompose((__) -> {
                     CompletableFuture<SchemaCompatibilityStrategy> future;
                     if (config().isTopicLevelPoliciesEnabled()) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/SchemasResource.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/SchemasResource.java
@@ -218,7 +218,7 @@ public class SchemasResource extends SchemasResourceBase {
             @PathParam("tenant") String tenant,
             @PathParam("namespace") String namespace,
             @PathParam("topic") String topic,
-            @ApiParam(value = "A JSON value presenting a schema playload."
+            @ApiParam(value = "A JSON value presenting a schema payload."
                     + " An example of the expected schema can be found down here.",
                examples = @Example(value = @ExampleProperty(mediaType = MediaType.APPLICATION_JSON,
                value = "{\"type\": \"STRING\", \"schema\": \"\", \"properties\": { \"key1\" : \"value1\" + } }")))
@@ -264,7 +264,7 @@ public class SchemasResource extends SchemasResourceBase {
             @PathParam("tenant") String tenant,
             @PathParam("namespace") String namespace,
             @PathParam("topic") String topic,
-            @ApiParam(value = "A JSON value presenting a schema playload."
+            @ApiParam(value = "A JSON value presenting a schema payload."
                             + " An example of the expected schema can be found down here.",
              examples = @Example(value = @ExampleProperty(mediaType = MediaType.APPLICATION_JSON,
              value = "{\"type\": \"STRING\", \"schema\": \"\"," + " \"properties\": { \"key1\" : \"value1\" + } }")))
@@ -304,7 +304,7 @@ public class SchemasResource extends SchemasResourceBase {
             @PathParam("tenant") String tenant,
             @PathParam("namespace") String namespace,
             @PathParam("topic") String topic,
-            @ApiParam(value = "A JSON value presenting a schema playload."
+            @ApiParam(value = "A JSON value presenting a schema payload."
                             + " An example of the expected schema can be found down here.",
             examples = @Example(value = @ExampleProperty(mediaType = MediaType.APPLICATION_JSON,
             value = "{\"type\": \"STRING\", \"schema\": \"\"," + " \"properties\": { \"key1\" : \"value1\" + } }")))

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiSchemaWithAuthTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiSchemaWithAuthTest.java
@@ -1,0 +1,166 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.admin;
+
+import com.google.common.collect.Sets;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.pulsar.broker.auth.MockedPulsarServiceBaseTest;
+import org.apache.pulsar.broker.authentication.AuthenticationProviderToken;
+import org.apache.pulsar.broker.authentication.utils.AuthTokenUtils;
+import org.apache.pulsar.client.admin.PulsarAdmin;
+import org.apache.pulsar.client.admin.PulsarAdminBuilder;
+import org.apache.pulsar.client.api.Schema;
+import org.apache.pulsar.client.impl.auth.AuthenticationToken;
+import org.apache.pulsar.common.policies.data.AuthAction;
+import org.apache.pulsar.common.policies.data.ClusterData;
+import org.apache.pulsar.common.policies.data.TenantInfoImpl;
+import org.apache.pulsar.common.schema.SchemaInfo;
+import org.mockito.Mockito;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+import javax.crypto.SecretKey;
+import java.util.Base64;
+import java.util.EnumSet;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
+
+/**
+ * Unit tests for schema admin api.
+ */
+@Slf4j
+@Test(groups = "broker-admin")
+public class AdminApiSchemaWithAuthTest extends MockedPulsarServiceBaseTest {
+
+    private static final SecretKey SECRET_KEY = AuthTokenUtils.createSecretKey(SignatureAlgorithm.HS256);
+    private static final String ADMIN_TOKEN = Jwts.builder().setSubject("admin").signWith(SECRET_KEY).compact();
+
+    private static final String PRODUCE_TOKEN = Jwts.builder().setSubject("producer").signWith(SECRET_KEY).compact();
+    private static final String CONSUME_TOKEN = Jwts.builder().setSubject("consumer").signWith(SECRET_KEY).compact();
+    private static final String PRODUCE_CONSUME_TOKEN = Jwts.builder().setSubject("producer+consumer").signWith(SECRET_KEY).compact();
+
+    @BeforeMethod
+    @Override
+    public void setup() throws Exception {
+        conf.setAuthorizationEnabled(true);
+        conf.setAuthenticationEnabled(true);
+        conf.getProperties().setProperty("tokenSecretKey", "data:;base64,"
+                + Base64.getEncoder().encodeToString(SECRET_KEY.getEncoded()));
+        Set<String> providers = new HashSet<>();
+        providers.add(AuthenticationProviderToken.class.getName());
+        Set<String> superUserRoles = new HashSet<>();
+        superUserRoles.add("admin");
+        conf.setSuperUserRoles(superUserRoles);
+        conf.setAuthenticationProviders(providers);
+        conf.setSystemTopicEnabled(false);
+        conf.setTopicLevelPoliciesEnabled(false);
+        super.internalSetup();
+
+        PulsarAdminBuilder pulsarAdminBuilder = PulsarAdmin.builder().serviceHttpUrl(brokerUrl != null
+                        ? brokerUrl.toString() : brokerUrlTls.toString())
+                .authentication(AuthenticationToken.class.getName(),
+                        ADMIN_TOKEN);
+        admin = Mockito.spy(pulsarAdminBuilder.build());
+
+        // Setup namespaces
+        admin.clusters().createCluster("test", ClusterData.builder().serviceUrl(pulsar.getWebServiceAddress()).build());
+        TenantInfoImpl tenantInfo = new TenantInfoImpl(Sets.newHashSet("role1", "role2"), Sets.newHashSet("test"));
+        admin.tenants().createTenant("schematest", tenantInfo);
+        admin.namespaces().createNamespace("schematest/test", Sets.newHashSet("test"));
+    }
+
+    @AfterMethod(alwaysRun = true)
+    @Override
+    public void cleanup() throws Exception {
+        super.internalCleanup();
+    }
+
+    @Test
+    public void testGetCreateDeleteSchema() throws Exception {
+        String topicName = "persistent://schematest/test/testCreateSchema";
+        PulsarAdmin adminWithoutPermission = PulsarAdmin.builder()
+                .serviceHttpUrl(brokerUrl != null ? brokerUrl.toString() : brokerUrlTls.toString())
+                .build();
+        PulsarAdmin adminWithProducerPermission = PulsarAdmin.builder()
+                .serviceHttpUrl(brokerUrl != null ? brokerUrl.toString() : brokerUrlTls.toString())
+                .authentication(AuthenticationToken.class.getName(), PRODUCE_TOKEN)
+                .build();
+        PulsarAdmin adminWithProducerConsumePermission = PulsarAdmin.builder()
+                .serviceHttpUrl(brokerUrl != null ? brokerUrl.toString() : brokerUrlTls.toString())
+                .authentication(AuthenticationToken.class.getName(), PRODUCE_CONSUME_TOKEN)
+                .build();
+        PulsarAdmin adminWithConsumerPermission = PulsarAdmin.builder()
+                .serviceHttpUrl(brokerUrl != null ? brokerUrl.toString() : brokerUrlTls.toString())
+                .authentication(AuthenticationToken.class.getName(), CONSUME_TOKEN)
+                .build();
+        SchemaInfo si = Schema.BOOL.getSchemaInfo();
+        try {
+            adminWithoutPermission.schemas().createSchema(topicName, si);
+            fail("Should have failed");
+        } catch (Exception ignore) {
+        }
+        admin.topics().grantPermission(topicName, "producer+consumer", EnumSet.of(AuthAction.produce, AuthAction.consume));
+        adminWithProducerConsumePermission.schemas().createSchema(topicName, si);
+        try {
+            adminWithoutPermission.schemas().getSchemaInfo(topicName);
+            fail("Should have failed");
+        } catch (Exception ignore) {
+        }
+        admin.topics().grantPermission(topicName, "consumer", EnumSet.of(AuthAction.consume));
+        SchemaInfo readSi = adminWithConsumerPermission.schemas().getSchemaInfo(topicName);
+        assertEquals(readSi, si);
+        try {
+            adminWithoutPermission.schemas().getSchemaInfo(topicName, 0);
+            fail("Should have failed");
+        } catch (Exception ignore) {
+        }
+        readSi = adminWithConsumerPermission.schemas().getSchemaInfo(topicName, 0);
+        assertEquals(readSi, si);
+        List<SchemaInfo> allSchemas = adminWithConsumerPermission.schemas().getAllSchemas(topicName);
+        assertEquals(allSchemas.size(), 1);
+        SchemaInfo schemaInfo2 = Schema.BOOL.getSchemaInfo();
+        try {
+            adminWithoutPermission.schemas().testCompatibility(topicName, schemaInfo2);
+            fail("Should have failed");
+        } catch (Exception ignore) {
+        }
+        boolean compatibility = adminWithConsumerPermission.schemas().testCompatibility(topicName, schemaInfo2).isCompatibility();
+        assertTrue(compatibility);
+        try {
+            adminWithoutPermission.schemas().getVersionBySchema(topicName, si);
+            fail("Should have failed");
+        } catch (Exception ignore) {
+        }
+        Long versionBySchema = adminWithConsumerPermission.schemas().getVersionBySchema(topicName, si);
+        assertEquals(versionBySchema, Long.valueOf(0L));
+        try {
+            adminWithoutPermission.schemas().deleteSchema(topicName);
+            fail("Should have failed");
+        } catch (Exception ignore) {
+        }
+        admin.topics().grantPermission(topicName, "producer", EnumSet.of(AuthAction.produce));
+        adminWithProducerPermission.schemas().deleteSchema(topicName);
+    }
+}


### PR DESCRIPTION
### Motivation
Currently, we need admin permissions to operate the schema API. This is because the admin permission was defined when the schema API was first added. See #1381.
Later, then adding authentication granularity with #6428, we don't change the schema API part.  So leave the admin permission today.

The schema should follow the permissions of the topic, so change the related method permission to `produce/consume`.

### Modifications
- `get` need `consume` permission
- `post` need `produce/consume` permission
- `delete` need `produce` permission

### Documentation

- [x] `doc-not-needed` 
(Please explain why)
