### PR TITLE
[fix][client] Fix duplicate messages caused by seek

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
@@ -2778,6 +2778,10 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
         return possibleSendToDeadLetterTopicMessages;
     }
 
+    protected boolean isDuringSeek() {
+        return duringSeek.get();
+    }
+
     private static final Logger log = LoggerFactory.getLogger(ConsumerImpl.class);
 
 }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiTopicsConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiTopicsConsumerImpl.java
@@ -252,6 +252,10 @@ public class MultiTopicsConsumerImpl<T> extends ConsumerBase<T> {
             messagesFuture = consumer.receiveAsync().thenApply(Collections::singletonList);
         }
         messagesFuture.thenAcceptAsync(messages -> {
+            if (consumer.isDuringSeek()) {
+                receiveMessageFromConsumer(consumer, batchReceive);
+                return;
+            }
             if (log.isDebugEnabled()) {
                 log.debug("[{}] [{}] Receive message from sub consumer:{}",
                     topic, subscription, consumer.getTopic());


### PR DESCRIPTION
Signed-off-by: Zixuan Liu <nodeces@gmail.com>

### Motivation

When subscribing to a message on a partitioned topic, do the seek operation and then consume the messages, which sometimes will receive duplicate messages. 

The root cause is that when a seek operation is performed if have the task in the `pendingReceives` queue, we will get old messages from before doing the seek operation.

### Modifications

- Add a seek check to the logic of the received message, when the seek operation is in progress, skip put the message to `incomingMessages` queue

### Verifying this change

`org.apache.pulsar.broker.service.SubscriptionSeekTest#testSeekByFunctionAndMultiTopic` cover this changes.

### Documentation

- [x] `doc-not-needed` 
