### PR TITLE
[fix][doc] Enable zk when starting standalone in pulsar-sql doc

### DIFF
--- a/site2/docs/sql-getting-started.md
+++ b/site2/docs/sql-getting-started.md
@@ -17,9 +17,16 @@ To query data in Pulsar with Pulsar SQL, complete the following steps.
 
 ```bash
 
-./bin/pulsar standalone
+PULSAR_STANDALONE_USE_ZOOKEEPER=1 ./bin/pulsar standalone
 
 ```
+
+:::note
+
+Starting the Pulsar standalone cluster from scratch doesn't enable zookeeper by default. 
+However, the Pulsar SQL depends on the zookeeper. Therefore, we need to set `PULSAR_STANDALONE_USE_ZOOKEEPER=1` to enable the zookeeper.
+
+:::
 
 2. Start a Pulsar SQL worker.
 

--- a/site2/docs/sql-getting-started.md
+++ b/site2/docs/sql-getting-started.md
@@ -23,8 +23,8 @@ PULSAR_STANDALONE_USE_ZOOKEEPER=1 ./bin/pulsar standalone
 
 :::note
 
-Starting the Pulsar standalone cluster from scratch doesn't enable zookeeper by default. 
-However, the Pulsar SQL depends on the zookeeper. Therefore, we need to set `PULSAR_STANDALONE_USE_ZOOKEEPER=1` to enable the zookeeper.
+Starting the Pulsar standalone cluster from scratch doesn't enable ZooKeeper by default. 
+However, the Pulsar SQL depends on ZooKeeper. Therefore, you need to set `PULSAR_STANDALONE_USE_ZOOKEEPER=1` to enable ZooKeeper.
 
 :::
 


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://docs.google.com/document/d/1d8Pw6ZbWk-_pCKdOmdvx9rnhPiyuxwq60_TrD68d7BA/edit#heading=h.trs9rsex3xom)*. 

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.

**(The sections below can be removed for hotfixes of typos)**
-->

Master Issue: #16354

### Motivation

After https://github.com/apache/pulsar/pull/15478 gets merged, the zookeeper won't be enabled by default when starting the pulsar standalone. But the pulsar SQL depends on the zookeeper. We need to set`PULSAR_STANDALONE_USE_ZOOKEEPER=1` to enable zookeeper when using the pulsar SQL as mentioned in https://github.com/apache/pulsar/issues/16354#issuecomment-1173092956.

### Modifications

* Add `PULSAR_STANDALONE_USE_ZOOKEEPER=1` before running pulsar standalone in pulsar-sql doc

These changes only need to apply to the doc of pulsar 2.11 and later.

### Documentation

Check the box below or label this PR directly.

Need to update docs? 

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)
  
- [ ] `doc-not-needed` 
(Please explain why)
  
- [x] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)