### PR TITLE
[fix][client]Fix miss flushing ack request when invoking pendingIndividualBatchAck

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PersistentAcknowledgmentsGroupingTracker.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PersistentAcknowledgmentsGroupingTracker.java
@@ -154,13 +154,15 @@ public class PersistentAcknowledgmentsGroupingTracker implements Acknowledgments
                     }
                 } finally {
                     this.lock.readLock().unlock();
-                    if (acknowledgementGroupTimeMicros == 0 || pendingIndividualAcks.size() >= MAX_ACK_GROUP_SIZE) {
+                    if (acknowledgementGroupTimeMicros == 0 || pendingIndividualAcks.size() >= MAX_ACK_GROUP_SIZE
+                            || pendingIndividualBatchIndexAcks.size() >= MAX_ACK_GROUP_SIZE) {
                         flush();
                     }
                 }
             } else {
                 addListAcknowledgment(messageIds);
-                if (acknowledgementGroupTimeMicros == 0 || pendingIndividualAcks.size() >= MAX_ACK_GROUP_SIZE) {
+                if (acknowledgementGroupTimeMicros == 0 || pendingIndividualAcks.size() >= MAX_ACK_GROUP_SIZE
+                        || pendingIndividualBatchIndexAcks.size() >= MAX_ACK_GROUP_SIZE) {
                     flush();
                 }
                 return CompletableFuture.completedFuture(null);

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PersistentAcknowledgmentsGroupingTracker.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PersistentAcknowledgmentsGroupingTracker.java
@@ -154,15 +154,13 @@ public class PersistentAcknowledgmentsGroupingTracker implements Acknowledgments
                     }
                 } finally {
                     this.lock.readLock().unlock();
-                    if (acknowledgementGroupTimeMicros == 0 || pendingIndividualAcks.size() >= MAX_ACK_GROUP_SIZE
-                            || pendingIndividualBatchIndexAcks.size() >= MAX_ACK_GROUP_SIZE) {
+                    if (acknowledgementGroupTimeMicros == 0 || pendingIndividualAcks.size() >= MAX_ACK_GROUP_SIZE) {
                         flush();
                     }
                 }
             } else {
                 addListAcknowledgment(messageIds);
-                if (acknowledgementGroupTimeMicros == 0 || pendingIndividualAcks.size() >= MAX_ACK_GROUP_SIZE
-                        || pendingIndividualBatchIndexAcks.size() >= MAX_ACK_GROUP_SIZE) {
+                if (acknowledgementGroupTimeMicros == 0 || pendingIndividualAcks.size() >= MAX_ACK_GROUP_SIZE) {
                     flush();
                 }
                 return CompletableFuture.completedFuture(null);
@@ -314,15 +312,9 @@ public class PersistentAcknowledgmentsGroupingTracker implements Acknowledgments
                 return this.currentIndividualAckFuture;
             } finally {
                 this.lock.readLock().unlock();
-                if (pendingIndividualBatchIndexAcks.size() >= MAX_ACK_GROUP_SIZE) {
-                    flush();
-                }
             }
         } else {
             doIndividualBatchAckAsync(batchMessageId);
-            if (pendingIndividualBatchIndexAcks.size() >= MAX_ACK_GROUP_SIZE) {
-                flush();
-            }
             return CompletableFuture.completedFuture(null);
         }
     }
@@ -368,6 +360,9 @@ public class PersistentAcknowledgmentsGroupingTracker implements Acknowledgments
                     return value;
                 });
         bitSet.clear(batchMessageId.getBatchIndex());
+        if (pendingIndividualBatchIndexAcks.size() >= MAX_ACK_GROUP_SIZE) {
+            flush();
+        }
     }
 
     private void doCumulativeAckAsync(MessageIdImpl msgId, BitSetRecyclable bitSet) {


### PR DESCRIPTION
### Motivation
#15877 missed another condition  where `flush` should be invoked.
Flush in  the method where the `pendingIndividualBatchIndexAck ` added. In avoid we  flushing  everywhere `pendingIndividualBatchIndexAck` added

### Modifications

Add flush in method `doIndividualBatchAckAsync` if size of pendingIndividualBatchIndexAcks gt MAX_ACK_GROUP_SIZE



### Documentation

Check the box below or label this PR directly.

Need to update docs? 


  
- [x] `doc-not-needed` 
(Please explain why)
