### PR TITLE
[doc] Removed a bracket. That made a code example not compile.

### DIFF
--- a/site2/docs/client-libraries-dotnet.md
+++ b/site2/docs/client-libraries-dotnet.md
@@ -88,7 +88,7 @@ This section describes how to create a producer.
   using DotPulsar;
   using DotPulsar.Extensions;
 
-  var producer = client.NewProducer())
+  var producer = client.NewProducer()
                        .Topic("persistent://public/default/mytopic")
                        .Create();
   


### PR DESCRIPTION
Hello, Apache Pulsar community!

I found a small bracket error in the Create producer DotPulsar code example. I have fixed it by removing the bracket.

Please let me if there is anything I can improve in this PR to get it accepted.

### Motivation
Helping others using Apache Pulsar by improving the docs.

### Modifications
Removed a bracket in client-libraries-dotnet.md

### Documentation

Check the box below or label this PR directly.

Need to update docs? 

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)
  
- [ ] `doc-not-needed` 
(Please explain why)
  
- [X] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)