### PR TITLE
[feat][workflow] Upgrade to new version of documentation bot

### DIFF
--- a/.github/workflows/ci-documentbot.yml
+++ b/.github/workflows/ci-documentbot.yml
@@ -17,7 +17,7 @@
 # under the License.
 #
 
-name: Auto Labeling
+name: Documentation Bot
 
 on:
   pull_request_target :
@@ -25,25 +25,29 @@ on:
       - opened
       - edited
       - labeled
-
-  
-
-# A GitHub token created for a PR coming from a fork doesn't have
-# 'admin' or 'write' permission (which is required to add labels)
-# To avoid this issue, you can use the `scheduled` event and run
-# this action on a certain interval.And check the label about the
-# document.
+      - unlabeled
 
 jobs:
-  labeling:
+  label:
     if: ${{ github.repository == 'apache/pulsar' }}
     permissions:
       pull-requests: write 
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-
-      - uses: apache/pulsar-test-infra/doc-label-check@master
+      - name: Checkout action
+        uses: actions/checkout@v3
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          label-pattern: '- \[(.*?)\] ?`(.+?)`' # matches '- [x] `label`'
+          repository: apache/pulsar-test-infra/docbot
+          ref: master
+
+      - name: Set up Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: 1.18
+
+      - name: Labeling
+        uses: apache/pulsar-test-infra/docbot@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          LABEL_WATCH_LIST: 'doc,doc-required,doc-not-needed,doc-complete'
+          LABEL_MISSING: 'doc-label-missing'


### PR DESCRIPTION
Master Issue: #15797

### Motivation

We have implemented the new documentation bot at https://github.com/apache/pulsar-test-infra/pull/43.
Now we can apply it to our workflow.

### Modifications

Replace the old action with the new version of documentation bot.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API: (yes / no)
  - The schema: (yes / no / don't know)
  - The default values of configurations: (yes / no)
  - The wire protocol: (yes / no)
  - The rest endpoints: (yes / no)
  - The admin cli options: (yes / no)
  - Anything that affects deployment: (yes / no / don't know)

### Documentation

Check the box below or label this PR directly.

Need to update docs? 

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)
  
- [ ] `doc-not-needed` 
(Please explain why)
  
- [x] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)