### PR TITLE
[fix][managedLedger] Release the entry in getEarliestMessagePublishTimeOfPos.

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
@@ -1203,6 +1203,8 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
                 } catch (IOException e) {
                     log.error("Error deserializing message for message position {}", nextPos, e);
                     future.completeExceptionally(e);
+                } finally {
+                    entry.release();
                 }
             }
 


### PR DESCRIPTION
### Motivation

Release the entry after using it in getEarliestMessagePublishTimeOfPos.

### Documentation

- [x] `doc-not-needed` 
(Please explain why)
