### PR TITLE
[fix][workflow] Cancel duplicate docbot workflows

### DIFF
--- a/.github/workflows/ci-cancel-duplicate-workflows.yaml
+++ b/.github/workflows/ci-cancel-duplicate-workflows.yaml
@@ -61,3 +61,9 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           cancelMode: allDuplicates
           workflowFileName: pulsar-ci.yaml
+      - name: cancel duplicate ci-documentbot.yml
+        uses: potiuk/cancel-workflow-runs@953e057dc81d3458935a18d1184c386b0f6b5738
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          cancelMode: allDuplicates
+          workflowFileName: ci-documentbot.yml


### PR DESCRIPTION
Master Issue: #15797 

### Motivation

Cancel duplicate docbot workflows.

### Modifications

Add docbot ci to cancel workflow.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API: (yes / no)
  - The schema: (yes / no / don't know)
  - The default values of configurations: (yes / no)
  - The wire protocol: (yes / no)
  - The rest endpoints: (yes / no)
  - The admin cli options: (yes / no)
  - Anything that affects deployment: (yes / no / don't know)

### Documentation

Check the box below or label this PR directly.

Need to update docs? 

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)
  
- [x] `doc-not-needed` 
(Please explain why)
  
- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)