### PR TITLE
[fix][pulsar-perf] Transactions: use the correct logger name

### DIFF
--- a/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceTransaction.java
+++ b/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceTransaction.java
@@ -687,7 +687,7 @@ public class PerformanceTransaction {
     static final DecimalFormat DEC = new PaddingDecimalFormat("0.000", 7);
     static final DecimalFormat INTFORMAT = new PaddingDecimalFormat("0", 7);
     static final DecimalFormat TOTALFORMAT = new DecimalFormat("0.000");
-    private static final Logger log = LoggerFactory.getLogger(PerformanceProducer.class);
+    private static final Logger log = LoggerFactory.getLogger(PerformanceTransaction.class);
 
 
     private static  List<List<Consumer<byte[]>>> buildConsumer(PulsarClient client, Arguments arguments)


### PR DESCRIPTION
### Motivation

`pulsar-perf transaction` uses the PerformanceProducer logger instead of its own.

### Modifications

Move the logger to `PerformanceTransaction.class`

- [x] `doc-not-needed` 