### PR TITLE
[branch-2.7][improve][ci] Add set up Java

### DIFF
--- a/.github/workflows/ci-build-multi-os.yaml
+++ b/.github/workflows/ci-build-multi-os.yaml
@@ -60,11 +60,13 @@ jobs:
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             ${{ runner.os }}-maven-
-      - name: Set up JDK 1.8
-        uses: actions/setup-java@v1
+
+      - name: Set up JDK 8
+        uses: actions/setup-java@v3
         if: steps.docs.outputs.changed_only == 'no'
         with:
-          java-version: 1.8
+          distribution: 'temurin'
+          java-version: 8
 
       - name: build package
         if: steps.docs.outputs.changed_only == 'no'

--- a/.github/workflows/ci-docker-build.yaml
+++ b/.github/workflows/ci-docker-build.yaml
@@ -58,11 +58,12 @@ jobs:
         with:
           args: site2 deployment .asf.yaml .ci ct.yaml
 
-      - name: Set up JDK 1.8
-        uses: actions/setup-java@v1
+      - name: Set up JDK 8
+        uses: actions/setup-java@v3
         if: steps.docs.outputs.changed_only == 'no'
         with:
-          java-version: 1.8
+          distribution: 'temurin'
+          java-version: 8
 
       - name: clean disk
         if: steps.docs.outputs.changed_only == 'no'

--- a/.github/workflows/ci-integration-backwards-compatibility.yaml
+++ b/.github/workflows/ci-integration-backwards-compatibility.yaml
@@ -58,11 +58,12 @@ jobs:
         with:
           args: site2 deployment .asf.yaml .ci ct.yaml
 
-      - name: Set up JDK 1.8
+      - name: Set up JDK 8
+        uses: actions/setup-java@v3
         if: steps.docs.outputs.changed_only == 'no'
-        uses: actions/setup-java@v1
         with:
-          java-version: 1.8
+          distribution: 'temurin'
+          java-version: 8
 
       - name: clean disk
         if: steps.docs.outputs.changed_only == 'no'

--- a/.github/workflows/ci-integration-cli.yaml
+++ b/.github/workflows/ci-integration-cli.yaml
@@ -58,11 +58,12 @@ jobs:
         with:
           args: site2 deployment .asf.yaml .ci ct.yaml
 
-      - name: Set up JDK 1.8
-        uses: actions/setup-java@v1
+      - name: Set up JDK 8
+        uses: actions/setup-java@v3
         if: steps.docs.outputs.changed_only == 'no'
         with:
-          java-version: 1.8
+          distribution: 'temurin'
+          java-version: 8
 
       - name: clean disk
         if: steps.docs.outputs.changed_only == 'no'

--- a/.github/workflows/ci-integration-function-state.yaml
+++ b/.github/workflows/ci-integration-function-state.yaml
@@ -58,11 +58,12 @@ jobs:
         with:
           args: site2 deployment .asf.yaml .ci ct.yaml
 
-      - name: Set up JDK 1.8
-        uses: actions/setup-java@v1
+      - name: Set up JDK 8
+        uses: actions/setup-java@v3
         if: steps.docs.outputs.changed_only == 'no'
         with:
-          java-version: 1.8
+          distribution: 'temurin'
+          java-version: 8
 
       - name: clean disk
         if: steps.docs.outputs.changed_only == 'no'

--- a/.github/workflows/ci-integration-messaging.yaml
+++ b/.github/workflows/ci-integration-messaging.yaml
@@ -58,11 +58,12 @@ jobs:
         with:
           args: site2 deployment .asf.yaml .ci ct.yaml
 
-      - name: Set up JDK 1.8
-        uses: actions/setup-java@v1
+      - name: Set up JDK 8
+        uses: actions/setup-java@v3
         if: steps.docs.outputs.changed_only == 'no'
         with:
-          java-version: 1.8
+          distribution: 'temurin'
+          java-version: 8
 
       - name: clean disk
         if: steps.docs.outputs.changed_only == 'no'

