### PR TITLE
[improvement][broker]: remove spammy log 'The count of topics on the bundle {} is less than 2, skip split!'

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/BundleSplitterTask.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/BundleSplitterTask.java
@@ -73,7 +73,9 @@ public class BundleSplitterTask implements BundleSplitStrategy {
                 final String bundle = entry.getKey();
                 final NamespaceBundleStats stats = entry.getValue();
                 if (stats.topics < 2) {
-                    log.info("The count of topics on the bundle {} is less than 2, skip split!", bundle);
+                    if (log.isDebugEnabled()) {
+                        log.debug("The count of topics on the bundle {} is less than 2, skip split!", bundle);
+                    }
                     continue;
                 }
                 double totalMessageRate = 0;


### PR DESCRIPTION
### Motivation

The log like "The count of topics on the bundle {} is less than 2, skip split!" is spammy and useless.

### Modifications

Move that line to level "DEBUG"

### Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

- [x] `doc-not-needed`
