### PR TITLE
[fix][doc] fix concepts-messaging.md did't show access mode.

### DIFF
--- a/site2/docs/concepts-messaging.md
+++ b/site2/docs/concepts-messaging.md
@@ -72,12 +72,12 @@ Producers send messages to brokers synchronously (sync) or asynchronously (async
 
 You can have different types of access modes on topics for producers.
 
-Access mode | Description
-:-----------|------------
-`Shared`           | Multiple producers can publish on a topic. <br /><br />This is the **default** setting.
-`Exclusive`        | Only one producer can publish on a topic. <br /><br />If there is already a producer connected, other producers trying to publish on this topic get errors immediately.<br /><br />The “old” producer is evicted and a “new” producer is selected to be the next exclusive producer if the “old” producer experiences a network partition with the broker.
-`ExclusiveWithFencing`|Only one producer can publish on a topic. <br /><br />If there is already a producer connected, it will be removed and invalidated immediately.
-`WaitForExclusive` | If there is already a producer connected, the producer creation is pending (rather than timing out) until the producer gets the `Exclusive` access.<br /><br />The producer that succeeds in becoming the exclusive one is treated as the leader. Consequently, if you want to implement a leader election scheme for your application, you can use this access mode. Note that the leader pattern scheme mentioned refers to using Pulsar as a Write-Ahead Log (WAL) which means the leader writes its "decisions" to the topic. On error cases, the leader will get notified it is no longer the leader *only* when it tries to write a message and fails on appropriate error, by the broker.
+| Access mode | Description |
+|:-----------|------------|
+|`Shared`           | Multiple producers can publish on a topic. <br /><br />This is the **default** setting.|
+|`Exclusive`        | Only one producer can publish on a topic. <br /><br />If there is already a producer connected, other producers trying to publish on this topic get errors immediately.<br /><br />The “old” producer is evicted and a “new” producer is selected to be the next exclusive producer if the “old” producer experiences a network partition with the broker.|
+|`ExclusiveWithFencing`|Only one producer can publish on a topic. <br /><br />If there is already a producer connected, it will be removed and invalidated immediately.|
+|`WaitForExclusive` | If there is already a producer connected, the producer creation is pending (rather than timing out) until the producer gets the `Exclusive` access.<br /><br />The producer that succeeds in becoming the exclusive one is treated as the leader. Consequently, if you want to implement a leader election scheme for your application, you can use this access mode. Note that the leader pattern scheme mentioned refers to using Pulsar as a Write-Ahead Log (WAL) which means the leader writes its "decisions" to the topic. On error cases, the leader will get notified it is no longer the leader *only* when it tries to write a message and fails on appropriate error, by the broker.|
 
 :::note
 


### PR DESCRIPTION
fix  no show error.

### Motivation

the access mode table did't show content. screen  :   https://imgur.com/sA6BhF9

### Modifications

update table typo.

### Verifying this change

no

### Does this pull request potentially affect one of the following parts:

### Documentation

- [ ] `doc` 
(Your PR contains doc changes)
