### PR TITLE
[improve][function] Support Record<?> as Function output type

### DIFF
--- a/pulsar-functions/api-java/src/main/java/org/apache/pulsar/functions/api/Context.java
+++ b/pulsar-functions/api-java/src/main/java/org/apache/pulsar/functions/api/Context.java
@@ -164,7 +164,9 @@ public interface Context extends BaseContext {
     <X> ConsumerBuilder<X> newConsumerBuilder(Schema<X> schema) throws PulsarClientException;
 
     /**
-     * Create a FunctionRecordBuilder.
+     * Creates a FunctionRecordBuilder initialized with values from this Context.
+     * It can be used in Functions to prepare a Record to return with default values taken from the Context and the
+     * input Record.
      *
      * @return the record builder instance
      */

--- a/pulsar-functions/api-java/src/main/java/org/apache/pulsar/functions/api/Context.java
+++ b/pulsar-functions/api-java/src/main/java/org/apache/pulsar/functions/api/Context.java
@@ -29,6 +29,7 @@ import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.client.api.TypedMessageBuilder;
 import org.apache.pulsar.common.classification.InterfaceAudience;
 import org.apache.pulsar.common.classification.InterfaceStability;
+import org.apache.pulsar.functions.api.utils.FunctionRecord;
 
 /**
  * Context provides contextual information to the executing function.
@@ -161,4 +162,11 @@ public interface Context extends BaseContext {
      * @throws PulsarClientException
      */
     <X> ConsumerBuilder<X> newConsumerBuilder(Schema<X> schema) throws PulsarClientException;
+
+    /**
+     * Create a FunctionRecordBuilder.
+     *
+     * @return the record builder instance
+     */
+    <X> FunctionRecord.FunctionRecordBuilder<X> newOutputRecordBuilder();
 }

