### PR TITLE
[improve][broker]add NamespacePolicies check before unload bundle when doLoadShedding

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/ModularLoadManagerImplTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/ModularLoadManagerImplTest.java
@@ -605,10 +605,10 @@ public class ModularLoadManagerImplTest {
         pulsar1.getBrokerService().updateRates();
         loadManager.updateAll();
 
-        // test1: no isolation police
+        // test1: no isolation policy
         assertTrue(loadManager.shouldNamespacePoliciesUnload(namespace, bundle, primaryHost));
 
-        // test2: as isolation police, there are not another broker to load the bundle.
+        // test2: as isolation policy, there are not another broker to load the bundle.
         String newPolicyJsonTemplate = "{\"namespaces\":[\"%s.*\"],\"primary\":[\"%s\"],"
                 + "\"secondary\":[\"%s\"],\"auto_failover_policy\":{\"policy_type\":\"min_available\",\"parameters\":{\"min_limit\":%s,\"usage_threshold\":80}}}";
         String newPolicyJson = String.format(newPolicyJsonTemplate, namespace, broker1Address,broker1Address, 1);
@@ -619,7 +619,7 @@ public class ModularLoadManagerImplTest {
         admin1.clusters().createNamespaceIsolationPolicy(cluster, newPolicyName, nsPolicyData);
         assertFalse(loadManager.shouldNamespacePoliciesUnload(namespace, bundle, broker1Address));
 
-        // test3: as isolation police, there are another can load the bundle.
+        // test3: as isolation policy, there are another can load the bundle.
         String newPolicyJson1 = String.format(newPolicyJsonTemplate, namespace, brokerAddress,brokerAddress, 1);
         NamespaceIsolationDataImpl nsPolicyData1 = jsonMapper.readValue(newPolicyJson1.getBytes(),
                 NamespaceIsolationDataImpl.class);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/ModularLoadManagerImplTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/ModularLoadManagerImplTest.java
@@ -47,6 +47,7 @@ import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
+import lombok.Cleanup;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.broker.PulsarServerException;
 import org.apache.pulsar.broker.PulsarService;
@@ -58,6 +59,8 @@ import org.apache.pulsar.broker.loadbalance.impl.ModularLoadManagerWrapper;
 import org.apache.pulsar.broker.loadbalance.impl.SimpleResourceAllocationPolicies;
 import org.apache.pulsar.client.admin.Namespaces;
 import org.apache.pulsar.client.admin.PulsarAdmin;
+import org.apache.pulsar.client.api.Producer;
+import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.common.naming.NamespaceBundle;
 import org.apache.pulsar.common.naming.NamespaceBundleFactory;
 import org.apache.pulsar.common.naming.NamespaceBundles;
@@ -576,6 +579,54 @@ public class ModularLoadManagerImplTest {
                 availableBrokers, brokerTopicLoadingPredicate);
         assertEquals(brokerCandidateCache.size(), 0);
 
+    }
+
+    @Test
+    public void testLoadSheddingWithNamespaceIsolationPolicies() throws Exception {
+
+        final String cluster = "use";
+        final String tenant = "my-tenant";
+        final String namespace = "my-tenant/use/my-ns";
+        final String bundle = "0x00000000_0xffffffff";
+        final String brokerAddress = pulsar1.getAdvertisedAddress();
+        final String broker1Address = pulsar1.getAdvertisedAddress() + 1;
+
+        admin1.clusters().createCluster(cluster, ClusterData.builder().serviceUrl("http://" + pulsar1.getAdvertisedAddress()).build());
+        admin1.tenants().createTenant(tenant,
+                new TenantInfoImpl(Sets.newHashSet("appid1", "appid2"), Sets.newHashSet(cluster)));
+        admin1.namespaces().createNamespace(namespace);
+
+        @Cleanup
+        PulsarClient pulsarClient = PulsarClient.builder().serviceUrl(pulsar1.getSafeWebServiceAddress()).build();
+        Producer<byte[]> producer = pulsarClient.newProducer().topic("persistent://" + namespace + "/my-topic1")
+                .create();
+        ModularLoadManagerImpl loadManager = (ModularLoadManagerImpl) ((ModularLoadManagerWrapper) pulsar1
+                .getLoadManager().get()).getLoadManager();
+        pulsar1.getBrokerService().updateRates();
+        loadManager.updateAll();
+
+        // test1: no isolation police
+        assertTrue(loadManager.shouldNamespacePoliciesUnload(namespace, bundle, primaryHost));
+
+        // test2: as isolation police, there are not another broker to load the bundle.
+        String newPolicyJsonTemplate = "{\"namespaces\":[\"%s.*\"],\"primary\":[\"%s\"],"
+                + "\"secondary\":[\"%s\"],\"auto_failover_policy\":{\"policy_type\":\"min_available\",\"parameters\":{\"min_limit\":%s,\"usage_threshold\":80}}}";
+        String newPolicyJson = String.format(newPolicyJsonTemplate, namespace, broker1Address,broker1Address, 1);
+        String newPolicyName = "my-ns-isolation-policies";
+        ObjectMapper jsonMapper = ObjectMapperFactory.create();
+        NamespaceIsolationDataImpl nsPolicyData = jsonMapper.readValue(newPolicyJson.getBytes(),
+                NamespaceIsolationDataImpl.class);
+        admin1.clusters().createNamespaceIsolationPolicy(cluster, newPolicyName, nsPolicyData);
+        assertFalse(loadManager.shouldNamespacePoliciesUnload(namespace, bundle, broker1Address));
+
+        // test3: as isolation police, there are another can load the bundle.
+        String newPolicyJson1 = String.format(newPolicyJsonTemplate, namespace, brokerAddress,brokerAddress, 1);
+        NamespaceIsolationDataImpl nsPolicyData1 = jsonMapper.readValue(newPolicyJson1.getBytes(),
+                NamespaceIsolationDataImpl.class);
+        admin1.clusters().updateNamespaceIsolationPolicy(cluster, newPolicyName, nsPolicyData1);
+        assertTrue(loadManager.shouldNamespacePoliciesUnload(namespace, bundle, primaryHost));
+
+        producer.close();
     }
 
     /**


### PR DESCRIPTION
### Motivation

Add NamespacePolicies check before unload bundle when doLoadShedding.
When unload the broker,  It's better to guarantee there are at least one another broker can load the bundle which satisfy the NamespacePolicies. Otherwise the bundle may not load successfully or turn in the loop which unload from the current broker and load by the broker again cause the client reconnect frequently.

### Modifications
1. add NamespacePolicies check before unload bundle when doLoadShedding in ModularLoadManagerImpl.class.
2. add unit test.

### Documentation

- [X] `doc-not-needed` 
 