### PR TITLE
Motify typo in pulsar-client-admin-shaded/pom.xml 

### DIFF
--- a/pulsar-client-admin-shaded/pom.xml
+++ b/pulsar-client-admin-shaded/pom.xml
@@ -27,7 +27,7 @@
     <groupId>org.apache.pulsar</groupId>
     <artifactId>pulsar</artifactId>
     <version>2.10.0-SNAPSHOT</version>
-    <relativePath>..</relativePath>
+    <relativePath>../pom.xml</relativePath>
   </parent>
 
   <artifactId>pulsar-client-admin</artifactId>

--- a/pulsar-zookeeper-utils/pom.xml
+++ b/pulsar-zookeeper-utils/pom.xml
@@ -26,7 +26,7 @@
     <groupId>org.apache.pulsar</groupId>
     <artifactId>pulsar</artifactId>
     <version>2.10.0-SNAPSHOT</version>
-    <relativePath>..</relativePath>
+    <relativePath>../pom.xml</relativePath>
   </parent>
 
   <artifactId>pulsar-zookeeper-utils</artifactId>


### PR DESCRIPTION
In the pulsar project, it is found that the <relativepath> tag of the "pom.xml" file in multiple sub modules is incorrect. Do you need to modify it?

`<parent>
    <groupId>org.apache.pulsar</groupId>
    <artifactId>pulsar</artifactId>
    <version>2.10.0-SNAPSHOT</version>
    <relativePath>../pom.xml</relativePath>
  </parent>`