### PR TITLE
[fix][python client] Fix `type` to `str` conversion in exceptions thrown in `definition.py`

### DIFF
--- a/pulsar-client-cpp/python/pulsar/schema/definition.py
+++ b/pulsar-client-cpp/python/pulsar/schema/definition.py
@@ -26,7 +26,7 @@ from enum import Enum, EnumMeta
 def _check_record_or_field(x):
     if (type(x) is type and not issubclass(x, Record)) \
             and not isinstance(x, Field):
-        raise Exception('Argument ' + x + ' is not a Record or a Field')
+        raise Exception('Argument ' + x.__name.__ + ' is not a Record or a Field')
 
 
 class RecordMeta(type):
@@ -188,7 +188,7 @@ class Record(metaclass=RecordMeta):
 
         if not isinstance(val, self.__class__):
             raise TypeError("Invalid type '%s' for sub-record field '%s'. Expected: %s" % (
-                type(val), name, self.__class__))
+                type(val), name, self.__class__.__name__))
         return val
 
     def default(self):
@@ -222,7 +222,8 @@ class Field(object):
             return self.default()
 
         if type(val) != self.python_type():
-            raise TypeError("Invalid type '%s' for field '%s'. Expected: %s" % (type(val), name, self.python_type()))
+            raise TypeError("Invalid type '%s' for field '%s'. Expected: %s"
+                            % (type(val), name, self.python_type().__name__))
         return val
 
     def schema(self):
@@ -368,7 +369,7 @@ class String(Field):
 class CustomEnum(Field):
     def __init__(self, enum_type, default=None, required=False, required_default=False):
         if not issubclass(enum_type, Enum):
-            raise Exception(enum_type + " is not a valid Enum type")
+            raise Exception(enum_type.__name__ + " is not a valid Enum type")
         self.enum_type = enum_type
         self.values = {}
         for x in enum_type.__members__.values():
@@ -400,7 +401,8 @@ class CustomEnum(Field):
                 raise TypeError(
                     "Invalid enum value '%s' for field '%s'. Expected: %s" % (val, name, self.values.keys()))
         elif type(val) != self.python_type():
-            raise TypeError("Invalid type '%s' for field '%s'. Expected: %s" % (type(val), name, self.python_type()))
+            raise TypeError("Invalid type '%s' for field '%s'. Expected: %s"
+                            % (type(val), name, self.python_type().__name__))
         else:
             return val
 
@@ -445,7 +447,7 @@ class Array(Field):
         for x in val:
             if type(x) != self.array_type.python_type():
                 raise TypeError('Array field ' + name + ' items should all be of type ' +
-                                self.array_type.type())
+                                self.array_type.type().__name__)
         return val
 
     def schema(self):
@@ -488,7 +490,7 @@ class Map(Field):
                 raise TypeError('Map keys for field ' + name + '  should all be strings')
             if type(v) != self.value_type.python_type():
                 raise TypeError('Map values for field ' + name + ' should all be of type '
-                                + self.value_type.python_type())
+                                + self.value_type.python_type().__name__)
 
         return val
 


### PR DESCRIPTION
Fixes #16457

### Motivation
In several places https://github.com/apache/pulsar/blob/master/pulsar-client-cpp/python/pulsar/schema/definition.py uses incorrect type (name) to string conversions when exceptions are raised (see for #16443 for examples). This might not be obvious at first sight because the call trace actually contains that somewhat resembles the intended exception message. The error occurs when the messages are created by concatenating "strings" with the + operator. This fails when one operand is a `type`.

### Modifications
Instead of attempting to directly convert a `type` to a `str`, I replaced all occurrences with `some_type.__name__`.

### Verifying this change
This change is a trivial rework / code cleanup without any test coverage.

- [x] `doc-not-needed`