### PR TITLE
Use auto-batching for exists() operations

### DIFF
--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/batching/OpExists.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/batching/OpExists.java
@@ -19,39 +19,23 @@
 package org.apache.pulsar.metadata.impl.batching;
 
 import java.util.concurrent.CompletableFuture;
+import lombok.AllArgsConstructor;
+import lombok.Data;
 
-public interface MetadataOp {
-    enum Type {
-        GET,
-        GET_CHILDREN,
-        PUT,
-        DELETE,
-        EXISTS,
+@Data
+@AllArgsConstructor
+public class OpExists implements MetadataOp {
+
+    private final String path;
+    private final CompletableFuture<Boolean> future = new CompletableFuture<>();
+
+    @Override
+    public Type getType() {
+        return Type.EXISTS;
     }
 
-    Type getType();
-
-    CompletableFuture<?> getFuture();
-
-    int size();
-
-    default OpGet asGet() {
-        return (OpGet) this;
-    }
-
-    default OpDelete asDelete() {
-        return (OpDelete) this;
-    }
-
-    default OpGetChildren asGetChildren() {
-        return (OpGetChildren) this;
-    }
-
-    default OpExists asExists() {
-        return (OpExists) this;
-    }
-
-    default OpPut asPut() {
-        return (OpPut) this;
+    @Override
+    public int size() {
+        return path.length();
     }
 }

--- a/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/MetadataStoreBatchingTest.java
+++ b/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/MetadataStoreBatchingTest.java
@@ -81,12 +81,17 @@ public class MetadataStoreBatchingTest extends BaseMetadataStoreTest {
 
         CompletableFuture<Optional<GetResult>> f1 = store.get(key1);
         CompletableFuture<Optional<GetResult>> f2 = store.get(key2);
+        CompletableFuture<Boolean> f3 = store.exists(key1);
+        CompletableFuture<Boolean> f4 = store.exists(key2);
 
         Optional<GetResult> r1 = f1.join();
         Optional<GetResult> r2 = f2.join();
 
         assertTrue(r1.isPresent());
         assertFalse(r2.isPresent());
+
+        assertTrue(f3.join());
+        assertFalse(f4.join());
     }
 
     @Test(dataProvider = "impl")


### PR DESCRIPTION
### Motivation

So far, we were not including the `exists()` calls in the MetadataStore auto-batching mechanism. There can be cases in which we have a large number of these calls (eg: when checking the existence of large number of topics), so it makes sense to include it too.
- [x] `doc-not-needed`
