### PR TITLE
[fix][tests] TieredStorageConfigurationTests - clear system properties

### DIFF
--- a/tiered-storage/jcloud/src/test/java/org/apache/bookkeeper/mledger/offload/jcloud/provider/TieredStorageConfigurationTests.java
+++ b/tiered-storage/jcloud/src/test/java/org/apache/bookkeeper/mledger/offload/jcloud/provider/TieredStorageConfigurationTests.java
@@ -217,9 +217,10 @@ public class TieredStorageConfigurationTests {
         System.setProperty("jclouds.region", "jclouds-region");
         TieredStorageConfiguration config = new TieredStorageConfiguration(map);
         Properties properties = config.getOverrides();
-        System.out.println(properties.toString());
         assertEquals(properties.get("jclouds.region"), "jclouds-region");
         assertEquals(config.getServiceEndpoint(), "http://localhost");
         assertEquals(properties.get("jclouds.SystemPropertyA"), "A");
+        System.clearProperty("jclouds.SystemPropertyA");
+        System.clearProperty("jclouds.region");
     }
 }


### PR DESCRIPTION
Motivation:
This PR https://github.com/apache/pulsar/pull/15710 introduced a new test case that set some system properties without clearing them.


Modification:
clean up the env, in order to not pollute the execution of the other tests
