### PR TITLE
[improve][java-client] Improve performance of multi-topic consumer with more than one IO thread

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBase.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBase.java
@@ -831,6 +831,9 @@ public abstract class ConsumerBase<T> extends HandlerState implements Consumer<T
     protected abstract void updateAutoScaleReceiverQueueHint();
 
     protected boolean hasEnoughMessagesForBatchReceive() {
+        if (batchReceivePolicy.getTimeoutMs() <= 0) {
+            return true;
+        }
         if (batchReceivePolicy.getMaxNumMessages() <= 0 && batchReceivePolicy.getMaxNumBytes() <= 0) {
             return false;
         }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBase.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBase.java
@@ -831,9 +831,6 @@ public abstract class ConsumerBase<T> extends HandlerState implements Consumer<T
     protected abstract void updateAutoScaleReceiverQueueHint();
 
     protected boolean hasEnoughMessagesForBatchReceive() {
-        if (batchReceivePolicy.getTimeoutMs() <= 0) {
-            return true;
-        }
         if (batchReceivePolicy.getMaxNumMessages() <= 0 && batchReceivePolicy.getMaxNumBytes() <= 0) {
             return false;
         }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MessagesImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MessagesImpl.java
@@ -80,7 +80,7 @@ public class MessagesImpl<T> implements Messages<T> {
         this.messageList.clear();
     }
 
-    public List<Message<T>> getMessageList() {
+    List<Message<T>> getMessageList() {
         return messageList;
     }
 

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MessagesImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MessagesImpl.java
@@ -29,7 +29,7 @@ import org.apache.pulsar.client.api.Messages;
 @NotThreadSafe
 public class MessagesImpl<T> implements Messages<T> {
 
-    private List<Message<T>> messageList;
+    private final List<Message<T>> messageList;
 
     private final int maxNumberOfMessages;
     private final long maxSizeOfMessages;
@@ -78,6 +78,10 @@ public class MessagesImpl<T> implements Messages<T> {
         this.currentNumberOfMessages = 0;
         this.currentSizeOfMessages = 0;
         this.messageList.clear();
+    }
+
+    public List<Message<T>> getMessageList() {
+        return messageList;
     }
 
     @Override

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiTopicsConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiTopicsConsumerImpl.java
@@ -1129,7 +1129,7 @@ public class MultiTopicsConsumerImpl<T> extends ConsumerBase<T> {
         BatchReceivePolicy internalBatchReceivePolicy = BatchReceivePolicy.builder()
                 .maxNumMessages(Math.max(configurationData.getReceiverQueueSize() / 2, 1))
                 .maxNumBytes(-1)
-                .timeout(0, TimeUnit.MILLISECONDS)
+                .timeout(1, TimeUnit.MILLISECONDS)
                 .build();
         configurationData.setBatchReceivePolicy(internalBatchReceivePolicy);
         return ConsumerImpl.newConsumerImpl(client, partitionName,


### PR DESCRIPTION
### Motivation

After running the test with the partitioned topic(partitioned topic with only 1 partition) and 4 IO threads.

```
bin/pulsar-perf produce test -r 500000 -s 1 -o 10000 -threads 2
bin/pulsar-perf consume test -q 100000 -ioThreads 4
```

The consumer got a very bad performance:

```
Profiling started

2022-07-01T23:03:13,230+0800 [main] INFO  org.apache.pulsar.testclient.PerformanceConsumer - Throughput received:  216223 msg --- 21517.245  msg/s --- 0.164 Mbit/s  --- Latency: mean: 2702.319 ms - med: 2644 - 95pct: 4594 - 99pct: 4758 - 99.9pct: 4844 - 99.99pct: 4854 - Max: 4854
2022-07-01T23:03:23,494+0800 [main] INFO  org.apache.pulsar.testclient.PerformanceConsumer - Throughput received:  812896 msg --- 58004.006  msg/s --- 0.443 Mbit/s  --- Latency: mean: 9826.540 ms - med: 9992 - 95pct: 12905 - 99pct: 13210 - 99.9pct: 13284 - 99.99pct: 13288 - Max: 13288
2022-07-01T23:03:33,506+0800 [main] INFO  org.apache.pulsar.testclient.PerformanceConsumer - Throughput received: 1548826 msg --- 73501.942  msg/s --- 0.561 Mbit/s  --- Latency: mean: 18000.596 ms - med: 18038 - 95pct: 22170 - 99pct: 22501 - 99.9pct: 22585 - 99.99pct: 22593 - Max: 22594
2022-07-01T23:03:43,519+0800 [main] INFO  org.apache.pulsar.testclient.PerformanceConsumer - Throughput received: 2271634 msg --- 72190.579  msg/s --- 0.551 Mbit/s  --- Latency: mean: 26907.162 ms - med: 26914 - 95pct: 30770 - 99pct: 31196 - 99.9pct: 31290 - 99.99pct: 31297 - Max: 31298
2022-07-01T23:03:53,527+0800 [main] INFO  org.apache.pulsar.testclient.PerformanceConsumer - Throughput received: 2852575 msg --- 58021.315  msg/s --- 0.443 Mbit/s  --- Latency: mean: 35547.844 ms - med: 35503 - 95pct: 39662 - 99pct: 40044 - 99.9pct: 40120 - 99.99pct: 40129 - Max: 40130
2022-07-01T23:04:03,539+0800 [main] INFO  org.apache.pulsar.testclient.PerformanceConsumer - Throughput received: 3317622 msg --- 46424.278  msg/s --- 0.354 Mbit/s  --- Latency: mean: 44615.969 ms - med: 44597 - 95pct: 48807 - 99pct: 49149 - 99.9pct: 49218 - 99.99pct: 49224 - Max: 49225
2022-07-01T23:04:13,554+0800 [main] INFO  org.apache.pulsar.testclient.PerformanceConsumer - Throughput received: 3715533 msg --- 39746.763  msg/s --- 0.303 Mbit/s  --- Latency: mean: 53487.733 ms - med: 53445 - 95pct: 57427 - 99pct: 58195 - 99.9pct: 58413 - 99.99pct: 58425 - Max: 58443
```

<img width="1849" alt="image" src="https://user-images.githubusercontent.com/12592133/176934828-18c2d258-4902-4aee-9c84-9582310e4823.png">

[consumer01.html.txt](https://github.com/apache/pulsar/files/9030384/consumer01.html.txt)

Use batch receive in the MultiTopicsConsumerImpl internal to fix the performance issue.
After this PR:

```
Profiling started

2022-07-04T18:11:26,136+0800 [main] INFO  org.apache.pulsar.testclient.PerformanceConsumer - Throughput received: 113768036 msg --- 1033960.241  msg/s --- 7.888 Mbit/s  --- Latency: mean: 26.907 ms - med: 11 - 95pct: 186 - 99pct: 333 - 99.9pct: 345 - 99.99pct: 346 - Max: 347
2022-07-04T18:11:36,148+0800 [main] INFO  org.apache.pulsar.testclient.PerformanceConsumer - Throughput received: 123437199 msg --- 965982.869  msg/s --- 7.370 Mbit/s  --- Latency: mean: 17.216 ms - med: 11 - 95pct: 81 - 99pct: 100 - 99.9pct: 202 - 99.99pct: 231 - Max: 242
Profiling started
2022-07-04T18:11:46,163+0800 [main] INFO  org.apache.pulsar.testclient.PerformanceConsumer - Throughput received: 133784660 msg --- 1033280.877  msg/s --- 7.883 Mbit/s  --- Latency: mean: 29.536 ms - med: 11 - 95pct: 169 - 99pct: 194 - 99.9pct: 198 - 99.99pct: 200 - Max: 200
2022-07-04T18:11:56,176+0800 [main] INFO  org.apache.pulsar.testclient.PerformanceConsumer - Throughput received: 143800200 msg --- 1000179.779  msg/s --- 7.631 Mbit/s  --- Latency: mean: 10.326 ms - med: 10 - 95pct: 17 - 99pct: 23 - 99.9pct: 28 - 99.99pct: 29 - Max: 30
2022-07-04T18:12:06,192+0800 [main] INFO  org.apache.pulsar.testclient.PerformanceConsumer - Throughput received: 153796349 msg --- 998201.268  msg/s --- 7.616 Mbit/s  --- Latency: mean: 12.046 ms - med: 9 - 95pct: 29 - 99pct: 35 - 99.9pct: 36 - 99.99pct: 37 - Max: 39
```

<img width="1844" alt="image" src="https://user-images.githubusercontent.com/12592133/176934992-bc53888a-eaff-4504-8bbb-71efb69bbcc4.png">

[consumer2.html.txt](https://github.com/apache/pulsar/files/9030386/consumer2.html.txt)

### Documentation

Check the box below or label this PR directly.

Need to update docs? 

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)
  
- [x] `doc-not-needed` 
(Please explain why)
  
- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)