### PR TITLE
[feature][connector] JDBC sinks: support upsert and row deletion

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -158,7 +158,7 @@ flexible messaging model and an intuitive client API.</description>
     <joda.version>2.10.5</joda.version>
     <jclouds.version>2.5.0</jclouds.version>
     <guice.version>5.1.0</guice.version>
-    <sqlite-jdbc.version>3.8.11.2</sqlite-jdbc.version>
+    <sqlite-jdbc.version>3.36.0.3</sqlite-jdbc.version>
     <mysql-jdbc.version>8.0.11</mysql-jdbc.version>
     <postgresql-jdbc.version>42.3.3</postgresql-jdbc.version>
     <clickhouse-jdbc.version>0.3.2</clickhouse-jdbc.version>

--- a/pulsar-io/jdbc/core/src/main/java/org/apache/pulsar/io/jdbc/BaseJdbcAutoSchemaSink.java
+++ b/pulsar-io/jdbc/core/src/main/java/org/apache/pulsar/io/jdbc/BaseJdbcAutoSchemaSink.java
@@ -21,8 +21,8 @@ package org.apache.pulsar.io.jdbc;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.Lists;
 import java.sql.PreparedStatement;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -44,37 +44,28 @@ import org.apache.pulsar.io.jdbc.JdbcUtils.ColumnId;
 public abstract class BaseJdbcAutoSchemaSink extends JdbcAbstractSink<GenericObject> {
 
     @Override
-    public void bindValue(PreparedStatement statement,
-                          Record<GenericObject> message, String action) throws Exception {
-        final GenericObject record = message.getValue();
-        Function<String, Object> recordValueGetter;
-        if (message.getSchema() != null && message.getSchema() instanceof KeyValueSchema) {
-            KeyValueSchema<GenericObject, GenericObject> keyValueSchema = (KeyValueSchema) message.getSchema();
+    public String generateUpsertQueryStatement() {
+        throw new IllegalStateException("UPSERT not supported");
+    }
 
-            final org.apache.pulsar.client.api.Schema<GenericObject> keySchema = keyValueSchema.getKeySchema();
-            final org.apache.pulsar.client.api.Schema<GenericObject> valueSchema = keyValueSchema.getValueSchema();
-            KeyValue<GenericObject, GenericObject> keyValue =
-                    (KeyValue<GenericObject, GenericObject>) record.getNativeObject();
-
-            final GenericObject key = keyValue.getKey();
-            final GenericObject value = keyValue.getValue();
-
-            Map<String, Object> data = new HashMap<>();
-            fillKeyValueSchemaData(keySchema, key, data);
-            fillKeyValueSchemaData(valueSchema, value, data);
-            recordValueGetter = (k) -> data.get(k);
-        } else {
-            recordValueGetter = (key) -> ((GenericRecord) record).getField(key);
-        }
-
-        List<ColumnId> columns = Lists.newArrayList();
-        if (action == null || action.equals(INSERT)) {
-            columns = tableDefinition.getColumns();
-        } else if (action.equals(DELETE)){
-            columns.addAll(tableDefinition.getKeyColumns());
-        } else if (action.equals(UPDATE)){
-            columns.addAll(tableDefinition.getNonKeyColumns());
-            columns.addAll(tableDefinition.getKeyColumns());
+    @Override
+    public void bindValue(PreparedStatement statement, Mutation mutation) throws Exception {
+        final List<ColumnId> columns = new ArrayList<>();
+        switch (mutation.getType()) {
+            case INSERT:
+                columns.addAll(tableDefinition.getColumns());
+                break;
+            case UPSERT:
+                columns.addAll(tableDefinition.getColumns());
+                columns.addAll(tableDefinition.getNonKeyColumns());
+                break;
+            case UPDATE:
+                columns.addAll(tableDefinition.getNonKeyColumns());
+                columns.addAll(tableDefinition.getKeyColumns());
+                break;
+            case DELETE:
+                columns.addAll(tableDefinition.getKeyColumns());
+                break;
         }
 
         int index = 1;
@@ -82,10 +73,10 @@ public abstract class BaseJdbcAutoSchemaSink extends JdbcAbstractSink<GenericObj
             String colName = columnId.getName();
             int colType = columnId.getType();
             if (log.isDebugEnabled()) {
-                log.debug("colName: {} colType: {}", colName, colType);
+                log.debug("getting value for column: {} type: {}", colName, colType);
             }
             try {
-                Object obj = recordValueGetter.apply(colName);
+                Object obj = mutation.getValues().apply(colName);
                 if (obj != null) {
                     setColumnValue(statement, index++, obj);
                 } else {
@@ -103,6 +94,66 @@ public abstract class BaseJdbcAutoSchemaSink extends JdbcAbstractSink<GenericObj
                 setColumnNull(statement, index++, colType);
             }
         }
+    }
+
+    @Override
+    public Mutation createMutation(Record<GenericObject> message) {
+        final GenericObject record = message.getValue();
+        Function<String, Object> recordValueGetter;
+        MutationType mutationType = null;
+        if (message.getSchema() != null && message.getSchema() instanceof KeyValueSchema) {
+            KeyValueSchema<GenericObject, GenericObject> keyValueSchema = (KeyValueSchema) message.getSchema();
+
+            final org.apache.pulsar.client.api.Schema<GenericObject> keySchema = keyValueSchema.getKeySchema();
+            final org.apache.pulsar.client.api.Schema<GenericObject> valueSchema = keyValueSchema.getValueSchema();
+            KeyValue<GenericObject, GenericObject> keyValue =
+                    (KeyValue<GenericObject, GenericObject>) record.getNativeObject();
+
+            final GenericObject key = keyValue.getKey();
+            final GenericObject value = keyValue.getValue();
+
+            boolean isDelete = false;
+            if (value == null) {
+                switch (jdbcSinkConfig.getNullValueAction()) {
+                    case DELETE:
+                        isDelete = true;
+                        break;
+                    case FAIL:
+                        throw new IllegalArgumentException("Got record with value NULL with nullValueAction=FAIL");
+                    default:
+                        break;
+                }
+            }
+            Map<String, Object> data = new HashMap<>();
+            fillKeyValueSchemaData(keySchema, key, data);
+            if (isDelete) {
+                mutationType = MutationType.DELETE;
+            } else {
+                fillKeyValueSchemaData(valueSchema, value, data);
+            }
+            recordValueGetter = (k) -> data.get(k);
+        } else {
+            recordValueGetter = (key) -> ((GenericRecord) record).getField(key);
+        }
+        String action = message.getProperties().get(ACTION_PROPERTY);
+        if (action != null) {
+            mutationType = MutationType.valueOf(action);
+        } else if (mutationType == null) {
+            switch (jdbcSinkConfig.getInsertMode()) {
+                case INSERT:
+                    mutationType = MutationType.INSERT;
+                    break;
+                case UPSERT:
+                    mutationType = MutationType.UPSERT;
+                    break;
+                case UPDATE:
+                    mutationType = MutationType.UPDATE;
+                    break;
+                default:
+                    throw new IllegalArgumentException("Unknown insert mode: " + jdbcSinkConfig.getInsertMode());
+            }
+        }
+        return new Mutation(mutationType, recordValueGetter);
     }
 
     private static void setColumnNull(PreparedStatement statement, int index, int type) throws Exception {
@@ -163,6 +214,9 @@ public abstract class BaseJdbcAutoSchemaSink extends JdbcAbstractSink<GenericObj
     private static void fillKeyValueSchemaData(org.apache.pulsar.client.api.Schema<GenericObject> schema,
                                         GenericObject record,
                                         Map<String, Object> data) {
+        if (record == null) {
+            return;
+        }
         switch (schema.getSchemaInfo().getType()) {
             case JSON:
                 final JsonNode jsonNode = (JsonNode) record.getNativeObject();
@@ -190,6 +244,9 @@ public abstract class BaseJdbcAutoSchemaSink extends JdbcAbstractSink<GenericObj
 
     @VisibleForTesting
     static Object convertAvroField(Object avroValue, Schema schema) {
+        if (avroValue == null) {
+            return null;
+        }
         switch (schema.getType()) {
             case NULL:
             case INT:

--- a/pulsar-io/jdbc/core/src/main/java/org/apache/pulsar/io/jdbc/JdbcSinkConfig.java
+++ b/pulsar-io/jdbc/core/src/main/java/org/apache/pulsar/io/jdbc/JdbcSinkConfig.java
@@ -86,6 +86,35 @@ public class JdbcSinkConfig implements Serializable {
     )
     private int batchSize = 200;
 
+    @FieldDoc(
+            required = false,
+            defaultValue = "INSERT",
+            help = "If it is configured as UPSERT, the sink will use upsert semantics rather than "
+                    + "plain INSERT/UPDATE statements. Upsert semantics refer to atomically adding a new row or "
+                    + "updating the existing row if there is a primary key constraint violation, "
+                    + "which provides idempotence."
+    )
+    private InsertMode insertMode = InsertMode.INSERT;
+
+    @FieldDoc(
+            required = false,
+            defaultValue = "FAIL",
+            help = "How to handle records with null values, possible options are DELETE or FAIL."
+    )
+    private NullValueAction nullValueAction = NullValueAction.FAIL;
+
+    public enum InsertMode {
+        INSERT,
+        UPSERT,
+        UPDATE;
+    }
+
+    public enum NullValueAction {
+        FAIL,
+        DELETE
+    }
+
+
     public static JdbcSinkConfig load(String yamlFile) throws IOException {
         ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
         return mapper.readValue(new File(yamlFile), JdbcSinkConfig.class);

--- a/pulsar-io/jdbc/core/src/main/java/org/apache/pulsar/io/jdbc/JdbcUtils.java
+++ b/pulsar-io/jdbc/core/src/main/java/org/apache/pulsar/io/jdbc/JdbcUtils.java
@@ -198,6 +198,13 @@ public class JdbcUtils {
         builder.append("UPDATE ");
         builder.append(table.tableId.getTableName());
         builder.append(" SET ");
+        StringJoiner setJoiner = buildUpdateSqlSetPart(table);
+        builder.append(setJoiner);
+        builder.append(combationWhere(table.keyColumns));
+        return builder.toString();
+    }
+
+    public static StringJoiner buildUpdateSqlSetPart(TableDefinition table) {
         StringJoiner setJoiner = new StringJoiner(",");
 
         table.nonKeyColumns.forEach((columnId) ->{
@@ -205,9 +212,7 @@ public class JdbcUtils {
             equals.add(columnId.getName()).add("? ");
             setJoiner.add(equals.toString());
         });
-        builder.append(setJoiner.toString());
-        builder.append(combationWhere(table.keyColumns));
-        return builder.toString();
+        return setJoiner;
     }
 
     public static PreparedStatement buildUpdateStatement(Connection connection, String updateSQL) throws SQLException {

--- a/pulsar-io/jdbc/core/src/test/java/org/apache/pulsar/io/jdbc/BaseJdbcAutoSchemaSinkTest.java
+++ b/pulsar-io/jdbc/core/src/test/java/org/apache/pulsar/io/jdbc/BaseJdbcAutoSchemaSinkTest.java
@@ -93,20 +93,20 @@ public class BaseJdbcAutoSchemaSinkTest {
     @Test(expectedExceptions = UnsupportedOperationException.class,
             expectedExceptionsMessageRegExp = "Unsupported avro schema type.*")
     public void testNotSupportedAvroTypesBytes() {
-        BaseJdbcAutoSchemaSink.convertAvroField(null, createFieldAndGetSchema((builder) ->
+        BaseJdbcAutoSchemaSink.convertAvroField(new Object(), createFieldAndGetSchema((builder) ->
                 builder.name("field").type().bytesType().noDefault()));
     }
 
     @Test(expectedExceptions = UnsupportedOperationException.class,
             expectedExceptionsMessageRegExp = "Unsupported avro schema type.*")
     public void testNotSupportedAvroTypesFixed() {
-        BaseJdbcAutoSchemaSink.convertAvroField(null, createFieldAndGetSchema((builder) ->
+        BaseJdbcAutoSchemaSink.convertAvroField(new Object(), createFieldAndGetSchema((builder) ->
                 builder.name("field").type().fixed("fix").size(16).noDefault()));
     }
     @Test(expectedExceptions = UnsupportedOperationException.class,
             expectedExceptionsMessageRegExp = "Unsupported avro schema type.*")
     public void testNotSupportedAvroTypesRecord() {
-        BaseJdbcAutoSchemaSink.convertAvroField(null, createFieldAndGetSchema((builder) ->
+        BaseJdbcAutoSchemaSink.convertAvroField(new Object(), createFieldAndGetSchema((builder) ->
                 builder.name("field").type()
                         .record("myrecord").fields()
                         .name("f1").type().intType().noDefault()
@@ -116,7 +116,7 @@ public class BaseJdbcAutoSchemaSinkTest {
     @Test(expectedExceptions = UnsupportedOperationException.class,
             expectedExceptionsMessageRegExp = "Unsupported avro schema type.*")
     public void testNotSupportedAvroTypesMap() {
-        BaseJdbcAutoSchemaSink.convertAvroField(null, createFieldAndGetSchema((builder) ->
+        BaseJdbcAutoSchemaSink.convertAvroField(new Object(), createFieldAndGetSchema((builder) ->
                 builder.name("field").type().map().values().stringType().noDefault()));
     }
 
@@ -124,8 +124,16 @@ public class BaseJdbcAutoSchemaSinkTest {
     @Test(expectedExceptions = UnsupportedOperationException.class,
             expectedExceptionsMessageRegExp = "Unsupported avro schema type.*")
     public void testNotSupportedAvroTypesArray() {
-        BaseJdbcAutoSchemaSink.convertAvroField(null, createFieldAndGetSchema((builder) ->
+        BaseJdbcAutoSchemaSink.convertAvroField(new Object(), createFieldAndGetSchema((builder) ->
                 builder.name("field").type().array().items().stringType().noDefault()));
+    }
+
+
+    @Test
+    public void testConvertAvroNullValue() {
+        Object converted = BaseJdbcAutoSchemaSink.convertAvroField(null, createFieldAndGetSchema((builder) ->
+                builder.name("field").type().stringType().noDefault()));
+        Assert.assertNull(converted);
     }
 
 

--- a/pulsar-io/jdbc/mariadb/src/main/java/org/apache/pulsar/io/jdbc/MariadbJdbcAutoSchemaSink.java
+++ b/pulsar-io/jdbc/mariadb/src/main/java/org/apache/pulsar/io/jdbc/MariadbJdbcAutoSchemaSink.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pulsar.io.jdbc;
 
+import java.util.stream.Collectors;
 import org.apache.pulsar.io.core.annotations.Connector;
 import org.apache.pulsar.io.core.annotations.IOType;
 
@@ -28,5 +29,13 @@ import org.apache.pulsar.io.core.annotations.IOType;
     configClass = JdbcSinkConfig.class
 )
 public class MariadbJdbcAutoSchemaSink extends BaseJdbcAutoSchemaSink {
+
+    @Override
+    public String generateUpsertQueryStatement() {
+        final String keys = tableDefinition.getKeyColumns().stream().map(JdbcUtils.ColumnId::getName)
+                .collect(Collectors.joining(","));
+        return JdbcUtils.buildInsertSql(tableDefinition)
+                + "ON DUPLICATE KEY UPDATE " + JdbcUtils.buildUpdateSqlSetPart(tableDefinition);
+    }
 
 }

--- a/pulsar-io/jdbc/postgres/src/main/java/org/apache/pulsar/io/jdbc/PostgresJdbcAutoSchemaSink.java
+++ b/pulsar-io/jdbc/postgres/src/main/java/org/apache/pulsar/io/jdbc/PostgresJdbcAutoSchemaSink.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pulsar.io.jdbc;
 
+import java.util.stream.Collectors;
 import org.apache.pulsar.io.core.annotations.Connector;
 import org.apache.pulsar.io.core.annotations.IOType;
 
@@ -29,4 +30,12 @@ import org.apache.pulsar.io.core.annotations.IOType;
 )
 public class PostgresJdbcAutoSchemaSink extends BaseJdbcAutoSchemaSink {
 
+    @Override
+    public String generateUpsertQueryStatement() {
+        final String keys = tableDefinition.getKeyColumns().stream().map(JdbcUtils.ColumnId::getName)
+                .collect(Collectors.joining(","));
+        return JdbcUtils.buildInsertSql(tableDefinition)
+                + " ON CONFLICT(" + keys + ") "
+                + "DO UPDATE SET " + JdbcUtils.buildUpdateSqlSetPart(tableDefinition);
+    }
 }

--- a/pulsar-io/jdbc/sqlite/src/main/java/org/apache/pulsar/io/jdbc/SqliteJdbcAutoSchemaSink.java
+++ b/pulsar-io/jdbc/sqlite/src/main/java/org/apache/pulsar/io/jdbc/SqliteJdbcAutoSchemaSink.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pulsar.io.jdbc;
 
+import java.util.stream.Collectors;
 import org.apache.pulsar.io.core.annotations.Connector;
 import org.apache.pulsar.io.core.annotations.IOType;
 
@@ -29,4 +30,12 @@ import org.apache.pulsar.io.core.annotations.IOType;
 )
 public class SqliteJdbcAutoSchemaSink extends BaseJdbcAutoSchemaSink {
 
+    @Override
+    public String generateUpsertQueryStatement() {
+        final String keys = tableDefinition.getKeyColumns().stream().map(JdbcUtils.ColumnId::getName)
+                .collect(Collectors.joining(","));
+        return JdbcUtils.buildInsertSql(tableDefinition)
+                + " ON CONFLICT(" + keys + ") "
+                + "DO UPDATE SET " + JdbcUtils.buildUpdateSqlSetPart(tableDefinition);
+    }
 }

--- a/pulsar-io/jdbc/sqlite/src/test/java/org/apache/pulsar/io/jdbc/JdbcUtilsTest.java
+++ b/pulsar-io/jdbc/sqlite/src/test/java/org/apache/pulsar/io/jdbc/JdbcUtilsTest.java
@@ -69,53 +69,54 @@ public class JdbcUtilsTest {
                 "PRIMARY KEY (firstName, lastName));"
         );
 
-        Connection connection = sqliteUtils.getConnection();
+        try (Connection connection = sqliteUtils.getConnection(true);) {
 
-        // Test getTableId
-        log.info("verify getTableId");
-        TableId id = JdbcUtils.getTableId(connection, tableName);
-        Assert.assertEquals(id.getTableName(), tableName);
+            // Test getTableId
+            log.info("verify getTableId");
+            TableId id = JdbcUtils.getTableId(connection, tableName);
+            Assert.assertEquals(id.getTableName(), tableName);
 
-        // Test get getTableDefinition
-        log.info("verify getTableDefinition");
-        List<String> keyList = Lists.newArrayList();
-        keyList.add("firstName");
-        keyList.add("lastName");
-        List<String> nonKeyList = Lists.newArrayList();
-        nonKeyList.add("age");
-        nonKeyList.add("long");
-        TableDefinition table = JdbcUtils.getTableDefinition(connection, id, keyList, nonKeyList);
-        Assert.assertEquals(table.getColumns().get(0).getName(), "firstName");
-        Assert.assertEquals(table.getColumns().get(0).getTypeName(), "TEXT");
-        Assert.assertEquals(table.getColumns().get(2).getName(), "age");
-        Assert.assertEquals(table.getColumns().get(2).getTypeName(), "INTEGER");
-        Assert.assertEquals(table.getColumns().get(7).getName(), "float");
-        Assert.assertEquals(table.getColumns().get(7).getTypeName(), "NUMERIC");
-        Assert.assertEquals(table.getKeyColumns().get(0).getName(), "firstName");
-        Assert.assertEquals(table.getKeyColumns().get(0).getTypeName(), "TEXT");
-        Assert.assertEquals(table.getKeyColumns().get(1).getName(), "lastName");
-        Assert.assertEquals(table.getKeyColumns().get(1).getTypeName(), "TEXT");
-        Assert.assertEquals(table.getNonKeyColumns().get(0).getName(), "age");
-        Assert.assertEquals(table.getNonKeyColumns().get(0).getTypeName(), "INTEGER");
-        Assert.assertEquals(table.getNonKeyColumns().get(1).getName(), "long");
-        Assert.assertEquals(table.getNonKeyColumns().get(1).getTypeName(), "INTEGER");
-        // Test get getTableDefinition
-        log.info("verify buildInsertSql");
-        String expctedInsertStatement = "INSERT INTO " + tableName +
-            "(firstName,lastName,age,bool,byte,short,long,float,double,bytes)" +
-            " VALUES(?,?,?,?,?,?,?,?,?,?)";
-        String insertStatement = JdbcUtils.buildInsertSql(table);
-        Assert.assertEquals(insertStatement, expctedInsertStatement);
-        log.info("verify buildUpdateSql");
-        String expectedUpdateStatement = "UPDATE " + tableName +
-                " SET age=? ,long=?  WHERE firstName=? AND lastName=?";
-        String updateStatement = JdbcUtils.buildUpdateSql(table);
-        Assert.assertEquals(updateStatement, expectedUpdateStatement);
-        log.info("verify buildDeleteSql");
-        String expectedDeleteStatement = "DELETE FROM " + tableName +
-                " WHERE firstName=? AND lastName=?";
-        String deleteStatement = JdbcUtils.buildDeleteSql(table);
-        Assert.assertEquals(deleteStatement, expectedDeleteStatement);
+            // Test get getTableDefinition
+            log.info("verify getTableDefinition");
+            List<String> keyList = Lists.newArrayList();
+            keyList.add("firstName");
+            keyList.add("lastName");
+            List<String> nonKeyList = Lists.newArrayList();
+            nonKeyList.add("age");
+            nonKeyList.add("long");
+            TableDefinition table = JdbcUtils.getTableDefinition(connection, id, keyList, nonKeyList);
+            Assert.assertEquals(table.getColumns().get(0).getName(), "firstName");
+            Assert.assertEquals(table.getColumns().get(0).getTypeName(), "TEXT");
+            Assert.assertEquals(table.getColumns().get(2).getName(), "age");
+            Assert.assertEquals(table.getColumns().get(2).getTypeName(), "INTEGER");
+            Assert.assertEquals(table.getColumns().get(7).getName(), "float");
+            Assert.assertEquals(table.getColumns().get(7).getTypeName(), "NUMERIC");
+            Assert.assertEquals(table.getKeyColumns().get(0).getName(), "firstName");
+            Assert.assertEquals(table.getKeyColumns().get(0).getTypeName(), "TEXT");
+            Assert.assertEquals(table.getKeyColumns().get(1).getName(), "lastName");
+            Assert.assertEquals(table.getKeyColumns().get(1).getTypeName(), "TEXT");
+            Assert.assertEquals(table.getNonKeyColumns().get(0).getName(), "age");
+            Assert.assertEquals(table.getNonKeyColumns().get(0).getTypeName(), "INTEGER");
+            Assert.assertEquals(table.getNonKeyColumns().get(1).getName(), "long");
+            Assert.assertEquals(table.getNonKeyColumns().get(1).getTypeName(), "INTEGER");
+            // Test get getTableDefinition
+            log.info("verify buildInsertSql");
+            String expctedInsertStatement = "INSERT INTO " + tableName +
+                    "(firstName,lastName,age,bool,byte,short,long,float,double,bytes)" +
+                    " VALUES(?,?,?,?,?,?,?,?,?,?)";
+            String insertStatement = JdbcUtils.buildInsertSql(table);
+            Assert.assertEquals(insertStatement, expctedInsertStatement);
+            log.info("verify buildUpdateSql");
+            String expectedUpdateStatement = "UPDATE " + tableName +
+                    " SET age=? ,long=?  WHERE firstName=? AND lastName=?";
+            String updateStatement = JdbcUtils.buildUpdateSql(table);
+            Assert.assertEquals(updateStatement, expectedUpdateStatement);
+            log.info("verify buildDeleteSql");
+            String expectedDeleteStatement = "DELETE FROM " + tableName +
+                    " WHERE firstName=? AND lastName=?";
+            String deleteStatement = JdbcUtils.buildDeleteSql(table);
+            Assert.assertEquals(deleteStatement, expectedDeleteStatement);
+        }
     }
 
 }

--- a/site2/docs/io-jdbc-sink.md
+++ b/site2/docs/io-jdbc-sink.md
@@ -8,6 +8,7 @@ The JDBC sink connectors allow pulling messages from Pulsar topics
 and persists the messages to ClickHouse, MariaDB, PostgreSQL, and SQLite.
 
 > Currently, INSERT, DELETE and UPDATE operations are supported.
+> SQLite, MariaDB and PostgreSQL also support UPSERT operations and idempotent writes.
 
 ## Configuration 
 
@@ -25,6 +26,8 @@ The configuration of all JDBC sink connectors has the following properties.
 | `key`       | String | false    | " " (empty string) | A comma-separated list containing the fields used in `where` condition of updating and deleting events.                  |
 | `timeoutMs` | int    | false    | 500                | The JDBC operation timeout in milliseconds.                                                                              |
 | `batchSize` | int    | false    | 200                | The batch size of updates made to the database.                                                                          |
+| `insertMode` | enum( INSERT,UPSERT,UPDATE) | false    | INSERT | If it is configured as UPSERT, the sink uses upsert semantics rather than plain INSERT/UPDATE statements. Upsert semantics refer to atomically adding a new row or updating the existing row if there is a primary key constraint violation, which provides idempotence. |
+| `nullValueAction` | enum(FAIL, DELETE) | false    | FAIL | How to handle records with NULL values. Possible options are `DELETE` or `FAIL`. |
 
 ### Example for ClickHouse
 


### PR DESCRIPTION
### Motivation

Currently JDBC sink will perform an insert query for most of the cases. The only way to execute an UPDATE or DELETE is to pass a specific property in the message properties. This is not handy and requires to all the sources to add this specific option.

The goal is to provide a way to upsert and delete records based on the record content while using key-value records.
1. Upsert: Insert or update the record based on the key fields.
2. Delete: if the value is NULL, delete the record for the given row.

### Modifications
* new config option `insertMode` with values
  * INSERT: only perform blindly insert (default, in order to not break upgrades)
  * UPDATE: only perform blindly update
  * UPSERT: use upsert query. Main issue is that there's no SQL standard so every sink has his own implementation (by default it throws a not supported exception)
* new config option `nullValueAction` with values
  * FAIL: update the row with null values (default, in order to not break upgrades)
  * DELETE: delete the row with the the given key/pk

Note that in order to not break compatibility the message property `ACTION` has the precedence on other logics.

For the upsert mode, only the following sinks support it:
- SqlLite
- Postgres
- MariaDB


Also upgraded SqlLite to 3.36.0.3 to support upsert

others will throw an exception and the message will be rejected

- [x] `doc` 