### PR TITLE
[improve][function] When restart function, if assigned work does not exist, print warn log.

### DIFF
--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/FunctionRuntimeManager.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/FunctionRuntimeManager.java
@@ -447,9 +447,8 @@ public class FunctionRuntimeManager implements AutoCloseable {
                         }
                     }
                     if (workerInfo == null) {
-                        if (log.isDebugEnabled()) {
-                            log.debug("[{}] has not been assigned yet", fullyQualifiedInstanceId);
-                        }
+                        log.warn("[{}] has not been assigned yet, assignment: [{}], workerList: [{}]",
+                                fullyQualifiedInstanceId, assignment, workerInfoList);
                         continue;
                     }
                     restartFunctionUsingPulsarAdmin(assignment, tenant, namespace, functionName, false);


### PR DESCRIPTION
### Motivation

In the implementation of the function framework, assignments are updated asynchronously to each worker.  When restarting the function, there may be some work in an assignment that does not exist.  This scenario should be printed warn log to the broker.

### Modifications
- When restart function, if assigned work does not exist, print warn log.

### Documentation
- [x] `doc-not-needed` 

