### PR TITLE
PIP-105: new API to get subscription properties

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
@@ -1619,8 +1619,8 @@ public class PersistentTopicsBase extends AdminResource {
                                                                             boolean authoritative) {
         validateTopicOwnershipAsync(topicName, authoritative)
                 .thenRun(() -> validateTopicOperation(topicName, TopicOperation.CONSUME))
-                .thenApply(__ -> {
-                    Topic topic = getTopicReference(topicName);
+                .thenCompose(__ -> getTopicReferenceAsync(topicName))
+                .thenApply((Topic topic) -> {
                     Subscription sub = topic.getSubscription(subName);
                     if (sub == null) {
                         throw new RestException(Status.NOT_FOUND,

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
@@ -1614,6 +1614,35 @@ public class PersistentTopicsBase extends AdminResource {
                 });
     }
 
+    private void internalGetSubscriptionPropertiesForNonPartitionedTopic(AsyncResponse asyncResponse,
+                                                                            String subName,
+                                                                            boolean authoritative) {
+        validateTopicOwnershipAsync(topicName, authoritative)
+                .thenRun(() -> validateTopicOperation(topicName, TopicOperation.CONSUME))
+                .thenApply(__ -> {
+                    Topic topic = getTopicReference(topicName);
+                    Subscription sub = topic.getSubscription(subName);
+                    if (sub == null) {
+                        throw new RestException(Status.NOT_FOUND,
+                                getSubNotFoundErrorMessage(topicName.toString(), subName));
+                    }
+                    return sub.getSubscriptionProperties();
+                }).thenAccept((Map<String, String> properties) -> {
+                    if (properties == null) {
+                        properties = Collections.emptyMap();
+                    }
+                    asyncResponse.resume(Response.ok(properties).build());
+                }).exceptionally(ex -> {
+                    Throwable cause = ex.getCause();
+                    // If the exception is not redirect exception we need to log it.
+                    if (!isRedirectException(ex)) {
+                        log.error("[{}] Failed to update subscription {} {}", clientAppId(), topicName, subName, cause);
+                    }
+                    asyncResponse.resume(new RestException(cause));
+                    return null;
+                });
+    }
+
     protected void internalDeleteSubscriptionForcefully(AsyncResponse asyncResponse,
                                                         String subName, boolean authoritative) {
         CompletableFuture<Void> future;
@@ -2403,6 +2432,91 @@ public class PersistentTopicsBase extends AdminResource {
                     } else {
                         internalUpdateSubscriptionPropertiesForNonPartitionedTopic(asyncResponse, subName,
                                 subscriptionProperties, authoritative);
+                    }
+                }, pulsar().getExecutor()).exceptionally(ex -> {
+                    log.error("[{}] Failed to update properties for subscription {} from topic {}",
+                            clientAppId(), subName, topicName, ex);
+                    resumeAsyncResponseExceptionally(asyncResponse, ex);
+                    return null;
+                });
+            }
+        }).exceptionally(ex -> {
+            // If the exception is not redirect exception we need to log it.
+            if (!isRedirectException(ex)) {
+                log.error("[{}] Failed to update subscription {} from topic {}",
+                        clientAppId(), subName, topicName, ex);
+            }
+            resumeAsyncResponseExceptionally(asyncResponse, ex);
+            return null;
+        });
+    }
+
+    protected void internalGetSubscriptionProperties(AsyncResponse asyncResponse, String subName,
+                                                        boolean authoritative) {
+        CompletableFuture<Void> future;
+        if (topicName.isGlobal()) {
+            future = validateGlobalNamespaceOwnershipAsync(namespaceName);
+        } else {
+            future = CompletableFuture.completedFuture(null);
+        }
+
+        future.thenCompose(__ -> validateTopicOwnershipAsync(topicName, authoritative)).thenAccept(__ -> {
+            if (topicName.isPartitioned()) {
+                internalGetSubscriptionPropertiesForNonPartitionedTopic(asyncResponse, subName,
+                        authoritative);
+            } else {
+                getPartitionedTopicMetadataAsync(topicName,
+                        authoritative, false).thenAcceptAsync(partitionMetadata -> {
+                    if (partitionMetadata.partitions > 0) {
+                        final List<CompletableFuture<Map<String, String>>> futures = Lists.newArrayList();
+
+                        for (int i = 0; i < partitionMetadata.partitions; i++) {
+                            TopicName topicNamePartition = topicName.getPartition(i);
+                            try {
+                                futures.add(pulsar().getAdminClient().topics()
+                                        .internalGetSubscriptionPropertiesAsync(topicNamePartition.toString(),
+                                                subName));
+                            } catch (Exception e) {
+                                log.error("[{}] Failed to update properties for subscription {} {}",
+                                        clientAppId(), topicNamePartition, subName,
+                                        e);
+                                asyncResponse.resume(new RestException(e));
+                                return;
+                            }
+                        }
+
+                        FutureUtil.waitForAll(futures).handle((result, exception) -> {
+                            if (exception != null) {
+                                Throwable t = exception.getCause();
+                                if (t instanceof NotFoundException) {
+                                    asyncResponse.resume(new RestException(Status.NOT_FOUND,
+                                            getSubNotFoundErrorMessage(topicName.toString(), subName)));
+                                    return null;
+                                } else {
+                                    log.error("[{}] Failed to get properties for subscription {} {}",
+                                            clientAppId(), topicName, subName, t);
+                                    asyncResponse.resume(new RestException(t));
+                                    return null;
+                                }
+                            }
+
+                            Map<String, String> result = new HashMap<>();
+                            futures.forEach(f -> {
+                                // in theory all the partitions have the same properties
+                                try {
+                                    result.putAll(f.get());
+                                } catch (Exception impossible) {
+                                    // we already waited for this Future
+                                    asyncResponse.resume(new RestException(impossible));
+                                }
+                            });
+
+                            asyncResponse.resume(Response.ok(result).build());
+                            return null;
+                        });
+                    } else {
+                        internalGetSubscriptionPropertiesForNonPartitionedTopic(asyncResponse, subName,
+                                authoritative);
                     }
                 }, pulsar().getExecutor()).exceptionally(ex -> {
                     log.error("[{}] Failed to update properties for subscription {} from topic {}",

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
@@ -2500,18 +2500,18 @@ public class PersistentTopicsBase extends AdminResource {
                                 }
                             }
 
-                            Map<String, String> result = new HashMap<>();
+                            Map<String, String> aggregatedResult = new HashMap<>();
                             futures.forEach(f -> {
                                 // in theory all the partitions have the same properties
                                 try {
-                                    result.putAll(f.get());
+                                    aggregatedResult.putAll(f.get());
                                 } catch (Exception impossible) {
                                     // we already waited for this Future
                                     asyncResponse.resume(new RestException(impossible));
                                 }
                             });
 
-                            asyncResponse.resume(Response.ok(result).build());
+                            asyncResponse.resume(Response.ok(aggregatedResult).build());
                             return null;
                         });
                     } else {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
@@ -2474,7 +2474,7 @@ public class PersistentTopicsBase extends AdminResource {
                             TopicName topicNamePartition = topicName.getPartition(i);
                             try {
                                 futures.add(pulsar().getAdminClient().topics()
-                                        .internalGetSubscriptionPropertiesAsync(topicNamePartition.toString(),
+                                        .getSubscriptionPropertiesAsync(topicNamePartition.toString(),
                                                 subName));
                             } catch (Exception e) {
                                 log.error("[{}] Failed to update properties for subscription {} {}",

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/PersistentTopics.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/PersistentTopics.java
@@ -1598,6 +1598,42 @@ public class PersistentTopics extends PersistentTopicsBase {
         }
     }
 
+    @GET
+    @Path("/{tenant}/{namespace}/{topic}/subscription/{subName}/properties")
+    @ApiOperation(value = "Replaces all the properties on the given subscription")
+    @ApiResponses(value = {
+            @ApiResponse(code = 307, message = "Current broker doesn't serve the namespace of this topic"),
+            @ApiResponse(code = 401, message = "Don't have permission to administrate resources on this tenant or"
+                    + "subscriber is not authorized to access this operation"),
+            @ApiResponse(code = 403, message = "Don't have admin permission"),
+            @ApiResponse(code = 404, message = "Topic/Subscription does not exist"),
+            @ApiResponse(code = 405, message = "Method Not Allowed"),
+            @ApiResponse(code = 500, message = "Internal server error"),
+            @ApiResponse(code = 503, message = "Failed to validate global cluster configuration")
+    })
+    public void getSubscriptionProperties(
+            @Suspended final AsyncResponse asyncResponse,
+            @ApiParam(value = "Specify the tenant", required = true)
+            @PathParam("tenant") String tenant,
+            @ApiParam(value = "Specify the namespace", required = true)
+            @PathParam("namespace") String namespace,
+            @ApiParam(value = "Specify topic name", required = true)
+            @PathParam("topic") @Encoded String encodedTopic,
+            @ApiParam(value = "Subscription", required = true)
+            @PathParam("subName") String encodedSubName,
+            @ApiParam(value = "Is authentication required to perform this operation")
+            @QueryParam("authoritative") @DefaultValue("false") boolean authoritative) {
+        try {
+            validateTopicName(tenant, namespace, encodedTopic);
+            internalGetSubscriptionProperties(asyncResponse, decode(encodedSubName),
+                    authoritative);
+        } catch (WebApplicationException wae) {
+            asyncResponse.resume(wae);
+        } catch (Exception e) {
+            asyncResponse.resume(new RestException(e));
+        }
+    }
+
     @POST
     @Path("/{tenant}/{namespace}/{topic}/subscription/{subName}/resetcursor")
     @ApiOperation(value = "Reset subscription to message position closest to given position.",

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiSubscriptionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiSubscriptionTest.java
@@ -152,6 +152,9 @@ public class AdminApiSubscriptionTest extends MockedPulsarServiceBaseTest {
                 SubscriptionStats subscriptionStats = admin.topics().getStats(topic + "-partition-" + i)
                         .getSubscriptions().get(subscriptionName);
                 assertEquals(value, subscriptionStats.getSubscriptionProperties().get("foo"));
+
+                Map<String, String> props = admin.topics().getSubscriptionProperties(topic + "-partition-" + i, subscriptionName);
+                assertEquals(value, props.get("foo"));
             }
 
             // properties are never null, but an empty map
@@ -159,6 +162,9 @@ public class AdminApiSubscriptionTest extends MockedPulsarServiceBaseTest {
                 SubscriptionStats subscriptionStats = admin.topics().getStats(topic + "-partition-" + i)
                         .getSubscriptions().get(subscriptionName2);
                 assertTrue(subscriptionStats.getSubscriptionProperties().isEmpty());
+
+                Map<String, String> props = admin.topics().getSubscriptionProperties(topic + "-partition-" + i, subscriptionName);
+                assertTrue(props.isEmpty());
             }
 
             // aggregated properties
@@ -166,12 +172,21 @@ public class AdminApiSubscriptionTest extends MockedPulsarServiceBaseTest {
                     .getSubscriptions().get(subscriptionName);
             assertEquals(value, subscriptionStats.getSubscriptionProperties().get("foo"));
 
+            Map<String, String> props = admin.topics().getSubscriptionProperties(topic, subscriptionName);
+            assertEquals(value, props.get("foo"));
+
         } else {
             SubscriptionStats subscriptionStats = admin.topics().getStats(topic).getSubscriptions().get(subscriptionName);
             assertEquals(value, subscriptionStats.getSubscriptionProperties().get("foo"));
 
+            Map<String, String> props = admin.topics().getSubscriptionProperties(topic, subscriptionName);
+            assertEquals(value, props.get("foo"));
+
             SubscriptionStats subscriptionStats2 = admin.topics().getStats(topic).getSubscriptions().get(subscriptionName2);
             assertTrue(subscriptionStats2.getSubscriptionProperties().isEmpty());
+
+            Map<String, String> props2 = admin.topics().getSubscriptionProperties(topic, subscriptionName2);
+            assertTrue(props2.isEmpty());
         }
 
         // clear the properties on subscriptionName
@@ -183,6 +198,9 @@ public class AdminApiSubscriptionTest extends MockedPulsarServiceBaseTest {
                 SubscriptionStats subscriptionStats = admin.topics().getStats(topic + "-partition-" + i)
                         .getSubscriptions().get(subscriptionName);
                 assertTrue(subscriptionStats.getSubscriptionProperties().isEmpty());
+
+                Map<String, String> props = admin.topics().getSubscriptionProperties(topic + "-partition-" + i, subscriptionName);
+                assertTrue(props.isEmpty());
             }
 
             // aggregated properties
@@ -190,9 +208,15 @@ public class AdminApiSubscriptionTest extends MockedPulsarServiceBaseTest {
                     .getSubscriptions().get(subscriptionName);
             assertTrue(subscriptionStats.getSubscriptionProperties().isEmpty());
 
+            Map<String, String> props = admin.topics().getSubscriptionProperties(topic, subscriptionName);
+            assertTrue(props.isEmpty());
+
         } else {
             SubscriptionStats subscriptionStats = admin.topics().getStats(topic).getSubscriptions().get(subscriptionName);
             assertTrue(subscriptionStats.getSubscriptionProperties().isEmpty());
+
+            Map<String, String> props = admin.topics().getSubscriptionProperties(topic, subscriptionName);
+            assertTrue(props.isEmpty());
         }
 
         // update the properties on subscriptionName
@@ -204,6 +228,9 @@ public class AdminApiSubscriptionTest extends MockedPulsarServiceBaseTest {
                 SubscriptionStats subscriptionStats = admin.topics().getStats(topic + "-partition-" + i)
                         .getSubscriptions().get(subscriptionName);
                 assertEquals(value, subscriptionStats.getSubscriptionProperties().get("foo"));
+
+                Map<String, String> props = admin.topics().getSubscriptionProperties(topic + "-partition-" + i, subscriptionName);
+                assertEquals(value, props.get("foo"));
             }
 
             // aggregated properties
@@ -211,12 +238,21 @@ public class AdminApiSubscriptionTest extends MockedPulsarServiceBaseTest {
                     .getSubscriptions().get(subscriptionName);
             assertEquals(value, subscriptionStats.getSubscriptionProperties().get("foo"));
 
+            Map<String, String> props = admin.topics().getSubscriptionProperties(topic, subscriptionName);
+            assertEquals(value, props.get("foo"));
+
         } else {
             SubscriptionStats subscriptionStats = admin.topics().getStats(topic).getSubscriptions().get(subscriptionName);
             assertEquals(value, subscriptionStats.getSubscriptionProperties().get("foo"));
 
+            Map<String, String> props = admin.topics().getSubscriptionProperties(topic, subscriptionName);
+            assertEquals(value, props.get("foo"));
+
             SubscriptionStats subscriptionStats2 = admin.topics().getStats(topic).getSubscriptions().get(subscriptionName2);
             assertTrue(subscriptionStats2.getSubscriptionProperties().isEmpty());
+
+            Map<String, String> props2 = admin.topics().getSubscriptionProperties(topic, subscriptionName2);
+            assertTrue(props2.isEmpty());
         }
 
     }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiSubscriptionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiSubscriptionTest.java
@@ -163,7 +163,7 @@ public class AdminApiSubscriptionTest extends MockedPulsarServiceBaseTest {
                         .getSubscriptions().get(subscriptionName2);
                 assertTrue(subscriptionStats.getSubscriptionProperties().isEmpty());
 
-                Map<String, String> props = admin.topics().getSubscriptionProperties(topic + "-partition-" + i, subscriptionName);
+                Map<String, String> props = admin.topics().getSubscriptionProperties(topic + "-partition-" + i, subscriptionName2);
                 assertTrue(props.isEmpty());
             }
 

--- a/pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/admin/Topics.java
+++ b/pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/admin/Topics.java
@@ -1840,6 +1840,15 @@ public interface Topics {
             throws PulsarAdminException;
 
     /**
+     * Get Subscription Properties on a topic subscription.
+     * @param topic
+     * @param subName
+     * @throws PulsarAdminException
+     */
+    Map<String, String> getSubscriptionProperties(String topic, String subName)
+            throws PulsarAdminException;
+
+    /**
      * Reset cursor position on a topic subscription.
      *
      * @param topic
@@ -1872,6 +1881,13 @@ public interface Topics {
      */
     CompletableFuture<Void>  updateSubscriptionPropertiesAsync(String topic, String subName,
                                                                Map<String, String> subscriptionProperties);
+
+    /**
+     * Get Subscription Properties on a topic subscription.
+     * @param topic
+     * @param subName
+     */
+    CompletableFuture<Map<String, String>> getSubscriptionPropertiesAsync(String topic, String subName);
 
     /**
      * Reset cursor position on a topic subscription.

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/TopicsImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/TopicsImpl.java
@@ -1214,6 +1214,12 @@ public class TopicsImpl extends BaseResource implements Topics {
     }
 
     @Override
+    public Map<String, String> getSubscriptionProperties(String topic, String subName)
+            throws PulsarAdminException {
+        return sync(() -> getSubscriptionPropertiesAsync(topic, subName));
+    }
+
+    @Override
     public CompletableFuture<Void> updateSubscriptionPropertiesAsync(String topic, String subName,
                                                                      Map<String, String> subscriptionProperties) {
         TopicName tn = validateTopic(topic);
@@ -1224,6 +1230,29 @@ public class TopicsImpl extends BaseResource implements Topics {
             subscriptionProperties = new HashMap<>();
         }
         return asyncPutRequest(path, Entity.entity(subscriptionProperties, MediaType.APPLICATION_JSON));
+    }
+
+    @Override
+    public CompletableFuture<Map<String, String>> getSubscriptionPropertiesAsync(String topic, String subName) {
+        TopicName tn = validateTopic(topic);
+        String encodedSubName = Codec.encode(subName);
+        WebTarget path = topicPath(tn, "subscription", encodedSubName,
+                "properties");
+        final CompletableFuture<Map<String, String>> future = new CompletableFuture<>();
+        asyncGetRequest(path,
+                new InvocationCallback<Map<String, String>>() {
+
+                    @Override
+                    public void completed(Map<String, String> response) {
+                        future.complete(response);
+                    }
+
+                    @Override
+                    public void failed(Throwable throwable) {
+                        future.completeExceptionally(getApiException(throwable.getCause()));
+                    }
+                });
+        return future;
     }
 
     @Override

--- a/pulsar-client-tools-test/src/test/java/org/apache/pulsar/admin/cli/PulsarAdminToolTest.java
+++ b/pulsar-client-tools-test/src/test/java/org/apache/pulsar/admin/cli/PulsarAdminToolTest.java
@@ -1495,6 +1495,10 @@ public class PulsarAdminToolTest {
         verify(mockTopics).updateSubscriptionProperties("persistent://myprop/clust/ns1/ds1", "sub1", new HashMap<>());
 
         cmdTopics = new CmdTopics(() -> admin);
+        cmdTopics.run(split("get-subscription-properties persistent://myprop/clust/ns1/ds1 -s sub1"));
+        verify(mockTopics).getSubscriptionProperties("persistent://myprop/clust/ns1/ds1", "sub1");
+
+        cmdTopics = new CmdTopics(() -> admin);
         props = new HashMap<>();
         props.put("a", "b");
         props.put("c", "d");

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdTopics.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdTopics.java
@@ -99,7 +99,7 @@ public class CmdTopics extends CmdBase {
         jcommander.addCommand("unsubscribe", new DeleteSubscription());
         jcommander.addCommand("create-subscription", new CreateSubscription());
         jcommander.addCommand("update-subscription-properties", new UpdateSubscriptionProperties());
-        jcommander.addCommand("update-subscription-properties", new GetSubscriptionProperties());
+        jcommander.addCommand("get-subscription-properties", new GetSubscriptionProperties());
 
         jcommander.addCommand("stats", new GetStats());
         jcommander.addCommand("stats-internal", new GetInternalStats());

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdTopics.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdTopics.java
@@ -73,6 +73,7 @@ import org.apache.pulsar.common.policies.data.PublishRate;
 import org.apache.pulsar.common.policies.data.RetentionPolicies;
 import org.apache.pulsar.common.policies.data.SubscribeRate;
 import org.apache.pulsar.common.util.DateFormatter;
+import org.apache.pulsar.common.util.ObjectMapperFactory;
 import org.apache.pulsar.common.util.RelativeTimeUtil;
 
 @Getter
@@ -98,6 +99,7 @@ public class CmdTopics extends CmdBase {
         jcommander.addCommand("unsubscribe", new DeleteSubscription());
         jcommander.addCommand("create-subscription", new CreateSubscription());
         jcommander.addCommand("update-subscription-properties", new UpdateSubscriptionProperties());
+        jcommander.addCommand("update-subscription-properties", new GetSubscriptionProperties());
 
         jcommander.addCommand("stats", new GetStats());
         jcommander.addCommand("stats-internal", new GetInternalStats());
@@ -1003,6 +1005,24 @@ public class CmdTopics extends CmdBase {
                 throw new ParameterException("If you set --clear then you should not pass any properties");
             }
             getTopics().updateSubscriptionProperties(topic, subscriptionName, map);
+        }
+    }
+
+    @Parameters(commandDescription = "Get the properties of a subscription on a topic")
+    private class GetSubscriptionProperties extends CliCommand {
+        @Parameter(description = "persistent://tenant/namespace/topic", required = true)
+        private java.util.List<String> params;
+
+        @Parameter(names = { "-s",
+                "--subscription" }, description = "Subscription to describe", required = true)
+        private String subscriptionName;
+
+        @Override
+        void run() throws Exception {
+            String topic = validateTopicName(params);
+            Map<String, String> result = getTopics().getSubscriptionProperties(topic, subscriptionName);
+            // Ensure we are using JSON and not Java toString()
+            System.out.println(ObjectMapperFactory.getThreadLocal().writeValueAsString(result));
         }
     }
 

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/cli/CLITest.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/cli/CLITest.java
@@ -216,7 +216,7 @@ public class CLITest extends PulsarTestSuite {
                     "" + subscriptionPrefix + i
             );
             assertEquals(
-                    resultGet.getStdout(), "{\"a\":\"e\"}",
+                    resultGet.getStdout().trim(), "{\"a\":\"e\"}",
                     "unexpected output " + resultGet.getStdout() + " - error " + resultGet.getStderr());
 
             ContainerExecResult resultClear = container.execCmd(
@@ -239,7 +239,7 @@ public class CLITest extends PulsarTestSuite {
                     "" + subscriptionPrefix + i
             );
             assertEquals(
-                    resultGetAfterClear.getStdout(), "{}",
+                    resultGetAfterClear.getStdout().trim(), "{}",
                     "unexpected output " + resultGetAfterClear.getStdout()
                             + " - error " + resultGetAfterClear.getStderr());
 

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/cli/CLITest.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/cli/CLITest.java
@@ -207,6 +207,20 @@ public class CLITest extends PulsarTestSuite {
             );
             resultUpdate.assertNoOutput();
 
+            ContainerExecResult resultGet = container.execCmd(
+                    PulsarCluster.ADMIN_SCRIPT,
+                    "topics",
+                    "update-subscription-properties",
+                    "-p",
+                    "a=e",
+                    "persistent://public/default/" + topic,
+                    "--subscription",
+                    "" + subscriptionPrefix + i
+            );
+            assertEquals(
+                    "{\"a\":\"e\"}", resultGet.getStdout(),
+                    "unexpected output " + resultGet.getStdout() + " - error " + resultGet.getStderr());
+
             ContainerExecResult resultClear = container.execCmd(
                     PulsarCluster.ADMIN_SCRIPT,
                     "topics",

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/cli/CLITest.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/cli/CLITest.java
@@ -210,15 +210,13 @@ public class CLITest extends PulsarTestSuite {
             ContainerExecResult resultGet = container.execCmd(
                     PulsarCluster.ADMIN_SCRIPT,
                     "topics",
-                    "update-subscription-properties",
-                    "-p",
-                    "a=e",
+                    "get-subscription-properties",
                     "persistent://public/default/" + topic,
                     "--subscription",
                     "" + subscriptionPrefix + i
             );
             assertEquals(
-                    "{\"a\":\"e\"}", resultGet.getStdout(),
+                    resultGet.getStdout(), "{\"a\":\"e\"}",
                     "unexpected output " + resultGet.getStdout() + " - error " + resultGet.getStderr());
 
             ContainerExecResult resultClear = container.execCmd(
@@ -231,6 +229,20 @@ public class CLITest extends PulsarTestSuite {
                     "" + subscriptionPrefix + i
             );
             resultClear.assertNoOutput();
+
+            ContainerExecResult resultGetAfterClear = container.execCmd(
+                    PulsarCluster.ADMIN_SCRIPT,
+                    "topics",
+                    "get-subscription-properties",
+                    "persistent://public/default/" + topic,
+                    "--subscription",
+                    "" + subscriptionPrefix + i
+            );
+            assertEquals(
+                    resultGetAfterClear.getStdout(), "{}",
+                    "unexpected output " + resultGetAfterClear.getStdout()
+                            + " - error " + resultGetAfterClear.getStderr());
+
             i++;
         }
     }


### PR DESCRIPTION
### Motivation

In PIP-105 we added support for Subscription Properties. You can read them using the "stats" command, but it is not very user friendly.

### Modifications

This patch adds a specific REST API to get the properties and a pulsar-admin command

### Verifying this change

This change added tests 

### Documentation

Check the box below or label this PR directly.

Need to update docs? 

- [x] `doc-not-needed` 
(Please explain why)
  
REST API and pulsar-admin docs are generated automatically