### PR TITLE
Bump jcommander version from 1.78 to 1.82

### DIFF
--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -309,7 +309,7 @@ pulsar-client-cpp/lib/checksum/crc32c_sw.cc
 This projects includes binary packages with the following licenses:
 
 The Apache Software License, Version 2.0
- * JCommander -- com.beust-jcommander-1.78.jar
+ * JCommander -- com.beust-jcommander-1.82.jar
  * High Performance Primitive Collections for Java -- com.carrotsearch-hppc-0.9.1.jar
  * Jackson
      - com.fasterxml.jackson.core-jackson-annotations-2.13.2.jar

--- a/pom.xml
+++ b/pom.xml
@@ -186,7 +186,7 @@ flexible messaging model and an intuitive client API.</description>
     <kafka.confluent.avroserializer.version>5.3.0</kafka.confluent.avroserializer.version>
     <aircompressor.version>0.20</aircompressor.version>
     <asynchttpclient.version>2.12.1</asynchttpclient.version>
-    <jcommander.version>1.78</jcommander.version>
+    <jcommander.version>1.82</jcommander.version>
     <commons-lang3.version>3.11</commons-lang3.version>
     <commons-configuration.version>1.10</commons-configuration.version>
     <commons-io.version>2.8.0</commons-io.version>

--- a/pulsar-sql/presto-distribution/LICENSE
+++ b/pulsar-sql/presto-distribution/LICENSE
@@ -386,7 +386,7 @@ The Apache Software License, Version 2.0
     - javax.servlet-api-4.0.1.jar
     - javax.ws.rs-api-2.1.jar
   * JCommander
-    - jcommander-1.78.jar
+    - jcommander-1.82.jar
   * FindBugs JSR305
     - jsr305-3.0.2.jar
   * Objenesis


### PR DESCRIPTION
### Motivation
That's a regular update, `jcommander` 1.78 was released in 2019.

### Modifications

Bump jcommander version from 1.78 to 1.82

### Documentation

Check the box below or label this PR directly.

Need to update docs? 

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)
  
- [x] `doc-not-needed` 
(Please explain why)
  
- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)