### PR TITLE
[improve][es-sink] Add error log for failed bulk records in ES sink

### DIFF
--- a/pulsar-io/elastic-search/src/main/java/org/apache/pulsar/io/elasticsearch/ElasticSearchClient.java
+++ b/pulsar-io/elastic-search/src/main/java/org/apache/pulsar/io/elasticsearch/ElasticSearchClient.java
@@ -73,9 +73,16 @@ public class ElasticSearchClient implements AutoCloseable {
                 }
                 int index = 0;
                 for (BulkProcessor.BulkOperationResult result: results) {
-                    final Record record = bulkOperationList.get(index++).getPulsarRecord();
+                    final Record<?> record = bulkOperationList.get(index++).getPulsarRecord();
                     if (result.isError()) {
                         record.fail();
+
+                        log.warn("Bulk request id={} failed, message id=[{}] index={} error={}", executionId,
+                                record.getMessage()
+                                        .map(m -> m.getMessageId().toString())
+                                        .orElse(""),
+                                result.getIndex(), result.getError());
+
                         checkForIrrecoverableError(result);
                     } else {
                         record.ack();


### PR DESCRIPTION
### Motivation

Currently, the ES sink doesn't show any error when any record in a bulk write fails, and the failure may persist until the developer fixed the issue.

### Modifications

Add a warning log when any record in bulk write fails.

### Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API: (yes / no)
  - The schema: (yes / no / don't know)
  - The default values of configurations: (yes / no)
  - The wire protocol: (yes / no)
  - The rest endpoints: (yes / no)
  - The admin cli options: (yes / no)
  - Anything that affects deployment: (yes / no / don't know)

### Documentation

Check the box below or label this PR directly.

Need to update docs? 

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)
  
- [x] `doc-not-needed` 
(Please explain why)
  
- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)