### PR TITLE
Transactions: fix race in TransactionMetaStoreHandler

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/TransactionMetaStoreHandler.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/TransactionMetaStoreHandler.java
@@ -105,9 +105,12 @@ public class TransactionMetaStoreHandler extends HandlerState
                 .create(),
             this);
         this.connectFuture = connectFuture;
-        this.connectionHandler.grabCnx();
+        this.internalPinnedExecutor = pulsarClient.getInternalExecutorService();
         this.timer = pulsarClient.timer();
-        internalPinnedExecutor = pulsarClient.getInternalExecutorService();
+    }
+
+    public void start() {
+        this.connectionHandler.grabCnx();
     }
 
     @Override

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/transaction/TransactionCoordinatorClientImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/transaction/TransactionCoordinatorClientImpl.java
@@ -94,6 +94,7 @@ public class TransactionCoordinatorClientImpl implements TransactionCoordinatorC
                                     i, pulsarClient, getTCAssignTopicName(i), connectFuture);
                             handlers[i] = handler;
                             handlerMap.put(i, handler);
+                            handler.start();
                         }
                     } else {
                         handlers = new TransactionMetaStoreHandler[1];
@@ -103,6 +104,7 @@ public class TransactionCoordinatorClientImpl implements TransactionCoordinatorC
                                 getTCAssignTopicName(-1), connectFuture);
                         handlers[0] = handler;
                         handlerMap.put(0, handler);
+                        handler.start();
                     }
 
                     STATE_UPDATER.set(TransactionCoordinatorClientImpl.this, State.READY);


### PR DESCRIPTION
### Motivation
Fixes #15375

the NPE happens because internalPinnedExecutor has not been assigned yet.

### Modifications

Refactor the constructor, in a way that "this" is not accessed from another thread while the constructor is not done yet.

### Verifying this change

This change is a trivial rework / code cleanup without any test coverage.