### PR TITLE
[fix][c++ client] rename function name: pulsar_producer_configuration_set_crypto_failure_action

### DIFF
--- a/pulsar-client-cpp/lib/c/c_ProducerConfiguration.cc
+++ b/pulsar-client-cpp/lib/c/c_ProducerConfiguration.cc
@@ -209,7 +209,7 @@ void pulsar_producer_configuration_set_default_crypto_key_reader(pulsar_producer
     conf->conf.setCryptoKeyReader(keyReader);
 }
 
-pulsar_producer_crypto_failure_action pulsar_producer_configuration_set_crypto_failure_action(
+pulsar_producer_crypto_failure_action pulsar_producer_configuration_get_crypto_failure_action(
     pulsar_producer_configuration_t *conf) {
     return (pulsar_producer_crypto_failure_action)conf->conf.getCryptoFailureAction();
 }


### PR DESCRIPTION

Fixes #16030 

### Motivation
Fix symlink error for function pulsar_producer_configuration_get_crypto_failure_action

### Modifications

Rename function name `pulsar_producer_configuration_set_crypto_failure_action` to `pulsar_producer_configuration_get_crypto_failure_action`

### Verifying this change

- [x] Make sure that the change passes the CI checks.
This change is a trivial rework / code cleanup without any test coverage.
