### PR TITLE
Revert "[feat][workflow] Upgrade to new version of documentation bot #16027"

### DIFF
--- a/.github/workflows/ci-documentbot.yml
+++ b/.github/workflows/ci-documentbot.yml
@@ -17,7 +17,7 @@
 # under the License.
 #
 
-name: Documentation Bot
+name: Auto Labeling
 
 on:
   pull_request_target :
@@ -25,29 +25,25 @@ on:
       - opened
       - edited
       - labeled
-      - unlabeled
+
+  
+
+# A GitHub token created for a PR coming from a fork doesn't have
+# 'admin' or 'write' permission (which is required to add labels)
+# To avoid this issue, you can use the `scheduled` event and run
+# this action on a certain interval.And check the label about the
+# document.
 
 jobs:
-  label:
+  labeling:
     if: ${{ github.repository == 'apache/pulsar' }}
     permissions:
       pull-requests: write 
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout action
-        uses: actions/checkout@v3
-        with:
-          repository: apache/pulsar-test-infra/docbot
-          ref: master
+      - uses: actions/checkout@v2
 
-      - name: Set up Go
-        uses: actions/setup-go@v3
+      - uses: apache/pulsar-test-infra/doc-label-check@master
         with:
-          go-version: 1.18
-
-      - name: Labeling
-        uses: apache/pulsar-test-infra/docbot@master
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          LABEL_WATCH_LIST: 'doc,doc-required,doc-not-needed,doc-complete'
-          LABEL_MISSING: 'doc-label-missing'
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          label-pattern: '- \[(.*?)\] ?`(.+?)`' # matches '- [x] `label`'


### PR DESCRIPTION
This reverts #16027 / commit f1d6b32b4513b8bec329b4fe13c8d10a934f1aa3.

All `label` jobs fail with error `Invalid repository 'apache/pulsar-test-infra/docbot'. Expected format {owner}/{repo}.` 

