### PR TITLE
[improve][rest] Add lookup REST Api swagger docs describe

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/lookup/v2/TopicLookup.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/lookup/v2/TopicLookup.java
@@ -50,7 +50,7 @@ public class TopicLookup extends TopicLookupBase {
     @Path("{topic-domain}/{tenant}/{namespace}/{topic}")
     @Produces(MediaType.APPLICATION_JSON)
     @ApiOperation(
-            value = "Look up a topic from the current serving broker.",
+            value = "Get the owner broker of the given topic.",
             response = LookupData.class
     )
     @ApiResponses(value = { @ApiResponse(code = 307,

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/lookup/v2/TopicLookup.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/lookup/v2/TopicLookup.java
@@ -81,7 +81,7 @@ public class TopicLookup extends TopicLookupBase {
     @Path("{topic-domain}/{tenant}/{namespace}/{topic}/bundle")
     @Produces(MediaType.APPLICATION_JSON)
     @ApiOperation(
-            value = "Get the namespace bundle which contains the given topic.",
+            value = "Get the namespace bundle which the given topic belongs to.",
             response = String.class
     )
     @ApiResponses(value = { @ApiResponse(code = 403, message = "Don't have admin permission"),

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/lookup/v2/TopicLookup.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/lookup/v2/TopicLookup.java
@@ -18,6 +18,8 @@
  */
 package org.apache.pulsar.broker.lookup.v2;
 
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
 import javax.ws.rs.DefaultValue;
@@ -34,9 +36,11 @@ import javax.ws.rs.core.MediaType;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.pulsar.broker.lookup.TopicLookupBase;
+import org.apache.pulsar.common.lookup.data.LookupData;
 import org.apache.pulsar.common.naming.TopicName;
 
 @Path("/v2/topic")
+@Api(value = "lookup", tags = "lookup")
 @Slf4j
 public class TopicLookup extends TopicLookupBase {
 
@@ -45,6 +49,10 @@ public class TopicLookup extends TopicLookupBase {
     @GET
     @Path("{topic-domain}/{tenant}/{namespace}/{topic}")
     @Produces(MediaType.APPLICATION_JSON)
+    @ApiOperation(
+            value = "Look up a topic from the current serving broker.",
+            response = LookupData.class
+    )
     @ApiResponses(value = { @ApiResponse(code = 307,
             message = "Current broker doesn't serve the namespace of this topic") })
     public void lookupTopicAsync(
@@ -72,6 +80,10 @@ public class TopicLookup extends TopicLookupBase {
     @GET
     @Path("{topic-domain}/{tenant}/{namespace}/{topic}/bundle")
     @Produces(MediaType.APPLICATION_JSON)
+    @ApiOperation(
+            value = "Get the namespace bundle which contains the given topic.",
+            response = String.class
+    )
     @ApiResponses(value = { @ApiResponse(code = 403, message = "Don't have admin permission"),
             @ApiResponse(code = 405, message = "Invalid topic domain type") })
     public String getNamespaceBundle(@PathParam("topic-domain") String topicDomain,


### PR DESCRIPTION
### Motivation

Current, Lookup REST Api no swagger docs annotations. will result in not being found on [Pulsar REST Api doc](https://pulsar.apache.org/admin-rest-api/?version=master).

### Modifications

- Add lookup REST Api swagger docs describe

### Documentation

- [x] `doc-not-needed` 
Docs has exist.
