### PR TITLE
[Fix][broker]Fix topic dispatch rate limiter not init on broker-level

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractTopic.java
@@ -890,6 +890,9 @@ public abstract class AbstractTopic implements Topic, TopicPolicyListener<TopicP
         }
     }
 
+    public void updateDispatchRateLimiter() {
+    }
+
     @Override
     public void resetBrokerPublishCountAndEnableReadIfRequired(boolean doneBrokerReset) {
         // topic rate not exceeded, and completed broker limiter reset.

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
@@ -2371,11 +2371,9 @@ public class BrokerService implements Closeable {
         this.pulsar().getExecutor().execute(() -> {
             // update message-rate for each topic
             forEachTopic(topic -> {
-                if (topic instanceof AbstractTopic) {
-                    ((AbstractTopic) topic).updateBrokerDispatchRate();
-                }
-                if (topic.getDispatchRateLimiter().isPresent()) {
-                    topic.getDispatchRateLimiter().get().updateDispatchRate();
+                if (topic instanceof PersistentTopic) {
+                    ((PersistentTopic) topic).updateBrokerDispatchRate();
+                    ((PersistentTopic) topic).updateDispatchRateLimiter();
                 }
             });
         });

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
@@ -2371,9 +2371,9 @@ public class BrokerService implements Closeable {
         this.pulsar().getExecutor().execute(() -> {
             // update message-rate for each topic
             forEachTopic(topic -> {
-                if (topic instanceof PersistentTopic) {
-                    ((PersistentTopic) topic).updateBrokerDispatchRate();
-                    ((PersistentTopic) topic).updateDispatchRateLimiter();
+                if (topic instanceof AbstractTopic) {
+                    ((AbstractTopic) topic).updateBrokerDispatchRate();
+                    ((AbstractTopic) topic).updateDispatchRateLimiter();
                 }
             });
         });

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -2361,6 +2361,11 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
         return checkPersistencePolicies();
     }
 
+    public void updateDispatchRateLimiter() {
+        initializeDispatchRateLimiterIfNeeded();
+        dispatchRateLimiter.ifPresent(DispatchRateLimiter::updateDispatchRate);
+    }
+
     @Override
     public CompletableFuture<Void> onPoliciesUpdate(Policies data) {
         if (log.isDebugEnabled()) {
@@ -2378,7 +2383,7 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
 
         isAllowAutoUpdateSchema = data.is_allow_auto_update_schema;
 
-        initializeDispatchRateLimiterIfNeeded();
+        updateDispatchRateLimiter();
 
         updateSubscribeRateLimiter();
 
@@ -2397,8 +2402,6 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
                 CompletableFuture<Void> replicationFuture = checkReplicationAndRetryOnFailure();
                 CompletableFuture<Void> dedupFuture = checkDeduplicationStatus();
                 CompletableFuture<Void> persistentPoliciesFuture = checkPersistencePolicies();
-                // update rate-limiter if policies updated
-                dispatchRateLimiter.ifPresent(DispatchRateLimiter::updateDispatchRate);
                 return CompletableFuture.allOf(replicationFuture, dedupFuture, persistentPoliciesFuture,
                         preCreateSubscriptionForCompactionIfNeeded());
             });
@@ -3014,10 +3017,7 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
         }
         updateTopicPolicy(policies);
 
-        initializeTopicDispatchRateLimiterIfNeeded(policies);
-
-        dispatchRateLimiter.ifPresent(DispatchRateLimiter::updateDispatchRate);
-
+        updateDispatchRateLimiter();
         updateSubscriptionsDispatcherRateLimiter().thenRun(() -> {
             updatePublishDispatcher();
             updateSubscribeRateLimiter();
@@ -3053,14 +3053,6 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
             }));
         });
         return FutureUtil.waitForAll(subscriptionCheckFutures);
