### PR TITLE
[improve][security] CVE-2022-33915 is false positive

### DIFF
--- a/src/owasp-dependency-check-false-positives.xml
+++ b/src/owasp-dependency-check-false-positives.xml
@@ -132,7 +132,7 @@
   <!-- CVE-2022-33915 is about Amazon AWS hotpatch -->
   <suppress>
     <notes><![CDATA[
-   file name: log4j-core-1.27.1.jar
+   file name: log4j-core-2.27.1.jar
    ]]></notes>
     <sha1>779f60f3844dadc3ef597976fcb1e5127b1f343d</sha1>
     <cve>CVE-2022-33915</cve>

--- a/src/owasp-dependency-check-false-positives.xml
+++ b/src/owasp-dependency-check-false-positives.xml
@@ -129,6 +129,15 @@
     <cve>CVE-2021-23214</cve>
   </suppress>
 
+  <!-- CVE-2022-33915 is about Amazon AWS hotpatch -->
+  <suppress>
+    <notes><![CDATA[
+   file name: log4j-core-1.27.1.jar
+   ]]></notes>
+    <sha1>779f60f3844dadc3ef597976fcb1e5127b1f343d</sha1>
+    <cve>CVE-2022-33915</cve>
+  </suppress>
+
 
 <!--  MariaDB client is being confused with MariaDB server-->
   <suppress>

--- a/src/owasp-dependency-check-false-positives.xml
+++ b/src/owasp-dependency-check-false-positives.xml
@@ -132,7 +132,7 @@
   <!-- CVE-2022-33915 is about Amazon AWS hotpatch -->
   <suppress>
     <notes><![CDATA[
-   file name: log4j-core-2.27.1.jar
+   file name: log4j-core-2.17.1.jar
    ]]></notes>
     <sha1>779f60f3844dadc3ef597976fcb1e5127b1f343d</sha1>
     <cve>CVE-2022-33915</cve>


### PR DESCRIPTION
Signed-off-by: tison <wander4096@gmail.com>

### Motivation

CVE-2022-33915 is about Amazon AWS hotpatch. We don't use that version and the failure reported by OWASP is false positive.

Reported when preparing patch #16320.

### Modifications

Suppress CVE-2022-33915.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API: (yes / no)
  - The schema: (yes / no / don't know)
  - The default values of configurations: (yes / no)
  - The wire protocol: (yes / no)
  - The rest endpoints: (yes / no)
  - The admin cli options: (yes / no)
  - Anything that affects deployment: (yes / no / don't know)

### Documentation

- [x] `doc-not-needed` 
