### PR TITLE
[fix][broker]fix npe when filterEntriesForConsumer

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractBaseDispatcher.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractBaseDispatcher.java
@@ -127,7 +127,7 @@ public abstract class AbstractBaseDispatcher implements Dispatcher {
         List<PositionImpl> entriesToRedeliver = CollectionUtils.isNotEmpty(entryFilters) ? new ArrayList<>() : null;
         for (int i = 0, entriesSize = entries.size(); i < entriesSize; i++) {
             Entry entry = entries.get(i);
-            if (entry == null) {
+            if (entry == null || entry.getDataBuffer() == null) {
                 continue;
             }
             ByteBuf metadataAndPayload = entry.getDataBuffer();


### PR DESCRIPTION
### Motivation
An npe exception was found in the exception log：
<img width="1460" alt="image" src="https://user-images.githubusercontent.com/19296967/177259582-474750fb-ebbc-45de-afa6-e2e8c70726d0.png">

By analyzing the code, it is found that in the filterEntriesForConsumer method, some entries may have been released, resulting in entry.getDataBuffer() is null. So we need to skip these entries.


### Documentation

Check the box below or label this PR directly.

Need to update docs? 

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)
  
- [x] `doc-not-needed` 
(Please explain why)
  
- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)