### PR TITLE
[cleanup][dependency] Remove use of JUnit

### DIFF
--- a/pulsar-functions/instance/src/test/java/org/apache/pulsar/functions/instance/SinkRecordTest.java
+++ b/pulsar-functions/instance/src/test/java/org/apache/pulsar/functions/instance/SinkRecordTest.java
@@ -18,9 +18,11 @@
  */
 package org.apache.pulsar.functions.instance;
 
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
 import org.apache.pulsar.functions.api.Record;
 import org.apache.pulsar.functions.source.PulsarRecord;
-import org.junit.Assert;
 import org.mockito.Mockito;
 import org.testng.annotations.Test;
 
@@ -38,10 +40,10 @@ public class SinkRecordTest {
         sinkRecord = new SinkRecord(Mockito.mock(Record.class), new Object());
         try {
             sinkRecord.individualAck();
-            Assert.fail("Should throw runtime exception");
+            fail("Should throw runtime exception");
         } catch (Exception e) {
-            Assert.assertTrue(e instanceof RuntimeException);
-            Assert.assertEquals(e.getMessage(), "SourceRecord class type must be PulsarRecord");
+            assertTrue(e instanceof RuntimeException);
+            assertEquals(e.getMessage(), "SourceRecord class type must be PulsarRecord");
         }
     }
 }

--- a/pulsar-io/file/src/test/java/org/apache/pulsar/io/file/FileSourceConfigTests.java
+++ b/pulsar-io/file/src/test/java/org/apache/pulsar/io/file/FileSourceConfigTests.java
@@ -18,15 +18,13 @@
  */
 package org.apache.pulsar.io.file;
 
-import static org.junit.Assert.assertFalse;
+import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
-
 import java.io.File;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
-
 import org.testng.annotations.Test;
 
 public class FileSourceConfigTests {

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/presto/TestPulsarSQLAuth.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/presto/TestPulsarSQLAuth.java
@@ -18,6 +18,9 @@
  */
 package org.apache.pulsar.tests.integration.presto;
 
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
 import io.jsonwebtoken.SignatureAlgorithm;
 import java.time.Duration;
 import java.util.EnumSet;
@@ -37,7 +40,6 @@ import org.apache.pulsar.tests.integration.docker.ContainerExecException;
 import org.apache.pulsar.tests.integration.docker.ContainerExecResult;
 import org.apache.pulsar.tests.integration.topologies.PulsarClusterSpec;
 import org.awaitility.Awaitility;
-import org.junit.Assert;
 import org.testng.annotations.Test;
 
 @Slf4j
@@ -119,9 +121,9 @@ public class TestPulsarSQLAuth extends TestPulsarSQLBase {
                                             "org.apache.pulsar.client.impl.auth.AuthenticationToken");
                                     put("auth-params", passToken);
                                 }});
-                        Assert.assertEquals(0, containerExecResult.getExitCode());
+                        assertEquals(containerExecResult.getExitCode(), 0);
                     } catch (ContainerExecException e) {
-                        Assert.fail(String.format("assertSQLExecution fail: %s", e.getLocalizedMessage()));
+                        fail(String.format("assertSQLExecution fail: %s", e.getLocalizedMessage()));
                     }
                 }
         );
@@ -134,12 +136,12 @@ public class TestPulsarSQLAuth extends TestPulsarSQLBase {
                                     "org.apache.pulsar.client.impl.auth.AuthenticationToken");
                             put("auth-params", "invalid-token");
                         }});
-                        Assert.fail("Should not pass");
+                        fail("Should not pass");
                     } catch (ContainerExecException e) {
                         // Authorization error
-                        Assert.assertEquals(1, e.getResult().getExitCode());
+                        assertEquals(e.getResult().getExitCode(), 1);
                         log.info(e.getResult().getStderr());
-                        Assert.assertTrue(e.getResult().getStderr().contains("Unable to authenticate"));
+                        assertTrue(e.getResult().getStderr().contains("Unable to authenticate"));
                     }
                 }
         );
@@ -152,12 +154,12 @@ public class TestPulsarSQLAuth extends TestPulsarSQLBase {
                                     "org.apache.pulsar.client.impl.auth.AuthenticationToken");
                             put("auth-params", deniedToken);
                         }});
-                        Assert.fail("Should not pass");
+                        fail("Should not pass");
                     } catch (ContainerExecException e) {
                         // Authorization error
-                        Assert.assertEquals(1, e.getResult().getExitCode());
+                        assertEquals(e.getResult().getExitCode(), 1);
                         log.info(e.getResult().getStderr());
-                        Assert.assertTrue(e.getResult().getStderr().contains("not authorized"));
+                        assertTrue(e.getResult().getStderr().contains("not authorized"));
                     }
                 }
         );
@@ -188,10 +190,10 @@ public class TestPulsarSQLAuth extends TestPulsarSQLBase {
                                     "org.apache.pulsar.client.impl.auth.AuthenticationToken");
                             put("auth-params", testToken);
                         }});
-                        Assert.fail("Should not pass");
+                        fail("Should not pass");
                     } catch (ContainerExecException e) {
                         // Authorization error
-                        Assert.assertEquals(1, e.getResult().getExitCode());
+                        assertEquals(e.getResult().getExitCode(), 1);
                         log.info(e.getResult().getStderr());
                     }
                 }
@@ -209,9 +211,9 @@ public class TestPulsarSQLAuth extends TestPulsarSQLBase {
                                     put("auth-params", testToken);
                                 }});
 
-                        Assert.assertEquals(0, containerExecResult.getExitCode());
+                        assertEquals(containerExecResult.getExitCode(), 0);
                     } catch (ContainerExecException e) {
-                        Assert.fail(String.format("assertSQLExecution fail: %s", e.getLocalizedMessage()));
+                        fail(String.format("assertSQLExecution fail: %s", e.getLocalizedMessage()));
                     }
                 }
         );


### PR DESCRIPTION
Signed-off-by: Zixuan Liu <nodeces@gmail.com>

### Motivation

Using TestNG instead of Junit.

### Documentation

- [x] `doc-not-needed` 