### PR TITLE
[improve][java client] No need print exception stack when DLQ send failed.

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
@@ -2001,15 +2001,20 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
                                 acknowledgeAsync(finalMessageId).whenComplete((v, ex) -> {
                                     if (ex != null) {
                                         log.warn("[{}] [{}] [{}] Failed to acknowledge the message {} of the original"
-                                                        + " topic but send to the DLQ successfully {}.",
-                                                topicName, subscription, consumerName, finalMessageId, ex.getMessage());
+                                                        + " topic but send to the DLQ successfully.",
+                                                topicName, subscription, consumerName, finalMessageId, ex);
                                     } else {
                                         result.complete(true);
                                     }
                                 });
                             }).exceptionally(ex -> {
-                                log.warn("[{}] [{}] [{}] Failed to send DLQ message to {} for message id {} : {}.",
-                                        topicName, subscription, consumerName, finalMessageId, ex.getMessage());
+                                if (ex instanceof PulsarClientException.ProducerQueueIsFullError) {
+                                    log.warn("[{}] [{}] [{}] Failed to send DLQ message to {} for message id {}: {}",
+                                            topicName, subscription, consumerName, finalMessageId, ex.getMessage());
+                                } else {
+                                    log.warn("[{}] [{}] [{}] Failed to send DLQ message to {} for message id {}",
+                                            topicName, subscription, consumerName, finalMessageId, ex);
+                                }
                                 result.complete(false);
                                 return null;
                     });

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
@@ -2001,15 +2001,15 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
                                 acknowledgeAsync(finalMessageId).whenComplete((v, ex) -> {
                                     if (ex != null) {
                                         log.warn("[{}] [{}] [{}] Failed to acknowledge the message {} of the original"
-                                                        + " topic but send to the DLQ successfully.",
-                                                topicName, subscription, consumerName, finalMessageId, ex);
+                                                        + " topic but send to the DLQ successfully {}.",
+                                                topicName, subscription, consumerName, finalMessageId, ex.getMessage());
                                     } else {
                                         result.complete(true);
                                     }
                                 });
                             }).exceptionally(ex -> {
-                                log.warn("[{}] [{}] [{}] Failed to send DLQ message to {} for message id {}",
-                                        topicName, subscription, consumerName, finalMessageId, ex);
+                                log.warn("[{}] [{}] [{}] Failed to send DLQ message to {} for message id {} : {}.",
+                                        topicName, subscription, consumerName, finalMessageId, ex.getMessage());
                                 result.complete(false);
                                 return null;
                     });


### PR DESCRIPTION
### Motivation

`ProducerQueueIsFullError` exception is encountered when sending DLQ, no need to print an exception stack. Because sending DLQ fails, it will be re-delivered.

### Modifications

- Only print exception message instead of exception stack.

### Documentation
- [x] `doc-not-needed` 
(Please explain why)
