### PR TITLE
Removing log4j-1.2-api from dependencies

### DIFF
--- a/buildtools/pom.xml
+++ b/buildtools/pom.xml
@@ -116,10 +116,6 @@
       <artifactId>log4j-slf4j-impl</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-1.2-api</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>jcl-over-slf4j</artifactId>
       <version>${slf4j.version}</version>

--- a/distribution/server/pom.xml
+++ b/distribution/server/pom.xml
@@ -127,11 +127,6 @@
 
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-1.2-api</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-api</artifactId>
     </dependency>
 

--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -394,7 +394,6 @@ The Apache Software License, Version 2.0
     - org.apache.logging.log4j-log4j-core-2.17.1.jar
     - org.apache.logging.log4j-log4j-slf4j-impl-2.17.1.jar
     - org.apache.logging.log4j-log4j-web-2.17.1.jar
-    - org.apache.logging.log4j-log4j-1.2-api-2.17.1.jar
  * Java Native Access JNA -- net.java.dev.jna-jna-4.2.0.jar
  * BookKeeper
     - org.apache.bookkeeper-bookkeeper-common-4.15.0.jar

--- a/managed-ledger/pom.xml
+++ b/managed-ledger/pom.xml
@@ -116,12 +116,6 @@
     </dependency>
 
     <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-1.2-api</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>


### PR DESCRIPTION
### Motivation

We no longer have any library using the log4j 1.2 API after ZooKeeper was upgraded to 3.5.x. We can then remove the compatibility API.