### PR TITLE
[feature][broker]Provide new load balance placement strategy implementation based on the least resource usage with weight

### DIFF
--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -1180,6 +1180,13 @@ loadBalancerLoadPlacementStrategy=org.apache.pulsar.broker.loadbalance.impl.Leas
 # It only takes effect in the ThresholdShedder strategy.
 loadBalancerBrokerThresholdShedderPercentage=10
 
+# The broker average resource usage difference threshold.
+# Average resource usage difference threshold to determine a broker whether to be a best candidate in LeastResourceUsageWithWeight.
+# (eg: broker1 with 10% resource usage with weight and broker2 with 30% and broker3 with 80% will have 40% average resource usage.
+# The placement strategy can select broker1 and broker2 as best candidates.)
+# It only takes effect in the LeastResourceUsageWithWeight strategy.
+loadBalancerAverageResourceUsageDifferenceThresholdShedderPercentage=10
+
 # Message-rate percentage threshold between highest and least loaded brokers for
 # uniform load shedding. (eg: broker1 with 50K msgRate and broker2 with 30K msgRate
 # will have 66% msgRate difference and load balancer can unload bundles from broker-1

--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -1185,7 +1185,7 @@ loadBalancerBrokerThresholdShedderPercentage=10
 # (eg: broker1 with 10% resource usage with weight and broker2 with 30% and broker3 with 80% will have 40% average resource usage.
 # The placement strategy can select broker1 and broker2 as best candidates.)
 # It only takes effect in the LeastResourceUsageWithWeight strategy.
-loadBalancerAverageResourceUsageDifferenceThresholdShedderPercentage=10
+loadBalancerAverageResourceUsageDifferenceThresholdPercentage=10
 
 # Message-rate percentage threshold between highest and least loaded brokers for
 # uniform load shedding. (eg: broker1 with 50K msgRate and broker2 with 30K msgRate

--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -1171,6 +1171,9 @@ defaultNamespaceBundleSplitAlgorithm=range_equally_divide
 # load shedding strategy, support OverloadShedder and ThresholdShedder, default is ThresholdShedder since 2.10.0
 loadBalancerLoadSheddingStrategy=org.apache.pulsar.broker.loadbalance.impl.ThresholdShedder
 
