### PR TITLE
[branch-2.7][fix][test] Upgrade the netty-tcnative to fix test

### DIFF
--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -374,7 +374,7 @@ The Apache Software License, Version 2.0
     - io.netty-netty-transport-native-epoll-4.1.68.Final.jar
     - io.netty-netty-transport-native-unix-common-4.1.68.Final.jar
     - io.netty-netty-transport-native-unix-common-4.1.68.Final-linux-x86_64.jar
-    - io.netty-netty-tcnative-boringssl-static-2.0.42.Final.jar
+    - io.netty-netty-tcnative-boringssl-static-2.0.48.Final.jar
  * Prometheus client
     - io.prometheus-simpleclient-0.5.0.jar
     - io.prometheus-simpleclient_common-0.5.0.jar

--- a/pom.xml
+++ b/pom.xml
@@ -101,7 +101,7 @@ flexible messaging model and an intuitive client API.</description>
     <bookkeeper.version>4.12.0</bookkeeper.version>
     <zookeeper.version>3.5.9</zookeeper.version>
     <netty.version>4.1.68.Final</netty.version>
-    <netty-tc-native.version>2.0.42.Final</netty-tc-native.version>
+    <netty-tc-native.version>2.0.48.Final</netty-tc-native.version>
     <jetty.version>9.4.43.v20210629</jetty.version>
     <jersey.version>2.31</jersey.version>
     <athenz.version>1.10.9</athenz.version>

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerServiceTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerServiceTest.java
@@ -61,7 +61,6 @@ import org.apache.bookkeeper.mledger.impl.ManagedLedgerImpl;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpGet;
-import org.apache.http.impl.client.DefaultHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.pulsar.broker.service.BrokerServiceException.PersistenceException;
 import org.apache.pulsar.broker.service.persistent.PersistentTopic;
@@ -829,6 +828,9 @@ public class BrokerServiceTest extends BrokerTestBase {
 
     @Test
     public void testTopicLoadingOnDisableNamespaceBundle() throws Exception {
+        conf.setWebServicePort(Optional.of(0));
+        restartBroker();
+
         final String namespace = "prop/disableBundle";
         admin.namespaces().createNamespace(namespace);
         admin.namespaces().setNamespaceReplicationClusters(namespace, Sets.newHashSet("test"));

--- a/pulsar-sql/presto-distribution/LICENSE
+++ b/pulsar-sql/presto-distribution/LICENSE
@@ -243,7 +243,7 @@ The Apache Software License, Version 2.0
     - netty-reactive-streams-2.0.4.jar
     - netty-resolver-4.1.68.Final.jar
     - netty-resolver-dns-4.1.68.Final.jar
-    - netty-tcnative-boringssl-static-2.0.42.Final.jar
+    - netty-tcnative-boringssl-static-2.0.48.Final.jar
     - netty-transport-4.1.68.Final.jar
     - netty-transport-native-epoll-4.1.68.Final-linux-x86_64.jar
     - netty-transport-native-unix-common-4.1.68.Final.jar


### PR DESCRIPTION
Signed-off-by: Zixuan Liu <nodeces@gmail.com>


### Motivation

Old netty-tcnative cannot use the OpenSSL provider, we need to upgrade the netty-tcnative.

### Modifications

- Upgrade the netty-tcnative from 2.0.42.Final to 2.0.48.Final
- Fix testTopicLoadingOnDisableNamespaceBundle test

### Documentation

- [x] `doc-not-needed` 
