### PR TITLE
[feature][broker] PIP 37: Support chunking with Shared subscription

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractBaseDispatcher.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractBaseDispatcher.java
@@ -100,7 +100,7 @@ public abstract class AbstractBaseDispatcher implements Dispatcher {
     public int filterEntriesForConsumer(List<Entry> entries, EntryBatchSizes batchSizes,
             SendMessageInfo sendMessageInfo, EntryBatchIndexesAcks indexesAcks,
             ManagedCursor cursor, boolean isReplayRead, Consumer consumer) {
-        return filterEntriesForConsumer(Optional.empty(), 0, entries, batchSizes, sendMessageInfo, indexesAcks, cursor,
+        return filterEntriesForConsumer(Optional.empty(), entries, batchSizes, sendMessageInfo, indexesAcks, cursor,
                 isReplayRead, consumer);
     }
 
@@ -108,13 +108,12 @@ public abstract class AbstractBaseDispatcher implements Dispatcher {
     /**
      * Filter entries with prefetched message metadata range so that there is no need to peek metadata from Entry.
      *
-     * @param optMetadataArray the optional message metadata array
-     * @param startOffset the index in `optMetadataArray` of the first Entry's message metadata
+     * @param optMetadataList optional message metadata list
      *
      * @see AbstractBaseDispatcher#filterEntriesForConsumer(List, EntryBatchSizes, SendMessageInfo,
      *   EntryBatchIndexesAcks, ManagedCursor, boolean, Consumer)
      */
-    public int filterEntriesForConsumer(Optional<MessageMetadata[]> optMetadataArray, int startOffset,
+    public int filterEntriesForConsumer(Optional<List<MessageMetadata>> optMetadataList,
              List<Entry> entries, EntryBatchSizes batchSizes, SendMessageInfo sendMessageInfo,
              EntryBatchIndexesAcks indexesAcks, ManagedCursor cursor, boolean isReplayRead, Consumer consumer) {
         int totalMessages = 0;
@@ -129,8 +128,8 @@ public abstract class AbstractBaseDispatcher implements Dispatcher {
                 continue;
             }
             ByteBuf metadataAndPayload = entry.getDataBuffer();
-            final int metadataIndex = i + startOffset;
-            final MessageMetadata msgMetadata = optMetadataArray.map(metadataArray -> metadataArray[metadataIndex])
+            final int index = i;
+            final MessageMetadata msgMetadata = optMetadataList.map(metadataList -> metadataList.get(index))
                     .orElseGet(() -> Commands.peekMessageMetadata(metadataAndPayload, subscription.toString(), -1));
             if (CollectionUtils.isNotEmpty(entryFilters)) {
                 fillContext(filterContext, msgMetadata, subscription, consumer);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/EntryAndMetadataList.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/EntryAndMetadataList.java
@@ -1,0 +1,144 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.service;
+
+import com.google.common.annotations.VisibleForTesting;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import lombok.Getter;
+import org.apache.bookkeeper.mledger.Entry;
+import org.apache.pulsar.common.api.proto.MessageMetadata;
+import org.apache.pulsar.common.protocol.Commands;
+
+@Getter
+public class EntryAndMetadataList {
+
+    private List<Entry> entries;
+    private List<MessageMetadata> metadataList;
+    @Getter
+    private int watermark;
+
+    public EntryAndMetadataList(final List<Entry> entries, final String subscription) {
+        this(entries, entries.stream()
+                .map(e -> Commands.peekAndCopyMessageMetadata(e.getDataBuffer(), subscription, -1))
+                .collect(Collectors.toList()));
+    }
+
+    @VisibleForTesting
+    EntryAndMetadataList(final List<Entry> entries, final List<MessageMetadata> metadataList) {
+        this.entries = entries;
+        this.metadataList = metadataList;
+        this.watermark = entries.size();
+    }
+
+    public int size() {
+        return entries.size();
+    }
+
+    /**
+     * it will sort the entries to make all chunks of the same message consistent in distribution.
+     *
+     * For example, if the original entries are:
+     *   M0, M1-C0, M2, M3, M1-C1, M4
+     * where M1 is a chunked message that has 2 chunks (C0 and C1).
+     * We should sort them to:
+     *   M0, M2, M3, M1-C0, M1-C1, M4
+     */
+    public void sortChunks() {
+        boolean hasChunks = metadataList.stream().anyMatch(MessageMetadata::hasUuid);
+        if (!hasChunks) {
+            watermark = metadataList.size();
+            return;
+        }
+        final Map<String, List<Integer>> uuidToIndexes = new HashMap<>();
+        final List<Entry> sortedEntries = new ArrayList<>();
+        final List<MessageMetadata> sortedMetadataList = new ArrayList<>();
+        for (int i = 0; i < entries.size(); i++) {
+            final MessageMetadata metadata = metadataList.get(i);
+            if (metadata == null) {
+                continue;
+            }
+            if (metadata.hasUuid()) {
+                final String uuid = metadata.getUuid();
+                final List<Integer> indexes = uuidToIndexes.computeIfAbsent(uuid, __ -> new ArrayList<>());
+                indexes.add(i);
+                if (metadata.getChunkId() + 1 == metadata.getNumChunksFromMsg()) {
+                    indexes.forEach(index -> {
+                        sortedEntries.add(entries.get(index));
+                        sortedMetadataList.add(metadataList.get(index));
+                    });
+                    uuidToIndexes.remove(uuid);
+                }
+            } else {
+                sortedEntries.add(entries.get(i));
+                sortedMetadataList.add(metadata);
+            }
+        }
+        watermark = sortedEntries.size();
+        // Process all incomplete chunks
+        uuidToIndexes.values().forEach(indexes -> {
+            indexes.forEach(index -> {
+                sortedEntries.add(entries.get(index));
+                sortedMetadataList.add(metadataList.get(index));
+            });
+        });
+        entries = sortedEntries;
+        metadataList = sortedMetadataList;
+    }
+
+    // NOTE: it must be called after sortChunks() to ensure chunks of the same message are distributed consistently.
+    public boolean containIncompleteChunks(int start, int end) {
+        String currentUuid = null;
+        Optional<Boolean> optIsLastChunk = Optional.empty();
+        for (int i = start; i < end; i++) {
+            final MessageMetadata metadata = metadataList.get(i);
+            if (metadata == null) {
+                continue;
+            }
+            if (metadata.hasUuid()) {
+                final String uuid = metadata.getUuid();
+                if (!uuid.equals(currentUuid)) {
+                    if (metadata.getChunkId() != 0) {
+                        return true;
+                    }
+                    if (optIsLastChunk.isPresent() && !optIsLastChunk.get()) {
+                        return true;
+                    }
+                    currentUuid = uuid;
+                }
+                optIsLastChunk = Optional.of(metadata.getChunkId() == metadata.getNumChunksFromMsg() - 1);
+            } else if (currentUuid != null) {
+                if (!optIsLastChunk.get()) {
+                    return true;
+                }
+            }
+        }
+        if (optIsLastChunk.isEmpty()) {
+            // There are no chunks
+            return false;
+        } else {
+            // Verify the last entry
+            return !optIsLastChunk.get();
+        }
+    }
+}

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/EntryAndMetadataList.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/EntryAndMetadataList.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pulsar.broker.service;
 
+import java.io.Closeable;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -29,82 +30,57 @@ import org.apache.pulsar.common.api.proto.MessageMetadata;
 import org.apache.pulsar.common.protocol.Commands;
 
 @Getter
-public class EntryAndMetadataList {
+public class EntryAndMetadataList implements Closeable {
 
+    private final List<IntRange> chunkIndexRanges = new ArrayList<>();
     private List<Entry> entries;
     private List<MessageMetadata> metadataList;
     private int watermark;
-    private boolean hasChunks;
 
+    /**
+     * It will first parse the metadata into the metadata list and then sort the entries and metadata list.
+     *
+     * The sort operation is performed to make all chunks of the same message consistent in distribution.
+     *
+     * All incomplete chunks, i.e. chunks whose message has N chunks but less than N chunks are received, will be put at
+     * the end. And the `watermark` field indicates the index of the first incomplete chunk. This design makes it easy
+     * to skip all incomplete chunks when dispatching entries to consumer.
+     *
+     * For example, assuming the original entries are:
+     *   M0, M1-C0, M2, M3-C0, M1-C1, M4
+     * where M1 and M3 are chunked messages that both have 2 chunks.
+     * We should sort them to:
+     *   M0, M3, M1-C0, M1-C1, M4, M3-C0
+     * and the watermark will be 5 that is the index of `M3-C0` because `M3-C1` is not received.
+     */
     public EntryAndMetadataList(final List<Entry> entries, final String subscription) {
         this.entries = entries;
         this.metadataList = new ArrayList<>();
         this.watermark = entries.size();
-        this.hasChunks = false;
-        entries.forEach(entry -> {
+
+        boolean hasChunks = false;
+        for (Entry entry : entries) {
             final MessageMetadata metadata =
                     Commands.peekAndCopyMessageMetadata(entry.getDataBuffer(), subscription, -1);
             if (!hasChunks && metadata != null && metadata.hasUuid()) {
                 hasChunks = true;
             }
             metadataList.add(metadata);
-        });
+        }
+        if (hasChunks) {
+            sortChunks();
+        }
+    }
+
+    @Override
+    public void close() {
+        chunkIndexRanges.forEach(IntRange::recycle);
     }
 
     public int size() {
         return entries.size();
     }
 
-    /**
-     * it will sort the entries to make all chunks of the same message consistent in distribution.
-     *
-     * For example, if the original entries are:
-     *   M0, M1-C0, M2, M3, M1-C1, M4
-     * where M1 is a chunked message that has 2 chunks (C0 and C1).
-     * We should sort them to:
-     *   M0, M2, M3, M1-C0, M1-C1, M4
-     */
-    public void sortChunks() {
-        if (!hasChunks) {
-            return;
-        }
-        final Map<String, List<Integer>> uuidToIndexes = new HashMap<>();
-        final List<Entry> sortedEntries = new ArrayList<>();
-        final List<MessageMetadata> sortedMetadataList = new ArrayList<>();
-        for (int i = 0; i < entries.size(); i++) {
-            final MessageMetadata metadata = metadataList.get(i);
-            if (metadata == null) {
-                continue;
-            }
-            if (metadata.hasUuid()) {
-                final String uuid = metadata.getUuid();
-                final List<Integer> indexes = uuidToIndexes.computeIfAbsent(uuid, __ -> new ArrayList<>());
-                indexes.add(i);
-                if (metadata.getChunkId() + 1 == metadata.getNumChunksFromMsg()) {
-                    indexes.forEach(index -> {
-                        sortedEntries.add(entries.get(index));
-                        sortedMetadataList.add(metadataList.get(index));
-                    });
-                    uuidToIndexes.remove(uuid);
-                }
-            } else {
-                sortedEntries.add(entries.get(i));
-                sortedMetadataList.add(metadata);
-            }
-        }
-        watermark = sortedEntries.size();
-        // Process all incomplete chunks
-        uuidToIndexes.values().forEach(indexes -> {
-            indexes.forEach(index -> {
-                sortedEntries.add(entries.get(index));
-                sortedMetadataList.add(metadataList.get(index));
-            });
-        });
-        entries = sortedEntries;
-        metadataList = sortedMetadataList;
-    }
-
-    // NOTE: it must be called after sortChunks() to ensure chunks of the same message are distributed consistently.
     public boolean containIncompleteChunks(int start, int end) {
         String currentUuid = null;
         Optional<Boolean> optIsLastChunk = Optional.empty();
@@ -138,5 +114,46 @@ public class EntryAndMetadataList {
             // Verify the last entry
             return !optIsLastChunk.get();
         }
+    }
+
+    private void sortChunks() {
+        final Map<String, List<Integer>> uuidToIndexes = new HashMap<>();
+        final List<Entry> sortedEntries = new ArrayList<>();
+        final List<MessageMetadata> sortedMetadataList = new ArrayList<>();
+        for (int i = 0; i < size(); i++) {
+            final MessageMetadata metadata = metadataList.get(i);
+            if (metadata == null) {
+                continue;
+            }
+            if (metadata.hasUuid()) {
+                final String uuid = metadata.getUuid();
+                final List<Integer> indexes = uuidToIndexes.computeIfAbsent(uuid, __ -> new ArrayList<>());
+                indexes.add(i);
+                if (metadata.getChunkId() + 1 == metadata.getNumChunksFromMsg()) {
+                    // A complete chunk is met
+                    int start = sortedEntries.size();
+                    int end = start + metadata.getNumChunksFromMsg();
+                    chunkIndexRanges.add(IntRange.get(start, end));
+                    indexes.forEach(index -> {
+                        sortedEntries.add(entries.get(index));
+                        sortedMetadataList.add(metadataList.get(index));
+                    });
+                    uuidToIndexes.remove(uuid);
+                }
+            } else {
+                sortedEntries.add(entries.get(i));
+                sortedMetadataList.add(metadata);
+            }
+        }
+        watermark = sortedEntries.size();
+        // Process all incomplete chunks
+        uuidToIndexes.values().forEach(indexes -> {
+            indexes.forEach(index -> {
+                sortedEntries.add(entries.get(index));
+                sortedMetadataList.add(metadataList.get(index));
+            });
+        });
+        entries = sortedEntries;
+        metadataList = sortedMetadataList;
     }
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/IntRange.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/IntRange.java
@@ -1,0 +1,77 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.service;
+
+import io.netty.util.Recycler;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * A recyclable int range.
+ */
+@RequiredArgsConstructor
+public class IntRange {
+
+    private static final Recycler<IntRange> RECYCLER = new Recycler<IntRange>() {
+        @Override
+        protected IntRange newObject(Handle<IntRange> handle) {
+            return new IntRange(handle);
+        }
+    };
+
+    private final Recycler.Handle<IntRange> handle;
+
+    // The left-closed and right-open range: [start, end)
+    @Getter
+    private int start;
+    @Getter
+    private int end;
+
+    @Override
+    public boolean equals(Object object) {
+        if (!(object instanceof IntRange)) {
+            return false;
+        }
+        IntRange other = (IntRange) object;
+        return start == other.start && end == other.end;
+    }
+
+    public boolean overlap(int start, int end) {
+        assert start <= end;
+        if (this.start < start) {
+            return this.end > start;
+        } else {
+            return end > this.start;
+        }
+    }
+
+    public static IntRange get(int start, int end) {
+        assert start <= end;
+        final IntRange range = RECYCLER.get();
+        range.start = start;
+        range.end = end;
+        return range;
+    }
+
+    public void recycle() {
+        start = -1;
+        end = -1;
+        handle.recycle(this);
+    }
+}

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/IntRange.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/IntRange.java
@@ -53,16 +53,16 @@ public class IntRange {
     }
 
     public boolean overlap(int start, int end) {
-        assert start <= end;
-        if (this.start < start) {
+        assert start < end;
+        if (this.start <= start) { // this.start <= start <= end
             return this.end > start;
-        } else {
-            return end > this.start;
+        } else { // start < this.start <= this.end
+            return this.start < end;
         }
     }
 
     public static IntRange get(int start, int end) {
-        assert start <= end;
+        assert start < end;
         final IntRange range = RECYCLER.get();
         range.start = start;
         range.end = end;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumers.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumers.java
@@ -32,6 +32,7 @@ import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.stream.Collectors;
+import lombok.Cleanup;
 import org.apache.bookkeeper.mledger.AsyncCallbacks.ReadEntriesCallback;
 import org.apache.bookkeeper.mledger.Entry;
 import org.apache.bookkeeper.mledger.ManagedCursor;
@@ -508,9 +509,9 @@ public class PersistentDispatcherMultipleConsumers extends AbstractDispatcherMul
             cursor.trimDeletedEntries(originalEntries);
         }
 
+        @Cleanup
         final EntryAndMetadataList entryAndMetadataList =
                 new EntryAndMetadataList(originalEntries, subscription.toString());
-        entryAndMetadataList.sortChunks();
 
         // The entry whose index is greater than the watermark must be a chunk from an incomplete message, skip them
         // and add them to the replay.

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/EntryAndMetadataListTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/EntryAndMetadataListTest.java
@@ -1,0 +1,128 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.service;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.apache.bookkeeper.mledger.Entry;
+import org.apache.bookkeeper.mledger.impl.EntryImpl;
+import org.apache.pulsar.common.api.proto.MessageMetadata;
+import org.testng.annotations.Test;
+
+public class EntryAndMetadataListTest {
+
+    @Test
+    public void testSortChunks() {
+        final EntryAndMetadataList entryAndMetadataList = attachMetadataList(
+                createMetadata("A", 0),
+                createMetadata("B", 0, 0, 3),
+                createMetadata("C", 0, 0, 4),
+                createMetadata("A", 1),
+                createMetadata("C", 0, 1, 4),
+                createMetadata("B", 0, 1, 3),
+                createMetadata("D", 0),
+                createMetadata("B", 0, 2, 3),
+                createMetadata("A", 2)
+        );
+        entryAndMetadataList.sortChunks();
+        final List<String> metadataDescriptionList = entryAndMetadataList.getMetadataList().stream()
+                .map(m -> {
+                    if (m == null) {
+                        return "null";
+                    } else if (m.hasUuid()) {
+                        return m.getProducerName() + "-" + m.getSequenceId() + "-" + m.getChunkId();
+                    } else {
+                        return m.getProducerName() + "-" + m.getSequenceId();
+                    }
+                }).collect(Collectors.toList());
+        assertEquals(metadataDescriptionList,
+                Arrays.asList("A-0", "A-1", "D-0", "B-0-0", "B-0-1", "B-0-2", "A-2", "C-0-0", "C-0-1"));
+        assertEquals(entryAndMetadataList.getWatermark(), 7);
+    }
+
+    @Test
+    public void testContainIncompleteChunks() {
+        final EntryAndMetadataList entryAndMetadataList = attachMetadataList(
+                createMetadata("A", 0),
+                createMetadata("B", 0),
+                // entry id range of chunk C-0: [2, 5)
+                createMetadata("C", 0, 0, 3),
+                createMetadata("C", 0, 1, 3),
+                createMetadata("C", 0, 2, 3),
+                // entry id range of chunk C-1: [5, 7)
+                createMetadata("C", 1, 0, 2),
+                createMetadata("C", 1, 1, 2),
+                createMetadata("B", 1),
+                // entry id range of chunk D-0: [8, 11)
+                createMetadata("D", 0, 0, 3),
+                createMetadata("D", 0, 1, 3),
+                createMetadata("D", 0, 2, 3)
+        );
+        final int size = entryAndMetadataList.getEntries().size();
+        for (int end = 1; end <= size; end++) {
+            if ((end > 2 && end < 5) || (end == 6) || (end > 8 && end < 11)) {
+                assertTrue(entryAndMetadataList.containIncompleteChunks(0, end));
+            } else {
+                assertFalse(entryAndMetadataList.containIncompleteChunks(0, end));
+            }
+        }
+        final Set<Integer> indexOfNotFirstChunk = new HashSet<>(Arrays.asList(3, 4, 6, 9, 10));
+        for (int start = 0; start < size; start++) {
+            if (indexOfNotFirstChunk.contains(start)) {
+                assertTrue(entryAndMetadataList.containIncompleteChunks(start, size));
+            } else {
+                assertFalse(entryAndMetadataList.containIncompleteChunks(start, size));
+            }
+        }
+    }
+
+    private static EntryAndMetadataList attachMetadataList(MessageMetadata... metadataList) {
+        final List<Entry> entries = new ArrayList<>();
+        for (int i = 0; i < metadataList.length; i++) {
+            entries.add(EntryImpl.create(0, i, "".getBytes()));
+        }
+        return new EntryAndMetadataList(entries, new ArrayList<>(Arrays.asList(metadataList)));
+    }
+
+    private static MessageMetadata createMetadata(String producerName, long sequenceId) {
+        final MessageMetadata metadata = createMetadata(producerName, sequenceId, 0, 0);
+        metadata.clearUuid();
+        metadata.clearChunkId();
+        metadata.clearNumChunksFromMsg();
+        return metadata;
+    }
+
+    private static MessageMetadata createMetadata(String producerName, long sequenceId, int chunkId, int numChunks) {
+        final MessageMetadata metadata = new MessageMetadata();
+        metadata.setProducerName(producerName);
+        metadata.setSequenceId(sequenceId);
+        metadata.setPublishTime(0L);
+        metadata.setUuid(producerName + "-" + sequenceId);
+        metadata.setChunkId(chunkId);
+        metadata.setNumChunksFromMsg(numChunks);
+        return metadata;
+    }
+}

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/EntryAndMetadataListTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/EntryAndMetadataListTest.java
@@ -20,7 +20,9 @@ package org.apache.pulsar.broker.service;
 
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertSame;
 import static org.testng.Assert.assertTrue;
+import io.netty.buffer.ByteBuf;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
@@ -29,14 +31,31 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import org.apache.bookkeeper.mledger.Entry;
 import org.apache.bookkeeper.mledger.impl.EntryImpl;
+import org.apache.pulsar.common.allocator.PulsarByteBufAllocator;
 import org.apache.pulsar.common.api.proto.MessageMetadata;
+import org.apache.pulsar.common.protocol.Commands;
 import org.testng.annotations.Test;
 
 public class EntryAndMetadataListTest {
 
     @Test
+    public void testNoChunk() {
+        final List<Entry> entries = attachMetadataList(
+                createMetadata("A", 0),
+                createMetadata("B", 0),
+                createMetadata("A", 1)
+        );
+        final EntryAndMetadataList entryAndMetadataList = new EntryAndMetadataList(entries, "sub");
+        assertFalse(entryAndMetadataList.isHasChunks());
+
+        entryAndMetadataList.sortChunks();
+        assertSame(entryAndMetadataList.getEntries(), entries);
+        assertEquals(entryAndMetadataList.getWatermark(), entries.size());
+    }
+
+    @Test
     public void testSortChunks() {
-        final EntryAndMetadataList entryAndMetadataList = attachMetadataList(
+        final EntryAndMetadataList entryAndMetadataList = new EntryAndMetadataList(attachMetadataList(
                 createMetadata("A", 0),
                 createMetadata("B", 0, 0, 3),
                 createMetadata("C", 0, 0, 4),
@@ -46,7 +65,8 @@ public class EntryAndMetadataListTest {
                 createMetadata("D", 0),
                 createMetadata("B", 0, 2, 3),
                 createMetadata("A", 2)
-        );
+        ), "sub");
+        assertTrue(entryAndMetadataList.isHasChunks());
         entryAndMetadataList.sortChunks();
         final List<String> metadataDescriptionList = entryAndMetadataList.getMetadataList().stream()
                 .map(m -> {
@@ -65,7 +85,7 @@ public class EntryAndMetadataListTest {
 
     @Test
     public void testContainIncompleteChunks() {
-        final EntryAndMetadataList entryAndMetadataList = attachMetadataList(
+        final EntryAndMetadataList entryAndMetadataList = new EntryAndMetadataList(attachMetadataList(
                 createMetadata("A", 0),
                 createMetadata("B", 0),
                 // entry id range of chunk C-0: [2, 5)
@@ -80,7 +100,7 @@ public class EntryAndMetadataListTest {
                 createMetadata("D", 0, 0, 3),
                 createMetadata("D", 0, 1, 3),
                 createMetadata("D", 0, 2, 3)
-        );
+        ), "sub");
         final int size = entryAndMetadataList.getEntries().size();
         for (int end = 1; end <= size; end++) {
             if ((end > 2 && end < 5) || (end == 6) || (end > 8 && end < 11)) {
@@ -99,12 +119,18 @@ public class EntryAndMetadataListTest {
         }
     }
 
-    private static EntryAndMetadataList attachMetadataList(MessageMetadata... metadataList) {
+    private static List<Entry> attachMetadataList(MessageMetadata... metadataList) {
         final List<Entry> entries = new ArrayList<>();
         for (int i = 0; i < metadataList.length; i++) {
-            entries.add(EntryImpl.create(0, i, "".getBytes()));
+            entries.add(createEntry(i, metadataList[i]));
         }
-        return new EntryAndMetadataList(entries, new ArrayList<>(Arrays.asList(metadataList)));
+        return entries;
+    }
+
+    private static Entry createEntry(long entryId, MessageMetadata metadata) {
+        final ByteBuf payload = Commands.serializeMetadataAndPayload(
+                Commands.ChecksumType.Crc32c, metadata, PulsarByteBufAllocator.DEFAULT.buffer());
+        return EntryImpl.create(0, entryId, payload);
     }
 
     private static MessageMetadata createMetadata(String producerName, long sequenceId) {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/EntryAndMetadataListTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/EntryAndMetadataListTest.java
@@ -63,7 +63,8 @@ public class EntryAndMetadataListTest {
                 createMetadata("B", 0, 1, 3),
                 createMetadata("D", 0),
                 createMetadata("B", 0, 2, 3),
-                createMetadata("A", 2)
+                createMetadata("A", 2),
+                createMetadata("A", 3, 1, 3)
         ), "sub");
         final List<String> metadataDescriptionList = entryAndMetadataList.getMetadataList().stream()
                 .map(m -> {
@@ -77,7 +78,9 @@ public class EntryAndMetadataListTest {
                 }).collect(Collectors.toList());
         // C-0 has 4 chunks while the latest chunk's id is 1, so C-0-0 and C-0-1 will be put at the end
         assertEquals(metadataDescriptionList,
-                Arrays.asList("A-0", "A-1", "D-0", "B-0-0", "B-0-1", "B-0-2", "A-2", "C-0-0", "C-0-1"));
+                Arrays.asList("A-0", "A-1", "D-0", "B-0-0", "B-0-1", "B-0-2", "A-2", "A-3-1", "C-0-0", "C-0-1"));
+        assertEquals(entryAndMetadataList.getEntries().stream().map(Entry::getEntryId).collect(Collectors.toList()),
+                Arrays.asList(0L, 3L, 6L, 1L, 5L, 7L, 8L, 9L, 2L, 4L));
         assertEquals(entryAndMetadataList.getChunkIndexRanges(), Collections.singletonList(IntRange.get(3, 6)));
         assertEquals(entryAndMetadataList.getWatermark(), 7);
     }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/IntRangeTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/IntRangeTest.java
@@ -1,0 +1,42 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.service;
+
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+import org.testng.annotations.Test;
+
+public class IntRangeTest {
+
+    @Test
+    public void testOverlap() {
+        final IntRange range = IntRange.get(1, 3);
+        assertFalse(range.overlap(0, 1));
+        assertTrue(range.overlap(0, 2));
+        assertTrue(range.overlap(0, 3));
+        assertTrue(range.overlap(0, 4));
+        assertTrue(range.overlap(1, 2));
+        assertTrue(range.overlap(1, 3));
+        assertTrue(range.overlap(1, 4));
+        assertTrue(range.overlap(2, 3));
+        assertTrue(range.overlap(2, 4));
+        assertFalse(range.overlap(3, 4));
+        range.recycle();
+    }
+}

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/MessageChunkingSharedSubscriptionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/MessageChunkingSharedSubscriptionTest.java
@@ -1,0 +1,182 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.client.impl;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertSame;
+import static org.testng.Assert.assertTrue;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Random;
+import java.util.stream.Collectors;
+import lombok.Cleanup;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.pulsar.client.api.Consumer;
+import org.apache.pulsar.client.api.Message;
+import org.apache.pulsar.client.api.MessageListener;
+import org.apache.pulsar.client.api.Producer;
+import org.apache.pulsar.client.api.ProducerConsumerBase;
+import org.apache.pulsar.client.api.PulsarClientException;
+import org.apache.pulsar.client.api.SubscriptionInitialPosition;
+import org.apache.pulsar.client.api.SubscriptionType;
+import org.awaitility.Awaitility;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+/**
+ * Test message chunking with Shared subscriptions.
+ */
+@Slf4j
+public class MessageChunkingSharedSubscriptionTest extends ProducerConsumerBase  {
+
+    private static final int MAX_MESSAGE_SIZE = 50;
+    private final List<List<Message<byte[]>>> messagesList = new ArrayList<>();
+    private final List<Consumer<byte[]>> consumerList = new ArrayList<>();
+
+    @BeforeClass
+    @Override
+    protected void setup() throws Exception {
+        this.conf.setMaxMessageSize(MAX_MESSAGE_SIZE);
+        super.internalSetup();
+        super.producerBaseSetup();
+    }
+
+    @AfterClass
+    @Override
+    protected void cleanup() throws Exception {
+        super.internalCleanup();
+    }
+
+    @AfterMethod(alwaysRun = true)
+    protected void cleanConsumersAndMessages() throws Exception {
+        messagesList.clear();
+        for (Consumer<byte[]> consumer : consumerList) {
+            consumer.close();
+        }
+        consumerList.clear();
+    }
+
+    @Test
+    public void testChunkedMessage() throws Exception {
+        final String topic = "test-chunked-message";
+        final int numConsumers = 3;
+        for (int i = 0; i < numConsumers; i++) {
+            addSharedConsumer(topic, 1000);
+        }
+        // The number of chunks are greater than `dispatcherMaxRoundRobinBatchSize` config
+        final int valueSize = MAX_MESSAGE_SIZE * conf.getDispatcherMaxRoundRobinBatchSize() + 1;
+        final byte[] value = createMessagePayload(valueSize);
+        @Cleanup final Producer<byte[]> producer = createProducer(topic);
+        final ChunkMessageIdImpl chunkMsgId = (ChunkMessageIdImpl) producer.newMessage().value(value).send();
+        final long numChunks = getNumOfChunks(chunkMsgId);
+        log.info("{} chunks were sent to {}", numChunks, chunkMsgId);
+        assertTrue(numChunks > conf.getDispatcherMaxRoundRobinBatchSize());
+
+        Awaitility.await().atMost(Duration.ofSeconds(5)).until(() ->
+                messagesList.stream().map(List::size).reduce(0, Integer::sum) > 0);
+
+        // Only 1 message could be received
+        final List<List<Message<byte[]>>> nonEmptyMessagesList =
+                messagesList.stream().filter(l -> !l.isEmpty()).collect(Collectors.toList());
+        assertEquals(nonEmptyMessagesList.size(), 1);
+        assertEquals(nonEmptyMessagesList.get(0).size(), 1);
+        assertEquals(nonEmptyMessagesList.get(0).get(0).getValue(), value);
+    }
+
+    @Test(timeOut = 10000)
+    public void testPermitsLimit() throws Exception {
+        final String topic = "test-permits-limit";
+        final int numConsumers = 10;
+        final int consumerIndexWithEnoughPermits = 7;
+        for (int i = 0; i < numConsumers; i++) {
+            if (i != consumerIndexWithEnoughPermits) {
+                addSharedConsumer(topic, 1);
+            } else {
+                addSharedConsumer(topic, 1000);
+            }
+        }
+
+        @Cleanup final Producer<byte[]> producer = createProducer(topic);
+        final List<byte[]> values = new ArrayList<>();
+        for (int i = 0; i < 2; i++) {
+            final byte[] value = createMessagePayload(5 * MAX_MESSAGE_SIZE + 1);
+            values.add(value);
+            final ChunkMessageIdImpl chunkMsgId = (ChunkMessageIdImpl) producer.newMessage().value(value).send();
+            final long numChunks = getNumOfChunks(chunkMsgId);
+            log.info("[{}] {} chunks were sent to {}", i, numChunks, chunkMsgId);
+        }
+
+        Awaitility.await().atMost(Duration.ofSeconds(5)).until(() ->
+                messagesList.stream().map(List::size).reduce(0, Integer::sum) >= values.size());
+
+        // Only 1 message could be received
+        final List<List<Message<byte[]>>> nonEmptyMessagesList =
+                messagesList.stream().filter(l -> !l.isEmpty()).collect(Collectors.toList());
+        assertEquals(nonEmptyMessagesList.size(), 1);
+        assertSame(nonEmptyMessagesList.get(0), messagesList.get(consumerIndexWithEnoughPermits));
+        final List<byte[]> receivedValues = nonEmptyMessagesList.get(0).stream()
+                .map(Message::getValue).collect(Collectors.toList());
+        assertEquals(receivedValues.size(), values.size());
+        for (int i = 0; i < values.size(); i++) {
+            assertEquals(receivedValues.get(i), values.get(i));
+        }
+    }
+
+    private Producer<byte[]> createProducer(final String topic) throws PulsarClientException {
+        return pulsarClient.newProducer().topic(topic)
+                .enableChunking(true)
+                .enableBatching(false)
+                .create();
+    }
+
+    private void addSharedConsumer(final String topic,
+                                   final Integer queueSize) throws PulsarClientException {
+        final List<Message<byte[]>> messages = Collections.synchronizedList(new ArrayList<>());
+        messagesList.add(messages);
+        consumerList.add(pulsarClient.newConsumer()
+                .topic(topic)
+                .subscriptionName("sub")
+                .subscriptionType(SubscriptionType.Shared)
+                .subscriptionInitialPosition(SubscriptionInitialPosition.Earliest)
+                .receiverQueueSize(queueSize)
+                .messageListener((MessageListener<byte[]>) (consumer, msg) -> {
+                    messages.add(msg);
+                    consumer.acknowledgeAsync(msg);
+                })
+                .subscribe());
+    }
+
+    private static long getNumOfChunks(final ChunkMessageIdImpl chunkMessageId) {
+        // assuming all chunks were in the same ledger
+        return chunkMessageId.getEntryId() - chunkMessageId.getFirstChunkMessageId().getEntryId();
+    }
+
+    private static byte[] createMessagePayload(final int size) {
+        final byte[] bytes = new byte[size];
+        final Random random = new Random();
+        for (int i = 0; i < size; i++) {
+            bytes[i] = (byte) random.nextInt(10);
+        }
+        return bytes;
+    }
+}

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/MessageChunkingTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/MessageChunkingTest.java
@@ -569,11 +569,11 @@ public class MessageChunkingTest extends ProducerConsumerBase {
                 consumer.acknowledgeAsync(msg);
             }).subscribe());
         }
-        final byte[] value = createMessagePayload(200).getBytes(StandardCharsets.UTF_8);
+        final byte[] value = createMessagePayload(1000).getBytes(StandardCharsets.UTF_8);
         pulsarClient.newProducer().topic(topic).enableBatching(false).enableChunking(true).create()
                 .newMessage().value(value).send();
 
-        Awaitility.await().atMost(Duration.ofSeconds(3)).until(() ->
+        Awaitility.await().atMost(Duration.ofSeconds(5)).until(() ->
             valuesList.stream().map(List::size).reduce(0, Integer::sum) > 0);
 
         // Only 1 message could be received

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
@@ -1262,7 +1262,7 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
 
         final int numMessages = msgMetadata.getNumMessagesInBatch();
         final int numChunks = msgMetadata.hasNumChunksFromMsg() ? msgMetadata.getNumChunksFromMsg() : 0;
-        final boolean isChunkedMessage = numChunks > 1 && conf.getSubscriptionType() != SubscriptionType.Shared;
+        final boolean isChunkedMessage = numChunks > 1;
 
         MessageIdImpl msgId = new MessageIdImpl(messageId.getLedgerId(), messageId.getEntryId(), getPartitionIndex());
         if (acknowledgmentsGroupingTracker.isDuplicate(msgId)) {


### PR DESCRIPTION
### Motivation

This is the first part to support chunking with Shared subscription.
Instead of adopting the solutions from the original proposal, this PR
uses a more simple way:
1. Skip dispatching the incomplete chunks and add them to the replay.
2. If a consumer's permits cannot receive a whole chunked message, skip
   this consumer.

### Modifications

Add an `EntryAndMetadataList` class to hold a list of entries and the
associated metadata instances, as well as the following methods:
- `sortChunks`: Sort the entries so that all chunks that belong to
  the same message will be distributed consistently. All incomplete
  chunks will be put at the end after the "watermark" index.
- `containIncompleteChunks`: Detect if the range  `[start, end]` has
  incomplete chunks.

Then, in the `PersistentDispatcherMultipleConsumers#sendMessages`,
leverage the `EntryAndMetadataList` class to implement the logic
described in the previous section.

Finally, cancel the limit in `ConsumerImpl` to process chunks for Shared
subscriptions.

### Verifying this change

`MessageChunkingTest#testChunkMessagesWithSharedSubscriptions` is added.

### Documentation

Check the box below or label this PR directly.

Need to update docs? 

- [x] `doc-required` 
(Your PR needs to update docs and you will update later)
  
- [ ] `doc-not-needed` 
(Please explain why)
  
- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)