### PR TITLE
[fix][client] Add initialization for the OpSendMsg

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
@@ -1337,15 +1337,15 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
         SendCallback callback;
         Runnable rePopulate;
         ChunkedMessageCtx chunkedMessageCtx;
-        long uncompressedSize;
-        long sequenceId;
-        long createdAt;
-        long firstSentAt;
-        long lastSentAt;
-        int retryCount;
+        long uncompressedSize = 0;
+        long sequenceId = -1L;
+        long createdAt = -1L;
+        long firstSentAt = -1L;
+        long lastSentAt = -1L;
+        int retryCount = 0;
         long batchSizeByte = 0;
         int numMessagesInBatch = 1;
-        long highestSequenceId;
+        long highestSequenceId = -1L;
         int totalChunks = 0;
         int chunkId = -1;
 

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
@@ -1337,20 +1337,41 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
         SendCallback callback;
         Runnable rePopulate;
         ChunkedMessageCtx chunkedMessageCtx;
-        long uncompressedSize = 0;
-        long sequenceId = -1L;
-        long createdAt = -1L;
-        long firstSentAt = -1L;
-        long lastSentAt = -1L;
-        int retryCount = 0;
+        long uncompressedSize;
+        long sequenceId;
+        long createdAt;
+        long firstSentAt;
+        long lastSentAt;
+        int retryCount;
         long batchSizeByte = 0;
         int numMessagesInBatch = 1;
-        long highestSequenceId = -1L;
+        long highestSequenceId;
         int totalChunks = 0;
         int chunkId = -1;
 
+        void initialize() {
+            msg = null;
+            msgs = null;
+            cmd = null;
+            callback = null;
+            rePopulate = null;
+            sequenceId = -1L;
+            createdAt = -1L;
+            firstSentAt = -1L;
+            lastSentAt = -1L;
+            highestSequenceId = -1L;
+            totalChunks = 0;
+            chunkId = -1;
+            uncompressedSize = 0;
+            retryCount = 0;
+            batchSizeByte = 0;
+            numMessagesInBatch = 1;
+            chunkedMessageCtx = null;
+        }
+
         static OpSendMsg create(MessageImpl<?> msg, ByteBufPair cmd, long sequenceId, SendCallback callback) {
             OpSendMsg op = RECYCLER.get();
+            op.initialize();
             op.msg = msg;
             op.cmd = cmd;
             op.callback = callback;
@@ -1362,6 +1383,7 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
 
         static OpSendMsg create(List<MessageImpl<?>> msgs, ByteBufPair cmd, long sequenceId, SendCallback callback) {
             OpSendMsg op = RECYCLER.get();
+            op.initialize();
             op.msgs = msgs;
             op.cmd = cmd;
             op.callback = callback;
@@ -1377,6 +1399,7 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
         static OpSendMsg create(List<MessageImpl<?>> msgs, ByteBufPair cmd, long lowestSequenceId,
                                 long highestSequenceId,  SendCallback callback) {
             OpSendMsg op = RECYCLER.get();
+            op.initialize();
             op.msgs = msgs;
             op.cmd = cmd;
             op.callback = callback;
@@ -1429,24 +1452,8 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
         }
 
         void recycle() {
-            msg = null;
-            msgs = null;
-            cmd = null;
-            callback = null;
-            rePopulate = null;
-            sequenceId = -1L;
-            createdAt = -1L;
-            firstSentAt = -1L;
-            lastSentAt = -1L;
-            highestSequenceId = -1L;
-            totalChunks = 0;
-            chunkId = -1;
-            uncompressedSize = 0;
-            retryCount = 0;
-            batchSizeByte = 0;
-            numMessagesInBatch = 1;
             ReferenceCountUtil.safeRelease(chunkedMessageCtx);
-            chunkedMessageCtx = null;
+            initialize();
             recyclerHandle.recycle(this);
         }
 


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://docs.google.com/document/d/1d8Pw6ZbWk-_pCKdOmdvx9rnhPiyuxwq60_TrD68d7BA/edit#heading=h.trs9rsex3xom)*. 

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.

**(The sections below can be removed for hotfixes of typos)**
-->


### Motivation

Some parameters in OpSendMsg are not specified with initialized values. 

These initial values are all relied upon by other codes. Such as here:
https://github.com/apache/pulsar/blob/eec46ddcba4d2b4f956e1b4d63154cc43087f507/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java#L1409-L1422

### Modifications

* Add the initialization for the OpSendMsg.

### Documentation

Check the box below or label this PR directly.

Need to update docs? 

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)
  
- [x] `doc-not-needed` 
(Please explain why)
  
- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)