### PR TITLE
[fix][common] Fix setManagedLedgerOffloadedReadPriority not work.

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/common/naming/ServiceConfigurationTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/common/naming/ServiceConfigurationTest.java
@@ -42,6 +42,7 @@ import lombok.Cleanup;
 import org.apache.pulsar.broker.ServiceConfiguration;
 import org.apache.pulsar.common.configuration.PulsarConfigurationLoader;
 import org.apache.pulsar.common.policies.data.InactiveTopicDeleteMode;
+import org.apache.pulsar.common.policies.data.OffloadPoliciesImpl;
 import org.testng.annotations.Test;
 
 @Test(groups = "broker-naming")
@@ -70,6 +71,8 @@ public class ServiceConfigurationTest {
         assertEquals(config.getMaxMessagePublishBufferSizeInMB(), -1);
         assertEquals(config.getManagedLedgerDataReadPriority(), "bookkeeper-first");
         assertEquals(config.getBacklogQuotaDefaultLimitGB(), 0.05);
+        OffloadPoliciesImpl offloadPolicies = OffloadPoliciesImpl.create(config.getProperties());
+        assertEquals(offloadPolicies.getManagedLedgerOffloadedReadPriority().getValue(), "bookkeeper-first");
     }
 
     @Test

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/OffloadPoliciesImpl.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/OffloadPoliciesImpl.java
@@ -255,6 +255,11 @@ public class OffloadPoliciesImpl implements Serializable, OffloadPolicies {
             setManagedLedgerOffloadDeletionLagInMillis(
                     Long.parseLong(properties.getProperty(DELETION_LAG_NAME_IN_CONF_FILE)));
         }
+
+        if (properties.containsKey("managedLedgerDataReadPriority")) {
+            setManagedLedgerOffloadedReadPriority(
+                    OffloadedReadPriority.fromString(properties.getProperty("managedLedgerDataReadPriority")));
+        }
     }
 
     public boolean driverSupported() {


### PR DESCRIPTION
Master Issue: #16432

### Motivation

It's named `managedLedgerDataReadPriority` in ServiceConfiguration , but named `managedLedgerOffloadedReadPriority` in OffloadPoliciesImpl.  So when copy properties, it' can't set the right field and cause OffloadPoliciesImpl to use the default value.

### Documentation

- [x] `doc-not-needed` 
