### PR TITLE
[fix][admin] Release LookupRequestSemaphore before returning data.

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/lookup/TopicLookupBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/lookup/TopicLookupBase.java
@@ -338,11 +338,6 @@ public class TopicLookupBase extends PulsarWebResource {
         asyncResponse.resume(cause);
     }
 
-    protected void completeLookupResponseSuccessfully(AsyncResponse asyncResponse, LookupData lookupData) {
-        pulsar().getBrokerService().getLookupRequestSemaphore().release();
-        asyncResponse.resume(lookupData);
-    }
-
     protected TopicName getTopicName(String topicDomain, String tenant, String cluster, String namespace,
             @Encoded String encodedTopic) {
         String decodedName = Codec.decode(encodedTopic);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/lookup/TopicLookupBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/lookup/TopicLookupBase.java
@@ -127,6 +127,7 @@ public class TopicLookupBase extends PulsarWebResource {
                                 log.debug("Lookup succeeded for topic {} -- broker: {}", topicName,
                                         result.getLookupData());
                             }
+                            pulsar().getBrokerService().getLookupRequestSemaphore().release();
                             return result.getLookupData();
                         }
                     });

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/lookup/TopicLookupBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/lookup/TopicLookupBase.java
@@ -130,6 +130,9 @@ public class TopicLookupBase extends PulsarWebResource {
                             pulsar().getBrokerService().getLookupRequestSemaphore().release();
                             return result.getLookupData();
                         }
+                    }).exceptionally(ex->{
+                        pulsar().getBrokerService().getLookupRequestSemaphore().release();
+                        throw FutureUtil.wrapToCompletionException(ex);
                     });
                 });
     }
@@ -330,12 +333,6 @@ public class TopicLookupBase extends PulsarWebResource {
         });
 
         return lookupfuture;
-    }
-
-    protected void completeLookupResponseExceptionally(AsyncResponse asyncResponse, Throwable t) {
-        pulsar().getBrokerService().getLookupRequestSemaphore().release();
-        Throwable cause = FutureUtil.unwrapCompletionException(t);
-        asyncResponse.resume(cause);
     }
 
     protected TopicName getTopicName(String topicDomain, String tenant, String cluster, String namespace,

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/lookup/TopicLookupBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/lookup/TopicLookupBase.java
@@ -29,7 +29,6 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import javax.ws.rs.Encoded;
 import javax.ws.rs.WebApplicationException;
-import javax.ws.rs.container.AsyncResponse;
 import javax.ws.rs.core.Response;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.pulsar.broker.PulsarService;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/lookup/TopicLookupBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/lookup/TopicLookupBase.java
@@ -337,6 +337,11 @@ public class TopicLookupBase extends PulsarWebResource {
         asyncResponse.resume(cause);
     }
 
+    protected void completeLookupResponseSuccessfully(AsyncResponse asyncResponse, LookupData lookupData) {
+        pulsar().getBrokerService().getLookupRequestSemaphore().release();
+        asyncResponse.resume(lookupData);
+    }
+
     protected TopicName getTopicName(String topicDomain, String tenant, String cluster, String namespace,
             @Encoded String encodedTopic) {
         String decodedName = Codec.decode(encodedTopic);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/lookup/v1/TopicLookup.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/lookup/v1/TopicLookup.java
@@ -77,7 +77,7 @@ public class TopicLookup extends TopicLookupBase {
                     if (log.isDebugEnabled()) {
                         log.debug("Failed to check exist for topic {} when lookup", topicName, ex);
                     }
-                    completeLookupResponseExceptionally(asyncResponse, ex);
+                    resumeAsyncResponseExceptionally(asyncResponse, ex);
                     return null;
                 });
     }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/lookup/v1/TopicLookup.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/lookup/v1/TopicLookup.java
@@ -72,7 +72,7 @@ public class TopicLookup extends TopicLookupBase {
             listenerName = listenerNameHeader;
         }
         internalLookupTopicAsync(topicName, authoritative, listenerName)
-                .thenAccept(lookupData -> completeLookupResponseSuccessfully(asyncResponse, lookupData))
+                .thenAccept(lookupData -> asyncResponse.resume(lookupData))
                 .exceptionally(ex -> {
                     if (log.isDebugEnabled()) {
                         log.debug("Failed to check exist for topic {} when lookup", topicName, ex);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/lookup/v1/TopicLookup.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/lookup/v1/TopicLookup.java
@@ -72,7 +72,7 @@ public class TopicLookup extends TopicLookupBase {
             listenerName = listenerNameHeader;
         }
         internalLookupTopicAsync(topicName, authoritative, listenerName)
-                .thenAccept(lookupData -> asyncResponse.resume(lookupData))
+                .thenAccept(lookupData -> completeLookupResponseSuccessfully(asyncResponse, lookupData))
                 .exceptionally(ex -> {
                     if (log.isDebugEnabled()) {
                         log.debug("Failed to check exist for topic {} when lookup", topicName, ex);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/lookup/v2/TopicLookup.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/lookup/v2/TopicLookup.java
@@ -64,7 +64,7 @@ public class TopicLookup extends TopicLookupBase {
                     if (log.isDebugEnabled()) {
                         log.debug("Failed to check exist for topic {} when lookup", topicName, ex);
                     }
-                    completeLookupResponseExceptionally(asyncResponse, ex);
+                    resumeAsyncResponseExceptionally(asyncResponse, ex);
                     return null;
                 });
     }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/lookup/v2/TopicLookup.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/lookup/v2/TopicLookup.java
@@ -59,7 +59,7 @@ public class TopicLookup extends TopicLookupBase {
             listenerName = listenerNameHeader;
         }
         internalLookupTopicAsync(topicName, authoritative, listenerName)
-                .thenAccept(lookupData -> asyncResponse.resume(lookupData))
+                .thenAccept(lookupData -> completeLookupResponseSuccessfully(asyncResponse, lookupData))
                 .exceptionally(ex -> {
                     if (log.isDebugEnabled()) {
                         log.debug("Failed to check exist for topic {} when lookup", topicName, ex);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/lookup/v2/TopicLookup.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/lookup/v2/TopicLookup.java
@@ -59,7 +59,7 @@ public class TopicLookup extends TopicLookupBase {
             listenerName = listenerNameHeader;
         }
         internalLookupTopicAsync(topicName, authoritative, listenerName)
-                .thenAccept(lookupData -> completeLookupResponseSuccessfully(asyncResponse, lookupData))
+                .thenAccept(lookupData -> asyncResponse.resume(lookupData))
                 .exceptionally(ex -> {
                     if (log.isDebugEnabled()) {
                         log.debug("Failed to check exist for topic {} when lookup", topicName, ex);


### PR DESCRIPTION
Fixes #15973

### Motivation

https://github.com/apache/pulsar/pull/14188 forget to release LookupRequestSemaphore before returning data.

https://github.com/apache/pulsar/blob/91fe3b2ce264c3a51c349b29d86e566633f91d07/pulsar-broker/src/main/java/org/apache/pulsar/broker/lookup/TopicLookupBase.java#L124-L131



### Documentation

- [x] `doc-not-needed` 
(Please explain why)
