### PR TITLE
[improve][broker] Use LinkedHashSet for config items of type Set to preserve elements order

### DIFF
--- a/pulsar-common/src/main/java/org/apache/pulsar/common/util/FieldParser.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/util/FieldParser.java
@@ -31,7 +31,6 @@ import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -213,7 +212,7 @@ public final class FieldParser {
             if (field.getType().equals(List.class)) {
                 field.set(obj, new ArrayList<>());
             } else if (field.getType().equals(Set.class)) {
-                field.set(obj, new HashSet<>());
+                field.set(obj, new LinkedHashSet<>());
             } else if (field.getType().equals(Optional.class)) {
                 field.set(obj, Optional.empty());
             } else {

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/util/FieldParser.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/util/FieldParser.java
@@ -32,6 +32,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -333,7 +334,7 @@ public final class FieldParser {
         String[] tokens = trim(val).split(",");
         return Arrays.stream(tokens).map(t -> {
             return convert(trim(t), type);
-        }).collect(Collectors.toSet());
+        }).collect(Collectors.toCollection(LinkedHashSet::new));
     }
 
     private static <K, V> Map<K, V> stringToMap(String strValue, Class<K> keyType, Class<V> valueType) {

--- a/pulsar-common/src/test/java/org/apache/pulsar/common/util/collections/FieldParserTest.java
+++ b/pulsar-common/src/test/java/org/apache/pulsar/common/util/collections/FieldParserTest.java
@@ -32,6 +32,7 @@ import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -54,6 +55,10 @@ public class FieldParserTest {
         assertEquals(integerToString(1), String.valueOf(1));
         assertEquals(stringToList("1,2,3", Integer.class).get(2), Integer.valueOf(3));
         assertTrue(stringToSet("1,2,3", Integer.class).contains(3));
+        // the order of values should be preserved for a Set configuration item
+        assertEquals(new ArrayList<>(stringToSet("1,2,3", Integer.class)), Arrays.asList(1, 2, 3));
+        assertEquals(new ArrayList<>(stringToSet("2,3,1", Integer.class)), Arrays.asList(2, 3, 1));
+        assertEquals(new ArrayList<>(stringToSet("3,2,1", Integer.class)), Arrays.asList(3, 2, 1));
         assertEquals(stringToBoolean("true"), Boolean.TRUE);
         assertEquals(stringToDouble("2.2"), Double.valueOf(2.2));
         assertEquals(stringToLong("2"), Long.valueOf(2));


### PR DESCRIPTION


<!--
### Contribution Checklist
  
  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://docs.google.com/document/d/1d8Pw6ZbWk-_pCKdOmdvx9rnhPiyuxwq60_TrD68d7BA/edit#heading=h.trs9rsex3xom)*. 

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.

**(The sections below can be removed for hotfixes of typos)**
-->

Fixes https://github.com/apache/pulsar/issues/16137

### Motivation

The order of items is not preserved for configuration fields of the type `Set`. Preserving the order of items in the config would make the program behavior to be more predictable, and may potentially make it possible for more operation flexibilities.

### Modifications

Create a `LinkedHashSet` rather than a `HashSet` when converting string to Set.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change is already covered by existing tests, such as `FieldParserTest.testConversion`.


### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API: (yes / no)
  - The schema: (yes / no / don't know)
  - The default values of configurations: (yes / no)
  - The wire protocol: (yes / no)
  - The rest endpoints: (yes / no)
  - The admin cli options: (yes / no)
  - Anything that affects deployment: (yes / no / don't know)

### Documentation

Check the box below or label this PR directly.

Need to update docs? 

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)
  
- [x] `doc-not-needed` 
(Please explain why)
  
- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)