### PR TITLE
[cleanup][pulsar] Remove warnings when testing deprecated code

### DIFF
--- a/pulsar-broker-common/src/test/java/org/apache/pulsar/broker/authentication/AuthenticationProviderTokenTest.java
+++ b/pulsar-broker-common/src/test/java/org/apache/pulsar/broker/authentication/AuthenticationProviderTokenTest.java
@@ -659,6 +659,8 @@ public class AuthenticationProviderTokenTest {
     }
 
 
+    // Deprecation warning suppressed as this test targets deprecated methods
+    @SuppressWarnings("deprecation")
     @Test
     public void testExpiringToken() throws Exception {
         SecretKey secretKey = AuthTokenUtils.createSecretKey(SignatureAlgorithm.HS256);

--- a/pulsar-broker-common/src/test/java/org/apache/pulsar/broker/validator/MultipleListenerValidatorTest.java
+++ b/pulsar-broker-common/src/test/java/org/apache/pulsar/broker/validator/MultipleListenerValidatorTest.java
@@ -32,6 +32,8 @@ import static org.testng.AssertJUnit.assertEquals;
  */
 public class MultipleListenerValidatorTest {
 
+    // Deprecation warning suppressed as this test targets deprecated methods
+    @SuppressWarnings("deprecation")
     @Test
     public void testGetAppliedAdvertised() throws Exception {
         ServiceConfiguration config = new ServiceConfiguration();

--- a/pulsar-broker-common/src/test/java/org/apache/pulsar/common/configuration/PulsarConfigurationLoaderTest.java
+++ b/pulsar-broker-common/src/test/java/org/apache/pulsar/common/configuration/PulsarConfigurationLoaderTest.java
@@ -22,8 +22,8 @@ import static org.apache.pulsar.common.configuration.PulsarConfigurationLoader.i
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertThrows;
 import static org.testng.Assert.assertTrue;
-import static org.testng.Assert.fail;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -40,7 +40,7 @@ import org.apache.pulsar.broker.ServiceConfiguration;
 import org.testng.annotations.Test;
 
 public class PulsarConfigurationLoaderTest {
-    public class MockConfiguration implements PulsarConfiguration {
+    public static class MockConfiguration implements PulsarConfiguration {
         private Properties properties = new Properties();
 
         private String metadataStoreUrl = "zk:localhost:2181";
@@ -49,7 +49,10 @@ public class PulsarConfigurationLoaderTest {
         private Optional<Integer> brokerServicePortTls = Optional.of(7651);
         private Optional<Integer> webServicePort = Optional.of(9080);
         private Optional<Integer> webServicePortTls = Optional.of(9443);
-        private int notExistFieldInServiceConfig = 0;
+
+        // This unused field is intentionally included to test the ignoreNonExistentMember feature of
+        // PulsarConfigurationLoader.convertFrom()
+        private String A_FIELD_THAT_IS_NOT_DECLARED_IN_ServiceConfiguration = "x";
 
         @Override
         public Properties getProperties() {
@@ -63,7 +66,7 @@ public class PulsarConfigurationLoaderTest {
     }
 
     @Test
-    public void testConfigurationConverting() throws Exception {
+    public void testConfigurationConverting() {
         MockConfiguration mockConfiguration = new MockConfiguration();
         ServiceConfiguration serviceConfiguration = PulsarConfigurationLoader.convertFrom(mockConfiguration);
 
@@ -74,18 +77,18 @@ public class PulsarConfigurationLoaderTest {
         assertEquals(serviceConfiguration.getBrokerServicePortTls().get(), Integer.valueOf((7651)));
         assertEquals(serviceConfiguration.getWebServicePort().get(), Integer.valueOf((9080)));
         assertEquals(serviceConfiguration.getWebServicePortTls().get(), Integer.valueOf((9443)));
-
-        // check whether exception causes
-        try {
-            PulsarConfigurationLoader.convertFrom(mockConfiguration, false);
-            fail();
-        } catch (Exception e) {
-            assertEquals(e.getClass(), IllegalArgumentException.class);
-        }
     }
 
     @Test
-    public void testPulsarConfiguraitonLoadingStream() throws Exception {
+    public void testConfigurationConverting_checkNonExistMember() {
+        assertThrows(IllegalArgumentException.class,
+                () -> PulsarConfigurationLoader.convertFrom(new MockConfiguration(), false));
+    }
+
+    // Deprecation warning suppressed as this test targets deprecated methods
+    @SuppressWarnings("deprecation")
+    @Test
+    public void testPulsarConfigurationLoadingStream() throws Exception {
         File testConfigFile = new File("tmp." + System.currentTimeMillis() + ".properties");
         if (testConfigFile.exists()) {
             testConfigFile.delete();
@@ -120,6 +123,7 @@ public class PulsarConfigurationLoaderTest {
         assertNotNull(serviceConfig);
         assertEquals(serviceConfig.getMetadataStoreUrl(), metadataStoreUrl);
         assertTrue(serviceConfig.isBrokerDeleteInactiveTopicsEnabled());
+
         assertEquals(serviceConfig.getBacklogQuotaDefaultLimitGB(), 18);
         assertEquals(serviceConfig.getClusterName(), "usc");
         assertEquals(serviceConfig.getBrokerClientAuthenticationParameters(), "role:my-role");
@@ -136,7 +140,7 @@ public class PulsarConfigurationLoaderTest {
     }
 
     @Test
-    public void testPulsarConfiguraitonLoadingProp() throws Exception {
+    public void testPulsarConfigurationLoadingProp() throws Exception {
         final String zk = "zk:localhost:2184";
         final Properties prop = new Properties();
         prop.setProperty("metadataStoreUrl", zk);
@@ -146,17 +150,12 @@ public class PulsarConfigurationLoaderTest {
     }
 
     @Test
-    public void testPulsarConfiguraitonComplete() throws Exception {
+    public void testPulsarConfigurationComplete() throws Exception {
         final String zk = "zk:localhost:2184";
         final Properties prop = new Properties();
         prop.setProperty("metadataStoreUrl", zk);
         final ServiceConfiguration serviceConfig = PulsarConfigurationLoader.create(prop, ServiceConfiguration.class);
-        try {
-            isComplete(serviceConfig);
-            fail("it should fail as config is not complete");
-        } catch (IllegalArgumentException e) {
-            // Ok
-        }
+        assertThrows(IllegalArgumentException.class, () -> isComplete(serviceConfig));
     }
 
     @Test
@@ -221,43 +220,19 @@ public class PulsarConfigurationLoaderTest {
 
     @Test
     public void testComplete() throws Exception {
-        TestCompleteObject complete = this.new TestCompleteObject();
+        TestCompleteObject complete = new TestCompleteObject();
         assertTrue(isComplete(complete));
     }
 
     @Test
-    public void testInComplete() throws IllegalAccessException {
-
-        try {
-            isComplete(this.new TestInCompleteObjectRequired());
-            fail("Should fail w/ illegal argument exception");
-        } catch (IllegalArgumentException iae) {
-            // OK, expected
-        }
-
-        try {
-            isComplete(this.new TestInCompleteObjectMin());
-            fail("Should fail w/ illegal argument exception");
-        } catch (IllegalArgumentException iae) {
-            // OK, expected
-        }
-
-        try {
-            isComplete(this.new TestInCompleteObjectMax());
-            fail("Should fail w/ illegal argument exception");
-        } catch (IllegalArgumentException iae) {
-            // OK, expected
-        }
-
-        try {
-            isComplete(this.new TestInCompleteObjectMix());
-            fail("Should fail w/ illegal argument exception");
-        } catch (IllegalArgumentException iae) {
-            // OK, expected
-        }
+    public void testIncomplete() throws IllegalAccessException {
+        assertThrows(IllegalArgumentException.class, () -> isComplete(new TestInCompleteObjectRequired()));
+        assertThrows(IllegalArgumentException.class, () -> isComplete(new TestInCompleteObjectMin()));
+        assertThrows(IllegalArgumentException.class, () -> isComplete(new TestInCompleteObjectMax()));
+        assertThrows(IllegalArgumentException.class, () -> isComplete(new TestInCompleteObjectMix()));
     }
 
-    class TestCompleteObject {
+    static class TestCompleteObject {
         @FieldContext(required = true)
         String required = "I am not null";
         @FieldContext(required = false)
@@ -268,25 +243,24 @@ public class PulsarConfigurationLoaderTest {
         int minValue = 2;
         @FieldContext(minValue = 1, maxValue = 3)
         int minMaxValue = 2;
-
     }
 
-    class TestInCompleteObjectRequired {
+    static class TestInCompleteObjectRequired {
         @FieldContext(required = true)
         String inValidRequired;
     }
 
-    class TestInCompleteObjectMin {
+    static class TestInCompleteObjectMin {
         @FieldContext(minValue = 1, maxValue = 3)
         long inValidMin = 0;
     }
 
-    class TestInCompleteObjectMax {
+    static class TestInCompleteObjectMax {
         @FieldContext(minValue = 1, maxValue = 3)
         long inValidMax = 4;
     }
 
-    class TestInCompleteObjectMix {
+    static class TestInCompleteObjectMix {
         @FieldContext(required = true)
         String inValidRequired;
         @FieldContext(minValue = 1, maxValue = 3)

--- a/pulsar-common/src/test/java/org/apache/pulsar/common/naming/NamespaceNameTest.java
+++ b/pulsar-common/src/test/java/org/apache/pulsar/common/naming/NamespaceNameTest.java
@@ -22,165 +22,162 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotEquals;
 import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
-import static org.testng.Assert.fail;
 
 import org.testng.annotations.Test;
 
 public class NamespaceNameTest {
 
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void namespace_invalidFormat() {
+        NamespaceName.get("namespace");
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void namespace_propertyNamespace() {
+        NamespaceName.get("property.namespace");
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void namespace_loopBackAddress() {
+        NamespaceName.get("0.0.0.0");
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void namespace_propertyNamespaceTopic() {
+        NamespaceName.get("property.namespace:topic");
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void namespace_propertyClusterNamespaceTopic() {
+        NamespaceName.get("property/cluster/namespace/topic");
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void namespace_null() {
+        NamespaceName.get(null);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void namespace_nullTenant() {
+        NamespaceName.get(null, "use", "ns1");
+    }
+
     @Test
-    public void namespace() {
-        try {
-            NamespaceName.get("namespace");
-            fail("Should have caused exception");
-        } catch (IllegalArgumentException e) {
-            // expected
-        }
-
-        try {
-            NamespaceName.get("property.namespace");
-            fail("Should have caused exception");
-        } catch (IllegalArgumentException e) {
-            // expected
-        }
-
-        try {
-            NamespaceName.get("0.0.0.0");
-            fail("Should have caused exception");
-        } catch (IllegalArgumentException e) {
-            // expected
-        }
-
-        try {
-            NamespaceName.get("property.namespace:topic");
-            fail("Should have raised exception");
-        } catch (IllegalArgumentException e) {
-            // Ok
-        }
-
-        try {
-            NamespaceName.get("property/cluster/namespace/topic");
-            fail("Should have raised exception");
-        } catch (IllegalArgumentException e) {
-            // Ok
-        }
-
-        try {
-            NamespaceName.get(null);
-        } catch (IllegalArgumentException e) {
-            // OK
-        }
-
-        try {
-            NamespaceName.get(null, "use", "ns1");
-        } catch (IllegalArgumentException e) {
-            // OK
-        }
-
+    public void namespace_persistentTopic() {
         assertEquals(NamespaceName.get("prop/cluster/ns").getPersistentTopicName("ds"),
                 "persistent://prop/cluster/ns/ds");
+    }
 
-        try {
-            NamespaceName.get("prop/cluster/ns").getTopicName(null, "ds");
-            fail("Should have raised exception");
-        } catch (IllegalArgumentException e) {
-            // Ok
-        }
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void namespace_topicNameNullDomain() {
+        NamespaceName.get("prop/cluster/ns").getTopicName(null, "ds");
+    }
 
+    @Test
+    public void namespace_persistentTopicExplicitDomain() {
         assertEquals(NamespaceName.get("prop/cluster/ns").getTopicName(TopicDomain.persistent, "ds"),
                 "persistent://prop/cluster/ns/ds");
-        assertEquals(NamespaceName.get("prop/cluster/ns"), NamespaceName.get("prop/cluster/ns"));
-        assertEquals(NamespaceName.get("prop/cluster/ns").toString(), "prop/cluster/ns");
-        assertNotEquals(NamespaceName.get("prop/cluster/ns"), "prop/cluster/ns");
+    }
 
+    @Test
+    public void namespace_equals() {
+        assertEquals(NamespaceName.get("prop/cluster/ns"), NamespaceName.get("prop/cluster/ns"));
+    }
+
+    @Test
+    public void namespace_toString() {
+        assertEquals(NamespaceName.get("prop/cluster/ns").toString(), "prop/cluster/ns");
+    }
+
+    @SuppressWarnings("AssertBetweenInconvertibleTypes")
+    @Test
+    public void namespace_equalsCheckType() {
+        assertNotEquals(NamespaceName.get("prop/cluster/ns"), "prop/cluster/ns");
+    }
+
+    @Test
+    public void namespace_vargEquivalentToParse() {
         assertEquals(NamespaceName.get("prop", "cluster", "ns"), NamespaceName.get("prop/cluster/ns"));
+    }
+
+    // Deprecation warning suppressed as this test targets deprecated methods
+    @SuppressWarnings("deprecation")
+    @Test
+    public void namespace_members() {
         assertEquals(NamespaceName.get("prop/cluster/ns").getTenant(), "prop");
         assertEquals(NamespaceName.get("prop/cluster/ns").getCluster(), "cluster");
         assertEquals(NamespaceName.get("prop/cluster/ns").getLocalName(), "ns");
+    }
 
-        try {
-            NamespaceName.get("ns").getTenant();
-            fail("old style namespace");
-        } catch (IllegalArgumentException e) {
-            // Ok
-        }
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void namespace_oldStyleNamespaceTenant() {
+        NamespaceName.get("ns").getTenant();
+    }
 
-        try {
-            NamespaceName.get("ns").getCluster();
-            fail("old style namespace");
-        } catch (IllegalArgumentException e) {
-            // Ok
-        }
+    // Deprecation warning suppressed as this test targets deprecated methods
+    @SuppressWarnings("deprecation")
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void namespace_oldStyleNamespaceCluster() {
+        NamespaceName.get("ns").getCluster();
+    }
 
-        try {
-            NamespaceName.get("ns").getLocalName();
-            fail("old style namespace");
-        } catch (IllegalArgumentException e) {
-            // Ok
-        }
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void namespace_oldStyleNamespaceLocalName() {
+        NamespaceName.get("ns").getLocalName();
+    }
 
-        try {
-            NamespaceName.get(null, "cluster", "namespace");
-            fail("Should have raised exception");
-        } catch (IllegalArgumentException e) {
-            // Ok
-        }
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void namespace_nullTenant2() {
+        NamespaceName.get(null, "cluster", "namespace");
+    }
 
-        try {
-            NamespaceName.get("", "cluster", "namespace");
-            fail("Should have raised exception");
-        } catch (IllegalArgumentException e) {
-            // Ok
-        }
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void namespace_emptyTenant() {
+        NamespaceName.get("", "cluster", "namespace");
+    }
 
-        try {
-            NamespaceName.get("/cluster/namespace");
-            fail("Should have raised exception");
-        } catch (IllegalArgumentException e) {
-            // Ok
-        }
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void namespace_emptyTenantElement() {
+        NamespaceName.get("/cluster/namespace");
+    }
 
-        try {
-            NamespaceName.get("pulsar//namespace");
-            fail("Should have raised exception");
-        } catch (IllegalArgumentException e) {
-            // Ok
-        }
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void namespace_missingCluster() {
+        NamespaceName.get("pulsar//namespace");
+    }
 
-        try {
-            NamespaceName.get("pulsar", null, "namespace");
-            fail("Should have raised exception");
-        } catch (IllegalArgumentException e) {
-            // Ok
-        }
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void namespace_nullCluster() {
+        NamespaceName.get("pulsar", null, "namespace");
+    }
 
-        try {
-            NamespaceName.get("pulsar", "", "namespace");
-            fail("Should have raised exception");
-        } catch (IllegalArgumentException e) {
-            // Ok
-        }
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void namespace_emptyCluster() {
+        NamespaceName.get("pulsar", "", "namespace");
+    }
 
-        try {
-            NamespaceName.get("pulsar", "cluster", null);
-            fail("Should have raised exception");
-        } catch (IllegalArgumentException e) {
-            // Ok
-        }
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void namespace_nullNamespace() {
+        NamespaceName.get("pulsar", "cluster", null);
+    }
 
-        try {
-            NamespaceName.get("pulsar", "cluster", "");
-            fail("Should have raised exception");
-        } catch (IllegalArgumentException e) {
-            // Ok
-        }
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void namespace_emptyNamespace() {
+        NamespaceName.get("pulsar", "cluster", "");
+    }
 
+    // Deprecation warning suppressed as this test targets deprecated methods
+    @SuppressWarnings("deprecation")
+    @Test
+    public void namespace_v2Namespace() {
         NamespaceName v2Namespace = NamespaceName.get("pulsar/colo1/testns-1");
         assertEquals(v2Namespace.getTenant(), "pulsar");
         assertEquals(v2Namespace.getCluster(), "colo1");
         assertEquals(v2Namespace.getLocalName(), "testns-1");
     }
 
+    // Deprecation warning suppressed as this test targets deprecated methods
+    @SuppressWarnings("deprecation")
     @Test
     void testNewScheme() {
         NamespaceName ns = NamespaceName.get("my-tenant/my-namespace");

--- a/pulsar-common/src/test/java/org/apache/pulsar/common/util/collections/ConcurrentOpenHashSetTest.java
+++ b/pulsar-common/src/test/java/org/apache/pulsar/common/util/collections/ConcurrentOpenHashSetTest.java
@@ -21,8 +21,8 @@ package org.apache.pulsar.common.util.collections;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotEquals;
+import static org.testng.Assert.assertThrows;
 import static org.testng.Assert.assertTrue;
-import static org.testng.Assert.fail;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -37,30 +37,15 @@ import org.testng.annotations.Test;
 
 import com.google.common.collect.Lists;
 
+// Deprecation warning suppressed as this test targets deprecated class
+@SuppressWarnings("deprecation")
 public class ConcurrentOpenHashSetTest {
 
     @Test
     public void testConstructor() {
-        try {
-            new ConcurrentOpenHashSet<String>(0);
-            fail("should have thrown exception");
-        } catch (IllegalArgumentException e) {
-            // ok
-        }
-
-        try {
-            new ConcurrentOpenHashSet<String>(16, 0);
-            fail("should have thrown exception");
-        } catch (IllegalArgumentException e) {
-            // ok
-        }
-
-        try {
-            new ConcurrentOpenHashSet<String>(4, 8);
-            fail("should have thrown exception");
-        } catch (IllegalArgumentException e) {
-            // ok
-        }
+        assertThrows(IllegalArgumentException.class, () -> new ConcurrentOpenHashSet<String>(0));
+        assertThrows(IllegalArgumentException.class, () -> new ConcurrentOpenHashSet<String>(16, 0));
+        assertThrows(IllegalArgumentException.class, () -> new ConcurrentOpenHashSet<String>(4, 8));
     }
 
     @Test
@@ -120,15 +105,15 @@ public class ConcurrentOpenHashSetTest {
                 .autoShrink(true)
                 .mapIdleFactor(0.25f)
                 .build();
-        assertTrue(set.capacity() == 4);
+        assertEquals(set.capacity(), 4);
 
         assertTrue(set.add("k1"));
         assertTrue(set.add("k2"));
         assertTrue(set.add("k3"));
 
-        assertTrue(set.capacity() == 8);
+        assertEquals(set.capacity(), 8);
         set.clear();
-        assertTrue(set.capacity() == 4);
+        assertEquals(set.capacity(), 4);
     }
 
     @Test
@@ -140,31 +125,31 @@ public class ConcurrentOpenHashSetTest {
                 .autoShrink(true)
                 .mapIdleFactor(0.25f)
                 .build();
-        assertTrue(map.capacity() == 4);
+        assertEquals(map.capacity(), 4);
 
         assertTrue(map.add("k1"));
         assertTrue(map.add("k2"));
         assertTrue(map.add("k3"));
 
         // expand hashmap
-        assertTrue(map.capacity() == 8);
+        assertEquals(map.capacity(), 8);
 
         assertTrue(map.remove("k1"));
         // not shrink
-        assertTrue(map.capacity() == 8);
+        assertEquals(map.capacity(), 8);
         assertTrue(map.remove("k2"));
         // shrink hashmap
-        assertTrue(map.capacity() == 4);
+        assertEquals(map.capacity(), 4);
 
         // expand hashmap
         assertTrue(map.add("k4"));
         assertTrue(map.add("k5"));
-        assertTrue(map.capacity() == 8);
+        assertEquals(map.capacity(), 8);
 
         //verify that the map does not keep shrinking at every remove() operation
         assertTrue(map.add("k6"));
         assertTrue(map.remove("k6"));
-        assertTrue(map.capacity() == 8);
+        assertEquals(map.capacity(), 8);
     }
 
     @Test

--- a/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/BacklogQuotaCompatibilityTest.java
+++ b/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/BacklogQuotaCompatibilityTest.java
@@ -40,6 +40,8 @@ public class BacklogQuotaCompatibilityTest {
 
     private final BacklogQuota.RetentionPolicy testPolicy = BacklogQuota.RetentionPolicy.consumer_backlog_eviction;
 
+    // Deprecation warning suppressed as this test targets deprecated methods
+    @SuppressWarnings("deprecation")
     @Test
     public void testV27ClientSetV28BrokerRead() throws Exception {
         Policies writePolicy = new Policies();
@@ -76,6 +78,8 @@ public class BacklogQuotaCompatibilityTest {
         Assert.assertEquals(readBacklogQuota.getPolicy(), testPolicy);
     }
 
+    // Deprecation warning suppressed as this test targets deprecated methods
+    @SuppressWarnings("deprecation")
     @Test
     public void testV28ClientSetV27BrokerRead() {
         BacklogQuotaImpl writeBacklogQuota = new BacklogQuotaImpl();

--- a/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/bookkeeper/LedgerUnderreplicationManagerTest.java
+++ b/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/bookkeeper/LedgerUnderreplicationManagerTest.java
@@ -241,7 +241,7 @@ public class LedgerUnderreplicationManagerTest extends BaseMetadataStoreTest {
 
     /**
      * Test that when a ledger has been marked as replicated, it
-     * will not be offered to anther client.
+     * will not be offered to another client.
      * This test checked that by marking two ledgers, and acquiring
      * them on a single client. It marks one as replicated and then
      * the client is killed. We then check that another client can


### PR DESCRIPTION
### Motivation
We wish to reduce warnings in the build output that don't add value to decrease build noise and generally increase the usefulness of warnings.

```
[WARNING] /Users/ewest/git/pulsar/pulsar-common/src/test/java/org/apache/pulsar/common/util/collections/ConcurrentOpenHashSetTest.java:[45,13] ConcurrentOpenHashSet(int) in org.apache.pulsar.common.util.collections.ConcurrentOpenHashSet has been deprecated
```

### Modifications
Tests that target deprecated code clearly have a good reason to do so. We should not generate compiler warnings for such code. In one case a monolithic test case has been split up to better target the warning supression.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API: no
  - The schema: no
  - The default values of configurations: no
  - The wire protocol: no
  - The rest endpoints: no
  - The admin cli options: no
  - Anything that affects deployment: no

### Documentation

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)
  
- [x] `doc-not-needed` 
Non-functional change
  
- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)