### PR TITLE
[client][python] getLastMessageIdAsync C binding

### DIFF
--- a/pulsar-client-cpp/README.md
+++ b/pulsar-client-cpp/README.md
@@ -280,7 +280,7 @@ ${PULSAR_PATH}/pulsar-test-service-stop.sh
 
 ## Requirements for Contributors
 
-It's recommended to install [LLVM](https://llvm.org/builds/) for `clang-tidy` and `clang-format`. Pulsar C++ client use `clang-format` 6.0+ to format files. 
+It's required to install [LLVM](https://llvm.org/builds/) for `clang-tidy` and `clang-format`. Pulsar C++ client use `clang-format` 6.0+ to format files.  `make format` will automatically format the files.
 
 Use `pulsar-client-cpp/docker-format.sh` to ensure the C++ sources are correctly formatted.
 

--- a/pulsar-client-cpp/README.md
+++ b/pulsar-client-cpp/README.md
@@ -280,7 +280,7 @@ ${PULSAR_PATH}/pulsar-test-service-stop.sh
 
 ## Requirements for Contributors
 
-It's required to install [LLVM](https://llvm.org/builds/) for `clang-tidy` and `clang-format`. Pulsar C++ client use `clang-format` 6.0+ to format files.  `make format` will automatically format the files.
+It's required to install [LLVM](https://llvm.org/builds/) for `clang-tidy` and `clang-format`. Pulsar C++ client use `clang-format` 6.0+ to format files.  `make format` automatically formats the files.
 
 Use `pulsar-client-cpp/docker-format.sh` to ensure the C++ sources are correctly formatted.
 

--- a/pulsar-client-cpp/include/pulsar/c/consumer.h
+++ b/pulsar-client-cpp/include/pulsar/c/consumer.h
@@ -236,7 +236,8 @@ PULSAR_PUBLIC pulsar_result pulsar_consumer_seek(pulsar_consumer_t *consumer, pu
 
 PULSAR_PUBLIC int pulsar_consumer_is_connected(pulsar_consumer_t *consumer);
 
-PULSAR_PUBLIC pulsar_result pulsar_consumer_get_last_message_id(pulsar_consumer_t *consumer, pulsar_message_id_t *messageId);
+PULSAR_PUBLIC pulsar_result pulsar_consumer_get_last_message_id(pulsar_consumer_t *consumer,
+                                                                pulsar_message_id_t *messageId);
 
 #ifdef __cplusplus
 }

--- a/pulsar-client-cpp/include/pulsar/c/consumer.h
+++ b/pulsar-client-cpp/include/pulsar/c/consumer.h
@@ -236,6 +236,8 @@ PULSAR_PUBLIC pulsar_result pulsar_consumer_seek(pulsar_consumer_t *consumer, pu
 
 PULSAR_PUBLIC int pulsar_consumer_is_connected(pulsar_consumer_t *consumer);
 
+PULSAR_PUBLIC pulsar_result pulsar_consumer_get_last_message_id(pulsar_consumer_t *consumer, pulsar_message_id_t *messageId);
+
 #ifdef __cplusplus
 }
 #endif

--- a/pulsar-client-cpp/lib/c/c_Consumer.cc
+++ b/pulsar-client-cpp/lib/c/c_Consumer.cc
@@ -143,3 +143,7 @@ pulsar_result pulsar_consumer_seek(pulsar_consumer_t *consumer, pulsar_message_i
 }
 
 int pulsar_consumer_is_connected(pulsar_consumer_t *consumer) { return consumer->consumer.isConnected(); }
+
+pulsar_result pulsar_consumer_get_last_message_id(pulsar_consumer_t *consumer, pulsar_message_id_t *messageId) {
+    return (pulsar_result)consumer->consumer.getLastMessageId(messageId->messageId);
+}

