### PR TITLE
[StructuredEventLog] Added support for Log4j2 structured logging if available

### DIFF
--- a/structured-event-log/pom.xml
+++ b/structured-event-log/pom.xml
@@ -37,6 +37,13 @@
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>
+
+    <!-- Optional runtime dependency on Log4j2 -->
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-core</artifactId>
+      <scope>provided</scope>
+    </dependency>
     <dependency>
       <groupId>org.hamcrest</groupId>
       <artifactId>hamcrest</artifactId>

--- a/structured-event-log/src/main/java/org/apache/pulsar/structuredeventlog/Initializer.java
+++ b/structured-event-log/src/main/java/org/apache/pulsar/structuredeventlog/Initializer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/structured-event-log/src/main/java/org/apache/pulsar/structuredeventlog/Initializer.java
+++ b/structured-event-log/src/main/java/org/apache/pulsar/structuredeventlog/Initializer.java
@@ -1,0 +1,44 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.structuredeventlog;
+
+import org.apache.pulsar.structuredeventlog.log4j2.Log4j2StructuredEventLog;
+import org.apache.pulsar.structuredeventlog.slf4j.Slf4jStructuredEventLog;
+
+class Initializer {
+    static StructuredEventLog get() {
+        return INSTANCE;
+    }
+
+    private static final StructuredEventLog INSTANCE;
+
+    static {
+        StructuredEventLog log = null;
+        try {
+            // Use Log4j2 if available in the classpath
+            Class.forName("org.apache.logging.log4j.LogManager");
+            log = Log4j2StructuredEventLog.INSTANCE;
+        } catch (Throwable t) {
+            // Fallback to Slf4j otherwise
+            log = Slf4jStructuredEventLog.INSTANCE;
+        }
+
+        INSTANCE = log;
+    }
+}

--- a/structured-event-log/src/main/java/org/apache/pulsar/structuredeventlog/StructuredEventLog.java
+++ b/structured-event-log/src/main/java/org/apache/pulsar/structuredeventlog/StructuredEventLog.java
@@ -18,8 +18,6 @@
  */
 package org.apache.pulsar.structuredeventlog;
 
-import org.apache.pulsar.structuredeventlog.slf4j.Slf4jStructuredEventLog;
-
 /**
  * Structured event logging interface
  *
@@ -85,7 +83,7 @@ public interface StructuredEventLog {
     /**
      * Create a new logger object, from which root events can be created.
      */
-    static StructuredEventLog newLogger() {
-        return Slf4jStructuredEventLog.INSTANCE;
+    static StructuredEventLog get() {
+        return Initializer.get();
     }
 }

