### PR TITLE
[fix][broker] Fix problem when user create topic with `-partition-` keywords.

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
@@ -2634,6 +2634,9 @@ public class BrokerService implements Closeable {
                                     if (metadata.partitions == 0
                                             && !topicExists
                                             && !topicName.isPartitioned()
+                                            // If the local topic name contains `-partition-` keywords,
+                                            // don't allow to create metadata
+                                            && !topicName.getLocalName().contains(TopicName.PARTITIONED_TOPIC_SUFFIX)
                                             && pulsar.getBrokerService().isAllowAutoTopicCreation(topicName)
                                             && pulsar.getBrokerService().isDefaultTopicTypePartitioned(topicName)) {
 


### PR DESCRIPTION
### Motivation

See mail to get context.   https://lists.apache.org/thread/7rbq5vp4hor6tx5nrhrg9xk8sq6sr4ft (maybe Gmail have a good format.)

### Modifications

- When users create topics with `-partition-` keywords, don't allow them to create partition metadata.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Documentation

- [x] `doc-not-needed` 