### PR TITLE
Fix wrong table format in client-libraries-go.md

### DIFF
--- a/site2/docs/client-libraries-go.md
+++ b/site2/docs/client-libraries-go.md
@@ -144,7 +144,7 @@ func main() {
 
 The following configurable parameters are available for Pulsar clients:
 
- Name | Description | Default
+| Name | Description | Default|
 | :-------- | :---------- |:---------- |
 | URL | Configure the service URL for the Pulsar service.<br /><br />If you have multiple brokers, you can set multiple Pulsar cluster addresses for a client. <br /><br />This parameter is **required**. |None |
 | ConnectionTimeout | Timeout for the establishment of a TCP connection | 30s |


### PR DESCRIPTION
### Motivation
 The official markdown table is a misplaced layout .
fix go docs markdown table layout.

![](https://images.xuthus.cc/images/SyAFCMF_fix-markdown-table.png )


### Modifications

fix go docs markdown table layout.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

Check the box below or label this PR directly.

Need to update docs? 

- [x] `doc-required` 
(Your PR needs to update docs and you will update later)
  
- [ ] `doc-not-needed` 
(Please explain why)
  
- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)