### PR TITLE
[fix][broker] Update cpu ResourceUsage before updating SystemResourceUsage usage

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/LinuxBrokerHostUsageImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/LinuxBrokerHostUsageImpl.java
@@ -113,12 +113,12 @@ public class LinuxBrokerHostUsageImpl implements BrokerHostUsage {
             usage.setBandwidthIn(new ResourceUsage(nicUsageRx, totalNicLimit));
             usage.setBandwidthOut(new ResourceUsage(nicUsageTx, totalNicLimit));
         }
+        usage.setCpu(new ResourceUsage(cpuUsage, totalCpuLimit));
 
         lastTotalNicUsageTx = totalNicUsageTx;
         lastTotalNicUsageRx = totalNicUsageRx;
         lastCollection = System.currentTimeMillis();
         this.usage = usage;
-        usage.setCpu(new ResourceUsage(cpuUsage, totalCpuLimit));
     }
 
     private double getTotalNicLimitWithConfiguration(List<String> nics) {


### PR DESCRIPTION
### Motivation
Update cpu ResourceUsage before updating SystemResourceUsage usage.


### Documentation

Check the box below or label this PR directly.

Need to update docs? 

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)
  
- [x] `doc-not-needed` 
(Please explain why)
  
- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)