### PR TITLE
Changed Docker Maven plugin from Spotify to fabric8

### DIFF
--- a/docker/pulsar-all/Dockerfile
+++ b/docker/pulsar-all/Dockerfile
@@ -21,11 +21,12 @@ FROM busybox as pulsar-all
 
 ARG PULSAR_IO_DIR
 ARG PULSAR_OFFLOADER_TARBALL
+ARG PULSAR_VERSION
 
 ADD ${PULSAR_IO_DIR} /connectors
 ADD ${PULSAR_OFFLOADER_TARBALL} /
 RUN mv /apache-pulsar-offloaders-*/offloaders /offloaders
 
-FROM apachepulsar/pulsar:latest
+FROM apachepulsar/pulsar:${PULSAR_VERSION}
 COPY --from=pulsar-all /connectors /pulsar/connectors
 COPY --from=pulsar-all /offloaders /pulsar/offloaders

--- a/docker/pulsar-all/pom.xml
+++ b/docker/pulsar-all/pom.xml
@@ -118,10 +118,10 @@
               </execution>
             </executions>
           </plugin>
+
           <plugin>
-            <groupId>com.spotify</groupId>
-            <artifactId>dockerfile-maven-plugin</artifactId>
-            <version>${dockerfile-maven.version}</version>
+            <groupId>io.fabric8</groupId>
+            <artifactId>docker-maven-plugin</artifactId>
             <executions>
               <execution>
                 <id>default</id>
@@ -129,48 +129,25 @@
                   <goal>build</goal>
                 </goals>
               </execution>
-              <execution>
-                <id>add-no-repo-and-version</id>
-                <goals>
-                  <goal>tag</goal>
-                </goals>
-                <configuration>
-                  <repository>pulsar-all</repository>
-                  <tag>${project.version}</tag>
-                </configuration>
-              </execution>
-              <execution>
-                <id>add-no-repo-and-latest</id>
-                <goals>
-                  <goal>tag</goal>
-                </goals>
-                <configuration>
-                  <repository>pulsar-all</repository>
-                  <tag>latest</tag>
-                </configuration>
-              </execution>
-              <execution>
-                <id>tag-and-push-latest</id>
-                <goals>
-                  <goal>tag</goal>
-                  <goal>push</goal>
-                </goals>
-                <configuration>
-                  <repository>${docker.organization}/pulsar-all</repository>
-                  <tag>latest</tag>
-                </configuration>
-              </execution>
             </executions>
             <configuration>
-              <repository>${docker.organization}/pulsar-all</repository>
-              <pullNewerImage>false</pullNewerImage>
-              <tag>${project.version}</tag>
-              <buildArgs>
-                <PULSAR_IO_DIR>target/apache-pulsar-io-connectors-${project.version}-bin</PULSAR_IO_DIR>
-                <PULSAR_OFFLOADER_TARBALL>target/pulsar-offloader-distribution-${project.version}-bin.tar.gz</PULSAR_OFFLOADER_TARBALL>
-              </buildArgs>
+              <verbose>true</verbose>
+              <images>
+                <image>
+                  <name>${docker.organization}/pulsar-all:${project.version}</name>
+                  <build>
+                    <dockerFileDir>${project.basedir}</dockerFileDir>
+                    <args>
+                      <PULSAR_IO_DIR>target/apache-pulsar-io-connectors-${project.version}-bin</PULSAR_IO_DIR>
+                      <PULSAR_OFFLOADER_TARBALL>target/pulsar-offloader-distribution-${project.version}-bin.tar.gz</PULSAR_OFFLOADER_TARBALL>
+                      <PULSAR_VERSION>${project.version}</PULSAR_VERSION>
+                    </args>
+                  </build>
+                </image>
+              </images>
             </configuration>
           </plugin>
+
         </plugins>
       </build>
     </profile>

--- a/docker/pulsar/pom.xml
+++ b/docker/pulsar/pom.xml
@@ -81,6 +81,7 @@
               </execution>
             </executions>
           </plugin>
+
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-antrun-plugin</artifactId>
@@ -102,59 +103,35 @@
               </execution>
             </executions>
           </plugin>
+
           <plugin>
-            <groupId>com.spotify</groupId>
-            <artifactId>dockerfile-maven-plugin</artifactId>
-            <version>${dockerfile-maven.version}</version>
+            <groupId>io.fabric8</groupId>
+            <artifactId>docker-maven-plugin</artifactId>
             <executions>
               <execution>
                 <id>default</id>
