### PR TITLE
[doc] Fix broken link to Transactions in the pulsar-perf page

### DIFF
--- a/site2/docs/performance-pulsar-perf.md
+++ b/site2/docs/performance-pulsar-perf.md
@@ -152,7 +152,7 @@ For the latest and complete information about `pulsar-perf`, including commands,
 
 ## Transactions
 
-This section shows how Pulsar Perf runs transactions. For more information, see [Pulsar transactions](txn-why).
+This section shows how Pulsar Perf runs transactions. For more information, see [Pulsar transactions](/txn-why).
 
 ### Use transaction
 


### PR DESCRIPTION
### Motivation
The link here goes to the not found page: https://pulsar.apache.org/docs/next/performance-pulsar-perf/#transactions

### Modifications

Fixed the link to point to https://pulsar.apache.org/docs/next/txn-why/
  
- [x] `doc` 