### PR TITLE
[fix][workflow] Support concurrency group and reusable workflow files in docbot

### DIFF
--- a/.github/workflows/ci-documentbot.yml
+++ b/.github/workflows/ci-documentbot.yml
@@ -27,6 +27,10 @@ on:
       - labeled
       - unlabeled
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   label:
     if: ${{ github.repository == 'apache/pulsar' }}

--- a/.github/workflows/ci-documentbot.yml
+++ b/.github/workflows/ci-documentbot.yml
@@ -50,7 +50,7 @@ jobs:
           go-version: 1.18
 
       - name: Labeling
-        uses: apache/pulsar-test-infra/docbot@master
+        uses: ./docbot
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           LABEL_WATCH_LIST: 'doc,doc-required,doc-not-needed,doc-complete'


### PR DESCRIPTION
Fixes #16046

### Motivation

Multiple workflows can be running concurrently while `labeled` event triggered instantly after `opened` event before the docbot workflow is running.

This scenario will cause an inconsistent state of action and confused results.

### Modifications

Added [`concurrency`](https://docs.github.com/en/actions/using-jobs/using-concurrency)

- `concurrency.group` means workflow using the same concurrency group will be pending
- `concurrency.cancel-in-progress` will cancel any currently running job or workflow in the same concurrency group. This option can resolve the inconsistent state issue.

### Tests
The demo can be found at https://github.com/open-github/pulsar/pull/12

![docbot-concurrency](https://user-images.githubusercontent.com/15963141/173613129-984b2d07-ddc6-4f65-a787-228880704919.gif)

And the workflow status

<img width="935" alt="image" src="https://user-images.githubusercontent.com/15963141/173613609-643b9163-eb16-4125-8cfa-1f58aecd499d.png">
