### PR TITLE
[fix][broker] Improve error msg when client is unauthorized

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
@@ -467,7 +467,7 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
                                 return null;
                             });
                 } else {
-                    final String msg = "Proxy Client is not authorized to Lookup";
+                    final String msg = "Client is not authorized to Lookup";
                     log.warn("[{}] {} with role {} on topic {}", remoteAddress, msg, getPrincipal(), topicName);
                     ctx.writeAndFlush(newLookupErrorResponse(ServerError.AuthorizationError, msg, requestId));
                     lookupSemaphore.release();
@@ -540,7 +540,7 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
                                 return null;
                             });
                 } else {
-                    final String msg = "Proxy Client is not authorized to Get Partition Metadata";
+                    final String msg = "Client is not authorized to Get Partition Metadata";
                     log.warn("[{}] {} with role {} on topic {}", remoteAddress, msg, getPrincipal(), topicName);
                     ctx.writeAndFlush(
                             Commands.newPartitionMetadataResponse(ServerError.AuthorizationError, msg, requestId));
@@ -2029,7 +2029,7 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
                             return null;
                         });
                 } else {
-                    final String msg = "Proxy Client is not authorized to GetTopicsOfNamespace";
+                    final String msg = "Client is not authorized to GetTopicsOfNamespace";
                     log.warn("[{}] {} with role {} on namespace {}", remoteAddress, msg, getPrincipal(), namespaceName);
                     commandSender.sendErrorResponse(requestId, ServerError.AuthorizationError, msg);
                     lookupSemaphore.release();


### PR DESCRIPTION
### Motivation

When a client attempts to perform certain actions using the pulsar protocol but is unauthorized, it gets an error that references the proxy, even when the proxy is not in use. This PR improves the clarity of the error message returned to the client.

Sample error from a client that targeted the broker directly:


> Caused by: org.apache.pulsar.client.api.PulsarClientException$AuthorizationException: {"errorMsg":"Proxy Client is not authorized to Get Partition Metadata","reqId":2752438136626111826, "remote":"broker.pulsar.com/10.53.129.179:6650", "local":"/10.233.82.53:63618"}
    at org.apache.pulsar.client.api.PulsarClientException.unwrap(PulsarClientException.java:1026)
    at org.apache.pulsar.client.impl.ProducerBuilderImpl.create(ProducerBuilderImpl.java:88)

### Modifications

* Remove `Proxy` from error messages that are due to insufficient permissions and not due to Proxy misconfiguration.

### Verifying this change

This is a trivial change.

### Does this pull request potentially affect one of the following parts:

This is not a breaking change in any way other than changing the message returned to the client.

### Documentation

- [x] `doc-not-needed` 