--- a/.github/workflows/ci-integration-process.yaml
+++ b/.github/workflows/ci-integration-process.yaml
@@ -58,11 +58,12 @@ jobs:
         with:
           args: site2 deployment .asf.yaml .ci ct.yaml
 
-      - name: Set up JDK 1.8
-        uses: actions/setup-java@v1
+      - name: Set up JDK 8
+        uses: actions/setup-java@v3
         if: steps.docs.outputs.changed_only == 'no'
         with:
-          java-version: 1.8
+          distribution: 'temurin'
+          java-version: 8
 
       - name: clean disk
         if: steps.docs.outputs.changed_only == 'no'

--- a/.github/workflows/ci-integration-schema.yaml
+++ b/.github/workflows/ci-integration-schema.yaml
@@ -58,11 +58,12 @@ jobs:
         with:
           args: site2 deployment .asf.yaml .ci ct.yaml
 
-      - name: Set up JDK 1.8
-        uses: actions/setup-java@v1
+      - name: Set up JDK 8
+        uses: actions/setup-java@v3
         if: steps.docs.outputs.changed_only == 'no'
         with:
-          java-version: 1.8
+          distribution: 'temurin'
+          java-version: 8
 
       - name: clean disk
         if: steps.docs.outputs.changed_only == 'no'

--- a/.github/workflows/ci-integration-sql.yaml
+++ b/.github/workflows/ci-integration-sql.yaml
@@ -58,11 +58,12 @@ jobs:
         with:
           args: site2 deployment .asf.yaml .ci ct.yaml
 
-      - name: Set up JDK 1.8
-        uses: actions/setup-java@v1
+      - name: Set up JDK 8
+        uses: actions/setup-java@v3
         if: steps.docs.outputs.changed_only == 'no'
         with:
-          java-version: 1.8
+          distribution: 'temurin'
+          java-version: 8
 
       - name: clean disk
         if: steps.docs.outputs.changed_only == 'no'

--- a/.github/workflows/ci-integration-standalone.yaml
+++ b/.github/workflows/ci-integration-standalone.yaml
@@ -58,11 +58,12 @@ jobs:
         with:
           args: site2 deployment .asf.yaml .ci ct.yaml
 
-      - name: Set up JDK 1.8
-        uses: actions/setup-java@v1
+      - name: Set up JDK 8
+        uses: actions/setup-java@v3
         if: steps.docs.outputs.changed_only == 'no'
         with:
-          java-version: 1.8
+          distribution: 'temurin'
+          java-version: 8
 
       - name: clean disk
         if: steps.docs.outputs.changed_only == 'no'

--- a/.github/workflows/ci-integration-thread.yaml
+++ b/.github/workflows/ci-integration-thread.yaml
@@ -58,11 +58,12 @@ jobs:
         with:
           args: site2 deployment .asf.yaml .ci ct.yaml
 
-      - name: Set up JDK 1.8
-        uses: actions/setup-java@v1
+      - name: Set up JDK 8
+        uses: actions/setup-java@v3
         if: steps.docs.outputs.changed_only == 'no'
         with:
-          java-version: 1.8
+          distribution: 'temurin'
+          java-version: 8
 
       - name: clean disk
         if: steps.docs.outputs.changed_only == 'no'

--- a/.github/workflows/ci-integration-tiered-filesystem.yaml
+++ b/.github/workflows/ci-integration-tiered-filesystem.yaml
@@ -58,11 +58,12 @@ jobs:
         with:
           args: site2 deployment .asf.yaml .ci ct.yaml
 
-      - name: Set up JDK 1.8
-        uses: actions/setup-java@v1
+      - name: Set up JDK 8
+        uses: actions/setup-java@v3
         if: steps.docs.outputs.changed_only == 'no'
         with:
-          java-version: 1.8
+          distribution: 'temurin'
+          java-version: 8
 
       - name: clean disk
         if: steps.docs.outputs.changed_only == 'no'