+# load balance placement strategy, support LeastLongTermMessageRate and LeastResourceUsageWithWeight
+loadBalancerLoadPlacementStrategy=org.apache.pulsar.broker.loadbalance.impl.LeastLongTermMessageRate
+
 # The broker resource usage threshold.
 # When the broker resource usage is greater than the pulsar cluster average resource usage,
 # the threshold shedder will be triggered to offload bundles from the broker.

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -2053,6 +2053,16 @@ public class ServiceConfiguration implements PulsarConfiguration {
     private int loadBalancerBrokerThresholdShedderPercentage = 10;
 
     @FieldContext(
+            dynamic = true,
+            category = CATEGORY_LOAD_BALANCER,
+            doc = "Average resource usage difference threshold to determine a broker whether to be a best candidate in "
+                    + "LeastResourceUsageWithWeight.(eg: broker1 with 10% resource usage with weight "
+                    + "and broker2 with 30% and broker3 with 80% will have 40% average resource usage. "
+                    + "The placement strategy can select broker1 and broker2 as best candidates.)"
+    )
+    private int loadBalancerAverageResourceUsageDifferenceThresholdShedderPercentage = 10;
+
+    @FieldContext(
         dynamic = true,
         category = CATEGORY_LOAD_BALANCER,
         doc = "Message-rate percentage threshold between highest and least loaded brokers for "

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -2060,7 +2060,7 @@ public class ServiceConfiguration implements PulsarConfiguration {
                     + "and broker2 with 30% and broker3 with 80% will have 40% average resource usage. "
                     + "The placement strategy can select broker1 and broker2 as best candidates.)"
     )
-    private int loadBalancerAverageResourceUsageDifferenceThresholdShedderPercentage = 10;
+    private int loadBalancerAverageResourceUsageDifferenceThresholdPercentage = 10;
 
     @FieldContext(
         dynamic = true,

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -1972,6 +1972,13 @@ public class ServiceConfiguration implements PulsarConfiguration {
     private String loadBalancerLoadSheddingStrategy = "org.apache.pulsar.broker.loadbalance.impl.ThresholdShedder";
 
     @FieldContext(
+            category = CATEGORY_LOAD_BALANCER,
+            doc = "load balance placement strategy"
+    )
+    private String loadBalancerLoadPlacementStrategy =
+            "org.apache.pulsar.broker.loadbalance.impl.LeastLongTermMessageRate";
+
+    @FieldContext(
         dynamic = true,
         category = CATEGORY_LOAD_BALANCER,
         doc = "Percentage of change to trigger load report update"

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/ModularLoadManagerStrategy.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/ModularLoadManagerStrategy.java
@@ -49,12 +49,18 @@ public interface ModularLoadManagerStrategy {
     /**
      * Create a placement strategy using the configuration.
      *
+     * @param conf ServiceConfiguration to use.
      * @return A placement strategy from the given configurations.
      */
-    static ModularLoadManagerStrategy create() {
+    static ModularLoadManagerStrategy create(final ServiceConfiguration conf) {
         try {
-            // Only one strategy at the moment.
-            return new LeastLongTermMessageRate();
+            Class<?> loadAssignmentClass = Class.forName(conf.getLoadBalancerLoadPlacementStrategy());
+            Object loadAssignmentInstance = loadAssignmentClass.getDeclaredConstructor().newInstance();
+            if (loadAssignmentInstance instanceof ModularLoadManagerStrategy) {
+                return (ModularLoadManagerStrategy) loadAssignmentInstance;
+            } else {
+                return new LeastLongTermMessageRate();
+            }
         } catch (Exception e) {
             // Ignore
         }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/ModularLoadManagerStrategy.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/ModularLoadManagerStrategy.java
@@ -22,6 +22,7 @@ import java.util.Optional;
 import java.util.Set;
 import org.apache.pulsar.broker.ServiceConfiguration;
 import org.apache.pulsar.broker.loadbalance.impl.LeastLongTermMessageRate;
+import org.apache.pulsar.common.util.Reflections;
 import org.apache.pulsar.policies.data.loadbalancer.BundleData;
 
 /**
@@ -54,13 +55,8 @@ public interface ModularLoadManagerStrategy {
      */
     static ModularLoadManagerStrategy create(final ServiceConfiguration conf) {
         try {
-            Class<?> loadAssignmentClass = Class.forName(conf.getLoadBalancerLoadPlacementStrategy());
-            Object loadAssignmentInstance = loadAssignmentClass.getDeclaredConstructor().newInstance();
-            if (loadAssignmentInstance instanceof ModularLoadManagerStrategy) {
-                return (ModularLoadManagerStrategy) loadAssignmentInstance;
-            } else {
-                return new LeastLongTermMessageRate();
-            }
+            return Reflections.createInstance(conf.getLoadBalancerLoadPlacementStrategy(),
+                    ModularLoadManagerStrategy.class, Thread.currentThread().getContextClassLoader());
         } catch (Exception e) {
             // Ignore
         }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/ModularLoadManagerStrategy.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/ModularLoadManagerStrategy.java
@@ -21,7 +21,6 @@ package org.apache.pulsar.broker.loadbalance;
 import java.util.Optional;
 import java.util.Set;
 import org.apache.pulsar.broker.ServiceConfiguration;
-import org.apache.pulsar.broker.loadbalance.impl.LeastLongTermMessageRate;
 import org.apache.pulsar.common.util.Reflections;
 import org.apache.pulsar.policies.data.loadbalancer.BundleData;
 
@@ -58,8 +57,9 @@ public interface ModularLoadManagerStrategy {
             return Reflections.createInstance(conf.getLoadBalancerLoadPlacementStrategy(),
                     ModularLoadManagerStrategy.class, Thread.currentThread().getContextClassLoader());
         } catch (Exception e) {
-            // Ignore
+            throw new RuntimeException(
+                    "Could not load LoadBalancerLoadPlacementStrategy:" + conf.getLoadBalancerLoadPlacementStrategy(),
+                    e);
         }
-        return new LeastLongTermMessageRate();
     }
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/LeastResourceUsageWithWeight.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/LeastResourceUsageWithWeight.java
@@ -137,7 +137,7 @@ public class LeastResourceUsageWithWeight implements ModularLoadManagerStrategy 
 
         final double avgUsage = totalUsage / candidates.size();
         final double diffThreshold =
-                conf.getLoadBalancerAverageResourceUsageDifferenceThresholdShedderPercentage() / 100.0;
+                conf.getLoadBalancerAverageResourceUsageDifferenceThresholdPercentage() / 100.0;
         brokerAvgResourceUsageWithWeight.forEach((broker, avgResUsage) -> {
             if (avgResUsage + diffThreshold <= avgUsage) {
                 bestBrokers.add(broker);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/LeastResourceUsageWithWeight.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/LeastResourceUsageWithWeight.java
@@ -1,0 +1,159 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.loadbalance.impl;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.ThreadLocalRandom;
+import org.apache.pulsar.broker.ServiceConfiguration;
+import org.apache.pulsar.broker.loadbalance.LoadData;
+import org.apache.pulsar.broker.loadbalance.ModularLoadManagerStrategy;
+import org.apache.pulsar.policies.data.loadbalancer.BrokerData;
+import org.apache.pulsar.policies.data.loadbalancer.BundleData;
+import org.apache.pulsar.policies.data.loadbalancer.LocalBrokerData;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Placement strategy which selects a broker based on which one has the least resource usage with weight.
+ * This strategy takes into account the historical load percentage and short-term load percentage, and thus will not
+ * cause cluster fluctuations due to short-term load jitter.
+ */
+public class LeastResourceUsageWithWeight implements ModularLoadManagerStrategy {
+    private static Logger log = LoggerFactory.getLogger(LeastResourceUsageWithWeight.class);
+
+    // Maintain this list to reduce object creation.
+    private final ArrayList<String> bestBrokers;
+    private final Map<String, Double> brokerAvgResourceUsageWithWeight;
+
+    public LeastResourceUsageWithWeight() {
+        this.bestBrokers = new ArrayList<>();
+        this.brokerAvgResourceUsageWithWeight = new HashMap<>();
+    }
+
+    // Form a score for a broker using its historical load and short-term load data with weight.
+    // Any broker at (or above) the overload threshold will have a score of POSITIVE_INFINITY.
+    private double getScore(final String broker, final BrokerData brokerData, final ServiceConfiguration conf) {
+        final double overloadThresholdPercentage = conf.getLoadBalancerBrokerOverloadedThresholdPercentage();
+        final double maxUsageWithWeightPercentage =
+                updateAndGetMaxResourceUsageWithWeight(broker, brokerData, conf) * 100;
+
+        if (maxUsageWithWeightPercentage > overloadThresholdPercentage) {
+            log.warn("Broker {} is overloaded: max resource usage with weight percentage: {}%",
+                    brokerData.getLocalData().getWebServiceUrl(), maxUsageWithWeightPercentage);
+            return Double.POSITIVE_INFINITY;
+        }
+
+        if (log.isDebugEnabled()) {
+            log.debug("Broker {} has max resource usage with weight percentage: {}%",
+                    brokerData.getLocalData().getWebServiceUrl(), maxUsageWithWeightPercentage);
+        }
+        return maxUsageWithWeightPercentage;
+    }
+
+    /**
+     * Update and get the max resource usage with weight of broker according to the service configuration.
+     *
+     * @param broker     the broker name.
+     * @param brokerData The broker load data.
+     * @param conf       The service configuration.
+     * @return the max resource usage with weight of broker
+     */
+    private double updateAndGetMaxResourceUsageWithWeight(String broker, BrokerData brokerData,
+                                                          ServiceConfiguration conf) {
+        final double historyPercentage = conf.getLoadBalancerHistoryResourcePercentage();
+        Double historyUsage = brokerAvgResourceUsageWithWeight.get(broker);
+        double resourceUsage = brokerData.getLocalData().getMaxResourceUsageWithWeight(
+                conf.getLoadBalancerCPUResourceWeight(),
+                conf.getLoadBalancerMemoryResourceWeight(),
+                conf.getLoadBalancerDirectMemoryResourceWeight(),
+                conf.getLoadBalancerBandwithInResourceWeight(),
+                conf.getLoadBalancerBandwithOutResourceWeight());
+        historyUsage = historyUsage == null
+                ? resourceUsage : historyUsage * historyPercentage + (1 - historyPercentage) * resourceUsage;
+        if (log.isDebugEnabled()) {
+            log.debug(
+                    "Broker {} get max resource usage with weight: {}, history resource percentage: {}%, CPU weight: "
+                            + "{}, MEMORY weight: {}, DIRECT MEMORY weight: {}, BANDWIDTH IN weight: {}, BANDWIDTH "
+                            + "OUT weight: {} ",
+                    broker, historyUsage, historyPercentage, conf.getLoadBalancerCPUResourceWeight(),
+                    conf.getLoadBalancerMemoryResourceWeight(), conf.getLoadBalancerDirectMemoryResourceWeight(),
+                    conf.getLoadBalancerBandwithInResourceWeight(),
+                    conf.getLoadBalancerBandwithOutResourceWeight());
+        }
+        brokerAvgResourceUsageWithWeight.put(broker, historyUsage);
+        return historyUsage;
+    }
+
+    /**
+     * Find a suitable broker to assign the given bundle to.
+     *
+     * @param candidates     The candidates for which the bundle may be assigned.
+     * @param bundleToAssign The data for the bundle to assign.
+     * @param loadData       The load data from the leader broker.
+     * @param conf           The service configuration.
+     * @return The name of the selected broker as it appears on ZooKeeper.
+     */
+    @Override
+    public Optional<String> selectBroker(Set<String> candidates, BundleData bundleToAssign, LoadData loadData,
+                                         ServiceConfiguration conf) {
+        bestBrokers.clear();
+        double minScore = Double.POSITIVE_INFINITY;
+        // Maintain of list of all the best scoring brokers and then randomly
+        // select one of them at the end.
+
+        for (String broker : candidates) {
+            final BrokerData brokerData = loadData.getBrokerData().get(broker);
+            final double score = getScore(broker, brokerData, conf);
+            if (score == Double.POSITIVE_INFINITY) {
+                final LocalBrokerData localData = brokerData.getLocalData();
+                log.warn(
+                        "Broker {} is overloaded: CPU: {}%, MEMORY: {}%, DIRECT MEMORY: {}%, BANDWIDTH IN: {}%, "
+                                + "BANDWIDTH OUT: {}%, CPU weight: {}, MEMORY weight: {}, DIRECT MEMORY weight: {}, "
+                                + "BANDWIDTH IN weight: {}, BANDWIDTH OUT weight: {}",
+                        broker, localData.getCpu().percentUsage(), localData.getMemory().percentUsage(),
+                        localData.getDirectMemory().percentUsage(), localData.getBandwidthIn().percentUsage(),
+                        localData.getBandwidthOut().percentUsage(), conf.getLoadBalancerCPUResourceWeight(),
+                        conf.getLoadBalancerMemoryResourceWeight(), conf.getLoadBalancerDirectMemoryResourceWeight(),
+                        conf.getLoadBalancerBandwithInResourceWeight(),
+                        conf.getLoadBalancerBandwithOutResourceWeight());
+            }
+            if (score < minScore) {
+                bestBrokers.clear();
+                bestBrokers.add(broker);
+                minScore = score;
+            } else if (score == minScore) {
+                bestBrokers.add(broker);
+            }
+        }
+        if (bestBrokers.isEmpty()) {
+            // Assign randomly if all brokers are overloaded.
+            bestBrokers.addAll(candidates);
+        }
+
+        if (bestBrokers.isEmpty()) {
+            // If still, it means there are no available brokers at this point.
+            return Optional.empty();
+        }
+        return Optional.of(bestBrokers.get(ThreadLocalRandom.current().nextInt(bestBrokers.size())));
+    }
+}

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/LeastResourceUsageWithWeight.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/LeastResourceUsageWithWeight.java
@@ -106,6 +106,7 @@ public class LeastResourceUsageWithWeight implements ModularLoadManagerStrategy 
 
     /**
      * Find a suitable broker to assign the given bundle to.
+     * This method is not thread safety.
      *
      * @param candidates     The candidates for which the bundle may be assigned.
      * @param bundleToAssign The data for the bundle to assign.
@@ -147,12 +148,19 @@ public class LeastResourceUsageWithWeight implements ModularLoadManagerStrategy 
         }
         if (bestBrokers.isEmpty()) {
             // Assign randomly if all brokers are overloaded.
+            log.warn("Assign randomly if all {} brokers are overloaded.", candidates.size());
             bestBrokers.addAll(candidates);
         }
 
         if (bestBrokers.isEmpty()) {
             // If still, it means there are no available brokers at this point.
+            log.error("There are no available brokers as candidates at this point for bundle: {}", bundleToAssign);
             return Optional.empty();
+        }
+
+        if (log.isDebugEnabled()) {
+            log.debug("Selected {} best brokers: {} from candidate brokers: {}", bestBrokers.size(), bestBrokers,
+                    candidates);
         }
         return Optional.of(bestBrokers.get(ThreadLocalRandom.current().nextInt(bestBrokers.size())));
     }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/LeastResourceUsageWithWeight.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/LeastResourceUsageWithWeight.java
@@ -24,23 +24,21 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ThreadLocalRandom;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.broker.ServiceConfiguration;
 import org.apache.pulsar.broker.loadbalance.LoadData;
 import org.apache.pulsar.broker.loadbalance.ModularLoadManagerStrategy;
 import org.apache.pulsar.policies.data.loadbalancer.BrokerData;
 import org.apache.pulsar.policies.data.loadbalancer.BundleData;
 import org.apache.pulsar.policies.data.loadbalancer.LocalBrokerData;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Placement strategy which selects a broker based on which one has the least resource usage with weight.
  * This strategy takes into account the historical load percentage and short-term load percentage, and thus will not
  * cause cluster fluctuations due to short-term load jitter.
  */
+@Slf4j
 public class LeastResourceUsageWithWeight implements ModularLoadManagerStrategy {
-    private static Logger log = LoggerFactory.getLogger(LeastResourceUsageWithWeight.class);
-
     // Maintain this list to reduce object creation.
     private final ArrayList<String> bestBrokers;
     private final Map<String, Double> brokerAvgResourceUsageWithWeight;
@@ -147,8 +145,8 @@ public class LeastResourceUsageWithWeight implements ModularLoadManagerStrategy 
         });
 
         if (bestBrokers.isEmpty()) {
-            // Assign randomly if all brokers are overloaded.
-            log.warn("Assign randomly if all {} brokers are overloaded.", candidates.size());
+            // Assign randomly as all brokers are overloaded.
+            log.warn("Assign randomly as all {} brokers are overloaded.", candidates.size());
             bestBrokers.addAll(candidates);
         }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/ModularLoadManagerImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/ModularLoadManagerImpl.java
@@ -265,7 +265,7 @@ public class ModularLoadManagerImpl implements ModularLoadManager {
         defaultStats.msgRateIn = DEFAULT_MESSAGE_RATE;
         defaultStats.msgRateOut = DEFAULT_MESSAGE_RATE;
 
-        placementStrategy = ModularLoadManagerStrategy.create();
+        placementStrategy = ModularLoadManagerStrategy.create(conf);
         policies = new SimpleResourceAllocationPolicies(pulsar);
         filterPipeline.add(new BrokerVersionFilter());
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/ModularLoadManagerStrategyTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/ModularLoadManagerStrategyTest.java
@@ -79,6 +79,7 @@ public class ModularLoadManagerStrategyTest {
         conf.setLoadBalancerBandwithInResourceWeight(1.0);
         conf.setLoadBalancerBandwithOutResourceWeight(1.0);
         conf.setLoadBalancerHistoryResourcePercentage(0.5);
+        conf.setLoadBalancerAverageResourceUsageDifferenceThresholdShedderPercentage(5);
 
         ModularLoadManagerStrategy strategy = new LeastResourceUsageWithWeight();
         assertEquals(strategy.selectBroker(brokerDataMap.keySet(), bundleData, loadData, conf), Optional.of("1"));
@@ -107,17 +108,9 @@ public class ModularLoadManagerStrategyTest {
         brokerDataMap.put("3", brokerData3);
         assertEquals(strategy.selectBroker(brokerDataMap.keySet(), bundleData, loadData, conf), Optional.of("1"));
 
-        brokerData1 = initBrokerData(32,100);
-        brokerData2 = initBrokerData(30,100);
-        brokerData3 = initBrokerData(38,100);
-        brokerDataMap.put("1", brokerData1);
-        brokerDataMap.put("2", brokerData2);
-        brokerDataMap.put("3", brokerData3);
-        assertEquals(strategy.selectBroker(brokerDataMap.keySet(), bundleData, loadData, conf), Optional.of("1"));
-
-        brokerData1 = initBrokerData(40,100);
-        brokerData2 = initBrokerData(30,100);
-        brokerData3 = initBrokerData(30,100);
+        brokerData1 = initBrokerData(35,100);
+        brokerData2 = initBrokerData(20,100);
+        brokerData3 = initBrokerData(45,100);
         brokerDataMap.put("1", brokerData1);
         brokerDataMap.put("2", brokerData2);
         brokerDataMap.put("3", brokerData3);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/ModularLoadManagerStrategyTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/ModularLoadManagerStrategyTest.java
@@ -64,23 +64,64 @@ public class ModularLoadManagerStrategyTest {
     public void testLeastResourceUsageWithWeight() {
         BundleData bundleData = new BundleData();
         BrokerData brokerData1 = initBrokerData(10, 100);
-        BrokerData brokerData2 = initBrokerData(20, 100);
-        BrokerData brokerData4 = initBrokerData(40, 100);
+        BrokerData brokerData2 = initBrokerData(30, 100);
+        BrokerData brokerData3 = initBrokerData(60, 100);
         LoadData loadData = new LoadData();
         Map<String, BrokerData> brokerDataMap = loadData.getBrokerData();
         brokerDataMap.put("1", brokerData1);
         brokerDataMap.put("2", brokerData2);
-        brokerDataMap.put("4", brokerData4);
+        brokerDataMap.put("3", brokerData3);
         ServiceConfiguration conf = new ServiceConfiguration();
-        conf.setLoadBalancerBrokerThresholdShedderPercentage(10);
+        conf.setLoadBalancerBrokerThresholdShedderPercentage(5);
         conf.setLoadBalancerCPUResourceWeight(1.0);
         conf.setLoadBalancerMemoryResourceWeight(0.1);
         conf.setLoadBalancerDirectMemoryResourceWeight(0.1);
         conf.setLoadBalancerBandwithInResourceWeight(1.0);
         conf.setLoadBalancerBandwithOutResourceWeight(1.0);
+        conf.setLoadBalancerHistoryResourcePercentage(0.5);
 
         ModularLoadManagerStrategy strategy = new LeastResourceUsageWithWeight();
         assertEquals(strategy.selectBroker(brokerDataMap.keySet(), bundleData, loadData, conf), Optional.of("1"));
+
+        brokerData1 = initBrokerData(20,100);
+        brokerData2 = initBrokerData(30,100);
+        brokerData3 = initBrokerData(50,100);
+        brokerDataMap.put("1", brokerData1);
+        brokerDataMap.put("2", brokerData2);
+        brokerDataMap.put("3", brokerData3);
+        assertEquals(strategy.selectBroker(brokerDataMap.keySet(), bundleData, loadData, conf), Optional.of("1"));
+
+        brokerData1 = initBrokerData(30,100);
+        brokerData2 = initBrokerData(30,100);
+        brokerData3 = initBrokerData(40,100);
+        brokerDataMap.put("1", brokerData1);
+        brokerDataMap.put("2", brokerData2);
+        brokerDataMap.put("3", brokerData3);
+        assertEquals(strategy.selectBroker(brokerDataMap.keySet(), bundleData, loadData, conf), Optional.of("1"));
+
+        brokerData1 = initBrokerData(30,100);
+        brokerData2 = initBrokerData(30,100);
+        brokerData3 = initBrokerData(40,100);
+        brokerDataMap.put("1", brokerData1);
+        brokerDataMap.put("2", brokerData2);
+        brokerDataMap.put("3", brokerData3);
+        assertEquals(strategy.selectBroker(brokerDataMap.keySet(), bundleData, loadData, conf), Optional.of("1"));
+
+        brokerData1 = initBrokerData(32,100);
+        brokerData2 = initBrokerData(30,100);
+        brokerData3 = initBrokerData(38,100);
+        brokerDataMap.put("1", brokerData1);
+        brokerDataMap.put("2", brokerData2);
+        brokerDataMap.put("3", brokerData3);
+        assertEquals(strategy.selectBroker(brokerDataMap.keySet(), bundleData, loadData, conf), Optional.of("1"));
+
+        brokerData1 = initBrokerData(40,100);
+        brokerData2 = initBrokerData(30,100);
+        brokerData3 = initBrokerData(30,100);
+        brokerDataMap.put("1", brokerData1);
+        brokerDataMap.put("2", brokerData2);
+        brokerDataMap.put("3", brokerData3);
+        assertEquals(strategy.selectBroker(brokerDataMap.keySet(), bundleData, loadData, conf), Optional.of("2"));
     }
 
     private BrokerData initBrokerData(double usage, double limit) {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/ModularLoadManagerStrategyTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/ModularLoadManagerStrategyTest.java
@@ -72,7 +72,6 @@ public class ModularLoadManagerStrategyTest {
         brokerDataMap.put("2", brokerData2);
         brokerDataMap.put("3", brokerData3);
         ServiceConfiguration conf = new ServiceConfiguration();
-        conf.setLoadBalancerBrokerThresholdShedderPercentage(5);
         conf.setLoadBalancerCPUResourceWeight(1.0);
         conf.setLoadBalancerMemoryResourceWeight(0.1);
         conf.setLoadBalancerDirectMemoryResourceWeight(0.1);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/ModularLoadManagerStrategyTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/ModularLoadManagerStrategyTest.java
@@ -78,7 +78,7 @@ public class ModularLoadManagerStrategyTest {
         conf.setLoadBalancerBandwithInResourceWeight(1.0);
         conf.setLoadBalancerBandwithOutResourceWeight(1.0);
         conf.setLoadBalancerHistoryResourcePercentage(0.5);
-        conf.setLoadBalancerAverageResourceUsageDifferenceThresholdShedderPercentage(5);
+        conf.setLoadBalancerAverageResourceUsageDifferenceThresholdPercentage(5);
 
         ModularLoadManagerStrategy strategy = new LeastResourceUsageWithWeight();
         assertEquals(strategy.selectBroker(brokerDataMap.keySet(), bundleData, loadData, conf), Optional.of("1"));


### PR DESCRIPTION
email discussion thread: https://lists.apache.org/thread/36vyyhndr4og175k2bz3mfdf5ctd2xky

### Motivation
See PIP-182 #16274 

### Modifications
See #16274 
 
The main idea of the new strategy is to unify the requirement of load shedding strategy and bundle placement strategy, which consider the resource usage with weight, including historical observations.

How to calculate a score for a broker ?
- use its historical load and short-term load data with weight, which can solve the case of load jitter in a broker.

How to select a broker for assignning bundle ?
- select a broker based on which one has the least average resource usage with weight.
- the random selection algorithm is better than the `minScore` among low load brokers, and use `loadBalancerAverageResourceUsageDifferenceThresholdShedderPercentage ` to adjust the size of the `randomization pool`

Below are screenshots of the effect of the new strategy with less time and fewer load balancing times.

<img width="1219" alt="image" src="https://user-images.githubusercontent.com/4970972/176441484-d9918d5e-e192-4a69-8522-be3ee394766d.png">

### Verifying this change

- [x]  Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.
### Does this pull request potentially affect one of the following parts:

If `yes` was chosen, please highlight the changes

- Dependencies (does it add or upgrade a dependency): (no)
- The public API: (no)
- The schema: (no)
- The default values of configurations: (no)
- The wire protocol: (no)
- The rest endpoints: (no)
- The admin cli options: (no)
- Anything that affects deployment: (no)

### Documentation
Check the box below and label this PR (if you have committer privilege).

Need to update docs? 
- [x] `doc` 
   Doc added in admin client api.