### PR TITLE
[improve][broker] add switch for enable/disable distribute bundles evenly in LoadManager

### DIFF
--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -1991,6 +1991,14 @@ public class ServiceConfiguration implements PulsarConfiguration {
             + " should be offload from some over-loaded broker to other under-loaded brokers"
     )
     private int loadBalancerSheddingIntervalMinutes = 1;
+
+    @FieldContext(
+            dynamic = true,
+            category = CATEGORY_LOAD_BALANCER,
+            doc = "enable/disable distribute bundles evenly"
+    )
+    private boolean loadBalancerDistributeBundlesEvenlyEnabled = true;
+
     @FieldContext(
         category = CATEGORY_LOAD_BALANCER,
         dynamic = true,

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/ModularLoadManagerImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/ModularLoadManagerImpl.java
@@ -828,10 +828,17 @@ public class ModularLoadManagerImpl implements ModularLoadManager {
                 LoadManagerShared.filterAntiAffinityGroupOwnedBrokers(pulsar, serviceUnit.toString(),
                         brokerCandidateCache,
                         brokerToNamespaceToBundleRange, brokerToFailureDomainMap);
-                // distribute bundles evenly to candidate-brokers
 
-                LoadManagerShared.removeMostServicingBrokersForNamespace(serviceUnit.toString(), brokerCandidateCache,
-                        brokerToNamespaceToBundleRange);
+                // distribute bundles evenly to candidate-brokers if enable
+                if (conf.isLoadBalancerDistributeBundlesEvenlyEnabled()) {
+                    LoadManagerShared.removeMostServicingBrokersForNamespace(serviceUnit.toString(),
+                            brokerCandidateCache,
+                            brokerToNamespaceToBundleRange);
+                    if (log.isDebugEnabled()) {
+                        log.debug("enable distribute bundles evenly to candidate-brokers, broker candidate count={}",
+                                brokerCandidateCache.size());
+                    }
+                }
                 log.info("{} brokers being considered for assignment of {}", brokerCandidateCache.size(), bundle);
 
                 // Use the filter pipeline to finalize broker candidates.


### PR DESCRIPTION
### Motivation
When we use `ModualLoadManager` as `LoadManager` in the pulsar cluster, and the load balancer shedding strategy is `ThresholdShedder`, we found that the unloaded bundles might be loaded by another broker which has resource usage above average load, and make the new broker be overloaded again, which frequently causes unloading bundles.
```
loadManagerClassName=org.apache.pulsar.broker.loadbalance.impl.ModularLoadManagerImpl
loadBalancerLoadSheddingStrategy=org.apache.pulsar.broker.loadbalance.impl.ThresholdShedder
loadBalancerBrokerThresholdShedderPercentage=10
```
We found that it tooks more than 10 hours and 400+ times to doing load shedding  in the cluster. And the cluster continue to unload bundles when some of topics are lots of traffic  in a short time. Below is the unload metric.
<img width="826" alt="image" src="https://user-images.githubusercontent.com/4970972/173722942-669971c4-51b4-4d59-b954-99a34e4f517d.png">
<img width="813" alt="image" src="https://user-images.githubusercontent.com/4970972/173723061-2c4d2758-33e4-4e92-8e27-8c3528b9eaf1.png">



The key reason is that some brokers with lower load  but more bundles can not be candidate due to distributing bundles evenly in LoadManager by force. Most of brokers are filtered out by the strategy, only 1 or 2 brokers can be candidate in the total 136 brokers as follows.
<img width="1186" alt="image" src="https://user-images.githubusercontent.com/4970972/173603516-2efefae4-d22b-445c-9414-6744d22e0323.png">

It could be much better to disable distribute bundles evenly in `LoadManager`, which can select the broker from those having resource usage below average load, so it can prevent the least loaded broker from quickly becoming heavily loaded.

Therefore, it recommend that enable distribute bundles evenly among all brokers by customers according to user scenarios .

After disabling distribute bundles evenly in `LoadManager`, the brokers with lower load but more bunldes can be candidate. It reduced the unload times and the cluster is stable with even load on each broker as follows.
<img width="1659" alt="image" src="https://user-images.githubusercontent.com/4970972/173613270-e79e7bdb-204e-4834-b98a-7f4980a54134.png">
<img width="1631" alt="image" src="https://user-images.githubusercontent.com/4970972/173613418-9bd41b73-1b79-4cac-b6b6-3b7cc772f743.png">

### Modifications
- Add a field property `loadBalancerDistributeBundlesEvenlyEnabled` for Load Balancer in `ServiceConfiguration`, keep it to be true as default.
- Add a switch to enable distribute bundles evenly in `ModularLoadManager`

### Verifying this change

- [x]  Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.
### Does this pull request potentially affect one of the following parts:

If `yes` was chosen, please highlight the changes

- Dependencies (does it add or upgrade a dependency): (no)
- The public API: (no)
- The schema: (no)
- The default values of configurations: (no)
- The wire protocol: (no)
- The rest endpoints: (no)
- The admin cli options: (no)
- Anything that affects deployment: (no)

### Documentation
Check the box below and label this PR (if you have committer privilege).

Need to update docs? 
- [x] `no-need-doc` 

- [x] `doc-not-needed`
