### PR TITLE
[fix][flaky-test] MessageTTLTest.testMessageExpiryAfterTopicUnload

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/MessageTTLTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/MessageTTLTest.java
@@ -26,6 +26,8 @@ import static org.testng.Assert.assertNotNull;
 import com.google.common.collect.Lists;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+
 import lombok.Cleanup;
 import org.apache.bookkeeper.mledger.impl.PositionImpl;
 import org.apache.pulsar.broker.service.persistent.PersistentTopic;
@@ -37,6 +39,7 @@ import org.apache.pulsar.common.policies.data.PersistentTopicInternalStats;
 import org.apache.pulsar.common.policies.data.Policies;
 import org.apache.pulsar.common.policies.data.TopicPolicies;
 import org.apache.pulsar.common.util.FutureUtil;
+import org.awaitility.Awaitility;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.annotations.AfterClass;
@@ -85,6 +88,7 @@ public class MessageTTLTest extends BrokerTestBase {
         }
         FutureUtil.waitForAll(sendFutureList).get();
         MessageIdImpl firstMessageId = (MessageIdImpl) sendFutureList.get(0).get();
+        MessageIdImpl lastMessageId = (MessageIdImpl) sendFutureList.get(sendFutureList.size() - 1).get();
         producer.close();
         // unload a reload the topic
         // this action created a new ledger
@@ -99,17 +103,17 @@ public class MessageTTLTest extends BrokerTestBase {
         assertEquals(statsBeforeExpire.markDeletePosition,
                 PositionImpl.get(firstMessageId.getLedgerId(), -1).toString());
 
-        // wall clock time, we have to make the message to be considered "expired"
-        Thread.sleep(this.conf.getTtlDurationDefaultInSeconds() * 2000L);
-        log.info("***** run message expiry now");
-        this.runMessageExpiryCheck();
-
-        // verify that the markDeletePosition was moved forward, and exacly to the last message
-        PersistentTopicInternalStats internalStatsAfterExpire = admin.topics().getInternalStats(topicName);
-        CursorStats statsAfterExpire = internalStatsAfterExpire.cursors.get(subscriptionName);
-        log.info("markDeletePosition after expire {}", statsAfterExpire.markDeletePosition);
-        assertEquals(statsAfterExpire.markDeletePosition, PositionImpl.get(3, numMsgs - 1 ).toString());
-
+        Awaitility.await().timeout(30, TimeUnit.SECONDS)
+                .pollDelay(3, TimeUnit.SECONDS).untilAsserted(() -> {
+            this.runMessageExpiryCheck();
+            log.info("***** run message expiry now");
+            // verify that the markDeletePosition was moved forward, and exacly to the last message
+            PersistentTopicInternalStats internalStatsAfterExpire = admin.topics().getInternalStats(topicName);
+            CursorStats statsAfterExpire = internalStatsAfterExpire.cursors.get(subscriptionName);
+            log.info("markDeletePosition after expire {}", statsAfterExpire.markDeletePosition);
+            assertEquals(statsAfterExpire.markDeletePosition, PositionImpl.get(lastMessageId.getLedgerId(),
+                    lastMessageId.getEntryId() ).toString());
+        });
     }
 
     @Test


### PR DESCRIPTION
Fixes #16460

### Motivation

Fix flaky test `MessageTTLTest.testMessageExpiryAfterTopicUnload`

### Modifications

Remove hard code ledger ID validation

### Documentation

Check the box below or label this PR directly.

Need to update docs? 

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)
  
- [x] `doc-not-needed` 
(Please explain why)
  
- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)