### PR TITLE
Bump cassandra driver version from 3.6.0 to 3.11.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -150,7 +150,7 @@ flexible messaging model and an intuitive client API.</description>
     <gson.version>2.8.9</gson.version>
     <sketches.version>0.8.3</sketches.version>
     <hbc-core.version>2.2.0</hbc-core.version>
-    <cassandra-driver-core.version>3.6.0</cassandra-driver-core.version>
+    <cassandra.version>3.11.2</cassandra.version>
     <aerospike-client.version>4.4.20</aerospike-client.version>
     <kafka-client.version>2.7.2</kafka-client.version>
     <rabbitmq-client.version>5.5.3</rabbitmq-client.version>
@@ -228,7 +228,6 @@ flexible messaging model and an intuitive client API.</description>
     <netty-reactive-streams.version>2.0.6</netty-reactive-streams.version>
 
     <!-- test dependencies -->
-    <cassandra.version>3.6.0</cassandra.version>
     <testcontainers.version>1.15.3</testcontainers.version>
     <hamcrest.version>2.2</hamcrest.version>
 

--- a/pulsar-io/cassandra/pom.xml
+++ b/pulsar-io/cassandra/pom.xml
@@ -51,7 +51,6 @@
     <dependency>
       <groupId>com.datastax.cassandra</groupId>
       <artifactId>cassandra-driver-core</artifactId>
-      <version>${cassandra.version}</version>
     </dependency>
 
   </dependencies>

--- a/pulsar-io/cassandra/pom.xml
+++ b/pulsar-io/cassandra/pom.xml
@@ -51,7 +51,7 @@
     <dependency>
       <groupId>com.datastax.cassandra</groupId>
       <artifactId>cassandra-driver-core</artifactId>
-      <version>${cassandra-driver-core.version}</version>
+      <version>${cassandra.version}</version>
     </dependency>
 
   </dependencies>

--- a/src/owasp-dependency-check-suppressions.xml
+++ b/src/owasp-dependency-check-suppressions.xml
@@ -448,5 +448,14 @@
         <cve>CVE-2021-46666</cve>
         <cve>CVE-2021-46667</cve>
     </suppress>
+    <!-- only affects the server -->
+    <suppress>
+        <notes><![CDATA[
+       file name: cassandra-driver-core-3.11.2.jar
+       ]]></notes>
+        <sha1>e0aad9f8611e710b9a0ce49747f7465ce07d8404</sha1>
+        <cve>CVE-2020-17516</cve>
+        <cve>CVE-2021-44521</cve>
+    </suppress>
 
 </suppressions>


### PR DESCRIPTION
### Motivation
that's a regular update, cassanrda driver 3.6.0 is released in year 2018. Keep update.