--- a/.github/workflows/ci-integration-tiered-jcloud.yaml
+++ b/.github/workflows/ci-integration-tiered-jcloud.yaml
@@ -58,11 +58,12 @@ jobs:
         with:
           args: site2 deployment .asf.yaml .ci ct.yaml
 
-      - name: Set up JDK 1.8
-        uses: actions/setup-java@v1
+      - name: Set up JDK 8
+        uses: actions/setup-java@v3
         if: steps.docs.outputs.changed_only == 'no'
         with:
-          java-version: 1.8
+          distribution: 'temurin'
+          java-version: 8
 
       - name: clean disk
         if: steps.docs.outputs.changed_only == 'no'

--- a/.github/workflows/ci-integration-transaction.yaml
+++ b/.github/workflows/ci-integration-transaction.yaml
@@ -58,11 +58,12 @@ jobs:
         with:
           args: site2 deployment .asf.yaml .ci ct.yaml
 
-      - name: Set up JDK 1.8
-        uses: actions/setup-java@v1
+      - name: Set up JDK 8
+        uses: actions/setup-java@v3
         if: steps.docs.outputs.changed_only == 'no'
         with:
-          java-version: 1.8
+          distribution: 'temurin'
+          java-version: 8
 
       - name: clean disk
         if: steps.docs.outputs.changed_only == 'no'

--- a/.github/workflows/ci-license.yaml
+++ b/.github/workflows/ci-license.yaml
@@ -59,11 +59,12 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-maven-
 
-      - name: Set up JDK 1.8
+      - name: Set up JDK 8
+        uses: actions/setup-java@v3
         if: steps.docs.outputs.changed_only == 'no'
-        uses: actions/setup-java@v1
         with:
-          java-version: 1.8
+          distribution: 'temurin'
+          java-version: 8
 
       # license check fails with 3.6.2 so we have to downgrade
       - name: Set up Maven

--- a/.github/workflows/ci-shade-test.yaml
+++ b/.github/workflows/ci-shade-test.yaml
@@ -58,11 +58,12 @@ jobs:
         with:
           args: site2 deployment .asf.yaml .ci ct.yaml
 
-      - name: Set up JDK 1.8
-        uses: actions/setup-java@v1
+      - name: Set up JDK 8
+        uses: actions/setup-java@v3
         if: steps.docs.outputs.changed_only == 'no'
         with:
-          java-version: 1.8
+          distribution: 'temurin'
+          java-version: 8
 
       - name: clean disk
         if: steps.docs.outputs.changed_only == 'no'

--- a/.github/workflows/ci-unit-broker-broker-gp1.yaml
+++ b/.github/workflows/ci-unit-broker-broker-gp1.yaml
@@ -61,6 +61,13 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-maven-
 
+      - name: Set up JDK 8
+        uses: actions/setup-java@v3
+        if: steps.docs.outputs.changed_only == 'no'
+        with:
+          distribution: 'temurin'
+          java-version: 8
+
       - name: build modules
         if: steps.docs.outputs.changed_only == 'no'
         run: mvn -B -ntp -q clean install -Pcore-modules -DskipTests

--- a/.github/workflows/ci-unit-broker-broker-gp2.yaml
+++ b/.github/workflows/ci-unit-broker-broker-gp2.yaml
@@ -60,12 +60,12 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-maven-
 
-      - name: Set up JDK 11
-        uses: actions/setup-java@v2
-        if: ${{ steps.check_changes.outputs.docs_only != 'true' }}
+      - name: Set up JDK 8
+        uses: actions/setup-java@v3
+        if: steps.docs.outputs.changed_only == 'no'
         with:
-          distribution: 'adopt'
-          java-version: 11
+          distribution: 'temurin'
+          java-version: 8
 
       - name: build modules
         if: steps.docs.outputs.changed_only == 'no'

--- a/.github/workflows/ci-unit-broker-client-api.yaml
+++ b/.github/workflows/ci-unit-broker-client-api.yaml
@@ -61,6 +61,13 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-maven-
 