--- a/structured-event-log/src/main/java/org/apache/pulsar/structuredeventlog/log4j2/Log4j2Event.java
+++ b/structured-event-log/src/main/java/org/apache/pulsar/structuredeventlog/log4j2/Log4j2Event.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/structured-event-log/src/main/java/org/apache/pulsar/structuredeventlog/log4j2/Log4j2Event.java
+++ b/structured-event-log/src/main/java/org/apache/pulsar/structuredeventlog/log4j2/Log4j2Event.java
@@ -1,0 +1,208 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.structuredeventlog.log4j2;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.message.StringMapMessage;
+import org.apache.pulsar.structuredeventlog.Event;
+import org.apache.pulsar.structuredeventlog.EventResources;
+import org.apache.pulsar.structuredeventlog.EventResourcesImpl;
+
+class Log4j2Event implements Event {
+    private static final Logger stringLogger = LogManager.getLogger();
+
+    private final Clock clock;
+    private String traceId = null;
+    private String parentId = null;
+    private List<Object> attributes = null;
+    private Level level = Level.INFO;
+    private Throwable throwable = null;
+    private Instant startTime = null;
+    private final EventResourcesImpl resources;
+
+    Log4j2Event(Clock clock, EventResourcesImpl parentResources) {
+        this.clock = clock;
+        this.resources = new EventResourcesImpl(parentResources);
+    }
+
+    @Override
+    public Event newChildEvent() {
+        return new Log4j2Event(clock, resources).traceId(traceId);
+    }
+
+    @Override
+    public Event traceId(String traceId) {
+        this.traceId = traceId;
+        return this;
+    }
+
+    @Override
+    public Event parentId(String parentId) {
+        this.parentId = parentId;
+        return this;
+    }
+
+    @Override
+    public Event timed() {
+        startTime = clock.instant();
+        return this;
+    }
+
+    @Override
+    public Event sampled(Object samplingKey, int duration, TimeUnit unit) {
+        throw new UnsupportedOperationException("TODO");
+    }
+
+    @Override
+    public Event resources(EventResources other) {
+        if (other instanceof EventResourcesImpl) {
+            this.resources.copyFrom((EventResourcesImpl) other);
+        }
+        return this;
+    }
+
+    @Override
+    public Event resource(String key, Object value) {
+        resources.resource(key, value);
+        return this;
+    }
+
+    @Override
+    public Event resource(String key, Supplier<String> value) {
+        resources.resource(key, value);
+        return this;
+    }
+
+    @Override
+    public Event attr(String key, Object value) {
+        getAttributes().add(key);
+        getAttributes().add(value);
+        return this;
+    }
+
+    @Override
+    public Event attr(String key, Supplier<String> value) {
+        this.attr(key, (Object) value);
+        return this;
+    }
+
+    @Override
+    public Event exception(Throwable t) {
+        this.throwable = t;
+        return this;
+    }
+
+    @Override
+    public Event atError() {
+        this.level = Level.ERROR;
+        return this;
+    }
+
+    @Override
+    public Event atInfo() {
+        this.level = Level.INFO;
+        return this;
+    }
+
+    @Override
+    public Event atWarn() {
+        this.level = Level.WARN;
+        return this;
+    }
+
+    @Override
+    public void log(Enum<?> event) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void log(String event) {
+        logInternal(stringLogger, event);
+    }
+
+    private void logInternal(Logger logger, String msg) {
+        StringMapMessage event = new StringMapMessage();
+        event.with("msg", msg);
+        if (traceId != null) {
+            event.with("traceId", traceId);
+        }
+        if (parentId != null) {
+            event.with("parentId", parentId);
+        }
+        resources.forEach(event::with);
+        if (attributes != null) {
+            EventResourcesImpl.forEach(attributes, event::with);
+        }
+        if (startTime != null) {
+            event.with("startTimestamp", startTime.toString());
+            event.with("durationMs", String.valueOf(Duration.between(startTime, clock.instant()).toMillis()));
+        }
+        switch (level) {
+            case ERROR:
+                if (throwable != null) {
+
+                    logger.error(event, throwable);
+                } else {
+                    logger.error(event);
+                }
+                break;
+            case WARN:
+                if (throwable != null) {
+                    logger.warn(event, throwable);
+                } else {
+                    logger.warn(event);
+                }
+                break;
+            case INFO:
+            default:
+                if (throwable != null) {
+                    logger.info(event, throwable);
+                } else {
+                    logger.info(event);
+                }
+                break;
+        }
+    }
+
+    @Override
+    public void stash() {
+        throw new UnsupportedOperationException("TODO");
+    }
+
+    private List<Object> getAttributes() {
+        if (attributes == null) {
+            attributes = new ArrayList<>();
+        }
+        return attributes;
+    }
+
+    enum Level {
+        INFO,
+        WARN,
+        ERROR
+    }
+}

--- a/structured-event-log/src/main/java/org/apache/pulsar/structuredeventlog/log4j2/Log4j2StructuredEventLog.java
+++ b/structured-event-log/src/main/java/org/apache/pulsar/structuredeventlog/log4j2/Log4j2StructuredEventLog.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/structured-event-log/src/main/java/org/apache/pulsar/structuredeventlog/log4j2/Log4j2StructuredEventLog.java
+++ b/structured-event-log/src/main/java/org/apache/pulsar/structuredeventlog/log4j2/Log4j2StructuredEventLog.java
@@ -1,0 +1,46 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.structuredeventlog.log4j2;
+
+import java.time.Clock;
+import org.apache.pulsar.structuredeventlog.Event;
+import org.apache.pulsar.structuredeventlog.EventResources;
+import org.apache.pulsar.structuredeventlog.EventResourcesImpl;
+import org.apache.pulsar.structuredeventlog.StructuredEventLog;
+
+public class Log4j2StructuredEventLog implements StructuredEventLog {
+    public static final Log4j2StructuredEventLog INSTANCE = new Log4j2StructuredEventLog();
+    // Visible for testing
+    Clock clock = Clock.systemUTC();
+
+    @Override
+    public Event newRootEvent() {
+        return new Log4j2Event(clock, null);
+    }
+
+    @Override
+    public EventResources newEventResources() {
+        return new EventResourcesImpl(null);
+    }
+
+    @Override
+    public Event unstash() {
+        throw new UnsupportedOperationException("TODO");
+    }
+}

