### PR TITLE
Avoid AuthenticationDataSource mutation for subscription name

### DIFF
--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authentication/AuthenticationDataSubscription.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authentication/AuthenticationDataSubscription.java
@@ -20,8 +20,6 @@ package org.apache.pulsar.broker.authentication;
 
 import java.net.SocketAddress;
 import java.security.cert.Certificate;
-import javax.net.ssl.SSLPeerUnverifiedException;
-import javax.net.ssl.SSLSession;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authentication/AuthenticationDataSubscription.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authentication/AuthenticationDataSubscription.java
@@ -25,65 +25,52 @@ import javax.net.ssl.SSLSession;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
-public class AuthenticationDataCommand implements AuthenticationDataSource {
-    protected final String authData;
-    protected final SocketAddress remoteAddress;
-    protected final SSLSession sslSession;
+public class AuthenticationDataSubscription implements AuthenticationDataSource {
+    private final AuthenticationDataSource authData;
+    private final String subscription;
 
-    public AuthenticationDataCommand(String authData) {
-        this(authData, null, null);
-    }
-
-    public AuthenticationDataCommand(String authData, SocketAddress remoteAddress, SSLSession sslSession) {
+    public AuthenticationDataSubscription(AuthenticationDataSource authData, String subscription) {
         this.authData = authData;
-        this.remoteAddress = remoteAddress;
-        this.sslSession = sslSession;
+        this.subscription = subscription;
     }
-
-    /*
-     * Command
-     */
 
     @Override
     public boolean hasDataFromCommand() {
-        return (authData != null);
+        return authData.hasDataFromCommand();
     }
 
     @Override
     public String getCommandData() {
-        return authData;
+        return authData.getCommandData();
     }
-
-    /*
-     * Peer
-     */
 
     @Override
     public boolean hasDataFromPeer() {
-        return (remoteAddress != null);
+        return authData.hasDataFromPeer();
     }
 
     @Override
     public SocketAddress getPeerAddress() {
-        return remoteAddress;
+        return authData.getPeerAddress();
     }
-
-    /*
-     * TLS
-     */
 
     @Override
     public boolean hasDataFromTls() {
-        return (sslSession != null);
+        return authData.hasDataFromTls();
     }
 
     @Override
     public Certificate[] getTlsCertificates() {
-        try {
-            return sslSession.getPeerCertificates();
-        } catch (SSLPeerUnverifiedException e) {
-            log.error("Failed to verify the peer's identity", e);
-            return null;
-        }
+        return authData.getTlsCertificates();
+    }
+
+    @Override
+    public boolean hasSubscription() {
+        return this.subscription != null;
+    }
+
+    @Override
+    public String getSubscription() {
+        return subscription;
     }
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
@@ -68,8 +68,8 @@ import org.apache.commons.lang3.mutable.MutableLong;
 import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.broker.ServiceConfiguration;
 import org.apache.pulsar.broker.TransactionMetadataStoreService;
-import org.apache.pulsar.broker.authentication.AuthenticationDataCommand;
 import org.apache.pulsar.broker.authentication.AuthenticationDataSource;
+import org.apache.pulsar.broker.authentication.AuthenticationDataSubscription;
 import org.apache.pulsar.broker.authentication.AuthenticationProvider;
 import org.apache.pulsar.broker.authentication.AuthenticationState;
 import org.apache.pulsar.broker.intercept.BrokerInterceptor;
@@ -381,19 +381,20 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
     // // Incoming commands handling
     // ////
 
-    private CompletableFuture<Boolean> isTopicOperationAllowed(TopicName topicName, TopicOperation operation) {
+    private CompletableFuture<Boolean> isTopicOperationAllowed(TopicName topicName, TopicOperation operation,
+                    AuthenticationDataSource authData) {
         if (!service.isAuthorizationEnabled()) {
             return CompletableFuture.completedFuture(true);
         }
         CompletableFuture<Boolean> isProxyAuthorizedFuture;
         if (originalPrincipal != null) {
             isProxyAuthorizedFuture = service.getAuthorizationService().allowTopicOperationAsync(
-                topicName, operation, originalPrincipal, getAuthenticationData());
+                topicName, operation, originalPrincipal, authData);
         } else {
             isProxyAuthorizedFuture = CompletableFuture.completedFuture(true);
         }
         CompletableFuture<Boolean> isAuthorizedFuture = service.getAuthorizationService().allowTopicOperationAsync(
-            topicName, operation, authRole, authenticationData);
+            topicName, operation, authRole, authData);
         return isProxyAuthorizedFuture.thenCombine(isAuthorizedFuture, (isProxyAuthorized, isAuthorized) -> {
             if (!isProxyAuthorized) {
                 log.warn("OriginalRole {} is not authorized to perform operation {} on topic {}",
@@ -410,15 +411,9 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
     private CompletableFuture<Boolean> isTopicOperationAllowed(TopicName topicName, String subscriptionName,
                                                                TopicOperation operation) {
         if (service.isAuthorizationEnabled()) {
-            if (authenticationData == null) {
-                authenticationData = new AuthenticationDataCommand("", subscriptionName);
-            } else {
-                authenticationData.setSubscription(subscriptionName);
-            }
-            if (originalAuthData != null) {
-                originalAuthData.setSubscription(subscriptionName);
-            }
-            return isTopicOperationAllowed(topicName, operation);
+            AuthenticationDataSource authData =
+                    new AuthenticationDataSubscription(getAuthenticationData(), subscriptionName);
+            return isTopicOperationAllowed(topicName, operation, authData);
         } else {
             return CompletableFuture.completedFuture(true);
         }
@@ -453,7 +448,8 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
                 lookupSemaphore.release();
                 return;
             }
-            isTopicOperationAllowed(topicName, TopicOperation.LOOKUP).thenApply(isAuthorized -> {
+            isTopicOperationAllowed(topicName, TopicOperation.LOOKUP, getAuthenticationData()).thenApply(
+                    isAuthorized -> {
                 if (isAuthorized) {
                     lookupTopicAsync(getBrokerService().pulsar(), topicName, authoritative,
                             getPrincipal(), getAuthenticationData(),
@@ -516,7 +512,8 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
                 lookupSemaphore.release();
                 return;
             }
-            isTopicOperationAllowed(topicName, TopicOperation.LOOKUP).thenApply(isAuthorized -> {
+            isTopicOperationAllowed(topicName, TopicOperation.LOOKUP, getAuthenticationData()).thenApply(
+                    isAuthorized -> {
                 if (isAuthorized) {
                     unsafeGetPartitionedTopicMetadataAsync(getBrokerService().pulsar(), topicName)
                         .handle((metadata, ex) -> {
@@ -1203,12 +1200,13 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
         }
 
         CompletableFuture<Boolean> isAuthorizedFuture = isTopicOperationAllowed(
-                topicName, TopicOperation.PRODUCE
+                topicName, TopicOperation.PRODUCE, getAuthenticationData()
         );
 
         if (!Strings.isNullOrEmpty(initialSubscriptionName)) {
             isAuthorizedFuture =
-                    isAuthorizedFuture.thenCombine(isTopicOperationAllowed(topicName, TopicOperation.SUBSCRIBE),
+                    isAuthorizedFuture.thenCombine(
+                            isTopicOperationAllowed(topicName, TopicOperation.SUBSCRIBE, getAuthenticationData()),
                             (canProduce, canSubscribe) -> canProduce && canSubscribe);
         }
 


### PR DESCRIPTION
### Motivation

The `authenticationData` field in `ServerCnx` is being mutated to add the `subscription` field that will be passed on to the authorization plugin. The problem is that `authenticationData` is scoped to the whole connection and it should be getting mutated for each consumer that is created on the connection. 

The current code leads to a race condition where the subscription name used in the authz plugin is already modified while we're looking at it. Instead, we should create a new object and enforce the final modifier.