### PR TITLE
[Broker] Terminate JVM when initialize-cluster-metadata command fails

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/PulsarClusterMetadataSetup.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/PulsarClusterMetadataSetup.java
@@ -232,6 +232,17 @@ public class PulsarClusterMetadataSetup {
             System.exit(1);
         }
 
+        try {
+            initializeCluster(arguments);
+        } catch (Exception e) {
+            System.err.println("Unexpected error occured.");
+            e.printStackTrace(System.err);
+            System.err.println("Terminating JVM...");
+            Runtime.getRuntime().halt(1);
+        }
+    }
+
+    private static void initializeCluster(Arguments arguments) throws Exception {
         log.info("Setting up cluster {} with metadata-store={} configuration-metadata-store={}", arguments.cluster,
                 arguments.metadataStoreUrl, arguments.configurationMetadataStore);
 


### PR DESCRIPTION
- the script gets stuck unless the JVM is terminated explicitly

Fixes an issue where the `bin/pulsar initialize-cluster-metadata` command gets stuck with these log lines as the last entries:
```
2022-06-13T11:33:41,805+0000 [main-SendThread(pulsar-luna-uswest1-staging-zookeeper-ca.pulsar.svc.cluster.local:2181)] INFO  org.apache.zookeeper.ClientCnxn - Opening socket connection to server pulsar-luna-uswest1-staging-zookeeper-ca.pulsar.svc.cluster.local/10.56.0.47:2181.
2022-06-13T11:33:41,805+0000 [main-SendThread(pulsar-luna-uswest1-staging-zookeeper-ca.pulsar.svc.cluster.local:2181)] INFO  org.apache.zookeeper.ClientCnxn - SASL config status: Will not attempt to authenticate using SASL (unknown error)
2022-06-13T11:33:42,814+0000 [main-SendThread(pulsar-luna-uswest1-staging-zookeeper-ca.pulsar.svc.cluster.local:2181)] WARN  org.apache.zookeeper.ClientCnxn - An exception was thrown while closing send thread for session 0x0.
java.net.ConnectException: Connection refused
	at sun.nio.ch.SocketChannelImpl.checkConnect(Native Method) ~[?:?]
	at sun.nio.ch.SocketChannelImpl.finishConnect(SocketChannelImpl.java:777) ~[?:?]
	at org.apache.zookeeper.ClientCnxnSocketNIO.doTransport(ClientCnxnSocketNIO.java:344) ~[org.apache.zookeeper-zookeeper-3.8.0.jar:3.8.0]
	at org.apache.zookeeper.ClientCnxn$SendThread.run(ClientCnxn.java:1282) [org.apache.zookeeper-zookeeper-3.8.0.jar:3.8.0]
2022-06-13T11:33:42,921+0000 [main] INFO  org.apache.zookeeper.ZooKeeper - Session: 0x0 closed
2022-06-13T11:33:42,921+0000 [main-EventThread] INFO  org.apache.zookeeper.ClientCnxn - EventThread shut down for session: 0x0
Exception in thread "main" org.apache.pulsar.metadata.api.MetadataStoreException: org.apache.zookeeper.KeeperException$ConnectionLossException: KeeperErrorCode = ConnectionLoss
	at org.apache.pulsar.metadata.impl.ZKMetadataStore.<init>(ZKMetadataStore.java:108)
	at org.apache.pulsar.metadata.impl.MetadataStoreFactoryImpl.newInstance(MetadataStoreFactoryImpl.java:56)
	at org.apache.pulsar.metadata.impl.MetadataStoreFactoryImpl.createExtended(MetadataStoreFactoryImpl.java:36)
	at org.apache.pulsar.metadata.api.extended.MetadataStoreExtended.create(MetadataStoreExtended.java:40)
	at org.apache.pulsar.PulsarClusterMetadataSetup.initMetadataStore(PulsarClusterMetadataSetup.java:380)
	at org.apache.pulsar.PulsarClusterMetadataSetup.main(PulsarClusterMetadataSetup.java:238)
Caused by: org.apache.zookeeper.KeeperException$ConnectionLossException: KeeperErrorCode = ConnectionLoss
	at org.apache.zookeeper.KeeperException.create(KeeperException.java:102)
	at org.apache.bookkeeper.zookeeper.ZooKeeperWatcherBase.waitForConnection(ZooKeeperWatcherBase.java:159)
	at org.apache.pulsar.metadata.impl.PulsarZooKeeperClient$Builder.build(PulsarZooKeeperClient.java:259)
	at org.apache.pulsar.metadata.impl.ZKMetadataStore.<init>(ZKMetadataStore.java:100)
	... 5 more
```

The PR will terminate the JVM when an exception happens to ensure that the command completes.