### PR TITLE
[fix][doc] Add an import statement to the Java code sample for Oauth2

### DIFF
--- a/site2/docs/concepts-messaging.md
+++ b/site2/docs/concepts-messaging.md
@@ -868,7 +868,7 @@ There are diverse system topics depending on namespaces. The following table out
 | Namespace | TopicName | Domain | Count | Usage |
 |-----------|-----------|--------|-------|-------|
 | pulsar/system | `transaction_coordinator_assign_${id}` | Persistent | Default 16 | Transaction coordinator |
-| pulsar/system | `_transaction_log${tc_id}` | Persistent | Default 16 | Transaction log |
+| pulsar/system | `__transaction_log_${tc_id}` | Persistent | Default 16 | Transaction log |
 | pulsar/system | `resource-usage` | Non-persistent | Default 4 | Resource group service |
 | host/port | `heartbeat` | Persistent | 1 | Heartbeat detection |
 | User-defined-ns | [`__change_events`](concepts-multi-tenancy.md#namespace-change-events-and-topic-level-policies) | Persistent | Default 4 | Topic events |

--- a/site2/docs/security-oauth2.md
+++ b/site2/docs/security-oauth2.md
@@ -18,7 +18,7 @@ The authentication type determines how to obtain an access token through an OAut
 
 :::note
 
-Currently, the Pulsar Java client only supports the `client_credentials` authentication type .
+Currently, the Pulsar Java client only supports the `client_credentials` authentication type.
 
 :::
 
@@ -82,6 +82,8 @@ You can use the OAuth2 authentication provider with the following Pulsar clients
 You can use the factory method to configure authentication for Pulsar Java client.
 
 ```java
+
+import org.apache.pulsar.client.impl.auth.oauth2.AuthenticationFactoryOAuth2; 
 
 URL issuerUrl = new URL("https://dev-kt-aa9ne.us.auth0.com");
 URL credentialsUrl = new URL("file:///path/to/KeyFile.json");
@@ -213,7 +215,11 @@ This example shows how to configure OAuth2 authentication in Node.js client.
 
 ```
 
-> Note: The support for OAuth2 authentication is only available in Node.js client 1.6.2 and later versions.
+:::note
+
+The support for OAuth2 authentication is only available in Node.js client 1.6.2 and later versions.
+
+:::
 
 ## Broker configuration
 To enable OAuth2 authentication in brokers, add the following parameters to the `broker.conf` or `standalone.conf` file.
@@ -251,7 +257,7 @@ tenants list
 
 ```
 
-Set the `admin-url` parameter to the Web service URL. A Web service URLis a combination of the protocol, hostname and port ID, such as `pulsar://localhost:6650`.
+Set the `admin-url` parameter to the Web service URL. A Web service URL is a combination of the protocol, hostname and port ID, such as `pulsar://localhost:6650`.
 Set the `privateKey`, `issuerUrl`, and `audience` parameters to the values based on the configuration in the key file. For details, see [authentication types](#authentication-types).
 
 ### pulsar-client
@@ -270,7 +276,7 @@ produce test-topic -m "test-message" -n 10
 
 ```
 
-Set the `admin-url` parameter to the Web service URL. A Web service URLis a combination of the protocol, hostname and port ID, such as `pulsar://localhost:6650`.
+Set the `admin-url` parameter to the Web service URL. A Web service URL is a combination of the protocol, hostname and port ID, such as `pulsar://localhost:6650`.
 Set the `privateKey`, `issuerUrl`, and `audience` parameters to the values based on the configuration in the key file. For details, see [authentication types](#authentication-types).
 
 ### pulsar-perf
@@ -288,5 +294,5 @@ bin/pulsar-perf produce --service-url pulsar+ssl://streamnative.cloud:6651 \
 
 ```
 
-Set the `admin-url` parameter to the Web service URL. A Web service URLis a combination of the protocol, hostname and port ID, such as `pulsar://localhost:6650`.
+Set the `admin-url` parameter to the Web service URL. A Web service URL is a combination of the protocol, hostname and port ID, such as `pulsar://localhost:6650`.
 Set the `privateKey`, `issuerUrl`, and `audience` parameters to the values based on the configuration in the key file. For details, see [authentication types](#authentication-types).

--- a/site2/website/versioned_docs/version-2.10.0/security-oauth2.md
+++ b/site2/website/versioned_docs/version-2.10.0/security-oauth2.md
@@ -19,7 +19,7 @@ The authentication type determines how to obtain an access token through an OAut
 
 :::note
 
-Currently, the Pulsar Java client only supports the `client_credentials` authentication type .
+Currently, the Pulsar Java client only supports the `client_credentials` authentication type.
 
 :::
 
@@ -83,6 +83,8 @@ You can use the OAuth2 authentication provider with the following Pulsar clients
 You can use the factory method to configure authentication for Pulsar Java client.
 
 ```java
+
+import org.apache.pulsar.client.impl.auth.oauth2.AuthenticationFactoryOAuth2; 
 
 URL issuerUrl = new URL("https://dev-kt-aa9ne.us.auth0.com");
 URL credentialsUrl = new URL("file:///path/to/KeyFile.json");
@@ -214,7 +216,11 @@ This example shows how to configure OAuth2 authentication in Node.js client.
 
 ```
 
-> Note: The support for OAuth2 authentication is only available in Node.js client 1.6.2 and later versions.
+:::note
+
+The support for OAuth2 authentication is only available in Node.js client 1.6.2 and later versions.
+
+:::
 
 ## CLI configuration
 
@@ -235,7 +241,7 @@ tenants list
 
 ```
 
-Set the `admin-url` parameter to the Web service URL. A Web service URLis a combination of the protocol, hostname and port ID, such as `pulsar://localhost:6650`.
+Set the `admin-url` parameter to the Web service URL. A Web service URL is a combination of the protocol, hostname and port ID, such as `pulsar://localhost:6650`.
 Set the `privateKey`, `issuerUrl`, and `audience` parameters to the values based on the configuration in the key file. For details, see [authentication types](#authentication-types).
 
 ### pulsar-client
@@ -254,7 +260,7 @@ produce test-topic -m "test-message" -n 10
 
 ```
 
-Set the `admin-url` parameter to the Web service URL. A Web service URLis a combination of the protocol, hostname and port ID, such as `pulsar://localhost:6650`.
+Set the `admin-url` parameter to the Web service URL. A Web service URL is a combination of the protocol, hostname and port ID, such as `pulsar://localhost:6650`.
 Set the `privateKey`, `issuerUrl`, and `audience` parameters to the values based on the configuration in the key file. For details, see [authentication types](#authentication-types).
 
 ### pulsar-perf
@@ -272,5 +278,5 @@ bin/pulsar-perf produce --service-url pulsar+ssl://streamnative.cloud:6651 \
 
 ```
 
-Set the `admin-url` parameter to the Web service URL. A Web service URLis a combination of the protocol, hostname and port ID, such as `pulsar://localhost:6650`.
+Set the `admin-url` parameter to the Web service URL. A Web service URL is a combination of the protocol, hostname and port ID, such as `pulsar://localhost:6650`.
 Set the `privateKey`, `issuerUrl`, and `audience` parameters to the values based on the configuration in the key file. For details, see [authentication types](#authentication-types).

--- a/site2/website/versioned_docs/version-2.6.1/security-oauth2.md
+++ b/site2/website/versioned_docs/version-2.6.1/security-oauth2.md
@@ -18,7 +18,7 @@ This library allows you to authenticate the Pulsar client by using an access tok
 The authentication type determines how to obtain an access token through an OAuth 2.0 authorization flow.
 
 #### Note
-> Currently, the Pulsar Java client only supports the `client_credentials` authentication type .
+> Currently, the Pulsar Java client only supports the `client_credentials` authentication type.
 
 #### Client credentials
 
@@ -79,6 +79,8 @@ You can use the OAuth2 authentication provider with the following Pulsar clients
 You can use the factory method to configure authentication for Pulsar Java client.
 
 ```java
+
+import org.apache.pulsar.client.impl.auth.oauth2.AuthenticationFactoryOAuth2; 
 
 String issuerUrl = "https://dev-kt-aa9ne.us.auth0.com";
 String credentialsUrl = "file:///path/to/KeyFile.json";
@@ -165,7 +167,7 @@ tenants list
 
 ```
 
-Set the `admin-url` parameter to the Web service URL. A Web service URLis a combination of the protocol, hostname and port ID, such as `pulsar://localhost:6650`.
+Set the `admin-url` parameter to the Web service URL. A Web service URL is a combination of the protocol, hostname and port ID, such as `pulsar://localhost:6650`.
 Set the `privateKey`, `issuerUrl`, and `audience` parameters to the values based on the configuration in the key file. For details, see [authentication types](#authentication-types).
 
 ### pulsar-client
@@ -184,7 +186,7 @@ produce test-topic -m "test-message" -n 10
 
 ```
 
-Set the `admin-url` parameter to the Web service URL. A Web service URLis a combination of the protocol, hostname and port ID, such as `pulsar://localhost:6650`.
+Set the `admin-url` parameter to the Web service URL. A Web service URL is a combination of the protocol, hostname and port ID, such as `pulsar://localhost:6650`.
 Set the `privateKey`, `issuerUrl`, and `audience` parameters to the values based on the configuration in the key file. For details, see [authentication types](#authentication-types).
 
 ### pulsar-perf
@@ -202,5 +204,5 @@ bin/pulsar-perf produce --service-url pulsar+ssl://streamnative.cloud:6651 \
 
 ```
 
-Set the `admin-url` parameter to the Web service URL. A Web service URLis a combination of the protocol, hostname and port ID, such as `pulsar://localhost:6650`.
+Set the `admin-url` parameter to the Web service URL. A Web service URL is a combination of the protocol, hostname and port ID, such as `pulsar://localhost:6650`.
 Set the `privateKey`, `issuerUrl`, and `audience` parameters to the values based on the configuration in the key file. For details, see [authentication types](#authentication-types).

--- a/site2/website/versioned_docs/version-2.6.2/security-oauth2.md
+++ b/site2/website/versioned_docs/version-2.6.2/security-oauth2.md
@@ -18,7 +18,7 @@ This library allows you to authenticate the Pulsar client by using an access tok
 The authentication type determines how to obtain an access token through an OAuth 2.0 authorization flow.
 
 #### Note
-> Currently, the Pulsar Java client only supports the `client_credentials` authentication type .
+> Currently, the Pulsar Java client only supports the `client_credentials` authentication type.
 
 #### Client credentials
 
@@ -79,6 +79,8 @@ You can use the OAuth2 authentication provider with the following Pulsar clients
 You can use the factory method to configure authentication for Pulsar Java client.
 
 ```java
+
+import org.apache.pulsar.client.impl.auth.oauth2.AuthenticationFactoryOAuth2; 
 
 String issuerUrl = "https://dev-kt-aa9ne.us.auth0.com";
 String credentialsUrl = "file:///path/to/KeyFile.json";
@@ -165,7 +167,7 @@ tenants list
 
 ```
 
-Set the `admin-url` parameter to the Web service URL. A Web service URLis a combination of the protocol, hostname and port ID, such as `pulsar://localhost:6650`.
+Set the `admin-url` parameter to the Web service URL. A Web service URL is a combination of the protocol, hostname and port ID, such as `pulsar://localhost:6650`.
 Set the `privateKey`, `issuerUrl`, and `audience` parameters to the values based on the configuration in the key file. For details, see [authentication types](#authentication-types).
 
 ### pulsar-client
@@ -184,7 +186,7 @@ produce test-topic -m "test-message" -n 10
 
 ```
 
-Set the `admin-url` parameter to the Web service URL. A Web service URLis a combination of the protocol, hostname and port ID, such as `pulsar://localhost:6650`.
+Set the `admin-url` parameter to the Web service URL. A Web service URL is a combination of the protocol, hostname and port ID, such as `pulsar://localhost:6650`.
 Set the `privateKey`, `issuerUrl`, and `audience` parameters to the values based on the configuration in the key file. For details, see [authentication types](#authentication-types).
 
 ### pulsar-perf
@@ -202,5 +204,5 @@ bin/pulsar-perf produce --service-url pulsar+ssl://streamnative.cloud:6651 \
 
 ```
 
-Set the `admin-url` parameter to the Web service URL. A Web service URLis a combination of the protocol, hostname and port ID, such as `pulsar://localhost:6650`.
+Set the `admin-url` parameter to the Web service URL. A Web service URL is a combination of the protocol, hostname and port ID, such as `pulsar://localhost:6650`.
 Set the `privateKey`, `issuerUrl`, and `audience` parameters to the values based on the configuration in the key file. For details, see [authentication types](#authentication-types).

--- a/site2/website/versioned_docs/version-2.6.3/security-oauth2.md
+++ b/site2/website/versioned_docs/version-2.6.3/security-oauth2.md
@@ -18,7 +18,7 @@ This library allows you to authenticate the Pulsar client by using an access tok
 The authentication type determines how to obtain an access token through an OAuth 2.0 authorization flow.
 
 #### Note
-> Currently, the Pulsar Java client only supports the `client_credentials` authentication type .
+> Currently, the Pulsar Java client only supports the `client_credentials` authentication type.
 
 #### Client credentials
 
@@ -79,6 +79,8 @@ You can use the OAuth2 authentication provider with the following Pulsar clients
 You can use the factory method to configure authentication for Pulsar Java client.
 
 ```java
+
+import org.apache.pulsar.client.impl.auth.oauth2.AuthenticationFactoryOAuth2; 
 
 String issuerUrl = "https://dev-kt-aa9ne.us.auth0.com";
 String credentialsUrl = "file:///path/to/KeyFile.json";
@@ -165,7 +167,7 @@ tenants list
 
 ```
 
-Set the `admin-url` parameter to the Web service URL. A Web service URLis a combination of the protocol, hostname and port ID, such as `pulsar://localhost:6650`.
+Set the `admin-url` parameter to the Web service URL. A Web service URL is a combination of the protocol, hostname and port ID, such as `pulsar://localhost:6650`.
 Set the `privateKey`, `issuerUrl`, and `audience` parameters to the values based on the configuration in the key file. For details, see [authentication types](#authentication-types).
 
 ### pulsar-client
@@ -184,7 +186,7 @@ produce test-topic -m "test-message" -n 10
 
 ```
 
-Set the `admin-url` parameter to the Web service URL. A Web service URLis a combination of the protocol, hostname and port ID, such as `pulsar://localhost:6650`.
+Set the `admin-url` parameter to the Web service URL. A Web service URL is a combination of the protocol, hostname and port ID, such as `pulsar://localhost:6650`.
 Set the `privateKey`, `issuerUrl`, and `audience` parameters to the values based on the configuration in the key file. For details, see [authentication types](#authentication-types).
 
 ### pulsar-perf
@@ -202,5 +204,5 @@ bin/pulsar-perf produce --service-url pulsar+ssl://streamnative.cloud:6651 \
 
 ```
 
-Set the `admin-url` parameter to the Web service URL. A Web service URLis a combination of the protocol, hostname and port ID, such as `pulsar://localhost:6650`.
+Set the `admin-url` parameter to the Web service URL. A Web service URL is a combination of the protocol, hostname and port ID, such as `pulsar://localhost:6650`.
 Set the `privateKey`, `issuerUrl`, and `audience` parameters to the values based on the configuration in the key file. For details, see [authentication types](#authentication-types).

--- a/site2/website/versioned_docs/version-2.6.4/security-oauth2.md
+++ b/site2/website/versioned_docs/version-2.6.4/security-oauth2.md
@@ -18,7 +18,7 @@ This library allows you to authenticate the Pulsar client by using an access tok
 The authentication type determines how to obtain an access token through an OAuth 2.0 authorization flow.
 
 #### Note
-> Currently, the Pulsar Java client only supports the `client_credentials` authentication type .
+> Currently, the Pulsar Java client only supports the `client_credentials` authentication type.
 
 #### Client credentials
 
@@ -79,6 +79,8 @@ You can use the Oauth2 authentication provider with the following Pulsar clients
 You can use the factory method to configure authentication for Pulsar Java client.
 
 ```java
+
+import org.apache.pulsar.client.impl.auth.oauth2.AuthenticationFactoryOAuth2; 
 
 String issuerUrl = "https://dev-kt-aa9ne.us.auth0.com/oauth/token";
 String credentialsUrl = "file:///path/to/KeyFile.json";

--- a/site2/website/versioned_docs/version-2.7.0/security-oauth2.md
+++ b/site2/website/versioned_docs/version-2.7.0/security-oauth2.md
@@ -18,7 +18,7 @@ This library allows you to authenticate the Pulsar client by using an access tok
 The authentication type determines how to obtain an access token through an OAuth 2.0 authorization flow.
 
 #### Note
-> Currently, the Pulsar Java client only supports the `client_credentials` authentication type .
+> Currently, the Pulsar Java client only supports the `client_credentials` authentication type.
 
 #### Client credentials
 
@@ -79,6 +79,8 @@ You can use the OAuth2 authentication provider with the following Pulsar clients
 You can use the factory method to configure authentication for Pulsar Java client.
 
 ```java
+
+import org.apache.pulsar.client.impl.auth.oauth2.AuthenticationFactoryOAuth2; 
 
 String issuerUrl = "https://dev-kt-aa9ne.us.auth0.com";
 String credentialsUrl = "file:///path/to/KeyFile.json";

--- a/site2/website/versioned_docs/version-2.7.1/security-oauth2.md
+++ b/site2/website/versioned_docs/version-2.7.1/security-oauth2.md
@@ -18,7 +18,7 @@ This library allows you to authenticate the Pulsar client by using an access tok
 The authentication type determines how to obtain an access token through an OAuth 2.0 authorization flow.
 
 #### Note
-> Currently, the Pulsar Java client only supports the `client_credentials` authentication type .
+> Currently, the Pulsar Java client only supports the `client_credentials` authentication type.
 
 #### Client credentials
 
@@ -79,6 +79,8 @@ You can use the OAuth2 authentication provider with the following Pulsar clients
 You can use the factory method to configure authentication for Pulsar Java client.
 
 ```java
+
+import org.apache.pulsar.client.impl.auth.oauth2.AuthenticationFactoryOAuth2; 
 
 String issuerUrl = "https://dev-kt-aa9ne.us.auth0.com";
 String credentialsUrl = "file:///path/to/KeyFile.json";

--- a/site2/website/versioned_docs/version-2.7.2/security-oauth2.md
+++ b/site2/website/versioned_docs/version-2.7.2/security-oauth2.md
@@ -18,7 +18,7 @@ This library allows you to authenticate the Pulsar client by using an access tok
 The authentication type determines how to obtain an access token through an OAuth 2.0 authorization flow.
 
 #### Note
-> Currently, the Pulsar Java client only supports the `client_credentials` authentication type .
+> Currently, the Pulsar Java client only supports the `client_credentials` authentication type.
 
 #### Client credentials
 
@@ -79,6 +79,8 @@ You can use the OAuth2 authentication provider with the following Pulsar clients
 You can use the factory method to configure authentication for Pulsar Java client.
 
 ```java
+
+import org.apache.pulsar.client.impl.auth.oauth2.AuthenticationFactoryOAuth2; 
 
 String issuerUrl = "https://dev-kt-aa9ne.us.auth0.com";
 String credentialsUrl = "file:///path/to/KeyFile.json";
@@ -186,7 +188,7 @@ tenants list
 
 ```
 
-Set the `admin-url` parameter to the Web service URL. A Web service URLis a combination of the protocol, hostname and port ID, such as `pulsar://localhost:6650`.
+Set the `admin-url` parameter to the Web service URL. A Web service URL is a combination of the protocol, hostname and port ID, such as `pulsar://localhost:6650`.
 Set the `privateKey`, `issuerUrl`, and `audience` parameters to the values based on the configuration in the key file. For details, see [authentication types](#authentication-types).
 
 ### pulsar-client
@@ -205,7 +207,7 @@ produce test-topic -m "test-message" -n 10
 
 ```
 
-Set the `admin-url` parameter to the Web service URL. A Web service URLis a combination of the protocol, hostname and port ID, such as `pulsar://localhost:6650`.
+Set the `admin-url` parameter to the Web service URL. A Web service URL is a combination of the protocol, hostname and port ID, such as `pulsar://localhost:6650`.
 Set the `privateKey`, `issuerUrl`, and `audience` parameters to the values based on the configuration in the key file. For details, see [authentication types](#authentication-types).
 
 ### pulsar-perf
@@ -223,5 +225,5 @@ bin/pulsar-perf produce --service-url pulsar+ssl://streamnative.cloud:6651 \
 
 ```
 
-Set the `admin-url` parameter to the Web service URL. A Web service URLis a combination of the protocol, hostname and port ID, such as `pulsar://localhost:6650`.
+Set the `admin-url` parameter to the Web service URL. A Web service URL is a combination of the protocol, hostname and port ID, such as `pulsar://localhost:6650`.
 Set the `privateKey`, `issuerUrl`, and `audience` parameters to the values based on the configuration in the key file. For details, see [authentication types](#authentication-types).

--- a/site2/website/versioned_docs/version-2.7.3/security-oauth2.md
+++ b/site2/website/versioned_docs/version-2.7.3/security-oauth2.md
@@ -18,7 +18,7 @@ This library allows you to authenticate the Pulsar client by using an access tok
 The authentication type determines how to obtain an access token through an OAuth 2.0 authorization flow.
 
 #### Note
-> Currently, the Pulsar Java client only supports the `client_credentials` authentication type .
+> Currently, the Pulsar Java client only supports the `client_credentials` authentication type.
 
 #### Client credentials
 
@@ -79,6 +79,8 @@ You can use the OAuth2 authentication provider with the following Pulsar clients
 You can use the factory method to configure authentication for Pulsar Java client.
 
 ```java
+
+import org.apache.pulsar.client.impl.auth.oauth2.AuthenticationFactoryOAuth2; 
 
 String issuerUrl = "https://dev-kt-aa9ne.us.auth0.com";
 String credentialsUrl = "file:///path/to/KeyFile.json";
@@ -186,7 +188,7 @@ tenants list
 
 ```
 
-Set the `admin-url` parameter to the Web service URL. A Web service URLis a combination of the protocol, hostname and port ID, such as `pulsar://localhost:6650`.
+Set the `admin-url` parameter to the Web service URL. A Web service URL is a combination of the protocol, hostname and port ID, such as `pulsar://localhost:6650`.
 Set the `privateKey`, `issuerUrl`, and `audience` parameters to the values based on the configuration in the key file. For details, see [authentication types](#authentication-types).
 
 ### pulsar-client
@@ -205,7 +207,7 @@ produce test-topic -m "test-message" -n 10
 
 ```
 
-Set the `admin-url` parameter to the Web service URL. A Web service URLis a combination of the protocol, hostname and port ID, such as `pulsar://localhost:6650`.
+Set the `admin-url` parameter to the Web service URL. A Web service URL is a combination of the protocol, hostname and port ID, such as `pulsar://localhost:6650`.
 Set the `privateKey`, `issuerUrl`, and `audience` parameters to the values based on the configuration in the key file. For details, see [authentication types](#authentication-types).
 
 ### pulsar-perf
@@ -223,5 +225,5 @@ bin/pulsar-perf produce --service-url pulsar+ssl://streamnative.cloud:6651 \
 
 ```
 
-Set the `admin-url` parameter to the Web service URL. A Web service URLis a combination of the protocol, hostname and port ID, such as `pulsar://localhost:6650`.
+Set the `admin-url` parameter to the Web service URL. A Web service URL is a combination of the protocol, hostname and port ID, such as `pulsar://localhost:6650`.
 Set the `privateKey`, `issuerUrl`, and `audience` parameters to the values based on the configuration in the key file. For details, see [authentication types](#authentication-types).

--- a/site2/website/versioned_docs/version-2.7.4/security-oauth2.md
+++ b/site2/website/versioned_docs/version-2.7.4/security-oauth2.md
@@ -18,7 +18,7 @@ This library allows you to authenticate the Pulsar client by using an access tok
 The authentication type determines how to obtain an access token through an OAuth 2.0 authorization flow.
 
 #### Note
-> Currently, the Pulsar Java client only supports the `client_credentials` authentication type .
+> Currently, the Pulsar Java client only supports the `client_credentials` authentication type.
 
 #### Client credentials
 
@@ -79,6 +79,8 @@ You can use the OAuth2 authentication provider with the following Pulsar clients
 You can use the factory method to configure authentication for Pulsar Java client.
 
 ```java
+
+import org.apache.pulsar.client.impl.auth.oauth2.AuthenticationFactoryOAuth2; 
 
 String issuerUrl = "https://dev-kt-aa9ne.us.auth0.com";
 String credentialsUrl = "file:///path/to/KeyFile.json";
@@ -186,7 +188,7 @@ tenants list
 
 ```
 
-Set the `admin-url` parameter to the Web service URL. A Web service URLis a combination of the protocol, hostname and port ID, such as `pulsar://localhost:6650`.
+Set the `admin-url` parameter to the Web service URL. A Web service URL is a combination of the protocol, hostname and port ID, such as `pulsar://localhost:6650`.
 Set the `privateKey`, `issuerUrl`, and `audience` parameters to the values based on the configuration in the key file. For details, see [authentication types](#authentication-types).
 
 ### pulsar-client
@@ -205,7 +207,7 @@ produce test-topic -m "test-message" -n 10
 
 ```
 
-Set the `admin-url` parameter to the Web service URL. A Web service URLis a combination of the protocol, hostname and port ID, such as `pulsar://localhost:6650`.
+Set the `admin-url` parameter to the Web service URL. A Web service URL is a combination of the protocol, hostname and port ID, such as `pulsar://localhost:6650`.
 Set the `privateKey`, `issuerUrl`, and `audience` parameters to the values based on the configuration in the key file. For details, see [authentication types](#authentication-types).
 
 ### pulsar-perf
@@ -223,5 +225,5 @@ bin/pulsar-perf produce --service-url pulsar+ssl://streamnative.cloud:6651 \
 
 ```
 
-Set the `admin-url` parameter to the Web service URL. A Web service URLis a combination of the protocol, hostname and port ID, such as `pulsar://localhost:6650`.
+Set the `admin-url` parameter to the Web service URL. A Web service URL is a combination of the protocol, hostname and port ID, such as `pulsar://localhost:6650`.
 Set the `privateKey`, `issuerUrl`, and `audience` parameters to the values based on the configuration in the key file. For details, see [authentication types](#authentication-types).

--- a/site2/website/versioned_docs/version-2.8.0/security-oauth2.md
+++ b/site2/website/versioned_docs/version-2.8.0/security-oauth2.md
@@ -17,8 +17,11 @@ This library allows you to authenticate the Pulsar client by using an access tok
 
 The authentication type determines how to obtain an access token through an OAuth 2.0 authorization flow.
 
-#### Note
-> Currently, the Pulsar Java client only supports the `client_credentials` authentication type .
+:::note
+
+Currently, the Pulsar Java client only supports the `client_credentials` authentication type.
+
+:::
 
 #### Client credentials
 
@@ -79,6 +82,8 @@ You can use the OAuth2 authentication provider with the following Pulsar clients
 You can use the factory method to configure authentication for Pulsar Java client.
 
 ```java
+
+import org.apache.pulsar.client.impl.auth.oauth2.AuthenticationFactoryOAuth2; 
 
 String issuerUrl = "https://dev-kt-aa9ne.us.auth0.com";
 String credentialsUrl = "file:///path/to/KeyFile.json";
@@ -186,7 +191,7 @@ tenants list
 
 ```
 
-Set the `admin-url` parameter to the Web service URL. A Web service URLis a combination of the protocol, hostname and port ID, such as `pulsar://localhost:6650`.
+Set the `admin-url` parameter to the Web service URL. A Web service URL is a combination of the protocol, hostname and port ID, such as `pulsar://localhost:6650`.
 Set the `privateKey`, `issuerUrl`, and `audience` parameters to the values based on the configuration in the key file. For details, see [authentication types](#authentication-types).
 
 ### pulsar-client
@@ -205,7 +210,7 @@ produce test-topic -m "test-message" -n 10
 
 ```
 
-Set the `admin-url` parameter to the Web service URL. A Web service URLis a combination of the protocol, hostname and port ID, such as `pulsar://localhost:6650`.
+Set the `admin-url` parameter to the Web service URL. A Web service URL is a combination of the protocol, hostname and port ID, such as `pulsar://localhost:6650`.
 Set the `privateKey`, `issuerUrl`, and `audience` parameters to the values based on the configuration in the key file. For details, see [authentication types](#authentication-types).
 
 ### pulsar-perf
@@ -223,5 +228,5 @@ bin/pulsar-perf produce --service-url pulsar+ssl://streamnative.cloud:6651 \
 
 ```
 
-Set the `admin-url` parameter to the Web service URL. A Web service URLis a combination of the protocol, hostname and port ID, such as `pulsar://localhost:6650`.
+Set the `admin-url` parameter to the Web service URL. A Web service URL is a combination of the protocol, hostname and port ID, such as `pulsar://localhost:6650`.
 Set the `privateKey`, `issuerUrl`, and `audience` parameters to the values based on the configuration in the key file. For details, see [authentication types](#authentication-types).

--- a/site2/website/versioned_docs/version-2.8.1/security-oauth2.md
+++ b/site2/website/versioned_docs/version-2.8.1/security-oauth2.md
@@ -17,8 +17,11 @@ This library allows you to authenticate the Pulsar client by using an access tok
 
 The authentication type determines how to obtain an access token through an OAuth 2.0 authorization flow.
 
-#### Note
-> Currently, the Pulsar Java client only supports the `client_credentials` authentication type .
+:::note
+
+Currently, the Pulsar Java client only supports the `client_credentials` authentication type.
+
+:::
 
 #### Client credentials
 
@@ -79,6 +82,8 @@ You can use the OAuth2 authentication provider with the following Pulsar clients
 You can use the factory method to configure authentication for Pulsar Java client.
 
 ```java
+
+import org.apache.pulsar.client.impl.auth.oauth2.AuthenticationFactoryOAuth2; 
 
 String issuerUrl = "https://dev-kt-aa9ne.us.auth0.com";
 String credentialsUrl = "file:///path/to/KeyFile.json";
@@ -186,7 +191,7 @@ tenants list
 
 ```
 
-Set the `admin-url` parameter to the Web service URL. A Web service URLis a combination of the protocol, hostname and port ID, such as `pulsar://localhost:6650`.
+Set the `admin-url` parameter to the Web service URL. A Web service URL is a combination of the protocol, hostname and port ID, such as `pulsar://localhost:6650`.
 Set the `privateKey`, `issuerUrl`, and `audience` parameters to the values based on the configuration in the key file. For details, see [authentication types](#authentication-types).
 
 ### pulsar-client
@@ -205,7 +210,7 @@ produce test-topic -m "test-message" -n 10
 
 ```
 
-Set the `admin-url` parameter to the Web service URL. A Web service URLis a combination of the protocol, hostname and port ID, such as `pulsar://localhost:6650`.
+Set the `admin-url` parameter to the Web service URL. A Web service URL is a combination of the protocol, hostname and port ID, such as `pulsar://localhost:6650`.
 Set the `privateKey`, `issuerUrl`, and `audience` parameters to the values based on the configuration in the key file. For details, see [authentication types](#authentication-types).
 
 ### pulsar-perf
@@ -223,5 +228,5 @@ bin/pulsar-perf produce --service-url pulsar+ssl://streamnative.cloud:6651 \
 
 ```
 
-Set the `admin-url` parameter to the Web service URL. A Web service URLis a combination of the protocol, hostname and port ID, such as `pulsar://localhost:6650`.
+Set the `admin-url` parameter to the Web service URL. A Web service URL is a combination of the protocol, hostname and port ID, such as `pulsar://localhost:6650`.
 Set the `privateKey`, `issuerUrl`, and `audience` parameters to the values based on the configuration in the key file. For details, see [authentication types](#authentication-types).

--- a/site2/website/versioned_docs/version-2.8.2/security-oauth2.md
+++ b/site2/website/versioned_docs/version-2.8.2/security-oauth2.md
@@ -17,8 +17,11 @@ This library allows you to authenticate the Pulsar client by using an access tok
 
 The authentication type determines how to obtain an access token through an OAuth 2.0 authorization flow.
 
-#### Note
-> Currently, the Pulsar Java client only supports the `client_credentials` authentication type .
+:::note
+
+Currently, the Pulsar Java client only supports the `client_credentials` authentication type.
+
+:::
 
 #### Client credentials
 
@@ -79,6 +82,8 @@ You can use the OAuth2 authentication provider with the following Pulsar clients
 You can use the factory method to configure authentication for Pulsar Java client.
 
 ```java
+
+import org.apache.pulsar.client.impl.auth.oauth2.AuthenticationFactoryOAuth2; 
 
 String issuerUrl = "https://dev-kt-aa9ne.us.auth0.com";
 String credentialsUrl = "file:///path/to/KeyFile.json";
@@ -186,7 +191,7 @@ tenants list
 
 ```
 
-Set the `admin-url` parameter to the Web service URL. A Web service URLis a combination of the protocol, hostname and port ID, such as `pulsar://localhost:6650`.
+Set the `admin-url` parameter to the Web service URL. A Web service URL is a combination of the protocol, hostname and port ID, such as `pulsar://localhost:6650`.
 Set the `privateKey`, `issuerUrl`, and `audience` parameters to the values based on the configuration in the key file. For details, see [authentication types](#authentication-types).
 
 ### pulsar-client
@@ -205,7 +210,7 @@ produce test-topic -m "test-message" -n 10
 
 ```
 
-Set the `admin-url` parameter to the Web service URL. A Web service URLis a combination of the protocol, hostname and port ID, such as `pulsar://localhost:6650`.
+Set the `admin-url` parameter to the Web service URL. A Web service URL is a combination of the protocol, hostname and port ID, such as `pulsar://localhost:6650`.
 Set the `privateKey`, `issuerUrl`, and `audience` parameters to the values based on the configuration in the key file. For details, see [authentication types](#authentication-types).
 
 ### pulsar-perf
@@ -223,5 +228,5 @@ bin/pulsar-perf produce --service-url pulsar+ssl://streamnative.cloud:6651 \
 
 ```
 
-Set the `admin-url` parameter to the Web service URL. A Web service URLis a combination of the protocol, hostname and port ID, such as `pulsar://localhost:6650`.
+Set the `admin-url` parameter to the Web service URL. A Web service URL is a combination of the protocol, hostname and port ID, such as `pulsar://localhost:6650`.
 Set the `privateKey`, `issuerUrl`, and `audience` parameters to the values based on the configuration in the key file. For details, see [authentication types](#authentication-types).

--- a/site2/website/versioned_docs/version-2.8.3/security-oauth2.md
+++ b/site2/website/versioned_docs/version-2.8.3/security-oauth2.md
@@ -17,8 +17,11 @@ This library allows you to authenticate the Pulsar client by using an access tok
 
 The authentication type determines how to obtain an access token through an OAuth 2.0 authorization flow.
 
-#### Note
-> Currently, the Pulsar Java client only supports the `client_credentials` authentication type .
+:::note
+
+Currently, the Pulsar Java client only supports the `client_credentials` authentication type.
+
+:::
 
 #### Client credentials
 
@@ -79,6 +82,8 @@ You can use the OAuth2 authentication provider with the following Pulsar clients
 You can use the factory method to configure authentication for Pulsar Java client.
 
 ```java
+
+import org.apache.pulsar.client.impl.auth.oauth2.AuthenticationFactoryOAuth2; 
 
 String issuerUrl = "https://dev-kt-aa9ne.us.auth0.com";
 String credentialsUrl = "file:///path/to/KeyFile.json";
@@ -186,7 +191,7 @@ tenants list
 
 ```
 
-Set the `admin-url` parameter to the Web service URL. A Web service URLis a combination of the protocol, hostname and port ID, such as `pulsar://localhost:6650`.
+Set the `admin-url` parameter to the Web service URL. A Web service URL is a combination of the protocol, hostname and port ID, such as `pulsar://localhost:6650`.
 Set the `privateKey`, `issuerUrl`, and `audience` parameters to the values based on the configuration in the key file. For details, see [authentication types](#authentication-types).
 
 ### pulsar-client
@@ -205,7 +210,7 @@ produce test-topic -m "test-message" -n 10
 
 ```
 
-Set the `admin-url` parameter to the Web service URL. A Web service URLis a combination of the protocol, hostname and port ID, such as `pulsar://localhost:6650`.
+Set the `admin-url` parameter to the Web service URL. A Web service URL is a combination of the protocol, hostname and port ID, such as `pulsar://localhost:6650`.
 Set the `privateKey`, `issuerUrl`, and `audience` parameters to the values based on the configuration in the key file. For details, see [authentication types](#authentication-types).
 
 ### pulsar-perf
@@ -223,5 +228,5 @@ bin/pulsar-perf produce --service-url pulsar+ssl://streamnative.cloud:6651 \
 
 ```
 
-Set the `admin-url` parameter to the Web service URL. A Web service URLis a combination of the protocol, hostname and port ID, such as `pulsar://localhost:6650`.
+Set the `admin-url` parameter to the Web service URL. A Web service URL is a combination of the protocol, hostname and port ID, such as `pulsar://localhost:6650`.
 Set the `privateKey`, `issuerUrl`, and `audience` parameters to the values based on the configuration in the key file. For details, see [authentication types](#authentication-types).

--- a/site2/website/versioned_docs/version-2.9.0/security-oauth2.md
+++ b/site2/website/versioned_docs/version-2.9.0/security-oauth2.md
@@ -17,8 +17,11 @@ This library allows you to authenticate the Pulsar client by using an access tok
 
 The authentication type determines how to obtain an access token through an OAuth 2.0 authorization flow.
 
-#### Note
-> Currently, the Pulsar Java client only supports the `client_credentials` authentication type .
+:::note
+
+Currently, the Pulsar Java client only supports the `client_credentials` authentication type.
+
+:::
 
 #### Client credentials
 
@@ -79,6 +82,8 @@ You can use the OAuth2 authentication provider with the following Pulsar clients
 You can use the factory method to configure authentication for Pulsar Java client.
 
 ```java
+
+import org.apache.pulsar.client.impl.auth.oauth2.AuthenticationFactoryOAuth2; 
 
 URL issuerUrl = new URL("https://dev-kt-aa9ne.us.auth0.com");
 URL credentialsUrl = new URL("file:///path/to/KeyFile.json");
@@ -186,7 +191,7 @@ tenants list
 
 ```
 
-Set the `admin-url` parameter to the Web service URL. A Web service URLis a combination of the protocol, hostname and port ID, such as `pulsar://localhost:6650`.
+Set the `admin-url` parameter to the Web service URL. A Web service URL is a combination of the protocol, hostname and port ID, such as `pulsar://localhost:6650`.
 Set the `privateKey`, `issuerUrl`, and `audience` parameters to the values based on the configuration in the key file. For details, see [authentication types](#authentication-types).
 
 ### pulsar-client
@@ -205,7 +210,7 @@ produce test-topic -m "test-message" -n 10
 
 ```
 
-Set the `admin-url` parameter to the Web service URL. A Web service URLis a combination of the protocol, hostname and port ID, such as `pulsar://localhost:6650`.
+Set the `admin-url` parameter to the Web service URL. A Web service URL is a combination of the protocol, hostname and port ID, such as `pulsar://localhost:6650`.
 Set the `privateKey`, `issuerUrl`, and `audience` parameters to the values based on the configuration in the key file. For details, see [authentication types](#authentication-types).
 
 ### pulsar-perf
@@ -223,5 +228,5 @@ bin/pulsar-perf produce --service-url pulsar+ssl://streamnative.cloud:6651 \
 
 ```
 
-Set the `admin-url` parameter to the Web service URL. A Web service URLis a combination of the protocol, hostname and port ID, such as `pulsar://localhost:6650`.
+Set the `admin-url` parameter to the Web service URL. A Web service URL is a combination of the protocol, hostname and port ID, such as `pulsar://localhost:6650`.
 Set the `privateKey`, `issuerUrl`, and `audience` parameters to the values based on the configuration in the key file. For details, see [authentication types](#authentication-types).

--- a/site2/website/versioned_docs/version-2.9.1/security-oauth2.md
+++ b/site2/website/versioned_docs/version-2.9.1/security-oauth2.md
@@ -17,8 +17,11 @@ This library allows you to authenticate the Pulsar client by using an access tok
 
 The authentication type determines how to obtain an access token through an OAuth 2.0 authorization flow.
 
-#### Note
-> Currently, the Pulsar Java client only supports the `client_credentials` authentication type .
+:::note
+
+Currently, the Pulsar Java client only supports the `client_credentials` authentication type.
+
+:::
 
 #### Client credentials
 
@@ -79,6 +82,8 @@ You can use the OAuth2 authentication provider with the following Pulsar clients
 You can use the factory method to configure authentication for Pulsar Java client.
 
 ```java
+
+import org.apache.pulsar.client.impl.auth.oauth2.AuthenticationFactoryOAuth2;
 
 URL issuerUrl = new URL("https://dev-kt-aa9ne.us.auth0.com");
 URL credentialsUrl = new URL("file:///path/to/KeyFile.json");
@@ -186,7 +191,7 @@ tenants list
 
 ```
 
-Set the `admin-url` parameter to the Web service URL. A Web service URLis a combination of the protocol, hostname and port ID, such as `pulsar://localhost:6650`.
+Set the `admin-url` parameter to the Web service URL. A Web service URL is a combination of the protocol, hostname and port ID, such as `pulsar://localhost:6650`.
 Set the `privateKey`, `issuerUrl`, and `audience` parameters to the values based on the configuration in the key file. For details, see [authentication types](#authentication-types).
 
 ### pulsar-client
@@ -205,7 +210,7 @@ produce test-topic -m "test-message" -n 10
 
 ```
 
-Set the `admin-url` parameter to the Web service URL. A Web service URLis a combination of the protocol, hostname and port ID, such as `pulsar://localhost:6650`.
+Set the `admin-url` parameter to the Web service URL. A Web service URL is a combination of the protocol, hostname and port ID, such as `pulsar://localhost:6650`.
 Set the `privateKey`, `issuerUrl`, and `audience` parameters to the values based on the configuration in the key file. For details, see [authentication types](#authentication-types).
 
 ### pulsar-perf
@@ -223,5 +228,5 @@ bin/pulsar-perf produce --service-url pulsar+ssl://streamnative.cloud:6651 \
 
 ```
 
-Set the `admin-url` parameter to the Web service URL. A Web service URLis a combination of the protocol, hostname and port ID, such as `pulsar://localhost:6650`.
+Set the `admin-url` parameter to the Web service URL. A Web service URL is a combination of the protocol, hostname and port ID, such as `pulsar://localhost:6650`.
 Set the `privateKey`, `issuerUrl`, and `audience` parameters to the values based on the configuration in the key file. For details, see [authentication types](#authentication-types).

--- a/site2/website/versioned_docs/version-2.9.2/security-oauth2.md
+++ b/site2/website/versioned_docs/version-2.9.2/security-oauth2.md
@@ -17,8 +17,11 @@ This library allows you to authenticate the Pulsar client by using an access tok
 
 The authentication type determines how to obtain an access token through an OAuth 2.0 authorization flow.
 
-#### Note
-> Currently, the Pulsar Java client only supports the `client_credentials` authentication type .
+:::note
+
+Currently, the Pulsar Java client only supports the `client_credentials` authentication type.
+
+:::
 
 #### Client credentials
 
@@ -79,6 +82,8 @@ You can use the OAuth2 authentication provider with the following Pulsar clients
 You can use the factory method to configure authentication for Pulsar Java client.
 
 ```java
+
+import org.apache.pulsar.client.impl.auth.oauth2.AuthenticationFactoryOAuth2; 
 
 URL issuerUrl = new URL("https://dev-kt-aa9ne.us.auth0.com");
 URL credentialsUrl = new URL("file:///path/to/KeyFile.json");
@@ -186,7 +191,7 @@ tenants list
 
 ```
 
-Set the `admin-url` parameter to the Web service URL. A Web service URLis a combination of the protocol, hostname and port ID, such as `pulsar://localhost:6650`.
+Set the `admin-url` parameter to the Web service URL. A Web service URL is a combination of the protocol, hostname and port ID, such as `pulsar://localhost:6650`.
 Set the `privateKey`, `issuerUrl`, and `audience` parameters to the values based on the configuration in the key file. For details, see [authentication types](#authentication-types).
 
 ### pulsar-client
@@ -205,7 +210,7 @@ produce test-topic -m "test-message" -n 10
 
 ```
 
-Set the `admin-url` parameter to the Web service URL. A Web service URLis a combination of the protocol, hostname and port ID, such as `pulsar://localhost:6650`.
+Set the `admin-url` parameter to the Web service URL. A Web service URL is a combination of the protocol, hostname and port ID, such as `pulsar://localhost:6650`.
 Set the `privateKey`, `issuerUrl`, and `audience` parameters to the values based on the configuration in the key file. For details, see [authentication types](#authentication-types).
 
 ### pulsar-perf
@@ -223,5 +228,5 @@ bin/pulsar-perf produce --service-url pulsar+ssl://streamnative.cloud:6651 \
 
 ```
 
-Set the `admin-url` parameter to the Web service URL. A Web service URLis a combination of the protocol, hostname and port ID, such as `pulsar://localhost:6650`.
+Set the `admin-url` parameter to the Web service URL. A Web service URL is a combination of the protocol, hostname and port ID, such as `pulsar://localhost:6650`.
 Set the `privateKey`, `issuerUrl`, and `audience` parameters to the values based on the configuration in the key file. For details, see [authentication types](#authentication-types).


### PR DESCRIPTION

### Modifications

1. Add an import statement to the Java code sample for Oauth2, and apply it to more historical versions in maintenance.
2. Correct the system topic name `__transaction_log_${tc_id}` added in #14795.

The preview looks good.
<img width="1750" alt="image" src="https://user-images.githubusercontent.com/60642177/173517837-6cfd686f-240b-4997-8b5e-64a3a72d9c7f.png">

### Documentation

- [x] `doc` 
