### PR TITLE
Exclude the Netty Reactive Stream from asynchttpclient

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -290,6 +290,10 @@ flexible messaging model and an intuitive client API.</description>
             <groupId>io.netty</groupId>
             <artifactId>*</artifactId>
           </exclusion>
+          <exclusion>
+            <groupId>com.typesafe.netty</groupId>
+            <artifactId>netty-reactive-streams</artifactId>
+          </exclusion>
         </exclusions>
       </dependency>
 

--- a/pulsar-client-tools/pom.xml
+++ b/pulsar-client-tools/pom.xml
@@ -73,6 +73,10 @@
       <artifactId>async-http-client</artifactId>
     </dependency>
     <dependency>
+      <groupId>com.typesafe.netty</groupId>
+      <artifactId>netty-reactive-streams</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
     </dependency>

--- a/pulsar-client/pom.xml
+++ b/pulsar-client/pom.xml
@@ -89,6 +89,11 @@
     </dependency>
 
     <dependency>
+      <groupId>com.typesafe.netty</groupId>
+      <artifactId>netty-reactive-streams</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>


### PR DESCRIPTION
---

*Motivation*

We upgrade the Netty Reactive Stream in the PR #15990,
but the asynchttpclient still uses it. We should use
our project dependency to address the CVE.

- [x] `doc-not-needed`