+                <phase>package</phase>
                 <goals>
                   <goal>build</goal>
                 </goals>
               </execution>
-              <execution>
-                <id>add-no-repo-and-version</id>
-                <goals>
-                  <goal>tag</goal>
-                </goals>
-                <configuration>
-                  <repository>pulsar</repository>
-                  <tag>${project.version}</tag>
-                </configuration>
-              </execution>
-              <execution>
-                <id>add-no-repo-and-latest</id>
-                <goals>
-                  <goal>tag</goal>
-                </goals>
-                <configuration>
-                  <repository>pulsar</repository>
-                  <tag>latest</tag>
-                </configuration>
-              </execution>
-              <execution>
-                <id>tag-and-push-latest</id>
-                <goals>
-                  <goal>tag</goal>
-                  <goal>push</goal>
-                </goals>
-                <configuration>
-                  <repository>${docker.organization}/pulsar</repository>
-                  <tag>latest</tag>
-                </configuration>
-              </execution>
             </executions>
             <configuration>
-              <repository>${docker.organization}/pulsar</repository>
-              <pullNewerImage>false</pullNewerImage>
-              <tag>${project.version}</tag>
-              <buildArgs>
-                <PULSAR_TARBALL>target/pulsar-server-distribution-${project.version}-bin.tar.gz</PULSAR_TARBALL>
-                <UBUNTU_MIRROR>${env.UBUNTU_MIRROR}</UBUNTU_MIRROR>
-              </buildArgs>
+              <verbose>true</verbose>
+              <images>
+                <image>
+                  <name>${docker.organization}/pulsar:${project.version}</name>
+                  <build>
+                    <dockerFileDir>${project.basedir}</dockerFileDir>
+                    <args>
+                      <PULSAR_TARBALL>target/pulsar-server-distribution-${project.version}-bin.tar.gz</PULSAR_TARBALL>
+                    </args>
+                  </build>
+                </image>
+              </images>
             </configuration>
           </plugin>
+
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-dependency-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -139,7 +139,7 @@ flexible messaging model and an intuitive client API.</description>
     <reflections.version>0.9.11</reflections.version>
     <swagger.version>1.6.2</swagger.version>
     <puppycrawl.checkstyle.version>8.37</puppycrawl.checkstyle.version>
-    <dockerfile-maven.version>1.4.13</dockerfile-maven.version>
+    <docker-maven.version>0.40.1</docker-maven.version>
     <typetools.version>0.5.0</typetools.version>
     <protobuf3.version>3.19.2</protobuf3.version>
     <protoc3.version>${protobuf3.version}</protoc3.version>
@@ -1886,6 +1886,11 @@ flexible messaging model and an intuitive client API.</description>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>properties-maven-plugin</artifactId>
           <version>${properties-maven-plugin.version}</version>
+        </plugin>
+        <plugin>
+          <groupId>io.fabric8</groupId>
+          <artifactId>docker-maven-plugin</artifactId>
+          <version>${docker-maven.version}</version>
         </plugin>
       </plugins>
     </pluginManagement>

--- a/tests/docker-images/java-test-image/pom.xml
+++ b/tests/docker-images/java-test-image/pom.xml
@@ -134,10 +134,10 @@
               </execution>
             </executions>
           </plugin>
+
           <plugin>
-            <groupId>com.spotify</groupId>
-            <artifactId>dockerfile-maven-plugin</artifactId>
-            <version>${dockerfile-maven.version}</version>
+            <groupId>io.fabric8</groupId>
+            <artifactId>docker-maven-plugin</artifactId>
             <executions>
               <execution>
                 <id>default</id>
@@ -146,29 +146,24 @@
                   <goal>build</goal>
                 </goals>
               </execution>
-              <execution>
-                <id>add-latest-tag</id>
-                <phase>package</phase>
-                <goals>
-                  <goal>tag</goal>
-                </goals>
-                <configuration>
-                  <repository>${docker.organization}/java-test-image</repository>
-                  <tag>latest</tag>
-                </configuration>
-              </execution>
             </executions>
             <configuration>
