### PR TITLE
[doc][stats] Improve documentation for unackedMessages stat

### DIFF
--- a/pulsar-client-admin-api/src/main/java/org/apache/pulsar/common/policies/data/ConsumerStats.java
+++ b/pulsar-client-admin-api/src/main/java/org/apache/pulsar/common/policies/data/ConsumerStats.java
@@ -54,7 +54,13 @@ public interface ConsumerStats {
     /** Number of available message permits for the consumer. */
     int getAvailablePermits();
 
-    /** Number of unacknowledged messages for the consumer. */
+    /**
+     * Number of unacknowledged messages for the consumer, where an unacknowledged message is one that has been
+     * sent to the consumer but not yet acknowledged. This field is only meaningful when using a
+     * {@link org.apache.pulsar.client.api.SubscriptionType} that tracks individual message acknowledgement, like
+     * {@link org.apache.pulsar.client.api.SubscriptionType#Shared} or
+     * {@link org.apache.pulsar.client.api.SubscriptionType#Key_Shared}.
+     */
     int getUnackedMessages();
 
     /** Number of average messages per entry for the consumer consumed. */

--- a/pulsar-client-admin-api/src/main/java/org/apache/pulsar/common/policies/data/SubscriptionStats.java
+++ b/pulsar-client-admin-api/src/main/java/org/apache/pulsar/common/policies/data/SubscriptionStats.java
@@ -66,10 +66,14 @@ public interface SubscriptionStats {
     /** Number of delayed messages currently being tracked. */
     long getMsgDelayed();
 
-    /** Number of unacknowledged messages for the subscription. */
+    /**
+     * Number of unacknowledged messages for the subscription, where an unacknowledged message is one that has been
+     * sent to a consumer but not yet acknowledged. Calculated by summing all {@link ConsumerStats#getUnackedMessages()}
+     * for this subscription. See {@link ConsumerStats#getUnackedMessages()} for additional details.
+     */
     long getUnackedMessages();
 
-    /** Whether this subscription is Exclusive or Shared or Failover. */
+    /** The subscription type as defined by {@link org.apache.pulsar.client.api.SubscriptionType}. */
     String getType();
 
     /** The name of the consumer that is active for single active consumer subscriptions i.e. failover or exclusive. */

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/stats/ConsumerStatsImpl.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/stats/ConsumerStatsImpl.java
@@ -59,7 +59,13 @@ public class ConsumerStatsImpl implements ConsumerStats {
     /** Number of available message permits for the consumer. */
     public int availablePermits;
 
-    /** Number of unacknowledged messages for the consumer. */
+    /**
+     * Number of unacknowledged messages for the consumer, where an unacknowledged message is one that has been
+     * sent to the consumer but not yet acknowledged. This field is only meaningful when using a
+     * {@link org.apache.pulsar.client.api.SubscriptionType} that tracks individual message acknowledgement, like
+     * {@link org.apache.pulsar.client.api.SubscriptionType#Shared} or
+     * {@link org.apache.pulsar.client.api.SubscriptionType#Key_Shared}.
+     */
     public int unackedMessages;
 
     /** Number of average messages per entry for the consumer consumed. */

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/stats/SubscriptionStatsImpl.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/stats/SubscriptionStatsImpl.java
@@ -73,10 +73,14 @@ public class SubscriptionStatsImpl implements SubscriptionStats {
     /** Number of delayed messages currently being tracked. */
     public long msgDelayed;
 
-    /** Number of unacknowledged messages for the subscription. */
+    /**
+     * Number of unacknowledged messages for the subscription, where an unacknowledged message is one that has been
+     * sent to a consumer but not yet acknowledged. Calculated by summing all {@link ConsumerStatsImpl#unackedMessages}
+     * for this subscription. See {@link ConsumerStatsImpl#unackedMessages} for additional details.
+     */
     public long unackedMessages;
 
-    /** Whether this subscription is Exclusive or Shared or Failover. */
+    /** The subscription type as defined by {@link org.apache.pulsar.client.api.SubscriptionType}.  */
     public String type;
 
     /** The name of the consumer that is active for single active consumer subscriptions i.e. failover or exclusive. */

--- a/site2/docs/admin-api-topics.md
+++ b/site2/docs/admin-api-topics.md
@@ -391,7 +391,7 @@ You can check the following statistics of a given non-partitioned topic.
 
           -   **msgDelayed**: Number of delayed messages currently being tracked.
 
-          -   **unackedMessages**: Number of unacknowledged messages for the subscription.
+          -   **unackedMessages**: Number of unacknowledged messages for the subscription, where an unacknowledged message is one that has been sent to a consumer but not yet acknowledged. This field is only meaningful when using a subscription that tracks individual message acknowledgement.
 
           -   **activeConsumerName**: The name of the consumer that is active for single active consumer subscriptions. For example, failover or exclusive. 
 
@@ -423,7 +423,7 @@ You can check the following statistics of a given non-partitioned topic.
 
                 -   **availablePermits**: The number of messages that the consumer has space for in the client library's listen queue. `0` means the client library's queue is full and `receive()` isn't being called. A non-zero value means this consumer is ready for dispatched messages.
 
-                -   **unackedMessages**: The number of unacknowledged messages for the consumer.
+                -   **unackedMessages**: The number of unacknowledged messages for the consumer, where an unacknowledged message is one that has been sent to the consumer but not yet acknowledged. This field is only meaningful when using a subscription that tracks individual message acknowledgement.
 
                 -   **blockedConsumerOnUnackedMsgs**: The flag used to verify if the consumer is blocked due to reaching threshold of the unacknowledged messages.
                 

--- a/site2/website/versioned_docs/version-2.10.0/admin-api-topics.md
+++ b/site2/website/versioned_docs/version-2.10.0/admin-api-topics.md
@@ -392,7 +392,7 @@ You can check the following statistics of a given non-partitioned topic.
 
           -   **msgDelayed**: Number of delayed messages currently being tracked.
 
-          -   **unackedMessages**: Number of unacknowledged messages for the subscription.
+          -   **unackedMessages**: Number of unacknowledged messages for the subscription, where an unacknowledged message is one that has been sent to a consumer but not yet acknowledged. This field is only meaningful when using a subscription that tracks individual message acknowledgement.
 
           -   **activeConsumerName**: The name of the consumer that is active for single active consumer subscriptions. For example, failover or exclusive. 
 
@@ -424,7 +424,7 @@ You can check the following statistics of a given non-partitioned topic.
 
                 -   **availablePermits**: The number of messages that the consumer has space for in the client library's listen queue. `0` means the client library's queue is full and `receive()` isn't being called. A non-zero value means this consumer is ready for dispatched messages.
 
-                -   **unackedMessages**: The number of unacknowledged messages for the consumer.
+                -   **unackedMessages**: The number of unacknowledged messages for the consumer, where an unacknowledged message is one that has been sent to the consumer but not yet acknowledged. This field is only meaningful when using a subscription that tracks individual message acknowledgement.
 
                 -   **blockedConsumerOnUnackedMsgs**: The flag used to verify if the consumer is blocked due to reaching threshold of the unacknowledged messages.
                 

--- a/site2/website/versioned_docs/version-2.7.0/admin-api-topics.md
+++ b/site2/website/versioned_docs/version-2.7.0/admin-api-topics.md
@@ -340,7 +340,7 @@ You can check the following statistics of a given non-partitioned topic.
 
                 -   **availablePermits**: The number of messages that the consumer has space for in the client library's listen queue. `0` means the client library's queue is full and `receive()` isn't being called. A non-zero value means this consumer is ready for dispatched messages.
 
-                -   **unackedMessages**: The number of unacknowledged messages for the consumer.
+                -   **unackedMessages**: The number of unacknowledged messages for the consumer, where an unacknowledged message is one that has been sent to the consumer but not yet acknowledged. This field is only meaningful when using a subscription that tracks individual message acknowledgement.
 
                 -   **blockedConsumerOnUnackedMsgs**: The flag used to verify if the consumer is blocked due to reaching threshold of the unacknowledged messages.
                 

--- a/site2/website/versioned_docs/version-2.7.1/admin-api-topics.md
+++ b/site2/website/versioned_docs/version-2.7.1/admin-api-topics.md
@@ -340,7 +340,7 @@ You can check the following statistics of a given non-partitioned topic.
 
                 -   **availablePermits**: The number of messages that the consumer has space for in the client library's listen queue. `0` means the client library's queue is full and `receive()` isn't being called. A non-zero value means this consumer is ready for dispatched messages.
 
-                -   **unackedMessages**: The number of unacknowledged messages for the consumer.
+                -   **unackedMessages**: The number of unacknowledged messages for the consumer, where an unacknowledged message is one that has been sent to the consumer but not yet acknowledged. This field is only meaningful when using a subscription that tracks individual message acknowledgement.
 
                 -   **blockedConsumerOnUnackedMsgs**: The flag used to verify if the consumer is blocked due to reaching threshold of the unacknowledged messages.
                 

--- a/site2/website/versioned_docs/version-2.7.2/admin-api-topics.md
+++ b/site2/website/versioned_docs/version-2.7.2/admin-api-topics.md
@@ -340,7 +340,7 @@ You can check the following statistics of a given non-partitioned topic.
 
                 -   **availablePermits**: The number of messages that the consumer has space for in the client library's listen queue. `0` means the client library's queue is full and `receive()` isn't being called. A non-zero value means this consumer is ready for dispatched messages.
 
-                -   **unackedMessages**: The number of unacknowledged messages for the consumer.
+                -   **unackedMessages**: The number of unacknowledged messages for the consumer, where an unacknowledged message is one that has been sent to the consumer but not yet acknowledged. This field is only meaningful when using a subscription that tracks individual message acknowledgement.
 
                 -   **blockedConsumerOnUnackedMsgs**: The flag used to verify if the consumer is blocked due to reaching threshold of the unacknowledged messages.
                 

--- a/site2/website/versioned_docs/version-2.7.3/admin-api-topics.md
+++ b/site2/website/versioned_docs/version-2.7.3/admin-api-topics.md
@@ -340,7 +340,7 @@ You can check the following statistics of a given non-partitioned topic.
 
                 -   **availablePermits**: The number of messages that the consumer has space for in the client library's listen queue. `0` means the client library's queue is full and `receive()` isn't being called. A non-zero value means this consumer is ready for dispatched messages.
 
-                -   **unackedMessages**: The number of unacknowledged messages for the consumer.
+                -   **unackedMessages**: The number of unacknowledged messages for the consumer, where an unacknowledged message is one that has been sent to the consumer but not yet acknowledged. This field is only meaningful when using a subscription that tracks individual message acknowledgement.
 
                 -   **blockedConsumerOnUnackedMsgs**: The flag used to verify if the consumer is blocked due to reaching threshold of the unacknowledged messages.
                 

--- a/site2/website/versioned_docs/version-2.7.4/admin-api-topics.md
+++ b/site2/website/versioned_docs/version-2.7.4/admin-api-topics.md
@@ -340,7 +340,7 @@ You can check the following statistics of a given non-partitioned topic.
 
                 -   **availablePermits**: The number of messages that the consumer has space for in the client library's listen queue. `0` means the client library's queue is full and `receive()` isn't being called. A non-zero value means this consumer is ready for dispatched messages.
 
-                -   **unackedMessages**: The number of unacknowledged messages for the consumer.
+                -   **unackedMessages**: The number of unacknowledged messages for the consumer, where an unacknowledged message is one that has been sent to the consumer but not yet acknowledged. This field is only meaningful when using a subscription that tracks individual message acknowledgement.
 
                 -   **blockedConsumerOnUnackedMsgs**: The flag used to verify if the consumer is blocked due to reaching threshold of the unacknowledged messages.
                 

--- a/site2/website/versioned_docs/version-2.8.0/admin-api-topics.md
+++ b/site2/website/versioned_docs/version-2.8.0/admin-api-topics.md
@@ -340,7 +340,7 @@ You can check the following statistics of a given non-partitioned topic.
 
                 -   **availablePermits**: The number of messages that the consumer has space for in the client library's listen queue. `0` means the client library's queue is full and `receive()` isn't being called. A non-zero value means this consumer is ready for dispatched messages.
 
-                -   **unackedMessages**: The number of unacknowledged messages for the consumer.
+                -   **unackedMessages**: The number of unacknowledged messages for the consumer, where an unacknowledged message is one that has been sent to the consumer but not yet acknowledged. This field is only meaningful when using a subscription that tracks individual message acknowledgement.
 
                 -   **blockedConsumerOnUnackedMsgs**: The flag used to verify if the consumer is blocked due to reaching threshold of the unacknowledged messages.
                 

--- a/site2/website/versioned_docs/version-2.8.1/admin-api-topics.md
+++ b/site2/website/versioned_docs/version-2.8.1/admin-api-topics.md
@@ -340,7 +340,7 @@ You can check the following statistics of a given non-partitioned topic.
 
                 -   **availablePermits**: The number of messages that the consumer has space for in the client library's listen queue. `0` means the client library's queue is full and `receive()` isn't being called. A non-zero value means this consumer is ready for dispatched messages.
 
-                -   **unackedMessages**: The number of unacknowledged messages for the consumer.
+                -   **unackedMessages**: The number of unacknowledged messages for the consumer, where an unacknowledged message is one that has been sent to the consumer but not yet acknowledged. This field is only meaningful when using a subscription that tracks individual message acknowledgement.
 
                 -   **blockedConsumerOnUnackedMsgs**: The flag used to verify if the consumer is blocked due to reaching threshold of the unacknowledged messages.
                 

--- a/site2/website/versioned_docs/version-2.8.2/admin-api-topics.md
+++ b/site2/website/versioned_docs/version-2.8.2/admin-api-topics.md
@@ -350,7 +350,7 @@ You can check the following statistics of a given non-partitioned topic.
 
                 -   **availablePermits**: The number of messages that the consumer has space for in the client library's listen queue. `0` means the client library's queue is full and `receive()` isn't being called. A non-zero value means this consumer is ready for dispatched messages.
 
-                -   **unackedMessages**: The number of unacknowledged messages for the consumer.
+                -   **unackedMessages**: The number of unacknowledged messages for the consumer, where an unacknowledged message is one that has been sent to the consumer but not yet acknowledged. This field is only meaningful when using a subscription that tracks individual message acknowledgement.
 
                 -   **blockedConsumerOnUnackedMsgs**: The flag used to verify if the consumer is blocked due to reaching threshold of the unacknowledged messages.
                 

--- a/site2/website/versioned_docs/version-2.8.3/admin-api-topics.md
+++ b/site2/website/versioned_docs/version-2.8.3/admin-api-topics.md
@@ -350,7 +350,7 @@ You can check the following statistics of a given non-partitioned topic.
 
                 -   **availablePermits**: The number of messages that the consumer has space for in the client library's listen queue. `0` means the client library's queue is full and `receive()` isn't being called. A non-zero value means this consumer is ready for dispatched messages.
 
-                -   **unackedMessages**: The number of unacknowledged messages for the consumer.
+                -   **unackedMessages**: The number of unacknowledged messages for the consumer, where an unacknowledged message is one that has been sent to the consumer but not yet acknowledged. This field is only meaningful when using a subscription that tracks individual message acknowledgement.
 
                 -   **blockedConsumerOnUnackedMsgs**: The flag used to verify if the consumer is blocked due to reaching threshold of the unacknowledged messages.
                 

--- a/site2/website/versioned_docs/version-2.9.0/admin-api-topics.md
+++ b/site2/website/versioned_docs/version-2.9.0/admin-api-topics.md
@@ -388,7 +388,7 @@ You can check the following statistics of a given non-partitioned topic.
 
           -   **msgDelayed**: Number of delayed messages currently being tracked.
 
-          -   **unackedMessages**: Number of unacknowledged messages for the subscription.
+          -   **unackedMessages**: Number of unacknowledged messages for the subscription, where an unacknowledged message is one that has been sent to a consumer but not yet acknowledged. This field is only meaningful when using a subscription that tracks individual message acknowledgement.
 
           -   **activeConsumerName**: The name of the consumer that is active for single active consumer subscriptions. For example, failover or exclusive. 
 
@@ -420,7 +420,7 @@ You can check the following statistics of a given non-partitioned topic.
 
                 -   **availablePermits**: The number of messages that the consumer has space for in the client library's listen queue. `0` means the client library's queue is full and `receive()` isn't being called. A non-zero value means this consumer is ready for dispatched messages.
 
-                -   **unackedMessages**: The number of unacknowledged messages for the consumer.
+                -   **unackedMessages**: The number of unacknowledged messages for the consumer, where an unacknowledged message is one that has been sent to the consumer but not yet acknowledged. This field is only meaningful when using a subscription that tracks individual message acknowledgement.
 
                 -   **blockedConsumerOnUnackedMsgs**: The flag used to verify if the consumer is blocked due to reaching threshold of the unacknowledged messages.
                 

--- a/site2/website/versioned_docs/version-2.9.1/admin-api-topics.md
+++ b/site2/website/versioned_docs/version-2.9.1/admin-api-topics.md
@@ -388,7 +388,7 @@ You can check the following statistics of a given non-partitioned topic.
 
           -   **msgDelayed**: Number of delayed messages currently being tracked.
 
-          -   **unackedMessages**: Number of unacknowledged messages for the subscription.
+          -   **unackedMessages**: Number of unacknowledged messages for the subscription, where an unacknowledged message is one that has been sent to a consumer but not yet acknowledged. This field is only meaningful when using a subscription that tracks individual message acknowledgement.
 
           -   **activeConsumerName**: The name of the consumer that is active for single active consumer subscriptions. For example, failover or exclusive. 
 
@@ -420,7 +420,7 @@ You can check the following statistics of a given non-partitioned topic.
 
                 -   **availablePermits**: The number of messages that the consumer has space for in the client library's listen queue. `0` means the client library's queue is full and `receive()` isn't being called. A non-zero value means this consumer is ready for dispatched messages.
 
-                -   **unackedMessages**: The number of unacknowledged messages for the consumer.
+                -   **unackedMessages**: The number of unacknowledged messages for the consumer, where an unacknowledged message is one that has been sent to the consumer but not yet acknowledged. This field is only meaningful when using a subscription that tracks individual message acknowledgement.
 
                 -   **blockedConsumerOnUnackedMsgs**: The flag used to verify if the consumer is blocked due to reaching threshold of the unacknowledged messages.
                 

--- a/site2/website/versioned_docs/version-2.9.2/admin-api-topics.md
+++ b/site2/website/versioned_docs/version-2.9.2/admin-api-topics.md
@@ -388,7 +388,7 @@ You can check the following statistics of a given non-partitioned topic.
 
           -   **msgDelayed**: Number of delayed messages currently being tracked.
 
-          -   **unackedMessages**: Number of unacknowledged messages for the subscription.
+          -   **unackedMessages**: Number of unacknowledged messages for the subscription, where an unacknowledged message is one that has been sent to a consumer but not yet acknowledged. This field is only meaningful when using a subscription that tracks individual message acknowledgement.
 
           -   **activeConsumerName**: The name of the consumer that is active for single active consumer subscriptions. For example, failover or exclusive. 
 
@@ -420,7 +420,7 @@ You can check the following statistics of a given non-partitioned topic.
 
                 -   **availablePermits**: The number of messages that the consumer has space for in the client library's listen queue. `0` means the client library's queue is full and `receive()` isn't being called. A non-zero value means this consumer is ready for dispatched messages.
 
-                -   **unackedMessages**: The number of unacknowledged messages for the consumer.
+                -   **unackedMessages**: The number of unacknowledged messages for the consumer, where an unacknowledged message is one that has been sent to the consumer but not yet acknowledged. This field is only meaningful when using a subscription that tracks individual message acknowledgement.
 
                 -   **blockedConsumerOnUnackedMsgs**: The flag used to verify if the consumer is blocked due to reaching threshold of the unacknowledged messages.
                 


### PR DESCRIPTION
### Motivation

I found the current documentation for `unackedMessages` ambiguous. This PR should make the docs clearer for future users.

### Modifications

* Update Javadocs and docs for `unackedMessages`
* Update Javadocs for subscription stats `type` since it was missing the `Key_Shared` subscription type.

### Verifying this change

This is a trivial change. I ran some tests to verify that my understanding is correct.

### Does this pull request potentially affect one of the following parts:

This is not a breaking change.

### Documentation
  
- [x] `doc` 