### PR TITLE
Make permissions of python docker image scripts effective

### DIFF
--- a/src/assembly-source-package.xml
+++ b/src/assembly-source-package.xml
@@ -36,8 +36,10 @@
       <excludes>
         <!-- need special permissions -->
         <exclude>src/*.sh</exclude>
+        <exclude>src/*.py</exclude>
         <exclude>pulsar-client-cpp/docker/*.sh</exclude>
         <exclude>docker/pulsar/scripts/*.sh</exclude>
+        <exclude>docker/pulsar/scripts/*.py</exclude>
 
         <!-- Pulsar standalone -->
         <exclude>data/**</exclude>


### PR DESCRIPTION
### Motivation

Makes the incomplete fix introduced by https://github.com/apache/pulsar/pull/11951 effective.

`mvn clean install -DskipTests` generates `target/apache-pulsar-2.X.0-src.tar.gz` as a source tarball. The unzipped tarball doesn't preserve the permissions specified in `src/assembly-source-package.xml` ([0755](https://github.com/apache/pulsar/pull/11951/files#diff-1ed0db2896b2c947f97af273efc5058fba5a0eb4620f8fde359c0c530f118694R111)) for the python scripts in `docker/pulsar/scripts`.  Instead the permissions are still too strict:

```
  -rw-r--r--  3076 Jan 22  2020 apply-config-from-env-with-prefix.py
  -rw-r--r--  3282 Jan 22  2020 apply-config-from-env.py
  -rw-r--r--  3325 Jan 22  2020 gen-yml-from-env.py
  -rw-r--r--  2911 Jan 22  2020 watch-znode.py
```

If the source are then used to generate a docker image (as it happens for candidate validation), the docker container running the pulsar image won't have enough permissions to run the scripts and it will exit with:

```
sh: 1: bin/apply-config-from-env.py: Permission denied
```

Release candidate validation was the way this issue was originally found. An incomplete fix is https://github.com/apache/pulsar/pull/11951. 

### Modifications

The problem with the [aforementioned PR](https://github.com/apache/pulsar/pull/11951) is that it doesn't initially exclude the python scripts from being packaged. As a result, they get tarred with the default permissions and the subsequent `<include>` doesn't have any effect on the mode of the files. Adding the `<exclude>` tags solves the issue.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency):  no
  - The public API: no
  - The schema: no 
  - The default values of configurations: no
  - The wire protocol: no
  - The rest endpoints: no
  - The admin cli options: no
  - Anything that affects deployment: yes

Only deployment of pulsar using a docker image generated from sources packaged via `mvn clean install -DskipTests`.

### Documentation

Check the box below or label this PR directly.

Need to update docs? 

- [ ] `doc-required` 
  
- [x] `doc-not-needed` 
It's a fix which will mainly ease release validation. 

- [ ] `doc` 

- [ ] `doc-complete`