### PR TITLE
[fix] [admin] [branch-2.9] fix reach max tenants error if the tenant already exists

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/TenantsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/TenantsBase.java
@@ -161,12 +161,12 @@ public class TenantsBase extends PulsarWebResource {
                     log.info("[{}] Created tenant {}", clientAppId(), tenant);
                     asyncResponse.resume(Response.noContent().build());
                 }).exceptionally(ex -> {
-                    log.error("[{}] Failed to create tenant {}", clientAppId, tenant, e);
+                    log.error("[{}] Failed to create tenant {}", clientAppId, tenant, ex);
                     asyncResponse.resume(new RestException(ex));
                     return null;
                 });
             }).exceptionally(ex -> {
-                log.error("[{}] Failed to create tenant {}", clientAppId(), tenant, e);
+                log.error("[{}] Failed to create tenant {}", clientAppId(), tenant, ex);
                 asyncResponse.resume(new RestException(ex));
                 return null;
             });


### PR DESCRIPTION
### Motivation

see #15932

At branch `master` REST API async change, there are many conflicts when cherry-picking #15932 PR, so I  create separate PR to fix branch-2.9

### Modifications

- Swap the execution order of duplicate validation and maximum validation
- Fixed incorrect logs 

### Documentation

- [ ] `doc-required` 
  
- [x] `doc-not-needed` 
  
- [ ] `doc` 

- [ ] `doc-complete`