+      - name: Set up JDK 8
+        uses: actions/setup-java@v3
+        if: steps.docs.outputs.changed_only == 'no'
+        with:
+          distribution: 'temurin'
+          java-version: 8
+
       - name: build modules
         if: steps.docs.outputs.changed_only == 'no'
         run: mvn -B -ntp -q install -Pcore-modules -DskipTests

--- a/.github/workflows/ci-unit-broker-client-impl.yaml
+++ b/.github/workflows/ci-unit-broker-client-impl.yaml
@@ -61,6 +61,13 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-maven-
 
+      - name: Set up JDK 8
+        uses: actions/setup-java@v3
+        if: steps.docs.outputs.changed_only == 'no'
+        with:
+          distribution: 'temurin'
+          java-version: 8
+
       - name: build modules
         if: steps.docs.outputs.changed_only == 'no'
         run: mvn -B -ntp -q install -Pcore-modules -DskipTests

--- a/.github/workflows/ci-unit-broker-other.yaml
+++ b/.github/workflows/ci-unit-broker-other.yaml
@@ -60,6 +60,13 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-maven-
 
+      - name: Set up JDK 8
+        uses: actions/setup-java@v3
+        if: steps.docs.outputs.changed_only == 'no'
+        with:
+          distribution: 'temurin'
+          java-version: 8
+
       - name: build modules
         if: steps.docs.outputs.changed_only == 'no'
         run: mvn -B -ntp -q clean install -Pcore-modules -DskipTests

--- a/.github/workflows/ci-unit-proxy.yaml
+++ b/.github/workflows/ci-unit-proxy.yaml
@@ -59,12 +59,13 @@ jobs:
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             ${{ runner.os }}-maven-
-      - name: Set up JDK 11
-        uses: actions/setup-java@v2
-        if: ${{ steps.check_changes.outputs.docs_only != 'true' }}
+
+      - name: Set up JDK 8
+        uses: actions/setup-java@v3
+        if: steps.docs.outputs.changed_only == 'no'
         with:
-          distribution: 'adopt'
-          java-version: 11
+          distribution: 'temurin'
+          java-version: 8
 
       - name: build modules pulsar-proxy
         if: steps.docs.outputs.changed_only == 'no'

--- a/.github/workflows/ci-unit.yaml
+++ b/.github/workflows/ci-unit.yaml
@@ -52,6 +52,13 @@ jobs:
         with:
           args: site2 deployment .asf.yaml .ci ct.yaml
 
+      - name: Set up JDK 8
+        uses: actions/setup-java@v3
+        if: steps.docs.outputs.changed_only == 'no'
+        with:
+          distribution: 'temurin'
+          java-version: 8
+
       - name: build and run unit tests exclude pulsar-broker and pulsar-proxy
         if: steps.docs.outputs.changed_only == 'no'
         run: ./build/retry.sh mvn -B -ntp install -PbrokerSkipTest -Dexclude="org/apache/pulsar/proxy/**/*.java,**/KafkaProducerSimpleConsumerTest.java,**/ManagedLedgerTest.java,**/TestPulsarKeyValueSchemaHandler.java,**/PrimitiveSchemaTest.java,**/BlobStoreManagedLedgerOffloaderTest.java"


### PR DESCRIPTION
Signed-off-by: Zixuan Liu <nodeces@gmail.com>

### Motivation

Some workflows do not have set up the Java, we need to add this step. If we do not set up the Java, the workflow uses the built-in Java 8, which seems unstable and causes the TLS tests to fail. I suggest we should use the Eclipse Temurin Java instead of the default Java, and switch Java 11 to Java 8 because Java 11 breaks the TLS test.

### Modifications

- Switch `actions/setup-java` from `v1` to `v3`, and use the Eclipse Temurin Java 8
- Add `actions/setup-java` to the workflow that does not set up the Java version

### Documentation
  
- [x] `doc-not-needed` 
