### PR TITLE
[fix][broker] fix DEFAULT_NAR_EXTRACTION_DIR cause NoClassDefFoundError

### DIFF
--- a/bin/pulsar
+++ b/bin/pulsar
@@ -290,6 +290,9 @@ if [[ -z "$IS_JAVA_8" ]]; then
   OPTS="$OPTS --add-opens java.base/sun.net=ALL-UNNAMED --add-opens java.management/sun.management=ALL-UNNAMED"
 fi
 
+# Specify default nar tmp dir
+OPTS="$OPTS -Dnar.extraction.tmpdir=$PULSAR_HOME/tmp"
+
 OPTS="-cp $PULSAR_CLASSPATH $OPTS"
 
 if [ $COMMAND == "bookie" ]; then

--- a/bin/pulsar
+++ b/bin/pulsar
@@ -290,9 +290,6 @@ if [[ -z "$IS_JAVA_8" ]]; then
   OPTS="$OPTS --add-opens java.base/sun.net=ALL-UNNAMED --add-opens java.management/sun.management=ALL-UNNAMED"
 fi
 
-# Specify default nar tmp dir
-OPTS="$OPTS -Dnar.extraction.tmpdir=$PULSAR_HOME/tmp"
-
 OPTS="-cp $PULSAR_CLASSPATH $OPTS"
 
 if [ $COMMAND == "bookie" ]; then

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/nar/NarClassLoader.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/nar/NarClassLoader.java
@@ -139,7 +139,8 @@ public class NarClassLoader extends URLClassLoader {
 
     private static final String TMP_DIR_PREFIX = "pulsar-nar";
 
-    public static final String DEFAULT_NAR_EXTRACTION_DIR = System.getProperty("nar.extraction.tmpdir");
+    public static final String DEFAULT_NAR_EXTRACTION_DIR = System.getProperty("nar.extraction.tmpdir") != null
+            ? System.getProperty("nar.extraction.tmpdir") : System.getProperty("java.io.tmpdir");
 
     static NarClassLoader getFromArchive(File narPath, Set<String> additionalJars, ClassLoader parent,
                                                 String narExtractionDirectory)

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/nar/NarClassLoader.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/nar/NarClassLoader.java
@@ -139,7 +139,7 @@ public class NarClassLoader extends URLClassLoader {
 
     private static final String TMP_DIR_PREFIX = "pulsar-nar";
 
-    public static final String DEFAULT_NAR_EXTRACTION_DIR = System.getProperty("java.io.tmpdir");
+    public static final String DEFAULT_NAR_EXTRACTION_DIR = System.getProperty("nar.extraction.tmpdir");
 
     static NarClassLoader getFromArchive(File narPath, Set<String> additionalJars, ClassLoader parent,
                                                 String narExtractionDirectory)


### PR DESCRIPTION
Fixes #15978

### Motivation

There's an issue reported about problems in load protocol handler .class file. This PR will specify default tmp dir;

### Modifications
Specify default tmp dir by `-Djava.io.tmpdir=$PULSAR_HOME/tmp`

  
- [X] `doc-needed` 

  