### PR TITLE
[improve][cli] Pulsar shell: include pulsar-shell in released tarballs - part 2

### DIFF
--- a/bin/pulsar-shell
+++ b/bin/pulsar-shell
@@ -17,6 +17,7 @@
 # specific language governing permissions and limitations
 # under the License.
 #
+
 # need this for relative symlinks
 PRG="$0"
 while [ -h "$PRG" ] ; do

--- a/bin/pulsar-shell
+++ b/bin/pulsar-shell
@@ -17,8 +17,19 @@
 # specific language governing permissions and limitations
 # under the License.
 #
+# need this for relative symlinks
+PRG="$0"
+while [ -h "$PRG" ] ; do
+  ls=`ls -ld "$PRG"`
+  link=`expr "$ls" : '.*-> \(.*\)$'`
+  if expr "$link" : '/.*' > /dev/null; then
+    PRG="$link"
+  else
+    PRG="`dirname "$PRG"`/$link"
+  fi
+done
 
-BINDIR=$(dirname "$0")
+BINDIR=$(dirname "$PRG")
 export PULSAR_HOME=`cd -P $BINDIR/..;pwd`
 . "$PULSAR_HOME/bin/pulsar-admin-common.sh"
 OPTS="-Dorg.jline.terminal.jansi=false $OPTS"

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -44,6 +44,7 @@
         <module>io</module>
         <module>offloaders</module>
         <module>server</module>
+        <module>shell</module>
       </modules>
     </profile>
 

--- a/distribution/shell/pom.xml
+++ b/distribution/shell/pom.xml
@@ -1,0 +1,89 @@
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.apache.pulsar</groupId>
+    <artifactId>distribution</artifactId>
+    <version>2.11.0-SNAPSHOT</version>
+    <relativePath>..</relativePath>
+  </parent>
+
+  <artifactId>pulsar-shell-distribution</artifactId>
+  <packaging>pom</packaging>
+  <name>Pulsar :: Distribution :: Shell</name>
+
+  <dependencies>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>pulsar-client-tools</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-core</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-web</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-slf4j-impl</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.prometheus</groupId>
+      <artifactId>simpleclient_log4j2</artifactId>
+    </dependency>
+
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-assembly-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>distro-assembly</id>
+            <phase>package</phase>
+            <goals>
+              <goal>single</goal>
+            </goals>
+            <configuration>
+              <attach>true</attach>
+              <tarLongFileMode>posix</tarLongFileMode>
+              <finalName>apache-pulsar-shell-${project.version}</finalName>
+              <descriptors>
+                <descriptor>src/assemble/shell.xml</descriptor>
+              </descriptors>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/distribution/shell/src/assemble/README
+++ b/distribution/shell/src/assemble/README
@@ -1,0 +1,4 @@
+
+Please refer to http://pulsar.apache.org/ for access to documentation.
+
+This package contains Pulsar shell and all the dependencies to run it.

--- a/distribution/shell/src/assemble/shell.xml
+++ b/distribution/shell/src/assemble/shell.xml
@@ -1,0 +1,72 @@
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<assembly xmlns="http://maven.apache.org/ASSEMBLY/2.1.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/ASSEMBLY/2.1.0 http://maven.apache.org/xsd/assembly-2.1.0.xsd">
+  <id>shell</id>
+  <formats>
+    <format>tar.gz</format>
+  </formats>
+  <includeBaseDirectory>true</includeBaseDirectory>
+  <files>
+    <file>
+      <source>${basedir}/../../LICENSE</source>
+      <outputDirectory>.</outputDirectory>
+      <fileMode>644</fileMode>
+    </file>
+    <file>
+      <source>${basedir}/src/assemble/README</source>
+      <destName>README</destName>
+      <outputDirectory>.</outputDirectory>
+      <fileMode>644</fileMode>
+    </file>
+
+    <file>
+      <outputDirectory>bin</outputDirectory>
+      <source>${basedir}/../../bin/pulsar-admin-common.sh</source>
+      <fileMode>755</fileMode>
+    </file>
+    <file>
+      <outputDirectory>bin</outputDirectory>
+      <source>${basedir}/../../bin/pulsar-shell</source>
+      <fileMode>755</fileMode>
+    </file>
+    <file>
+      <outputDirectory>conf</outputDirectory>
+      <source>${basedir}/../../conf/client.conf</source>
+    </file>
+    <file>
+      <outputDirectory>conf</outputDirectory>
+      <source>${basedir}/../../conf/log4j2.yaml</source>
+    </file>
+  </files>
+
+  <dependencySets>
+    <dependencySet>
+      <outputDirectory>lib</outputDirectory>
+      <unpack>false</unpack>
+      <scope>compile</scope>
+      <excludes>
+        <exclude>org.projectlombok:lombok</exclude>
+      </excludes>
+    </dependencySet>
+  </dependencySets>
+</assembly>

--- a/pulsar-client-tools/pom.xml
+++ b/pulsar-client-tools/pom.xml
@@ -19,7 +19,7 @@
 
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.apache.pulsar</groupId>
@@ -71,6 +71,10 @@
       <artifactId>netty-reactive-streams</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.conscrypt</groupId>
+      <artifactId>conscrypt-openjdk-uber</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
     </dependency>
@@ -104,10 +108,10 @@
     </dependency>
 
     <dependency>
-    	<groupId>org.apache.pulsar</groupId>
-    	<artifactId>pulsar-io-batch-discovery-triggerers</artifactId>
-    	<version>${project.version}</version>
-    	<scope>test</scope>
+      <groupId>org.apache.pulsar</groupId>
+      <artifactId>pulsar-io-batch-discovery-triggerers</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.jline</groupId>


### PR DESCRIPTION
Master Issue: #16250
### Motivation
See master issue under "Distribution" section.

### Changes

New tarball `pulsar-shell` under `distribution` directory. It generates a tarball with:
- `pulsar-client-tools` dependency (and transitive)
- log dependencies
- README + NOTICE as other packages
- bin/pulsar-shell and bin/pulsar-admin-common.sh scripts
- conf/client.conf for default configuration

- [x] `doc-required` 
