### PR TITLE
[cleanup][buildtools] Prevent shade plugin warning

### DIFF
--- a/buildtools/pom.xml
+++ b/buildtools/pom.xml
@@ -200,6 +200,14 @@
               <shadedPattern>org.apache.pulsar.buildtools.shaded.org.apache.commons.lang3</shadedPattern>
             </relocation>
           </relocations>
+          <filters>
+            <filter>
+              <artifact>org.apache.commons:commons-lang3</artifact>
+              <excludes>
+                <exclude>META-INF/MANIFEST.MF</exclude>
+              </excludes>
+            </filter>
+          </filters>
         </configuration>
         <executions>
           <execution>


### PR DESCRIPTION
### Motivation
Remove superfluous noise from the build:

```
[WARNING] buildtools-2.11.0-SNAPSHOT.jar, commons-lang3-3.11.jar define 1 overlapping resource:
[WARNING]   - META-INF/MANIFEST.MF
[WARNING] maven-shade-plugin has detected that some class files are
[WARNING] present in two or more JARs. When this happens, only one
[WARNING] single version of the class is copied to the uber jar.
[WARNING] Usually this is not harmful and you can skip these warnings,
[WARNING] otherwise try to manually exclude artifacts based on
[WARNING] mvn dependency:tree -Ddetail=true and the above output.
[WARNING] See http://maven.apache.org/plugins/maven-shade-plugin/
```

### Modifications
Explicitly excluded `MANIFEST.MF` file from `commons-lang` during shade so that it doesn't conflict with generated manifest file.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): No
  - The public API: No
  - The schema: No
  - The default values of configurations: No
  - The wire protocol: No
  - The rest endpoints: No
  - The admin cli options: No
  - Anything that affects deployment: No

### Documentation

Check the box below or label this PR directly.

Need to update docs? 

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)
  
- [x] `doc-not-needed` 
Trival build clean-up
  
- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)