### PR TITLE
[fix][broker] Retry when DistributedIdGenerator has BadVersion error

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/DistributedIdGenerator.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/DistributedIdGenerator.java
@@ -51,7 +51,7 @@ public class DistributedIdGenerator {
     public DistributedIdGenerator(CoordinationService cs, String path, String prefix) throws Exception {
         this.prefix = prefix;
         this.counter = new AtomicLong(0);
-        this.generatorInstanceId = cs.getNextCounterValueWithRetry(path, 5).get();
+        this.generatorInstanceId = cs.getNextCounterValue(path).get();
         log.info("Broker distributed id generator started with instance id {}-{}", prefix, generatorInstanceId);
     }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/DistributedIdGenerator.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/DistributedIdGenerator.java
@@ -51,7 +51,7 @@ public class DistributedIdGenerator {
     public DistributedIdGenerator(CoordinationService cs, String path, String prefix) throws Exception {
         this.prefix = prefix;
         this.counter = new AtomicLong(0);
-        this.generatorInstanceId = cs.getNextCounterValue(path).get();
+        this.generatorInstanceId = cs.getNextCounterValueWithRetry(path, 5).get();
         log.info("Broker distributed id generator started with instance id {}-{}", prefix, generatorInstanceId);
     }
 

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/api/coordination/CoordinationService.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/api/coordination/CoordinationService.java
@@ -56,4 +56,21 @@ public interface CoordinationService extends AutoCloseable {
      *             if there's a failure in incrementing the counter
      */
     CompletableFuture<Long> getNextCounterValue(String path);
+
+    /**
+     * Increment a counter identified by the specified path and return the current value.
+     * The counter value will be guaranteed to be unique within the context of the path.
+     * It will retry when {@link org.apache.pulsar.metadata.api.MetadataStoreException} happened.
+     *
+     * If the maximum number of retries is reached and still failed,
+     * the feature will complete with exception {@link org.apache.pulsar.metadata.api.MetadataStoreException}.
+     *
+     * @param path
+     *            The path that identifies a particular counter
+     * @param count
+     *            The retry count.
+     * @return
+     *            A future that will track the completion of the operation
+     */
+    CompletableFuture<Long> getNextCounterValueWithRetry(String path, int count);
 }

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/api/coordination/CoordinationService.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/api/coordination/CoordinationService.java
@@ -48,7 +48,10 @@ public interface CoordinationService extends AutoCloseable {
      * Increment a counter identified by the specified path and return the current value.
      *
      * The counter value will be guaranteed to be unique within the context of the path.
+     * It will retry when {@link org.apache.pulsar.metadata.api.MetadataStoreException} happened.
      *
+     * If the maximum number of retries is reached and still failed,
+     * the feature will complete with exception {@link org.apache.pulsar.metadata.api.MetadataStoreException}.
      * @param path
      *            the path that identifies a particular counter
      * @return a future that will track the completion of the operation
@@ -57,20 +60,4 @@ public interface CoordinationService extends AutoCloseable {
      */
     CompletableFuture<Long> getNextCounterValue(String path);
 
-    /**
-     * Increment a counter identified by the specified path and return the current value.
-     * The counter value will be guaranteed to be unique within the context of the path.
-     * It will retry when {@link org.apache.pulsar.metadata.api.MetadataStoreException} happened.
-     *
-     * If the maximum number of retries is reached and still failed,
-     * the feature will complete with exception {@link org.apache.pulsar.metadata.api.MetadataStoreException}.
-     *
-     * @param path
-     *            The path that identifies a particular counter
-     * @param count
-     *            The retry count.
-     * @return
-     *            A future that will track the completion of the operation
-     */
-    CompletableFuture<Long> getNextCounterValueWithRetry(String path, int count);
 }

--- a/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/CounterTest.java
+++ b/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/CounterTest.java
@@ -18,10 +18,22 @@
  */
 package org.apache.pulsar.metadata;
 
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotEquals;
+import static org.testng.Assert.fail;
+
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Supplier;
 import lombok.Cleanup;
 import org.apache.pulsar.metadata.api.MetadataStoreConfig;
+import org.apache.pulsar.metadata.api.MetadataStoreException;
+import org.apache.pulsar.metadata.api.Stat;
 import org.apache.pulsar.metadata.api.coordination.CoordinationService;
 import org.apache.pulsar.metadata.api.extended.MetadataStoreExtended;
 import org.apache.pulsar.metadata.coordination.impl.CoordinationServiceImpl;
@@ -48,7 +60,7 @@ public class CounterTest extends BaseMetadataStoreTest {
         @Cleanup
         CoordinationService cs2 = new CoordinationServiceImpl(store);
 
-        long l4 = cs1.getNextCounterValue("/my/path").join();
+        long l4 = cs2.getNextCounterValue("/my/path").join();
         assertNotEquals(l3, l4);
     }
 
@@ -83,6 +95,56 @@ public class CounterTest extends BaseMetadataStoreTest {
         long l4 = cs2.getNextCounterValue("/my/path").join();
         assertNotEquals(l1, l4);
         assertNotEquals(l2, l4);
+        assertNotEquals(l3, l4);
+    }
+
+    @Test(dataProvider = "impl")
+    public void testGetNextCounterRetry(String provider, Supplier<String> urlSupplier) throws Exception {
+        @Cleanup
+        MetadataStoreExtended store = MetadataStoreExtended.create(urlSupplier.get(),
+                MetadataStoreConfig.builder().build());
+
+        MetadataStoreExtended spy = spy(store);
+
+        @Cleanup
+        CoordinationService cs1 = new CoordinationServiceImpl(spy);
+
+        AtomicInteger count = new AtomicInteger(0);
+        CompletableFuture<Stat> future = new CompletableFuture<>();
+        future.completeExceptionally(new MetadataStoreException.BadVersionException(""));
+        when(spy.put(eq("/my/path"), eq(new byte[0]), eq(Optional.empty())))
+                .thenAnswer(__ -> {
+                    // Retry three times, then it will return success.
+                    if (count.incrementAndGet() <= 3) {
+                        return future;
+                    }
+                    reset(spy);
+                    return CompletableFuture.completedFuture(null);
+                });
+
+        long l1 = cs1.getNextCounterValue("/my/path").join();
+        long l2 = cs1.getNextCounterValue("/my/path").join();
+        long l3 = cs1.getNextCounterValue("/my/path").join();
+
+        assertNotEquals(l1, l2);
+        assertNotEquals(l2, l3);
+
+        when(spy.put(eq("/my/path1"), eq(new byte[0]), eq(Optional.empty())))
+                .thenReturn(future);
+
+        try {
+            cs1.getNextCounterValue("/my/path1").join();
+            fail("Should fail with MetadataStoreException.");
+        } catch (Exception ex) {
+            assertEquals(ex.getCause().getMessage(), "The number of retries has exhausted");
+        }
+
+        reset(spy);
+
+        @Cleanup
+        CoordinationService cs2 = new CoordinationServiceImpl(store);
+
+        long l4 = cs2.getNextCounterValue("/my/path").join();
         assertNotEquals(l3, l4);
     }
 }


### PR DESCRIPTION
Fixes #16454

### Motivation

See #16454

When starting several brokers concurrently, there is a risk that one will fail with the following error:

```
2022-06-27T16:23:42,169+0000 [main] ERROR org.apache.pulsar.broker.PulsarService - Failed to start Pulsar service: org.apache.pulsar.metadata.api.MetadataStoreException$BadVersionException: org.apache.zookeeper.KeeperException$BadVersionException: KeeperErrorCode = BadVersion for /counters/producer-name
java.util.concurrent.ExecutionException: org.apache.pulsar.metadata.api.MetadataStoreException$BadVersionException: org.apache.zookeeper.KeeperException$BadVersionException: KeeperErrorCode = BadVersion for /counters/producer-name
        at java.util.concurrent.CompletableFuture.reportGet(CompletableFuture.java:395) ~[?:?]
        at java.util.concurrent.CompletableFuture.get(CompletableFuture.java:1999) ~[?:?]
        at org.apache.pulsar.broker.service.DistributedIdGenerator.<init>(DistributedIdGenerator.java:54) ~[com.datastax.oss-pulsar-broker-2.10.0.6.jar:2.10.0.6]
        at org.apache.pulsar.broker.service.BrokerService.start(BrokerService.java:460) ~[com.datastax.oss-pulsar-broker-2.10.0.6.jar:2.10.0.
```
The key problem is `org.apache.pulsar.metadata.api.MetadataStoreException$BadVersionException: org.apache.zookeeper.KeeperException$BadVersionException: KeeperErrorCode = BadVersion` for `/counters/producer-name`, and in looking at the `/counters/producer-name` initialization, I can see that it does not handle retries in the event of a `BadVersion` error.

### Modifications

Add a retry version of `getNextCounterValue` in `CoordinationService`.

### Documentation

Check the box below or label this PR directly.

Need to update docs? 

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)
  
- [x] `doc-not-needed` 
(Please explain why)
  
- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)