### PR TITLE
[fix][doc] make the JDK version consistent in readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ required plugins.
 1. Open Maven Importing Settings dialog by going to 
    **Settings** -> **Build, Execution, Deployment** -> **Build Tools** -> **Maven** -> **Importing**.
 
-2. Choose **Use Project JDK** for **JDK for Importer** setting. This uses the Java 11 JDK for running Maven 
+2. Choose **Use Project JDK** for **JDK for Importer** setting. This uses the Java 17 JDK for running Maven 
    when importing the project to IntelliJ. Some of the configuration in the Maven build is conditional based on 
    the JDK version. Incorrect configuration gets chosen when the "JDK for Importer" isn't the same as the "Project JDK".
 


### PR DESCRIPTION
Fixes #16052 

### Motivation
The [README.md](https://github.com/apache/pulsar/blob/master/README.md#configure-java-version-for-maven-in-intellij) explains how to configure JDK version for maven, and says the purpose is "uses the Java 11 JDK for running Maven when importing the project to IntelliJ"; However, use project JDK will leverage JDK 17 instead of JDK 11, the project jdk version should be 17 in the context.

### Modifications
Change the version to 17 to make it consistent within README.md


### Verifying this change

- [X] Make sure that the change passes the CI checks.
This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:
  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: ( no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

Check the box below or label this PR directly.

Need to update docs? 

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)
  
- [ ] `doc-not-needed` 
(Please explain why)
  
- [X] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)