--- a/pulsar-client-cpp/lib/c/c_Consumer.cc
+++ b/pulsar-client-cpp/lib/c/c_Consumer.cc
@@ -144,6 +144,7 @@ pulsar_result pulsar_consumer_seek(pulsar_consumer_t *consumer, pulsar_message_i
 
 int pulsar_consumer_is_connected(pulsar_consumer_t *consumer) { return consumer->consumer.isConnected(); }
 
-pulsar_result pulsar_consumer_get_last_message_id(pulsar_consumer_t *consumer, pulsar_message_id_t *messageId) {
+pulsar_result pulsar_consumer_get_last_message_id(pulsar_consumer_t *consumer,
+                                                  pulsar_message_id_t *messageId) {
     return (pulsar_result)consumer->consumer.getLastMessageId(messageId->messageId);
 }

--- a/pulsar-client-cpp/lib/checksum/crc32c_arm.h
+++ b/pulsar-client-cpp/lib/checksum/crc32c_arm.h
@@ -37,11 +37,11 @@
 #define crc32c_u16(crc, v) __crc32ch(crc, v)
 #define crc32c_u32(crc, v) __crc32cw(crc, v)
 #define crc32c_u64(crc, v) __crc32cd(crc, v)
-#define PREF4X64L1(buffer, PREF_OFFSET, ITR)                                                              \
-    __asm__("PRFM PLDL1KEEP, [%x[v],%[c]]" ::[v] "r"(buffer), [c] "I"((PREF_OFFSET) + ((ITR) + 0) * 64)); \
-    __asm__("PRFM PLDL1KEEP, [%x[v],%[c]]" ::[v] "r"(buffer), [c] "I"((PREF_OFFSET) + ((ITR) + 1) * 64)); \
-    __asm__("PRFM PLDL1KEEP, [%x[v],%[c]]" ::[v] "r"(buffer), [c] "I"((PREF_OFFSET) + ((ITR) + 2) * 64)); \
-    __asm__("PRFM PLDL1KEEP, [%x[v],%[c]]" ::[v] "r"(buffer), [c] "I"((PREF_OFFSET) + ((ITR) + 3) * 64));
+#define PREF4X64L1(buffer, PREF_OFFSET, ITR)                                                                \
+    __asm__("PRFM PLDL1KEEP, [%x[v],%[c]]" ::[v] "r"(buffer), [ c ] "I"((PREF_OFFSET) + ((ITR) + 0) * 64)); \
+    __asm__("PRFM PLDL1KEEP, [%x[v],%[c]]" ::[v] "r"(buffer), [ c ] "I"((PREF_OFFSET) + ((ITR) + 1) * 64)); \
+    __asm__("PRFM PLDL1KEEP, [%x[v],%[c]]" ::[v] "r"(buffer), [ c ] "I"((PREF_OFFSET) + ((ITR) + 2) * 64)); \
+    __asm__("PRFM PLDL1KEEP, [%x[v],%[c]]" ::[v] "r"(buffer), [ c ] "I"((PREF_OFFSET) + ((ITR) + 3) * 64));
 
 #define PREF1KL1(buffer, PREF_OFFSET)    \
     PREF4X64L1(buffer, (PREF_OFFSET), 0) \

--- a/pulsar-client-cpp/lib/checksum/crc32c_arm.h
+++ b/pulsar-client-cpp/lib/checksum/crc32c_arm.h
@@ -37,11 +37,11 @@
 #define crc32c_u16(crc, v) __crc32ch(crc, v)
 #define crc32c_u32(crc, v) __crc32cw(crc, v)
 #define crc32c_u64(crc, v) __crc32cd(crc, v)
-#define PREF4X64L1(buffer, PREF_OFFSET, ITR)                                                                \
-    __asm__("PRFM PLDL1KEEP, [%x[v],%[c]]" ::[v] "r"(buffer), [ c ] "I"((PREF_OFFSET) + ((ITR) + 0) * 64)); \
-    __asm__("PRFM PLDL1KEEP, [%x[v],%[c]]" ::[v] "r"(buffer), [ c ] "I"((PREF_OFFSET) + ((ITR) + 1) * 64)); \
-    __asm__("PRFM PLDL1KEEP, [%x[v],%[c]]" ::[v] "r"(buffer), [ c ] "I"((PREF_OFFSET) + ((ITR) + 2) * 64)); \
-    __asm__("PRFM PLDL1KEEP, [%x[v],%[c]]" ::[v] "r"(buffer), [ c ] "I"((PREF_OFFSET) + ((ITR) + 3) * 64));
+#define PREF4X64L1(buffer, PREF_OFFSET, ITR)                                                              \
+    __asm__("PRFM PLDL1KEEP, [%x[v],%[c]]" ::[v] "r"(buffer), [c] "I"((PREF_OFFSET) + ((ITR) + 0) * 64)); \
+    __asm__("PRFM PLDL1KEEP, [%x[v],%[c]]" ::[v] "r"(buffer), [c] "I"((PREF_OFFSET) + ((ITR) + 1) * 64)); \
+    __asm__("PRFM PLDL1KEEP, [%x[v],%[c]]" ::[v] "r"(buffer), [c] "I"((PREF_OFFSET) + ((ITR) + 2) * 64)); \
+    __asm__("PRFM PLDL1KEEP, [%x[v],%[c]]" ::[v] "r"(buffer), [c] "I"((PREF_OFFSET) + ((ITR) + 3) * 64));
 
 #define PREF1KL1(buffer, PREF_OFFSET)    \
     PREF4X64L1(buffer, (PREF_OFFSET), 0) \

--- a/pulsar-client-cpp/python/pulsar/__init__.py
+++ b/pulsar-client-cpp/python/pulsar/__init__.py
@@ -1253,7 +1253,12 @@ class Consumer:
         Check if the consumer is connected or not.
         """
         return self._consumer.is_connected()
-
+    
+    def get_last_message_id(self):
+        """
+        Get the last message id.
+        """
+        return self._consumer.get_last_message_id()
 
 
 class Reader:

--- a/pulsar-client-cpp/python/pulsar_test.py
+++ b/pulsar-client-cpp/python/pulsar_test.py
@@ -753,6 +753,18 @@ class PulsarTest(TestCase):
         self._check_value_error(lambda: client.create_reader(topic, MessageId.earliest, reader_name=5))
         client.close()
 
+    def test_get_last_message_id(self):
+        client = Client(self.serviceUrl)
+        consumer = client.subscribe(
+            "persistent://public/default/topic_name_test", "topic_name_test_sub", consumer_type=ConsumerType.Shared
+        )
+        producer = client.create_producer("persistent://public/default/topic_name_test")
+        msg_id = producer.send(b"hello")
+
+        msg = consumer.receive(TM)
+        self.assertEqual(msg.message_id(), msg_id)
+        client.close()
+
     def test_publish_compact_and_consume(self):
         client = Client(self.serviceUrl)
         topic = "compaction_%s" % (uuid.uuid4())

--- a/pulsar-client-cpp/python/pulsar_test.py
+++ b/pulsar-client-cpp/python/pulsar_test.py
@@ -762,6 +762,7 @@ class PulsarTest(TestCase):
         msg_id = producer.send(b"hello")
 
         msg = consumer.receive(TM)
+        msg_id = consumer.get_last_message_id()
         self.assertEqual(msg.message_id(), msg_id)
         client.close()
 

--- a/pulsar-client-cpp/python/pulsar_test.py
+++ b/pulsar-client-cpp/python/pulsar_test.py
@@ -762,7 +762,6 @@ class PulsarTest(TestCase):
         msg_id = producer.send(b"hello")
 
         msg = consumer.receive(TM)
-        msg_id = consumer.get_last_message_id()
         self.assertEqual(msg.message_id(), msg_id)
         client.close()
 

--- a/pulsar-client-cpp/python/src/consumer.cc
+++ b/pulsar-client-cpp/python/src/consumer.cc
@@ -83,6 +83,16 @@ void Consumer_seek_timestamp(Consumer& consumer, uint64_t timestamp) {
 
 bool Consumer_is_connected(Consumer& consumer) { return consumer.isConnected(); }
 
+MessageId Consumer_get_last_message_id(Consumer& consumer) {
+    MessageId msgId;
+    Result res;
+    Py_BEGIN_ALLOW_THREADS res = consumer.getLastMessageId(msgId);
+    Py_END_ALLOW_THREADS
+
+        CHECK_RESULT(res);
+    return msgId;
+}
+
 void export_consumer() {
     using namespace boost::python;
 
@@ -105,5 +115,6 @@ void export_consumer() {
         .def("redeliver_unacknowledged_messages", &Consumer::redeliverUnacknowledgedMessages)
         .def("seek", &Consumer_seek)
         .def("seek", &Consumer_seek_timestamp)
-        .def("is_connected", &Consumer_is_connected);
+        .def("is_connected", &Consumer_is_connected)
+        .def("get_last_message_id", &Consumer_get_last_message_id);
 }


### PR DESCRIPTION
### Motivation

Python function getLastMessageId

It is a C binding for https://github.com/apache/pulsar/pull/16182 to implement get_last_message_id() in Python client.

### Modifications

Add Python/C binding code for get_last_message_id()

### Verifying this change

It compiles.
- [x] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.


### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (yes)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

Check the box below or label this PR directly.

Need to update docs? 

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)
  
- [ ] `doc-not-needed` 

  
- [x] `doc` 
Python Doc is updated in __init__.py

- [ ] `doc-complete`
(Docs have been already added)