### PR TITLE
[improve][standalone]Remove check if default namespace exists

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/zookeeper/LocalBookkeeperEnsemble.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/zookeeper/LocalBookkeeperEnsemble.java
@@ -369,21 +369,16 @@ public class LocalBookkeeperEnsemble {
                  .build())
             .buildAdmin()) {
 
+            LOG.info("Creating default namespace");
             try {
-                NamespaceProperties ns = FutureUtils.result(admin.getNamespace("default"));
-                LOG.info("'default' namespace for table service : {}", ns);
-            } catch (NamespaceNotFoundException nnfe) {
-                LOG.info("Creating default namespace");
-                try {
-                    NamespaceProperties ns =
+                NamespaceProperties ns =
                         FutureUtils.result(admin.createNamespace("default", NamespaceConfiguration.newBuilder()
-                            .setDefaultStreamConf(DEFAULT_STREAM_CONF)
-                            .build()));
-                    LOG.info("Successfully created 'default' namespace :\n{}", ns);
-                } catch (NamespaceExistsException nee) {
-                    // namespace already exists
-                    LOG.warn("Namespace 'default' already existed.");
-                }
+                                .setDefaultStreamConf(DEFAULT_STREAM_CONF)
+                                .build()));
+                LOG.info("Successfully created 'default' namespace :\n{}", ns);
+            } catch (NamespaceExistsException nee) {
+                // namespace already exists
+                LOG.warn("Namespace 'default' already existed.");
             }
         }
     }


### PR DESCRIPTION
### Motivation
When startup of standalone, the below error would be throw
```
2022-06-27T21:29:38,779+0800 [client-scheduler-OrderedScheduler-0-0] ERROR org.apache.bookkeeper.clients.impl.internal.RootRangeClientImplWithRetries - Reason for the failure {}
io.grpc.StatusRuntimeException: NOT_FOUND
at io.grpc.Status.asRuntimeException(Status.java:535) ~[io.grpc-grpc-api-1.42.1.jar:1.42.1]
at io.grpc.stub.ClientCalls$UnaryStreamToFuture.onClose(ClientCalls.java:534) ~[io.grpc-grpc-stub-1.42.1.jar:1.42.1]
at io.grpc.internal.DelayedClientCall$DelayedListener$3.run(DelayedClientCall.java:463) ~[io.grpc-grpc-core-1.42.1.jar:1.42.1]
at io.grpc.internal.DelayedClientCall$DelayedListener.delayOrExecute(DelayedClientCall.java:427) ~[io.grpc-grpc-core-1.42.1.jar:1.42.1]
at io.grpc.internal.DelayedClientCall$DelayedListener.onClose(DelayedClientCall.java:460) ~[io.grpc-grpc-core-1.42.1.jar:1.42.1]
at io.grpc.internal.ClientCallImpl.closeObserver(ClientCallImpl.java:562) ~[io.grpc-grpc-core-1.42.1.jar:1.42.1]
at io.grpc.internal.ClientCallImpl.access$300(ClientCallImpl.java:70) ~[io.grpc-grpc-core-1.42.1.jar:1.42.1]
at io.grpc.internal.ClientCallImpl$ClientStreamListenerImpl$1StreamClosed.runInternal(ClientCallImpl.java:743) ~[io.grpc-grpc-core-1.42.1.jar:1.42.1]
at io.grpc.internal.ClientCallImpl$ClientStreamListenerImpl$1StreamClosed.runInContext(ClientCallImpl.java:722) ~[io.grpc-grpc-core-1.42.1.jar:1.42.1]
at io.grpc.internal.ContextRunnable.run(ContextRunnable.java:37) ~[io.grpc-grpc-core-1.42.1.jar:1.42.1]
at io.grpc.internal.SerializingExecutor.run(SerializingExecutor.java:133) ~[io.grpc-grpc-core-1.42.1.jar:1.42.1]
at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149) ~[?:1.8.0_312]
at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624) ~[?:1.8.0_312]
at java.lang.Thread.run(Thread.java:748) [?:1.8.0_312]
```
Mistakenly thought the startup failed。

### Modifications

Remove  `admin.getNamespace("default")` before creating namepsace.

Instead, throw `NamespaceExistsException ` if namespace exists.



### Documentation

Check the box below or label this PR directly.

Need to update docs? 

- [x] `doc-not-needed` 