-              <repository>${docker.organization}/java-test-image</repository>
-              <tag>${project.version}</tag>
-              <pullNewerImage>false</pullNewerImage>
-              <noCache>true</noCache>
-              <buildArgs>
-                <PULSAR_TARBALL>target/pulsar-server-distribution-bin.tar.gz</PULSAR_TARBALL>
-                <UBUNTU_MIRROR>${env.UBUNTU_MIRROR}</UBUNTU_MIRROR>
-              </buildArgs>
+              <verbose>true</verbose>
+              <images>
+                <image>
+                  <name>${docker.organization}/java-test-image:latest</name>
+                  <build>
+                    <dockerFileDir>${project.basedir}</dockerFileDir>
+                    <args>
+                      <PULSAR_TARBALL>target/pulsar-server-distribution-bin.tar.gz</PULSAR_TARBALL>
+                      <UBUNTU_MIRROR>${env.UBUNTU_MIRROR}</UBUNTU_MIRROR>
+                    </args>
+                  </build>
+                </image>
+              </images>
             </configuration>
           </plugin>
+
         </plugins>
       </build>
     </profile>

--- a/tests/docker-images/latest-version-image/Dockerfile
+++ b/tests/docker-images/latest-version-image/Dockerfile
@@ -17,9 +17,11 @@
 # under the License.
 #
 
+ARG PULSAR_VERSION
+
 # build go lang examples first in a separate layer
 
-FROM apachepulsar/pulsar:latest as pulsar-function-go
+FROM apachepulsar/pulsar:${PULSAR_VERSION} as pulsar-function-go
 
 # Use root for builder
 USER root
@@ -50,12 +52,12 @@ RUN cd /go/src/github.com/apache/pulsar/pulsar-function-go/pf && go install
 RUN cd /go/src/github.com/apache/pulsar/pulsar-function-go/examples && go install ./...
 
 # Reference pulsar-all to copy connectors from there
-FROM apachepulsar/pulsar-all:latest as pulsar-all
+FROM apachepulsar/pulsar-all:${PULSAR_VERSION} as pulsar-all
 
 ########################################
 ###### Main image build
 ########################################
-FROM apachepulsar/pulsar:latest
+FROM apachepulsar/pulsar:${PULSAR_VERSION}
 
 # Switch to run as the root user to simplify building container and then running
 # supervisord. Each of the pulsar components are spawned by supervisord and their

--- a/tests/docker-images/latest-version-image/pom.xml
+++ b/tests/docker-images/latest-version-image/pom.xml
@@ -100,10 +100,10 @@
               </execution>
             </executions>
           </plugin>
+
           <plugin>
-            <groupId>com.spotify</groupId>
-            <artifactId>dockerfile-maven-plugin</artifactId>
-            <version>${dockerfile-maven.version}</version>
+            <groupId>io.fabric8</groupId>
+            <artifactId>docker-maven-plugin</artifactId>
             <executions>
               <execution>
                 <id>default</id>
@@ -112,25 +112,23 @@
                   <goal>build</goal>
                 </goals>
               </execution>
-              <execution>
-                <id>add-latest-tag</id>
-                <phase>package</phase>
-                <goals>
-                  <goal>tag</goal>
-                </goals>
-                <configuration>
-                  <repository>${docker.organization}/pulsar-test-latest-version</repository>
-                  <tag>latest</tag>
-                </configuration>
-              </execution>
             </executions>
             <configuration>
-              <repository>${docker.organization}/pulsar-test-latest-version</repository>
-              <tag>${project.version}</tag>
-              <pullNewerImage>false</pullNewerImage>
-              <noCache>true</noCache>
+              <verbose>true</verbose>
+              <images>
+                <image>
+                  <name>${docker.organization}/pulsar-test-latest-version:latest</name>
+                  <build>
+                    <dockerFileDir>${project.basedir}</dockerFileDir>
+                    <args>
+                      <PULSAR_VERSION>${project.version}</PULSAR_VERSION>
+                    </args>
+                  </build>
+                </image>
+              </images>
             </configuration>
           </plugin>
+
         </plugins>
       </build>
     </profile>


### PR DESCRIPTION
### Motivation

The maven plugin `com.spotify:dockerfile-maven-plugin` that we are using to build Docker images has been discontinued and not supported for quite some time. There are also things that don't work anymore with this plugin, like for example building on M1 Mac with an ARM based JVM. 

The suggested replacement is `io.fabric8:docker-maven-plugin` (https://dmp.fabric8.io) which is actively mantained.
- [x] `doc-not-needed`
