### PR TITLE
Update swagger documentation for query param: authoritative

### DIFF
--- a/site2/website/static/swagger/2.10.0/swagger.json
+++ b/site2/website/static/swagger/2.10.0/swagger.json
@@ -6243,7 +6243,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6317,7 +6317,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6387,7 +6387,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6448,7 +6448,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6497,7 +6497,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6562,7 +6562,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6620,7 +6620,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6672,7 +6672,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6724,7 +6724,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6789,7 +6789,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6862,7 +6862,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6906,7 +6906,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6971,7 +6971,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7080,7 +7080,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7121,13 +7121,13 @@
         }, {
           "name" : "isGlobal",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
           "required" : false,
           "type" : "boolean",
           "default" : false
         }, {
           "name" : "authoritative",
           "in" : "query",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7176,13 +7176,13 @@
         }, {
           "name" : "isGlobal",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
           "required" : false,
           "type" : "boolean",
           "default" : false
         }, {
           "name" : "authoritative",
           "in" : "query",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7234,7 +7234,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7290,7 +7290,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7334,7 +7334,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7386,7 +7386,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7433,7 +7433,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7485,7 +7485,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7537,7 +7537,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7581,7 +7581,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7645,7 +7645,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7710,7 +7710,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7774,7 +7774,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7815,7 +7815,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7873,7 +7873,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7910,7 +7910,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7971,7 +7971,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8038,7 +8038,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8113,7 +8113,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8183,7 +8183,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8233,7 +8233,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8295,7 +8295,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8347,7 +8347,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8397,7 +8397,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8456,7 +8456,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8508,7 +8508,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8558,7 +8558,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8620,7 +8620,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8678,7 +8678,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8722,7 +8722,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8790,7 +8790,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8842,7 +8842,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8892,7 +8892,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8954,7 +8954,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -9012,7 +9012,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -9059,7 +9059,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -9112,7 +9112,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -9164,7 +9164,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -9211,7 +9211,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -9264,7 +9264,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -9316,7 +9316,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -9370,7 +9370,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -9414,13 +9414,13 @@
         }, {
           "name" : "isGlobal",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
           "required" : false,
           "type" : "boolean",
           "default" : false
         }, {
           "name" : "authoritative",
           "in" : "query",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -9476,7 +9476,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -9537,7 +9537,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -9596,7 +9596,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -9672,7 +9672,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -9713,7 +9713,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -9771,7 +9771,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -9821,7 +9821,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -9900,7 +9900,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -9975,7 +9975,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -10127,7 +10127,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -10381,7 +10381,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -10425,7 +10425,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -10492,7 +10492,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -10544,7 +10544,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -10594,7 +10594,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -10652,7 +10652,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -10704,7 +10704,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -10745,7 +10745,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -10809,7 +10809,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -10867,7 +10867,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -10917,7 +10917,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -10978,7 +10978,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -11036,7 +11036,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -11080,7 +11080,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -11141,13 +11141,13 @@
         }, {
           "name" : "isGlobal",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
           "required" : false,
           "type" : "boolean",
           "default" : false
         }, {
           "name" : "authoritative",
           "in" : "query",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -11205,7 +11205,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -11252,7 +11252,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -11307,7 +11307,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -11364,7 +11364,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -11455,7 +11455,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -11505,7 +11505,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -11632,7 +11632,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -11696,7 +11696,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -11776,7 +11776,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -11848,7 +11848,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -11915,7 +11915,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -11971,7 +11971,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -12046,7 +12046,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -12128,7 +12128,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -12203,7 +12203,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -12267,7 +12267,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -12334,7 +12334,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -12418,7 +12418,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -12462,7 +12462,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -12526,7 +12526,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -12572,13 +12572,13 @@
         }, {
           "name" : "isGlobal",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
           "required" : false,
           "type" : "boolean",
           "default" : false
         }, {
           "name" : "authoritative",
           "in" : "query",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -12622,13 +12622,13 @@
         }, {
           "name" : "isGlobal",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
           "required" : false,
           "type" : "boolean",
           "default" : false
         }, {
           "name" : "authoritative",
           "in" : "query",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -12684,13 +12684,13 @@
         }, {
           "name" : "isGlobal",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
           "required" : false,
           "type" : "boolean",
           "default" : false
         }, {
           "name" : "authoritative",
           "in" : "query",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -12739,7 +12739,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -12797,7 +12797,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -12867,7 +12867,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -12925,7 +12925,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -12965,7 +12965,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -13125,7 +13125,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -13199,7 +13199,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -13269,7 +13269,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -13330,7 +13330,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -13379,7 +13379,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -13444,7 +13444,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -13502,7 +13502,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -13554,7 +13554,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -13606,7 +13606,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -13671,7 +13671,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -13744,7 +13744,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -13788,7 +13788,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -13853,7 +13853,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -13962,7 +13962,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -14003,13 +14003,13 @@
         }, {
           "name" : "isGlobal",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
           "required" : false,
           "type" : "boolean",
           "default" : false
         }, {
           "name" : "authoritative",
           "in" : "query",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -14058,13 +14058,13 @@
         }, {
           "name" : "isGlobal",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
           "required" : false,
           "type" : "boolean",
           "default" : false
         }, {
           "name" : "authoritative",
           "in" : "query",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -14116,7 +14116,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -14172,7 +14172,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -14216,7 +14216,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -14268,7 +14268,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -14315,7 +14315,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -14367,7 +14367,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -14419,7 +14419,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -14463,7 +14463,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -14527,7 +14527,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -14592,7 +14592,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -14656,7 +14656,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -14697,7 +14697,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -14755,7 +14755,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -14792,7 +14792,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -14853,7 +14853,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -14923,7 +14923,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -14998,7 +14998,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -15068,7 +15068,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -15118,7 +15118,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -15180,7 +15180,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -15232,7 +15232,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -15282,7 +15282,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -15341,7 +15341,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -15393,7 +15393,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -15443,7 +15443,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -15505,7 +15505,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -15563,7 +15563,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -15607,7 +15607,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -15675,7 +15675,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -15727,7 +15727,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -15777,7 +15777,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -15839,7 +15839,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -15897,7 +15897,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -15944,7 +15944,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -15997,7 +15997,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -16049,7 +16049,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -16096,7 +16096,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -16149,7 +16149,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -16201,7 +16201,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -16255,7 +16255,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -16299,13 +16299,13 @@
         }, {
           "name" : "isGlobal",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
           "required" : false,
           "type" : "boolean",
           "default" : false
         }, {
           "name" : "authoritative",
           "in" : "query",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -16361,7 +16361,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -16422,7 +16422,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -16481,7 +16481,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -16557,7 +16557,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -16598,7 +16598,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -16656,7 +16656,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -16706,7 +16706,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -16785,7 +16785,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -16860,7 +16860,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -17013,7 +17013,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -17267,7 +17267,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -17311,7 +17311,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -17378,7 +17378,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -17430,7 +17430,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -17480,7 +17480,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -17538,7 +17538,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -17590,7 +17590,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -17631,7 +17631,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -17695,7 +17695,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -17753,7 +17753,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -17803,7 +17803,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -17864,7 +17864,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -17922,7 +17922,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -17966,7 +17966,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -18027,13 +18027,13 @@
         }, {
           "name" : "isGlobal",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
           "required" : false,
           "type" : "boolean",
           "default" : false
         }, {
           "name" : "authoritative",
           "in" : "query",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -18091,7 +18091,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -18138,7 +18138,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -18193,7 +18193,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -18250,7 +18250,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -18344,7 +18344,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -18394,7 +18394,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -18521,7 +18521,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -18585,7 +18585,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -18665,7 +18665,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -18737,7 +18737,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -18804,7 +18804,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -18860,7 +18860,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -18935,7 +18935,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -19017,7 +19017,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -19092,7 +19092,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -19156,7 +19156,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -19223,7 +19223,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -19307,7 +19307,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -19351,7 +19351,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -19415,7 +19415,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -19461,13 +19461,13 @@
         }, {
           "name" : "isGlobal",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
           "required" : false,
           "type" : "boolean",
           "default" : false
         }, {
           "name" : "authoritative",
           "in" : "query",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -19511,13 +19511,13 @@
         }, {
           "name" : "isGlobal",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
           "required" : false,
           "type" : "boolean",
           "default" : false
         }, {
           "name" : "authoritative",
           "in" : "query",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -19573,13 +19573,13 @@
         }, {
           "name" : "isGlobal",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
           "required" : false,
           "type" : "boolean",
           "default" : false
         }, {
           "name" : "authoritative",
           "in" : "query",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -19628,7 +19628,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -19686,7 +19686,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -19756,7 +19756,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -19814,7 +19814,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -19866,7 +19866,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false

--- a/site2/website/static/swagger/2.4.0/swagger.json
+++ b/site2/website/static/swagger/2.4.0/swagger.json
@@ -3603,7 +3603,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -3663,7 +3663,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -3723,7 +3723,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -3781,7 +3781,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -3833,7 +3833,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -3895,7 +3895,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -4004,7 +4004,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -4053,7 +4053,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -4117,7 +4117,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -4179,7 +4179,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -4240,7 +4240,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -4295,7 +4295,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -4455,7 +4455,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -4679,7 +4679,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -4734,7 +4734,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -4803,7 +4803,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -4872,7 +4872,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -4936,7 +4936,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -5015,7 +5015,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -5087,7 +5087,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -5148,7 +5148,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -5220,7 +5220,7 @@
         }, {
           "name" : "replicated",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean"
         } ],
