### PR TITLE
[cleanup][broker]Cleanup check replication clusters is null

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -3023,9 +3023,7 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
             updateSubscribeRateLimiter();
             replicators.forEach((name, replicator) -> replicator.updateRateLimiter());
             checkMessageExpiry();
-            if (policies.getReplicationClusters() != null) {
-                checkReplicationAndRetryOnFailure();
-            }
+            checkReplicationAndRetryOnFailure();
 
             checkDeduplicationStatus();
 


### PR DESCRIPTION
### Motivation


* There is no need to  check `policies.getReplicationClusters() != null` because we have used `HierarchyTopicPolicies#replicationClusters`

### Modifications

* Remove  checking `policies.getReplicationClusters() != null`

### Verifying this change

- [x] Make sure that the change passes the CI checks.


Need to update docs? 

- [x] `doc-not-needed` 
(Please explain why)