### PR TITLE
Remove Label from required checks

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -49,7 +49,6 @@ github:
         # Contexts are the names of checks that must pass.
         # See ./github/workflows/README.md for more documentation on this list.
         contexts:
-          - label
           - build
           - cpp-tests
           - Changed files check


### PR DESCRIPTION
Fixes #16437 

### Motivation

The label check must not be included.

### Modifications

Change `.asf.yaml`

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

### Documentation

Check the box below or label this PR directly.

- [X] `doc-not-needed` 
Simple configuration change
