### PR TITLE
[fix][broker] KeyShared stickyHashRange subscription: Fix not be able to receive a message when send a can‘t match consumer message

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentStickyKeyDispatcherMultipleConsumers.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentStickyKeyDispatcherMultipleConsumers.java
@@ -226,6 +226,7 @@ public class PersistentStickyKeyDispatcherMultipleConsumers extends PersistentDi
             if (c != null) {
                 groupedEntries.computeIfAbsent(c, k -> new ArrayList<>()).add(entry);
                 consumerStickyKeyHashesMap.computeIfAbsent(c, k -> new HashSet<>()).add(stickyKeyHash);
+                unMatchConsumerBackoff.reset();
             } else {
                 topic.getBrokerService().executor().schedule(() -> {
                     addMessageToReplay(ledgerId, entryId, stickyKeyHash);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/KeySharedSubscriptionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/KeySharedSubscriptionTest.java
@@ -365,8 +365,7 @@ public class KeySharedSubscriptionTest extends ProducerConsumerBase {
 
     @Test(dataProvider = "batch")
     public void testKeySendAndReceiveWithHashRangeExclusiveStickyKeyUnMatchConsumer(boolean enableBatch)
-            throws PulsarClientException, InterruptedException {
-        this.conf.setSubscriptionKeySharedEnable(true);
+            throws PulsarClientException {
         String topic = "persistent://public/default/key_shared_none_key_exclusive-" + UUID.randomUUID();
 
         int slot = Murmur3_32Hash.getInstance().makeHash("key1".getBytes())


### PR DESCRIPTION
Fixes #15898 

### Motivation

Now, when can‘t match the consumer message will add the entry to the list of messages to be redelivered, this will lead to other consumers may not be able to receive a message.

### Modifications

Add backoff for the redelivering message when the message can't match a consumer

### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Documentation

Check the box below or label this PR directly.

Need to update docs? 
  
- [x] `doc-not-needed` 