@@ -5274,7 +5274,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -5338,7 +5338,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -5477,7 +5477,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -5537,7 +5537,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -5597,7 +5597,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -5655,7 +5655,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -5707,7 +5707,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -5769,7 +5769,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -5878,7 +5878,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -5939,7 +5939,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6003,7 +6003,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6065,7 +6065,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6126,7 +6126,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6181,7 +6181,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6365,7 +6365,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6589,7 +6589,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6656,7 +6656,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6725,7 +6725,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6794,7 +6794,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6858,7 +6858,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6937,7 +6937,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7009,7 +7009,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7070,7 +7070,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7142,7 +7142,7 @@
         }, {
           "name" : "replicated",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean"
         } ],
@@ -7196,7 +7196,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7260,7 +7260,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7324,7 +7324,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false

--- a/site2/website/static/swagger/2.4.1/swagger.json
+++ b/site2/website/static/swagger/2.4.1/swagger.json
@@ -3632,7 +3632,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -3692,7 +3692,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -3752,7 +3752,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -3810,7 +3810,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -3862,7 +3862,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -3924,7 +3924,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -4033,7 +4033,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -4082,7 +4082,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -4146,7 +4146,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -4208,7 +4208,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -4276,7 +4276,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -4331,7 +4331,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -4491,7 +4491,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -4715,7 +4715,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -4770,7 +4770,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -4839,7 +4839,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -4908,7 +4908,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -4972,7 +4972,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -5051,7 +5051,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -5123,7 +5123,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -5184,7 +5184,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -5256,7 +5256,7 @@
         }, {
           "name" : "replicated",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean"
         } ],
@@ -5310,7 +5310,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -5374,7 +5374,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -5513,7 +5513,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -5573,7 +5573,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -5633,7 +5633,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -5691,7 +5691,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -5743,7 +5743,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -5805,7 +5805,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -5914,7 +5914,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -5975,7 +5975,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6039,7 +6039,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6101,7 +6101,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6169,7 +6169,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6224,7 +6224,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6408,7 +6408,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6632,7 +6632,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6699,7 +6699,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6768,7 +6768,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6837,7 +6837,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6901,7 +6901,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6980,7 +6980,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7052,7 +7052,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7113,7 +7113,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7185,7 +7185,7 @@
         }, {
           "name" : "replicated",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean"
         } ],
@@ -7239,7 +7239,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7303,7 +7303,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7367,7 +7367,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false

--- a/site2/website/static/swagger/2.4.2/swagger.json
+++ b/site2/website/static/swagger/2.4.2/swagger.json
@@ -3644,7 +3644,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -3704,7 +3704,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -3764,7 +3764,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -3822,7 +3822,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -3874,7 +3874,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -3936,7 +3936,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -4045,7 +4045,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -4094,7 +4094,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -4158,7 +4158,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -4220,7 +4220,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -4288,7 +4288,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -4343,7 +4343,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -4525,7 +4525,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -4749,7 +4749,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -4804,7 +4804,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -4873,7 +4873,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -4942,7 +4942,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -5006,7 +5006,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -5085,7 +5085,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -5157,7 +5157,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -5218,7 +5218,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -5290,7 +5290,7 @@
         }, {
           "name" : "replicated",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean"
         } ],
@@ -5344,7 +5344,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -5399,7 +5399,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -5538,7 +5538,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -5598,7 +5598,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -5658,7 +5658,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -5716,7 +5716,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -5768,7 +5768,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -5830,7 +5830,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -5939,7 +5939,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6000,7 +6000,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6064,7 +6064,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6126,7 +6126,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6194,7 +6194,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6249,7 +6249,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6440,7 +6440,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6664,7 +6664,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6731,7 +6731,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6800,7 +6800,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6869,7 +6869,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6933,7 +6933,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7012,7 +7012,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7084,7 +7084,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7145,7 +7145,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7217,7 +7217,7 @@
         }, {
           "name" : "replicated",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean"
         } ],
@@ -7271,7 +7271,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7326,7 +7326,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7390,7 +7390,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false

--- a/site2/website/static/swagger/2.5.0/swagger.json
+++ b/site2/website/static/swagger/2.5.0/swagger.json
@@ -3796,7 +3796,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -3856,7 +3856,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -3916,7 +3916,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -3974,7 +3974,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -4026,7 +4026,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -4088,7 +4088,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -4197,7 +4197,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -4255,7 +4255,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -4319,7 +4319,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -4381,7 +4381,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -4449,7 +4449,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -4504,7 +4504,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -4701,7 +4701,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -4925,7 +4925,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -4989,7 +4989,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -5058,7 +5058,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -5127,7 +5127,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -5191,7 +5191,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -5270,7 +5270,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -5342,7 +5342,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -5403,7 +5403,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -5475,7 +5475,7 @@
         }, {
           "name" : "replicated",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean"
         } ],
@@ -5529,7 +5529,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -5584,7 +5584,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -5735,7 +5735,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -5795,7 +5795,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -5855,7 +5855,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -5913,7 +5913,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -5965,7 +5965,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6027,7 +6027,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6136,7 +6136,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6197,7 +6197,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6261,7 +6261,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6323,7 +6323,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6391,7 +6391,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6446,7 +6446,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6643,7 +6643,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6867,7 +6867,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6934,7 +6934,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7003,7 +7003,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7072,7 +7072,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7136,7 +7136,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7215,7 +7215,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7287,7 +7287,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7348,7 +7348,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7420,7 +7420,7 @@
         }, {
           "name" : "replicated",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean"
         } ],
@@ -7474,7 +7474,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7529,7 +7529,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7593,7 +7593,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false

--- a/site2/website/static/swagger/2.5.1/swagger.json
+++ b/site2/website/static/swagger/2.5.1/swagger.json
@@ -3924,7 +3924,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -3984,7 +3984,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -4044,7 +4044,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -4102,7 +4102,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -4154,7 +4154,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -4216,7 +4216,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -4373,7 +4373,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -4431,7 +4431,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -4489,7 +4489,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -4551,7 +4551,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -4619,7 +4619,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -4681,7 +4681,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -4878,7 +4878,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -5102,7 +5102,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -5173,7 +5173,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -5242,7 +5242,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -5311,7 +5311,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -5375,7 +5375,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -5454,7 +5454,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -5526,7 +5526,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -5587,7 +5587,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -5659,7 +5659,7 @@
         }, {
           "name" : "replicated",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean"
         } ],
@@ -5713,7 +5713,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -5768,7 +5768,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -5919,7 +5919,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -5979,7 +5979,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6039,7 +6039,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6097,7 +6097,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6149,7 +6149,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6211,7 +6211,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6368,7 +6368,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6429,7 +6429,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6487,7 +6487,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6549,7 +6549,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6617,7 +6617,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6679,7 +6679,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6876,7 +6876,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7100,7 +7100,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7174,7 +7174,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7243,7 +7243,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7312,7 +7312,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7376,7 +7376,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7455,7 +7455,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7527,7 +7527,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7588,7 +7588,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7660,7 +7660,7 @@
         }, {
           "name" : "replicated",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean"
         } ],
@@ -7714,7 +7714,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7769,7 +7769,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7833,7 +7833,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false

--- a/site2/website/static/swagger/2.5.2/swagger.json
+++ b/site2/website/static/swagger/2.5.2/swagger.json
@@ -3983,7 +3983,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -4043,7 +4043,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -4103,7 +4103,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -4161,7 +4161,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -4213,7 +4213,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -4275,7 +4275,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -4432,7 +4432,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -4490,7 +4490,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -4548,7 +4548,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -4610,7 +4610,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -4678,7 +4678,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -4740,7 +4740,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -4937,7 +4937,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -5161,7 +5161,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -5232,7 +5232,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -5301,7 +5301,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -5370,7 +5370,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -5434,7 +5434,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -5513,7 +5513,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -5585,7 +5585,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -5646,7 +5646,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -5710,7 +5710,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -5779,7 +5779,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -5834,7 +5834,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -5985,7 +5985,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6045,7 +6045,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6105,7 +6105,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6163,7 +6163,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6215,7 +6215,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6277,7 +6277,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6434,7 +6434,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6495,7 +6495,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6553,7 +6553,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6615,7 +6615,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6683,7 +6683,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6745,7 +6745,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6942,7 +6942,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7166,7 +7166,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7240,7 +7240,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7309,7 +7309,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7378,7 +7378,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7442,7 +7442,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7521,7 +7521,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7593,7 +7593,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7654,7 +7654,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7718,7 +7718,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7787,7 +7787,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7842,7 +7842,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7906,7 +7906,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false

