### PR TITLE
[cleanup][pulsar] Remove warnings for deprecated API use

### DIFF
--- a/pulsar-functions/runtime/src/test/java/org/apache/pulsar/functions/worker/WorkerApiV2ResourceConfigTest.java
+++ b/pulsar-functions/runtime/src/test/java/org/apache/pulsar/functions/worker/WorkerApiV2ResourceConfigTest.java
@@ -54,7 +54,7 @@ public class WorkerApiV2ResourceConfigTest {
         assertEquals("sample/standalone/functions", wc.getPulsarFunctionsNamespace());
         assertEquals(3, wc.getNumFunctionPackageReplicas());
         assertEquals(TEST_NAME + "-worker", wc.getWorkerId());
-        assertEquals(new Integer(1234), wc.getWorkerPort());
+        assertEquals(Integer.valueOf(1234), wc.getWorkerPort());
     }
 
     @Test
@@ -66,7 +66,7 @@ public class WorkerApiV2ResourceConfigTest {
         assertEquals("test-function-metadata-topic", wc.getFunctionMetadataTopicName());
         assertEquals(3, wc.getNumFunctionPackageReplicas());
         assertEquals("test-worker", wc.getWorkerId());
-        assertEquals(new Integer(7654), wc.getWorkerPort());
+        assertEquals(Integer.valueOf(7654), wc.getWorkerPort());
         assertEquals(200, wc.getMaxPendingAsyncRequests());
     }
 

