### PR TITLE
Revert "[fix][broker] Reject auto create partitioned topic when topic name contains ``-partition-`` (#14920)

### DIFF
--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/PulsarServerException.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/PulsarServerException.java
@@ -44,10 +44,4 @@ public class PulsarServerException extends IOException {
             super(t);
         }
     }
-    public static class InvalidTopicNameException extends PulsarServerException {
-
-        public InvalidTopicNameException(String message) {
-            super(message);
-        }
-    }
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/AdminResource.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/AdminResource.java
@@ -37,7 +37,6 @@ import javax.ws.rs.core.Response.Status;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.bookkeeper.client.BookKeeper;
 import org.apache.bookkeeper.mledger.ManagedLedgerException;
-import org.apache.pulsar.broker.PulsarServerException;
 import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.broker.ServiceConfiguration;
 import org.apache.pulsar.broker.web.PulsarWebResource;
@@ -482,9 +481,6 @@ public abstract class AdminResource extends PulsarWebResource {
         } catch (Exception e) {
             if (e.getCause() instanceof RestException) {
                 throw (RestException) e.getCause();
-            }
-            if (e.getCause() instanceof PulsarServerException.InvalidTopicNameException) {
-                throw new RestException(Status.PRECONDITION_FAILED, e.getCause().getMessage());
             }
             throw new RestException(e);
         }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
@@ -2655,11 +2655,6 @@ public class BrokerService implements Closeable {
 
     @SuppressWarnings("deprecation")
     private CompletableFuture<PartitionedTopicMetadata> createDefaultPartitionedTopicAsync(TopicName topicName) {
-        if (topicName.getLocalName().contains(TopicName.PARTITIONED_TOPIC_SUFFIX)) {
-            return FutureUtil.failedFuture(new PulsarServerException.
-                    InvalidTopicNameException(
-                            String.format("Invalid topic name: %s , should not contain -partition-", topicName)));
-        }
         final int defaultNumPartitions = pulsar.getBrokerService().getDefaultNumPartitions(topicName);
         final int maxPartitions = pulsar().getConfig().getMaxNumPartitionsPerPartitionedTopic();
         checkArgument(defaultNumPartitions > 0,

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/PersistentTopicTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/PersistentTopicTest.java
@@ -29,15 +29,12 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNull;
-import static org.testng.Assert.fail;
 import java.lang.reflect.Field;
-import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import com.google.common.collect.Sets;
-import lombok.Cleanup;
 import org.apache.bookkeeper.client.LedgerHandle;
 import org.apache.bookkeeper.mledger.ManagedLedger;
 import org.apache.pulsar.broker.service.BrokerTestBase;
@@ -45,8 +42,6 @@ import org.apache.pulsar.client.api.Consumer;
 import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.MessageRoutingMode;
 import org.apache.pulsar.client.api.Producer;
-import org.apache.pulsar.client.api.PulsarClient;
-import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.client.api.SubscriptionType;
 import org.apache.pulsar.common.naming.NamespaceBundle;
@@ -273,39 +268,5 @@ public class PersistentTopicTest extends BrokerTestBase {
         for (Producer producer : producerSet) {
             producer.close();
         }
-    }
-
-    @Test
-    public void testAutoCreatePartitionedTopicThatNameIncludePartition() throws Exception {
-        final String topicName = "persistent://prop/autoNs/failedcreate-partition-abcde";
-        final String ns = "prop/autoNs";
-        admin.namespaces().createNamespace(ns);
-        pulsar.getConfiguration().setAllowAutoTopicCreationType("partitioned");
-        try {
-            @Cleanup
-            Producer<byte[]> producer = pulsarClient.newProducer().topic(topicName)
-                    .create();
-            fail("unexpected operation");
-        } catch (PulsarClientException ex) {
-           assertTrue(ex.getMessage()
-                    .contains("Invalid topic name"));
-        }
-        assertEquals(admin.topics().getList(ns).size(), 0);
-        URI tcpLookupUrl = new URI(pulsar.getBrokerServiceUrl());
-        PulsarClient client = PulsarClient.builder()
-                .serviceUrl(tcpLookupUrl.toString())
-                .build();
-        try {
-            @Cleanup
-            Producer<byte[]> producer = client.newProducer()
-                    .topic(topicName)
-                    .create();
-            fail("unexpected operation");
-        } catch (PulsarClientException ex) {
-            assertTrue(ex.getMessage()
-                    .contains("Invalid topic name"));
-        }
-        assertEquals(admin.topics().getList(ns).size(), 0);
-        pulsar.getConfiguration().setAllowAutoTopicCreationType("non-partitioned");
     }
 }


### PR DESCRIPTION
This pull request reverts commit #14920 

### Motivation

Revert PR #14920 because it may affect the DLQ when the user enables `auto-creation` and the creative type is `partitioned`.

### Modifications

- Revert the PR #14920.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Documentation

- [x] `doc-not-needed` 