### PR TITLE
[branch-2.9] Disable testReuseFork for broker_group_2

### DIFF
--- a/build/run_unit_group.sh
+++ b/build/run_unit_group.sh
@@ -42,7 +42,7 @@ function broker_group_1() {
 }
 
 function broker_group_2() {
-  $MVN_TEST_COMMAND -pl pulsar-broker -Dgroups='schema,utils,functions-worker,broker-io,broker-discovery,broker-compaction,broker-naming,websocket,other'
+  $MVN_TEST_COMMAND -pl pulsar-broker -Dgroups='schema,utils,functions-worker,broker-io,broker-discovery,broker-compaction,broker-naming,websocket,other' -DtestReuseFork=false
 }
 
 function broker_client_api() {


### PR DESCRIPTION
Fix https://github.com/apache/pulsar/runs/6833250379?check_suite_focus=true

```
Error:  Tests run: 4, Failures: 1, Errors: 0, Skipped: 3, Time elapsed: 9.736 s <<< FAILURE! - in org.apache.pulsar.broker.service.BrokerServiceBundlesCacheInvalidationTest
Error:  testRecreateNamespace(org.apache.pulsar.broker.service.BrokerServiceBundlesCacheInvalidationTest)  Time elapsed: 0.223 s  <<< FAILURE!
java.lang.NullPointerException
	at java.base/java.lang.String.getBytes(String.java:963)
	at org.apache.pulsar.client.impl.schema.StringSchema.encode(StringSchema.java:101)
	at org.apache.pulsar.client.impl.schema.StringSchema.encode(StringSchema.java:37)
	at org.apache.pulsar.client.impl.TypedMessageBuilderImpl.value(TypedMessageBuilderImpl.java:175)
	at org.apache.pulsar.client.impl.ProducerBase.send(ProducerBase.java:65)
	at org.apache.pulsar.broker.service.BrokerServiceBundlesCacheInvalidationTest.testRecreateNamespace(BrokerServiceBundlesCacheInvalidationTest.java:57)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at org.testng.internal.MethodInvocationHelper.invokeMethod(MethodInvocationHelper.java:132)
	at org.testng.internal.InvokeMethodRunnable.runOne(InvokeMethodRunnable.java:45)
	at org.testng.internal.InvokeMethodRunnable.call(InvokeMethodRunnable.java:73)
	at org.testng.internal.InvokeMethodRunnable.call(InvokeMethodRunnable.java:11)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:829)
```

Not 100% sure what's going on for now, but looks like It's related to the concurrency issue in the class initialization. Just found some related information.
    
https://maven.apache.org/surefire/maven-surefire-plugin/examples/fork-options-and-parallel-execution.html#parallel-test-execution
    
https://github.com/testcontainers/testcontainers-java/issues/2939#issuecomment-649810918
