### PR TITLE
[cleanup][proxy] Use correct address for HAProxyMessage destination

### DIFF
--- a/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/DirectProxyHandler.java
+++ b/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/DirectProxyHandler.java
@@ -247,7 +247,7 @@ public class DirectProxyHandler {
                 InetSocketAddress clientAddress = (InetSocketAddress) inboundChannel.remoteAddress();
                 String sourceAddress = clientAddress.getAddress().getHostAddress();
                 int sourcePort = clientAddress.getPort();
-                InetSocketAddress proxyAddress = (InetSocketAddress) inboundChannel.remoteAddress();
+                InetSocketAddress proxyAddress = (InetSocketAddress) outboundChannel.localAddress();
                 String destinationAddress = proxyAddress.getAddress().getHostAddress();
                 int destinationPort = proxyAddress.getPort();
                 HAProxyMessage msg = new HAProxyMessage(HAProxyProtocolVersion.V1, HAProxyCommand.PROXY,

--- a/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/DirectProxyHandler.java
+++ b/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/DirectProxyHandler.java
@@ -243,11 +243,11 @@ public class DirectProxyHandler {
                     .addListener(ChannelFutureListener.FIRE_EXCEPTION_ON_FAILURE);
         } else {
             if (inboundChannel.remoteAddress() instanceof InetSocketAddress
-                    && outboundChannel.localAddress() instanceof InetSocketAddress) {
+                    && inboundChannel.localAddress() instanceof InetSocketAddress) {
                 InetSocketAddress clientAddress = (InetSocketAddress) inboundChannel.remoteAddress();
                 String sourceAddress = clientAddress.getAddress().getHostAddress();
                 int sourcePort = clientAddress.getPort();
-                InetSocketAddress proxyAddress = (InetSocketAddress) outboundChannel.localAddress();
+                InetSocketAddress proxyAddress = (InetSocketAddress) inboundChannel.localAddress();
                 String destinationAddress = proxyAddress.getAddress().getHostAddress();
                 int destinationPort = proxyAddress.getPort();
                 HAProxyMessage msg = new HAProxyMessage(HAProxyProtocolVersion.V1, HAProxyCommand.PROXY,


### PR DESCRIPTION
### Motivation

When reading through the Proxy code, I noticed that the `remoteAddress` was used where it probably makes sense to use the `localAddress`.

After researching it a bit with the AWS docs https://docs.aws.amazon.com/elasticloadbalancing/latest/classic/enable-proxy-protocol.html and the protocol spec http://www.haproxy.org/download/1.8/doc/proxy-protocol.txt, I think this implementation is correct.

### Modifications

* Replace `inboundChannel.localAddress` with `inboundChannel.localAddress`.
* Fix type checking

- [x] `doc-not-needed`