### PR TITLE
[Improve][Doc] C++ and Python support only RSA

### DIFF
--- a/site2/docs/security-encryption.md
+++ b/site2/docs/security-encryption.md
@@ -100,7 +100,7 @@ Reader<byte[]> reader = pulsarClient.newReader()
 Client client("pulsar://localhost:6650");
 std::string topic = "persistent://my-tenant/my-ns/my-topic";
 // DefaultCryptoKeyReader is a built-in implementation that reads public key and private key from files
-auto keyReader = std::make_shared<DefaultCryptoKeyReader>("test_ecdsa_pubkey.pem", "test_ecdsa_privkey.pem");
+auto keyReader = std::make_shared<DefaultCryptoKeyReader>("test_rsa_pubkey.pem", "test_rsa_privkey.pem");
 
 Producer producer;
 ProducerConfiguration producerConf;
@@ -130,7 +130,7 @@ from pulsar import Client, CryptoKeyReader
 client = Client('pulsar://localhost:6650')
 topic = 'persistent://my-tenant/my-ns/my-topic'
 # CryptoKeyReader is a built-in implementation that reads public key and private key from files
-key_reader = CryptoKeyReader('test_ecdsa_pubkey.pem', 'test_ecdsa_privkey.pem')
+key_reader = CryptoKeyReader('test_rsa_pubkey.pem', 'test_rsa_privkey.pem')
 
 producer = client.create_producer(
     topic=topic,


### PR DESCRIPTION
Cosmetic change to clarify that C++ and Python supports only RSA keys


### Modifications

Cosmetic

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

Check the box below or label this PR directly.

Need to update docs? 

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)
  
- [ ] `doc-not-needed` 
(Please explain why)
  
- [ X ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)