### PR TITLE
[fix][python client] Fixed schema validate_type method throw a wrong exception

### DIFF
--- a/pulsar-client-cpp/python/pulsar/schema/definition.py
+++ b/pulsar-client-cpp/python/pulsar/schema/definition.py
@@ -444,8 +444,8 @@ class Array(Field):
 
         for x in val:
             if type(x) != self.array_type.python_type():
-                raise TypeError('Array field ' + name + ' items should all be of type '
-                                + self.array_type.python_type())
+                raise TypeError('Array field ' + name + ' items should all be of type ' +
+                                str(self.array_type.python_type()))
         return val
 
     def schema(self):

--- a/pulsar-client-cpp/python/schema_test.py
+++ b/pulsar-client-cpp/python/schema_test.py
@@ -1279,5 +1279,13 @@ class SchemaTest(TestCase):
         self.assertTrue(b'_default' not in b)
         self.assertTrue(b'_required' not in b)
         self.assertTrue(b'_required_default' not in b)
+
+    def test_schema_array_wrong_type(self):
+        class SomeSchema(Record):
+            some_field = Array(Integer(), required=False, default=[])
+        # descriptive error message
+        with self.assertRaises(TypeError) as e:
+            SomeSchema(some_field=["not", "integer"])
+        self.assertEqual(str(e.exception), "Array field some_field items should all be of type <class 'int'>")
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
Fixes #16056 


### Motivation
 
The validate_type method in definition.py was intended to throw a TypeError when  type of elements in array is incorrect, but the `self.array_type.python_type()` would return int type, which can not be concatenated with string. This would cause a confusing error output

### Modifications
Explicitly construct a string with python_type info

### Verifying this change

- [ ] Make sure that the change passes the CI checks.


This change added tests and can be verified as follows:

  - Added a unit test method named test_schema_array_wrong_type, see pulsar-client-cpp/python/schema_test.py

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API: (yes / **no**)
  - The schema: (yes / **no** / don't know)
  - The default values of configurations: (yes / **no**)
  - The wire protocol: (yes / **no**)
  - The rest endpoints: (yes / **no**)
  - The admin cli options: (yes / **no**)
  - Anything that affects deployment: (yes / **no** / don't know)

### Documentation

Check the box below or label this PR directly.

Need to update docs? 

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)
  
- [ x] `doc-not-needed` 
(Please explain why)
  
- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)