--- a/site2/website/static/swagger/2.6.0/swagger.json
+++ b/site2/website/static/swagger/2.6.0/swagger.json
@@ -4563,7 +4563,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -4626,7 +4626,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -4689,7 +4689,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -4750,7 +4750,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -4802,7 +4802,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -4867,7 +4867,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -4976,7 +4976,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -5037,7 +5037,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -5098,7 +5098,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -5173,7 +5173,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -5234,7 +5234,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -5299,7 +5299,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -5370,7 +5370,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -5435,7 +5435,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -5510,7 +5510,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -5651,7 +5651,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -5884,7 +5884,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -5965,7 +5965,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6037,7 +6037,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6109,7 +6109,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6176,7 +6176,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6258,7 +6258,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6333,7 +6333,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6397,7 +6397,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6464,7 +6464,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6536,7 +6536,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6594,7 +6594,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6748,7 +6748,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6811,7 +6811,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6874,7 +6874,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6935,7 +6935,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6987,7 +6987,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7052,7 +7052,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7161,7 +7161,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7222,7 +7222,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7286,7 +7286,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7361,7 +7361,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7422,7 +7422,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7487,7 +7487,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7558,7 +7558,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7623,7 +7623,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7698,7 +7698,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7839,7 +7839,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8072,7 +8072,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8156,7 +8156,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8228,7 +8228,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8300,7 +8300,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8367,7 +8367,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8449,7 +8449,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8524,7 +8524,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8588,7 +8588,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8655,7 +8655,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8727,7 +8727,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8785,7 +8785,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8852,7 +8852,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8910,7 +8910,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false

--- a/site2/website/static/swagger/2.6.1/swagger.json
+++ b/site2/website/static/swagger/2.6.1/swagger.json
@@ -4666,7 +4666,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -4729,7 +4729,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -4792,7 +4792,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -4853,7 +4853,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -4905,7 +4905,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -4970,7 +4970,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -5079,7 +5079,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -5140,7 +5140,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -5201,7 +5201,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -5276,7 +5276,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -5337,7 +5337,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -5402,7 +5402,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -5473,7 +5473,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -5538,7 +5538,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -5613,7 +5613,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -5754,7 +5754,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -5987,7 +5987,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6068,7 +6068,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6140,7 +6140,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6212,7 +6212,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6279,7 +6279,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6361,7 +6361,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6436,7 +6436,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6500,7 +6500,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6567,7 +6567,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6639,7 +6639,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6697,7 +6697,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6851,7 +6851,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6914,7 +6914,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6977,7 +6977,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7038,7 +7038,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7090,7 +7090,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7155,7 +7155,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7264,7 +7264,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7325,7 +7325,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7389,7 +7389,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7464,7 +7464,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7525,7 +7525,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7590,7 +7590,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7661,7 +7661,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7726,7 +7726,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7801,7 +7801,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7942,7 +7942,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8175,7 +8175,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8259,7 +8259,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8331,7 +8331,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8403,7 +8403,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8470,7 +8470,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8552,7 +8552,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8627,7 +8627,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8691,7 +8691,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8758,7 +8758,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8830,7 +8830,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8888,7 +8888,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8955,7 +8955,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -9013,7 +9013,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false

--- a/site2/website/static/swagger/2.6.2/swagger.json
+++ b/site2/website/static/swagger/2.6.2/swagger.json
@@ -4717,7 +4717,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -4780,7 +4780,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -4850,7 +4850,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -4911,7 +4911,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -5099,7 +5099,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -5164,7 +5164,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -5273,7 +5273,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -5334,7 +5334,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -5395,7 +5395,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -5470,7 +5470,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -5531,7 +5531,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -5596,7 +5596,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -5667,7 +5667,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -5732,7 +5732,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -5807,7 +5807,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -5948,7 +5948,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6188,7 +6188,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6269,7 +6269,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6341,7 +6341,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6413,7 +6413,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6480,7 +6480,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6562,7 +6562,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6637,7 +6637,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6701,7 +6701,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6768,7 +6768,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6843,7 +6843,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6901,7 +6901,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7055,7 +7055,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7118,7 +7118,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7188,7 +7188,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7249,7 +7249,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7437,7 +7437,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7502,7 +7502,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7611,7 +7611,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7672,7 +7672,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7736,7 +7736,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7811,7 +7811,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7872,7 +7872,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7937,7 +7937,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8008,7 +8008,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8073,7 +8073,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8148,7 +8148,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8289,7 +8289,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8529,7 +8529,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8613,7 +8613,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8685,7 +8685,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8757,7 +8757,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8824,7 +8824,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8906,7 +8906,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8981,7 +8981,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -9045,7 +9045,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -9112,7 +9112,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -9187,7 +9187,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -9245,7 +9245,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -9312,7 +9312,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -9370,7 +9370,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false

--- a/site2/website/static/swagger/2.7.0/swagger.json
+++ b/site2/website/static/swagger/2.7.0/swagger.json
@@ -4861,7 +4861,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -4924,7 +4924,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -4994,7 +4994,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -5055,7 +5055,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -5243,7 +5243,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -5308,7 +5308,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6010,7 +6010,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6165,7 +6165,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6226,7 +6226,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6293,7 +6293,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6368,7 +6368,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7139,7 +7139,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7204,7 +7204,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7381,7 +7381,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7446,7 +7446,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7521,7 +7521,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7662,7 +7662,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8274,7 +8274,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8476,7 +8476,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8548,7 +8548,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8620,7 +8620,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8687,7 +8687,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8769,7 +8769,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8844,7 +8844,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8908,7 +8908,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8975,7 +8975,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -9171,7 +9171,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -9229,7 +9229,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -9383,7 +9383,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -9446,7 +9446,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -9516,7 +9516,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -9577,7 +9577,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -9765,7 +9765,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -9830,7 +9830,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -10532,7 +10532,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -10687,7 +10687,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -10748,7 +10748,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -10818,7 +10818,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -10893,7 +10893,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -11664,7 +11664,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -11729,7 +11729,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -11906,7 +11906,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -11971,7 +11971,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -12046,7 +12046,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -12187,7 +12187,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -12799,7 +12799,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -13004,7 +13004,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -13076,7 +13076,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -13148,7 +13148,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -13215,7 +13215,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -13297,7 +13297,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -13372,7 +13372,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -13436,7 +13436,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -13503,7 +13503,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -13699,7 +13699,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -13757,7 +13757,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -13824,7 +13824,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -13882,7 +13882,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false

--- a/site2/website/static/swagger/2.7.1/swagger.json
+++ b/site2/website/static/swagger/2.7.1/swagger.json
@@ -4999,7 +4999,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -5062,7 +5062,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -5132,7 +5132,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -5193,7 +5193,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -5381,7 +5381,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -5446,7 +5446,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6148,7 +6148,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6303,7 +6303,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6364,7 +6364,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6431,7 +6431,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6506,7 +6506,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7527,7 +7527,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7592,7 +7592,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7772,7 +7772,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7844,7 +7844,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7919,7 +7919,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8060,7 +8060,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8672,7 +8672,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8881,7 +8881,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8945,7 +8945,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -9025,7 +9025,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -9097,7 +9097,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -9164,7 +9164,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -9246,7 +9246,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -9321,7 +9321,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -9385,7 +9385,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -9452,7 +9452,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -9648,7 +9648,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -9706,7 +9706,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -9860,7 +9860,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -9923,7 +9923,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -9993,7 +9993,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -10054,7 +10054,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -10242,7 +10242,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -10307,7 +10307,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -11009,7 +11009,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -11164,7 +11164,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -11225,7 +11225,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -11295,7 +11295,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -11370,7 +11370,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -12391,7 +12391,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -12456,7 +12456,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -12636,7 +12636,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -12708,7 +12708,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -12783,7 +12783,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -12924,7 +12924,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -13536,7 +13536,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -13748,7 +13748,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -13812,7 +13812,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -13892,7 +13892,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -13964,7 +13964,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -14031,7 +14031,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -14113,7 +14113,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -14188,7 +14188,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -14252,7 +14252,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -14319,7 +14319,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -14515,7 +14515,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -14573,7 +14573,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -14640,7 +14640,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -14698,7 +14698,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false

--- a/site2/website/static/swagger/2.7.2/swagger.json
+++ b/site2/website/static/swagger/2.7.2/swagger.json
@@ -5019,7 +5019,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -5082,7 +5082,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -5152,7 +5152,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -5213,7 +5213,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -5401,7 +5401,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -5466,7 +5466,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6168,7 +6168,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6323,7 +6323,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6384,7 +6384,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6451,7 +6451,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6526,7 +6526,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7547,7 +7547,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7612,7 +7612,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7792,7 +7792,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7864,7 +7864,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7939,7 +7939,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8080,7 +8080,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8692,7 +8692,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8901,7 +8901,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8965,7 +8965,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -9045,7 +9045,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -9117,7 +9117,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -9184,7 +9184,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -9266,7 +9266,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -9341,7 +9341,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -9405,7 +9405,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -9472,7 +9472,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -9668,7 +9668,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -9726,7 +9726,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -9880,7 +9880,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -9943,7 +9943,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -10013,7 +10013,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -10074,7 +10074,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -10262,7 +10262,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -10327,7 +10327,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -11029,7 +11029,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -11184,7 +11184,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -11245,7 +11245,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -11315,7 +11315,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -11390,7 +11390,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -12411,7 +12411,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -12476,7 +12476,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -12656,7 +12656,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -12728,7 +12728,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -12803,7 +12803,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -12944,7 +12944,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -13556,7 +13556,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -13768,7 +13768,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -13832,7 +13832,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -13912,7 +13912,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -13984,7 +13984,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -14051,7 +14051,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -14133,7 +14133,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -14208,7 +14208,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -14272,7 +14272,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -14339,7 +14339,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -14535,7 +14535,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -14593,7 +14593,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -14660,7 +14660,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -14718,7 +14718,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false

