### PR TITLE
[fix][docs] Corrected comment in shared consumer section

### DIFF
--- a/site2/docs/client-libraries-java.md
+++ b/site2/docs/client-libraries-java.md
@@ -1114,7 +1114,7 @@ Consumer consumer2 = client.newConsumer()
         .subscriptionName("my-subscription")
         .subscriptionType(SubscriptionType.Shared)
         .subscribe()
-//Both consumer1 and consumer 2 is active consumers.
+//Both consumer1 and consumer2 are active consumers.
 
 ```
 

--- a/site2/website/versioned_docs/version-2.1.1-incubating/client-libraries-java.md
+++ b/site2/website/versioned_docs/version-2.1.1-incubating/client-libraries-java.md
@@ -1114,7 +1114,7 @@ Consumer consumer2 = client.newConsumer()
         .subscriptionName("my-subscription")
         .subscriptionType(SubscriptionType.Shared)
         .subscribe()
-//Both consumer1 and consumer 2 is active consumers.
+//Both consumer1 and consumer2 are active consumers.
 
 ```
 

--- a/site2/website/versioned_docs/version-2.10.0/client-libraries-java.md
+++ b/site2/website/versioned_docs/version-2.10.0/client-libraries-java.md
@@ -1115,7 +1115,7 @@ Consumer consumer2 = client.newConsumer()
         .subscriptionName("my-subscription")
         .subscriptionType(SubscriptionType.Shared)
         .subscribe()
-//Both consumer1 and consumer 2 is active consumers.
+//Both consumer1 and consumer2 are active consumers.
 
 ```
 

--- a/site2/website/versioned_docs/version-2.2.0/client-libraries-java.md
+++ b/site2/website/versioned_docs/version-2.2.0/client-libraries-java.md
@@ -1114,7 +1114,7 @@ Consumer consumer2 = client.newConsumer()
         .subscriptionName("my-subscription")
         .subscriptionType(SubscriptionType.Shared)
         .subscribe()
-//Both consumer1 and consumer 2 is active consumers.
+//Both consumer1 and consumer2 are active consumers.
 
 ```
 

--- a/site2/website/versioned_docs/version-2.3.0/client-libraries-java.md
+++ b/site2/website/versioned_docs/version-2.3.0/client-libraries-java.md
@@ -1114,7 +1114,7 @@ Consumer consumer2 = client.newConsumer()
         .subscriptionName("my-subscription")
         .subscriptionType(SubscriptionType.Shared)
         .subscribe()
-//Both consumer1 and consumer 2 is active consumers.
+//Both consumer1 and consumer2 are active consumers.
 
 ```
 

--- a/site2/website/versioned_docs/version-2.3.2/client-libraries-java.md
+++ b/site2/website/versioned_docs/version-2.3.2/client-libraries-java.md
@@ -1114,7 +1114,7 @@ Consumer consumer2 = client.newConsumer()
         .subscriptionName("my-subscription")
         .subscriptionType(SubscriptionType.Shared)
         .subscribe()
-//Both consumer1 and consumer 2 is active consumers.
+//Both consumer1 and consumer2 are active consumers.
 
 ```
 

--- a/site2/website/versioned_docs/version-2.4.0/client-libraries-java.md
+++ b/site2/website/versioned_docs/version-2.4.0/client-libraries-java.md
@@ -491,7 +491,7 @@ Consumer consumer2 = client.newConsumer()
         .subscriptionName("my-subscription")
         .subscriptionType(SubscriptionType.Shared)
         .subscribe()
-//Both consumer1 and consumer 2 is active consumers.
+//Both consumer1 and consumer2 are active consumers.
 
 ```
 

--- a/site2/website/versioned_docs/version-2.4.1/client-libraries-java.md
+++ b/site2/website/versioned_docs/version-2.4.1/client-libraries-java.md
@@ -517,7 +517,7 @@ Consumer consumer2 = client.newConsumer()
         .subscriptionName("my-subscription")
         .subscriptionType(SubscriptionType.Shared)
         .subscribe()
-//Both consumer1 and consumer 2 is active consumers.
+//Both consumer1 and consumer2 are active consumers.
 
 ```
 

