### PR TITLE
[cleanup][functions] Remove unused code

### DIFF
--- a/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/kubernetes/KubernetesRuntime.java
+++ b/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/kubernetes/KubernetesRuntime.java
@@ -88,7 +88,6 @@ import org.apache.pulsar.functions.runtime.RuntimeUtils;
 import org.apache.pulsar.functions.secretsproviderconfigurator.SecretsProviderConfigurator;
 import org.apache.pulsar.functions.utils.Actions;
 import org.apache.pulsar.functions.utils.FunctionCommon;
-import org.apache.pulsar.packages.management.core.common.PackageType;
 
 /**
  * Kubernetes based runtime for running functions.
@@ -855,13 +854,8 @@ public class KubernetesRuntime implements Runtime {
     }
 
     private List<String> getDownloadCommand(Function.FunctionDetails functionDetails, String userCodeFilePath) {
-        if (Arrays.stream(PackageType.values()).anyMatch(type ->
-            functionDetails.getPackageUrl().startsWith(type.toString()))) {
-            return getPackageDownloadCommand(functionDetails.getPackageUrl(), userCodeFilePath);
-        } else {
-            return getDownloadCommand(functionDetails.getTenant(), functionDetails.getNamespace(),
+        return getDownloadCommand(functionDetails.getTenant(), functionDetails.getNamespace(),
                 functionDetails.getName(), userCodeFilePath);
-        }
     }
 
     private List<String> getDownloadCommand(String tenant, String namespace, String name, String userCodeFilePath) {
@@ -906,39 +900,6 @@ public class KubernetesRuntime implements Runtime {
                 name,
                 "--destination-file",
                 userCodeFilePath);
-    }
-
-    private List<String> getPackageDownloadCommand(String packageName, String userCodeFilePath) {
-        // add auth plugin and parameters if necessary
-        if (authenticationEnabled && authConfig != null) {
-            if (isNotBlank(authConfig.getClientAuthenticationPlugin())
-                && isNotBlank(authConfig.getClientAuthenticationParameters())
-                && instanceConfig.getFunctionAuthenticationSpec() != null) {
-                return Arrays.asList(
-                    pulsarRootDir + configAdminCLI,
-                    "--auth-plugin",
-                    authConfig.getClientAuthenticationPlugin(),
-                    "--auth-params",
-                    authConfig.getClientAuthenticationParameters(),
-                    "--admin-url",
-                    pulsarAdminUrl,
-                    "packages",
-                    "download",
-                    packageName,
-                    "--path",
-                    userCodeFilePath);
-            }
-        }
-
-        return Arrays.asList(
-            pulsarRootDir + configAdminCLI,
-            "--admin-url",
-            pulsarAdminUrl,
-            "packages",
-            "download",
-            packageName,
-            "--path",
-            userCodeFilePath);
     }
 
     private static String setShardIdEnvironmentVariableCommand() {

--- a/pulsar-functions/runtime/src/test/java/org/apache/pulsar/functions/runtime/kubernetes/KubernetesRuntimeTest.java
+++ b/pulsar-functions/runtime/src/test/java/org/apache/pulsar/functions/runtime/kubernetes/KubernetesRuntimeTest.java
@@ -804,24 +804,6 @@ public class KubernetesRuntimeTest {
         assertEquals(spec.getSpec().getTemplate().getSpec().getServiceAccountName(), "my-service-account");
     }
 
-    @Test
-    public void testCustomKubernetesDownloadCommands() throws Exception {
-        InstanceConfig config = createJavaInstanceConfig(FunctionDetails.Runtime.JAVA, false);
-        config.setFunctionDetails(createFunctionDetails(FunctionDetails.Runtime.JAVA, false, (fb) -> {
-            return fb.setPackageUrl("function://public/default/test@v1");
-        }));
-
-        factory = createKubernetesRuntimeFactory(null, 10, 1.0, 1.0);
-
-        verifyJavaInstance(config, pulsarRootDir + "/instances/deps", false);
-        KubernetesRuntime container = factory.createContainer(config, userJarFile, userJarFile, 30l);
-        V1StatefulSet spec = container.createStatefulSet();
-        String expectedDownloadCommand = "pulsar-admin --admin-url http://localhost:8080 packages download "
-            + "function://public/default/test@v1 --path " + pulsarRootDir + "/" + userJarFile;
-        String containerCommand = spec.getSpec().getTemplate().getSpec().getContainers().get(0).getCommand().get(2);
-        assertTrue(containerCommand.contains(expectedDownloadCommand));
-    }
-
     InstanceConfig createGolangInstanceConfig() {
         InstanceConfig config = new InstanceConfig();
 
@@ -1129,25 +1111,6 @@ public class KubernetesRuntimeTest {
         factory = createKubernetesRuntimeFactory(null, 10, 1.0, 1.0, Optional.empty(), downloadDirectory);
 
         verifyJavaInstance(config, pulsarRootDir + "/instances/deps", false, factory.getDownloadDirectory());
-    }
-
-    @Test
-    public void testCustomKubernetesDownloadCommandsWithDownloadDirectoryDefined() throws Exception {
-        String downloadDirectory = "download/pulsar_functions";
-        InstanceConfig config = createJavaInstanceConfig(FunctionDetails.Runtime.JAVA, false);
-        config.setFunctionDetails(createFunctionDetails(FunctionDetails.Runtime.JAVA, false, (fb) -> {
-            return fb.setPackageUrl("function://public/default/test@v1");
-        }));
-
-        factory = createKubernetesRuntimeFactory(null, 10, 1.0, 1.0, Optional.empty(), downloadDirectory);
-
-        verifyJavaInstance(config, pulsarRootDir + "/instances/deps", false, factory.getDownloadDirectory());
-        KubernetesRuntime container = factory.createContainer(config, userJarFile, userJarFile, 30l);
-        V1StatefulSet spec = container.createStatefulSet();
-        String expectedDownloadCommand = "pulsar-admin --admin-url http://localhost:8080 packages download "
-                + "function://public/default/test@v1 --path " + factory.getDownloadDirectory() + "/" + userJarFile;
-        String containerCommand = spec.getSpec().getTemplate().getSpec().getContainers().get(0).getCommand().get(2);
-        assertTrue(containerCommand.contains(expectedDownloadCommand));
     }
 
     @Test


### PR DESCRIPTION
### Motivation

Since #3969, `packageUrl` is not set anymore in FunctionDetails so code that depend on it can be removed.
In the case of KubernetesRuntime we currently download the function itself and not the package.
This change doesn't modify this behaviour.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

no

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API: (yes / no)
  - The schema: (yes / no / don't know)
  - The default values of configurations: (yes / no)
  - The wire protocol: (yes / no)
  - The rest endpoints: (yes / no)
  - The admin cli options: (yes / no)
  - Anything that affects deployment: (yes / no / don't know)

### Documentation

Check the box below or label this PR directly.

Need to update docs? 

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)
  
- [x] `doc-not-needed` 
cleanup
  
- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)