### PR TITLE
[doc] Transactions: fix code samples indentation

### DIFF
--- a/site2/docs/txn-use.md
+++ b/site2/docs/txn-use.md
@@ -93,10 +93,10 @@ Let’s walk through this example step by step.
 
 ```
 
-Consumer<byte[]> sinkConsumer = pulsarClient
+Consumer<byte[]> consumer = pulsarClient
     .newConsumer()
     .topic(transferTopic)
-    .subscriptionName("sink-topic")
+    .subscriptionName("transaction-sub")
     .subscriptionInitialPosition(SubscriptionInitialPosition.Earliest)
     .subscriptionType(SubscriptionType.Shared)
     .enableBatchIndexAcknowledgment(true) // enable batch index acknowledgement

--- a/site2/docs/txn-use.md
+++ b/site2/docs/txn-use.md
@@ -69,12 +69,9 @@ This section provides an example of how to use the transaction API to send and r
    ```
    
    PulsarClient client = PulsarClient.builder()
-
-   .serviceUrl(“pulsar://localhost:6650”)
-
-   .enableTransaction(true)
-
-   .build();
+      .serviceUrl(“pulsar://localhost:6650”)
+      .enableTransaction(true)
+      .build();
    
    ```
 
@@ -100,8 +97,7 @@ Consumer<byte[]> sinkConsumer = pulsarClient
     .newConsumer()
     .topic(transferTopic)
     .subscriptionName("sink-topic")
-
-.subscriptionInitialPosition(SubscriptionInitialPosition.Earliest)
+    .subscriptionInitialPosition(SubscriptionInitialPosition.Earliest)
     .subscriptionType(SubscriptionType.Shared)
     .enableBatchIndexAcknowledgment(true) // enable batch index acknowledgement
     .subscribe();


### PR DESCRIPTION
### Modifications

- Fixed the indentation of the code samples in the page: https://pulsar.apache.org/docs/next/txn-use
  
- [x] `doc` 