### PR TITLE
[feature][cli] Pulsar shell - Env variables interpolation - part 4

### DIFF
--- a/bin/pulsar-admin-common.sh
+++ b/bin/pulsar-admin-common.sh
@@ -91,6 +91,13 @@ PULSAR_CLASSPATH="`dirname $PULSAR_LOG_CONF`:$PULSAR_CLASSPATH"
 OPTS="$OPTS -Dlog4j.configurationFile=`basename $PULSAR_LOG_CONF`"
 OPTS="$OPTS -Djava.net.preferIPv4Stack=true"
 
+IS_JAVA_8=`$JAVA -version 2>&1 |grep version|grep '"1\.8'`
+# Start --add-opens options
+# '--add-opens' option is not supported in jdk8
+if [[ -z "$IS_JAVA_8" ]]; then
+  OPTS="$OPTS --add-opens java.base/sun.net=ALL-UNNAMED"
+fi
+
 OPTS="-cp $PULSAR_CLASSPATH $OPTS"
 
 OPTS="$OPTS $PULSAR_EXTRA_OPTS"

--- a/bin/pulsar-shell
+++ b/bin/pulsar-shell
@@ -24,4 +24,4 @@ export PULSAR_HOME=`cd -P $BINDIR/..;pwd`
 
 #Change to PULSAR_HOME to support relative paths
 cd "$PULSAR_HOME"
-exec $JAVA $OPTS org.apache.pulsar.client.cli.PulsarClientTool $PULSAR_CLIENT_CONF "$@"
+exec $JAVA $OPTS org.apache.pulsar.shell.PulsarShell $PULSAR_CLIENT_CONF "$@"

--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -552,6 +552,7 @@ BSD 3-clause "New" or "Revised" License
  * LevelDB -- (included in org.rocksdb.*.jar) -- licenses/LICENSE-LevelDB.txt
  * JSR305 -- com.google.code.findbugs-jsr305-3.0.2.jar -- licenses/LICENSE-JSR305.txt
  * JLine -- jline-jline-2.14.6.jar -- licenses/LICENSE-JLine.txt
+ * JLine3 -- org.jline-jline-3.21.0.jar -- licenses/LICENSE-JLine.txt
 
 BSD 2-Clause License
  * HdrHistogram -- org.hdrhistogram-HdrHistogram-2.1.9.jar -- licenses/LICENSE-HdrHistogram.txt

--- a/pom.xml
+++ b/pom.xml
@@ -117,6 +117,7 @@ flexible messaging model and an intuitive client API.</description>
     <bookkeeper.version>4.15.0</bookkeeper.version>
     <zookeeper.version>3.8.0</zookeeper.version>
     <commons-cli.version>1.5.0</commons-cli.version>
+    <commons-text.version>1.9</commons-text.version>
     <snappy.version>1.1.8.4</snappy.version> <!-- ZooKeeper server -->
     <dropwizardmetrics.version>4.1.12.1</dropwizardmetrics.version> <!-- ZooKeeper server -->
     <curator.version>5.1.0</curator.version>

--- a/pom.xml
+++ b/pom.xml
@@ -197,6 +197,7 @@ flexible messaging model and an intuitive client API.</description>
     <caffeine.version>2.9.1</caffeine.version>
     <java-semver.version>0.9.0</java-semver.version>
     <jline.version>2.14.6</jline.version>
+    <jline3.version>3.21.0</jline3.version>
     <hppc.version>0.9.1</hppc.version>
     <spark-streaming_2.10.version>2.1.0</spark-streaming_2.10.version>
     <assertj-core.version>3.18.1</assertj-core.version>
@@ -1562,6 +1563,7 @@ flexible messaging model and an intuitive client API.</description>
             <pulsar-admin>SCRIPT_STYLE</pulsar-admin>
             <pulsar-perf>SCRIPT_STYLE</pulsar-perf>
             <pulsar-client>SCRIPT_STYLE</pulsar-client>
+            <pulsar-shell>SCRIPT_STYLE</pulsar-shell>
             <bookkeeper>SCRIPT_STYLE</bookkeeper>
             <tfvars>SCRIPT_STYLE</tfvars>
           </mapping>

