### PR TITLE
[fix][C++ client] Fix the close of Client might stuck or return a wrong result

### DIFF
--- a/pulsar-client-cpp/lib/ReaderImpl.h
+++ b/pulsar-client-cpp/lib/ReaderImpl.h
@@ -42,7 +42,7 @@ class PULSAR_PUBLIC ReaderImpl : public std::enable_shared_from_this<ReaderImpl>
     ReaderImpl(const ClientImplPtr client, const std::string& topic, const ReaderConfiguration& conf,
                const ExecutorServicePtr listenerExecutor, ReaderCallback readerCreatedCallback);
 
-    void start(const MessageId& startMessageId);
+    void start(const MessageId& startMessageId, std::function<void(const ConsumerImplBaseWeakPtr&)> callback);
 
     const std::string& getTopic() const;
 
@@ -65,8 +65,6 @@ class PULSAR_PUBLIC ReaderImpl : public std::enable_shared_from_this<ReaderImpl>
     bool isConnected() const;
 
    private:
-    void handleConsumerCreated(Result result, ConsumerImplBaseWeakPtr consumer);
-
     void messageListener(Consumer consumer, const Message& msg);
 
     void acknowledgeIfNecessary(Result result, const Message& msg);


### PR DESCRIPTION
Fixes https://github.com/apache/pulsar/issues/15976

### Motivation

Currently even if the producer, consumer, or reader failed to
create, it would still be added to the producers or consumers in
`Client`. `Client::close` first closes the internal producers and
consumers, if the producers or consumers to close include failed
producers or consumers, `Client::close` would return
`ResultAlreadyClosed`. Even worse, closing a failed partitioned producer
might stuck.

It also makes the Python test `test_listener_name_client` flaky because
`client.close()` will throw an exception if the underlying
`Client::close` call in C++ client doesn't return `ResultOk`.

### Modifications

- Only adding the created producer or consumer to the internal list of
  `Client` after the creation succeeded.
- Add `ClientTest.testWrongListener` to verify when producer, consumer,
  reader failed to create, the internal producer list and consumer list
  are both empty. And `client.close()` would return `ResultOk`.

### Documentation

Check the box below or label this PR directly.

Need to update docs? 

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)
  
- [x] `doc-not-needed` 
(Please explain why)
  
- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)