### PR TITLE
[fix][broker]Fix removing replica clusters on topic-policies not take effect

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -305,7 +305,6 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
     @Override
     public CompletableFuture<Void> initialize() {
         List<CompletableFuture<Void>> futures = new ArrayList<>();
-        futures.add(initTopicPolicy());
         for (ManagedCursor cursor : ledger.getCursors()) {
             if (cursor.getName().startsWith(replicatorPrefix)) {
                 String localCluster = brokerService.pulsar().getConfiguration().getClusterName();
@@ -341,7 +340,9 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
                     this.isEncryptionRequired = policies.encryption_required;
 
                     isAllowAutoUpdateSchema = policies.is_allow_auto_update_schema;
-                }).exceptionally(ex -> {
+                })
+                .thenCompose(ignore -> initTopicPolicy())
+                .exceptionally(ex -> {
                     log.warn("[{}] Error getting policies {} and isEncryptionRequired will be set to false",
                             topic, ex.getMessage());
                     isEncryptionRequired = false;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -3023,9 +3023,7 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
             updateSubscribeRateLimiter();
             replicators.forEach((name, replicator) -> replicator.updateRateLimiter());
             checkMessageExpiry();
-            if (policies.getReplicationClusters() != null) {
-                checkReplicationAndRetryOnFailure();
-            }
+            checkReplicationAndRetryOnFailure();
 
             checkDeduplicationStatus();
 


### PR DESCRIPTION
### Motivation


* Fix `org.apache.pulsar.client.admin.Topics#removeReplicationClusters` not taking effect:  Because we have used `HierarchyTopicPolicies` to save topic-level policies,  so we shoud  removing `policies.getReplicationClusters() != null`.

### Modifications

* Removing  `policies.getReplicationClusters() != null` when topic-level policies updating
* Also, we need initialize namespace-policy first and then initialize topic-policy when `PersistentTopic#initialize`.  The reason is that：
  * namespace-policy always has local cluster name in `Policies#replication_clusters` when using adminV2.
  * topic-policy may not  contains local cluster name in `TopicPolicies#replicationClusters`.
  * If we follow the steps listed below, the persistent topic will be deleted unexpectedly, which makes the `TopicPoliciesTest#testGetSetSubscribeRate` test failure.
     1.  `admin.topics().createPartitionedTopic`, which just create zookeeper nodes without `PersistentTopic` creating
     2.   `admin.namespaces().setSubscribeRate`, namespace-policy will be set with local cluster name in `Policies#replication_clusters`. But because  step.a just create zookeeper nodes, so the policy will not be applied to `PersistentTopic` now.
     3. `admin.topicPolicies().setSubscribeRate`, topic-policy will be set with no local cluster name in `TopicPolicies#replicationClusters`.
     4. `pulsarClient1.newConsumer().subscriptionName("sub1").topic(persistenceTopic).consumerName("test").subscribe()`, will create `PersistentTopic`
     5. if we initialize topic-policy first, the `HierarchyTopicPolicies#replicationClusters` will be empty , and the `PersistentTopic` will be deleted unexpectedly. line:1377
     https://github.com/apache/pulsar/blob/603a5cdd8e4f82a27c1341c93eb6162862d1e970/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java#L1357-L1378

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change added tests and can be verified as follows:

*(example:)*
  - *Added UT `org.apache.pulsar.broker.service.ReplicatorTopicPoliciesTest#testRemoveReplicationClusters`


### Documentation

  
- [x] `doc-not-needed` 

