### PR TITLE
[test][fix]Fix UT MessageDispatchThrottlingTest#testDispatchRateCompatibility2

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/MessageDispatchThrottlingTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/MessageDispatchThrottlingTest.java
@@ -25,6 +25,7 @@ import com.google.common.collect.Sets;
 
 import java.lang.reflect.Field;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -1072,7 +1073,8 @@ public class MessageDispatchThrottlingTest extends ProducerConsumerBase {
         PersistentTopic topic = (PersistentTopic) pulsar.getBrokerService().getOrCreateTopic(topicName).get();
         Optional<DispatchRateLimiter> dispatchRateLimiter;
 
-        Policies policies = new Policies();
+        Policies policies = admin.namespaces().getPolicies(namespace);
+        policies.clusterSubscribeRate = new HashMap<>();
         DispatchRateImpl clusterDispatchRate = DispatchRateImpl.builder()
                 .dispatchThrottlingRateInMsg(100)
                 .dispatchThrottlingRateInByte(512)


### PR DESCRIPTION
### Motivation

* https://github.com/apache/pulsar/pull/15986   modiy the `MessageDispatchThrottlingTest#testDispatchRateCompatibility2` and test failure, which throw `Topic is already fenced` exceptions

* The reason can be  located at line:1381
https://github.com/apache/pulsar/blob/5cbaddcccb7183bedb3e98895c4fb34e84415f9a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java#L1361-L1382

because `topicPolicies.getReplicationClusters()` is empty if we just new a `Policies`. And then if we call `topic.onPoliciesUpdate` the topic will be deleted

### Modifications

*  Using `admin.namespaces().getPolicies(namespace)`  instead of `new Policies()`. Because  `topicPolicies#replicationClusters` will be auto created as broker's clusterName if we did't set it manually when creating namespace.

### Verifying this change

- [x] Make sure that the change passes the CI checks.



### Documentation

Check the box below or label this PR directly.

  
- [x] `doc-not-needed` 