--- a/site2/website/versioned_docs/version-2.4.2/client-libraries-java.md
+++ b/site2/website/versioned_docs/version-2.4.2/client-libraries-java.md
@@ -517,7 +517,7 @@ Consumer consumer2 = client.newConsumer()
         .subscriptionName("my-subscription")
         .subscriptionType(SubscriptionType.Shared)
         .subscribe()
-//Both consumer1 and consumer 2 is active consumers.
+//Both consumer1 and consumer2 are active consumers.
 
 ```
 

--- a/site2/website/versioned_docs/version-2.5.0/client-libraries-java.md
+++ b/site2/website/versioned_docs/version-2.5.0/client-libraries-java.md
@@ -612,7 +612,7 @@ Consumer consumer2 = client.newConsumer()
         .subscriptionName("my-subscription")
         .subscriptionType(SubscriptionType.Shared)
         .subscribe()
-//Both consumer1 and consumer 2 is active consumers.
+//Both consumer1 and consumer2 are active consumers.
 
 ```
 

--- a/site2/website/versioned_docs/version-2.5.1/client-libraries-java.md
+++ b/site2/website/versioned_docs/version-2.5.1/client-libraries-java.md
@@ -614,7 +614,7 @@ Consumer consumer2 = client.newConsumer()
         .subscriptionName("my-subscription")
         .subscriptionType(SubscriptionType.Shared)
         .subscribe()
-//Both consumer1 and consumer 2 is active consumers.
+//Both consumer1 and consumer2 are active consumers.
 
 ```
 

--- a/site2/website/versioned_docs/version-2.5.2/client-libraries-java.md
+++ b/site2/website/versioned_docs/version-2.5.2/client-libraries-java.md
@@ -614,7 +614,7 @@ Consumer consumer2 = client.newConsumer()
         .subscriptionName("my-subscription")
         .subscriptionType(SubscriptionType.Shared)
         .subscribe()
-//Both consumer1 and consumer 2 is active consumers.
+//Both consumer1 and consumer2 are active consumers.
 
 ```
 

--- a/site2/website/versioned_docs/version-2.6.0/client-libraries-java.md
+++ b/site2/website/versioned_docs/version-2.6.0/client-libraries-java.md
@@ -634,7 +634,7 @@ Consumer consumer2 = client.newConsumer()
         .subscriptionName("my-subscription")
         .subscriptionType(SubscriptionType.Shared)
         .subscribe()
-//Both consumer1 and consumer 2 is active consumers.
+//Both consumer1 and consumer2 are active consumers.
 
 ```
 

--- a/site2/website/versioned_docs/version-2.6.1/client-libraries-java.md
+++ b/site2/website/versioned_docs/version-2.6.1/client-libraries-java.md
@@ -615,7 +615,7 @@ Consumer consumer2 = client.newConsumer()
         .subscriptionName("my-subscription")
         .subscriptionType(SubscriptionType.Shared)
         .subscribe()
-//Both consumer1 and consumer 2 is active consumers.
+//Both consumer1 and consumer2 are active consumers.
 
 ```
 

--- a/site2/website/versioned_docs/version-2.6.2/client-libraries-java.md
+++ b/site2/website/versioned_docs/version-2.6.2/client-libraries-java.md
@@ -615,7 +615,7 @@ Consumer consumer2 = client.newConsumer()
         .subscriptionName("my-subscription")
         .subscriptionType(SubscriptionType.Shared)
         .subscribe()
