### PR TITLE
[Improve][broker]  When calculating resource usage, use getMaxResourceUsageWithWeight instead of getMaxResourceUsage

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/LeastLongTermMessageRate.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/LeastLongTermMessageRate.java
@@ -52,7 +52,11 @@ public class LeastLongTermMessageRate implements ModularLoadManagerStrategy {
     // Any broker at (or above) the overload threshold will have a score of POSITIVE_INFINITY.
     private static double getScore(final BrokerData brokerData, final ServiceConfiguration conf) {
         final double overloadThreshold = conf.getLoadBalancerBrokerOverloadedThresholdPercentage() / 100.0;
-        final double maxUsage = brokerData.getLocalData().getMaxResourceUsage();
+        final double maxUsage = brokerData.getLocalData().getMaxResourceUsageWithWeight(
+                conf.getLoadBalancerCPUResourceWeight(),
+                conf.getLoadBalancerMemoryResourceWeight(), conf.getLoadBalancerDirectMemoryResourceWeight(),
+                conf.getLoadBalancerBandwithInResourceWeight(),
+                conf.getLoadBalancerBandwithOutResourceWeight());
         if (maxUsage > overloadThreshold) {
             log.warn("Broker {} is overloaded: max usage={}", brokerData.getLocalData().getWebServiceUrl(), maxUsage);
             return Double.POSITIVE_INFINITY;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/ModularLoadManagerImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/ModularLoadManagerImpl.java
@@ -872,7 +872,12 @@ public class ModularLoadManagerImpl implements ModularLoadManager {
                 }
 
                 final double overloadThreshold = conf.getLoadBalancerBrokerOverloadedThresholdPercentage() / 100.0;
-                final double maxUsage = loadData.getBrokerData().get(broker.get()).getLocalData().getMaxResourceUsage();
+                final double maxUsage = loadData.getBrokerData().get(broker.get()).getLocalData()
+                        .getMaxResourceUsageWithWeight(
+                        conf.getLoadBalancerCPUResourceWeight(),
+                        conf.getLoadBalancerMemoryResourceWeight(), conf.getLoadBalancerDirectMemoryResourceWeight(),
+                        conf.getLoadBalancerBandwithInResourceWeight(),
+                        conf.getLoadBalancerBandwithOutResourceWeight());
                 if (maxUsage > overloadThreshold) {
                     // All brokers that were in the filtered list were overloaded, so check if there is a better broker
                     LoadManagerShared.applyNamespacePolicies(serviceUnit, policies, brokerCandidateCache,

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/ModularLoadManagerImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/ModularLoadManagerImpl.java
@@ -453,8 +453,19 @@ public class ModularLoadManagerImpl implements ModularLoadManager {
             // Always update after surpassing the maximum interval.
             return true;
         }
+
+        double lastDataMaxResourceUsage = lastData.getMaxResourceUsageWithWeight(
+                conf.getLoadBalancerCPUResourceWeight(),
+                conf.getLoadBalancerMemoryResourceWeight(), conf.getLoadBalancerDirectMemoryResourceWeight(),
+                conf.getLoadBalancerBandwithInResourceWeight(),
+                conf.getLoadBalancerBandwithOutResourceWeight());
+        double localDataMaxResourceUsage = localData.getMaxResourceUsageWithWeight(
+                conf.getLoadBalancerCPUResourceWeight(),
+                conf.getLoadBalancerMemoryResourceWeight(), conf.getLoadBalancerDirectMemoryResourceWeight(),
+                conf.getLoadBalancerBandwithInResourceWeight(),
+                conf.getLoadBalancerBandwithOutResourceWeight());
         final double maxChange = Math
-                .max(100.0 * (Math.abs(lastData.getMaxResourceUsage() - localData.getMaxResourceUsage())),
+                .max(100.0 * (Math.abs(lastDataMaxResourceUsage - localDataMaxResourceUsage)),
                         Math.max(percentChange(lastData.getMsgRateIn() + lastData.getMsgRateOut(),
                                 localData.getMsgRateIn() + localData.getMsgRateOut()),
                                 Math.max(

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/OverloadShedder.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/OverloadShedder.java
@@ -36,10 +36,10 @@ import org.slf4j.LoggerFactory;
 /**
  * Load shedding strategy which will attempt to shed exactly one bundle on brokers which are overloaded, that is, whose
  * maximum system resource usage exceeds loadBalancerBrokerOverloadedThresholdPercentage. To see which resources are
- * considered when determining the maximum system resource, see {@link LocalBrokerData#getMaxResourceUsage()}. A bundle
- * is recommended for unloading off that broker if and only if the following conditions hold: The broker has at
- * least two bundles assigned and the broker has at least one bundle that has not been unloaded recently according to
- * LoadBalancerSheddingGracePeriodMinutes. The unloaded bundle will be the most expensive bundle in terms of message
+ * considered when determining the maximum system resource, see {@link LocalBrokerData#getMaxResourceUsageWithWeight}.
+ * A bundle is recommended for unloading off that broker if and only if the following conditions hold: The broker has
+ * at least two bundles assigned and the broker has at least one bundle that has not been unloaded recently according
+ * to LoadBalancerSheddingGracePeriodMinutes. The unloaded bundle will be the most expensive bundle in terms of message
  * rate that has not been recently unloaded. Note that this strategy does not take into account "underloaded" brokers
  * when determining which bundles to unload. If you are looking for a strategy that spreads load evenly across
  * all brokers, see {@link ThresholdShedder}.
@@ -71,7 +71,11 @@ public class OverloadShedder implements LoadSheddingStrategy {
         loadData.getBrokerData().forEach((broker, brokerData) -> {
 
             final LocalBrokerData localData = brokerData.getLocalData();
-            final double currentUsage = localData.getMaxResourceUsage();
+            final double currentUsage = localData.getMaxResourceUsageWithWeight(
+                    conf.getLoadBalancerCPUResourceWeight(),
+                    conf.getLoadBalancerMemoryResourceWeight(), conf.getLoadBalancerDirectMemoryResourceWeight(),
+                    conf.getLoadBalancerBandwithInResourceWeight(),
+                    conf.getLoadBalancerBandwithOutResourceWeight());
             if (currentUsage < overloadThreshold) {
                 if (log.isDebugEnabled()) {
                     log.debug("[{}] Broker is not overloaded, ignoring at this point ({})", broker,

--- a/pulsar-common/src/main/java/org/apache/pulsar/policies/data/loadbalancer/LocalBrokerData.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/policies/data/loadbalancer/LocalBrokerData.java
@@ -235,7 +235,8 @@ public class LocalBrokerData implements LoadManagerReport {
     }
 
     public double getMaxResourceUsage() {
-        return getMaxResourceUsageWithWeight(1.0, 1.0, 1.0, 1.0, 1.0);
+        return max(cpu.percentUsage(), memory.percentUsage(), directMemory.percentUsage(), bandwidthIn.percentUsage(),
+                bandwidthOut.percentUsage()) / 100;
     }
 
     public String printResourceUsage() {

--- a/pulsar-common/src/main/java/org/apache/pulsar/policies/data/loadbalancer/LocalBrokerData.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/policies/data/loadbalancer/LocalBrokerData.java
@@ -235,8 +235,7 @@ public class LocalBrokerData implements LoadManagerReport {
     }
 
     public double getMaxResourceUsage() {
-        return max(cpu.percentUsage(), memory.percentUsage(), directMemory.percentUsage(), bandwidthIn.percentUsage(),
-                bandwidthOut.percentUsage()) / 100;
+        return getMaxResourceUsageWithWeight(1.0, 1.0, 1.0, 1.0, 1.0);
     }
 
     public String printResourceUsage() {


### PR DESCRIPTION
### Motivation
Use getMaxResourceUsageWithWeight instead of getMaxResourceUsage in selectBrokerForAssignment.

### Documentation

Check the box below or label this PR directly.

Need to update docs? 

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)
  
- [x] `doc-not-needed` 
(Please explain why)
  
- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)