### PR TITLE
[fix][broker]Fix getInternalStats occasional lack of LeaderInfo again

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -1971,40 +1971,43 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
         stats.state = ml.getState().toString();
 
         stats.ledgers = Lists.newArrayList();
-        List<CompletableFuture<String>> futures = Lists.newArrayList();
+        Set<CompletableFuture<String>> futures = Sets.newConcurrentHashSet();
         CompletableFuture<Set<String>> availableBookiesFuture =
                 brokerService.pulsar().getPulsarResources().getBookieResources().listAvailableBookiesAsync();
-        futures.add(availableBookiesFuture.handle((strings, throwable) -> null));
-        availableBookiesFuture.whenComplete((bookies, e) -> {
-            if (e != null) {
-                log.error("[{}] Failed to fetch available bookies.", topic, e);
-                statFuture.completeExceptionally(e);
-            } else {
-                ml.getLedgersInfo().forEach((id, li) -> {
-                    LedgerInfo info = new LedgerInfo();
-                    info.ledgerId = li.getLedgerId();
-                    info.entries = li.getEntries();
-                    info.size = li.getSize();
-                    info.offloaded = li.hasOffloadContext() && li.getOffloadContext().getComplete();
-                    stats.ledgers.add(info);
-                    if (includeLedgerMetadata) {
-                        futures.add(ml.getLedgerMetadata(li.getLedgerId()).handle((lMetadata, ex) -> {
-                            if (ex == null) {
-                                info.metadata = lMetadata;
+        futures.add(
+            availableBookiesFuture
+                .whenComplete((bookies, e) -> {
+                    if (e != null) {
+                        log.error("[{}] Failed to fetch available bookies.", topic, e);
+                        statFuture.completeExceptionally(e);
+                    } else {
+                        ml.getLedgersInfo().forEach((id, li) -> {
+                            LedgerInfo info = new LedgerInfo();
+                            info.ledgerId = li.getLedgerId();
+                            info.entries = li.getEntries();
+                            info.size = li.getSize();
+                            info.offloaded = li.hasOffloadContext() && li.getOffloadContext().getComplete();
+                            stats.ledgers.add(info);
+                            if (includeLedgerMetadata) {
+                                futures.add(ml.getLedgerMetadata(li.getLedgerId()).handle((lMetadata, ex) -> {
+                                    if (ex == null) {
+                                        info.metadata = lMetadata;
+                                    }
+                                    return null;
+                                }));
+                                futures.add(ml.getEnsemblesAsync(li.getLedgerId()).handle((ensembles, ex) -> {
+                                    if (ex == null) {
+                                        info.underReplicated =
+                                            !bookies.containsAll(ensembles.stream().map(BookieId::toString)
+                                                .collect(Collectors.toList()));
+                                    }
+                                    return null;
+                                }));
                             }
-                            return null;
-                        }));
-                        futures.add(ml.getEnsemblesAsync(li.getLedgerId()).handle((ensembles, ex) -> {
-                            if (ex == null) {
-                                info.underReplicated = !bookies.containsAll(ensembles.stream().map(BookieId::toString)
-                                        .collect(Collectors.toList()));
-                            }
-                            return null;
-                        }));
+                        });
                     }
-                });
-            }
-        });
+                })
+                .handle((strings, throwable) -> null));
 
         // Add ledger info for compacted topic ledger if exist.
         LedgerInfo info = new LedgerInfo();
@@ -2120,16 +2123,11 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
         } else {
             schemaStoreLedgersFuture.complete(null);
         }
-        schemaStoreLedgersFuture.thenRun(() -> {
-            if (futures != null) {
-                FutureUtil.waitForAll(futures).handle((res, ex) -> {
-                    statFuture.complete(stats);
-                    return null;
-                });
-            } else {
+        schemaStoreLedgersFuture.thenRun(() ->
+            FutureUtil.waitForAll(futures).handle((res, ex) -> {
                 statFuture.complete(stats);
-            }
-        }).exceptionally(e -> {
+                return null;
+            })).exceptionally(e -> {
             statFuture.completeExceptionally(e);
             return null;
         });

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -1971,7 +1971,7 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
         stats.state = ml.getState().toString();
 
         stats.ledgers = Lists.newArrayList();
-        Set<CompletableFuture<String>> futures = Sets.newConcurrentHashSet();
+        Set<CompletableFuture<?>> futures = Sets.newConcurrentHashSet();
         CompletableFuture<Set<String>> availableBookiesFuture =
                 brokerService.pulsar().getPulsarResources().getBookieResources().listAvailableBookiesAsync();
         futures.add(
@@ -2007,7 +2007,7 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
                         });
                     }
                 })
-                .handle((strings, throwable) -> null));
+        );
 
         // Add ledger info for compacted topic ledger if exist.
         LedgerInfo info = new LedgerInfo();


### PR DESCRIPTION
### Motivation
* AdminApiTest is flaky. The testGetPartitionedStatsInternal test method fails sporadically.  This PR https://github.com/apache/pulsar/pull/13656 has tried to fix the bug, but I find the test `AdminApiTest#testGetPartitionedStatsInternal` can also be failure.
 * The root cause is the `availableBookiesFuture#handle` can run before `availableBookiesFuture#whenComplete`. Because there is no guarantee that `CompleteFuture`  will run `handle` and `whenComplete` and so on in order. For example,
```
    public static void main(String[] args) {
        CompletableFuture<String> future = new CompletableFuture<>();
        CompletableFuture<String> appFuture = future.thenApply(s -> s);

        appFuture.handle((res, throwable) -> {
            System.out.println("handle");
            return null;
        });
        appFuture.whenComplete((res, ex) -> {
            System.out.println("complete");
        });
        future.complete("hello");
    }
```
the result will be 
```
handle
complete
```
But if we remove `thenApply` like this:
```
 public static void main(String[] args) {
        CompletableFuture<String> future = new CompletableFuture<>();
        CompletableFuture<String> appFuture = future; // remove thenApply

        appFuture.handle((res, throwable) -> {
            System.out.println("handle");
            return null;
        });
        appFuture.whenComplete((res, ex) -> {
            System.out.println("complete");
        });
        future.complete("hello");
    }
```
the result will be
```
complete
handle
```

### Modifications

* Moving `handle`  after `whenComplete`
* Also remove  checking `futures != null` because futures can not be null
* Modify `futures` as `ConcurrentHashSet` because `futures` will run in multi-thread

### Verifying this change

- [x] Make sure that the change passes the CI checks.


### Documentation

  
- [x] `doc-not-needed` 
