### PR TITLE
[feature][pulsar-io] Support transactions for JDBC connector

### DIFF
--- a/pulsar-io/jdbc/core/src/main/java/org/apache/pulsar/io/jdbc/JdbcAbstractSink.java
+++ b/pulsar-io/jdbc/core/src/main/java/org/apache/pulsar/io/jdbc/JdbcAbstractSink.java
@@ -137,7 +137,7 @@ public abstract class JdbcAbstractSink<T> implements Sink<T> {
 
     @Override
     public void close() throws Exception {
-        if (connection != null && !connection.getAutoCommit()) {
+        if (connection != null && jdbcSinkConfig.isUseTransactions()) {
             connection.commit();
         }
         if (insertStatement != null) {
@@ -262,7 +262,7 @@ public abstract class JdbcAbstractSink<T> implements Sink<T> {
                             throw new IllegalArgumentException(msg);
                     }
                 }
-                if (!connection.getAutoCommit()) {
+                if (jdbcSinkConfig.isUseTransactions()) {
                     connection.commit();
                 }
                 swapList.forEach(Record::ack);
@@ -270,7 +270,7 @@ public abstract class JdbcAbstractSink<T> implements Sink<T> {
                 log.error("Got exception ", e.getMessage(), e);
                 swapList.forEach(Record::fail);
                 try {
-                    if (!connection.getAutoCommit()) {
+                    if (jdbcSinkConfig.isUseTransactions()) {
                         connection.rollback();
                     }
                 } catch (Exception ex) {

--- a/pulsar-io/jdbc/core/src/main/java/org/apache/pulsar/io/jdbc/JdbcAbstractSink.java
+++ b/pulsar-io/jdbc/core/src/main/java/org/apache/pulsar/io/jdbc/JdbcAbstractSink.java
@@ -23,6 +23,7 @@ import com.google.common.collect.Lists;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.PreparedStatement;
+import java.sql.SQLFeatureNotSupportedException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -92,7 +93,11 @@ public abstract class JdbcAbstractSink<T> implements Sink<T> {
 
         Class.forName(JdbcUtils.getDriverClassName(jdbcSinkConfig.getJdbcUrl()));
         connection = DriverManager.getConnection(jdbcSinkConfig.getJdbcUrl(), properties);
-        connection.setAutoCommit(false);
+        try {
+            connection.setAutoCommit(false);
+        } catch (SQLFeatureNotSupportedException e) {
+            log.warn(e.getMessage());
+        }
         log.info("Opened jdbc connection: {}, autoCommit: {}", jdbcUrl, connection.getAutoCommit());
 
         tableName = jdbcSinkConfig.getTableName();

--- a/pulsar-io/jdbc/core/src/main/java/org/apache/pulsar/io/jdbc/JdbcAbstractSink.java
+++ b/pulsar-io/jdbc/core/src/main/java/org/apache/pulsar/io/jdbc/JdbcAbstractSink.java
@@ -269,6 +269,13 @@ public abstract class JdbcAbstractSink<T> implements Sink<T> {
             } catch (Exception e) {
                 log.error("Got exception ", e.getMessage(), e);
                 swapList.forEach(Record::fail);
+                try {
+                    if (!connection.getAutoCommit()) {
+                        connection.rollback();
+                    }
+                } catch (Exception ex) {
+                    throw new RuntimeException(ex);
+                }
             }
 
             if (swapList.size() != count) {

--- a/pulsar-io/jdbc/core/src/main/java/org/apache/pulsar/io/jdbc/JdbcSinkConfig.java
+++ b/pulsar-io/jdbc/core/src/main/java/org/apache/pulsar/io/jdbc/JdbcSinkConfig.java
@@ -85,6 +85,12 @@ public class JdbcSinkConfig implements Serializable {
         help = "The batch size of updates made to the database"
     )
     private int batchSize = 200;
+    @FieldDoc(
+            required = false,
+            defaultValue = "true",
+            help = "Enable transactions of the database."
+    )
+    private boolean useTransactions = true;
 
     @FieldDoc(
             required = false,

--- a/site2/docs/io-jdbc-sink.md
+++ b/site2/docs/io-jdbc-sink.md
@@ -28,6 +28,7 @@ The configuration of all JDBC sink connectors has the following properties.
 | `batchSize` | int    | false    | 200                | The batch size of updates made to the database.                                                                          |
 | `insertMode` | enum( INSERT,UPSERT,UPDATE) | false    | INSERT | If it is configured as UPSERT, the sink uses upsert semantics rather than plain INSERT/UPDATE statements. Upsert semantics refer to atomically adding a new row or updating the existing row if there is a primary key constraint violation, which provides idempotence. |
 | `nullValueAction` | enum(FAIL, DELETE) | false    | FAIL | How to handle records with NULL values. Possible options are `DELETE` or `FAIL`. |
+| `useTransactions` | boolean | false    | true               | Enable transactions of the database.
 
 ### Example for ClickHouse
 
@@ -41,6 +42,7 @@ The configuration of all JDBC sink connectors has the following properties.
         "password": "password",
         "jdbcUrl": "jdbc:clickhouse://localhost:8123/pulsar_clickhouse_jdbc_sink",
         "tableName": "pulsar_clickhouse_jdbc_sink"
+        "useTransactions": "false"
      }
   }
   
@@ -60,6 +62,7 @@ The configuration of all JDBC sink connectors has the following properties.
       password: "password"
       jdbcUrl: "jdbc:clickhouse://localhost:8123/pulsar_clickhouse_jdbc_sink"
       tableName: "pulsar_clickhouse_jdbc_sink"
+      useTransactions: "false"
   
   ```
 


### PR DESCRIPTION
Fixes #16291

### Motivation

Some JDBC connection (e.g clickhouse) doesn't support transactions, we can add a config for JdbcSinkConfig to avoid it
See:
```java
    public void setAutoCommit(boolean autoCommit) throws SQLException {
        if (!autoCommit) {
            throw new SQLFeatureNotSupportedException("Transactions are not supported");
        }
    }
```

### Modifications

Add useTransactions config for JdbcSinkConfig, if `useTransactions = false` we do not set `autoCommit = false` and we do not use commit/rollback

### Verifying this change

- [x] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API: (yes / no)
  - The schema: (yes / no / don't know)
  - The default values of configurations: (yes / no)
  - The wire protocol: (yes / no)
  - The rest endpoints: (yes / no)
  - The admin cli options: (yes / no)
  - Anything that affects deployment: (yes / no / don't know)

### Documentation

Check the box below or label this PR directly.

Need to update docs? 

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)
  
- [ ] `doc-not-needed` 
(Please explain why)
  
- [x] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)