### PR TITLE
[Branch-2.7][Cherry-pick] Fix getting the last message-id from an empty compact ledger.

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/compaction/CompactedTopicImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/compaction/CompactedTopicImpl.java
@@ -302,11 +302,16 @@ public class CompactedTopicImpl implements CompactedTopic {
         if (compactionHorizon == null) {
             return CompletableFuture.completedFuture(null);
         }
-        return compactedTopicContext.thenCompose(context ->
-                readEntries(context.ledger, context.ledger.getLastAddConfirmed(), context.ledger.getLastAddConfirmed())
-                        .thenCompose(entries -> entries.size() > 0
-                                ? CompletableFuture.completedFuture(entries.get(0))
-                                : CompletableFuture.completedFuture(null)));
+        return compactedTopicContext.thenCompose(context -> {
+                    if (context.ledger.getLastAddConfirmed() == -1) {
+                        return CompletableFuture.completedFuture(null);
+                    }
+                    return readEntries(context.ledger, context.ledger.getLastAddConfirmed(),
+                            context.ledger.getLastAddConfirmed())
+                            .thenCompose(entries -> entries.size() > 0
+                                    ? CompletableFuture.completedFuture(entries.get(0))
+                                    : CompletableFuture.completedFuture(null));
+                });
     }
 
     private static int comparePositionAndMessageId(PositionImpl p, MessageIdData m) {


### PR DESCRIPTION
Cherry-pick #13476

### Motivation

Currently, if the last confirmed entry is an empty ledger, getting the last message-id operation will get data from the compact ledger, if the compact ledger is also an empty ledger, it will encounter `IncorrectParameterException`.

**Broker error message**
```
[pulsar-io-29-9] ERROR org.apache.bookkeeper.client.LedgerHandle - IncorrectParameterException on ledgerId:617 firstEntry:-1 lastEntry:-1
```

**Client error log**
```
Exception in thread "main" org.apache.pulsar.client.api.PulsarClientException$BrokerMetadataException: The subscription reader-bf9246cfcb of the topic persistent://public/ns-test/t1 gets the last message id was failed
{"errorMsg":"Failed to read last entry of the compacted Ledger Incorrect parameter input","reqId":79405902881798690, "remote":"localhost/127.0.0.1:6650", "local":"/127.0.0.1:55207"}
	at org.apache.pulsar.client.api.PulsarClientException.unwrap(PulsarClientException.java:1034)
	at org.apache.pulsar.client.impl.ConsumerImpl.hasMessageAvailable(ConsumerImpl.java:2001)
	at org.apache.pulsar.client.impl.ReaderImpl.hasMessageAvailable(ReaderImpl.java:181)
	at org.apache.pulsar.compaction.CompactedTopicTest.main(CompactedTopicTest.java:730)
```

### Modifications

Check the compact ledger entry id before reading an entry from the compact ledger, if there is no entry, return a null value.

### Verifying this change

Add a new test to verify getting the last message-id from an empty compact ledger.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

Check the box below and label this PR (if you have committer privilege).

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)