-//Both consumer1 and consumer 2 is active consumers.
+//Both consumer1 and consumer2 are active consumers.
 
 ```
 

--- a/site2/website/versioned_docs/version-2.6.3/client-libraries-java.md
+++ b/site2/website/versioned_docs/version-2.6.3/client-libraries-java.md
@@ -615,7 +615,7 @@ Consumer consumer2 = client.newConsumer()
         .subscriptionName("my-subscription")
         .subscriptionType(SubscriptionType.Shared)
         .subscribe()
-//Both consumer1 and consumer 2 is active consumers.
+//Both consumer1 and consumer2 are active consumers.
 
 ```
 

--- a/site2/website/versioned_docs/version-2.6.4/client-libraries-java.md
+++ b/site2/website/versioned_docs/version-2.6.4/client-libraries-java.md
@@ -615,7 +615,7 @@ Consumer consumer2 = client.newConsumer()
         .subscriptionName("my-subscription")
         .subscriptionType(SubscriptionType.Shared)
         .subscribe()
-//Both consumer1 and consumer 2 is active consumers.
+//Both consumer1 and consumer2 are active consumers.
 
 ```
 

--- a/site2/website/versioned_docs/version-2.7.0/client-libraries-java.md
+++ b/site2/website/versioned_docs/version-2.7.0/client-libraries-java.md
@@ -655,7 +655,7 @@ Consumer consumer2 = client.newConsumer()
         .subscriptionName("my-subscription")
         .subscriptionType(SubscriptionType.Shared)
         .subscribe()
-//Both consumer1 and consumer 2 is active consumers.
+//Both consumer1 and consumer2 are active consumers.
 
 ```
 

--- a/site2/website/versioned_docs/version-2.7.1/client-libraries-java.md
+++ b/site2/website/versioned_docs/version-2.7.1/client-libraries-java.md
@@ -655,7 +655,7 @@ Consumer consumer2 = client.newConsumer()
         .subscriptionName("my-subscription")
         .subscriptionType(SubscriptionType.Shared)
         .subscribe()
-//Both consumer1 and consumer 2 is active consumers.
+//Both consumer1 and consumer2 are active consumers.
 
 ```
 

--- a/site2/website/versioned_docs/version-2.7.2/client-libraries-java.md
+++ b/site2/website/versioned_docs/version-2.7.2/client-libraries-java.md
@@ -655,7 +655,7 @@ Consumer consumer2 = client.newConsumer()
         .subscriptionName("my-subscription")
         .subscriptionType(SubscriptionType.Shared)
         .subscribe()
-//Both consumer1 and consumer 2 is active consumers.
+//Both consumer1 and consumer2 are active consumers.
 
 ```
 

--- a/site2/website/versioned_docs/version-2.7.3/client-libraries-java.md
+++ b/site2/website/versioned_docs/version-2.7.3/client-libraries-java.md
@@ -655,7 +655,7 @@ Consumer consumer2 = client.newConsumer()
         .subscriptionName("my-subscription")
         .subscriptionType(SubscriptionType.Shared)
         .subscribe()
-//Both consumer1 and consumer 2 is active consumers.
+//Both consumer1 and consumer2 are active consumers.
 
 ```
 

--- a/site2/website/versioned_docs/version-2.7.4/client-libraries-java.md
+++ b/site2/website/versioned_docs/version-2.7.4/client-libraries-java.md
@@ -655,7 +655,7 @@ Consumer consumer2 = client.newConsumer()
         .subscriptionName("my-subscription")
         .subscriptionType(SubscriptionType.Shared)
         .subscribe()
-//Both consumer1 and consumer 2 is active consumers.
+//Both consumer1 and consumer2 are active consumers.
 
 ```
 

--- a/site2/website/versioned_docs/version-2.8.0/client-libraries-java.md
+++ b/site2/website/versioned_docs/version-2.8.0/client-libraries-java.md
@@ -655,7 +655,7 @@ Consumer consumer2 = client.newConsumer()
         .subscriptionName("my-subscription")
         .subscriptionType(SubscriptionType.Shared)
         .subscribe()
