### PR TITLE
[fix][doc] Added Java M1 installation instruction to Next version as well

### DIFF
--- a/site2/docs/getting-started-standalone.md
+++ b/site2/docs/getting-started-standalone.md
@@ -30,6 +30,64 @@ Broker is only supported on 64-bit JVM.
 
 :::
 
+#### Install JDK on M1
+In the current version, Pulsar uses a BookKeeper version which in turn uses RocksDB. RocksDB is compiled to work on x86 architecture and not ARM. Therefore, Pulsar can only work with x86 JDK. This is planned to be fixed in future versions of Pulsar.
+
+One of the ways to easily install an x86 JDK is to use [SDKMan](http://sdkman.io) as outlined in the following steps:
+
+1. Install [SDKMan](http://sdkman.io).
+
+* Method 1: follow instructions on the SDKMan website.
+
+* Method 2: if you have [Homebrew](https://brew.sh) installed, enter the following command.
+
+```shell
+
+brew install sdkman
+
+```
+
+2. Turn on Rosetta2 compatibility for SDKMan by editing `~/.sdkman/etc/config` and changing the following property from `false` to `true`.
+
+```properties
+
+sdkman_rosetta2_compatible=true
+
+```
+
+3. Close the current shell / terminal window and open a new one.
+4. Make sure you don't have any previously installed JVM of the same version by listing existing installed versions.
+
+```shell
+
+sdk list java|grep installed
+
+```
+
+Example output:
+
+```text
+
+               | >>> | 17.0.3.6.1   | amzn    | installed  | 17.0.3.6.1-amzn
+
+```
+
+If you have any Java 17 version installed, uninstall it.
+
+```shell
+
+sdk uinstall java 17.0.3.6.1
+
+```
+
+5. Install any Java versions greater than Java 8.
+
+```shell
+
+ sdk install java 17.0.3.6.1-amzn
+
+```
+
 ### Install Pulsar using binary release
 
 To get started with Pulsar, download a binary tarball release in one of the following ways:


### PR DESCRIPTION
### Modifications

* Port the changes made to 2.10 documentation on installing JDK for Apple M1 chip to Next version

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.

### Documentation

Check the box below or label this PR directly.

Need to update docs? 

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)
  
- [ ] `doc-not-needed` 
(Please explain why)
  
- [x] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)