### PR TITLE
[fix][client] Fix JDK17 compatibility issue

### DIFF
--- a/bin/pulsar-client
+++ b/bin/pulsar-client
@@ -94,6 +94,13 @@ PULSAR_CLASSPATH="`dirname $PULSAR_LOG_CONF`:$PULSAR_CLASSPATH"
 OPTS="$OPTS -Dlog4j.configurationFile=`basename $PULSAR_LOG_CONF`"
 OPTS="$OPTS -Djava.net.preferIPv4Stack=true"
 
+IS_JAVA_8=`$JAVA -version 2>&1 |grep version|grep '"1\.8'`
+# Start --add-opens options
+# '--add-opens' option is not supported in jdk8
+if [[ -z "$IS_JAVA_8" ]]; then
+  OPTS="$OPTS --add-opens java.base/sun.net=ALL-UNNAMED"
+fi
+
 OPTS="-cp $PULSAR_CLASSPATH $OPTS"
 
 OPTS="$OPTS $PULSAR_EXTRA_OPTS"


### PR DESCRIPTION

Fixes #15349


### Motivation

When using the JDK17, pulsar-client throws exception `module java.base does not export sun.net to unnamed module`, it is good to fix it.

### Modifications

Add `--add-opens java.base/sun.net=ALL-UNNAMED` to java option when using JDK17.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Documentation

Check the box below or label this PR directly.

Need to update docs? 

- [x] `doc-not-needed` 
