### PR TITLE
[fix][admin] Fix get-publish-rete Admin API handle exception behavior

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/Namespaces.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/Namespaces.java
@@ -773,9 +773,10 @@ public class Namespaces extends NamespacesBase {
             @PathParam("namespace") String namespace) {
         validateNamespaceName(property, namespace);
         internalGetPublishRateAsync()
-                .thenAccept(publishRate -> asyncResponse.resume(publishRate))
+                .thenAccept(asyncResponse::resume)
                 .exceptionally(ex -> {
                     log.error("Failed to get publish rate for namespace {}", namespaceName, ex);
+                    resumeAsyncResponseExceptionally(asyncResponse, ex);
                     return null;
                 });
     }


### PR DESCRIPTION
### Motivation

Currently, the `getPublishRate` admin API does not handle the exception when `internalGetPublishRateAsync` exceptionally.


### Modifications

Resume async response exceptionally when `internalGetPublishRateAsync`  method has an exception.

### Documentation

Check the box below or label this PR directly.

Need to update docs? 

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)
  
- [x] `doc-not-needed` 
(Please explain why)
  
- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)