### PR TITLE
[fix][function] Ensure bytes is a well-formed UTF-8 byte sequence when decode the `FunctionState` bytes to string

### DIFF
--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/api/ComponentImpl.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/api/ComponentImpl.java
@@ -30,6 +30,7 @@ import static org.apache.pulsar.functions.utils.FunctionCommon.getUniquePackageN
 import static org.apache.pulsar.functions.utils.FunctionCommon.isFunctionCodeBuiltin;
 import static org.apache.pulsar.functions.worker.rest.RestUtils.throwUnavailableException;
 import static org.apache.pulsar.functions.worker.rest.api.FunctionsImpl.downloadPackageFile;
+import com.google.common.base.Utf8;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufUtil;
 import io.netty.buffer.Unpooled;
@@ -1262,13 +1263,13 @@ public abstract class ComponentImpl implements Component<PulsarWorkerService> {
                     if (kv.isNumber()) {
                         value = new FunctionState(key, null, null, kv.numberValue(), kv.version());
                     } else {
-                        try {
-                            value = new FunctionState(key, new String(ByteBufUtil
-                                    .getBytes(kv.value(), kv.value().readerIndex(), kv.value().readableBytes()), UTF_8),
+                        byte[] bytes = ByteBufUtil.getBytes(kv.value());
+                        if (Utf8.isWellFormed(bytes)) {
+                            value = new FunctionState(key, new String(bytes, UTF_8),
                                     null, null, kv.version());
-                        } catch (Exception e) {
+                        } else {
                             value = new FunctionState(
-                                    key, null, ByteBufUtil.getBytes(kv.value()), null, kv.version());
+                                    key, null, bytes, null, kv.version());
                         }
                     }
                 }

--- a/tests/docker-images/java-test-functions/src/main/java/org/apache/pulsar/tests/integration/io/TestByteStateSource.java
+++ b/tests/docker-images/java-test-functions/src/main/java/org/apache/pulsar/tests/integration/io/TestByteStateSource.java
@@ -1,0 +1,55 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.tests.integration.io;
+
+import java.nio.ByteBuffer;
+import java.util.Base64;
+import java.util.Map;
+import org.apache.pulsar.functions.api.Record;
+import org.apache.pulsar.io.core.Source;
+import org.apache.pulsar.io.core.SourceContext;
+
+public class TestByteStateSource implements Source<byte[]> {
+
+    private SourceContext sourceContext;
+
+    public static final String VALUE_BASE64 = "0a8001127e0a172e6576656e74732e437573746f6d65724372656174656412630a243"
+                                              + "2336366666263652d623038342d346631352d616565342d326330643135356131666"
+                                              + "36312026e311a3700000000000000000000000000000000000000000000000000000"
+                                              + "000000000000000000000000000000000000000000000000000000000";
+
+    @Override
+    public void open(Map<String, Object> config, SourceContext sourceContext) throws Exception {
+        sourceContext.putState("initial", ByteBuffer.wrap(Base64.getDecoder().decode(VALUE_BASE64)));
+        this.sourceContext = sourceContext;
+    }
+
+    @Override
+    public Record<byte[]> read() throws Exception {
+        Thread.sleep(50);
+        ByteBuffer initial = sourceContext.getState("initial");
+        sourceContext.putState("now", initial);
+        return initial::array;
+    }
+
+    @Override
+    public void close() throws Exception {
+
+    }
+}

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/functions/PulsarStateTest.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/functions/PulsarStateTest.java
@@ -18,6 +18,14 @@
  */
 package org.apache.pulsar.tests.integration.functions;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.apache.pulsar.tests.integration.functions.utils.CommandGenerator.JAVAJAR;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
+import com.google.common.base.Utf8;
+import java.util.Base64;
 import lombok.Cleanup;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
@@ -38,13 +46,8 @@ import org.apache.pulsar.tests.integration.functions.utils.CommandGenerator.Runt
 import org.apache.pulsar.tests.integration.suites.PulsarStandaloneTestSuite;
 import org.apache.pulsar.tests.integration.topologies.PulsarCluster;
 import org.awaitility.Awaitility;
+import org.testng.Assert;
 import org.testng.annotations.Test;
-
-import static java.nio.charset.StandardCharsets.UTF_8;
-import static org.apache.pulsar.tests.integration.functions.utils.CommandGenerator.JAVAJAR;
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertTrue;
-import static org.testng.Assert.fail;
 
 /**
  * State related test cases.
@@ -56,6 +59,11 @@ public class PulsarStateTest extends PulsarStandaloneTestSuite {
         "wordcount_function.WordCountFunction";
 
     public static final String WORDCOUNT_PYTHON_FILE = "wordcount_function.py";
+
+    public static final String VALUE_BASE64 = "0a8001127e0a172e6576656e74732e437573746f6d65724372656174656412630a243"
+                                              + "2336366666263652d623038342d346631352d616565342d326330643135356131666"
+                                              + "36312026e311a3700000000000000000000000000000000000000000000000000000"
+                                              + "000000000000000000000000000000000000000000000000000000000";
 
     @Test(groups = {"python_state", "state", "function", "python_function"})
     public void testPythonWordCountFunction() throws Exception {
@@ -181,6 +189,54 @@ public class PulsarStateTest extends PulsarStandaloneTestSuite {
         deleteSink(sinkName);
 
         getSinkInfoNotFound(sinkName);
+    }
+
+    @Test(groups = {"java_state", "state", "function", "java_function"})
+    public void testBytes2StringNotUTF8() {
+        byte[] valueBytes = Base64.getDecoder().decode(VALUE_BASE64);
+        Assert.assertFalse(Utf8.isWellFormed(valueBytes));
+        Assert.assertNotEquals(valueBytes, new String(valueBytes, UTF_8).getBytes(UTF_8));
+    }
+
+    @Test(groups = {"java_state", "state", "function", "java_function"})
+    public void testSourceByteState() throws Exception {
+        String outputTopicName = "test-state-source-output-" + randomName(8);
+        String sourceName = "test-state-source-" + randomName(8);
+
+        submitSourceConnector(sourceName, outputTopicName, "org.apache.pulsar.tests.integration.io.TestByteStateSource",  JAVAJAR);
+
+        // get source info
+        getSourceInfoSuccess(sourceName);
+
+        // get source status
+        getSourceStatus(sourceName);
+
+        try (PulsarAdmin admin = PulsarAdmin.builder().serviceHttpUrl(container.getHttpServiceUrl()).build()) {
+
+            Awaitility.await().ignoreExceptions().untilAsserted(() -> {
+                SourceStatus status = admin.sources().getSourceStatus("public", "default", sourceName);
+                assertEquals(status.getInstances().size(), 1);
+                assertTrue(status.getInstances().get(0).getStatus().numWritten > 0);
+            });
+
+            {
+                FunctionState functionState =
+                        admin.functions().getFunctionState("public", "default", sourceName, "initial");
+                assertNull(functionState.getStringValue());
+                assertEquals(functionState.getByteValue(), Base64.getDecoder().decode(VALUE_BASE64));
+            }
+
+            Awaitility.await().ignoreExceptions().untilAsserted(() -> {
+                FunctionState functionState = admin.functions().getFunctionState("public", "default", sourceName, "now");
+                assertNull(functionState.getStringValue());
+                assertEquals(functionState.getByteValue(), Base64.getDecoder().decode(VALUE_BASE64));
+            });
+        }
+
+        // delete source
+        deleteSource(sourceName);
+
+        getSourceInfoNotFound(sourceName);
     }
 
     private void submitSourceConnector(String sourceName,

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/functions/PulsarStateTest.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/functions/PulsarStateTest.java
@@ -21,6 +21,8 @@ package org.apache.pulsar.tests.integration.functions;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.pulsar.tests.integration.functions.utils.CommandGenerator.JAVAJAR;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotEquals;
 import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
@@ -46,7 +48,6 @@ import org.apache.pulsar.tests.integration.functions.utils.CommandGenerator.Runt
 import org.apache.pulsar.tests.integration.suites.PulsarStandaloneTestSuite;
 import org.apache.pulsar.tests.integration.topologies.PulsarCluster;
 import org.awaitility.Awaitility;
-import org.testng.Assert;
 import org.testng.annotations.Test;
 
 /**
@@ -194,8 +195,8 @@ public class PulsarStateTest extends PulsarStandaloneTestSuite {
     @Test(groups = {"java_state", "state", "function", "java_function"})
     public void testBytes2StringNotUTF8() {
         byte[] valueBytes = Base64.getDecoder().decode(VALUE_BASE64);
-        Assert.assertFalse(Utf8.isWellFormed(valueBytes));
-        Assert.assertNotEquals(valueBytes, new String(valueBytes, UTF_8).getBytes(UTF_8));
+        assertFalse(Utf8.isWellFormed(valueBytes));
+        assertNotEquals(valueBytes, new String(valueBytes, UTF_8).getBytes(UTF_8));
     }
 
     @Test(groups = {"java_state", "state", "function", "java_function"})


### PR DESCRIPTION
Fixes #16193 

### Motivation

Now, if put a byte[] type state to a function, they can get an incorrect string type state using admin API.

The root cause is that bytes may not be a well-formed UTF-8 byte sequence, so we should not decode it to a UTF-8 string.

References: 
[Unicode6.2.0](http://www.unicode.org/versions/Unicode6.2.0/ch03.pdf)

### Modifications

Add a check the bytes whether is a well-formed UTF-8 byte sequence when decode the `FunctionState` bytes.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change is already covered by existing tests, such as `testSourceByteState`, `testBytes2StringNotUTF8`

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API: (yes / no)
  - The schema: (yes / no / don't know)
  - The default values of configurations: (yes / no)
  - The wire protocol: (yes / no)
  - The rest endpoints: (yes / no)
  - The admin cli options: (yes / no)
  - Anything that affects deployment: (yes / no / don't know)

### Documentation

Check the box below or label this PR directly.

Need to update docs? 

- [x] `doc-not-needed` 
(Please explain why)