### PR TITLE
[Branch-2.7][Cherry-pick] Fix lost compaction data due to compaction properties missed during reset-cursor.

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
@@ -2294,7 +2294,8 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
             if (highestPositionToDelete.compareTo((PositionImpl) cursor.getMarkDeletedPosition()) > 0
                     && highestPositionToDelete.compareTo((PositionImpl) cursor.getManagedLedger().getLastConfirmedEntry()) <= 0
                     && !(!cursor.isDurable() && cursor instanceof NonDurableCursorImpl && ((NonDurableCursorImpl) cursor).isReadCompacted())) {
-                cursor.asyncMarkDelete(highestPositionToDelete, new MarkDeleteCallback() {
+                cursor.asyncMarkDelete(highestPositionToDelete, cursor.getProperties(), new MarkDeleteCallback() {
+
                     @Override
                     public void markDeleteComplete(Object ctx) {
                     }


### PR DESCRIPTION
Cherry-pick #12698
### Motivation

Fix lost compaction data due to compaction properties missed during reset-cursor.

1. The compaction reader will seek to the earliest position to read data from the topic, but the compaction properties missed during the cursor reset, this will lead to the inited compaction subscribe without compaction horizon, so the compaction reader will skip the last compacted data. It will only happen when init the compaction subscription, so can introduced by the loadbalance or topic unloading manually.

2. Advance the cursor should also keep the properties, otherwise, the properties will lost during the cursor trimming.

### Changes

1. Keep the properties for resetting the cursor while the cursor is for data compaction.
2. Copy the properties to the new mark delete entry while advance the cursor, this is triggered byt the managed ledger internal, so it's not only for compacted topic, the internal task should not loss the properties when trimming the cursor.

### Tests

New tests added to make sure the compaction will not loss data during topic unloading and the reader can read all the compacted data after the compaction task complete

### Documentation

Check the box below and label this PR (if you have committer privilege).

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)