-    }
-
-    private void initializeTopicDispatchRateLimiterIfNeeded(TopicPolicies policies) {
-        synchronized (dispatchRateLimiterLock) {
-            if (!dispatchRateLimiter.isPresent() && policies.getDispatchRate() != null) {
-                this.dispatchRateLimiter = Optional.of(new DispatchRateLimiter(this, Type.TOPIC));
-            }
-        }
     }
 
     protected CompletableFuture<Void> initTopicPolicy() {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -2361,6 +2361,7 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
         return checkPersistencePolicies();
     }
 
+    @Override
     public void updateDispatchRateLimiter() {
         initializeDispatchRateLimiterIfNeeded();
         dispatchRateLimiter.ifPresent(DispatchRateLimiter::updateDispatchRate);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/TopicDispatchRateLimiterTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/TopicDispatchRateLimiterTest.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.pulsar.broker.service;
 
 import static org.testng.Assert.assertEquals;

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/TopicDispatchRateLimiterTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/TopicDispatchRateLimiterTest.java
@@ -1,0 +1,124 @@
+package org.apache.pulsar.broker.service;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+import lombok.Cleanup;
+import org.apache.pulsar.broker.service.persistent.PersistentTopic;
+import org.apache.pulsar.client.api.Producer;
+import org.apache.pulsar.common.policies.data.DispatchRate;
+import org.awaitility.Awaitility;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+@Test(groups = "broker")
+public class TopicDispatchRateLimiterTest extends BrokerTestBase {
+    @BeforeMethod
+    @Override
+    protected void setup() throws Exception {
+        conf.setDispatchThrottlingRatePerTopicInMsg(0);
+        conf.setDispatchThrottlingRatePerTopicInByte(0L);
+        super.baseSetup();
+    }
+
+    @AfterMethod(alwaysRun = true)
+    @Override
+    protected void cleanup() throws Exception {
+        super.internalCleanup();
+    }
+
+    @Test
+    public void testTopicDispatchRateLimiterPerTopicInMsgOnlyBrokerLevel() throws Exception {
+        final String topicName = "persistent://" + newTopicName();
+
+        @Cleanup
+        Producer<byte[]> producer = pulsarClient.newProducer().topic(topicName).create();
+        PersistentTopic topic = (PersistentTopic) pulsar.getBrokerService().getOrCreateTopic(topicName).get();
+        assertNotNull(topic);
+        assertTrue(topic.getDispatchRateLimiter().isEmpty());
+
+        admin.brokers().updateDynamicConfiguration("dispatchThrottlingRatePerTopicInMsg", "100");
+        Awaitility.await().untilAsserted(() ->
+            assertEquals(pulsar.getConfig().getDispatchThrottlingRatePerTopicInMsg(), 100));
+
+        Awaitility.await().untilAsserted(() ->
+            assertTrue(topic.getDispatchRateLimiter().isPresent()));
+        assertEquals(topic.getDispatchRateLimiter().get().getAvailableDispatchRateLimitOnMsg(), 100L);
+    }
+
+    @Test
+    public void testTopicDispatchRateLimiterPerTopicInByteOnlyBrokerLevel() throws Exception {
+        final String topicName = "persistent://" + newTopicName();
+
+        @Cleanup
+        Producer<byte[]> producer = pulsarClient.newProducer().topic(topicName).create();
+        PersistentTopic topic = (PersistentTopic) pulsar.getBrokerService().getOrCreateTopic(topicName).get();
+        assertNotNull(topic);
+        assertTrue(topic.getDispatchRateLimiter().isEmpty());
+
+        admin.brokers().updateDynamicConfiguration("dispatchThrottlingRatePerTopicInByte", "1000");
+        Awaitility.await().untilAsserted(() ->
+            assertEquals(pulsar.getConfig().getDispatchThrottlingRatePerTopicInByte(), 1000L));
+
+        Awaitility.await().untilAsserted(() ->
+            assertTrue(topic.getDispatchRateLimiter().isPresent()));
+        assertEquals(topic.getDispatchRateLimiter().get().getAvailableDispatchRateLimitOnByte(), 1000L);
+    }
+
+    @Test
+    public void testTopicDispatchRateLimiterOnlyNamespaceLevel() throws Exception {
+        final String topicName = "persistent://" + newTopicName();
+
+        @Cleanup
+        Producer<byte[]> producer = pulsarClient.newProducer().topic(topicName).create();
+        PersistentTopic topic = (PersistentTopic) pulsar.getBrokerService().getOrCreateTopic(topicName).get();
+        assertNotNull(topic);
+        assertTrue(topic.getDispatchRateLimiter().isEmpty());
+
+        DispatchRate dispatchRate = DispatchRate
+            .builder()
+            .dispatchThrottlingRateInMsg(100)
+            .dispatchThrottlingRateInByte(1000L)
+            .build();
+        admin.namespaces().setDispatchRate("prop/ns-abc", dispatchRate);
+
+        Awaitility.await().untilAsserted(() -> {
+            assertNotNull(admin.namespaces().getDispatchRate("prop/ns-abc"));
+            assertEquals(admin.namespaces().getDispatchRate("prop/ns-abc").getDispatchThrottlingRateInMsg(), 100);
+            assertEquals(admin.namespaces().getDispatchRate("prop/ns-abc").getDispatchThrottlingRateInByte(), 1000L);
+        });
+
+        Awaitility.await().untilAsserted(() -> assertTrue(topic.getDispatchRateLimiter().isPresent()));
+        assertEquals(topic.getDispatchRateLimiter().get().getAvailableDispatchRateLimitOnMsg(), 100);
+        assertEquals(topic.getDispatchRateLimiter().get().getAvailableDispatchRateLimitOnByte(), 1000L);
+    }
+
+    @Test
+    public void testTopicDispatchRateLimiterOnlyTopicLevel() throws Exception {
+        final String topicName = "persistent://" + newTopicName();
+
+        @Cleanup
+        Producer<byte[]> producer = pulsarClient.newProducer().topic(topicName).create();
+        PersistentTopic topic = (PersistentTopic) pulsar.getBrokerService().getOrCreateTopic(topicName).get();
+        assertNotNull(topic);
+        assertTrue(topic.getDispatchRateLimiter().isEmpty());
+
+        DispatchRate dispatchRate = DispatchRate
+            .builder()
+            .dispatchThrottlingRateInMsg(100)
+            .dispatchThrottlingRateInByte(1000L)
+            .build();
+        admin.topicPolicies().setDispatchRate(topicName, dispatchRate);
+
+        Awaitility.await().untilAsserted(() -> {
+            assertNotNull(admin.topicPolicies().getDispatchRate(topicName));
+            assertEquals(admin.topicPolicies().getDispatchRate(topicName).getDispatchThrottlingRateInMsg(), 100);
+            assertEquals(admin.topicPolicies().getDispatchRate(topicName).getDispatchThrottlingRateInByte(), 1000L);
+        });
+
+        Awaitility.await().untilAsserted(() ->  assertTrue(topic.getDispatchRateLimiter().isPresent()));
+        assertEquals(topic.getDispatchRateLimiter().get().getAvailableDispatchRateLimitOnMsg(), 100);
+        assertEquals(topic.getDispatchRateLimiter().get().getAvailableDispatchRateLimitOnByte(), 1000L);
+    }
+}


### PR DESCRIPTION
### Motivation


* Fix dispatch rate limiter doesn't be initialized on broker-level: 
* * If `DispatchRateLimiter`  is disabled at first, then we update only broker-level dispatch rate dynamicly, it will not take affect because `topic.getDispatchRateLimiter().isPresent()` is false, line:2377
https://github.com/apache/pulsar/blob/8914b84115bacaf38fe892d66533c1b70431acbf/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java#L2370-L2379

### Modifications

*  Create a method `updateDispatchRateLimiter()` to initialize and update the dispatch rate limiter

### Verifying this change

- [x] Make sure that the change passes the CI checks.


This change added tests and can be verified as follows:

  - *Added UT `TopicDispatchRateLimiterTest`*

### Documentation

Check the box below or label this PR directly.

Need to update docs? 

  
- [x] `doc-not-needed` 