--- a/site2/website/static/swagger/2.7.3/swagger.json
+++ b/site2/website/static/swagger/2.7.3/swagger.json
@@ -5019,7 +5019,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -5082,7 +5082,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -5152,7 +5152,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -5213,7 +5213,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -5262,7 +5262,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -5321,7 +5321,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -5367,7 +5367,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -5413,7 +5413,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -5478,7 +5478,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -5539,7 +5539,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -5583,7 +5583,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -5636,7 +5636,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -5733,7 +5733,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -5774,7 +5774,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -5823,7 +5823,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -5869,7 +5869,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -5910,7 +5910,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -5957,7 +5957,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -5997,7 +5997,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6038,7 +6038,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6084,7 +6084,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6124,7 +6124,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6168,7 +6168,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6220,7 +6220,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6285,7 +6285,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6337,7 +6337,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6378,7 +6378,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6424,7 +6424,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6461,7 +6461,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6522,7 +6522,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6589,7 +6589,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6664,7 +6664,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6722,7 +6722,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6766,7 +6766,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6822,7 +6822,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6868,7 +6868,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6912,7 +6912,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6965,7 +6965,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7011,7 +7011,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7055,7 +7055,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7111,7 +7111,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7157,7 +7157,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7201,7 +7201,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7257,7 +7257,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7303,7 +7303,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7347,7 +7347,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7403,7 +7403,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7449,7 +7449,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7490,7 +7490,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7537,7 +7537,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7577,7 +7577,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7618,7 +7618,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7665,7 +7665,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7705,7 +7705,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7753,7 +7753,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7797,7 +7797,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7846,7 +7846,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7911,7 +7911,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7975,7 +7975,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8016,7 +8016,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8062,7 +8062,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8112,7 +8112,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8184,7 +8184,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8259,7 +8259,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8406,7 +8406,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8643,7 +8643,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8687,7 +8687,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8742,7 +8742,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8788,7 +8788,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8832,7 +8832,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8884,7 +8884,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8930,7 +8930,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8974,7 +8974,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -9029,7 +9029,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -9081,7 +9081,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -9153,7 +9153,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -9197,7 +9197,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -9249,7 +9249,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -9311,7 +9311,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -9375,7 +9375,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -9455,7 +9455,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -9527,7 +9527,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -9594,7 +9594,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -9676,7 +9676,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -9751,7 +9751,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -9815,7 +9815,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -9882,7 +9882,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -9954,7 +9954,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -9998,7 +9998,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -10050,7 +10050,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -10099,7 +10099,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -10157,7 +10157,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -10311,7 +10311,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -10374,7 +10374,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -10444,7 +10444,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -10505,7 +10505,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -10554,7 +10554,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -10613,7 +10613,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -10659,7 +10659,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -10705,7 +10705,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -10770,7 +10770,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -10831,7 +10831,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -10875,7 +10875,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -10928,7 +10928,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -11025,7 +11025,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -11066,7 +11066,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -11115,7 +11115,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -11161,7 +11161,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -11202,7 +11202,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -11249,7 +11249,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -11289,7 +11289,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -11330,7 +11330,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -11376,7 +11376,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -11416,7 +11416,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -11460,7 +11460,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -11512,7 +11512,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -11577,7 +11577,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -11629,7 +11629,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -11670,7 +11670,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -11716,7 +11716,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -11753,7 +11753,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -11814,7 +11814,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -11884,7 +11884,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -11959,7 +11959,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -12017,7 +12017,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -12061,7 +12061,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -12117,7 +12117,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -12163,7 +12163,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -12207,7 +12207,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -12260,7 +12260,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -12306,7 +12306,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -12350,7 +12350,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -12406,7 +12406,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -12452,7 +12452,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -12496,7 +12496,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -12552,7 +12552,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -12598,7 +12598,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -12642,7 +12642,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -12698,7 +12698,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -12744,7 +12744,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -12785,7 +12785,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -12832,7 +12832,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -12872,7 +12872,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -12913,7 +12913,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -12960,7 +12960,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -13000,7 +13000,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -13048,7 +13048,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -13092,7 +13092,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -13141,7 +13141,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -13206,7 +13206,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -13270,7 +13270,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -13311,7 +13311,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -13357,7 +13357,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -13407,7 +13407,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -13479,7 +13479,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -13554,7 +13554,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -13701,7 +13701,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -13938,7 +13938,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -13982,7 +13982,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -14037,7 +14037,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -14083,7 +14083,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -14127,7 +14127,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -14179,7 +14179,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -14225,7 +14225,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -14269,7 +14269,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -14324,7 +14324,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -14376,7 +14376,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -14451,7 +14451,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -14495,7 +14495,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -14547,7 +14547,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -14609,7 +14609,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -14673,7 +14673,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -14753,7 +14753,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -14825,7 +14825,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -14892,7 +14892,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -14974,7 +14974,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -15049,7 +15049,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -15113,7 +15113,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -15180,7 +15180,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -15252,7 +15252,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -15296,7 +15296,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -15348,7 +15348,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -15397,7 +15397,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -15455,7 +15455,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -15522,7 +15522,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -15580,7 +15580,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false

--- a/site2/website/static/swagger/2.7.4/swagger.json
+++ b/site2/website/static/swagger/2.7.4/swagger.json
@@ -5019,7 +5019,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -5082,7 +5082,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -5152,7 +5152,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -5213,7 +5213,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -5262,7 +5262,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -5321,7 +5321,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -5367,7 +5367,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -5413,7 +5413,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -5478,7 +5478,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -5539,7 +5539,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -5583,7 +5583,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -5636,7 +5636,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -5733,7 +5733,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -5774,7 +5774,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -5823,7 +5823,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -5869,7 +5869,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -5910,7 +5910,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -5957,7 +5957,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -5997,7 +5997,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6038,7 +6038,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6084,7 +6084,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6124,7 +6124,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6168,7 +6168,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6220,7 +6220,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6285,7 +6285,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6337,7 +6337,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6378,7 +6378,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6424,7 +6424,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6461,7 +6461,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6522,7 +6522,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6589,7 +6589,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6664,7 +6664,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6722,7 +6722,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6766,7 +6766,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6822,7 +6822,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6868,7 +6868,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6912,7 +6912,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6965,7 +6965,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7011,7 +7011,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7055,7 +7055,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7111,7 +7111,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7157,7 +7157,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7201,7 +7201,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7257,7 +7257,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7303,7 +7303,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7347,7 +7347,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7403,7 +7403,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7449,7 +7449,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7490,7 +7490,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7537,7 +7537,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7577,7 +7577,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7618,7 +7618,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7665,7 +7665,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7705,7 +7705,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7753,7 +7753,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7797,7 +7797,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7846,7 +7846,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7911,7 +7911,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7975,7 +7975,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8016,7 +8016,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8062,7 +8062,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8112,7 +8112,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8184,7 +8184,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8259,7 +8259,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8406,7 +8406,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8643,7 +8643,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8687,7 +8687,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8742,7 +8742,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8788,7 +8788,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8832,7 +8832,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8884,7 +8884,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8930,7 +8930,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8974,7 +8974,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -9029,7 +9029,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -9081,7 +9081,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -9153,7 +9153,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -9197,7 +9197,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -9249,7 +9249,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -9311,7 +9311,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -9375,7 +9375,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -9455,7 +9455,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -9527,7 +9527,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -9594,7 +9594,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -9676,7 +9676,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -9751,7 +9751,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -9815,7 +9815,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -9882,7 +9882,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -9954,7 +9954,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -9998,7 +9998,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -10050,7 +10050,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -10099,7 +10099,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -10157,7 +10157,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -10224,7 +10224,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -10282,7 +10282,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -10436,7 +10436,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -10499,7 +10499,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -10569,7 +10569,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -10630,7 +10630,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -10679,7 +10679,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -10738,7 +10738,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -10784,7 +10784,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -10830,7 +10830,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -10895,7 +10895,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -10956,7 +10956,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -11000,7 +11000,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -11053,7 +11053,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -11150,7 +11150,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -11191,7 +11191,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -11240,7 +11240,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -11286,7 +11286,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -11327,7 +11327,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -11374,7 +11374,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -11414,7 +11414,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -11455,7 +11455,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -11501,7 +11501,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -11541,7 +11541,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -11585,7 +11585,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -11637,7 +11637,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -11702,7 +11702,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -11754,7 +11754,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -11795,7 +11795,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -11841,7 +11841,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -11878,7 +11878,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -11939,7 +11939,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -12009,7 +12009,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -12084,7 +12084,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -12142,7 +12142,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -12186,7 +12186,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -12242,7 +12242,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -12288,7 +12288,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -12332,7 +12332,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -12385,7 +12385,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -12431,7 +12431,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -12475,7 +12475,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -12531,7 +12531,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -12577,7 +12577,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -12621,7 +12621,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -12677,7 +12677,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -12723,7 +12723,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -12767,7 +12767,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -12823,7 +12823,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -12869,7 +12869,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -12910,7 +12910,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -12957,7 +12957,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -12997,7 +12997,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -13038,7 +13038,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -13085,7 +13085,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -13125,7 +13125,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -13173,7 +13173,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -13217,7 +13217,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -13266,7 +13266,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -13331,7 +13331,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -13395,7 +13395,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -13436,7 +13436,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -13482,7 +13482,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -13532,7 +13532,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -13604,7 +13604,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -13679,7 +13679,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -13826,7 +13826,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -14063,7 +14063,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -14107,7 +14107,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -14162,7 +14162,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -14208,7 +14208,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -14252,7 +14252,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -14304,7 +14304,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -14350,7 +14350,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -14394,7 +14394,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -14449,7 +14449,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -14501,7 +14501,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -14576,7 +14576,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -14620,7 +14620,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -14672,7 +14672,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -14734,7 +14734,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -14798,7 +14798,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -14878,7 +14878,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -14950,7 +14950,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -15017,7 +15017,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -15099,7 +15099,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -15174,7 +15174,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -15238,7 +15238,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -15305,7 +15305,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -15377,7 +15377,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -15421,7 +15421,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -15473,7 +15473,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -15522,7 +15522,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -15580,7 +15580,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -15647,7 +15647,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -15705,7 +15705,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false

