### PR TITLE
[fix][broker] Fix NPE when drop backlog for time limit.

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BacklogQuotaManager.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BacklogQuotaManager.java
@@ -215,7 +215,7 @@ public class BacklogQuotaManager {
                     Position oldestPosition = slowestConsumer.getMarkDeletedPosition();
                     ManagedLedgerInfo.LedgerInfo ledgerInfo = mLedger.getLedgerInfo(oldestPosition.getLedgerId()).get();
                     // Timestamp only > 0 if ledger has been closed
-                    if (ledgerInfo.getTimestamp() > 0
+                    if (ledgerInfo != null && ledgerInfo.getTimestamp() > 0
                             && currentMillis - ledgerInfo.getTimestamp() > quota.getLimitTime()) {
                         // skip whole ledger for the slowest cursor
                         PositionImpl nextPosition = mLedger.getNextValidPosition(

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BacklogQuotaManager.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BacklogQuotaManager.java
@@ -215,9 +215,7 @@ public class BacklogQuotaManager {
                     Position oldestPosition = slowestConsumer.getMarkDeletedPosition();
                     ManagedLedgerInfo.LedgerInfo ledgerInfo = mLedger.getLedgerInfo(oldestPosition.getLedgerId()).get();
                     if (ledgerInfo == null) {
-                        PositionImpl nextPosition = mLedger.getNextValidPosition(
-                                PositionImpl.get(ledgerInfo.getLedgerId() + 1, 0));
-                        slowestConsumer.resetCursor(nextPosition);
+                        slowestConsumer.resetCursor(mLedger.getNextValidPosition((PositionImpl) oldestPosition));
                         continue;
                     }
                     // Timestamp only > 0 if ledger has been closed

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BacklogQuotaManager.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BacklogQuotaManager.java
@@ -214,8 +214,13 @@ public class BacklogQuotaManager {
                     ManagedCursor slowestConsumer = mLedger.getSlowestConsumer();
                     Position oldestPosition = slowestConsumer.getMarkDeletedPosition();
                     ManagedLedgerInfo.LedgerInfo ledgerInfo = mLedger.getLedgerInfo(oldestPosition.getLedgerId()).get();
+                    if (ledgerInfo == null) {
+                        PositionImpl nextPosition = mLedger.getNextValidPosition(PositionImpl.get(ledgerInfo.getLedgerId() + 1, 0));
+                        slowestConsumer.resetCursor(nextPosition);
+                        continue;
+                    }
                     // Timestamp only > 0 if ledger has been closed
-                    if (ledgerInfo != null && ledgerInfo.getTimestamp() > 0
+                    if (ledgerInfo.getTimestamp() > 0
                             && currentMillis - ledgerInfo.getTimestamp() > quota.getLimitTime()) {
                         // skip whole ledger for the slowest cursor
                         PositionImpl nextPosition = mLedger.getNextValidPosition(

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BacklogQuotaManager.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BacklogQuotaManager.java
@@ -215,7 +215,8 @@ public class BacklogQuotaManager {
                     Position oldestPosition = slowestConsumer.getMarkDeletedPosition();
                     ManagedLedgerInfo.LedgerInfo ledgerInfo = mLedger.getLedgerInfo(oldestPosition.getLedgerId()).get();
                     if (ledgerInfo == null) {
-                        PositionImpl nextPosition = mLedger.getNextValidPosition(PositionImpl.get(ledgerInfo.getLedgerId() + 1, 0));
+                        PositionImpl nextPosition = mLedger.getNextValidPosition(
+                                PositionImpl.get(ledgerInfo.getLedgerId() + 1, 0));
                         slowestConsumer.resetCursor(nextPosition);
                         continue;
                     }


### PR DESCRIPTION
### Motivation

When broker do `monitorBacklogQuota`, there may throw NPE.
```
2022-06-24T18:14:38,360-0400 [pulsar-backlog-quota-checker-29-1] ERROR org.apache.pulsar.broker.service.BacklogQuotaManager - [persistent://enmv/epnmccs-yang/ECLIPSE-epnmccs-yang-ms-east-partition-1] Error resetting cursor for slowest consumer [ENMV_CCS_SUBSCRIPTION]
java.lang.NullPointerException: null
 at org.apache.pulsar.broker.service.BacklogQuotaManager.dropBacklogForTimeLimit(BacklogQuotaManager.java:247) 
 at org.apache.pulsar.broker.service.BacklogQuotaManager.handleExceededBacklogQuota(BacklogQuotaManager.java:127) 
 at org.apache.pulsar.broker.service.BrokerService.lambda$monitorBacklogQuota$78(BrokerService.java:1721) 
 at java.util.Optional.ifPresent(Optional.java:183) ~[?:?]
 at org.apache.pulsar.broker.service.BrokerService.lambda$forEachTopic$77(BrokerService.java:1705) 
 at org.apache.pulsar.common.util.collections.ConcurrentOpenHashMap$Section.forEach(ConcurrentOpenHashMap.java:544)
 at org.apache.pulsar.common.util.collections.ConcurrentOpenHashMap.forEach(ConcurrentOpenHashMap.java:272) 
 at org.apache.pulsar.broker.service.BrokerService.forEachTopic(BrokerService.java:1703) 
 at org.apache.pulsar.broker.service.BrokerService.monitorBacklogQuota(BrokerService.java:1714) 
 
```

Below is the related code : 
https://github.com/apache/pulsar/blob/a3f52891593e093c27b583094a1fbfd09bbbae1a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BacklogQuotaManager.java#L241-L257

The root cause is that the slowest consumer ledgerId may be trimmed, so we need to check `ledgerInfo`.

### Documentation

- [x] `doc-not-needed` 
(Please explain why)
  