### PR TITLE
[improve][broker]Specify default nar tmp dir

### DIFF
--- a/bin/pulsar
+++ b/bin/pulsar
@@ -307,6 +307,9 @@ if [[ -z "$IS_JAVA_8" ]]; then
   OPTS="$OPTS --add-opens jdk.management/com.sun.management.internal=ALL-UNNAMED"
 fi
 
+# Specify default nar tmp dir
+OPTS="$OPTS -Dnar.extraction.tmpdir=$PULSAR_HOME/tmp"
+
 OPTS="-cp $PULSAR_CLASSPATH $OPTS"
 
 if [ $COMMAND == "bookie" ]; then


### PR DESCRIPTION
Master Issue: #15978

relate to PR #15979

### Motivation

In some Linux os, like Centos or RedHat will auto clean the file in the /tmp dir when 7 days or 30 days the file not be used, In this way, the .class file will loss, so we should change the default nar tmp dir to `$PULSAR_HOME ` will better.
The PR #15979  help we get the `DEFAULT_NAR_EXTRACTION_DIR` from `nar.extraction.tmpdir`.

### Modifications

Change the `DEFAULT_NAR_EXTRACTION_DIR`;

- [X] `doc-required` 
The `DEFAULT_NAR_EXTRACTION_DIR` change to the `$PULSAR_HOME/tmp`,  user should permit pulsar can write/read the dir.