### PR TITLE
[improve][broker]correct the semantics of loadBalancerHistoryResourcePercentage

### DIFF
--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -1181,7 +1181,7 @@ loadBalancerMsgThroughputMultiplierDifferenceShedderThreshold=4
 
 # When calculating new resource usage, the history usage accounts for.
 # It only takes effect in the ThresholdShedder strategy.
-loadBalancerHistoryResourcePercentage=0.9
+loadBalancerHistoryResourcePercentage=90
 
 # The BandWithIn usage weight when calculating new resource usage.
 # It only takes effect in the ThresholdShedder strategy.

--- a/conf/standalone.conf
+++ b/conf/standalone.conf
@@ -820,7 +820,7 @@ loadBalancerBrokerThresholdShedderPercentage=10
 
 # When calculating new resource usage, the history usage accounts for.
 # It only takes effect in the ThresholdShedder strategy.
-loadBalancerHistoryResourcePercentage=0.9
+loadBalancerHistoryResourcePercentage=90
 
 # The BandWithIn usage weight when calculating new resource usage.
 # It only takes effect in the ThresholdShedder strategy.

--- a/deployment/terraform-ansible/templates/broker.conf
+++ b/deployment/terraform-ansible/templates/broker.conf
@@ -946,7 +946,7 @@ loadBalancerBrokerThresholdShedderPercentage=10
 
 # When calculating new resource usage, the history usage accounts for.
 # It only take effect in ThresholdShedder strategy.
-loadBalancerHistoryResourcePercentage=0.9
+loadBalancerHistoryResourcePercentage=90
 
 # The BandWithIn usage weight when calculating new resourde usage.
 # It only take effect in ThresholdShedder strategy.

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -2050,7 +2050,7 @@ public class ServiceConfiguration implements PulsarConfiguration {
             category = CATEGORY_LOAD_BALANCER,
             doc = "Resource history Usage Percentage When adding new resource usage info"
     )
-    private double loadBalancerHistoryResourcePercentage = 0.9;
+    private double loadBalancerHistoryResourcePercentage = 90;
 
     @FieldContext(
             dynamic = true,

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/ThresholdShedder.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/ThresholdShedder.java
@@ -157,13 +157,14 @@ public class ThresholdShedder implements LoadSheddingStrategy {
                                           final double historyPercentage, final ServiceConfiguration conf) {
         Double historyUsage =
                 brokerAvgResourceUsage.get(broker);
+        final double historyProportion = historyPercentage / 100.0;
         double resourceUsage = localBrokerData.getMaxResourceUsageWithWeight(
                 conf.getLoadBalancerCPUResourceWeight(),
                 conf.getLoadBalancerMemoryResourceWeight(), conf.getLoadBalancerDirectMemoryResourceWeight(),
                 conf.getLoadBalancerBandwithInResourceWeight(),
                 conf.getLoadBalancerBandwithOutResourceWeight());
         historyUsage = historyUsage == null
-                ? resourceUsage : historyUsage * historyPercentage + (1 - historyPercentage) * resourceUsage;
+                ? resourceUsage : historyUsage * historyProportion + (1 - historyProportion) * resourceUsage;
 
         brokerAvgResourceUsage.put(broker, historyUsage);
         return historyUsage;

--- a/site2/docs/reference-configuration.md
+++ b/site2/docs/reference-configuration.md
@@ -705,7 +705,7 @@ You can set the log level and configuration in the  [log4j2.yaml](https://github
 | loadBalancerBrokerThresholdShedderPercentage | The broker resource usage threshold. When the broker resource usage is greater than the pulsar cluster average resource usage, the threshold shedder is triggered to offload bundles from the broker. It only takes effect in the ThresholdShedder strategy. | 10 |
 | loadBalancerMsgRateDifferenceShedderThreshold | Message-rate percentage threshold between highest and least loaded brokers for uniform load shedding. | 50 |
 | loadBalancerMsgThroughputMultiplierDifferenceShedderThreshold | Message-throughput threshold between highest and least loaded brokers for uniform load shedding. | 4 |
-| loadBalancerHistoryResourcePercentage | The history usage when calculating new resource usage. It only takes effect in the ThresholdShedder strategy. | 0.9 |
+| loadBalancerHistoryResourcePercentage | The history usage when calculating new resource usage. It only takes effect in the ThresholdShedder strategy. | 90 |
 | loadBalancerBandwithInResourceWeight | The BandWithIn usage weight when calculating new resource usage. It only takes effect in the ThresholdShedder strategy. | 1.0 |
 | loadBalancerBandwithOutResourceWeight | The BandWithOut usage weight when calculating new resource usage. It only takes effect in the ThresholdShedder strategy. | 1.0 |
 | loadBalancerCPUResourceWeight | The CPU usage weight when calculating new resource usage. It only takes effect in the ThresholdShedder strategy. | 1.0 |


### PR DESCRIPTION
### Motivation
correct the semantics of loadBalancerHistoryResourcePercentage like `loadBalancerBrokerOverloadedThresholdPercentage` and  `loadBalancerBrokerThresholdShedderPercentage`, 
https://github.com/apache/pulsar/blob/bb0bfb904da90030c171ceac0159142d2bdb51b7/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java#L2026-L2038


### Modifications
correct the semantics of loadBalancerHistoryResourcePercentage 

### Verifying this change

- [x]  Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:
If `yes` was chosen, please highlight the changes

- Dependencies (does it add or upgrade a dependency): (no)
- The public API: (no)
- The schema: (no)
- The default values of configurations: (no)
- The wire protocol: (no)
- The rest endpoints: (no)
- The admin cli options: (no)
- Anything that affects deployment: (no)

### Documentation
Check the box below and label this PR (if you have committer privilege).

Need to update docs? 
- [x] `doc-not-needed` 