-//Both consumer1 and consumer 2 is active consumers.
+//Both consumer1 and consumer2 are active consumers.
 
 ```
 

--- a/site2/website/versioned_docs/version-2.8.1/client-libraries-java.md
+++ b/site2/website/versioned_docs/version-2.8.1/client-libraries-java.md
@@ -658,7 +658,7 @@ Consumer consumer2 = client.newConsumer()
         .subscriptionName("my-subscription")
         .subscriptionType(SubscriptionType.Shared)
         .subscribe()
-//Both consumer1 and consumer 2 is active consumers.
+//Both consumer1 and consumer2 are active consumers.
 
 ```
 

--- a/site2/website/versioned_docs/version-2.8.2/client-libraries-java.md
+++ b/site2/website/versioned_docs/version-2.8.2/client-libraries-java.md
@@ -658,7 +658,7 @@ Consumer consumer2 = client.newConsumer()
         .subscriptionName("my-subscription")
         .subscriptionType(SubscriptionType.Shared)
         .subscribe()
-//Both consumer1 and consumer 2 is active consumers.
+//Both consumer1 and consumer2 are active consumers.
 
 ```
 

--- a/site2/website/versioned_docs/version-2.8.3/client-libraries-java.md
+++ b/site2/website/versioned_docs/version-2.8.3/client-libraries-java.md
@@ -658,7 +658,7 @@ Consumer consumer2 = client.newConsumer()
         .subscriptionName("my-subscription")
         .subscriptionType(SubscriptionType.Shared)
         .subscribe()
-//Both consumer1 and consumer 2 is active consumers.
+//Both consumer1 and consumer2 are active consumers.
 
 ```
 

--- a/site2/website/versioned_docs/version-2.9.0/client-libraries-java.md
+++ b/site2/website/versioned_docs/version-2.9.0/client-libraries-java.md
@@ -658,7 +658,7 @@ Consumer consumer2 = client.newConsumer()
         .subscriptionName("my-subscription")
         .subscriptionType(SubscriptionType.Shared)
         .subscribe()
-//Both consumer1 and consumer 2 is active consumers.
+//Both consumer1 and consumer2 are active consumers.
 
 ```
 

--- a/site2/website/versioned_docs/version-2.9.1/client-libraries-java.md
+++ b/site2/website/versioned_docs/version-2.9.1/client-libraries-java.md
@@ -658,7 +658,7 @@ Consumer consumer2 = client.newConsumer()
         .subscriptionName("my-subscription")
         .subscriptionType(SubscriptionType.Shared)
         .subscribe()
-//Both consumer1 and consumer 2 is active consumers.
+//Both consumer1 and consumer2 are active consumers.
 
 ```
 

--- a/site2/website/versioned_docs/version-2.9.2/client-libraries-java.md
+++ b/site2/website/versioned_docs/version-2.9.2/client-libraries-java.md
@@ -658,7 +658,7 @@ Consumer consumer2 = client.newConsumer()
         .subscriptionName("my-subscription")
         .subscriptionType(SubscriptionType.Shared)
         .subscribe()
-//Both consumer1 and consumer 2 is active consumers.
+//Both consumer1 and consumer2 are active consumers.
 
 ```
 


### PR DESCRIPTION

### Motivation

* The shared consumer example comment indicates <code>Both consumer1 and **consumer 2 is** active consumers</code>

### Modifications

* Updated comment section to refer to the proper variable <code>Both consumer1 and **consumer2 are** active consumers</code>

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): no
  - The public API: no
  - The schema: no
  - The default values of configurations: no
  - The wire protocol: no
  - The rest endpoints: no
  - The admin cli options: no
  - Anything that affects deployment: no

### Documentation

Check the box below or label this PR directly.

Need to update docs? 

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)
  
- [ ] `doc-not-needed` 
(Please explain why)
  
- [x] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)