### PR TITLE
Remove unnecessary apple m1 profile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2345,18 +2345,6 @@ flexible messaging model and an intuitive client API.</description>
         </plugins>
       </reporting>
     </profile>
-    <profile>
-      <id>mac-apple-silicon</id>
-      <activation>
-        <os>
-          <family>mac</family>
-          <arch>aarch64</arch>
-        </os>
-      </activation>
-      <properties>
-        <os.detected.classifier>osx-x86_64</os.detected.classifier>
-      </properties>
-    </profile>
 
     <profile>
       <id>pulsar-io-tests</id>


### PR DESCRIPTION
### Motivation
This profile is introduced in #13076. Now new version of grpc can work well on m1 mac without this profile.

### Modifications
Remove unnecessary apple m1 profile

### Verifying this change
test on my m1 mbp

### Documentation

Check the box below or label this PR directly.

Need to update docs? 
  
- [x] `doc-not-needed` 