### PR TITLE
[client][python] Add support for consumer get_last_message_id

### DIFF
--- a/pulsar-client-cpp/include/pulsar/Consumer.h
+++ b/pulsar-client-cpp/include/pulsar/Consumer.h
@@ -390,6 +390,11 @@ class PULSAR_PUBLIC Consumer {
      */
     bool isConnected() const;
 
+    /**
+     * Get the latest message id for the consumer's topic.
+     */
+    virtual void getLastMessageIdAsync(BrokerGetLastMessageIdCallback callback);
+
    private:
     ConsumerImplBasePtr impl_;
     explicit Consumer(ConsumerImplBasePtr);

--- a/pulsar-client-cpp/lib/Consumer.cc
+++ b/pulsar-client-cpp/lib/Consumer.cc
@@ -250,4 +250,12 @@ Result Consumer::seek(uint64_t timestamp) {
 
 bool Consumer::isConnected() const { return impl_ && impl_->isConnected(); }
 
+void Consumer::getLastMessageIdAsync(BrokerGetLastMessageIdCallback callback) {
+    if (!impl_) {
+        callback(ResultConsumerNotInitialized);
+        return;
+    }
+    impl_->getLastMessageIdAsync(callback);
+}
+
 }  // namespace pulsar

--- a/pulsar-client-cpp/python/pulsar/__init__.py
+++ b/pulsar-client-cpp/python/pulsar/__init__.py
@@ -1241,6 +1241,12 @@ class Consumer:
         """
         self._consumer.seek(messageid)
 
+    def get_last_message_id(self):
+        """
+        Get the latest message id for a topic.
+        """
+        self._consumer.get_last_message_id()
+
     def close(self):
         """
         Close the consumer.

--- a/pulsar-client-cpp/python/pulsar/__init__.py
+++ b/pulsar-client-cpp/python/pulsar/__init__.py
@@ -1243,7 +1243,7 @@ class Consumer:
 
     def get_last_message_id(self):
         """
-        Get the latest message id for a topic.
+        Get the latest message id for the consumer's topic.
         """
         self._consumer.get_last_message_id()
 

--- a/pulsar-client-cpp/python/pulsar_test.py
+++ b/pulsar-client-cpp/python/pulsar_test.py
@@ -486,6 +486,23 @@ class PulsarTest(TestCase):
         self.assertFalse(consumer.is_connected())
         client.close()
 
+    def test_consumer_get_last_message_id(self):
+        client = Client(self.serviceUrl)
+        topic = "test_consumer_get_last_message_id"
+        sub = "sub"
+        consumer = client.subscribe(topic, sub)
+
+        producer = client.create_producer(topic)
+
+        for i in range(10):
+            producer.send(b"hello-%d" % i)
+            message_id = consumer.get_last_message_id()
+            self.assertEqual(message_id.entry_id, i - 1)
+
+        producer.close()
+        consumer.close()
+        client.close()
+
     def test_reader_simple(self):
         client = Client(self.serviceUrl)
         reader = client.create_reader("my-python-topic-reader-simple", MessageId.earliest)

--- a/pulsar-client-cpp/python/src/consumer.cc
+++ b/pulsar-client-cpp/python/src/consumer.cc
@@ -83,7 +83,7 @@ void Consumer_seek_timestamp(Consumer& consumer, uint64_t timestamp) {
 
 void Consumer_get_last_message_id(Consumer& consumer) {
     waitForAsyncResult(
-        [&consumer](ResultCallback callback) { consumer.getLastMessageIdAsync(callback); });
+        [&consumer](BrokerGetLastMessageIdCallback callback) { consumer.getLastMessageIdAsync(callback); });
 }
 
 bool Consumer_is_connected(Consumer& consumer) { return consumer.isConnected(); }

--- a/pulsar-client-cpp/python/src/consumer.cc
+++ b/pulsar-client-cpp/python/src/consumer.cc
@@ -81,6 +81,11 @@ void Consumer_seek_timestamp(Consumer& consumer, uint64_t timestamp) {
         [timestamp, &consumer](ResultCallback callback) { consumer.seekAsync(timestamp, callback); });
 }
 
+void Consumer_get_last_message_id(Consumer& consumer) {
+    waitForAsyncResult(
+        [&consumer](ResultCallback callback) { consumer.getLastMessageIdAsync(callback); });
+}
+
 bool Consumer_is_connected(Consumer& consumer) { return consumer.isConnected(); }
 
 void export_consumer() {
@@ -105,5 +110,6 @@ void export_consumer() {
         .def("redeliver_unacknowledged_messages", &Consumer::redeliverUnacknowledgedMessages)
         .def("seek", &Consumer_seek)
         .def("seek", &Consumer_seek_timestamp)
+        .def("get_last_message_id", &Consumer_get_last_message_id)
         .def("is_connected", &Consumer_is_connected);
 }


### PR DESCRIPTION
Fixes #15985

### Motivation

Add the `get_last_message_id` method to the python consumer. This method is already present in the C++ client.

### Modifications

* Add method call to `consumer.cc`
* Add test 

### Verifying this change

There is a test to verify this change.

### Does this pull request potentially affect one of the following parts:

It expands the python client library.

### Documentation
Docs will be auto-generated for this addition.