### PR TITLE
[fix][test] Catch exception when update data in mockZookeeper

### DIFF
--- a/testmocks/src/main/java/org/apache/zookeeper/MockZooKeeper.java
+++ b/testmocks/src/main/java/org/apache/zookeeper/MockZooKeeper.java
@@ -540,15 +540,14 @@ public class MockZooKeeper extends ZooKeeper {
                 if (watcher != null) {
                     watchers.put(path, watcher);
                 }
+                cb.processResult(0, path, ctx, children);
             } catch (Throwable ex) {
                 log.error("get children : {} error", path, ex);
                 cb.processResult(KeeperException.Code.SYSTEMERROR.intValue(), path, ctx, null);
-                return;
             } finally {
                 unlockIfLocked();
             }
 
-            cb.processResult(0, path, ctx, children);
         });
     }
 
@@ -645,14 +644,13 @@ public class MockZooKeeper extends ZooKeeper {
                     String child = relativePath.split("/", 2)[0];
                     children.add(child);
                 });
+                cb.processResult(0, path, ctx, new ArrayList<>(children), new Stat());
             } catch (Throwable ex) {
                 log.error("get children : {} error", path, ex);
                 cb.processResult(KeeperException.Code.SYSTEMERROR.intValue(), path, ctx, null, null);
-                return;
             } finally {
                 unlockIfLocked();
             }
-            cb.processResult(0, path, ctx, new ArrayList<>(children), new Stat());
         });
 
     }
@@ -988,7 +986,7 @@ public class MockZooKeeper extends ZooKeeper {
                                     parent)));
                     triggerPersistentWatches(path, parent, EventType.NodeDeleted);
                 }
-            } catch (Exception ex) {
+            } catch (Throwable ex) {
                 log.error("delete path : {} error", path, ex);
                 cb.processResult(KeeperException.Code.SYSTEMERROR.intValue(), path, ctx);
             } finally {


### PR DESCRIPTION
### Motivation

Catch exception when updating data in `mockZookeeper`. this problem looks like https://github.com/apache/pulsar/pull/15755

And move `lock()` into try/catch block in case of throwing exception from the lock.
https://github.com/apache/pulsar/blob/f519e22823e80c1771716f011ecb6d693d507d2c/testmocks/src/main/java/org/apache/zookeeper/MockZooKeeper.java#L213-L226

Also fix https://github.com/apache/pulsar/issues/16483

### Modifications

- Add catch for MockZookeeper.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API: (yes / no)
  - The schema: (yes / no / don't know)
  - The default values of configurations: (yes / no)
  - The wire protocol: (yes / no)
  - The rest endpoints: (yes / no)
  - The admin cli options: (yes / no)
  - Anything that affects deployment: (yes / no / don't know)

### Documentation

Check the box below or label this PR directly.

Need to update docs? 

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)
  
- [x] `doc-not-needed` 
(Please explain why)
  
- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)