### PR TITLE
[doc] Add a step about JDK17 configuration to the Pulsar SQL document

### DIFF
--- a/site2/docs/sql-getting-started.md
+++ b/site2/docs/sql-getting-started.md
@@ -23,12 +23,11 @@ To query data in Pulsar with Pulsar SQL, complete the following steps.
 
 2. Adjust configuration.
 
-If you use JDK17, you need to add the following options to the configuration file `conf/presto/jvm.config`. Please note that these two lines can not be put into one line.
+If you use JDK17, you need to add the following options to the configuration file `conf/presto/jvm.config`.
 
 ```bash
 
---add-opens
-java.base/java.lang=ALL-UNNAMED
+--add-opens=java.base/java.lang=ALL-UNNAMED
 
 ```
 

--- a/site2/docs/sql-getting-started.md
+++ b/site2/docs/sql-getting-started.md
@@ -21,7 +21,18 @@ To query data in Pulsar with Pulsar SQL, complete the following steps.
 
 ```
 
-2. Start a Pulsar SQL worker.
+2. Adjust configuration. (JDK17)
+
+If you use JDK17, you need to add the following options to the configuration file `conf/presto/jvm.config`. Please note that these two lines can not be put into one line.
+
+```bash
+
+--add-opens
+java.base/java.lang=ALL-UNNAMED
+
+```
+
+3. Start a Pulsar SQL worker.
 
 ```bash
 
@@ -29,7 +40,7 @@ To query data in Pulsar with Pulsar SQL, complete the following steps.
 
 ```
 
-3. After initializing Pulsar standalone cluster and the SQL worker, run SQL CLI.
+4. After initializing Pulsar standalone cluster and the SQL worker, run SQL CLI.
 
 ```bash
 
@@ -37,7 +48,7 @@ To query data in Pulsar with Pulsar SQL, complete the following steps.
 
 ```
 
-4. Test with SQL commands.
+5. Test with SQL commands.
 
 ```bash
 
@@ -79,7 +90,7 @@ Splits: 19 total, 19 done (100.00%)
 
 Since there is no data in Pulsar, no records is returned. 
 
-5. Start the built-in connector _DataGeneratorSource_ and ingest some mock data.
+6. Start the built-in connector _DataGeneratorSource_ and ingest some mock data.
 
 ```bash
 

--- a/site2/docs/sql-getting-started.md
+++ b/site2/docs/sql-getting-started.md
@@ -21,7 +21,7 @@ To query data in Pulsar with Pulsar SQL, complete the following steps.
 
 ```
 
-2. Adjust configuration. (JDK17)
+2. Adjust configuration.
 
 If you use JDK17, you need to add the following options to the configuration file `conf/presto/jvm.config`. Please note that these two lines can not be put into one line.
 

--- a/site2/docs/sql-getting-started.md
+++ b/site2/docs/sql-getting-started.md
@@ -23,7 +23,7 @@ To query data in Pulsar with Pulsar SQL, complete the following steps.
 
 2. Adjust configuration.
 
-If you use JDK17, you need to add the following options to the configuration file `conf/presto/jvm.config`.
+If you use JDK17 and Pulsar version is less or equal than 2.10, you need to add the following options to the configuration file `conf/presto/jvm.config`.
 
 ```bash
 

--- a/site2/website/versioned_docs/version-2.10.0/sql-getting-started.md
+++ b/site2/website/versioned_docs/version-2.10.0/sql-getting-started.md
@@ -22,7 +22,18 @@ To query data in Pulsar with Pulsar SQL, complete the following steps.
 
 ```
 
-2. Start a Pulsar SQL worker.
+2. Adjust configuration. (JDK17)
+
+If you use JDK17, you need to add the following options to the configuration file `conf/presto/jvm.config`. Please note that these two lines can not be put into one line.
+
+```bash
+
+--add-opens
+java.base/java.lang=ALL-UNNAMED
+
+```
+
+3. Start a Pulsar SQL worker.
 
 ```bash
 
@@ -30,7 +41,7 @@ To query data in Pulsar with Pulsar SQL, complete the following steps.
 
 ```
 
-3. After initializing Pulsar standalone cluster and the SQL worker, run SQL CLI.
+4. After initializing Pulsar standalone cluster and the SQL worker, run SQL CLI.
 
 ```bash
 
@@ -38,7 +49,7 @@ To query data in Pulsar with Pulsar SQL, complete the following steps.
 
 ```
 
-4. Test with SQL commands.
+5. Test with SQL commands.
 
 ```bash
 
@@ -81,7 +92,7 @@ Splits: 19 total, 19 done (100.00%)
 
 Since there is no data in Pulsar, no records is returned. 
 
-5. Start the built-in connector _DataGeneratorSource_ and ingest some mock data.
+6. Start the built-in connector _DataGeneratorSource_ and ingest some mock data.
 
 ```bash
 

--- a/site2/website/versioned_docs/version-2.10.0/sql-getting-started.md
+++ b/site2/website/versioned_docs/version-2.10.0/sql-getting-started.md
@@ -24,12 +24,11 @@ To query data in Pulsar with Pulsar SQL, complete the following steps.
 
 2. Adjust configuration.
 
-If you use JDK17, you need to add the following options to the configuration file `conf/presto/jvm.config`. Please note that these two lines can not be put into one line.
+If you use JDK17, you need to add the following options to the configuration file `conf/presto/jvm.config`.
 
 ```bash
 
---add-opens
-java.base/java.lang=ALL-UNNAMED
+--add-opens=java.base/java.lang=ALL-UNNAMED
 
 ```
 

--- a/site2/website/versioned_docs/version-2.10.0/sql-getting-started.md
+++ b/site2/website/versioned_docs/version-2.10.0/sql-getting-started.md
@@ -24,7 +24,7 @@ To query data in Pulsar with Pulsar SQL, complete the following steps.
 
 2. Adjust configuration.
 
-If you use JDK17, you need to add the following options to the configuration file `conf/presto/jvm.config`.
+If you use JDK17 and Pulsar version is less or equal than 2.10, you need to add the following options to the configuration file `conf/presto/jvm.config`.
 
 ```bash
 

--- a/site2/website/versioned_docs/version-2.10.0/sql-getting-started.md
+++ b/site2/website/versioned_docs/version-2.10.0/sql-getting-started.md
@@ -22,7 +22,7 @@ To query data in Pulsar with Pulsar SQL, complete the following steps.
 
 ```
 
-2. Adjust configuration. (JDK17)
+2. Adjust configuration.
 
 If you use JDK17, you need to add the following options to the configuration file `conf/presto/jvm.config`. Please note that these two lines can not be put into one line.
 


### PR DESCRIPTION
Fixes #15830

### Motivation

Currently, when the users use JDK17 and run the command `./bin/pulsar sql-worker run` according to the document [Query data with Pulsar SQL](https://pulsar.apache.org/docs/next/sql-getting-started), they will get an error. We need to direct the user to add the options `--add-opens java.base/java.lang=ALL-UNNAMED` to config file so that the SQL worker can be started successfully.

### Modifications

Add a step about JDK17 configuration to the Pulsar SQL document.
I only revise the document of version `2.10.0` and `next` version now.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Documentation

- [x] `doc` 
