### PR TITLE
[fix][doc] Adjust the install command of the gtest and gmock in document

### DIFF
--- a/pulsar-client-cpp/README.md
+++ b/pulsar-client-cpp/README.md
@@ -103,7 +103,10 @@ apt-get install -y g++ cmake libssl-dev libcurl4-openssl-dev liblog4cxx-dev \
 cd /usr/src/gtest
 sudo cmake .
 sudo make
-sudo cp *.a /usr/lib
+
+# Copy the libraries you just built to the OS library path.
+# GTEST_LIB_PATH may be `/usr/src/gtest`, `/usr/src/gtest/lib` or other path you provided when building gtest above.
+sudo cp ${GTEST_LIB_PATH}/*.a /usr/lib
 ```
 
 
@@ -113,7 +116,10 @@ sudo cp *.a /usr/lib
 cd /usr/src/gmock
 sudo cmake .
 sudo make
-sudo cp *.a /usr/lib
+
+# Copy the libraries you just built to the OS library path.
+# GMOCK_LIB_PATH may be `/usr/src/gmock`, `/usr/src/gmock/lib` or other path you provided when building gmock above.
+sudo cp ${GMOCK_LIB_PATH}/*.a /usr/lib
 ```
 
 


### PR DESCRIPTION

Fixes #15935 

### Motivation

Currently, the command `sudo cp *.a /usr/lib` in the file `pulsar-client-cpp/README.md` sometimes failed. Because when building gtest and gmock, the libs `*.a` may not always be placed at the source code root path `/usr/src/gtest` and `/usr/src/gmock`. The path depends on the version of the gtest and gmock and depends on the configuration when building. So when the developers use the command `sudo cp *.a /usr/lib` directly, it may fail.

### Modifications

Adjust the command and explain it in the document `pulsar-client-cpp/README.md`.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Documentation

- [x] `doc` 
(Your PR contains doc changes)
