### PR TITLE
[improve][broker][monitoring] metrics data flow control

### DIFF
--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -2407,6 +2407,11 @@ public class ServiceConfiguration implements PulsarConfiguration {
     )
     private boolean metricsBufferResponse = false;
     @FieldContext(
+            category = CATEGORY_METRICS,
+            doc = "Max number of bytes that metrics data send to client every second"
+    )
+    private int metricsDataFlowPermitPerSecond = 0;
+    @FieldContext(
         category = CATEGORY_METRICS,
         doc = "If true, export consumer level metrics otherwise namespace level"
     )

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/MetricsDataFlowController.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/MetricsDataFlowController.java
@@ -1,0 +1,71 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.stats;
+
+import io.netty.buffer.ByteBuf;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.locks.LockSupport;
+
+public class MetricsDataFlowController {
+
+    private final ByteBuf buffer;
+    private final int flowPermit;
+    private final OutputStream output;
+    private final TimeWindow<AtomicLong> window;
+
+    public MetricsDataFlowController(ByteBuf buffer, OutputStream output, int flowPermit) {
+        this.buffer = buffer;
+        this.flowPermit = flowPermit;
+        this.window = new TimeWindow<>(2, 1000);
+        this.output = output;
+    }
+
+    private void recordAndFlush(int size) {
+        long now = System.currentTimeMillis();
+        WindowWrap<AtomicLong> wrap = this.window.current(__ -> new AtomicLong(0), now);
+        @SuppressWarnings("all")
+        long start = wrap.start();
+        if (wrap.value().addAndGet(size) > this.flowPermit) {
+            long nextWindowStart = start + window.interval();
+            LockSupport.parkUntil(nextWindowStart);
+            this.recordAndFlush(size);
+        }
+    }
+
+
+    public void flushBuffer() throws IOException {
+        int readIndex = this.buffer.readerIndex();
+        int readableBytes = buffer.readableBytes();
+        byte[] tmpBuf = new byte[512];
+        int totalRead = 0;
+        while (true) {
+            int readable = Math.min(readableBytes - totalRead, 512);
+            if (readable <= 0) {
+                return;
+            }
+            buffer.getBytes(readIndex + totalRead, tmpBuf);
+            this.recordAndFlush(readable);
+            output.write(tmpBuf, 0, readable);
+            totalRead += readable;
+        }
+    }
+
+}

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/TimeWindow.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/TimeWindow.java
@@ -19,6 +19,8 @@
 package org.apache.pulsar.broker.stats;
 
 import java.util.concurrent.atomic.AtomicReferenceArray;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Function;
 
 public final class TimeWindow<T> {
@@ -26,11 +28,19 @@ public final class TimeWindow<T> {
     private final int sampleCount;
     private final AtomicReferenceArray<WindowWrap<T>> array;
 
+    private final Lock updateLock = new ReentrantLock();
+
     public TimeWindow(int sampleCount, int interval) {
         this.sampleCount = sampleCount;
         this.interval = interval;
         this.array = new AtomicReferenceArray<>(sampleCount);
     }
+
+
+    public WindowWrap<T> current(Function<T, T> function) {
+        return current(function, System.currentTimeMillis());
+    }
+
 
     /**
      * return current time window data.
@@ -38,34 +48,44 @@ public final class TimeWindow<T> {
      * @param function generate data.
      * @return
      */
-    public synchronized WindowWrap<T> current(Function<T, T> function) {
-        long millis = System.currentTimeMillis();
-
-        if (millis < 0) {
+    public WindowWrap<T> current(Function<T, T> function, long timeMillis) {
+        if (timeMillis < 0) {
             return null;
         }
-        int idx = calculateTimeIdx(millis);
-        long windowStart = calculateWindowStart(millis);
+
+        int idx = calculateTimeIdx(timeMillis);
+        // Calculate current bucket start time.
+        long windowStart = calculateWindowStart(timeMillis);
         while (true) {
             WindowWrap<T> old = array.get(idx);
             if (old == null) {
-                WindowWrap<T> window = new WindowWrap<>(interval, windowStart, null);
+                WindowWrap<T> window = new WindowWrap<>(interval, windowStart, function.apply(null));
                 if (array.compareAndSet(idx, null, window)) {
-                    T value = null == function ? null : function.apply(null);
-                    window.value(value);
                     return window;
                 } else {
+                    // Contention failed, the thread will yield its time slice to wait for bucket available.
                     Thread.yield();
                 }
             } else if (windowStart == old.start()) {
                 return old;
             } else if (windowStart > old.start()) {
-                T value = null == function ? null : function.apply(old.value());
-                old.value(value);
-                old.resetWindowStart(windowStart);
-                return old;
+                if (updateLock.tryLock()) {
+                    try {
+                        // Successfully get the update lock, now we reset the bucket.
+                        T value = null == function ? null : function.apply(old.value());
+                        old.value(value);
+                        old.resetWindowStart(windowStart);
+                        return old;
+                    } finally {
+                        updateLock.unlock();
+                    }
+                } else {
+                    // Contention failed, the thread will yield its time slice to wait for bucket available.
+                    Thread.yield();
+                }
             } else {
-                //it should never goes here
+                //when windowStart < old.value()
+                // Should not go through here, as the provided time is already behind.
                 throw new IllegalStateException();
             }
         }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/functions/worker/PulsarFunctionTestUtils.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/functions/worker/PulsarFunctionTestUtils.java
@@ -54,6 +54,14 @@ public class PulsarFunctionTestUtils {
         return result.toString();
     }
 
+    public static HttpURLConnection getPrometheusMetrics0(int metricsPort) throws IOException {
+        StringBuilder result = new StringBuilder();
+        URL url = new URL(String.format("http://%s:%s/metrics", "localhost", metricsPort));
+        HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+        conn.setRequestMethod("GET");
+        return conn;
+    }
+
     @Test
     void testParseMetrics() throws IOException {
         String sampleMetrics = IOUtils.toString(getClass().getClassLoader()


### PR DESCRIPTION
### Motivation

add metrics data flow control when Prometheus scrape metrics, to prevent high network usage.

### Modifications

1. add `MetricsDataFlowController` class
2. add `metricsDataFlowPermitPerSecond` configuration

### Documentation

Check the box below or label this PR directly.

Need to update docs? 

- [x] `doc-required` 
(Your PR needs to update docs and you will update later)
  
- [ ] `doc-not-needed` 
(Please explain why)
  
- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)