### PR TITLE
[Fix][pulsar-io] KCA: handle kafka preCommit() returning earlier offsets than requested

### DIFF
--- a/pulsar-io/kafka-connect-adaptor/src/main/java/org/apache/pulsar/io/kafka/connect/KafkaConnectSink.java
+++ b/pulsar-io/kafka-connect-adaptor/src/main/java/org/apache/pulsar/io/kafka/connect/KafkaConnectSink.java
@@ -313,7 +313,7 @@ public class KafkaConnectSink implements Sink<GenericObject> {
 
         if (sourceRecord.getMessage().isPresent()) {
             // Use index added by org.apache.pulsar.common.intercept.AppendIndexMetadataInterceptor if present.
-            // Requires enableExposingBrokerEntryMetadataToClient=true on brokers.
+            // Requires exposingBrokerEntryMetadataToClientEnabled=true on brokers.
             if (useIndexAsOffset && sourceRecord.getMessage().get().hasIndex()) {
                 return sourceRecord.getMessage().get()
                         .getIndex().orElse(-1L);

--- a/pulsar-io/kafka-connect-adaptor/src/main/java/org/apache/pulsar/io/kafka/connect/PulsarKafkaConnectSinkConfig.java
+++ b/pulsar-io/kafka-connect-adaptor/src/main/java/org/apache/pulsar/io/kafka/connect/PulsarKafkaConnectSinkConfig.java
@@ -77,7 +77,7 @@ public class PulsarKafkaConnectSinkConfig implements Serializable {
             defaultValue = "true",
             help = "Allows use of message index instead of message sequenceId as offset, if available.\n"
                     + "Requires AppendIndexMetadataInterceptor and "
-                    + "enableExposingBrokerEntryMetadataToClient=true on brokers.")
+                    + "exposingBrokerEntryMetadataToClientEnabled=true on brokers.")
     private boolean useIndexAsOffset = true;
 
     @FieldDoc(


### PR DESCRIPTION
### Motivation

preCommit() can return offsets earlier than ones KCA requested to flush.
Only ack messages up to the committed offsets to avoid skipping data on connector restart.

### Modifications

code change + test

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

Added unit test

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

NO

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API: (yes / no)
  - The schema: (yes / no / don't know)
  - The default values of configurations: (yes / no)
  - The wire protocol: (yes / no)
  - The rest endpoints: (yes / no)
  - The admin cli options: (yes / no)
  - Anything that affects deployment: (yes / no / don't know)

### Documentation

Check the box below or label this PR directly.

Need to update docs? 

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)
  
- [x] `doc-not-needed` 
(Please explain why)
  
- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)