### PR TITLE
[improve][doc] Update the json config file for cassandra sink connector

### DIFF
--- a/site2/docs/io-quickstart.md
+++ b/site2/docs/io-quickstart.md
@@ -212,15 +212,25 @@ You can create a configuration file through one of the following methods.
 
   ```json
   
-  {
-      "roots": "localhost:9042",
-      "keyspace": "pulsar_test_keyspace",
-      "columnFamily": "pulsar_test_table",
-      "keyname": "key",
-      "columnName": "col"
+  {   
+      "configs": 
+      {
+          "roots": "localhost:9042",
+          "keyspace": "pulsar_test_keyspace",
+          "columnFamily": "pulsar_test_table",
+          "keyname": "key",
+          "columnName": "col"
+      }
   }
   
   ```
+
+You can also create the above configuration JSON file using the following commands:
+```
+touch config.json
+json='{"configs":{"roots":"localhost:9042","keyspace":"pulsar_test_keyspace","columnFamily":"pulsar_test_table","keyname":"key","columnName":"col"}}'
+echo $json > config.json
+```
 
 * YAML
 


### PR DESCRIPTION
The JSON config file was not working on Cassandra as a sink-connector.
The updated one does.

I also added commands to add the config file via the command line for readers using the Pulsar docker image.