--- a/pulsar-functions/utils/src/test/java/org/apache/pulsar/functions/utils/FunctionConfigUtilsTest.java
+++ b/pulsar-functions/utils/src/test/java/org/apache/pulsar/functions/utils/FunctionConfigUtilsTest.java
@@ -76,7 +76,7 @@ public class FunctionConfigUtilsTest {
         functionConfig.setForwardSourceMessageProperty(true);
         functionConfig.setUserConfig(new HashMap<>());
         functionConfig.setAutoAck(true);
-        functionConfig.setTimeoutMs(2000l);
+        functionConfig.setTimeoutMs(2000L);
         functionConfig.setRuntimeFlags("-DKerberos");
         ProducerConfig producerConfig = new ProducerConfig();
         producerConfig.setMaxPendingMessages(100);
@@ -117,7 +117,7 @@ public class FunctionConfigUtilsTest {
         functionConfig.setForwardSourceMessageProperty(true);
         functionConfig.setUserConfig(new HashMap<>());
         functionConfig.setAutoAck(true);
-        functionConfig.setTimeoutMs(2000l);
+        functionConfig.setTimeoutMs(2000L);
         functionConfig.setWindowConfig(new WindowConfig().setWindowLengthCount(10));
         ProducerConfig producerConfig = new ProducerConfig();
         producerConfig.setMaxPendingMessages(100);
@@ -322,7 +322,7 @@ public class FunctionConfigUtilsTest {
         FunctionConfig mergedConfig = FunctionConfigUtils.validateUpdate(functionConfig, newFunctionConfig);
         assertEquals(
                 mergedConfig.getMaxMessageRetries(),
-                new Integer(10)
+                Integer.valueOf(10)
         );
         mergedConfig.setMaxMessageRetries(functionConfig.getMaxMessageRetries());
         assertEquals(
@@ -361,7 +361,7 @@ public class FunctionConfigUtilsTest {
         FunctionConfig mergedConfig = FunctionConfigUtils.validateUpdate(functionConfig, newFunctionConfig);
         assertEquals(
                 mergedConfig.getParallelism(),
-                new Integer(101)
+                Integer.valueOf(101)
         );
         mergedConfig.setParallelism(functionConfig.getParallelism());
         assertEquals(
@@ -375,8 +375,8 @@ public class FunctionConfigUtilsTest {
         FunctionConfig functionConfig = createFunctionConfig();
         Resources resources = new Resources();
         resources.setCpu(0.3);
-        resources.setRam(1232l);
-        resources.setDisk(123456l);
+        resources.setRam(1232L);
+        resources.setDisk(123456L);
         FunctionConfig newFunctionConfig = createUpdatedFunctionConfig("resources", resources);
         FunctionConfig mergedConfig = FunctionConfigUtils.validateUpdate(functionConfig, newFunctionConfig);
         assertEquals(
@@ -395,7 +395,7 @@ public class FunctionConfigUtilsTest {
         FunctionConfig functionConfig = createFunctionConfig();
         WindowConfig windowConfig = new WindowConfig();
         windowConfig.setSlidingIntervalCount(123);
-        windowConfig.setSlidingIntervalDurationMs(123l);
+        windowConfig.setSlidingIntervalDurationMs(123L);
         FunctionConfig newFunctionConfig = createUpdatedFunctionConfig("windowConfig", windowConfig);
         FunctionConfig mergedConfig = FunctionConfigUtils.validateUpdate(functionConfig, newFunctionConfig);
         assertEquals(
@@ -412,11 +412,11 @@ public class FunctionConfigUtilsTest {
     @Test
     public void testMergeDifferentTimeout() {
         FunctionConfig functionConfig = createFunctionConfig();
-        FunctionConfig newFunctionConfig = createUpdatedFunctionConfig("timeoutMs", 102l);
+        FunctionConfig newFunctionConfig = createUpdatedFunctionConfig("timeoutMs", 102L);
         FunctionConfig mergedConfig = FunctionConfigUtils.validateUpdate(functionConfig, newFunctionConfig);
         assertEquals(
                 mergedConfig.getTimeoutMs(),
-                new Long(102l)
+                Long.valueOf(102L)
         );
         mergedConfig.setTimeoutMs(functionConfig.getTimeoutMs());
         assertEquals(
@@ -462,7 +462,7 @@ public class FunctionConfigUtilsTest {
         functionConfig.setForwardSourceMessageProperty(false);
         functionConfig.setUserConfig(new HashMap<>());
         functionConfig.setAutoAck(true);
-        functionConfig.setTimeoutMs(2000l);
+        functionConfig.setTimeoutMs(2000L);
         functionConfig.setWindowConfig(new WindowConfig().setWindowLengthCount(10));
         functionConfig.setCleanupSubscription(true);
         functionConfig.setRuntimeFlags("-Dfoo=bar");

--- a/pulsar-functions/utils/src/test/java/org/apache/pulsar/functions/utils/SinkConfigUtilsTest.java
+++ b/pulsar-functions/utils/src/test/java/org/apache/pulsar/functions/utils/SinkConfigUtilsTest.java
@@ -26,7 +26,6 @@ import lombok.experimental.Accessors;
 import org.apache.pulsar.common.functions.ConsumerConfig;
 import org.apache.pulsar.common.functions.FunctionConfig;
 import org.apache.pulsar.common.functions.Resources;
-import org.apache.pulsar.common.io.ConnectorDefinition;
 import org.apache.pulsar.common.io.SinkConfig;
 import org.apache.pulsar.config.validation.ConfigValidationAnnotations;
 import org.apache.pulsar.functions.api.utils.IdentityFunction;
@@ -52,8 +51,6 @@ import static org.testng.Assert.expectThrows;
  * Unit test of {@link SinkConfigUtilsTest}.
  */
 public class SinkConfigUtilsTest {
-
-    private ConnectorDefinition defn;
 
     @Data
     @Accessors(chain = true)
@@ -94,7 +91,7 @@ public class SinkConfigUtilsTest {
         sinkConfig.setRetainKeyOrdering(false);
         sinkConfig.setAutoAck(true);
         sinkConfig.setCleanupSubscription(false);
-        sinkConfig.setTimeoutMs(2000l);
+        sinkConfig.setTimeoutMs(2000L);
         sinkConfig.setRuntimeFlags("-DKerberos");
         sinkConfig.setCleanupSubscription(true);
 
@@ -341,7 +338,7 @@ public class SinkConfigUtilsTest {
         SinkConfig mergedConfig = SinkConfigUtils.validateUpdate(sinkConfig, newSinkConfig);
         assertEquals(
                 mergedConfig.getParallelism(),
-                new Integer(101)
+                Integer.valueOf(101)
         );
         mergedConfig.setParallelism(sinkConfig.getParallelism());
         assertEquals(
@@ -355,8 +352,8 @@ public class SinkConfigUtilsTest {
         SinkConfig sinkConfig = createSinkConfig();
         Resources resources = new Resources();
         resources.setCpu(0.3);
-        resources.setRam(1232l);
-        resources.setDisk(123456l);
+        resources.setRam(1232L);
+        resources.setDisk(123456L);
         SinkConfig newSinkConfig = createUpdatedSinkConfig("resources", resources);
         SinkConfig mergedConfig = SinkConfigUtils.validateUpdate(sinkConfig, newSinkConfig);
         assertEquals(
@@ -373,11 +370,11 @@ public class SinkConfigUtilsTest {
     @Test
     public void testMergeDifferentTimeout() {
         SinkConfig sinkConfig = createSinkConfig();
-        SinkConfig newSinkConfig = createUpdatedSinkConfig("timeoutMs", 102l);
+        SinkConfig newSinkConfig = createUpdatedSinkConfig("timeoutMs", 102L);
         SinkConfig mergedConfig = SinkConfigUtils.validateUpdate(sinkConfig, newSinkConfig);
         assertEquals(
                 mergedConfig.getTimeoutMs(),
-                new Long(102l)
+                Long.valueOf(102L)
         );
         mergedConfig.setTimeoutMs(sinkConfig.getTimeoutMs());
         assertEquals(
@@ -415,7 +412,7 @@ public class SinkConfigUtilsTest {
     }
 
     @Test
-    public void testValidateConfig() throws IOException {
+    public void testValidateConfig() {
         SinkConfig sinkConfig = createSinkConfig();
 
         // Good config
@@ -444,7 +441,7 @@ public class SinkConfigUtilsTest {
         sinkConfig.setRetainKeyOrdering(false);
         sinkConfig.setConfigs(new HashMap<>());
         sinkConfig.setAutoAck(true);
-        sinkConfig.setTimeoutMs(2000l);
+        sinkConfig.setTimeoutMs(2000L);
         sinkConfig.setCleanupSubscription(true);
         sinkConfig.setArchive("DummyArchive.nar");
         sinkConfig.setCleanupSubscription(true);

--- a/pulsar-functions/utils/src/test/java/org/apache/pulsar/functions/utils/SourceConfigUtilsTest.java
+++ b/pulsar-functions/utils/src/test/java/org/apache/pulsar/functions/utils/SourceConfigUtilsTest.java
@@ -26,7 +26,6 @@ import org.apache.pulsar.common.functions.FunctionConfig;
 import org.apache.pulsar.common.functions.ProducerConfig;
 import org.apache.pulsar.common.functions.Resources;
 import org.apache.pulsar.common.io.BatchSourceConfig;
-import org.apache.pulsar.common.io.ConnectorDefinition;
 import org.apache.pulsar.common.io.SourceConfig;
 import org.apache.pulsar.config.validation.ConfigValidationAnnotations;
 import org.apache.pulsar.functions.proto.Function;
@@ -34,7 +33,6 @@ import org.apache.pulsar.io.core.BatchSourceTriggerer;
 import org.apache.pulsar.io.core.SourceContext;
 import org.testng.annotations.Test;
 
-import java.io.IOException;
 import java.lang.reflect.Field;
 import java.util.HashMap;
 import java.util.Map;
@@ -49,8 +47,6 @@ import static org.testng.Assert.expectThrows;
  * Unit test of {@link SourceConfigUtilsTest}.
  */
 public class SourceConfigUtilsTest {
-
-    private ConnectorDefinition defn;
 
     @Data
     @Accessors(chain = true)
@@ -79,7 +75,7 @@ public class SourceConfigUtilsTest {
     }
 
     @Test
-    public void testConvertBackFidelity() throws IOException  {
+    public void testConvertBackFidelity() {
         SourceConfig sourceConfig = createSourceConfig();
         Function.FunctionDetails functionDetails = SourceConfigUtils.convert(sourceConfig, new SourceConfigUtils.ExtractedSourceDetails(null, null));
         SourceConfig convertedConfig = SourceConfigUtils.convertFromDetails(functionDetails);
@@ -93,7 +89,7 @@ public class SourceConfigUtilsTest {
     }
 
     @Test
-    public void testConvertBackFidelityWithBatch() throws IOException  {
+    public void testConvertBackFidelityWithBatch() {
         SourceConfig sourceConfig = createSourceConfigWithBatch();
         Function.FunctionDetails functionDetails = SourceConfigUtils.convert(sourceConfig, new SourceConfigUtils.ExtractedSourceDetails(null, null));
         SourceConfig convertedConfig = SourceConfigUtils.convertFromDetails(functionDetails);
@@ -215,7 +211,7 @@ public class SourceConfigUtilsTest {
         SourceConfig mergedConfig = SourceConfigUtils.validateUpdate(sourceConfig, newSourceConfig);
         assertEquals(
                 mergedConfig.getParallelism(),
-                new Integer(101)
+                Integer.valueOf(101)
         );
         mergedConfig.setParallelism(sourceConfig.getParallelism());
         assertEquals(
@@ -229,8 +225,8 @@ public class SourceConfigUtilsTest {
         SourceConfig sourceConfig = createSourceConfig();
         Resources resources = new Resources();
         resources.setCpu(0.3);
-        resources.setRam(1232l);
-        resources.setDisk(123456l);
+        resources.setRam(1232L);
+        resources.setDisk(123456L);
         SourceConfig newSourceConfig = createUpdatedSourceConfig("resources", resources);
         SourceConfig mergedConfig = SourceConfigUtils.validateUpdate(sourceConfig, newSourceConfig);
         assertEquals(
@@ -289,7 +285,7 @@ public class SourceConfigUtilsTest {
     }
 
     @Test
-    public void testValidateConfig() throws IOException {
+    public void testValidateConfig() {
         SourceConfig sourceConfig = createSourceConfig();
 
         // Good config

--- a/tiered-storage/jcloud/src/test/java/org/apache/bookkeeper/mledger/offload/jcloud/provider/TieredStorageConfigurationTests.java
+++ b/tiered-storage/jcloud/src/test/java/org/apache/bookkeeper/mledger/offload/jcloud/provider/TieredStorageConfigurationTests.java
@@ -89,8 +89,8 @@ public class TieredStorageConfigurationTests {
         
         assertEquals(config.getRegion(), "us-east-1");
         assertEquals(config.getBucket(), "test bucket");
-        assertEquals(config.getMaxBlockSizeInBytes(), new Integer(1));
-        assertEquals(config.getReadBufferSizeInBytes(), new Integer(500));
+        assertEquals(config.getMaxBlockSizeInBytes(), Integer.valueOf(1));
+        assertEquals(config.getReadBufferSizeInBytes(), Integer.valueOf(500));
         assertEquals(config.getServiceEndpoint(), "http://some-url:9093");
     }
     
@@ -99,7 +99,7 @@ public class TieredStorageConfigurationTests {
      */
     @Test
     public final void awsS3BackwardCompatiblePropertiesTest() {
-        Map<String, String> map = new HashMap<String,String>(); 
+        Map<String, String> map = new HashMap<>();
         map.put(TieredStorageConfiguration.BLOB_STORE_PROVIDER_KEY, JCloudBlobStoreProvider.AWS_S3.getDriver());
         map.put(BC_S3_BUCKET, "test bucket");
         map.put(BC_S3_ENDPOINT, "http://some-url:9093");
@@ -110,8 +110,8 @@ public class TieredStorageConfigurationTests {
         
         assertEquals(config.getRegion(), "test region");
         assertEquals(config.getBucket(), "test bucket");
-        assertEquals(config.getMaxBlockSizeInBytes(), new Integer(12));
-        assertEquals(config.getReadBufferSizeInBytes(), new Integer(500));
+        assertEquals(config.getMaxBlockSizeInBytes(), Integer.valueOf(12));
+        assertEquals(config.getReadBufferSizeInBytes(), Integer.valueOf(500));
         assertEquals(config.getServiceEndpoint(), "http://some-url:9093");
     }
 
@@ -187,8 +187,8 @@ public class TieredStorageConfigurationTests {
         
         assertEquals(config.getRegion(), "us-east-1");
         assertEquals(config.getBucket(), "test bucket");
-        assertEquals(config.getMaxBlockSizeInBytes(), new Integer(1));
-        assertEquals(config.getReadBufferSizeInBytes(), new Integer(500));
+        assertEquals(config.getMaxBlockSizeInBytes(), Integer.valueOf(1));
+        assertEquals(config.getReadBufferSizeInBytes(), Integer.valueOf(500));
     }
     
     /**
@@ -206,8 +206,8 @@ public class TieredStorageConfigurationTests {
         
         assertEquals(config.getRegion(), "test region");
         assertEquals(config.getBucket(), "test bucket");
-        assertEquals(config.getMaxBlockSizeInBytes(), new Integer(12));
-        assertEquals(config.getReadBufferSizeInBytes(), new Integer(500));
+        assertEquals(config.getMaxBlockSizeInBytes(), Integer.valueOf(12));
+        assertEquals(config.getReadBufferSizeInBytes(), Integer.valueOf(500));
     }
 
     @Test


### PR DESCRIPTION
Uses `Long`/`Integer.valueOf(...)` over `new` to reduce warning-related build noise:

```
[WARNING] ... Integer(int) in java.lang.Integer has been deprecated and marked for removal
```

### Motivation
To reduce noise when building and elevate the usefulness of warnings.

### Modifications

* `new Long(...)` -> `Long.valueOf(...)`
* `new Integer(...)` -> `Integer.valueOf(...)`
* Used Long literal recommended suffix `L` instead of `l`
* Removed one unused field.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API: no
  - The schema: no
  - The default values of configurations: no
  - The wire protocol: no
  - The rest endpoints: no
  - The admin cli options: no
  - Anything that affects deployment: no

### Documentation

Need to update docs? 

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)
  
- [x] `doc-not-needed` 
(Please explain why)
  
- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)