### PR TITLE
Modify the broker.conf with bundle number

### DIFF
--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -258,7 +258,7 @@ brokerDeduplicationEntriesInterval=1000
 brokerDeduplicationProducerInactivityTimeoutMinutes=360
 
 # When a namespace is created without specifying the number of bundle, this
-# value will be used as the default
+# value will be used as the default，the maximum number of namespaces is 2147483648.
 defaultNumberOfNamespaceBundles=4
 
 # The maximum number of namespaces that each tenant can create
@@ -1145,7 +1145,7 @@ loadBalancerNamespaceBundleMaxMsgRate=30000
 # maximum bandwidth (in + out) in a bundle, otherwise bundle split will be triggered
 loadBalancerNamespaceBundleMaxBandwidthMbytes=100
 
-# maximum number of bundles in a namespace
+# maximum number of bundles in a namespace when loadBalance triggers bundle auto split
 loadBalancerNamespaceMaximumBundles=128
 
 # Override the auto-detection of the network interfaces max speed.


### PR DESCRIPTION


### Motivation


Many community partners have doubts and misunderstandings about this parameter, so the modification is more clear

### Modifications
1）modify the description
# When a namespace is created without specifying the number of bundle, this
# value will be used as the default，the maximum number of namespaces is 2147483648.
defaultNumberOfNamespaceBundles=4


2）modify the description
# maximum number of bundles in a namespace when loadBalance triggers bundle auto split
loadBalancerNamespaceMaximumBundles=128

### Verifying this change
no


### Documentation

Check the box below or label this PR directly.

Need to update docs? 

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)
  
- [x] `doc-not-needed` 
(Please explain why)
  
- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)