### PR TITLE
[fix][pulsar] Bump pyyaml from 5.3.1 to 5.4.1 to solve CVE-2020-14343

### DIFF
--- a/docker/pulsar/Dockerfile
+++ b/docker/pulsar/Dockerfile
@@ -59,12 +59,14 @@ RUN sed -i "s|http://archive\.ubuntu\.com/ubuntu/|${UBUNTU_MIRROR:-mirror://mirr
      && apt-get update \
      && apt-get -y dist-upgrade \
      && apt-get -y install --no-install-recommends openjdk-17-jdk-headless netcat dnsutils less procps iputils-ping \
-                 python3 python3-yaml python3-kazoo python3-pip \
+                 python3 python3-kazoo python3-pip \
                  curl ca-certificates \
      && apt-get -y --purge autoremove \
      && apt-get autoclean \
      && apt-get clean \
      && rm -rf /var/lib/apt/lists/*
+
+RUN pip3 install pyyaml==5.4.1
 
 # Pulsar currently writes to the below directories, assuming the default configuration.
 # Note that number 4 is the reason that pulsar components need write access to the /pulsar directory.


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://docs.google.com/document/d/1d8Pw6ZbWk-_pCKdOmdvx9rnhPiyuxwq60_TrD68d7BA/edit#heading=h.trs9rsex3xom)*. 

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.

**(The sections below can be removed for hotfixes of typos)**
-->

### Motivation

Apt-get latest version of python3-yaml is 5.3.1, but this version contains [CVE-2020-14343](https://nvd.nist.gov/vuln/detail/CVE-2020-14343). 


### Modifications

Use pip to install pyyaml in order to get a version without the vulnerability.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

Hopefully existing tests verify the functionality that pyyaml is used for.


### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): Yes
  - The public API: don't know
  - The schema: don't know
  - The default values of configurations: don't know
  - The wire protocol: don't know
  - The rest endpoints: don't know
  - The admin cli options: don't know
  - Anything that affects deployment: don't know

### Documentation

Check the box below or label this PR directly.

Need to update docs? 

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)
  
- [X] `doc-not-needed` 
Security fix; should not affect intended behavior.
  
- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)