--- a/pulsar-client-tools-test/src/test/java/org/apache/pulsar/client/cli/DocumentTest.java
+++ b/pulsar-client-tools-test/src/test/java/org/apache/pulsar/client/cli/DocumentTest.java
@@ -60,7 +60,7 @@ public class DocumentTest extends BrokerTestBase {
     @Test
     public void testGenerator() {
         PulsarClientTool pulsarClientTool = new PulsarClientTool(new Properties());
-        JCommander commander = pulsarClientTool.commandParser;
+        JCommander commander = pulsarClientTool.jcommander;
         CmdGenerateDocumentation document = new CmdGenerateDocumentation();
         for (Map.Entry<String, JCommander> cmd : commander.getCommands().entrySet()) {
             String res = document.generateDocument(cmd.getKey(), commander);

--- a/pulsar-client-tools/pom.xml
+++ b/pulsar-client-tools/pom.xml
@@ -101,6 +101,11 @@
       <artifactId>jline</artifactId>
       <version>${jline3.version}</version>
     </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-text</artifactId>
+      <version>${commons-text.version}</version>
+    </dependency>
 
   </dependencies>
 

--- a/pulsar-client-tools/pom.xml
+++ b/pulsar-client-tools/pom.xml
@@ -96,6 +96,12 @@
     	<version>${project.version}</version>
     	<scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.jline</groupId>
+      <artifactId>jline</artifactId>
+      <version>${jline3.version}</version>
+    </dependency>
+
   </dependencies>
 
   <build>

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdBase.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdBase.java
@@ -130,4 +130,8 @@ public abstract class CmdBase {
         }
         return map;
     }
+
+    public JCommander getJcommander() {
+        return jcommander;
+    }
 }

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/client/cli/CmdGenerateDocumentation.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/client/cli/CmdGenerateDocumentation.java
@@ -40,7 +40,7 @@ public class CmdGenerateDocumentation {
 
     public int run() throws PulsarClientException {
         PulsarClientTool pulsarClientTool = new PulsarClientTool(new Properties());
-        JCommander commander = pulsarClientTool.commandParser;
+        JCommander commander = pulsarClientTool.jcommander;
         if (commandNames.size() == 0) {
             for (Map.Entry<String, JCommander> cmd : commander.getCommands().entrySet()) {
                 if (cmd.getKey().equals("generate_documentation")) {

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/client/cli/PulsarClientTool.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/client/cli/PulsarClientTool.java
@@ -29,6 +29,7 @@ import com.beust.jcommander.Parameters;
 import java.io.FileInputStream;
 import java.util.Arrays;
 import java.util.Properties;
+import lombok.Getter;
 import org.apache.pulsar.PulsarVersion;
 import org.apache.pulsar.client.api.Authentication;
 import org.apache.pulsar.client.api.AuthenticationFactory;
@@ -38,37 +39,42 @@ import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.client.api.PulsarClientException.UnsupportedAuthenticationException;
 import org.apache.pulsar.client.api.SizeUnit;
 
-@Parameters(commandDescription = "Produce or consume messages on a specified topic")
+
 public class PulsarClientTool {
 
-    @Parameter(names = { "--url" }, description = "Broker URL to which to connect.")
-    String serviceURL = null;
+    @Getter
+    @Parameters(commandDescription = "Produce or consume messages on a specified topic")
+    public static class RootParams {
+        @Parameter(names = { "--url" }, description = "Broker URL to which to connect.")
+        String serviceURL = null;
 
-    @Parameter(names = { "--proxy-url" }, description = "Proxy-server URL to which to connect.")
-    String proxyServiceURL = null;
+        @Parameter(names = { "--proxy-url" }, description = "Proxy-server URL to which to connect.")
+        String proxyServiceURL = null;
 
-    @Parameter(names = { "--proxy-protocol" }, description = "Proxy protocol to select type of routing at proxy.")
-    ProxyProtocol proxyProtocol = null;
+        @Parameter(names = { "--proxy-protocol" }, description = "Proxy protocol to select type of routing at proxy.")
+        ProxyProtocol proxyProtocol = null;
 
-    @Parameter(names = { "--auth-plugin" }, description = "Authentication plugin class name.")
-    String authPluginClassName = null;
+        @Parameter(names = { "--auth-plugin" }, description = "Authentication plugin class name.")
+        String authPluginClassName = null;
 
-    @Parameter(names = { "--listener-name" }, description = "Listener name for the broker.")
-    String listenerName = null;
+        @Parameter(names = { "--listener-name" }, description = "Listener name for the broker.")
+        String listenerName = null;
 
-    @Parameter(
-        names = { "--auth-params" },
-        description = "Authentication parameters, whose format is determined by the implementation "
-                + "of method `configure` in authentication plugin class, for example \"key1:val1,key2:val2\" "
-                + "or \"{\"key1\":\"val1\",\"key2\":\"val2\"}.")
-    String authParams = null;
+        @Parameter(
+            names = { "--auth-params" },
+            description = "Authentication parameters, whose format is determined by the implementation "
+                    + "of method `configure` in authentication plugin class, for example \"key1:val1,key2:val2\" "
+                    + "or \"{\"key1\":\"val1\",\"key2\":\"val2\"}.")
+        String authParams = null;
 
-    @Parameter(names = { "-v", "--version" }, description = "Get version of pulsar client")
-    boolean version;
+        @Parameter(names = { "-v", "--version" }, description = "Get version of pulsar client")
+        boolean version;
 
-    @Parameter(names = { "-h", "--help", }, help = true, description = "Show this help.")
-    boolean help;
+        @Parameter(names = { "-h", "--help", }, help = true, description = "Show this help.")
+        boolean help;
+    }
 
+    protected RootParams rootParams;
     boolean tlsAllowInsecureConnection;
     boolean tlsEnableHostnameVerification;
     String tlsTrustCertsFilePath;
@@ -79,21 +85,15 @@ public class PulsarClientTool {
     String tlsTrustStorePath;
     String tlsTrustStorePassword;
 
-    JCommander commandParser;
+    protected JCommander jcommander;
     IUsageFormatter usageFormatter;
     CmdProduce produceCommand;
     CmdConsume consumeCommand;
     CmdGenerateDocumentation generateDocumentation;
 
     public PulsarClientTool(Properties properties) {
-        this.serviceURL = isNotBlank(properties.getProperty("brokerServiceUrl"))
-                ? properties.getProperty("brokerServiceUrl") : properties.getProperty("webServiceUrl");
-        // fallback to previous-version serviceUrl property to maintain backward-compatibility
-        if (isBlank(this.serviceURL)) {
-            this.serviceURL = properties.getProperty("serviceUrl");
-        }
-        this.authPluginClassName = properties.getProperty("authPlugin");
-        this.authParams = properties.getProperty("authParams");
+        rootParams = new RootParams();
+        initRootParamsFromProperties(properties);
         this.tlsAllowInsecureConnection = Boolean
                 .parseBoolean(properties.getProperty("tlsAllowInsecureConnection", "false"));
         this.tlsEnableHostnameVerification = Boolean
@@ -106,67 +106,82 @@ public class PulsarClientTool {
         this.tlsTrustStorePath = properties.getProperty("tlsTrustStorePath");
         this.tlsTrustStorePassword = properties.getProperty("tlsTrustStorePassword");
 
+        initJCommander();
+    }
+
+    protected void initJCommander() {
         produceCommand = new CmdProduce();
         consumeCommand = new CmdConsume();
         generateDocumentation = new CmdGenerateDocumentation();
 
-        this.commandParser = new JCommander();
-        this.usageFormatter = new DefaultUsageFormatter(this.commandParser);
-        commandParser.setProgramName("pulsar-client");
-        commandParser.addObject(this);
-        commandParser.addCommand("produce", produceCommand);
-        commandParser.addCommand("consume", consumeCommand);
-        commandParser.addCommand("generate_documentation", generateDocumentation);
+        this.jcommander = new JCommander();
+        this.usageFormatter = new DefaultUsageFormatter(this.jcommander);
+        jcommander.setProgramName("pulsar-client");
+        jcommander.addObject(rootParams);
+        jcommander.addCommand("produce", produceCommand);
+        jcommander.addCommand("consume", consumeCommand);
+        jcommander.addCommand("generate_documentation", generateDocumentation);
+    }
+
+    protected void initRootParamsFromProperties(Properties properties) {
+        this.rootParams.serviceURL = isNotBlank(properties.getProperty("brokerServiceUrl"))
+                ? properties.getProperty("brokerServiceUrl") : properties.getProperty("webServiceUrl");
+        // fallback to previous-version serviceUrl property to maintain backward-compatibility
+        if (isBlank(this.rootParams.serviceURL)) {
+            this.rootParams.serviceURL = properties.getProperty("serviceUrl");
+        }
+        this.rootParams.authPluginClassName = properties.getProperty("authPlugin");
+        this.rootParams.authParams = properties.getProperty("authParams");
     }
 
     private void updateConfig() throws UnsupportedAuthenticationException {
         ClientBuilder clientBuilder = PulsarClient.builder()
                 .memoryLimit(0, SizeUnit.BYTES);
         Authentication authentication = null;
-        if (isNotBlank(this.authPluginClassName)) {
-            authentication = AuthenticationFactory.create(authPluginClassName, authParams);
+        if (isNotBlank(this.rootParams.authPluginClassName)) {
+            authentication = AuthenticationFactory.create(rootParams.authPluginClassName, rootParams.authParams);
             clientBuilder.authentication(authentication);
         }
-        if (isNotBlank(this.listenerName)) {
-            clientBuilder.listenerName(this.listenerName);
+        if (isNotBlank(this.rootParams.listenerName)) {
+            clientBuilder.listenerName(this.rootParams.listenerName);
         }
         clientBuilder.allowTlsInsecureConnection(this.tlsAllowInsecureConnection);
         clientBuilder.tlsTrustCertsFilePath(this.tlsTrustCertsFilePath);
         clientBuilder.enableTlsHostnameVerification(this.tlsEnableHostnameVerification);
-        clientBuilder.serviceUrl(serviceURL);
+        clientBuilder.serviceUrl(rootParams.serviceURL);
 
         clientBuilder.useKeyStoreTls(useKeyStoreTls)
                 .tlsTrustStoreType(tlsTrustStoreType)
                 .tlsTrustStorePath(tlsTrustStorePath)
                 .tlsTrustStorePassword(tlsTrustStorePassword);
 
-        if (isNotBlank(proxyServiceURL)) {
-            if (proxyProtocol == null) {
+        if (isNotBlank(rootParams.proxyServiceURL)) {
+            if (rootParams.proxyProtocol == null) {
                 System.out.println("proxy-protocol must be provided with proxy-url");
                 System.exit(-1);
             }
-            clientBuilder.proxyServiceUrl(proxyServiceURL, proxyProtocol);
+            clientBuilder.proxyServiceUrl(rootParams.proxyServiceURL, rootParams.proxyProtocol);
         }
-        this.produceCommand.updateConfig(clientBuilder, authentication, this.serviceURL);
-        this.consumeCommand.updateConfig(clientBuilder, authentication, this.serviceURL);
+        this.produceCommand.updateConfig(clientBuilder, authentication, this.rootParams.serviceURL);
+        this.consumeCommand.updateConfig(clientBuilder, authentication, this.rootParams.serviceURL);
     }
 
     public int run(String[] args) {
         try {
-            commandParser.parse(args);
+            jcommander.parse(args);
 
-            if (isBlank(this.serviceURL)) {
-                commandParser.usage();
+            if (isBlank(this.rootParams.serviceURL)) {
+                jcommander.usage();
                 return -1;
             }
 
-            if (version) {
+            if (rootParams.version) {
                 System.out.println("Current version of pulsar client is: " + PulsarVersion.getVersion());
                 return 0;
             }
 
-            if (help) {
-                commandParser.usage();
+            if (rootParams.help) {
+                jcommander.usage();
                 return 0;
             }
 
@@ -179,7 +194,7 @@ public class PulsarClientTool {
                 return -1;
             }
 
-            String chosenCommand = commandParser.getParsedCommand();
+            String chosenCommand = jcommander.getParsedCommand();
             if ("produce".equals(chosenCommand)) {
                 return produceCommand.run();
             } else if ("consume".equals(chosenCommand)) {
@@ -187,14 +202,18 @@ public class PulsarClientTool {
             } else if ("generate_documentation".equals(chosenCommand)) {
                 return generateDocumentation.run();
             } else {
-                commandParser.usage();
+                jcommander.usage();
                 return -1;
             }
         } catch (Exception e) {
             System.out.println(e.getMessage());
-            String chosenCommand = commandParser.getParsedCommand();
+            String chosenCommand = jcommander.getParsedCommand();
             if (e instanceof ParameterException) {
-                usageFormatter.usage(chosenCommand);
+                try {
+                    usageFormatter.usage(chosenCommand);
+                } catch (ParameterException noCmd) {
+                    e.printStackTrace();
+                }
             } else {
                 e.printStackTrace();
             }

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/shell/AdminShell.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/shell/AdminShell.java
@@ -1,0 +1,73 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.shell;
+
+import com.beust.jcommander.JCommander;
+import com.beust.jcommander.Parameters;
+import java.util.Properties;
+import org.apache.pulsar.admin.cli.PulsarAdminTool;
+
+/**
+ * Pulsar Admin tool extension for Pulsar shell.
+ */
+@Parameters(commandDescription = "Admin console")
+public class AdminShell extends PulsarAdminTool implements ShellCommandsProvider {
+
+    public AdminShell(Properties properties) throws Exception {
+        super(properties);
+    }
+
+    @Override
+    public String getName() {
+        return "admin";
+    }
+
+    @Override
+    public String getServiceUrl() {
+        return null;
+    }
+
+    @Override
+    public String getAdminUrl() {
+        return rootParams.getServiceUrl();
+    }
+
+    @Override
+    public void setupState(Properties properties) {
+        setupCommands(b -> null);
+    }
+
+    @Override
+    public JCommander getJCommander() {
+        return jcommander;
+    }
+
+    @Override
+    public void cleanupState(Properties properties) {
+        rootParams = new RootParams();
+        initRootParamsFromProperties(properties);
+        initJCommander();
+    }
+
+
+    @Override
+    public void runCommand(String[] args) throws Exception {
+        run(args);
+    }
+}

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/shell/AdminShell.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/shell/AdminShell.java
@@ -50,6 +50,7 @@ public class AdminShell extends PulsarAdminTool implements ShellCommandsProvider
 
     @Override
     public void setupState(Properties properties) {
+        getJCommander().setProgramName(getName());
         setupCommands(b -> null);
     }
 
@@ -67,7 +68,7 @@ public class AdminShell extends PulsarAdminTool implements ShellCommandsProvider
 
 
     @Override
-    public void runCommand(String[] args) throws Exception {
-        run(args);
+    public boolean runCommand(String[] args) throws Exception {
+        return run(args);
     }
 }

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/shell/ClientShell.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/shell/ClientShell.java
@@ -1,0 +1,71 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.shell;
+
+import com.beust.jcommander.JCommander;
+import com.beust.jcommander.Parameters;
+import java.util.Properties;
+import org.apache.pulsar.client.cli.PulsarClientTool;
+
+/**
+ * Pulsar Client tool extension for Pulsar shell.
+ */
+@Parameters(commandDescription = "Produce or consume messages on a specified topic")
+public class ClientShell extends PulsarClientTool implements ShellCommandsProvider {
+
+    public ClientShell(Properties properties) {
+        super(properties);
+    }
+
+    @Override
+    public String getName() {
+        return "client";
+    }
+
+    @Override
+    public String getServiceUrl() {
+        return rootParams.getServiceURL();
+    }
+
+    @Override
+    public String getAdminUrl() {
+        return null;
+    }
+
+    @Override
+    public void setupState(Properties properties) {
+    }
+
+    @Override
+    public void cleanupState(Properties properties) {
+        rootParams = new RootParams();
+        initRootParamsFromProperties(properties);
+        initJCommander();
+    }
+
+    @Override
+    public JCommander getJCommander() {
+        return jcommander;
+    }
+
+    @Override
+    public void runCommand(String[] args) throws Exception {
+        run(args);
+    }
+}

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/shell/ClientShell.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/shell/ClientShell.java
@@ -50,6 +50,7 @@ public class ClientShell extends PulsarClientTool implements ShellCommandsProvid
 
     @Override
     public void setupState(Properties properties) {
+        getJCommander().setProgramName(getName());
     }
 
     @Override
@@ -65,7 +66,8 @@ public class ClientShell extends PulsarClientTool implements ShellCommandsProvid
     }
 
     @Override
-    public void runCommand(String[] args) throws Exception {
-        run(args);
+    public boolean runCommand(String[] args) throws Exception {
+        final int returnCode = run(args);
+        return returnCode == 0;
     }
 }

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/shell/JCommanderCompleter.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/shell/JCommanderCompleter.java
@@ -1,0 +1,118 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.shell;
+
+import com.beust.jcommander.JCommander;
+import com.beust.jcommander.ParameterDescription;
+import com.beust.jcommander.WrappedParameter;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.apache.pulsar.admin.cli.CmdBase;
+import org.jline.builtins.Completers;
+import org.jline.reader.Completer;
+import org.jline.reader.impl.completer.NullCompleter;
+import org.jline.reader.impl.completer.StringsCompleter;
+
+/**
+ * Convert JCommander instance to JLine3 completers.
+ */
+public class JCommanderCompleter {
+
+    private JCommanderCompleter() {
+    }
+
+    public static List<Completer> createCompletersForCommand(String program,
+                                                             JCommander command) {
+        command.setProgramName(program);
+        return createCompletersForCommand(Collections.emptyList(),
+                command,
+                List.of(NullCompleter.INSTANCE));
+    }
+
+    private static List<Completer> createCompletersForCommand(List<Completer> preCompleters,
+                                                              JCommander command,
+                                                              List<Completer> postCompleters) {
+        List<Completer> all = new ArrayList<>();
+        addCompletersForCommand(preCompleters, postCompleters, all, command);
+        return all;
+    }
+
+    private static void addCompletersForCommand(List<Completer> preCompleters,
+                                                List<Completer> postCompleters,
+                                                List<Completer> result,
+                                                JCommander command) {
+        final Collection<Completers.OptDesc> options;
+        final Map<String, JCommander> subCommands;
+
+        if (command.getObjects().get(0) instanceof CmdBase) {
+            CmdBase cmdBase = (CmdBase) command.getObjects().get(0);
+            subCommands = cmdBase.getJcommander().getCommands();
+            options = cmdBase.getJcommander().getParameters().stream().map(JCommanderCompleter::createOptionDescriptors)
+                    .collect(Collectors.toList());
+        } else {
+            subCommands = command.getCommands();
+            options = command.getParameters().stream().map(JCommanderCompleter::createOptionDescriptors)
+                    .collect(Collectors.toList());
+        }
+
+        final StringsCompleter cmdStringsCompleter = new StringsCompleter(command.getProgramName());
+
+        for (int i = 0; i < options.size() + 1; i++) {
+            List<Completer> completersChain = new ArrayList<>();
+            completersChain.addAll(preCompleters);
+            completersChain.add(cmdStringsCompleter);
+            for (int j = 0; j < i; j++) {
+                completersChain.add(new Completers.OptionCompleter(options, preCompleters.size() + 1 + j));
+            }
+            for (Map.Entry<String, JCommander> subCommand : subCommands.entrySet()) {
+                addCompletersForCommand(completersChain, postCompleters, result, subCommand.getValue());
+            }
+            completersChain.addAll(postCompleters);
+            result.add(new OptionStrictArgumentCompleter(completersChain));
+        }
+    }
+
+
+    private static Completers.OptDesc createOptionDescriptors(ParameterDescription param) {
+        Completer valueCompleter = null;
+        boolean isBooleanArg = param.getObject() instanceof Boolean || param.getDefault() instanceof Boolean
+                || param.getObject().getClass().isAssignableFrom(Boolean.class);
+        if (!isBooleanArg) {
+            valueCompleter = Completers.AnyCompleter.INSTANCE;
+        }
+
+        final WrappedParameter parameter = param.getParameter();
+        String shortOption = null;
+        String longOption = null;
+        final String[] parameterNames = parameter.names();
+        for (String parameterName : parameterNames) {
+            if (parameterName.startsWith("--")) {
+                longOption = parameterName;
+            } else if (parameterName.startsWith("-")) {
+                shortOption = parameterName;
+            }
+        }
+        return new Completers.OptDesc(shortOption, longOption, param.getDescription(), valueCompleter);
+    }
+
+}

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/shell/OptionStrictArgumentCompleter.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/shell/OptionStrictArgumentCompleter.java
@@ -1,0 +1,127 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.shell;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Objects;
+import org.jline.builtins.Completers;
+import org.jline.reader.Candidate;
+import org.jline.reader.Completer;
+import org.jline.reader.LineReader;
+import org.jline.reader.ParsedLine;
+import org.jline.reader.impl.completer.ArgumentCompleter;
+
+/**
+ * Same as {@link ArgumentCompleter} but with more strict validation for options.
+ */
+public class OptionStrictArgumentCompleter implements Completer {
+
+    private final List<Completer> completers = new ArrayList<>();
+
+    private boolean strict = true;
+    private boolean strictCommand = true;
+
+    public List<Completer> getCompleters() {
+        return completers;
+    }
+
+
+    /**
+     * Create a new completer.
+     *
+     * @param completers    The embedded completers
+     */
+    public OptionStrictArgumentCompleter(final Collection<Completer> completers) {
+        Objects.requireNonNull(completers);
+        this.completers.addAll(completers);
+    }
+
+    public OptionStrictArgumentCompleter(final Completer... completers) {
+        this(Arrays.asList(completers));
+    }
+
+
+    @Override
+    public void complete(LineReader reader, ParsedLine line, List<Candidate> candidates) {
+        Objects.requireNonNull(line);
+        Objects.requireNonNull(candidates);
+
+        if (line.wordIndex() < 0) {
+            return;
+        }
+
+        Completer completer;
+
+        // if we are beyond the end of the completers, just use the last one
+        if (line.wordIndex() >= completers.size()) {
+            completer = completers.get(completers.size() - 1);
+        } else {
+            completer = completers.get(line.wordIndex());
+        }
+
+
+        // ensure that all the previous completers are successful
+        // before allowing this completer to pass (only if strict).
+        for (int i = strictCommand ? 0 : 1; strict && (i < line.wordIndex()); i++) {
+            int idx = i >= completers.size() ? (completers.size() - 1) : i;
+            if (idx == 0 && !strictCommand) {
+                continue;
+            }
+            Completer sub = completers.get(idx);
+
+            List<? extends CharSequence> args = line.words();
+            String arg = (args == null || i >= args.size()) ? "" : args.get(i).toString();
+
+            List<Candidate> subCandidates = new LinkedList<>();
+            /**
+             * This is the part that differs from the original ArgumentCompleter.
+             * It matches only if there's an actual option.
+             * The implementation of OptionCompleter will return the same candidate even if it is
+             * not part of the options set because options are not required.
+             */
+            if (sub instanceof Completers.OptionCompleter) {
+                if (arg.startsWith("-")) {
+                    sub.complete(reader, new ArgumentCompleter.ArgumentLine(arg, arg.length()), subCandidates);
+                } else {
+                    return;
+                }
+            } else {
+                sub.complete(reader, new ArgumentCompleter.ArgumentLine(arg, arg.length()), subCandidates);
+            }
+
+
+            boolean found = false;
+            for (Candidate cand : subCandidates) {
+                if (cand.value().equals(arg)) {
+                    found = true;
+                    break;
+                }
+            }
+            if (!found) {
+                return;
+            }
+        }
+        completer.complete(reader, line, candidates);
+    }
+
+}

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/shell/PulsarShell.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/shell/PulsarShell.java
@@ -1,0 +1,256 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.shell;
+
+import com.beust.jcommander.JCommander;
+import com.beust.jcommander.Parameter;
+import java.io.FileInputStream;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.function.Function;
+import org.jline.reader.Completer;
+import org.jline.reader.LineReader;
+import org.jline.reader.LineReaderBuilder;
+import org.jline.reader.ParsedLine;
+import org.jline.reader.impl.completer.AggregateCompleter;
+import org.jline.terminal.Terminal;
+import org.jline.terminal.TerminalBuilder;
+import org.jline.utils.AttributedStringBuilder;
+import org.jline.utils.AttributedStyle;
+
+/**
+ * Main Pulsar shell class invokable from the pulsar-shell script.
+ */
+public class PulsarShell {
+
+    private static final String EXIT_MESSAGE = "Goodbye!";
+    private static final String PROPERTY_PERSIST_HISTORY_ENABLED = "shellHistoryPersistEnabled";
+    private static final String PROPERTY_PERSIST_HISTORY_PATH = "shellHistoryPersistPath";
+
+    static final class MainOptions {
+        @Parameter(names = {"-h", "--help"}, help = true, description = "Show this help.")
+        boolean help;
+    }
+
+    public static void main(String[] args) throws Exception {
+        if (args.length == 0) {
+            System.out.println("Usage: pulsar-shell CONF_FILE_PATH");
+            System.exit(0);
+            return;
+        }
+
+        String configFile = args[0];
+        Properties properties = new Properties();
+        try (FileInputStream fis = new FileInputStream(configFile)) {
+            properties.load(fis);
+        }
+        new PulsarShell().run(properties);
+    }
+
+    public void run(Properties properties) throws Exception {
+        final Terminal terminal = TerminalBuilder.builder().build();
+        run(properties, (providersMap) -> {
+            List<Completer> completers = new ArrayList<>();
+            String serviceUrl = "";
+            String adminUrl = "";
+            for (ShellCommandsProvider provider : providersMap.values()) {
+                provider.setupState(properties);
+                final JCommander jCommander = provider.getJCommander();
+                if (jCommander != null) {
+                    jCommander.createDescriptions();
+                    completers.addAll(JCommanderCompleter
+                            .createCompletersForCommand(provider.getName(), jCommander));
+                }
+
+                final String providerServiceUrl = provider.getServiceUrl();
+                if (providerServiceUrl != null) {
+                    serviceUrl = providerServiceUrl;
+                }
+                final String providerAdminUrl = provider.getAdminUrl();
+                if (providerAdminUrl != null) {
+                    adminUrl = providerAdminUrl;
+                }
+            }
+
+            Completer completer = new AggregateCompleter(completers);
+
+            LineReaderBuilder readerBuilder = LineReaderBuilder.builder()
+                    .terminal(terminal)
+                    .completer(completer)
+                    .variable(LineReader.INDENTATION, 2)
+                    .option(LineReader.Option.INSERT_BRACKET, true);
+
+            configureHistory(properties, readerBuilder);
+            LineReader reader = readerBuilder.build();
+
+            final String welcomeMessage =
+                    String.format("Welcome to Pulsar shell!\n  Service URL: %s\n  Admin URL: %s\n\n "
+                                    + "Type 'help' to get started or try the autocompletion (TAB button).\n",
+                            serviceUrl, adminUrl);
+            output(welcomeMessage, terminal);
+            return reader;
+        }, (providerMap) -> terminal);
+    }
+
+    private void configureHistory(Properties properties, LineReaderBuilder readerBuilder) {
+        final boolean isPersistHistoryEnabled = Boolean.parseBoolean(properties.getProperty(
+                PROPERTY_PERSIST_HISTORY_ENABLED, "true"));
+        if (isPersistHistoryEnabled) {
+            final String persistHistoryPath = properties
+                    .getProperty(PROPERTY_PERSIST_HISTORY_PATH, Paths.get(System.getProperty("user.home"),
+                            ".pulsar-shell.history").toFile().getAbsolutePath());
+            readerBuilder
+                    .variable(LineReader.HISTORY_FILE, persistHistoryPath);
+        }
+    }
+
+    public void run(Properties properties,
+                    Function<Map<String, ShellCommandsProvider>, LineReader> readerBuilder,
+                    Function<Map<String, ShellCommandsProvider>, Terminal> terminalBuilder) throws Exception {
+        System.setProperty("org.jline.terminal.dumb", "true");
+
+        final JCommander mainCommander = new JCommander();
+        final MainOptions mainOptions = new MainOptions();
+        mainCommander.addObject(mainOptions);
+
+        final Map<String, ShellCommandsProvider> providersMap = registerProviders(mainCommander, properties);
+
+        final LineReader reader = readerBuilder.apply(providersMap);
+        final Terminal terminal = terminalBuilder.apply(providersMap);
+        final String prompt = createPrompt();
+        Runtime.getRuntime().addShutdownHook(new Thread(() -> quit(terminal)));
+        while (true) {
+            String line;
+            try {
+                line = reader.readLine(prompt).trim();
+            } catch (org.jline.reader.UserInterruptException userInterruptException) {
+                break;
+            }
+            if (line.isBlank()) {
+                continue;
+            }
+            if (isQuitCommand(line)) {
+                break;
+            }
+            final List<String> words = parseLine(reader, line);
+
+            if (mainOptions.help) {
+                mainCommander.usage();
+                continue;
+            }
+
+            final ShellCommandsProvider pulsarShellCommandsProvider = getProviderFromArgs(mainCommander, words);
+            if (pulsarShellCommandsProvider == null) {
+                mainCommander.usage();
+                continue;
+            }
+            String[] argv = extractAndConvertArgs(words);
+            try {
+                pulsarShellCommandsProvider.runCommand(argv);
+            } catch (Throwable t) {
+                t.printStackTrace(terminal.writer());
+            } finally {
+                pulsarShellCommandsProvider.cleanupState(properties);
+            }
+        }
+    }
+
+    private static ShellCommandsProvider getProviderFromArgs(JCommander mainCommander, List<String> words) {
+        final String providerCmd = words.get(0);
+        final JCommander commander = mainCommander.getCommands().get(providerCmd);
+        if (commander == null) {
+            return null;
+        }
+        return (ShellCommandsProvider) commander.getObjects().get(0);
+    }
+
+    private static String createPrompt() {
+        return new AttributedStringBuilder()
+                .style(AttributedStyle.DEFAULT.foreground(25, 143, 255).background(230, 241, 255))
+                .append("pulsar>")
+                .style(AttributedStyle.DEFAULT)
+                .append(" ")
+                .toAnsi();
+    }
+
+    private static List<String> parseLine(LineReader reader, String line) {
+        final ParsedLine pl = reader.getParser().parse(line, 0);
+        final List<String> words = pl.words();
+        return words;
+    }
+
+    private static void quit(Terminal terminal) {
+        output(EXIT_MESSAGE, terminal);
+    }
+
+    private static void output(String message, Terminal terminal) {
+        terminal.writer().println(message);
+        terminal.writer().flush();
+    }
+
+    private static boolean isQuitCommand(String line) {
+        return line.equalsIgnoreCase("quit") || line.equalsIgnoreCase("exit");
+    }
+
+    private static String[] extractAndConvertArgs(List<String> words) {
+        List<String> parsed = new ArrayList<>();
+        for (String s : words.subList(1, words.size())) {
+            if (s.startsWith("-") && s.contains("=")) {
+                final String[] split = s.split("=", 2);
+                parsed.add(split[0]);
+                parsed.add(split[1]);
+            } else {
+                parsed.add(s);
+            }
+        }
+
+        String[] argv = parsed.toArray(new String[parsed.size()]);
+        return argv;
+    }
+
+    private Map<String, ShellCommandsProvider> registerProviders(JCommander commander, Properties properties)
+            throws Exception {
+        final Map<String, ShellCommandsProvider> providerMap = new HashMap<>();
+        registerProvider(createAdminShell(properties), commander, providerMap);
+        registerProvider(createClientShell(properties), commander, providerMap);
+        return providerMap;
+    }
+
+    protected AdminShell createAdminShell(Properties properties) throws Exception {
+        return new AdminShell(properties);
+    }
+
+    protected ClientShell createClientShell(Properties properties) {
+        return new ClientShell(properties);
+    }
+
+    private static void registerProvider(ShellCommandsProvider provider,
+                                         JCommander commander,
+                                         Map<String, ShellCommandsProvider> providerMap) {
+
+        final String name = provider.getName();
+        commander.addCommand(name, provider);
+        providerMap.put(name, provider);
+    }
+
+}

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/shell/ShellCommandsProvider.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/shell/ShellCommandsProvider.java
@@ -1,0 +1,78 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.shell;
+
+import com.beust.jcommander.JCommander;
+import java.util.Properties;
+
+/**
+ * Commands provider for Pulsar shell.
+ */
+public interface ShellCommandsProvider {
+
+    /**
+     * Name of the commands. This will be used as program name.
+     * @return
+     */
+    String getName();
+
+    /**
+     * Current service url for connecting to brokers. If the provider doesn't need brokers connection
+     * or the service url is not set it must return null.
+     * @return service url
+     */
+    String getServiceUrl();
+
+    /**
+     * Current admin url for connecting to pulsar admin. If the provider doesn't need brokers connection
+     * or the admin url is not set it must return null.
+     * @return admin url
+     */
+    String getAdminUrl();
+
+    /**
+     * Init state before a command is executed.
+     * If the implementing class rely on JCommander, it's suggested to not recycle JCommander
+     * objects because they are meant to single-shot usage.
+     * @param properties
+     */
+    void setupState(Properties properties);
+
+    /**
+     * Cleanup state after a command is executed.
+     * If the implementing class rely on JCommander, it's suggested to not recycle JCommander
+     * objects because they are meant to single-shot usage.
+     * @param properties
+     */
+    void cleanupState(Properties properties);
+
+    /**
+     * Return JCommander instance, if exists.
+     * @return
+     */
+    JCommander getJCommander();
+
+    /**
+     * Run command for the passed args.
+     *
+     * @param args arguments for the command. Note that the first word of the user command is omitted.
+     * @throws Exception if any error occurs. The shell session will not be closed.
+     */
+    void runCommand(String[] args) throws Exception;
+}

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/shell/ShellCommandsProvider.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/shell/ShellCommandsProvider.java
@@ -74,5 +74,5 @@ public interface ShellCommandsProvider {
      * @param args arguments for the command. Note that the first word of the user command is omitted.
      * @throws Exception if any error occurs. The shell session will not be closed.
      */
-    void runCommand(String[] args) throws Exception;
+    boolean runCommand(String[] args) throws Exception;
 }

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/shell/package-info.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/shell/package-info.java
@@ -1,0 +1,19 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.shell;

--- a/pulsar-client-tools/src/test/java/org/apache/pulsar/shell/JCommanderCompleterTest.java
+++ b/pulsar-client-tools/src/test/java/org/apache/pulsar/shell/JCommanderCompleterTest.java
@@ -1,0 +1,43 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.shell;
+
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+import java.util.List;
+import java.util.Properties;
+import org.jline.reader.Completer;
+import org.testng.annotations.Test;
+
+public class JCommanderCompleterTest {
+
+    @Test
+    public void test() throws Exception {
+        final AdminShell shell = new AdminShell(new Properties());
+        shell.setupState(new Properties());
+        final List<Completer> completers = JCommanderCompleter.createCompletersForCommand("admin",
+                shell.getJCommander());
+        assertFalse(completers.isEmpty());
+        for (Completer completer : completers) {
+            assertTrue(completer instanceof OptionStrictArgumentCompleter);
+        }
+    }
+
+}

--- a/pulsar-client-tools/src/test/java/org/apache/pulsar/shell/PulsarShellTest.java
+++ b/pulsar-client-tools/src/test/java/org/apache/pulsar/shell/PulsarShellTest.java
@@ -1,0 +1,130 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.shell;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.Properties;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.atomic.AtomicReference;
+import lombok.SneakyThrows;
+import org.apache.pulsar.client.admin.PulsarAdmin;
+import org.apache.pulsar.client.admin.PulsarAdminBuilder;
+import org.apache.pulsar.client.admin.Topics;
+import org.apache.pulsar.client.cli.CmdProduce;
+import org.jline.reader.EndOfFileException;
+import org.jline.reader.UserInterruptException;
+import org.jline.reader.impl.LineReaderImpl;
+import org.jline.terminal.Terminal;
+import org.jline.terminal.TerminalBuilder;
+import org.powermock.reflect.Whitebox;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+
+
+public class PulsarShellTest {
+
+    private static final Logger log = LoggerFactory.getLogger(PulsarShellTest.class);
+
+    private PulsarAdminBuilder pulsarAdminBuilder;
+    private PulsarAdmin pulsarAdmin;
+
+    private Topics topics;
+
+    static class MockLineReader extends LineReaderImpl {
+
+        private BlockingQueue<String> commandsQueue = new LinkedBlockingQueue<>();
+
+        public MockLineReader(Terminal terminal) throws IOException {
+            super(terminal);
+        }
+
+        public void addCmd(String cmd) {
+            commandsQueue.add(cmd);
+        }
+
+        @Override
+        @SneakyThrows
+        public String readLine(String prompt) throws UserInterruptException, EndOfFileException {
+            final String cmd = commandsQueue.take();
+            log.info("writing command: {}", cmd);
+            return cmd;
+
+        }
+    }
+
+    @BeforeMethod(alwaysRun = true)
+    public void setup() throws Exception {
+        pulsarAdminBuilder = mock(PulsarAdminBuilder.class);
+        pulsarAdmin = mock(PulsarAdmin.class);
+        when(pulsarAdminBuilder.build()).thenReturn(pulsarAdmin);
+        topics = mock(Topics.class);
+        when(pulsarAdmin.topics()).thenReturn(topics);
+    }
+
+
+    @Test
+    public void mainTest() throws Exception{
+        AtomicReference<CmdProduce> cmdProduceHolder = new AtomicReference<>();
+        Terminal terminal = TerminalBuilder.builder().build();
+        final MockLineReader linereader = new MockLineReader(terminal);
+
+        final Properties props = new Properties();
+        props.setProperty("webServiceUrl", "http://localhost:8080");
+        linereader.addCmd("admin topics create my-topic --metadata a=b ");
+        linereader.addCmd("client produce -m msg my-topic");
+        linereader.addCmd("quit");
+        new PulsarShell(){
+            @Override
+            protected AdminShell createAdminShell(Properties properties) throws Exception {
+                return new AdminShell(properties) {
+                    @Override
+                    protected PulsarAdminBuilder createAdminBuilder(Properties properties) {
+                        return pulsarAdminBuilder;
+                    }
+                };
+            }
+
+            @Override
+            protected ClientShell createClientShell(Properties properties) {
+                final ClientShell clientShell = new ClientShell(properties);
+                final Object current = Whitebox.getInternalState(clientShell, "produceCommand");
+                cmdProduceHolder.set(spy((CmdProduce) current));
+                Whitebox.setInternalState(clientShell, "produceCommand", cmdProduceHolder.get());
+                return clientShell;
+            }
+
+        }.run(props, (a) -> linereader, (a) -> terminal);
+        verify(topics).createNonPartitionedTopic(eq("persistent://public/default/my-topic"), any(Map.class));
+        verify(cmdProduceHolder.get()).run();
+
+    }
+
+}

--- a/pulsar-client-tools/src/test/java/org/apache/pulsar/shell/PulsarShellTest.java
+++ b/pulsar-client-tools/src/test/java/org/apache/pulsar/shell/PulsarShellTest.java
@@ -21,10 +21,11 @@ package org.apache.pulsar.shell;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.fail;
 import java.io.IOException;
 import java.util.Map;
 import java.util.Properties;
@@ -80,6 +81,52 @@ public class PulsarShellTest {
         }
     }
 
+    private static class TestPulsarShell extends PulsarShell {
+
+        private final PulsarAdminBuilder pulsarAdminBuilder;
+        AtomicReference<CmdProduce> cmdProduceHolder = new AtomicReference<>();
+        Integer exitCode;
+
+        public TestPulsarShell(PulsarAdminBuilder pulsarAdminBuilder) {
+            this.pulsarAdminBuilder = pulsarAdminBuilder;
+        }
+
+        @Override
+        protected AdminShell createAdminShell(Properties properties) throws Exception {
+            return new AdminShell(properties) {
+                @Override
+                protected PulsarAdminBuilder createAdminBuilder(Properties properties) {
+                    return pulsarAdminBuilder;
+                }
+            };
+        }
+
+        @Override
+        protected ClientShell createClientShell(Properties properties) {
+            final ClientShell clientShell = new ClientShell(properties);
+            final CmdProduce cmdProduce = mock(CmdProduce.class);
+            cmdProduceHolder.set(cmdProduce);
+            Whitebox.setInternalState(clientShell, "produceCommand", cmdProduceHolder.get());
+            return clientShell;
+        }
+
+        @Override
+        protected void exit(int exitCode) {
+            this.exitCode = exitCode;
+            if (exitCode != 0) {
+                throw new SystemExitCalledException(exitCode);
+            }
+        }
+    }
+
+    private static class SystemExitCalledException extends RuntimeException {
+        private int code;
+
+        public SystemExitCalledException(int code) {
+            this.code = code;
+        }
+    }
+
     @BeforeMethod(alwaysRun = true)
     public void setup() throws Exception {
         pulsarAdminBuilder = mock(PulsarAdminBuilder.class);
@@ -91,8 +138,7 @@ public class PulsarShellTest {
 
 
     @Test
-    public void mainTest() throws Exception{
-        AtomicReference<CmdProduce> cmdProduceHolder = new AtomicReference<>();
+    public void testInteractiveMode() throws Exception{
         Terminal terminal = TerminalBuilder.builder().build();
         final MockLineReader linereader = new MockLineReader(terminal);
 
@@ -101,30 +147,50 @@ public class PulsarShellTest {
         linereader.addCmd("admin topics create my-topic --metadata a=b ");
         linereader.addCmd("client produce -m msg my-topic");
         linereader.addCmd("quit");
-        new PulsarShell(){
-            @Override
-            protected AdminShell createAdminShell(Properties properties) throws Exception {
-                return new AdminShell(properties) {
-                    @Override
-                    protected PulsarAdminBuilder createAdminBuilder(Properties properties) {
-                        return pulsarAdminBuilder;
-                    }
-                };
-            }
-
-            @Override
-            protected ClientShell createClientShell(Properties properties) {
-                final ClientShell clientShell = new ClientShell(properties);
-                final Object current = Whitebox.getInternalState(clientShell, "produceCommand");
-                cmdProduceHolder.set(spy((CmdProduce) current));
-                Whitebox.setInternalState(clientShell, "produceCommand", cmdProduceHolder.get());
-                return clientShell;
-            }
-
-        }.run(props, (a) -> linereader, (a) -> terminal);
+        final TestPulsarShell testPulsarShell = new TestPulsarShell(pulsarAdminBuilder);
+        testPulsarShell.run(new String[]{}, props, (a) -> linereader, (a) -> terminal);
         verify(topics).createNonPartitionedTopic(eq("persistent://public/default/my-topic"), any(Map.class));
-        verify(cmdProduceHolder.get()).run();
+        verify(testPulsarShell.cmdProduceHolder.get()).run();
+        assertEquals((int) testPulsarShell.exitCode, 0);
 
+    }
+
+    @Test
+    public void testFileMode() throws Exception{
+        Terminal terminal = TerminalBuilder.builder().build();
+        final MockLineReader linereader = new MockLineReader(terminal);
+        final Properties props = new Properties();
+        props.setProperty("webServiceUrl", "http://localhost:8080");
+
+        final String shellFile = Thread.currentThread()
+                .getContextClassLoader().getResource("test-shell-file").getFile();
+
+        final TestPulsarShell testPulsarShell = new TestPulsarShell(pulsarAdminBuilder);
+        testPulsarShell.run(new String[]{"-f", shellFile}, props, (a) -> linereader, (a) -> terminal);
+        verify(topics).createNonPartitionedTopic(eq("persistent://public/default/my-topic"), any(Map.class));
+        verify(testPulsarShell.cmdProduceHolder.get()).run();
+    }
+
+    @Test
+    public void testFileModeExitOnError() throws Exception{
+        Terminal terminal = TerminalBuilder.builder().build();
+        final MockLineReader linereader = new MockLineReader(terminal);
+        final Properties props = new Properties();
+        props.setProperty("webServiceUrl", "http://localhost:8080");
+
+        final String shellFile = Thread.currentThread()
+                .getContextClassLoader().getResource("test-shell-file-error").getFile();
+
+        final TestPulsarShell testPulsarShell = new TestPulsarShell(pulsarAdminBuilder);
+        try {
+            testPulsarShell.run(new String[]{"-f", shellFile, "-e"}, props, (a) -> linereader, (a) -> terminal);
+            fail();
+        }  catch (SystemExitCalledException ex) {
+            assertEquals(ex.code, 1);
+        }
+
+        verify(topics).createNonPartitionedTopic(eq("persistent://public/default/my-topic"), any(Map.class));
+        verify(testPulsarShell.cmdProduceHolder.get(), times(0)).run();
     }
 
 }

--- a/pulsar-client-tools/src/test/java/org/apache/pulsar/shell/PulsarShellTest.java
+++ b/pulsar-client-tools/src/test/java/org/apache/pulsar/shell/PulsarShellTest.java
@@ -27,6 +27,8 @@ import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.fail;
 import java.io.IOException;
+import java.util.Arrays;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.BlockingQueue;
@@ -172,7 +174,7 @@ public class PulsarShellTest {
     }
 
     @Test
-    public void testFileModeExitOnError() throws Exception{
+    public void testFileModeExitOnError() throws Exception {
         Terminal terminal = TerminalBuilder.builder().build();
         final MockLineReader linereader = new MockLineReader(terminal);
         final Properties props = new Properties();
@@ -193,4 +195,30 @@ public class PulsarShellTest {
         verify(testPulsarShell.cmdProduceHolder.get(), times(0)).run();
     }
 
+    @Test
+    public void testSubstituteVariables() throws Exception {
+        Map<String, String> vars = new HashMap<>();
+        vars.put("mytopic", "the-topic");
+        assertEquals(
+                PulsarShell.substituteVariables(Arrays.asList("admin", "topics", "create", "${mytopic}"), vars),
+                Arrays.asList("admin", "topics", "create", "the-topic")
+        );
+        assertEquals(
+                PulsarShell.substituteVariables(Arrays.asList("admin", "topics", "create", "\\${mytopic}"), vars),
+                Arrays.asList("admin", "topics", "create", "${mytopic}")
+        );
+        assertEquals(
+                PulsarShell.substituteVariables(Arrays.asList("admin", "topics", "create", "${MYTOPIC}"), vars),
+                Arrays.asList("admin", "topics", "create", "${MYTOPIC}")
+        );
+        assertEquals(
+                PulsarShell.substituteVariables(Arrays.asList("admin", "topics", "create", "$mytopic"), vars),
+                Arrays.asList("admin", "topics", "create", "the-topic")
+        );
+        assertEquals(
+                PulsarShell.substituteVariables(Arrays.asList("admin", "topics", "create", "\\$mytopic"), vars),
+                Arrays.asList("admin", "topics", "create", "$mytopic")
+        );
+
+    }
 }

--- a/pulsar-client-tools/src/test/resources/test-shell-file
+++ b/pulsar-client-tools/src/test/resources/test-shell-file
@@ -1,0 +1,3 @@
+admin topics create my-topic --metadata a=b
+
+client produce -m msg my-topic

--- a/pulsar-client-tools/src/test/resources/test-shell-file-error
+++ b/pulsar-client-tools/src/test/resources/test-shell-file-error
@@ -1,0 +1,3 @@
+admin topics create my-topic --metadata a=b
+admin notexist-command
+client produce -m msg my-topic


### PR DESCRIPTION
Master Issue: #16250 

### Motivation

In order to help cluster operators to create scripts and automation around Pulsar shell, it's very useful to have the possibility to read env variables inside the cli.

### Modifications
- Added Bash variable replacement inside the CLI. The only supported formats are ${variable:-default} and $variable.
- The replacement is handled by commons-text library  (`StringsSubstitutor`).


Usages:
```
export tenant=mytenant
export namespace=mynamespace

./bin/pulsar-shell
pulsar> admin tenants create $tenant
pulsar> admin tenants create $tenant/$namespace

```


- [x] `doc-required` 