### PR TITLE
When generate doc, ignore the hidden parameters.

### DIFF
--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/BaseGenerateDocumentation.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/BaseGenerateDocumentation.java
@@ -90,7 +90,7 @@ public abstract class BaseGenerateDocumentation {
         sb.append("|---|---|---|---|---|\n");
         for (Field field : fields) {
             FieldContext fieldContext = field.getAnnotation(FieldContext.class);
-            if (fieldContext == null) {
+            if (fieldContext == null || fieldContext.deprecated()) {
                 continue;
             }
             field.setAccessible(true);

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/BaseGenerateDocumentation.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/BaseGenerateDocumentation.java
@@ -90,7 +90,7 @@ public abstract class BaseGenerateDocumentation {
         sb.append("|---|---|---|---|---|\n");
         for (Field field : fields) {
             FieldContext fieldContext = field.getAnnotation(FieldContext.class);
-            if (fieldContext == null || fieldContext.deprecated()) {
+            if (fieldContext == null) {
                 continue;
             }
             field.setAccessible(true);

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdGenerateDocument.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdGenerateDocument.java
@@ -121,10 +121,10 @@ public class CmdGenerateDocument extends CmdBase {
                     sb.append("|Flag|Description|Default|\n");
                     sb.append("|---|---|---|\n");
                 }
-                options.forEach((option) ->
-                    sb.append("| `").append(option.getNames())
-                            .append("` | ").append(option.getDescription().replace("\n", " "))
-                            .append("|").append(option.getDefault()).append("|\n")
+                options.stream().filter(ele -> !ele.getParameterAnnotation().hidden()).forEach((option) ->
+                        sb.append("| `").append(option.getNames())
+                                .append("` | ").append(option.getDescription().replace("\n", " "))
+                                .append("|").append(option.getDefault()).append("|\n")
                 );
             });
             System.out.println(sb.toString());

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/client/cli/CmdGenerateDocumentation.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/client/cli/CmdGenerateDocumentation.java
@@ -78,7 +78,7 @@ public class CmdGenerateDocumentation {
         sb.append("|Flag|Description|Default|\n");
         sb.append("|---|---|---|\n");
         List<ParameterDescription> options = cmd.getParameters();
-        options.forEach((option) ->
+        options.stream().filter(ele -> !ele.getParameterAnnotation().hidden()).forEach((option) ->
                 sb.append("| `").append(option.getNames())
                         .append("` | ").append(option.getDescription().replace("\n", " "))
                         .append("|").append(option.getDefault()).append("|\n")

--- a/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/CmdGenerateDocumentation.java
+++ b/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/CmdGenerateDocumentation.java
@@ -113,7 +113,7 @@ public class CmdGenerateDocumentation {
         sb.append("|Flag|Description|Default|\n");
         sb.append("|---|---|---|\n");
         List<ParameterDescription> options = cmd.getParameters();
-        options.forEach((option) ->
+        options.stream().filter(ele -> !ele.getParameterAnnotation().hidden()).forEach((option) ->
                 sb.append("| `").append(option.getNames())
                         .append("` | ").append(option.getDescription().replace("\n", " "))
                         .append("|").append(option.getDefault()).append("|\n")


### PR DESCRIPTION
Fixes #15771

### Documentation

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)
  
- [ ] `doc-not-needed` 
(Please explain why)
  
- [x] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)