### PR TITLE
[fix] [broker] [fix] [broker] Consumer status is inconsistent because operations addConsumer and disconnect of PersistentSubscription compete with each other

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentTopicTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentTopicTest.java
@@ -795,7 +795,7 @@ public class PersistentTopicTest extends MockedBookKeeperTestCase {
     public void testAddRemoveConsumer() throws Exception {
         PersistentTopic topic = new PersistentTopic(successTopicName, ledgerMock, brokerService);
         PersistentSubscription sub = new PersistentSubscription(topic, "sub-1", cursorMock, false);
-
+        topic.getSubscriptions().put("sub-1", sub);
         // 1. simple add consumer
         Consumer consumer = new Consumer(sub, SubType.Exclusive, topic.getName(), 1 /* consumer id */, 0, "Cons1"/* consumer name */,
                 true, serverCnx, "myrole-1", Collections.emptyMap(), false /* read compacted */, null, MessageId.latest, DEFAULT_CONSUMER_EPOCH);


### PR DESCRIPTION
### Motivation
E.g. `consumer.subscribe` and `topic.unload` executed at the same time:

| Time | `consumer.subscribe` | `topic.unload` |
| ----------- | ----------- | ----------- |
| 1 | consumer.subscribe |  |
| 2 | create persistent topic |  |
| 3 | create persistent subscription |  |
| 4 |      | topic.unload |
| 5 |      | topic.close |
| 6 | persistent-subscription.addConsumer | persistent-subscription.disconnect |
| 7 | add consumer finish | Because dispathcer is empty, no consumers are closed  |
| 8 | response client: success |  |
| 9 | consumer.receiveMessage |  |

After step 9: 
- consumer considers the subscription successful
- broker considers topic unload success

But the consumer will not receive any message.

### Modifications

Make two operations `addConsumer` and `disconnect` executed sequentially.

### Documentation

Check the box below or label this PR directly.

Need to update docs? 

- [ ] `doc-required` 
(Your PR needs to update docs, and you will update later)
  
- [x] `doc-not-needed` 
(Please explain why)
  
- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)