--- a/site2/website/static/swagger/2.8.0/swagger.json
+++ b/site2/website/static/swagger/2.8.0/swagger.json
@@ -5956,7 +5956,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6019,7 +6019,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6089,7 +6089,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6150,7 +6150,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6343,7 +6343,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6408,7 +6408,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7130,7 +7130,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7290,7 +7290,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7351,7 +7351,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7418,7 +7418,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7493,7 +7493,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8539,7 +8539,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8604,7 +8604,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8789,7 +8789,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8861,7 +8861,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8936,7 +8936,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -9077,7 +9077,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -9833,7 +9833,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -10047,7 +10047,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -10111,7 +10111,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -10191,7 +10191,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -10263,7 +10263,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -10330,7 +10330,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -10412,7 +10412,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -10487,7 +10487,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -10551,7 +10551,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -10618,7 +10618,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -10907,7 +10907,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -10965,7 +10965,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -11005,7 +11005,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -11159,7 +11159,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -11222,7 +11222,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -11292,7 +11292,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -11353,7 +11353,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -11546,7 +11546,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -11611,7 +11611,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -12333,7 +12333,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -12493,7 +12493,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -12554,7 +12554,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -12624,7 +12624,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -12699,7 +12699,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -13745,7 +13745,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -13810,7 +13810,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -13995,7 +13995,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -14067,7 +14067,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -14142,7 +14142,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -14283,7 +14283,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -15039,7 +15039,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -15256,7 +15256,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -15320,7 +15320,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -15400,7 +15400,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -15472,7 +15472,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -15539,7 +15539,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -15621,7 +15621,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -15696,7 +15696,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -15760,7 +15760,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -15827,7 +15827,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -16116,7 +16116,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -16174,7 +16174,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -16241,7 +16241,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -16299,7 +16299,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -16351,7 +16351,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false

--- a/site2/website/static/swagger/2.8.1/swagger.json
+++ b/site2/website/static/swagger/2.8.1/swagger.json
@@ -5983,7 +5983,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6046,7 +6046,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6116,7 +6116,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6177,7 +6177,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6226,7 +6226,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6285,7 +6285,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6336,7 +6336,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6382,7 +6382,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6447,7 +6447,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6513,7 +6513,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6557,7 +6557,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6610,7 +6610,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6712,7 +6712,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6753,7 +6753,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6802,7 +6802,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6848,7 +6848,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6898,7 +6898,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6936,7 +6936,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6981,7 +6981,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7022,7 +7022,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7068,7 +7068,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7113,7 +7113,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7157,7 +7157,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7209,7 +7209,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7274,7 +7274,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7331,7 +7331,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7372,7 +7372,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7418,7 +7418,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7455,7 +7455,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7516,7 +7516,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7583,7 +7583,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7658,7 +7658,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7721,7 +7721,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7765,7 +7765,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7821,7 +7821,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7867,7 +7867,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7911,7 +7911,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7964,7 +7964,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8010,7 +8010,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8054,7 +8054,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8110,7 +8110,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8161,7 +8161,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8205,7 +8205,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8261,7 +8261,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8307,7 +8307,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8351,7 +8351,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8407,7 +8407,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8458,7 +8458,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8499,7 +8499,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8546,7 +8546,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8591,7 +8591,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8632,7 +8632,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8679,7 +8679,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8724,7 +8724,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8772,7 +8772,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8816,7 +8816,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8865,7 +8865,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8930,7 +8930,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8999,7 +8999,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -9040,7 +9040,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -9086,7 +9086,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -9136,7 +9136,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -9208,7 +9208,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -9283,7 +9283,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -9430,7 +9430,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -9677,7 +9677,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -9721,7 +9721,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -9776,7 +9776,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -9822,7 +9822,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -9866,7 +9866,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -9918,7 +9918,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -9969,7 +9969,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -10013,7 +10013,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -10068,7 +10068,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -10119,7 +10119,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -10163,7 +10163,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -10218,7 +10218,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -10270,7 +10270,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -10347,7 +10347,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -10391,7 +10391,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -10512,7 +10512,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -10576,7 +10576,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -10656,7 +10656,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -10728,7 +10728,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -10795,7 +10795,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -10870,7 +10870,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -10952,7 +10952,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -11027,7 +11027,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -11091,7 +11091,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -11158,7 +11158,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -11235,7 +11235,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -11279,7 +11279,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -11331,7 +11331,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -11377,7 +11377,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -11421,7 +11421,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -11482,7 +11482,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -11540,7 +11540,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -11607,7 +11607,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -11665,7 +11665,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -11705,7 +11705,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -11859,7 +11859,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -11922,7 +11922,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -11992,7 +11992,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -12053,7 +12053,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -12102,7 +12102,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -12161,7 +12161,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -12212,7 +12212,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -12258,7 +12258,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -12323,7 +12323,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -12389,7 +12389,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -12433,7 +12433,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -12486,7 +12486,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -12588,7 +12588,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -12629,7 +12629,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -12678,7 +12678,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -12724,7 +12724,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -12774,7 +12774,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -12812,7 +12812,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -12857,7 +12857,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -12898,7 +12898,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -12944,7 +12944,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -12989,7 +12989,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -13033,7 +13033,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -13085,7 +13085,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -13150,7 +13150,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -13207,7 +13207,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -13248,7 +13248,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -13294,7 +13294,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -13331,7 +13331,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -13392,7 +13392,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -13462,7 +13462,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -13537,7 +13537,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -13600,7 +13600,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -13644,7 +13644,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -13700,7 +13700,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -13746,7 +13746,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -13790,7 +13790,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -13843,7 +13843,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -13889,7 +13889,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -13933,7 +13933,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -13989,7 +13989,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -14040,7 +14040,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -14084,7 +14084,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -14140,7 +14140,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -14186,7 +14186,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -14230,7 +14230,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -14286,7 +14286,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -14337,7 +14337,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -14378,7 +14378,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -14425,7 +14425,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -14470,7 +14470,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -14511,7 +14511,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -14558,7 +14558,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -14603,7 +14603,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -14651,7 +14651,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -14695,7 +14695,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -14744,7 +14744,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -14809,7 +14809,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -14878,7 +14878,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -14919,7 +14919,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -14965,7 +14965,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -15015,7 +15015,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -15087,7 +15087,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -15162,7 +15162,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -15309,7 +15309,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -15556,7 +15556,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -15600,7 +15600,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -15655,7 +15655,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -15701,7 +15701,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -15745,7 +15745,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -15797,7 +15797,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -15848,7 +15848,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -15892,7 +15892,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -15947,7 +15947,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -15998,7 +15998,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -16042,7 +16042,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -16097,7 +16097,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -16149,7 +16149,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -16229,7 +16229,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -16273,7 +16273,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -16394,7 +16394,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -16458,7 +16458,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -16538,7 +16538,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -16610,7 +16610,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -16677,7 +16677,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -16752,7 +16752,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -16834,7 +16834,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -16909,7 +16909,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -16973,7 +16973,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -17040,7 +17040,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -17117,7 +17117,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -17161,7 +17161,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -17213,7 +17213,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -17259,7 +17259,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -17303,7 +17303,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -17364,7 +17364,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -17422,7 +17422,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -17489,7 +17489,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -17547,7 +17547,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -17599,7 +17599,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false

