### PR TITLE
Support mechanism to provide external zookeeper-server list to build global/configuration zookeeper

### DIFF
--- a/docker/pulsar/scripts/generate-zookeeper-config.sh
+++ b/docker/pulsar/scripts/generate-zookeeper-config.sh
@@ -34,14 +34,22 @@ DOMAIN=`hostname -d`
 IDX=1
 for SERVER in $(echo $ZOOKEEPER_SERVERS | tr "," "\n")
 do
-    echo "server.$IDX=$SERVER.$DOMAIN:2888:3888" >> $CONF_FILE
-
-    if [ "$HOSTNAME" == "$SERVER" ]; then
-        MY_ID=$IDX
-        echo "Current server id $MY_ID"
+    if [[ ! -z "$EXTERNAL_PROVIDED_SERVERS" && $(fgrep -ix $EXTERNAL_PROVIDED_SERVERS <<< "true") ]]; then
+       echo "server.$IDX=$SERVER" >> $CONF_FILE
+       # external zk-server connect string starts with hostname
+       if [[ "$SERVER" == "$HOSTNAME"* ]]; then
+         MY_ID=$IDX
+         echo "Current server id $MY_ID"
+       fi
+    else
+       echo "server.$IDX=$SERVER.$DOMAIN:2888:3888" >> $CONF_FILE
+       if [ "$HOSTNAME" == "$SERVER" ]; then
+         MY_ID=$IDX
+         echo "Current server id $MY_ID"
+       fi
     fi
 
-	((IDX++))
+    ((IDX++))
 done
 
 # For ZooKeeper container we need to initialize the ZK id


### PR DESCRIPTION
### Motivation
This PR requires for : https://github.com/apache/pulsar-helm-chart/pull/269 

Right now, [chart dynamically](https://github.com/apache/pulsar-helm-chart/blob/master/charts/pulsar/templates/zookeeper-statefulset.yaml#L140) creates zk cluster with zk pods initialized in the same namespace. However, for global/configuration zookeeper, user requires to build zk clusters with pods deployed in different namespaces. Therefore, user needs a mechanism to pass an external list of zk-servers to the chart and build zk-cluster with pods across different namespaces.

### Modification
- Chart should be considering zk-value's configuration for external zookeeper and generate zk-configuration file with appropriate zk-server list and unique id of that zookeeper.

This PR allows user to generate zk-config with external zk-server list and also updates appropriate zk-id file.

### Result
Fixes: https://github.com/apache/pulsar-helm-chart/issues/268