### PR TITLE
[cleanup] CLI: fix pulsar-websocket dependency importing only needed jars

### DIFF
--- a/pulsar-client-tools/pom.xml
+++ b/pulsar-client-tools/pom.xml
@@ -80,6 +80,21 @@
       <groupId>${project.groupId}</groupId>
       <artifactId>pulsar-websocket</artifactId>
       <version>${project.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty.websocket</groupId>
+      <artifactId>javax-websocket-client-impl</artifactId>
+      <version>${jetty.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.swagger</groupId>
+      <artifactId>swagger-core</artifactId>
     </dependency>
 
     <!-- functions related dependencies (begin) -->


### PR DESCRIPTION
### Motivation
`pulsar-client-tools` imports `pulsar-websocket` to run commands using the jetty websocket-client.
`pulsar-websocket` has huge dependencies since it depends on `pulsar-broker-common`.

This is useful in case you want to package the client-tools module in a standalone artifact (like https://github.com/apache/pulsar/pull/16332)

### Modifications

* Import only what needed to make it compilable (websocket client and swagger)
It doesn't affect the runtime execution since the classpath used by the CLI tools is the same as other commands



- [x] `doc-not-needed` 
