### PR TITLE
Upgrade Netty Reactive Streams to 2.0.6

### DIFF
--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -332,7 +332,7 @@ The Apache Software License, Version 2.0
     - com.google.guava-failureaccess-1.0.1.jar
     - com.google.guava-listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.jar
  * J2ObjC Annotations -- com.google.j2objc-j2objc-annotations-1.3.jar
- * Netty Reactive Streams -- com.typesafe.netty-netty-reactive-streams-2.0.4.jar
+ * Netty Reactive Streams -- com.typesafe.netty-netty-reactive-streams-2.0.6.jar
  * Swagger
     - io.swagger-swagger-annotations-1.6.2.jar
     - io.swagger-swagger-core-1.6.2.jar

--- a/pom.xml
+++ b/pom.xml
@@ -225,6 +225,7 @@ flexible messaging model and an intuitive client API.</description>
     <seancfoley.ipaddress.version>5.3.3</seancfoley.ipaddress.version>
     <disruptor.version>3.4.3</disruptor.version>
     <zstd-jni.version>1.5.2-3</zstd-jni.version>
+    <netty-reactive-streams.version>2.0.6</netty-reactive-streams.version>
 
     <!-- test dependencies -->
     <cassandra.version>3.6.0</cassandra.version>
@@ -1289,6 +1290,12 @@ flexible messaging model and an intuitive client API.</description>
         <groupId>com.github.luben</groupId>
         <artifactId>zstd-jni</artifactId>
         <version>${zstd-jni.version}</version>
+      </dependency>
+
+      <dependency>
+          <groupId>com.typesafe.netty</groupId>
+          <artifactId>netty-reactive-streams</artifactId>
+          <version>${netty-reactive-streams.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/pulsar-sql/presto-distribution/LICENSE
+++ b/pulsar-sql/presto-distribution/LICENSE
@@ -241,7 +241,7 @@ The Apache Software License, Version 2.0
     - netty-handler-proxy-4.1.77.Final.jar
     - netty-common-4.1.77.Final.jar
     - netty-handler-4.1.77.Final.jar
-    - netty-reactive-streams-2.0.4.jar
+    - netty-reactive-streams-2.0.6.jar
     - netty-resolver-4.1.77.Final.jar
     - netty-resolver-dns-4.1.77.Final.jar
     - netty-tcnative-boringssl-static-2.0.52.Final.jar


### PR DESCRIPTION
### Motivation

https://nvd.nist.gov/vuln/detail/CVE-2019-20444#range-6908693

Upgrade from 2.0.4 to 2.0.6