--- a/site2/website/static/swagger/2.8.2/swagger.json
+++ b/site2/website/static/swagger/2.8.2/swagger.json
@@ -5989,7 +5989,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6052,7 +6052,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6122,7 +6122,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6183,7 +6183,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6232,7 +6232,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6291,7 +6291,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6342,7 +6342,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6388,7 +6388,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6453,7 +6453,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6519,7 +6519,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6563,7 +6563,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6616,7 +6616,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6718,7 +6718,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6759,7 +6759,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6808,7 +6808,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6854,7 +6854,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6904,7 +6904,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6942,7 +6942,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6987,7 +6987,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7028,7 +7028,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7074,7 +7074,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7119,7 +7119,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7163,7 +7163,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7215,7 +7215,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7280,7 +7280,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7337,7 +7337,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7378,7 +7378,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7424,7 +7424,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7461,7 +7461,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7522,7 +7522,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7589,7 +7589,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7664,7 +7664,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7727,7 +7727,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7771,7 +7771,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7827,7 +7827,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7873,7 +7873,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7917,7 +7917,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7970,7 +7970,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8016,7 +8016,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8060,7 +8060,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8116,7 +8116,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8167,7 +8167,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8211,7 +8211,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8267,7 +8267,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8313,7 +8313,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8357,7 +8357,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8413,7 +8413,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8464,7 +8464,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8505,7 +8505,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8552,7 +8552,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8597,7 +8597,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8638,7 +8638,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8685,7 +8685,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8730,7 +8730,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8778,7 +8778,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8822,7 +8822,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8871,7 +8871,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8936,7 +8936,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -9005,7 +9005,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -9046,7 +9046,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -9092,7 +9092,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -9142,7 +9142,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -9214,7 +9214,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -9289,7 +9289,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -9436,7 +9436,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -9683,7 +9683,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -9727,7 +9727,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -9782,7 +9782,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -9828,7 +9828,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -9872,7 +9872,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -9924,7 +9924,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -9975,7 +9975,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -10019,7 +10019,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -10074,7 +10074,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -10125,7 +10125,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -10169,7 +10169,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -10224,7 +10224,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -10276,7 +10276,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -10353,7 +10353,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -10397,7 +10397,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -10518,7 +10518,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -10582,7 +10582,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -10662,7 +10662,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -10734,7 +10734,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -10801,7 +10801,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -10876,7 +10876,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -10958,7 +10958,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -11033,7 +11033,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -11097,7 +11097,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -11164,7 +11164,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -11241,7 +11241,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -11285,7 +11285,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -11337,7 +11337,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -11383,7 +11383,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -11427,7 +11427,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -11488,7 +11488,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -11546,7 +11546,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -11613,7 +11613,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -11671,7 +11671,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -11711,7 +11711,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -11865,7 +11865,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -11928,7 +11928,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -11998,7 +11998,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -12059,7 +12059,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -12108,7 +12108,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -12167,7 +12167,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -12218,7 +12218,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -12264,7 +12264,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -12329,7 +12329,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -12395,7 +12395,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -12439,7 +12439,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -12492,7 +12492,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -12594,7 +12594,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -12635,7 +12635,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -12684,7 +12684,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -12730,7 +12730,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -12780,7 +12780,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -12818,7 +12818,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -12863,7 +12863,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -12904,7 +12904,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -12950,7 +12950,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -12995,7 +12995,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -13039,7 +13039,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -13091,7 +13091,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -13156,7 +13156,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -13213,7 +13213,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -13254,7 +13254,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -13300,7 +13300,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -13337,7 +13337,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -13398,7 +13398,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -13468,7 +13468,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -13543,7 +13543,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -13606,7 +13606,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -13650,7 +13650,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -13706,7 +13706,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -13752,7 +13752,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -13796,7 +13796,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -13849,7 +13849,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -13895,7 +13895,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -13939,7 +13939,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -13995,7 +13995,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -14046,7 +14046,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -14090,7 +14090,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -14146,7 +14146,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -14192,7 +14192,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -14236,7 +14236,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -14292,7 +14292,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -14343,7 +14343,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -14384,7 +14384,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -14431,7 +14431,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -14476,7 +14476,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -14517,7 +14517,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -14564,7 +14564,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -14609,7 +14609,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -14657,7 +14657,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -14701,7 +14701,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -14750,7 +14750,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -14815,7 +14815,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -14884,7 +14884,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -14925,7 +14925,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -14971,7 +14971,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -15021,7 +15021,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -15093,7 +15093,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -15168,7 +15168,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -15315,7 +15315,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -15562,7 +15562,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -15606,7 +15606,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -15661,7 +15661,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -15707,7 +15707,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -15751,7 +15751,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -15803,7 +15803,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -15854,7 +15854,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -15898,7 +15898,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -15953,7 +15953,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -16004,7 +16004,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -16048,7 +16048,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -16103,7 +16103,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -16155,7 +16155,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -16235,7 +16235,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -16279,7 +16279,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -16400,7 +16400,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -16464,7 +16464,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -16544,7 +16544,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -16616,7 +16616,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -16683,7 +16683,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -16758,7 +16758,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -16840,7 +16840,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -16915,7 +16915,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -16979,7 +16979,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -17046,7 +17046,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -17123,7 +17123,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -17167,7 +17167,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -17219,7 +17219,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -17265,7 +17265,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -17309,7 +17309,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -17370,7 +17370,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -17428,7 +17428,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -17495,7 +17495,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -17553,7 +17553,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -17605,7 +17605,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false

--- a/site2/website/static/swagger/2.8.3/swagger.json
+++ b/site2/website/static/swagger/2.8.3/swagger.json
@@ -5989,7 +5989,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6052,7 +6052,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6122,7 +6122,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6183,7 +6183,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6232,7 +6232,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6291,7 +6291,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6342,7 +6342,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6388,7 +6388,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6453,7 +6453,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6519,7 +6519,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6563,7 +6563,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6616,7 +6616,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6718,7 +6718,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6759,7 +6759,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6808,7 +6808,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6854,7 +6854,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6904,7 +6904,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6942,7 +6942,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6987,7 +6987,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7028,7 +7028,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7074,7 +7074,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7119,7 +7119,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7163,7 +7163,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7215,7 +7215,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7280,7 +7280,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7337,7 +7337,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7378,7 +7378,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7424,7 +7424,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7461,7 +7461,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7522,7 +7522,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7589,7 +7589,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7664,7 +7664,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7727,7 +7727,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7771,7 +7771,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7827,7 +7827,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7873,7 +7873,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7917,7 +7917,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7970,7 +7970,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8016,7 +8016,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8060,7 +8060,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8116,7 +8116,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8167,7 +8167,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8211,7 +8211,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8267,7 +8267,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8313,7 +8313,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8357,7 +8357,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8413,7 +8413,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8464,7 +8464,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8505,7 +8505,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8552,7 +8552,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8597,7 +8597,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8638,7 +8638,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8685,7 +8685,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8730,7 +8730,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8778,7 +8778,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8822,7 +8822,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8871,7 +8871,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8936,7 +8936,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -9005,7 +9005,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -9046,7 +9046,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -9092,7 +9092,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -9142,7 +9142,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -9214,7 +9214,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -9289,7 +9289,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -9436,7 +9436,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -9683,7 +9683,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -9727,7 +9727,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -9782,7 +9782,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -9828,7 +9828,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -9872,7 +9872,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -9924,7 +9924,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -9975,7 +9975,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -10019,7 +10019,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -10074,7 +10074,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -10125,7 +10125,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -10169,7 +10169,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -10224,7 +10224,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -10276,7 +10276,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -10353,7 +10353,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -10397,7 +10397,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -10518,7 +10518,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -10582,7 +10582,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -10662,7 +10662,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -10734,7 +10734,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -10801,7 +10801,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -10876,7 +10876,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -10958,7 +10958,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -11033,7 +11033,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -11097,7 +11097,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -11164,7 +11164,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -11241,7 +11241,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -11285,7 +11285,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -11337,7 +11337,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -11383,7 +11383,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -11427,7 +11427,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -11488,7 +11488,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -11546,7 +11546,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -11613,7 +11613,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -11671,7 +11671,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -11711,7 +11711,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -11865,7 +11865,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -11928,7 +11928,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -11998,7 +11998,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -12059,7 +12059,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -12108,7 +12108,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -12167,7 +12167,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -12218,7 +12218,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -12264,7 +12264,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -12329,7 +12329,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -12395,7 +12395,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -12439,7 +12439,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -12492,7 +12492,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -12594,7 +12594,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -12635,7 +12635,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -12684,7 +12684,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -12730,7 +12730,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -12780,7 +12780,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -12818,7 +12818,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -12863,7 +12863,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -12904,7 +12904,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -12950,7 +12950,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -12995,7 +12995,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -13039,7 +13039,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -13091,7 +13091,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -13156,7 +13156,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -13213,7 +13213,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -13254,7 +13254,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -13300,7 +13300,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -13337,7 +13337,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -13398,7 +13398,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -13468,7 +13468,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -13543,7 +13543,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -13606,7 +13606,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -13650,7 +13650,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -13706,7 +13706,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -13752,7 +13752,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -13796,7 +13796,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -13849,7 +13849,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -13895,7 +13895,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -13939,7 +13939,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -13995,7 +13995,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -14046,7 +14046,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -14090,7 +14090,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -14146,7 +14146,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -14192,7 +14192,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -14236,7 +14236,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -14292,7 +14292,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -14343,7 +14343,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -14384,7 +14384,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -14431,7 +14431,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -14476,7 +14476,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -14517,7 +14517,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -14564,7 +14564,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -14609,7 +14609,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -14657,7 +14657,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -14701,7 +14701,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -14750,7 +14750,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -14815,7 +14815,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -14884,7 +14884,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -14925,7 +14925,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -14971,7 +14971,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -15021,7 +15021,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -15093,7 +15093,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -15168,7 +15168,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -15315,7 +15315,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -15562,7 +15562,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -15606,7 +15606,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -15661,7 +15661,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -15707,7 +15707,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -15751,7 +15751,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -15803,7 +15803,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -15854,7 +15854,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -15898,7 +15898,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -15953,7 +15953,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -16004,7 +16004,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -16048,7 +16048,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -16103,7 +16103,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -16155,7 +16155,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -16235,7 +16235,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -16279,7 +16279,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -16400,7 +16400,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -16464,7 +16464,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -16544,7 +16544,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -16616,7 +16616,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -16683,7 +16683,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -16758,7 +16758,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -16840,7 +16840,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -16915,7 +16915,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -16979,7 +16979,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -17046,7 +17046,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -17123,7 +17123,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -17167,7 +17167,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -17219,7 +17219,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -17265,7 +17265,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -17309,7 +17309,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -17370,7 +17370,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -17428,7 +17428,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -17495,7 +17495,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -17553,7 +17553,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -17605,7 +17605,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false

