### PR TITLE
[improve][function] Support Record<?> as WindowFunction output type

### DIFF
--- a/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/FunctionCommon.java
+++ b/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/FunctionCommon.java
@@ -107,9 +107,9 @@ public class FunctionCommon {
         // if window function
         if (isWindowConfigPresent) {
             if (WindowFunction.class.isAssignableFrom(userClass)) {
-                typeArgs = TypeResolver.resolveRawArguments(WindowFunction.class, userClass);
+                typeArgs = getFunctionTypesUnwrappingRecordIfNeeded(WindowFunction.class, userClass);
             } else {
-                typeArgs = TypeResolver.resolveRawArguments(java.util.function.Function.class, userClass);
+                typeArgs = getFunctionTypesUnwrappingRecordIfNeeded(java.util.function.Function.class, userClass);
                 if (!typeArgs[0].equals(Collection.class)) {
                     throw new IllegalArgumentException("Window function must take a collection as input");
                 }
@@ -120,24 +120,23 @@ public class FunctionCommon {
             }
         } else {
             if (Function.class.isAssignableFrom(userClass)) {
-                typeArgs = TypeResolver.resolveRawArguments(Function.class, userClass);
-                if (typeArgs[1].equals(Record.class)) {
-                    Type type = TypeResolver.resolveGenericType(Function.class, userClass);
-                    Type recordType = ((ParameterizedType) type).getActualTypeArguments()[1];
-                    Type actualInputType = ((ParameterizedType) recordType).getActualTypeArguments()[0];
-                    typeArgs[1] = (Class<?>) actualInputType;
-                }
+                typeArgs = getFunctionTypesUnwrappingRecordIfNeeded(Function.class, userClass);
             } else {
-                typeArgs = TypeResolver.resolveRawArguments(java.util.function.Function.class, userClass);
-                if (typeArgs[1].equals(Record.class)) {
-                    Type type = TypeResolver.resolveGenericType(java.util.function.Function.class, userClass);
-                    Type recordType = ((ParameterizedType) type).getActualTypeArguments()[1];
-                    Type actualInputType = ((ParameterizedType) recordType).getActualTypeArguments()[0];
-                    typeArgs[1] = (Class<?>) actualInputType;
-                }
+                typeArgs = getFunctionTypesUnwrappingRecordIfNeeded(java.util.function.Function.class, userClass);
             }
         }
 
+        return typeArgs;
+    }
+
+    private static Class<?>[] getFunctionTypesUnwrappingRecordIfNeeded(Class<?> type, Class<?> subType) {
+        Class<?>[] typeArgs = TypeResolver.resolveRawArguments(type, subType);
+        if (typeArgs[1].equals(Record.class)) {
+            Type genericType = TypeResolver.resolveGenericType(type, subType);
+            Type recordType = ((ParameterizedType) genericType).getActualTypeArguments()[1];
+            Type actualInputType = ((ParameterizedType) recordType).getActualTypeArguments()[0];
+            typeArgs[1] = (Class<?>) actualInputType;
+        }
         return typeArgs;
     }
 

--- a/pulsar-functions/utils/src/test/java/org/apache/pulsar/functions/utils/FunctionCommonTest.java
+++ b/pulsar-functions/utils/src/test/java/org/apache/pulsar/functions/utils/FunctionCommonTest.java
@@ -153,9 +153,25 @@ public class FunctionCommonTest {
                 }, true
             },
             {
+                new WindowFunction<String, Record<Integer>>() {
+                    @Override
+                    public Record<Integer> process(Collection<Record<String>> input, WindowContext context) throws Exception {
+                        return null;
+                    }
+                }, true
+            },
+            {
                 new java.util.function.Function<Collection<String>, Integer>() {
                     @Override
                     public Integer apply(Collection<String> strings) {
+                        return null;
+                    }
+                }, true
+            },
+            {
+                new java.util.function.Function<Collection<String>, Record<Integer>>() {
+                    @Override
+                    public Record<Integer> apply(Collection<String> strings) {
                         return null;
                     }
                 }, true


### PR DESCRIPTION
### Motivation
Same as https://github.com/apache/pulsar/pull/16041 for WindowFunction

### Modifications

Detect and unwrap Record type in getFunctionTypes if the class is a WindowFunction

### Verifying this change

- [ ] Make sure that the change passes the CI checks.


This change added tests and can be verified as follows:

Run `FunctionCommonTest::testGetFunctionTypes`

### Does this pull request potentially affect one of the following parts:
no

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API: (yes / no)
  - The schema: (yes / no / don't know)
  - The default values of configurations: (yes / no)
  - The wire protocol: (yes / no)
  - The rest endpoints: (yes / no)
  - The admin cli options: (yes / no)
  - Anything that affects deployment: (yes / no / don't know)

### Documentation

Check the box below or label this PR directly.

Need to update docs? 

- [x] `doc-required` 
(Your PR needs to update docs and you will update later)
  
- [ ] `doc-not-needed` 
(Please explain why)
  
- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)