### PR TITLE
[fix][env] Support the java version like 'XX-internal' in env file

### DIFF
--- a/conf/bkenv.sh
+++ b/conf/bkenv.sh
@@ -53,6 +53,10 @@ for token in $("$JAVA_BIN" -version 2>&1 | grep 'version "'); do
           JAVA_MAJOR_VERSION=${BASH_REMATCH[1]}
         fi
         break
+    elif [[ $token =~ \"([[:digit:]]+)(.*)\" ]]; then
+        # Process the java versions without dots, such as `17-internal`.
+        JAVA_MAJOR_VERSION=${BASH_REMATCH[1]}
+        break
     fi
 done
 

--- a/conf/bkenv.sh
+++ b/conf/bkenv.sh
@@ -46,7 +46,7 @@ else
   JAVA_BIN="$JAVA_HOME/bin/java"
 fi
 for token in $("$JAVA_BIN" -version 2>&1 | grep 'version "'); do
-    if [[ $token =~ \"([[:digit:]]+)\.([[:digit:]]+)\.(.*)\" ]]; then
+    if [[ $token =~ \"([[:digit:]]+)\.([[:digit:]]+)(.*)\" ]]; then
         if [[ ${BASH_REMATCH[1]} == "1" ]]; then
           JAVA_MAJOR_VERSION=${BASH_REMATCH[2]}
         else

--- a/conf/pulsar_env.sh
+++ b/conf/pulsar_env.sh
@@ -53,7 +53,7 @@ else
   JAVA_BIN="$JAVA_HOME/bin/java"
 fi
 for token in $("$JAVA_BIN" -version 2>&1 | grep 'version "'); do
-    if [[ $token =~ \"([[:digit:]]+)\.([[:digit:]]+)\.(.*)\" ]]; then
+    if [[ $token =~ \"([[:digit:]]+)\.([[:digit:]]+)(.*)\" ]]; then
         if [[ ${BASH_REMATCH[1]} == "1" ]]; then
           JAVA_MAJOR_VERSION=${BASH_REMATCH[2]}
         else

--- a/conf/pulsar_env.sh
+++ b/conf/pulsar_env.sh
@@ -60,6 +60,9 @@ for token in $("$JAVA_BIN" -version 2>&1 | grep 'version "'); do
           JAVA_MAJOR_VERSION=${BASH_REMATCH[1]}
         fi
         break
+    elif [[ $token =~ \"([[:digit:]]+)(.*)\" ]]; then
+        JAVA_MAJOR_VERSION=${BASH_REMATCH[1]}
+        break
     fi
 done
 

--- a/conf/pulsar_env.sh
+++ b/conf/pulsar_env.sh
@@ -61,6 +61,7 @@ for token in $("$JAVA_BIN" -version 2>&1 | grep 'version "'); do
         fi
         break
     elif [[ $token =~ \"([[:digit:]]+)(.*)\" ]]; then
+        # Process the java versions without dots, such as `17-internal`.
         JAVA_MAJOR_VERSION=${BASH_REMATCH[1]}
         break
     fi


### PR DESCRIPTION
Related to #15670, cc'ing its author @lhotari .

### Motivation

My local JDKs are almost built from the source code, such as [JDK Mainline](https://github.com/openjdk/jdk), so when I use the command `java -version`, I may get the following output message:

```
openjdk version "19-internal" 2022-09-20
OpenJDK Runtime Environment (build 19-internal-adhoc.lgx.jdk)
OpenJDK 64-Bit Server VM (build 19-internal-adhoc.lgx.jdk, mixed mode, sharing)

or

openjdk version "17-internal" 2021-09-14
OpenJDK Runtime Environment (build 17-internal+0-adhoc.lgx.jdk17u)
OpenJDK 64-Bit Server VM (build 17-internal+0-adhoc.lgx.jdk17u, mixed mode, sharing)
```

Unfortunately, the code of `pulsar_env.sh` which was integrated in #15670 yesterday didn't support it, so when I use `./bin/pulsar standalone` locally, I get the following error message:

```
[0.000s][warning][gc] -Xloggc is deprecated. Will use -Xlog:gc:/home/lgx/source/java/pulsar/logs/pulsar_gc_%p.log instead.
Unrecognized VM option 'PrintGCDateStamps'
Error: Could not create the Java Virtual Machine.
Error: A fatal exception has occurred. Program will exit.
```

I know I can use the JDK release version to avoid this issue. But I am an JDK developer and almost use the internal version built from the source code. By using such internal version, I can find and solve some bugs related to both OpenJDK and Pulsar as soon as possible.

### Modifications

Add the conditional statement into file `pulsar_env.sh` to support the java internal version.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Documentation

- [x] `doc-not-needed` 
  