--- a/pulsar-functions/api-java/src/main/java/org/apache/pulsar/functions/api/utils/FunctionRecord.java
+++ b/pulsar-functions/api-java/src/main/java/org/apache/pulsar/functions/api/utils/FunctionRecord.java
@@ -39,7 +39,17 @@ public class FunctionRecord<T> implements Record<T> {
     private final Integer partitionIndex;
     private final Long recordSequence;
 
-    public static <T> FunctionRecord.FunctionRecordBuilder<T> from(Context context) {
+    /**
+     * Creates a builder for a Record from a Function Context.
+     * The builder is initialized with the output topic from the Context and with the topicName, key, eventTime,
+     * properties, partitionId, partitionIndex and recordSequence from the Context input Record.
+     * It doesn't initialize a Message at the moment.
+     *
+     * @param context a Function Context
+     * @param <T> type of Record to build
+     * @return a Record builder initialised with values from the Function Context
+     */
+     public static <T> FunctionRecord.FunctionRecordBuilder<T> from(Context context) {
         Record<?> currentRecord = context.getCurrentRecord();
         FunctionRecordBuilder<T> builder = new FunctionRecordBuilder<T>()
                 .destinationTopic(context.getOutputTopic())
@@ -50,8 +60,6 @@ public class FunctionRecord<T> implements Record<T> {
         currentRecord.getPartitionId().ifPresent(builder::partitionId);
         currentRecord.getPartitionIndex().ifPresent(builder::partitionIndex);
         currentRecord.getRecordSequence().ifPresent(builder::recordSequence);
-
-        // TODO: add message
 
         return builder;
     }

--- a/pulsar-functions/api-java/src/main/java/org/apache/pulsar/functions/api/utils/FunctionRecord.java
+++ b/pulsar-functions/api-java/src/main/java/org/apache/pulsar/functions/api/utils/FunctionRecord.java
@@ -1,0 +1,109 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.functions.api.utils;
+
+import java.util.Map;
+import java.util.Optional;
+import lombok.Builder;
+import org.apache.pulsar.client.api.Schema;
+import org.apache.pulsar.functions.api.Context;
+import org.apache.pulsar.functions.api.Record;
+
+@Builder(builderMethodName = "")
+public class FunctionRecord<T> implements Record<T> {
+
+    private final T value;
+    private final String topicName;
+    private final String destinationTopic;
+    private final Map<String, String> properties;
+    private final String key;
+    private final Schema<T> schema;
+    private final Long eventTime;
+    private final String partitionId;
+    private final Integer partitionIndex;
+    private final Long recordSequence;
+
+    public static <T> FunctionRecord.FunctionRecordBuilder<T> from(Context context) {
+        Record<?> currentRecord = context.getCurrentRecord();
+        FunctionRecordBuilder<T> builder = new FunctionRecordBuilder<T>()
+                .destinationTopic(context.getOutputTopic())
+                .properties(currentRecord.getProperties());
+        currentRecord.getTopicName().ifPresent(builder::topicName);
+        currentRecord.getKey().ifPresent(builder::key);
+        currentRecord.getEventTime().ifPresent(builder::eventTime);
+        currentRecord.getPartitionId().ifPresent(builder::partitionId);
+        currentRecord.getPartitionIndex().ifPresent(builder::partitionIndex);
+        currentRecord.getRecordSequence().ifPresent(builder::recordSequence);
+
+        // TODO: add message
+
+        return builder;
+    }
+
+    @Override
+    public T getValue() {
+        return value;
+    }
+
+    @Override
+    public Optional<String> getTopicName() {
+        return Optional.ofNullable(topicName);
+    }
+
+    @Override
+    public Optional<String> getDestinationTopic() {
+        return Optional.ofNullable(destinationTopic);
+    }
+
+    @Override
+    public Map<String, String> getProperties() {
+        return properties;
+    }
+
+    @Override
+    public Optional<String> getKey() {
+        return Optional.ofNullable(key);
+    }
+
+    @Override
+    public Schema<T> getSchema() {
+        return schema;
+    }
+
+    @Override
+    public Optional<Long> getEventTime() {
+        return Optional.ofNullable(eventTime);
+    }
+
+    @Override
+    public Optional<String> getPartitionId() {
+        return Optional.ofNullable(partitionId);
+    }
+
+    @Override
+    public Optional<Integer> getPartitionIndex() {
+        return Optional.ofNullable(partitionIndex);
+    }
+
+    @Override
+    public Optional<Long> getRecordSequence() {
+        return Optional.ofNullable(recordSequence);
+    }
+
+}

--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/AbstractSinkRecord.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/AbstractSinkRecord.java
@@ -38,6 +38,8 @@ public abstract class AbstractSinkRecord<T> implements Record<T> {
         this.sourceRecord = sourceRecord;
     }
 
+    public abstract boolean shouldAlwaysSetMessageProperties();
+
     public Record<?> getSourceRecord() {
         return sourceRecord;
     }

--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/AbstractSinkRecord.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/AbstractSinkRecord.java
@@ -1,0 +1,116 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.functions.instance;
+
+import java.util.Optional;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+import org.apache.pulsar.client.api.Schema;
+import org.apache.pulsar.client.impl.schema.AutoConsumeSchema;
+import org.apache.pulsar.client.impl.schema.KeyValueSchemaImpl;
+import org.apache.pulsar.functions.api.KVRecord;
+import org.apache.pulsar.functions.api.Record;
+import org.apache.pulsar.functions.source.PulsarRecord;
+
+@EqualsAndHashCode
+@ToString
+public abstract class AbstractSinkRecord<T> implements Record<T> {
+
+    private final Record<?> sourceRecord;
+
+    protected AbstractSinkRecord(Record<?> sourceRecord) {
+        this.sourceRecord = sourceRecord;
+    }
+
+    public Record<?> getSourceRecord() {
+        return sourceRecord;
+    }
+
+    @Override
+    public Optional<String> getTopicName() {
+        return sourceRecord.getTopicName();
+    }
+
+    @Override
+    public void ack() {
+        sourceRecord.ack();
+    }
+
+    /**
+     * Some sink sometimes wants to control the ack type.
+     */
+    public void cumulativeAck() {
+        if (sourceRecord instanceof PulsarRecord) {
+            PulsarRecord pulsarRecord = (PulsarRecord) sourceRecord;
+            pulsarRecord.cumulativeAck();
+        } else {
+            throw new RuntimeException("SourceRecord class type must be PulsarRecord");
+        }
+    }
+
+    /**
+     * Some sink sometimes wants to control the ack type.
+     */
+    public void individualAck() {
+        if (sourceRecord instanceof PulsarRecord) {
+            PulsarRecord pulsarRecord = (PulsarRecord) sourceRecord;
+            pulsarRecord.individualAck();
+        } else {
+            throw new RuntimeException("SourceRecord class type must be PulsarRecord");
+        }
+    }
+
+    @Override
+    public void fail() {
+        sourceRecord.fail();
+    }
+
+    protected static <T> Schema<T> getRecordSchema(Record<T> record) {
+        if (record == null) {
+            return null;
+        }
+
+        if (record.getSchema() != null) {
+            // unwrap actual schema
+            Schema<T> schema = record.getSchema();
+            // AutoConsumeSchema is a special schema, that comes into play
+            // when the Sink is going to handle any Schema
+            // usually you see Sink<GenericObject> or Sink<GenericRecord> in this case
+            if (schema instanceof AutoConsumeSchema) {
+                // extract the Schema from the message, this is the most accurate schema we have
+                // see PIP-85
+                if (record.getMessage().isPresent()
+                        && record.getMessage().get().getReaderSchema().isPresent()) {
+                    schema = (Schema<T>) record.getMessage().get().getReaderSchema().get();
+                } else {
+                    schema = (Schema<T>) ((AutoConsumeSchema) schema).getInternalSchema();
+                }
+            }
+            return schema;
+        }
+
+        if (record instanceof KVRecord) {
+            KVRecord kvRecord = (KVRecord) record;
+            return KeyValueSchemaImpl.of(kvRecord.getKeySchema(), kvRecord.getValueSchema(),
+                    kvRecord.getKeyValueEncodingType());
+        }
+
+        return null;
+    }
+}

--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/ContextImpl.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/ContextImpl.java
@@ -62,6 +62,7 @@ import org.apache.pulsar.common.util.FutureUtil;
 import org.apache.pulsar.functions.api.Context;
 import org.apache.pulsar.functions.api.Record;
 import org.apache.pulsar.functions.api.StateStore;
+import org.apache.pulsar.functions.api.utils.FunctionRecord;
 import org.apache.pulsar.functions.instance.state.DefaultStateStore;
 import org.apache.pulsar.functions.instance.state.StateManager;
 import org.apache.pulsar.functions.instance.stats.ComponentStatsManager;
@@ -479,6 +480,11 @@ class ContextImpl implements Context, SinkContext, SourceContext, AutoCloseable 
     @Override
     public <T> ConsumerBuilder<T> newConsumerBuilder(Schema<T> schema) throws PulsarClientException {
         return this.client.newConsumer(schema);
+    }
+
+    @Override
+    public <X> FunctionRecord.FunctionRecordBuilder<X> newOutputRecordBuilder() {
+        return FunctionRecord.from(this);
     }
 
     @Override

--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/JavaInstanceRunnable.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/JavaInstanceRunnable.java
@@ -375,8 +375,14 @@ public class JavaInstanceRunnable implements AutoCloseable, Runnable {
         if (componentType == org.apache.pulsar.functions.proto.Function.FunctionDetails.ComponentType.SINK) {
             Thread.currentThread().setContextClassLoader(functionClassLoader);
         }
+        AbstractSinkRecord<?> sinkRecord;
+        if (output instanceof Record) {
+            sinkRecord = new TargetSinkRecord<>(srcRecord, (Record) output);
+        } else {
+            sinkRecord = new SinkRecord<>(srcRecord, output);
+        }
         try {
-            this.sink.write(new SinkRecord<>(srcRecord, output));
+            this.sink.write(sinkRecord);
         } catch (Exception e) {
             log.info("Encountered exception in sink write: ", e);
             stats.incrSinkExceptions(e);

--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/JavaInstanceRunnable.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/JavaInstanceRunnable.java
@@ -377,7 +377,7 @@ public class JavaInstanceRunnable implements AutoCloseable, Runnable {
         }
         AbstractSinkRecord<?> sinkRecord;
         if (output instanceof Record) {
-            sinkRecord = new TargetSinkRecord<>(srcRecord, (Record) output);
+            sinkRecord = new OutputRecordSinkRecord<>(srcRecord, (Record) output);
         } else {
             sinkRecord = new SinkRecord<>(srcRecord, output);
         }

--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/OutputRecordSinkRecord.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/OutputRecordSinkRecord.java
@@ -28,11 +28,11 @@ import org.apache.pulsar.functions.api.Record;
 
 @EqualsAndHashCode(callSuper = true)
 @ToString
-public class TargetSinkRecord<T> extends AbstractSinkRecord<T> {
+class OutputRecordSinkRecord<T> extends AbstractSinkRecord<T> {
 
     private final Record<T> sinkRecord;
 
-    public TargetSinkRecord(Record<T> sourceRecord, Record<T> sinkRecord) {
+    OutputRecordSinkRecord(Record<T> sourceRecord, Record<T> sinkRecord) {
         super(sourceRecord);
         this.sinkRecord = sinkRecord;
     }
@@ -85,5 +85,10 @@ public class TargetSinkRecord<T> extends AbstractSinkRecord<T> {
     @Override
     public Optional<Message<T>> getMessage() {
         return sinkRecord.getMessage();
+    }
+
+    @Override
+    public boolean shouldAlwaysSetMessageProperties() {
+        return true;
     }
 }

--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/SinkRecord.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/SinkRecord.java
@@ -87,4 +87,9 @@ public class SinkRecord<T> extends AbstractSinkRecord<T> {
     public Optional<Message<T>> getMessage() {
         return sourceRecord.getMessage();
     }
+
+    @Override
+    public boolean shouldAlwaysSetMessageProperties() {
+        return false;
+    }
 }

--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/TargetSinkRecord.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/TargetSinkRecord.java
@@ -28,63 +28,62 @@ import org.apache.pulsar.functions.api.Record;
 
 @EqualsAndHashCode(callSuper = true)
 @ToString
-public class SinkRecord<T> extends AbstractSinkRecord<T> {
-    private final Record<T> sourceRecord;
-    private final T value;
+public class TargetSinkRecord<T> extends AbstractSinkRecord<T> {
 
-    public SinkRecord(Record<T> sourceRecord, T value) {
+    private final Record<T> sinkRecord;
+
+    public TargetSinkRecord(Record<T> sourceRecord, Record<T> sinkRecord) {
         super(sourceRecord);
-        this.sourceRecord = sourceRecord;
-        this.value = value;
+        this.sinkRecord = sinkRecord;
     }
 
     @Override
     public Optional<String> getKey() {
-        return sourceRecord.getKey();
+        return sinkRecord.getKey();
     }
 
     @Override
     public T getValue() {
-        return value;
+        return sinkRecord.getValue();
     }
 
     @Override
     public Optional<String> getPartitionId() {
-        return sourceRecord.getPartitionId();
+        return sinkRecord.getPartitionId();
     }
 
     @Override
     public Optional<Integer> getPartitionIndex() {
-        return sourceRecord.getPartitionIndex();
+        return sinkRecord.getPartitionIndex();
     }
 
     @Override
     public Optional<Long> getRecordSequence() {
-        return sourceRecord.getRecordSequence();
+        return sinkRecord.getRecordSequence();
     }
 
-    @Override
+     @Override
     public Map<String, String> getProperties() {
-        return sourceRecord.getProperties();
+        return sinkRecord.getProperties();
     }
 
     @Override
     public Optional<String> getDestinationTopic() {
-        return sourceRecord.getDestinationTopic();
+        return sinkRecord.getDestinationTopic();
     }
 
     @Override
     public Schema<T> getSchema() {
-        return getRecordSchema(sourceRecord);
+        return getRecordSchema(sinkRecord);
     }
 
     @Override
     public Optional<Long> getEventTime() {
-        return sourceRecord.getEventTime();
+        return sinkRecord.getEventTime();
     }
 
     @Override
     public Optional<Message<T>> getMessage() {
-        return sourceRecord.getMessage();
+        return sinkRecord.getMessage();
     }
 }

--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/sink/PulsarSink.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/sink/PulsarSink.java
@@ -59,8 +59,8 @@ import org.apache.pulsar.common.schema.KeyValueEncodingType;
 import org.apache.pulsar.common.schema.SchemaType;
 import org.apache.pulsar.common.util.Reflections;
 import org.apache.pulsar.functions.api.Record;
+import org.apache.pulsar.functions.instance.AbstractSinkRecord;
 import org.apache.pulsar.functions.instance.FunctionResultRouter;
-import org.apache.pulsar.functions.instance.SinkRecord;
 import org.apache.pulsar.functions.instance.stats.ComponentStatsManager;
 import org.apache.pulsar.functions.source.PulsarRecord;
 import org.apache.pulsar.functions.source.TopicSchema;
@@ -85,9 +85,9 @@ public class PulsarSink<T> implements Sink<T> {
 
     private interface PulsarSinkProcessor<T> {
 
-        TypedMessageBuilder<T> newMessage(SinkRecord<T> record);
+        TypedMessageBuilder<T> newMessage(AbstractSinkRecord<T> record);
 
-        void sendOutputMessage(TypedMessageBuilder<T> msg, SinkRecord<T> record);
+        void sendOutputMessage(TypedMessageBuilder<T> msg, AbstractSinkRecord<T> record);
 
         void close() throws Exception;
     }
@@ -183,17 +183,17 @@ public class PulsarSink<T> implements Sink<T> {
             }
         }
 
-        public Function<Throwable, Void> getPublishErrorHandler(SinkRecord<T> record, boolean failSource) {
+        public Function<Throwable, Void> getPublishErrorHandler(AbstractSinkRecord<T> record, boolean failSource) {
 
             return throwable -> {
-                Record<T> srcRecord = record.getSourceRecord();
+                Record<?> srcRecord = record.getSourceRecord();
                 if (failSource) {
                     srcRecord.fail();
                 }
 
                 String topic = record.getDestinationTopic().orElse(pulsarSinkConfig.getTopic());
 
-                String errorMsg = null;
+                String errorMsg;
                 if (srcRecord instanceof PulsarRecord) {
                     errorMsg = String.format("Failed to publish to topic [%s] with error [%s] with src message id [%s]",
                             topic, throwable.getMessage(), ((PulsarRecord) srcRecord).getMessageId());
@@ -234,7 +234,7 @@ public class PulsarSink<T> implements Sink<T> {
         }
 
         @Override
-        public TypedMessageBuilder<T> newMessage(SinkRecord<T> record) {
+        public TypedMessageBuilder<T> newMessage(AbstractSinkRecord<T> record) {
             Schema<T> schemaToWrite = record.getSchema();
             if (record.getSourceRecord() instanceof PulsarRecord) {
                 // we are receiving data directly from another Pulsar topic
@@ -256,7 +256,7 @@ public class PulsarSink<T> implements Sink<T> {
         }
 
         @Override
-        public void sendOutputMessage(TypedMessageBuilder<T> msg, SinkRecord<T> record) {
+        public void sendOutputMessage(TypedMessageBuilder<T> msg, AbstractSinkRecord<T> record) {
             msg.sendAsync().thenAccept(messageId -> {
                 //no op
             }).exceptionally(getPublishErrorHandler(record, false));
@@ -270,7 +270,7 @@ public class PulsarSink<T> implements Sink<T> {
         }
 
         @Override
-        public void sendOutputMessage(TypedMessageBuilder<T> msg, SinkRecord<T> record) {
+        public void sendOutputMessage(TypedMessageBuilder<T> msg, AbstractSinkRecord<T> record) {
             msg.sendAsync()
                     .thenAccept(messageId -> record.ack())
                     .exceptionally(getPublishErrorHandler(record, true));
@@ -285,7 +285,7 @@ public class PulsarSink<T> implements Sink<T> {
         }
 
         @Override
-        public TypedMessageBuilder<T> newMessage(SinkRecord<T> record) {
+        public TypedMessageBuilder<T> newMessage(AbstractSinkRecord<T> record) {
             if (!record.getPartitionId().isPresent()) {
                 throw new RuntimeException(
                         "PartitionId needs to be specified for every record while in Effectively-once mode");
@@ -311,7 +311,7 @@ public class PulsarSink<T> implements Sink<T> {
         }
 
         @Override
-        public void sendOutputMessage(TypedMessageBuilder<T> msg, SinkRecord<T> record) {
+        public void sendOutputMessage(TypedMessageBuilder<T> msg, AbstractSinkRecord<T> record) {
 
             if (!record.getRecordSequence().isPresent()) {
                 throw new RuntimeException(
@@ -367,7 +367,7 @@ public class PulsarSink<T> implements Sink<T> {
 
     @Override
     public void write(Record<T> record) {
-        SinkRecord<T> sinkRecord = (SinkRecord<T>) record;
+        AbstractSinkRecord<T> sinkRecord = (AbstractSinkRecord<T>) record;
         TypedMessageBuilder<T> msg = pulsarSinkProcessor.newMessage(sinkRecord);
 
         if (record.getKey().isPresent() && !(record.getSchema() instanceof KeyValueSchema

--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/sink/PulsarSink.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/sink/PulsarSink.java
@@ -377,7 +377,8 @@ public class PulsarSink<T> implements Sink<T> {
 
         msg.value(record.getValue());
 
-        if (!record.getProperties().isEmpty() && pulsarSinkConfig.isForwardSourceMessageProperty()) {
+        if (!record.getProperties().isEmpty()
+            && (sinkRecord.shouldAlwaysSetMessageProperties() || pulsarSinkConfig.isForwardSourceMessageProperty())) {
             msg.properties(record.getProperties());
         }
 

--- a/pulsar-functions/instance/src/test/java/org/apache/pulsar/functions/instance/ContextImplTest.java
+++ b/pulsar-functions/instance/src/test/java/org/apache/pulsar/functions/instance/ContextImplTest.java
@@ -30,8 +30,12 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
 import java.nio.ByteBuffer;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import org.apache.pulsar.client.admin.PulsarAdmin;
@@ -350,5 +354,69 @@ public class ContextImplTest {
             // pass
         }
 
+    }
+
+    @Test
+    public void testNewOutputRecordBuilder() {
+        Map<String, String> properties = new HashMap<>();
+        properties.put("prop-key", "prop-value");
+        long now = System.currentTimeMillis();
+        context.setCurrentMessageContext(new Record<String>() {
+            @Override
+            public Optional<String> getTopicName() {
+                return Optional.of("input-topic");
+            }
+
+            @Override
+            public Optional<String> getKey() {
+                return Optional.of("input-key");
+            }
+
+            @Override
+            public Schema<String> getSchema() {
+                return Schema.STRING;
+            }
+
+            @Override
+            public String getValue() {
+                return "input-value";
+            }
+
+            @Override
+            public Optional<Long> getEventTime() {
+                return Optional.of(now);
+            }
+
+            @Override
+            public Optional<String> getPartitionId() {
+                return Optional.of("input-partition-id");
+            }
+
+            @Override
+            public Optional<Integer> getPartitionIndex() {
+                return Optional.of(42);
+            }
+
+            @Override
+            public Optional<Long> getRecordSequence() {
+                return Optional.of(43L);
+            }
+
+            @Override
+            public Map<String, String> getProperties() {
+                return properties;
+            }
+        });
+        Record<Integer> record = context.<Integer>newOutputRecordBuilder().build();
+        assertEquals(record.getTopicName().get(), "input-topic");
+        assertEquals(record.getKey().get(), "input-key");
+        assertEquals(record.getEventTime(), Optional.of(now));
+        assertEquals(record.getPartitionId().get(), "input-partition-id");
+        assertEquals(record.getPartitionIndex(), Optional.of(42));
+        assertEquals(record.getRecordSequence(), Optional.of(43L));
+        assertTrue(record.getProperties().containsKey("prop-key"));
+        assertEquals(record.getProperties().get("prop-key"), "prop-value");
+        assertNull(record.getValue());
+        assertNull(record.getSchema());
     }
 }

--- a/pulsar-functions/java-examples/src/main/java/org/apache/pulsar/functions/api/examples/RecordFunction.java
+++ b/pulsar-functions/java-examples/src/main/java/org/apache/pulsar/functions/api/examples/RecordFunction.java
@@ -1,0 +1,43 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.functions.api.examples;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.pulsar.functions.api.Context;
+import org.apache.pulsar.functions.api.Function;
+import org.apache.pulsar.functions.api.Record;
+
+public class RecordFunction implements Function<String, Record<String>> {
+
+    @Override
+    public Record<String> process(String input, Context context) throws Exception {
+        String publishTopic = (String) context.getUserConfigValueOrDefault("publish-topic", "publishtopic");
+        String output = String.format("%s!", input);
+
+        Map<String, String> properties = new HashMap<>(context.getCurrentRecord().getProperties());
+        context.getCurrentRecord().getTopicName().ifPresent(topic -> properties.put("input_topic", topic));
+
+        return context.<String>newOutputRecordBuilder()
+                .destinationTopic(publishTopic)
+                .value(output)
+                .properties(properties)
+                .build();
+    }
+}

--- a/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/FunctionCommon.java
+++ b/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/FunctionCommon.java
@@ -54,6 +54,7 @@ import org.apache.pulsar.common.nar.NarClassLoader;
 import org.apache.pulsar.common.nar.NarClassLoaderBuilder;
 import org.apache.pulsar.common.util.ClassLoaderUtils;
 import org.apache.pulsar.functions.api.Function;
+import org.apache.pulsar.functions.api.Record;
 import org.apache.pulsar.functions.api.WindowFunction;
 import org.apache.pulsar.functions.proto.Function.FunctionDetails.Runtime;
 import org.apache.pulsar.functions.utils.io.ConnectorUtils;
@@ -120,8 +121,20 @@ public class FunctionCommon {
         } else {
             if (Function.class.isAssignableFrom(userClass)) {
                 typeArgs = TypeResolver.resolveRawArguments(Function.class, userClass);
+                if (typeArgs[1].equals(Record.class)) {
+                    Type type = TypeResolver.resolveGenericType(Function.class, userClass);
+                    Type recordType = ((ParameterizedType) type).getActualTypeArguments()[1];
+                    Type actualInputType = ((ParameterizedType) recordType).getActualTypeArguments()[0];
+                    typeArgs[1] = (Class<?>) actualInputType;
+                }
             } else {
                 typeArgs = TypeResolver.resolveRawArguments(java.util.function.Function.class, userClass);
+                if (typeArgs[1].equals(Record.class)) {
+                    Type type = TypeResolver.resolveGenericType(java.util.function.Function.class, userClass);
+                    Type recordType = ((ParameterizedType) type).getActualTypeArguments()[1];
+                    Type actualInputType = ((ParameterizedType) recordType).getActualTypeArguments()[0];
+                    typeArgs[1] = (Class<?>) actualInputType;
+                }
             }
         }
 

--- a/pulsar-functions/utils/src/test/java/org/apache/pulsar/functions/utils/FunctionCommonTest.java
+++ b/pulsar-functions/utils/src/test/java/org/apache/pulsar/functions/utils/FunctionCommonTest.java
@@ -19,9 +19,16 @@
 
 package org.apache.pulsar.functions.utils;
 
+import java.util.Collection;
 import org.apache.pulsar.client.impl.MessageIdImpl;
 import org.apache.pulsar.common.util.FutureUtil;
+import org.apache.pulsar.functions.api.Context;
+import org.apache.pulsar.functions.api.Function;
+import org.apache.pulsar.functions.api.Record;
+import org.apache.pulsar.functions.api.WindowContext;
+import org.apache.pulsar.functions.api.WindowFunction;
 import org.testng.Assert;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import java.io.File;
@@ -100,5 +107,67 @@ public class FunctionCommonTest {
         MessageIdImpl id = (MessageIdImpl) FunctionCommon.getMessageId(sequenceId);
         assertEquals(lid, id.getLedgerId());
         assertEquals(eid, id.getEntryId());
+    }
+
+    @DataProvider(name = "function")
+    public Object[][] functionProvider() {
+        return new Object[][] {
+            {
+                new Function<String, Integer>() {
+                    @Override
+                    public Integer process(String input, Context context) throws Exception {
+                        return null;
+                    }
+                }, false
+            },
+            {
+                new Function<String, Record<Integer>>() {
+                    @Override
+                    public Record<Integer> process(String input, Context context) throws Exception {
+                        return null;
+                    }
+                }, false
+            },
+            {
+                new java.util.function.Function<String, Integer>() {
+                    @Override
+                    public Integer apply(String s) {
+                        return null;
+                    }
+                }, false
+            },
+            {
+                new java.util.function.Function<String, Record<Integer>>() {
+                    @Override
+                    public Record<Integer> apply(String s) {
+                        return null;
+                    }
+                }, false
+            },
+            {
+                new WindowFunction<String, Integer>() {
+                    @Override
+                    public Integer process(Collection<Record<String>> input, WindowContext context) throws Exception {
+                        return null;
+                    }
+                }, true
+            },
+            {
+                new java.util.function.Function<Collection<String>, Integer>() {
+                    @Override
+                    public Integer apply(Collection<String> strings) {
+                        return null;
+                    }
+                }, true
+            }
+        };
+    }
+
+    @Test(dataProvider = "function")
+    public void testGetFunctionTypes(Object function, boolean isWindowConfigPresent) {
+        Class<?>[] types = FunctionCommon.getFunctionTypes(function.getClass(), isWindowConfigPresent);
+        assertEquals(types.length, 2);
+        assertEquals(types[0], String.class);
+        assertEquals(types[1], Integer.class);
     }
 }

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/functions/PulsarFunctionsTest.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/functions/PulsarFunctionsTest.java
@@ -72,6 +72,7 @@ import org.apache.pulsar.functions.api.examples.AutoSchemaFunction;
 import org.apache.pulsar.functions.api.examples.AvroSchemaTestFunction;
 import org.apache.pulsar.functions.api.examples.MergeTopicFunction;
 import org.apache.pulsar.functions.api.examples.InitializableFunction;
+import org.apache.pulsar.functions.api.examples.RecordFunction;
 import org.apache.pulsar.functions.api.examples.pojo.AvroTestObject;
 import org.apache.pulsar.functions.api.examples.pojo.Users;
 import org.apache.pulsar.functions.api.examples.serde.CustomObject;
@@ -1706,6 +1707,66 @@ public abstract class PulsarFunctionsTest extends PulsarFunctionsTestBase {
                     i++;
                 }
             } while (message != null);
+        } finally {
+            pulsarCluster.dumpFunctionLogs(functionName);
+        }
+
+        deleteFunction(functionName);
+
+        getFunctionInfoNotFound(functionName);
+    }
+
+    protected void testRecordFunction() throws Exception {
+        log.info("start RecordFunction function test ...");
+
+        String ns = "public/ns-recordfunction-" + randomName(8);
+        @Cleanup
+        PulsarAdmin pulsarAdmin = getPulsarAdmin();
+        pulsarAdmin.namespaces().createNamespace(ns);
+
+        @Cleanup
+        PulsarClient pulsarClient = getPulsarClient();
+
+        final int numMessages = 10;
+        final String inputTopic = ns + "/test-string-input-" + randomName(8);
+        final String outputTopic = ns + "/test-string-output-" + randomName(8);
+        @Cleanup
+        Consumer<String> consumer = pulsarClient
+                .newConsumer(Schema.STRING)
+                .subscriptionName("test")
+                .subscriptionInitialPosition(SubscriptionInitialPosition.Earliest)
+                .topic("publishtopic")
+                .subscribe();
+
+        final String functionName = "test-record-fn-" + randomName(8);
+        submitFunction(
+                Runtime.JAVA,
+                inputTopic,
+                outputTopic,
+                functionName,
+                null,
+                RecordFunction.class.getName(),
+                Schema.AUTO_CONSUME());
+        try {
+            @Cleanup
+            Producer<String> producer = pulsarClient
+                    .newProducer(Schema.STRING)
+                    .topic(inputTopic)
+                    .create();
+            for (int i = 0; i < numMessages; i++) {
+                producer.send("message" + i);
+            }
+
+            getFunctionInfoSuccess(functionName);
+
+            getFunctionStatus(functionName, numMessages, true);
+
+            for (int i = 0; i < numMessages; i++) {
+                Message<String> msg = consumer.receive(30, TimeUnit.SECONDS);
+                log.info("Received: {}", msg.getValue());
+                assertEquals(msg.getValue(), "message" + i + "!");
+                assertEquals(msg.getProperty("input_topic"), "persistent://" + inputTopic);
+            }
         } finally {
             pulsarCluster.dumpFunctionLogs(functionName);
         }

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/functions/java/PulsarFunctionsJavaTest.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/functions/java/PulsarFunctionsJavaTest.java
@@ -165,7 +165,7 @@ public class PulsarFunctionsJavaTest extends PulsarFunctionsTest {
 
     @Test(groups = {"java_function", "function"})
     public void testMergeFunctionTest() throws Exception {
-	    testMergeFunction();
+        testMergeFunction();
     }
 
     @Test(groups = {"java_function", "function"})

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/functions/java/PulsarFunctionsJavaTest.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/functions/java/PulsarFunctionsJavaTest.java
@@ -166,7 +166,7 @@ public class PulsarFunctionsJavaTest extends PulsarFunctionsTest {
     @Test(groups = {"java_function", "function"})
     public void testMergeFunctionTest() throws Exception {
 	    testMergeFunction();
-   }
+    }
 
     @Test(groups = {"java_function", "function"})
     public void testGenericObjectFunction() throws Exception {
@@ -186,6 +186,11 @@ public class PulsarFunctionsJavaTest extends PulsarFunctionsTest {
     @Test(groups = {"java_function", "function"})
     public void testGenericObjectRemoveFiledFunctionKeyValue() throws Exception {
         testGenericObjectFunction(REMOVE_AVRO_FIELD_FUNCTION_JAVA_CLASS, true, true);
+    }
+
+    @Test(groups = {"java_function", "function"})
+    public void testRecordFunctionTest() throws Exception {
+        testRecordFunction();
     }
 
 }


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://docs.google.com/document/d/1d8Pw6ZbWk-_pCKdOmdvx9rnhPiyuxwq60_TrD68d7BA/edit#heading=h.trs9rsex3xom)*. 

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.

**(The sections below can be removed for hotfixes of typos)**
-->

### Motivation

Currently, when a user wants to dynamically set the output topic, the message properties or change the output schema in a Function, the only possibility is to create a Function that returns `Void` , use the Context and manually create a message with `Context::newOutputMessage`.  The [TypedMessageBuilderPublish](https://github.com/apache/pulsar/blob/master/pulsar-functions/java-examples/src/main/java/org/apache/pulsar/functions/api/examples/TypedMessageBuilderPublish.java) Function in `pulsar-functions-api-examples` shows how to do that.
This way of doing is not intuitive and it would be better to return a structure like `Record` that carries this info.

### Modifications

This PR adds support for returning `Record` in a Function.
* In `JavaInstanceRunnable::sendOutputMessage`, we check the type of the output object and if it's of type `Record` we create a `TargetSinkRecord` instead of a `SinkRecord`. `TargetSinkRecord` uses the info from the output record in the various Record methods that are used by the Sink when creating the output message.
* When registering the Function, in `getFunctionTypes`, if the output type is a Record, we get the wrapped type as type for the Sink.
* A utility method `newOutputRecordBuilder` is added to `Context` that returns a `FunctionRecord` builder initialized with the info from the source record. The builder methods can then be used to override these values as needed.
* A `RecordFunction` is added in the Function examples to demonstrate the use of this feature
* An integration test is added `PulsarFunctionsJavaTest`

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change added tests and can be verified as follows:

Run `PulsarFunctionsJavaTest:: testRecordFunctionTest `

### Does this pull request potentially affect one of the following parts:
yes

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API: (yes / no)
 Yes.
     - adds `Record<>` as a possible return type for Functions
     - adds a `newOutputRecordBuilder` method to `Context`

  - The schema: (yes / no / don't know)
  - The default values of configurations: (yes / no)
  - The wire protocol: (yes / no)
  - The rest endpoints: (yes / no)
  - The admin cli options: (yes / no)
  - Anything that affects deployment: (yes / no / don't know)

### Documentation

Check the box below or label this PR directly.

Need to update docs? 

- [x] `doc-required` 
(Your PR needs to update docs and you will update later)
  
- [ ] `doc-not-needed` 
(Please explain why)
  
- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)