### PR TITLE
[improve][broker] Reject create partition topic when exist conflict non-partitioned topic.

### DIFF
--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/PulsarServerException.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/PulsarServerException.java
@@ -44,4 +44,14 @@ public class PulsarServerException extends IOException {
             super(t);
         }
     }
+
+    public static class ConflictException extends PulsarServerException {
+        public ConflictException(String msg) {
+            super(msg);
+        }
+
+        public ConflictException(Throwable t) {
+            super(t);
+        }
+    }
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/AdminResource.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/AdminResource.java
@@ -42,7 +42,6 @@ import org.apache.pulsar.broker.ServiceConfiguration;
 import org.apache.pulsar.broker.web.PulsarWebResource;
 import org.apache.pulsar.broker.web.RestException;
 import org.apache.pulsar.client.admin.internal.TopicsImpl;
-import org.apache.pulsar.common.api.proto.CommandGetTopicsOfNamespace;
 import org.apache.pulsar.common.naming.Constants;
 import org.apache.pulsar.common.naming.NamespaceBundle;
 import org.apache.pulsar.common.naming.NamespaceName;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
@@ -3541,7 +3541,7 @@ public class PersistentTopicsBase extends AdminResource {
             ret = CompletableFuture.completedFuture(null);
         }
         return ret
-                .thenCompose(__ -> checkTopicExistsAsync(topicName))
+                .thenCompose(__ -> pulsar().getBrokerService().checkIfPartitionExist(topicName))
                 .thenCompose(exist -> {
                     if (!exist) {
                         throw new RestException(Status.NOT_FOUND, getTopicNotFoundErrorMessage(topicName.toString()));

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/NamespaceService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/NamespaceService.java
@@ -1106,10 +1106,7 @@ public class NamespaceService implements AutoCloseable {
 
     public CompletableFuture<List<String>> getFullListOfTopics(NamespaceName namespaceName) {
         return getListOfPersistentTopics(namespaceName)
-                .thenCombine(getListOfNonPersistentTopics(namespaceName),
-                        (persistentTopics, nonPersistentTopics) -> {
-                            return ListUtils.union(persistentTopics, nonPersistentTopics);
-                        });
+                .thenCombine(getListOfNonPersistentTopics(namespaceName), ListUtils::union);
     }
 
     public CompletableFuture<List<String>> getOwnedTopicListForNamespaceBundle(NamespaceBundle bundle) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
@@ -2680,7 +2680,9 @@ public class BrokerService implements Closeable {
                                         pulsar.getBrokerService()
                                                 .checkIfPartitionExist(topicName)
                                                 .thenCompose(exist -> {
-                                                    if (!exist) return createDefaultPartitionedTopicAsync(topicName);
+                                                    if (!exist) {
+                                                        return createDefaultPartitionedTopicAsync(topicName);
+                                                    }
                                                     String msg = String.format(
                                                             "Failed to create already existing topic %s", topicName);
                                                     log.warn(msg);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/AutoCreatePartitionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/AutoCreatePartitionTest.java
@@ -1,0 +1,76 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.client.impl;
+
+import lombok.Cleanup;
+import org.apache.pulsar.client.admin.PulsarAdminException;
+import org.apache.pulsar.client.api.Producer;
+import org.apache.pulsar.client.api.ProducerConsumerBase;
+import org.apache.pulsar.client.api.PulsarClientException;
+import org.apache.pulsar.common.naming.TopicName;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+import java.util.UUID;
+
+@Test(groups = "broker-impl")
+public class AutoCreatePartitionTest extends ProducerConsumerBase {
+
+    @BeforeClass(alwaysRun = true)
+    public void setup() throws Exception {
+        conf.setAllowAutoTopicCreation(true);
+        super.internalSetup();
+        super.producerBaseSetup();
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void cleanup() throws Exception {
+        super.internalCleanup();
+    }
+
+
+    @Test
+    public void testRejectCreatePartitionedTopicWhenHasPartitionNameTopic() throws PulsarClientException, PulsarAdminException, InterruptedException {
+        String topicName = "persistent://public/default/test" + UUID.randomUUID();
+        String partitionName = TopicName.get(topicName).getPartition(0).toString();
+
+        // rely on auto-creation mechanism to create partitioned topic
+        @Cleanup
+        Producer<byte[]> producer = pulsarClient.newProducer()
+                .topic(partitionName)
+                .create();
+
+        // Expect create non-partitioned topic.
+        admin.topics().getStats(partitionName);
+        // Change the conf
+        conf.setAllowAutoTopicCreationType("partitioned");
+        conf.setDefaultNumPartitions(3);
+        try {
+            @Cleanup
+            Producer<byte[]> producer2 = pulsarClient.newProducer()
+                    .topic(topicName)
+                    .create();
+            Assert.fail("Unexpected behaviour");
+        } catch (Exception ex) {
+            Assert.assertTrue(ex.getMessage().contains("Failed to create already existing topic"));
+        }
+    }
+
+}


### PR DESCRIPTION
### Motivation

When creating a partitioned topic we have to check if this topic partition name is conflict with exist non-partitioned topic name.

### Modifications

- Add validation when creating a partitioned topic by the socket.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Documentation

Check the box below or label this PR directly.

Need to update docs? 

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)
  
- [x] `doc-not-needed` 
(Please explain why)
  
- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)