### PR TITLE
[improve][broker] Recycle OpReadEntry in some corner cases

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
@@ -857,6 +857,7 @@ public class ManagedCursorImpl implements ManagedCursor {
                     ctx, maxPosition);
 
             if (!WAITING_READ_OP_UPDATER.compareAndSet(this, null, op)) {
+                op.recycle();
                 callback.readEntriesFailed(new ManagedLedgerException("We can only have a single waiting callback"),
                         ctx);
                 return;
@@ -939,7 +940,11 @@ public class ManagedCursorImpl implements ManagedCursor {
         if (log.isDebugEnabled()) {
             log.debug("[{}] [{}] Cancel pending read request", ledger.getName(), name);
         }
-        return WAITING_READ_OP_UPDATER.getAndSet(this, null) != null;
+        final OpReadEntry op = WAITING_READ_OP_UPDATER.getAndSet(this, null);
+        if (op != null) {
+            op.recycle();
+        }
+        return op != null;
     }
 
     public boolean hasPendingReadRequest() {

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/OpReadEntry.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/OpReadEntry.java
@@ -19,12 +19,10 @@
 package org.apache.bookkeeper.mledger.impl;
 
 import static org.apache.bookkeeper.mledger.util.SafeRun.safeRun;
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Lists;
 import io.netty.util.Recycler;
 import io.netty.util.Recycler.Handle;
 import java.util.List;
-import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.bookkeeper.mledger.AsyncCallbacks.ReadEntriesCallback;
 import org.apache.bookkeeper.mledger.Entry;
 import org.apache.bookkeeper.mledger.ManagedLedgerException;
@@ -35,9 +33,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 class OpReadEntry implements ReadEntriesCallback {
-
-    private static AtomicInteger createCount = null;
-    private static AtomicInteger recycleCount = null;
 
     ManagedCursorImpl cursor;
     PositionImpl readPosition;
@@ -53,9 +48,6 @@ class OpReadEntry implements ReadEntriesCallback {
     public static OpReadEntry create(ManagedCursorImpl cursor, PositionImpl readPositionRef, int count,
             ReadEntriesCallback callback, Object ctx, PositionImpl maxPosition) {
         OpReadEntry op = RECYCLER.get();
-        if (createCount != null) {
-            createCount.getAndIncrement();
-        }
         op.readPosition = cursor.ledger.startReadOperationOnLedger(readPositionRef);
         op.cursor = cursor;
         op.count = count;
@@ -194,33 +186,7 @@ class OpReadEntry implements ReadEntriesCallback {
         entries = null;
         nextReadPosition = null;
         maxPosition = null;
-        if (recycleCount != null) {
-            recycleCount.getAndIncrement();
-        }
         recyclerHandle.recycle(this);
-    }
-
-
-    @VisibleForTesting
-    static void enableTesting() {
-        createCount = new AtomicInteger(0);
-        recycleCount = new AtomicInteger(0);
-    }
-
-    @VisibleForTesting
-    static void disableTesting() {
-        createCount = null;
-        recycleCount = null;
-    }
-
-    @VisibleForTesting
-    static int getCreateCount() {
-        return createCount.get();
-    }
-
-    @VisibleForTesting
-    static int getRecycleCount() {
-        return recycleCount.get();
     }
 
     private static final Logger log = LoggerFactory.getLogger(OpReadEntry.class);

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/OpReadEntry.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/OpReadEntry.java
@@ -36,8 +36,8 @@ import org.slf4j.LoggerFactory;
 
 class OpReadEntry implements ReadEntriesCallback {
 
-    private static volatile AtomicInteger createCount = null;
-    private static volatile AtomicInteger recycleCount = null;
+    private static AtomicInteger createCount = null;
+    private static AtomicInteger recycleCount = null;
 
     ManagedCursorImpl cursor;
     PositionImpl readPosition;


### PR DESCRIPTION
### Motivation

`ManagedCursorImpl` maintains a field `waitingReadOp` as the cache of
the `OpReadEntry` created in `asyncReadEntriesOrWait` when there are no
more entries to read. However, there are two cases that the created
`OpReadEntry` are not recycled:
1. `asyncReadEntriesOrWait` is called repeatedly when `waitingReadOp` is
   not null and there are no more entries. The new created `OpReadEntry`
  cannot pass the CAS check but it's not recycled.
2. `cancelPendingReadRequest` is called. The `waitingReadOp` is just set
   with null and the previous reference is not recycled.

### Modifications

For the two cases described above, recycle the `OpReadEntry` objects.

### Verifying this change

Add `testOpReadEntryRecycle` to reproduce the corner cases and verify the
count of `recycle()` calls.

### Documentation

Check the box below or label this PR directly.

Need to update docs? 

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)
  
- [x] `doc-not-needed` 
(Please explain why)
  
- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)