### PR TITLE
[fix][flaky-test] Fix flaky test testDynamicConfigurationTopicAutoCreationPartitionedWhenDefaultMoreThanMax

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerServiceAutoTopicCreationTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerServiceAutoTopicCreationTest.java
@@ -37,6 +37,7 @@ import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.partition.PartitionedTopicMetadata;
 import org.apache.pulsar.common.policies.data.AutoTopicCreationOverride;
 import org.apache.pulsar.common.policies.data.TopicType;
+import org.awaitility.Awaitility;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.AfterMethod;
@@ -510,6 +511,10 @@ public class BrokerServiceAutoTopicCreationTest extends BrokerTestBase{
 
         // set maxNumPartitionsPerPartitionedTopic, make maxNumPartitionsPerPartitionedTopic < defaultNumPartitions
         admin.brokers().updateDynamicConfiguration("maxNumPartitionsPerPartitionedTopic", "1");
+        // Make sure the dynamic cache is updated to prevent the flaky test.
+        Awaitility.await().untilAsserted(() ->
+                assertEquals(admin.brokers().getAllDynamicConfigurations()
+                        .get("maxNumPartitionsPerPartitionedTopic"), "1"));
         topic = "persistent://" + namespaceName + "/test-dynamicConfiguration-topic-auto-creation-"
                 + UUID.randomUUID();
         producer = pulsarClient.newProducer().topic(topic).create();


### PR DESCRIPTION
Fixes #16384

### Motivation

Fix flaky test testDynamicConfigurationTopicAutoCreationPartitionedWhenDefaultMoreThanMax.
Make sure the dynamic cache is updated to prevent the flaky test.

### Documentation

Check the box below or label this PR directly.

Need to update docs? 

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)
  
- [x] `doc-not-needed` 
(Please explain why)
  
- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)