### PR TITLE
[improve][cli] Perf: Align hostname-verification to be the same as pulsar-admin

### DIFF
--- a/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceBaseArguments.java
+++ b/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceBaseArguments.java
@@ -55,7 +55,7 @@ public abstract class PerformanceBaseArguments {
     public Boolean tlsAllowInsecureConnection = null;
 
     @Parameter(names = {
-            "--tls-hostname-verification" }, description = "Enable TLS hostname verification")
+            "--tls-enable-hostname-verification" }, description = "Enable TLS hostname verification")
     public Boolean tlsHostnameVerificationEnable = null;
 
     @Parameter(names = { "-c",

--- a/site2/docs/reference-cli-tools.md
+++ b/site2/docs/reference-cli-tools.md
@@ -551,7 +551,7 @@ Commands `consume`, `produce`, `read` and `transaction` share the following clie
 |`--listener-name`|Listener name for the broker||
 |`-lt`, `--num-listener-threads`|Set the number of threads to be used for message listeners|1|
 |`--tls-allow-insecure`|Allow insecure TLS connection||
-|`--tls-hostname-verification`|Enable TLS hostname verification||
+|`--tls-enable-hostname-verification`|Enable TLS hostname verification||
 |`--trust-cert-file`|Path for the trusted TLS certificate file||
 |`-u`, `--service-url`|Pulsar service URL||
 


### PR DESCRIPTION
### Motivation
Follow up of https://github.com/apache/pulsar/pull/16090

See the discussion here: https://github.com/apache/pulsar/pull/16090#discussion_r902794380
It's better to introduce the new parameter as the same used in the `pulsar-admin` command.

The current command hasn't been released yet so it's not a problem changing it now

### Modifications

* moved `pulsar-perf .. --tls--hostname-verification` to `pulsar-perf .. --tls-enable-hostname-verification` 

- [x] `doc-not-needed` 