### PR TITLE
[improve][pulsar-client-tools][ISSUE-16082] - Updated set retention time description and added test cases including default time

### DIFF
--- a/pulsar-client-tools-test/src/test/java/org/apache/pulsar/admin/cli/PulsarAdminToolTest.java
+++ b/pulsar-client-tools-test/src/test/java/org/apache/pulsar/admin/cli/PulsarAdminToolTest.java
@@ -23,6 +23,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.longThat;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -590,6 +591,20 @@ public class PulsarAdminToolTest {
         verify(mockNamespaces).setRetention("myprop/clust/ns1",
                 new RetentionPolicies(60, 1));
 
+        // Test with default time unit (seconds)
+        namespaces = new CmdNamespaces(() -> admin);
+        reset(mockNamespaces);
+        namespaces.run(split("set-retention myprop/clust/ns1 -t 120 -s 20M"));
+        verify(mockNamespaces).setRetention("myprop/clust/ns1",
+                new RetentionPolicies(2, 20));
+
+        // Test with explicit time unit (seconds)
+        namespaces = new CmdNamespaces(() -> admin);
+        reset(mockNamespaces);
+        namespaces.run(split("set-retention myprop/clust/ns1 -t 120s -s 20M"));
+        verify(mockNamespaces).setRetention("myprop/clust/ns1",
+                new RetentionPolicies(2, 20));
+
         namespaces.run(split("get-retention myprop/clust/ns1"));
         verify(mockNamespaces).getRetention("myprop/clust/ns1");
 
@@ -948,6 +963,21 @@ public class PulsarAdminToolTest {
         cmdTopics.run(split("set-retention persistent://myprop/clust/ns1/ds1 -t 10m -s 20M"));
         verify(mockTopicsPolicies).setRetention("persistent://myprop/clust/ns1/ds1",
                 new RetentionPolicies(10, 20));
+
+        // Test with default time unit (seconds)
+        cmdTopics = new CmdTopicPolicies(() -> admin);
+        reset(mockTopicsPolicies);
+        cmdTopics.run(split("set-retention persistent://myprop/clust/ns1/ds1 -t 180 -s 20M"));
+        verify(mockTopicsPolicies).setRetention("persistent://myprop/clust/ns1/ds1",
+                new RetentionPolicies(3, 20));
+
+        // Test with explicit time unit (seconds)
+        cmdTopics = new CmdTopicPolicies(() -> admin);
+        reset(mockTopicsPolicies);
+        cmdTopics.run(split("set-retention persistent://myprop/clust/ns1/ds1 -t 180s -s 20M"));
+        verify(mockTopicsPolicies).setRetention("persistent://myprop/clust/ns1/ds1",
+                new RetentionPolicies(3, 20));
+
         cmdTopics.run(split("remove-retention persistent://myprop/clust/ns1/ds1"));
         verify(mockTopicsPolicies).removeRetention("persistent://myprop/clust/ns1/ds1");
 
@@ -1122,6 +1152,18 @@ public class PulsarAdminToolTest {
         cmdTopics.run(split("set-retention persistent://myprop/clust/ns1/ds1 -t 10m -s 20M -g"));
         verify(mockGlobalTopicsPolicies).setRetention("persistent://myprop/clust/ns1/ds1",
                 new RetentionPolicies(10, 20));
+
+        cmdTopics = new CmdTopicPolicies(() -> admin);
+        cmdTopics.run(split("set-retention persistent://myprop/clust/ns1/ds1 -t 1440s -s 20M -g"));
+        verify(mockGlobalTopicsPolicies).setRetention("persistent://myprop/clust/ns1/ds1",
+                new RetentionPolicies(24, 20));
+
+        cmdTopics = new CmdTopicPolicies(() -> admin);
+        reset(mockGlobalTopicsPolicies);
+        cmdTopics.run(split("set-retention persistent://myprop/clust/ns1/ds1 -t 1440 -s 20M -g"));
+        verify(mockGlobalTopicsPolicies).setRetention("persistent://myprop/clust/ns1/ds1",
+                new RetentionPolicies(24, 20));
+
         cmdTopics.run(split("remove-retention persistent://myprop/clust/ns1/ds1 -g"));
         verify(mockGlobalTopicsPolicies).removeRetention("persistent://myprop/clust/ns1/ds1");
 

--- a/pulsar-client-tools-test/src/test/java/org/apache/pulsar/admin/cli/PulsarAdminToolTest.java
+++ b/pulsar-client-tools-test/src/test/java/org/apache/pulsar/admin/cli/PulsarAdminToolTest.java
@@ -605,6 +605,20 @@ public class PulsarAdminToolTest {
         verify(mockNamespaces).setRetention("myprop/clust/ns1",
                 new RetentionPolicies(2, 20));
 
+        // Test size with default size less than 1 mb
+        namespaces = new CmdNamespaces(() -> admin);
+        reset(mockNamespaces);
+        namespaces.run(split("set-retention myprop/clust/ns1 -t 120s -s 4096"));
+        verify(mockNamespaces).setRetention("myprop/clust/ns1",
+                new RetentionPolicies(2, 0));
+
+        // Test size with default size greater than 1mb
+        namespaces = new CmdNamespaces(() -> admin);
+        reset(mockNamespaces);
+        namespaces.run(split("set-retention myprop/clust/ns1 -t 180 -s " + (2 * 1024 * 1024)));
+        verify(mockNamespaces).setRetention("myprop/clust/ns1",
+                new RetentionPolicies(3, 2));
+
         namespaces.run(split("get-retention myprop/clust/ns1"));
         verify(mockNamespaces).getRetention("myprop/clust/ns1");
 
@@ -977,6 +991,20 @@ public class PulsarAdminToolTest {
         cmdTopics.run(split("set-retention persistent://myprop/clust/ns1/ds1 -t 180s -s 20M"));
         verify(mockTopicsPolicies).setRetention("persistent://myprop/clust/ns1/ds1",
                 new RetentionPolicies(3, 20));
+
+        // Test size with default size less than 1 mb
+        cmdTopics = new CmdTopicPolicies(() -> admin);
+        reset(mockTopicsPolicies);
+        cmdTopics.run(split("set-retention persistent://myprop/clust/ns1/ds1 -t 180 -s 4096"));
+        verify(mockTopicsPolicies).setRetention("persistent://myprop/clust/ns1/ds1",
+                new RetentionPolicies(3, 0));
+
+        // Test size with default size greater than 1mb
+        cmdTopics = new CmdTopicPolicies(() -> admin);
+        reset(mockTopicsPolicies);
+        cmdTopics.run(split("set-retention persistent://myprop/clust/ns1/ds1 -t 180 -s " + (2 * 1024 * 1024)));
+        verify(mockTopicsPolicies).setRetention("persistent://myprop/clust/ns1/ds1",
+                new RetentionPolicies(3, 2));
 
         cmdTopics.run(split("remove-retention persistent://myprop/clust/ns1/ds1"));
         verify(mockTopicsPolicies).removeRetention("persistent://myprop/clust/ns1/ds1");

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdNamespaces.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdNamespaces.java
@@ -744,14 +744,14 @@ public class CmdNamespaces extends CmdBase {
         @Parameter(names = { "--time",
                 "-t" }, description = "Retention time with optional time unit suffix "
                         + "eg: 100m, 3h, 2d, 5w. "
-                        + "The suffix character can be s for seconds, m for minutes, h for hours, "
-                        + "d for days, w for weeks or y for years. "
                         + "If no time unit is specified the default is seconds, eg: "
                         + "-t 120 will set retention to 2 minutes. "
                         + "0 means no retention and -1 means infinite time retention.", required = true)
         private String retentionTimeStr;
 
-        @Parameter(names = { "--size", "-s" }, description = "Retention size limit (eg: 10M, 16G, 3T). "
+        @Parameter(names = { "--size", "-s" }, description = "Retention size limit with optional size unit suffix "
+                + "eg: 4096, 10M, 16G, 3T.  The size unit suffix character can be k/K, m/M, g/G, or t/T.  "
+                + "If the size unit suffix is not specified, the default unit is bytes. "
                 + "0 or less than 1MB means no retention and -1 means infinite size retention", required = true)
         private String limitStr;
 

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdNamespaces.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdNamespaces.java
@@ -742,8 +742,13 @@ public class CmdNamespaces extends CmdBase {
         private java.util.List<String> params;
 
         @Parameter(names = { "--time",
-                "-t" }, description = "Retention time in minutes (or minutes, hours,days,weeks eg: 100m, 3h, 2d, 5w). "
-                        + "0 means no retention and -1 means infinite time retention", required = true)
+                "-t" }, description = "Retention time with optional time unit suffix "
+                        + "eg: 100m, 3h, 2d, 5w. "
+                        + "The suffix character can be s for seconds, m for minutes, h for hours, "
+                        + "d for days, w for weeks or y for years. "
+                        + "If no time unit is specified the default is seconds, eg: "
+                        + "-t 120 will set retention to 2 minutes. "
+                        + "0 means no retention and -1 means infinite time retention.", required = true)
         private String retentionTimeStr;
 
         @Parameter(names = { "--size", "-s" }, description = "Retention size limit (eg: 10M, 16G, 3T). "

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdNamespaces.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdNamespaces.java
@@ -742,15 +742,15 @@ public class CmdNamespaces extends CmdBase {
         private java.util.List<String> params;
 
         @Parameter(names = { "--time",
-                "-t" }, description = "Retention time with optional time unit suffix "
-                        + "eg: 100m, 3h, 2d, 5w. "
-                        + "If no time unit is specified the default is seconds, eg: "
-                        + "-t 120 will set retention to 2 minutes. "
+                "-t" }, description = "Retention time with optional time unit suffix. "
+                        + "For example, 100m, 3h, 2d, 5w. "
+                        + "If the time unit is not specified, the default unit is seconds. For example, "
+                        + "-t 120 sets retention to 2 minutes. "
                         + "0 means no retention and -1 means infinite time retention.", required = true)
         private String retentionTimeStr;
 
-        @Parameter(names = { "--size", "-s" }, description = "Retention size limit with optional size unit suffix "
-                + "eg: 4096, 10M, 16G, 3T.  The size unit suffix character can be k/K, m/M, g/G, or t/T.  "
+        @Parameter(names = { "--size", "-s" }, description = "Retention size limit with optional size unit suffix. "
+                + "For example, 4096, 10M, 16G, 3T.  The size unit suffix character can be k/K, m/M, g/G, or t/T.  "
                 + "If the size unit suffix is not specified, the default unit is bytes. "
                 + "0 or less than 1MB means no retention and -1 means infinite size retention", required = true)
         private String limitStr;

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdTopicPolicies.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdTopicPolicies.java
@@ -527,11 +527,18 @@ public class CmdTopicPolicies extends CmdBase {
         private List<String> params;
 
         @Parameter(names = { "--time",
-                "-t" }, description = "Retention time in minutes (or minutes, hours,days,weeks eg: 100m, 3h, 2d, 5w). "
-                + "0 means no retention and -1 means infinite time retention", required = true)
+                "-t" }, description = "Retention time with optional time unit suffix "
+                + "eg: 100m, 3h, 2d, 5w. "
+                + "The suffix character can be s for seconds, m for minutes, h for hours, "
+                + "d for days, w for weeks or y for years. "
+                + "If no time unit is specified the default is seconds, eg: "
+                + "-t 120 will set retention to 2 minutes. "
+                + "0 means no retention and -1 means infinite time retention.", required = true)
         private String retentionTimeStr;
 
-        @Parameter(names = { "--size", "-s" }, description = "Retention size limit (eg: 10M, 16G, 3T). "
+        @Parameter(names = { "--size", "-s" }, description = "Retention size limit with optional size unit suffix "
+                + "eg: 4096, 10M, 16G, 3T.  The size unit suffix character can be k/K, m/M, g/G, or t/T.  "
+                + "If the size unit suffix is not specified, the default unit is bytes. "
                 + "0 or less than 1MB means no retention and -1 means infinite size retention", required = true)
         private String limitStr;
 

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdTopicPolicies.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdTopicPolicies.java
@@ -527,15 +527,15 @@ public class CmdTopicPolicies extends CmdBase {
         private List<String> params;
 
         @Parameter(names = { "--time",
-                "-t" }, description = "Retention time with optional time unit suffix "
-                + "eg: 100m, 3h, 2d, 5w. "
-                + "If no time unit is specified the default is seconds, eg: "
-                + "-t 120 will set retention to 2 minutes. "
+                "-t" }, description = "Retention time with optional time unit suffix. "
+                + "For example, 100m, 3h, 2d, 5w. "
+                + "If the time unit is not specified, the default unit is seconds. For example, "
+                + "-t 120 sets retention to 2 minutes. "
                 + "0 means no retention and -1 means infinite time retention.", required = true)
         private String retentionTimeStr;
 
-        @Parameter(names = { "--size", "-s" }, description = "Retention size limit with optional size unit suffix "
-                + "eg: 4096, 10M, 16G, 3T.  The size unit suffix character can be k/K, m/M, g/G, or t/T.  "
+        @Parameter(names = { "--size", "-s" }, description = "Retention size limit with optional size unit suffix. "
+                + "For example, 4096, 10M, 16G, 3T.  The size unit suffix character can be k/K, m/M, g/G, or t/T.  "
                 + "If the size unit suffix is not specified, the default unit is bytes. "
                 + "0 or less than 1MB means no retention and -1 means infinite size retention", required = true)
         private String limitStr;

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdTopicPolicies.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdTopicPolicies.java
@@ -529,8 +529,6 @@ public class CmdTopicPolicies extends CmdBase {
         @Parameter(names = { "--time",
                 "-t" }, description = "Retention time with optional time unit suffix "
                 + "eg: 100m, 3h, 2d, 5w. "
-                + "The suffix character can be s for seconds, m for minutes, h for hours, "
-                + "d for days, w for weeks or y for years. "
                 + "If no time unit is specified the default is seconds, eg: "
                 + "-t 120 will set retention to 2 minutes. "
                 + "0 means no retention and -1 means infinite time retention.", required = true)

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdTopics.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdTopics.java
@@ -1904,15 +1904,13 @@ public class CmdTopics extends CmdBase {
         @Parameter(names = { "--time",
                 "-t" }, description = "Retention time with optional time unit suffix "
                 + "eg: 100m, 3h, 2d, 5w. "
-                + "The suffix character can be s for seconds, m for minutes, h for hours, "
-                + "d for days, w for weeks or y for years. "
                 + "If no time unit is specified the default is seconds, eg: "
                 + "-t 120 will set retention to 2 minutes. "
                 + "0 means no retention and -1 means infinite time retention.", required = true)
         private String retentionTimeStr;
 
         @Parameter(names = { "--size", "-s" }, description = "Retention size limit with optional size unit suffix "
-                + "eg: 4096, 10M, 16G, 3T.  The size unit suffix character can be k/K, m/M, g/G, or t/G.  "
+                + "eg: 4096, 10M, 16G, 3T.  The size unit suffix character can be k/K, m/M, g/G, or t/T.  "
                 + "If the size unit suffix is not specified, the default unit is bytes. "
                 + "0 or less than 1MB means no retention and -1 means infinite size retention", required = true)
         private String limitStr;

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdTopics.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdTopics.java
@@ -1902,11 +1902,18 @@ public class CmdTopics extends CmdBase {
         private java.util.List<String> params;
 
         @Parameter(names = { "--time",
-                "-t" }, description = "Retention time in minutes (or minutes, hours,days,weeks eg: 100m, 3h, 2d, 5w). "
-                + "0 means no retention and -1 means infinite time retention", required = true)
+                "-t" }, description = "Retention time with optional time unit suffix "
+                + "eg: 100m, 3h, 2d, 5w. "
+                + "The suffix character can be s for seconds, m for minutes, h for hours, "
+                + "d for days, w for weeks or y for years. "
+                + "If no time unit is specified the default is seconds, eg: "
+                + "-t 120 will set retention to 2 minutes. "
+                + "0 means no retention and -1 means infinite time retention.", required = true)
         private String retentionTimeStr;
 
-        @Parameter(names = { "--size", "-s" }, description = "Retention size limit (eg: 10M, 16G, 3T). "
+        @Parameter(names = { "--size", "-s" }, description = "Retention size limit with optional size unit suffix "
+                + "eg: 4096, 10M, 16G, 3T.  The size unit suffix character can be k/K, m/M, g/G, or t/G.  "
+                + "If the size unit suffix is not specified, the default unit is bytes. "
                 + "0 or less than 1MB means no retention and -1 means infinite size retention", required = true)
         private String limitStr;
 

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdTopics.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdTopics.java
@@ -1902,15 +1902,15 @@ public class CmdTopics extends CmdBase {
         private java.util.List<String> params;
 
         @Parameter(names = { "--time",
-                "-t" }, description = "Retention time with optional time unit suffix "
-                + "eg: 100m, 3h, 2d, 5w. "
-                + "If no time unit is specified the default is seconds, eg: "
+                "-t" }, description = "Retention time with optional time unit suffix. "
+                + "For example, 100m, 3h, 2d, 5w. "
+                + "If the time unit is not specified, the default unit is seconds. For example, "
                 + "-t 120 will set retention to 2 minutes. "
                 + "0 means no retention and -1 means infinite time retention.", required = true)
         private String retentionTimeStr;
 
-        @Parameter(names = { "--size", "-s" }, description = "Retention size limit with optional size unit suffix "
-                + "eg: 4096, 10M, 16G, 3T.  The size unit suffix character can be k/K, m/M, g/G, or t/T.  "
+        @Parameter(names = { "--size", "-s" }, description = "Retention size limit with optional size unit suffix. "
+                + "For example, 4096, 10M, 16G, 3T.  The size unit suffix character can be k/K, m/M, g/G, or t/T.  "
                 + "If the size unit suffix is not specified, the default unit is bytes. "
                 + "0 or less than 1MB means no retention and -1 means infinite size retention", required = true)
         private String limitStr;


### PR DESCRIPTION
Fixes #16082 

### Motivation

* The help option for set retention indicates `-t` option is `Retention time in minutes` but if no time unit is specified, it is assumed to be seconds.

### Modifications

* Updated description for time option and added unit test cases with default value (without time unit suffix) and with seconds time unit.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change added tests and can be verified as follows:
  - Added unit tests for to `PulsarAdminToolTest` with and without time unit suffix.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): no
  - The public API: no
  - The schema: no
  - The default values of configurations: no
  - The wire protocol: no
  - The rest endpoints: no
  - The admin cli options: no
  - Anything that affects deployment: no

### Documentation

Check the box below or label this PR directly.

Need to update docs? 

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)
  
- [x] `doc-not-needed` 
This is a change in argument description.
  
- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)