--- a/structured-event-log/src/main/java/org/apache/pulsar/structuredeventlog/log4j2/package-info.java
+++ b/structured-event-log/src/main/java/org/apache/pulsar/structuredeventlog/log4j2/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/structured-event-log/src/main/java/org/apache/pulsar/structuredeventlog/log4j2/package-info.java
+++ b/structured-event-log/src/main/java/org/apache/pulsar/structuredeventlog/log4j2/package-info.java
@@ -1,0 +1,19 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.structuredeventlog.log4j2;

--- a/structured-event-log/src/test/java/org/apache/pulsar/structuredeventlog/slf4j/StructuredEventLogTest.java
+++ b/structured-event-log/src/test/java/org/apache/pulsar/structuredeventlog/slf4j/StructuredEventLogTest.java
@@ -76,7 +76,7 @@ public class StructuredEventLogTest {
 
     @Test
     public void testTraceId() throws Exception {
-        StructuredEventLog log = StructuredEventLog.newLogger();
+        StructuredEventLog log = StructuredEventLog.get();
 
         Event e = log.newRootEvent();
         e.newChildEvent().log("child");
@@ -97,7 +97,7 @@ public class StructuredEventLogTest {
 
     @Test
     public void testParentId() throws Exception {
-        StructuredEventLog log = StructuredEventLog.newLogger();
+        StructuredEventLog log = StructuredEventLog.get();
 
         Event e1 = log.newRootEvent();
         Event e2 = e1.newChildEvent();
@@ -124,7 +124,7 @@ public class StructuredEventLogTest {
 
     @Test
     public void testResources() throws Exception {
-        StructuredEventLog log = StructuredEventLog.newLogger();
+        StructuredEventLog log = StructuredEventLog.get();
 
         EventResources res = log.newEventResources()
             .resource("r1", "v1")
@@ -167,7 +167,7 @@ public class StructuredEventLogTest {
 
     @Test
     public void testResourcesNullTest() throws Exception {
-        StructuredEventLog log = StructuredEventLog.newLogger();
+        StructuredEventLog log = StructuredEventLog.get();
 
         EventResources res = log.newEventResources()
             .resource(null, "v1")
@@ -205,7 +205,7 @@ public class StructuredEventLogTest {
 
     @Test
     public void testAttributes() throws Exception {
-        StructuredEventLog log = StructuredEventLog.newLogger();
+        StructuredEventLog log = StructuredEventLog.get();
 
         Event e1 = log.newRootEvent()
             .attr("a1", "v1")
@@ -238,7 +238,7 @@ public class StructuredEventLogTest {
 
     @Test
     public void testAttributedNullTest() throws Exception {
-        StructuredEventLog log = StructuredEventLog.newLogger();
+        StructuredEventLog log = StructuredEventLog.get();
 
         log.newRootEvent()
             .attr(null, "v1")
@@ -262,7 +262,7 @@ public class StructuredEventLogTest {
 
     @Test
     public void testInfoLevel() throws Exception {
-        StructuredEventLog log = StructuredEventLog.newLogger();
+        StructuredEventLog log = StructuredEventLog.get();
 
         log.newRootEvent().log("info1");
         log.newRootEvent().atInfo().log("info2");
@@ -281,7 +281,7 @@ public class StructuredEventLogTest {
     @SuppressWarnings("unchecked")
     @Test
     public void testInfoLevelException() throws Exception {
-        StructuredEventLog log = StructuredEventLog.newLogger();
+        StructuredEventLog log = StructuredEventLog.get();
 
         log.newRootEvent().exception(new Throwable("cause1")).log("info1");
         log.newRootEvent().atInfo().exception(new Throwable("cause2")).log("info2");
@@ -296,7 +296,7 @@ public class StructuredEventLogTest {
 
     @Test
     public void testWarnLevel() throws Exception {
-        StructuredEventLog log = StructuredEventLog.newLogger();
+        StructuredEventLog log = StructuredEventLog.get();
 
         log.newRootEvent().atWarn().log("warn1");
 
@@ -308,7 +308,7 @@ public class StructuredEventLogTest {
     @SuppressWarnings("unchecked")
     @Test
     public void testWarnLevelException() throws Exception {
-        StructuredEventLog log = StructuredEventLog.newLogger();
+        StructuredEventLog log = StructuredEventLog.get();
 
         log.newRootEvent().atWarn().exception(new Throwable("cause1")).log("warn1");
 
@@ -319,7 +319,7 @@ public class StructuredEventLogTest {
 
     @Test
     public void testErrorLevel() throws Exception {
-        StructuredEventLog log = StructuredEventLog.newLogger();
+        StructuredEventLog log = StructuredEventLog.get();
 
         log.newRootEvent().atError().log("error1");
 
@@ -331,7 +331,7 @@ public class StructuredEventLogTest {
     @SuppressWarnings("unchecked")
     @Test
     public void testErrorLevelException() throws Exception {
-        StructuredEventLog log = StructuredEventLog.newLogger();
+        StructuredEventLog log = StructuredEventLog.get();
 
         log.newRootEvent().atError().exception(new Throwable("cause1")).log("error1");
 
@@ -344,7 +344,7 @@ public class StructuredEventLogTest {
     @Test
     public void testTimedEvent() throws Exception {
         MockClock clock = new MockClock();
-        StructuredEventLog log = StructuredEventLog.newLogger();
+        StructuredEventLog log = StructuredEventLog.get();
         ((Slf4jStructuredEventLog)log).clock = clock;
         Event e = log.newRootEvent().timed();
         clock.advanceTime(1234, TimeUnit.MILLISECONDS);
@@ -363,7 +363,7 @@ public class StructuredEventLogTest {
 
     @Test
     public void testEventGroups() throws Exception {
-        StructuredEventLog log = StructuredEventLog.newLogger();
+        StructuredEventLog log = StructuredEventLog.get();
         log.newRootEvent().log(Events.TEST_EVENT);
 
         List<Map<String, Object>> logged = getLogged();
@@ -379,7 +379,7 @@ public class StructuredEventLogTest {
 
     @Test
     public void testBareEnum() throws Exception {
-        StructuredEventLog log = StructuredEventLog.newLogger();
+        StructuredEventLog log = StructuredEventLog.get();
         log.newRootEvent().log(BareEvents.BARE_EVENT);
 
         List<Map<String, Object>> logged = getLogged();

--- a/structured-event-log/src/test/java/org/apache/pulsar/structuredeventlog/slf4j/StructuredEventLogTest.java
+++ b/structured-event-log/src/test/java/org/apache/pulsar/structuredeventlog/slf4j/StructuredEventLogTest.java
@@ -76,7 +76,7 @@ public class StructuredEventLogTest {
 
     @Test
     public void testTraceId() throws Exception {
-        StructuredEventLog log = StructuredEventLog.get();
+        StructuredEventLog log = Slf4jStructuredEventLog.INSTANCE;
 
         Event e = log.newRootEvent();
         e.newChildEvent().log("child");
@@ -97,7 +97,7 @@ public class StructuredEventLogTest {
 
     @Test
     public void testParentId() throws Exception {
-        StructuredEventLog log = StructuredEventLog.get();
+        StructuredEventLog log = Slf4jStructuredEventLog.INSTANCE;
 
         Event e1 = log.newRootEvent();
         Event e2 = e1.newChildEvent();
@@ -124,7 +124,7 @@ public class StructuredEventLogTest {
 
     @Test
     public void testResources() throws Exception {
-        StructuredEventLog log = StructuredEventLog.get();
+        StructuredEventLog log = Slf4jStructuredEventLog.INSTANCE;
 
         EventResources res = log.newEventResources()
             .resource("r1", "v1")
@@ -167,7 +167,7 @@ public class StructuredEventLogTest {
 
     @Test
     public void testResourcesNullTest() throws Exception {
-        StructuredEventLog log = StructuredEventLog.get();
+        StructuredEventLog log = Slf4jStructuredEventLog.INSTANCE;
 
         EventResources res = log.newEventResources()
             .resource(null, "v1")
@@ -205,7 +205,7 @@ public class StructuredEventLogTest {
 
     @Test
     public void testAttributes() throws Exception {
-        StructuredEventLog log = StructuredEventLog.get();
+        StructuredEventLog log = Slf4jStructuredEventLog.INSTANCE;
 
         Event e1 = log.newRootEvent()
             .attr("a1", "v1")
@@ -238,7 +238,7 @@ public class StructuredEventLogTest {
 
     @Test
     public void testAttributedNullTest() throws Exception {
-        StructuredEventLog log = StructuredEventLog.get();
+        StructuredEventLog log = Slf4jStructuredEventLog.INSTANCE;
 
         log.newRootEvent()
             .attr(null, "v1")
@@ -262,7 +262,7 @@ public class StructuredEventLogTest {
 
     @Test
     public void testInfoLevel() throws Exception {
-        StructuredEventLog log = StructuredEventLog.get();
+        StructuredEventLog log = Slf4jStructuredEventLog.INSTANCE;
 
         log.newRootEvent().log("info1");
         log.newRootEvent().atInfo().log("info2");
@@ -281,7 +281,7 @@ public class StructuredEventLogTest {
     @SuppressWarnings("unchecked")
     @Test
     public void testInfoLevelException() throws Exception {
-        StructuredEventLog log = StructuredEventLog.get();
+        StructuredEventLog log = Slf4jStructuredEventLog.INSTANCE;
 
         log.newRootEvent().exception(new Throwable("cause1")).log("info1");
         log.newRootEvent().atInfo().exception(new Throwable("cause2")).log("info2");
@@ -296,7 +296,7 @@ public class StructuredEventLogTest {
 
     @Test
     public void testWarnLevel() throws Exception {
-        StructuredEventLog log = StructuredEventLog.get();
+        StructuredEventLog log = Slf4jStructuredEventLog.INSTANCE;
 
         log.newRootEvent().atWarn().log("warn1");
 
@@ -308,7 +308,7 @@ public class StructuredEventLogTest {
     @SuppressWarnings("unchecked")
     @Test
     public void testWarnLevelException() throws Exception {
-        StructuredEventLog log = StructuredEventLog.get();
+        StructuredEventLog log = Slf4jStructuredEventLog.INSTANCE;
 
         log.newRootEvent().atWarn().exception(new Throwable("cause1")).log("warn1");
 
@@ -319,7 +319,7 @@ public class StructuredEventLogTest {
 
     @Test
     public void testErrorLevel() throws Exception {
-        StructuredEventLog log = StructuredEventLog.get();
+        StructuredEventLog log = Slf4jStructuredEventLog.INSTANCE;
 
         log.newRootEvent().atError().log("error1");
 
@@ -331,7 +331,7 @@ public class StructuredEventLogTest {
     @SuppressWarnings("unchecked")
     @Test
     public void testErrorLevelException() throws Exception {
-        StructuredEventLog log = StructuredEventLog.get();
+        StructuredEventLog log = Slf4jStructuredEventLog.INSTANCE;
 
         log.newRootEvent().atError().exception(new Throwable("cause1")).log("error1");
 
@@ -344,8 +344,8 @@ public class StructuredEventLogTest {
     @Test
     public void testTimedEvent() throws Exception {
         MockClock clock = new MockClock();
-        StructuredEventLog log = StructuredEventLog.get();
-        ((Slf4jStructuredEventLog)log).clock = clock;
+        Slf4jStructuredEventLog log = Slf4jStructuredEventLog.INSTANCE;
+        log.clock = clock;
         Event e = log.newRootEvent().timed();
         clock.advanceTime(1234, TimeUnit.MILLISECONDS);
         e.log("timed");
@@ -363,7 +363,7 @@ public class StructuredEventLogTest {
 
     @Test
     public void testEventGroups() throws Exception {
-        StructuredEventLog log = StructuredEventLog.get();
+        StructuredEventLog log = Slf4jStructuredEventLog.INSTANCE;
         log.newRootEvent().log(Events.TEST_EVENT);
 
         List<Map<String, Object>> logged = getLogged();
@@ -379,7 +379,7 @@ public class StructuredEventLogTest {
 
     @Test
     public void testBareEnum() throws Exception {
-        StructuredEventLog log = StructuredEventLog.get();
+        StructuredEventLog log = Slf4jStructuredEventLog.INSTANCE;
         log.newRootEvent().log(BareEvents.BARE_EVENT);
 
         List<Map<String, Object>> logged = getLogged();


### PR DESCRIPTION
### Motivation

Re-vamping the work on structured logs. Added support for sending events directly to Log4j2 if available, so we can pass all the arguments as a single object without using MDC approach.

- [x] `doc-not-needed`