### PR TITLE
[clean][broker]Cleanup DispatchRateLimiter#onPoliciesUpdate

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/DispatchRateLimiter.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/DispatchRateLimiter.java
@@ -277,43 +277,6 @@ public class DispatchRateLimiter {
     }
 
     @SuppressWarnings("deprecation")
-    public void onPoliciesUpdate(Policies data) {
-        String cluster = brokerService.pulsar().getConfiguration().getClusterName();
-
-        DispatchRate dispatchRate;
-
-        switch (type) {
-            case TOPIC:
-                dispatchRate = data.topicDispatchRate.get(cluster);
-                if (dispatchRate == null) {
-                    dispatchRate = data.clusterDispatchRate.get(cluster);
-                }
-                break;
-            case SUBSCRIPTION:
-                dispatchRate = data.subscriptionDispatchRate.get(cluster);
-                break;
-            case REPLICATOR:
-                dispatchRate = data.replicatorDispatchRate.get(cluster);
-                break;
-            default:
-                log.error("error DispatchRateLimiter type: {} ", type);
-                dispatchRate = null;
-        }
-
-        // update dispatch-rate only if it's configured in policies else ignore
-        if (dispatchRate != null) {
-            final DispatchRate newDispatchRate = createDispatchRate();
-
-            // if policy-throttling rate is disabled and cluster-throttling is enabled then apply
-            // cluster-throttling rate
-            if (!isDispatchRateEnabled(dispatchRate) && isDispatchRateEnabled(newDispatchRate)) {
-                dispatchRate = newDispatchRate;
-            }
-            updateDispatchRate(dispatchRate);
-        }
-    }
-
-    @SuppressWarnings("deprecation")
     public static DispatchRateImpl getPoliciesDispatchRate(final String cluster,
                                                            Optional<Policies> policies,
                                                            Type type) {


### PR DESCRIPTION
### Motivation


* Cleanup  `DispatchRateLimiter#onPoliciesUpdate` because it is deprecation and nowhere invoke it
* Also `MessageDispatchThrottlingTest#testDispatchRateCompatibility2` has no meaning if it call `DispatchRateLimiter#onPoliciesUpdate` to test compatibility, we need fix this UT

### Modifications

* Cleanup `DispatchRateLimiter#onPoliciesUpdate`
* Fix `MessageDispatchThrottlingTest#testDispatchRateCompatibility2` 

### Verifying this change

- [x] Make sure that the change passes the CI checks.


Need to update docs? 

  
- [x] `doc-not-needed` 