--- a/site2/website/static/swagger/2.9.0/swagger.json
+++ b/site2/website/static/swagger/2.9.0/swagger.json
@@ -5989,7 +5989,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6052,7 +6052,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6122,7 +6122,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6183,7 +6183,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6232,7 +6232,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6291,7 +6291,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6342,7 +6342,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6388,7 +6388,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6440,7 +6440,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6505,7 +6505,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6571,7 +6571,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6615,7 +6615,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6668,7 +6668,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6770,7 +6770,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6811,7 +6811,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6860,7 +6860,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6906,7 +6906,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6956,7 +6956,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6994,7 +6994,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7039,7 +7039,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7080,7 +7080,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7126,7 +7126,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7171,7 +7171,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7215,7 +7215,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7267,7 +7267,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7332,7 +7332,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7389,7 +7389,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7430,7 +7430,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7476,7 +7476,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7513,7 +7513,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7574,7 +7574,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7641,7 +7641,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7716,7 +7716,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7779,7 +7779,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7823,7 +7823,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7879,7 +7879,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7925,7 +7925,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7969,7 +7969,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8022,7 +8022,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8068,7 +8068,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8112,7 +8112,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8168,7 +8168,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8219,7 +8219,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8263,7 +8263,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8319,7 +8319,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8365,7 +8365,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8409,7 +8409,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8465,7 +8465,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8516,7 +8516,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8557,7 +8557,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8604,7 +8604,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8649,7 +8649,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8690,7 +8690,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8737,7 +8737,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8782,7 +8782,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8830,7 +8830,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8874,7 +8874,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8930,7 +8930,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8991,7 +8991,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -9056,7 +9056,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -9125,7 +9125,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -9166,7 +9166,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -9212,7 +9212,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -9262,7 +9262,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -9334,7 +9334,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -9409,7 +9409,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -9562,7 +9562,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -9809,7 +9809,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -9853,7 +9853,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -9908,7 +9908,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -9954,7 +9954,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -9998,7 +9998,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -10050,7 +10050,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -10101,7 +10101,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -10145,7 +10145,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -10200,7 +10200,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -10251,7 +10251,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -10295,7 +10295,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -10350,7 +10350,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -10402,7 +10402,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -10479,7 +10479,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -10523,7 +10523,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -10644,7 +10644,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -10708,7 +10708,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -10788,7 +10788,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -10860,7 +10860,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -10927,7 +10927,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -11002,7 +11002,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -11084,7 +11084,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -11159,7 +11159,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -11223,7 +11223,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -11290,7 +11290,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -11367,7 +11367,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -11411,7 +11411,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -11463,7 +11463,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -11509,7 +11509,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -11553,7 +11553,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -11614,7 +11614,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -11672,7 +11672,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -11742,7 +11742,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -11800,7 +11800,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -11840,7 +11840,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -11994,7 +11994,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -12057,7 +12057,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -12127,7 +12127,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -12188,7 +12188,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -12237,7 +12237,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -12296,7 +12296,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -12347,7 +12347,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -12393,7 +12393,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -12445,7 +12445,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -12510,7 +12510,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -12576,7 +12576,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -12620,7 +12620,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -12673,7 +12673,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -12775,7 +12775,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -12816,7 +12816,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -12865,7 +12865,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -12911,7 +12911,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -12961,7 +12961,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -12999,7 +12999,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -13044,7 +13044,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -13085,7 +13085,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -13131,7 +13131,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -13176,7 +13176,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -13220,7 +13220,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -13272,7 +13272,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -13337,7 +13337,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -13394,7 +13394,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -13435,7 +13435,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -13481,7 +13481,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -13518,7 +13518,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -13579,7 +13579,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -13649,7 +13649,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -13724,7 +13724,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -13787,7 +13787,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -13831,7 +13831,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -13887,7 +13887,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -13933,7 +13933,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -13977,7 +13977,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -14030,7 +14030,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -14076,7 +14076,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -14120,7 +14120,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -14176,7 +14176,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -14227,7 +14227,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -14271,7 +14271,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -14327,7 +14327,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -14373,7 +14373,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -14417,7 +14417,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -14473,7 +14473,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -14524,7 +14524,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -14565,7 +14565,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -14612,7 +14612,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -14657,7 +14657,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -14698,7 +14698,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -14745,7 +14745,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -14790,7 +14790,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -14838,7 +14838,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -14882,7 +14882,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -14938,7 +14938,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -14999,7 +14999,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -15064,7 +15064,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -15133,7 +15133,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -15174,7 +15174,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -15220,7 +15220,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -15270,7 +15270,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -15342,7 +15342,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -15417,7 +15417,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -15570,7 +15570,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -15817,7 +15817,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -15861,7 +15861,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -15916,7 +15916,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -15962,7 +15962,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -16006,7 +16006,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -16058,7 +16058,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -16109,7 +16109,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -16153,7 +16153,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -16208,7 +16208,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -16259,7 +16259,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -16303,7 +16303,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -16358,7 +16358,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -16410,7 +16410,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -16490,7 +16490,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -16534,7 +16534,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -16655,7 +16655,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -16719,7 +16719,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -16799,7 +16799,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -16871,7 +16871,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -16938,7 +16938,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -17013,7 +17013,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -17095,7 +17095,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -17170,7 +17170,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -17234,7 +17234,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -17301,7 +17301,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -17378,7 +17378,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -17422,7 +17422,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -17474,7 +17474,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -17520,7 +17520,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -17564,7 +17564,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -17625,7 +17625,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -17683,7 +17683,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -17753,7 +17753,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -17811,7 +17811,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -17863,7 +17863,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false

--- a/site2/website/static/swagger/2.9.1/swagger.json
+++ b/site2/website/static/swagger/2.9.1/swagger.json
@@ -5989,7 +5989,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6052,7 +6052,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6122,7 +6122,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6183,7 +6183,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6232,7 +6232,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6291,7 +6291,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6342,7 +6342,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6388,7 +6388,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6440,7 +6440,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6505,7 +6505,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6571,7 +6571,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6615,7 +6615,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6668,7 +6668,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6770,7 +6770,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6811,7 +6811,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6860,7 +6860,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6906,7 +6906,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6956,7 +6956,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6994,7 +6994,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7039,7 +7039,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7080,7 +7080,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7126,7 +7126,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7171,7 +7171,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7215,7 +7215,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7267,7 +7267,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7332,7 +7332,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7389,7 +7389,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7430,7 +7430,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7476,7 +7476,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7513,7 +7513,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7574,7 +7574,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7641,7 +7641,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7716,7 +7716,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7779,7 +7779,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7823,7 +7823,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7879,7 +7879,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7925,7 +7925,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7969,7 +7969,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8022,7 +8022,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8068,7 +8068,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8112,7 +8112,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8168,7 +8168,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8219,7 +8219,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8263,7 +8263,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8319,7 +8319,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8365,7 +8365,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8409,7 +8409,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8465,7 +8465,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8516,7 +8516,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8557,7 +8557,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8604,7 +8604,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8649,7 +8649,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8690,7 +8690,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8737,7 +8737,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8782,7 +8782,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8830,7 +8830,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8874,7 +8874,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8930,7 +8930,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8991,7 +8991,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -9056,7 +9056,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -9125,7 +9125,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -9166,7 +9166,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -9212,7 +9212,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -9262,7 +9262,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -9334,7 +9334,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -9409,7 +9409,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -9562,7 +9562,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -9809,7 +9809,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -9853,7 +9853,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -9908,7 +9908,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -9954,7 +9954,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -9998,7 +9998,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -10050,7 +10050,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -10101,7 +10101,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -10145,7 +10145,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -10200,7 +10200,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -10251,7 +10251,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -10295,7 +10295,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -10350,7 +10350,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -10402,7 +10402,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -10479,7 +10479,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -10523,7 +10523,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -10644,7 +10644,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -10708,7 +10708,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -10788,7 +10788,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -10860,7 +10860,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -10927,7 +10927,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -11002,7 +11002,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -11084,7 +11084,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -11159,7 +11159,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -11223,7 +11223,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -11290,7 +11290,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -11367,7 +11367,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -11411,7 +11411,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -11463,7 +11463,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -11509,7 +11509,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -11553,7 +11553,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -11614,7 +11614,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -11672,7 +11672,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -11742,7 +11742,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -11800,7 +11800,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -11840,7 +11840,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -11994,7 +11994,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -12057,7 +12057,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -12127,7 +12127,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -12188,7 +12188,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -12237,7 +12237,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -12296,7 +12296,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -12347,7 +12347,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -12393,7 +12393,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -12445,7 +12445,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -12510,7 +12510,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -12576,7 +12576,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -12620,7 +12620,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -12673,7 +12673,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -12775,7 +12775,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -12816,7 +12816,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -12865,7 +12865,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -12911,7 +12911,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -12961,7 +12961,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -12999,7 +12999,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -13044,7 +13044,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -13085,7 +13085,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -13131,7 +13131,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -13176,7 +13176,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -13220,7 +13220,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -13272,7 +13272,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -13337,7 +13337,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -13394,7 +13394,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -13435,7 +13435,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -13481,7 +13481,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -13518,7 +13518,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -13579,7 +13579,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -13649,7 +13649,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -13724,7 +13724,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -13787,7 +13787,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -13831,7 +13831,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -13887,7 +13887,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -13933,7 +13933,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -13977,7 +13977,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -14030,7 +14030,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -14076,7 +14076,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -14120,7 +14120,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -14176,7 +14176,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -14227,7 +14227,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -14271,7 +14271,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -14327,7 +14327,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -14373,7 +14373,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -14417,7 +14417,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -14473,7 +14473,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -14524,7 +14524,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -14565,7 +14565,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -14612,7 +14612,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -14657,7 +14657,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -14698,7 +14698,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -14745,7 +14745,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -14790,7 +14790,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -14838,7 +14838,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -14882,7 +14882,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -14938,7 +14938,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -14999,7 +14999,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -15064,7 +15064,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -15133,7 +15133,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -15174,7 +15174,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -15220,7 +15220,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -15270,7 +15270,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -15342,7 +15342,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -15417,7 +15417,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -15570,7 +15570,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -15817,7 +15817,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -15861,7 +15861,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -15916,7 +15916,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -15962,7 +15962,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -16006,7 +16006,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -16058,7 +16058,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -16109,7 +16109,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -16153,7 +16153,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -16208,7 +16208,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -16259,7 +16259,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -16303,7 +16303,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -16358,7 +16358,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -16410,7 +16410,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -16490,7 +16490,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -16534,7 +16534,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -16655,7 +16655,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -16719,7 +16719,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -16799,7 +16799,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -16871,7 +16871,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -16938,7 +16938,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -17013,7 +17013,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -17095,7 +17095,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -17170,7 +17170,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -17234,7 +17234,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -17301,7 +17301,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -17378,7 +17378,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -17422,7 +17422,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -17474,7 +17474,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -17520,7 +17520,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -17564,7 +17564,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -17625,7 +17625,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -17683,7 +17683,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -17753,7 +17753,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -17811,7 +17811,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -17863,7 +17863,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false

