### PR TITLE
Add first message's properties to batch message metadata.

### DIFF
--- a/pulsar-common/src/main/java/org/apache/pulsar/common/protocol/Commands.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/protocol/Commands.java
@@ -1668,12 +1668,13 @@ public class Commands {
             messageMetadata.setReplicatedFrom(builder.getReplicatedFrom());
         }
         if (builder.getReplicateTosCount() > 0) {
-            for (int i = 0; i < builder.getReplicateTosCount(); i++) {
-                messageMetadata.addReplicateTo(builder.getReplicateToAt(i));
-            }
+            messageMetadata.addAllReplicateTos(builder.getReplicateTosList());
         }
         if (builder.hasSchemaVersion()) {
             messageMetadata.setSchemaVersion(builder.getSchemaVersion());
+        }
+        if (builder.getPropertiesCount() > 0) {
+            messageMetadata.addAllProperties(builder.getPropertiesList());
         }
 
         return builder.getSequenceId();

--- a/pulsar-common/src/test/java/org/apache/pulsar/common/protocol/CommandsTest.java
+++ b/pulsar-common/src/test/java/org/apache/pulsar/common/protocol/CommandsTest.java
@@ -7,7 +7,7 @@
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an

--- a/pulsar-common/src/test/java/org/apache/pulsar/common/protocol/CommandsTest.java
+++ b/pulsar-common/src/test/java/org/apache/pulsar/common/protocol/CommandsTest.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.pulsar.common.protocol;
 
 import org.apache.pulsar.common.api.proto.MessageMetadata;

--- a/pulsar-common/src/test/java/org/apache/pulsar/common/protocol/CommandsTest.java
+++ b/pulsar-common/src/test/java/org/apache/pulsar/common/protocol/CommandsTest.java
@@ -1,0 +1,24 @@
+package org.apache.pulsar.common.protocol;
+
+import org.apache.pulsar.common.api.proto.MessageMetadata;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class CommandsTest {
+
+    @Test
+    public void initBatchMessageMetadataTest() {
+        MessageMetadata messageMetadata = new MessageMetadata();
+        MessageMetadata builder = new MessageMetadata();
+        builder.setPublishTime(System.currentTimeMillis());
+        builder.setProducerName("p1");
+        builder.setSequenceId(1);
+        builder.addReplicateTo("rep1");
+        builder.addReplicateTo("rep2");
+        builder.addProperty().setKey("key1").setValue("value1");
+        builder.addProperty().setKey("key2").setValue("value2");
+        Commands.initBatchMessageMetadata(messageMetadata, builder);
+        Assert.assertEquals(2, messageMetadata.getPropertiesCount());
+        Assert.assertEquals(2, messageMetadata.getReplicateTosCount());
+    }
+}


### PR DESCRIPTION
### Motivation
When use java client to build batch message, properties in single message can not add to batch message’s metadata.

### Modifications
Add first message's properties to batch message's metadata.

### Verifying this change
 New unit test added.

### Documentation

Check the box below or label this PR directly.

Need to update docs? 

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)
  
- [x] `doc-not-needed` 
(Please explain why)
  
- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)