--- a/site2/website/static/swagger/2.9.2/swagger.json
+++ b/site2/website/static/swagger/2.9.2/swagger.json
@@ -6173,7 +6173,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6236,7 +6236,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6306,7 +6306,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6367,7 +6367,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6416,7 +6416,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6475,7 +6475,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6526,7 +6526,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6572,7 +6572,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6624,7 +6624,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6689,7 +6689,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6755,7 +6755,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6799,7 +6799,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6852,7 +6852,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6954,7 +6954,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -6995,7 +6995,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7044,7 +7044,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7090,7 +7090,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7140,7 +7140,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7178,7 +7178,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7223,7 +7223,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7264,7 +7264,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7310,7 +7310,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7355,7 +7355,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7399,7 +7399,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7451,7 +7451,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7516,7 +7516,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7573,7 +7573,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7614,7 +7614,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7660,7 +7660,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7697,7 +7697,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7758,7 +7758,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7825,7 +7825,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7900,7 +7900,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -7963,7 +7963,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8007,7 +8007,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8063,7 +8063,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8109,7 +8109,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8153,7 +8153,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8206,7 +8206,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8252,7 +8252,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8296,7 +8296,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8352,7 +8352,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8403,7 +8403,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8447,7 +8447,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8503,7 +8503,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8549,7 +8549,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8593,7 +8593,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8649,7 +8649,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8700,7 +8700,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8741,7 +8741,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8788,7 +8788,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8833,7 +8833,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8874,7 +8874,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8921,7 +8921,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -8966,7 +8966,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -9014,7 +9014,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -9058,7 +9058,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -9114,7 +9114,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -9175,7 +9175,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -9240,7 +9240,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -9309,7 +9309,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -9350,7 +9350,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -9396,7 +9396,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -9446,7 +9446,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -9518,7 +9518,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -9593,7 +9593,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -9746,7 +9746,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -9993,7 +9993,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -10037,7 +10037,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -10092,7 +10092,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -10138,7 +10138,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -10182,7 +10182,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -10234,7 +10234,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -10285,7 +10285,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -10329,7 +10329,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -10384,7 +10384,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -10435,7 +10435,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -10479,7 +10479,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -10534,7 +10534,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -10586,7 +10586,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -10663,7 +10663,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -10707,7 +10707,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -10828,7 +10828,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -10892,7 +10892,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -10972,7 +10972,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -11044,7 +11044,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -11111,7 +11111,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -11186,7 +11186,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -11268,7 +11268,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -11343,7 +11343,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -11407,7 +11407,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -11474,7 +11474,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -11551,7 +11551,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -11595,7 +11595,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -11647,7 +11647,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -11693,7 +11693,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -11737,7 +11737,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -11798,7 +11798,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -11856,7 +11856,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -11926,7 +11926,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -11984,7 +11984,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -12024,7 +12024,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -12178,7 +12178,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -12241,7 +12241,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -12311,7 +12311,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -12372,7 +12372,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -12421,7 +12421,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -12480,7 +12480,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -12531,7 +12531,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -12577,7 +12577,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -12629,7 +12629,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -12694,7 +12694,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -12760,7 +12760,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -12804,7 +12804,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -12857,7 +12857,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -12959,7 +12959,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -13000,7 +13000,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -13049,7 +13049,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -13095,7 +13095,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -13145,7 +13145,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -13183,7 +13183,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -13228,7 +13228,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -13269,7 +13269,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -13315,7 +13315,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -13360,7 +13360,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -13404,7 +13404,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -13456,7 +13456,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -13521,7 +13521,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -13578,7 +13578,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -13619,7 +13619,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -13665,7 +13665,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -13702,7 +13702,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -13763,7 +13763,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -13833,7 +13833,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -13908,7 +13908,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -13971,7 +13971,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -14015,7 +14015,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -14071,7 +14071,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -14117,7 +14117,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -14161,7 +14161,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -14214,7 +14214,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -14260,7 +14260,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -14304,7 +14304,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -14360,7 +14360,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -14411,7 +14411,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -14455,7 +14455,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -14511,7 +14511,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -14557,7 +14557,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -14601,7 +14601,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -14657,7 +14657,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -14708,7 +14708,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -14749,7 +14749,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -14796,7 +14796,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -14841,7 +14841,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -14882,7 +14882,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -14929,7 +14929,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -14974,7 +14974,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -15022,7 +15022,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -15066,7 +15066,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -15122,7 +15122,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -15183,7 +15183,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -15248,7 +15248,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -15317,7 +15317,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -15358,7 +15358,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -15404,7 +15404,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -15454,7 +15454,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -15526,7 +15526,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -15601,7 +15601,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -15754,7 +15754,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -16001,7 +16001,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -16045,7 +16045,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -16100,7 +16100,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -16146,7 +16146,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -16190,7 +16190,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -16242,7 +16242,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -16293,7 +16293,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -16337,7 +16337,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -16392,7 +16392,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -16443,7 +16443,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -16487,7 +16487,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -16542,7 +16542,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -16594,7 +16594,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -16674,7 +16674,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -16718,7 +16718,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -16839,7 +16839,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -16903,7 +16903,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -16983,7 +16983,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -17055,7 +17055,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -17122,7 +17122,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -17197,7 +17197,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -17279,7 +17279,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -17354,7 +17354,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -17418,7 +17418,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -17485,7 +17485,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -17562,7 +17562,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -17606,7 +17606,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -17658,7 +17658,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -17704,7 +17704,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -17748,7 +17748,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -17809,7 +17809,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -17867,7 +17867,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -17937,7 +17937,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -17995,7 +17995,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -18047,7 +18047,7 @@
         }, {
           "name" : "authoritative",
           "in" : "query",
-          "description" : "Is authentication required to perform this operation",
+          "description" : "Whether leader broker redirected this call to this broker. For internal use.",
           "required" : false,
           "type" : "boolean",
           "default" : false


### PR DESCRIPTION
### Motivation

Applies the changes from https://github.com/apache/pulsar/pull/16222 to the generated swagger for older versions. Since this is only updating a comment, I don't think this presents any issues for backwards compatibility. However, if something thinks it does, please let me know.

### Modifications

* Replace `Is authentication required to perform this operation` with `Whether leader broker redirected this call to this broker. For internal use.`
* Update several of the `isGlobal` blocks so that we remove the `authoritative` description and put the correct description in the `authoritative` block.

### Verifying this change

This is a trivial rework of the swagger docs.

### Does this pull request potentially affect one of the following parts:

This updates the already generated swagger. That could be an issue, but I don't think it will be.

### Documentation
  
- [x] `doc` 