### PR TITLE
[fix][io-quickstart][docs] Corrected split sentence in tip

### DIFF
--- a/site2/website/versioned_docs/version-2.10.0/io-quickstart.md
+++ b/site2/website/versioned_docs/version-2.10.0/io-quickstart.md
@@ -450,12 +450,11 @@ This section demonstrates how to connect Pulsar to PostgreSQL.
 :::tip
 
 * Make sure you have Docker installed. If you do not have one, see [install Docker](https://docs.docker.com/docker-for-mac/install/).
-* The JDBC sink connector pulls messages from Pulsar topics 
+* The JDBC sink connector pulls messages from Pulsar topics and persists the messages to ClickHouse, MariaDB, PostgreSQL, or SQlite.
 
 :::
 
-and persists the messages to ClickHouse, MariaDB, PostgreSQL, or SQlite. 
->For more information, see [JDBC sink connector](io-jdbc-sink.md).
+>For more information, see [JDBC sink connector](io-jdbc-sink).
 
 
 ### Setup a PostgreSQL cluster

--- a/site2/website/versioned_docs/version-2.10.0/io-quickstart.md
+++ b/site2/website/versioned_docs/version-2.10.0/io-quickstart.md
@@ -454,7 +454,7 @@ This section demonstrates how to connect Pulsar to PostgreSQL.
 
 :::
 
->For more information, see [JDBC sink connector](io-jdbc-sink).
+>For more information, see [JDBC sink connector](io-jdbc-sink.md).
 
 
 ### Setup a PostgreSQL cluster

--- a/site2/website/versioned_docs/version-2.10.1/io-quickstart.md
+++ b/site2/website/versioned_docs/version-2.10.1/io-quickstart.md
@@ -450,10 +450,10 @@ This section demonstrates how to connect Pulsar to PostgreSQL.
 :::tip
 
 * Make sure you have Docker installed. If you do not have one, see [install Docker](https://docs.docker.com/docker-for-mac/install/).
+* The JDBC sink connector pulls messages from Pulsar topics and persists the messages to ClickHouse, MariaDB, PostgreSQL, or SQlite.
 
 :::
 
-The JDBC sink connector pulls messages from Pulsar topics and persists the messages to ClickHouse, MariaDB, PostgreSQL, or SQlite. 
 >For more information, see [JDBC sink connector](io-jdbc-sink.md).
 
 

--- a/site2/website/versioned_docs/version-2.10.1/io-quickstart.md
+++ b/site2/website/versioned_docs/version-2.10.1/io-quickstart.md
@@ -450,11 +450,10 @@ This section demonstrates how to connect Pulsar to PostgreSQL.
 :::tip
 
 * Make sure you have Docker installed. If you do not have one, see [install Docker](https://docs.docker.com/docker-for-mac/install/).
-* The JDBC sink connector pulls messages from Pulsar topics 
 
 :::
 
-and persists the messages to ClickHouse, MariaDB, PostgreSQL, or SQlite. 
+The JDBC sink connector pulls messages from Pulsar topics and persists the messages to ClickHouse, MariaDB, PostgreSQL, or SQlite. 
 >For more information, see [JDBC sink connector](io-jdbc-sink.md).
 
 

--- a/site2/website/versioned_docs/version-2.5.0/io-quickstart.md
+++ b/site2/website/versioned_docs/version-2.5.0/io-quickstart.md
@@ -451,11 +451,10 @@ This section demonstrates how to connector Pulsar to MySQL.
 :::tip
 
 * Make sure you have Docker installed. If you do not have one, see [install Docker](https://docs.docker.com/docker-for-mac/install/).
-* The JDBC sink connector pulls messages from Pulsar topics 
 
 :::
 
-and persists the messages to MySQL or SQlite. For more information, see [JDBC sink connector](io-jdbc-sink).
+The JDBC sink connector pulls messages from Pulsar topics and persists the messages to MySQL or SQlite. For more information, see [JDBC sink connector](io-jdbc-sink).
 
 
 ### Setup a MySQL cluster

--- a/site2/website/versioned_docs/version-2.5.0/io-quickstart.md
+++ b/site2/website/versioned_docs/version-2.5.0/io-quickstart.md
@@ -451,10 +451,9 @@ This section demonstrates how to connector Pulsar to MySQL.
 :::tip
 
 * Make sure you have Docker installed. If you do not have one, see [install Docker](https://docs.docker.com/docker-for-mac/install/).
+* The JDBC sink connector pulls messages from Pulsar topics and persists the messages to MySQL or SQlite. For more information, see [JDBC sink connector](io-jdbc-sink).
 
 :::
-
-The JDBC sink connector pulls messages from Pulsar topics and persists the messages to MySQL or SQlite. For more information, see [JDBC sink connector](io-jdbc-sink).
 
 
 ### Setup a MySQL cluster

--- a/site2/website/versioned_docs/version-2.5.1/io-quickstart.md
+++ b/site2/website/versioned_docs/version-2.5.1/io-quickstart.md
@@ -451,11 +451,10 @@ This section demonstrates how to connector Pulsar to MySQL.
 :::tip
 
 * Make sure you have Docker installed. If you do not have one, see [install Docker](https://docs.docker.com/docker-for-mac/install/).
-* The JDBC sink connector pulls messages from Pulsar topics 
 
 :::
 
-and persists the messages to MySQL or SQlite. For more information, see [JDBC sink connector](io-jdbc-sink).
+The JDBC sink connector pulls messages from Pulsar topics and persists the messages to MySQL or SQlite. For more information, see [JDBC sink connector](io-jdbc-sink).
 
 
 ### Setup a MySQL cluster

--- a/site2/website/versioned_docs/version-2.5.1/io-quickstart.md
+++ b/site2/website/versioned_docs/version-2.5.1/io-quickstart.md
@@ -451,10 +451,10 @@ This section demonstrates how to connector Pulsar to MySQL.
 :::tip
 
 * Make sure you have Docker installed. If you do not have one, see [install Docker](https://docs.docker.com/docker-for-mac/install/).
+* The JDBC sink connector pulls messages from Pulsar topics and persists the messages to MySQL or SQlite. For more information, see [JDBC sink connector](io-jdbc-sink).
 
 :::
 
-The JDBC sink connector pulls messages from Pulsar topics and persists the messages to MySQL or SQlite. For more information, see [JDBC sink connector](io-jdbc-sink).
 
 
 ### Setup a MySQL cluster

--- a/site2/website/versioned_docs/version-2.5.2/io-quickstart.md
+++ b/site2/website/versioned_docs/version-2.5.2/io-quickstart.md
@@ -451,11 +451,10 @@ This section demonstrates how to connector Pulsar to MySQL.
 :::tip
 
 * Make sure you have Docker installed. If you do not have one, see [install Docker](https://docs.docker.com/docker-for-mac/install/).
-* The JDBC sink connector pulls messages from Pulsar topics 
 
 :::
 
-and persists the messages to MySQL or SQlite. For more information, see [JDBC sink connector](io-jdbc-sink).
+The JDBC sink connector pulls messages from Pulsar topics and persists the messages to MySQL or SQlite. For more information, see [JDBC sink connector](io-jdbc-sink).
 
 
 ### Setup a MySQL cluster

--- a/site2/website/versioned_docs/version-2.5.2/io-quickstart.md
+++ b/site2/website/versioned_docs/version-2.5.2/io-quickstart.md
@@ -451,10 +451,10 @@ This section demonstrates how to connector Pulsar to MySQL.
 :::tip
 
 * Make sure you have Docker installed. If you do not have one, see [install Docker](https://docs.docker.com/docker-for-mac/install/).
+* The JDBC sink connector pulls messages from Pulsar topics and persists the messages to MySQL or SQlite. For more information, see [JDBC sink connector](io-jdbc-sink).
 
 :::
 
-The JDBC sink connector pulls messages from Pulsar topics and persists the messages to MySQL or SQlite. For more information, see [JDBC sink connector](io-jdbc-sink).
 
 
 ### Setup a MySQL cluster

--- a/site2/website/versioned_docs/version-2.6.0/io-quickstart.md
+++ b/site2/website/versioned_docs/version-2.6.0/io-quickstart.md
@@ -451,11 +451,10 @@ This section demonstrates how to connect Pulsar to PostgreSQL.
 :::tip
 
 * Make sure you have Docker installed. If you do not have one, see [install Docker](https://docs.docker.com/docker-for-mac/install/).
-* The JDBC sink connector pulls messages from Pulsar topics 
 
 :::
 
-and persists the messages to ClickHouse, MariaDB, PostgreSQL, or SQlite. 
+The JDBC sink connector pulls messages from Pulsar topics and persists the messages to ClickHouse, MariaDB, PostgreSQL, or SQlite. 
 >For more information, see [JDBC sink connector](io-jdbc-sink).
 
 

--- a/site2/website/versioned_docs/version-2.6.0/io-quickstart.md
+++ b/site2/website/versioned_docs/version-2.6.0/io-quickstart.md
@@ -451,10 +451,10 @@ This section demonstrates how to connect Pulsar to PostgreSQL.
 :::tip
 
 * Make sure you have Docker installed. If you do not have one, see [install Docker](https://docs.docker.com/docker-for-mac/install/).
+* The JDBC sink connector pulls messages from Pulsar topics and persists the messages to ClickHouse, MariaDB, PostgreSQL, or SQlite.
 
 :::
 
-The JDBC sink connector pulls messages from Pulsar topics and persists the messages to ClickHouse, MariaDB, PostgreSQL, or SQlite. 
 >For more information, see [JDBC sink connector](io-jdbc-sink).
 
 

--- a/site2/website/versioned_docs/version-2.6.1/io-quickstart.md
+++ b/site2/website/versioned_docs/version-2.6.1/io-quickstart.md
@@ -447,11 +447,10 @@ This section demonstrates how to connect Pulsar to PostgreSQL.
 :::tip
 
 * Make sure you have Docker installed. If you do not have one, see [install Docker](https://docs.docker.com/docker-for-mac/install/).
-* The JDBC sink connector pulls messages from Pulsar topics 
 
 :::
 
-and persists the messages to ClickHouse, MariaDB, PostgreSQL, or SQlite. 
+The JDBC sink connector pulls messages from Pulsar topics and persists the messages to ClickHouse, MariaDB, PostgreSQL, or SQlite. 
 >For more information, see [JDBC sink connector](io-jdbc-sink).
 
 

--- a/site2/website/versioned_docs/version-2.6.1/io-quickstart.md
+++ b/site2/website/versioned_docs/version-2.6.1/io-quickstart.md
@@ -447,10 +447,10 @@ This section demonstrates how to connect Pulsar to PostgreSQL.
 :::tip
 
 * Make sure you have Docker installed. If you do not have one, see [install Docker](https://docs.docker.com/docker-for-mac/install/).
+* The JDBC sink connector pulls messages from Pulsar topics and persists the messages to ClickHouse, MariaDB, PostgreSQL, or SQlite.
 
 :::
 
-The JDBC sink connector pulls messages from Pulsar topics and persists the messages to ClickHouse, MariaDB, PostgreSQL, or SQlite. 
 >For more information, see [JDBC sink connector](io-jdbc-sink).
 
 

--- a/site2/website/versioned_docs/version-2.6.2/io-quickstart.md
+++ b/site2/website/versioned_docs/version-2.6.2/io-quickstart.md
@@ -447,11 +447,10 @@ This section demonstrates how to connect Pulsar to PostgreSQL.
 :::tip
 
 * Make sure you have Docker installed. If you do not have one, see [install Docker](https://docs.docker.com/docker-for-mac/install/).
-* The JDBC sink connector pulls messages from Pulsar topics 
 
 :::
 
-and persists the messages to ClickHouse, MariaDB, PostgreSQL, or SQlite. 
+The JDBC sink connector pulls messages from Pulsar topics and persists the messages to ClickHouse, MariaDB, PostgreSQL, or SQlite. 
 >For more information, see [JDBC sink connector](io-jdbc-sink).
 
 

--- a/site2/website/versioned_docs/version-2.6.2/io-quickstart.md
+++ b/site2/website/versioned_docs/version-2.6.2/io-quickstart.md
@@ -447,10 +447,10 @@ This section demonstrates how to connect Pulsar to PostgreSQL.
 :::tip
 
 * Make sure you have Docker installed. If you do not have one, see [install Docker](https://docs.docker.com/docker-for-mac/install/).
+* The JDBC sink connector pulls messages from Pulsar topics and persists the messages to ClickHouse, MariaDB, PostgreSQL, or SQlite.
 
 :::
 
-The JDBC sink connector pulls messages from Pulsar topics and persists the messages to ClickHouse, MariaDB, PostgreSQL, or SQlite. 
 >For more information, see [JDBC sink connector](io-jdbc-sink).
 
 

--- a/site2/website/versioned_docs/version-2.6.3/io-quickstart.md
+++ b/site2/website/versioned_docs/version-2.6.3/io-quickstart.md
@@ -447,11 +447,10 @@ This section demonstrates how to connect Pulsar to PostgreSQL.
 :::tip
 
 * Make sure you have Docker installed. If you do not have one, see [install Docker](https://docs.docker.com/docker-for-mac/install/).
-* The JDBC sink connector pulls messages from Pulsar topics 
 
 :::
 
-and persists the messages to ClickHouse, MariaDB, PostgreSQL, or SQlite. 
+The JDBC sink connector pulls messages from Pulsar topics and persists the messages to ClickHouse, MariaDB, PostgreSQL, or SQlite. 
 >For more information, see [JDBC sink connector](io-jdbc-sink).
 
 

--- a/site2/website/versioned_docs/version-2.6.3/io-quickstart.md
+++ b/site2/website/versioned_docs/version-2.6.3/io-quickstart.md
@@ -447,10 +447,10 @@ This section demonstrates how to connect Pulsar to PostgreSQL.
 :::tip
 
 * Make sure you have Docker installed. If you do not have one, see [install Docker](https://docs.docker.com/docker-for-mac/install/).
+* The JDBC sink connector pulls messages from Pulsar topics and persists the messages to ClickHouse, MariaDB, PostgreSQL, or SQlite.
 
 :::
 
-The JDBC sink connector pulls messages from Pulsar topics and persists the messages to ClickHouse, MariaDB, PostgreSQL, or SQlite. 
 >For more information, see [JDBC sink connector](io-jdbc-sink).
 
 

--- a/site2/website/versioned_docs/version-2.6.4/io-quickstart.md
+++ b/site2/website/versioned_docs/version-2.6.4/io-quickstart.md
@@ -447,11 +447,10 @@ This section demonstrates how to connect Pulsar to PostgreSQL.
 :::tip
 
 * Make sure you have Docker installed. If you do not have one, see [install Docker](https://docs.docker.com/docker-for-mac/install/).
-* The JDBC sink connector pulls messages from Pulsar topics 
 
 :::
 
-and persists the messages to ClickHouse, MariaDB, PostgreSQL, or SQlite. 
+The JDBC sink connector pulls messages from Pulsar topics and persists the messages to ClickHouse, MariaDB, PostgreSQL, or SQlite. 
 >For more information, see [JDBC sink connector](io-jdbc-sink).
 
 

--- a/site2/website/versioned_docs/version-2.6.4/io-quickstart.md
+++ b/site2/website/versioned_docs/version-2.6.4/io-quickstart.md
@@ -447,10 +447,10 @@ This section demonstrates how to connect Pulsar to PostgreSQL.
 :::tip
 
 * Make sure you have Docker installed. If you do not have one, see [install Docker](https://docs.docker.com/docker-for-mac/install/).
+* The JDBC sink connector pulls messages from Pulsar topics and persists the messages to ClickHouse, MariaDB, PostgreSQL, or SQlite.
 
 :::
 
-The JDBC sink connector pulls messages from Pulsar topics and persists the messages to ClickHouse, MariaDB, PostgreSQL, or SQlite. 
 >For more information, see [JDBC sink connector](io-jdbc-sink).
 
 

--- a/site2/website/versioned_docs/version-2.7.0/io-quickstart.md
+++ b/site2/website/versioned_docs/version-2.7.0/io-quickstart.md
@@ -450,11 +450,10 @@ This section demonstrates how to connect Pulsar to PostgreSQL.
 :::tip
 
 * Make sure you have Docker installed. If you do not have one, see [install Docker](https://docs.docker.com/docker-for-mac/install/).
-* The JDBC sink connector pulls messages from Pulsar topics 
 
 :::
 
-and persists the messages to ClickHouse, MariaDB, PostgreSQL, or SQlite. 
+The JDBC sink connector pulls messages from Pulsar topics and persists the messages to ClickHouse, MariaDB, PostgreSQL, or SQlite. 
 >For more information, see [JDBC sink connector](io-jdbc-sink).
 
 

--- a/site2/website/versioned_docs/version-2.7.0/io-quickstart.md
+++ b/site2/website/versioned_docs/version-2.7.0/io-quickstart.md
@@ -450,10 +450,10 @@ This section demonstrates how to connect Pulsar to PostgreSQL.
 :::tip
 
 * Make sure you have Docker installed. If you do not have one, see [install Docker](https://docs.docker.com/docker-for-mac/install/).
+* The JDBC sink connector pulls messages from Pulsar topics and persists the messages to ClickHouse, MariaDB, PostgreSQL, or SQlite.
 
 :::
 
-The JDBC sink connector pulls messages from Pulsar topics and persists the messages to ClickHouse, MariaDB, PostgreSQL, or SQlite. 
 >For more information, see [JDBC sink connector](io-jdbc-sink).
 
 

--- a/site2/website/versioned_docs/version-2.7.1/io-quickstart.md
+++ b/site2/website/versioned_docs/version-2.7.1/io-quickstart.md
@@ -450,11 +450,10 @@ This section demonstrates how to connect Pulsar to PostgreSQL.
 :::tip
 
 * Make sure you have Docker installed. If you do not have one, see [install Docker](https://docs.docker.com/docker-for-mac/install/).
-* The JDBC sink connector pulls messages from Pulsar topics 
 
 :::
 
-and persists the messages to ClickHouse, MariaDB, PostgreSQL, or SQlite. 
+The JDBC sink connector pulls messages from Pulsar topics and persists the messages to ClickHouse, MariaDB, PostgreSQL, or SQlite. 
 >For more information, see [JDBC sink connector](io-jdbc-sink).
 
 

--- a/site2/website/versioned_docs/version-2.7.1/io-quickstart.md
+++ b/site2/website/versioned_docs/version-2.7.1/io-quickstart.md
@@ -450,10 +450,10 @@ This section demonstrates how to connect Pulsar to PostgreSQL.
 :::tip
 
 * Make sure you have Docker installed. If you do not have one, see [install Docker](https://docs.docker.com/docker-for-mac/install/).
+* The JDBC sink connector pulls messages from Pulsar topics and persists the messages to ClickHouse, MariaDB, PostgreSQL, or SQlite.
 
 :::
 
-The JDBC sink connector pulls messages from Pulsar topics and persists the messages to ClickHouse, MariaDB, PostgreSQL, or SQlite. 
 >For more information, see [JDBC sink connector](io-jdbc-sink).
 
 

--- a/site2/website/versioned_docs/version-2.7.2/io-quickstart.md
+++ b/site2/website/versioned_docs/version-2.7.2/io-quickstart.md
@@ -450,11 +450,10 @@ This section demonstrates how to connect Pulsar to PostgreSQL.
 :::tip
 
 * Make sure you have Docker installed. If you do not have one, see [install Docker](https://docs.docker.com/docker-for-mac/install/).
-* The JDBC sink connector pulls messages from Pulsar topics 
 
 :::
 
-and persists the messages to ClickHouse, MariaDB, PostgreSQL, or SQlite. 
+The JDBC sink connector pulls messages from Pulsar topics and persists the messages to ClickHouse, MariaDB, PostgreSQL, or SQlite. 
 >For more information, see [JDBC sink connector](io-jdbc-sink).
 
 

--- a/site2/website/versioned_docs/version-2.7.2/io-quickstart.md
+++ b/site2/website/versioned_docs/version-2.7.2/io-quickstart.md
@@ -450,10 +450,10 @@ This section demonstrates how to connect Pulsar to PostgreSQL.
 :::tip
 
 * Make sure you have Docker installed. If you do not have one, see [install Docker](https://docs.docker.com/docker-for-mac/install/).
+* The JDBC sink connector pulls messages from Pulsar topics and persists the messages to ClickHouse, MariaDB, PostgreSQL, or SQlite.
 
 :::
 
-The JDBC sink connector pulls messages from Pulsar topics and persists the messages to ClickHouse, MariaDB, PostgreSQL, or SQlite. 
 >For more information, see [JDBC sink connector](io-jdbc-sink).
 
 

--- a/site2/website/versioned_docs/version-2.7.3/io-quickstart.md
+++ b/site2/website/versioned_docs/version-2.7.3/io-quickstart.md
@@ -450,11 +450,10 @@ This section demonstrates how to connect Pulsar to PostgreSQL.
 :::tip
 
 * Make sure you have Docker installed. If you do not have one, see [install Docker](https://docs.docker.com/docker-for-mac/install/).
-* The JDBC sink connector pulls messages from Pulsar topics 
 
 :::
 
-and persists the messages to ClickHouse, MariaDB, PostgreSQL, or SQlite. 
+The JDBC sink connector pulls messages from Pulsar topics and persists the messages to ClickHouse, MariaDB, PostgreSQL, or SQlite. 
 >For more information, see [JDBC sink connector](io-jdbc-sink).
 
 

--- a/site2/website/versioned_docs/version-2.7.3/io-quickstart.md
+++ b/site2/website/versioned_docs/version-2.7.3/io-quickstart.md
@@ -450,10 +450,10 @@ This section demonstrates how to connect Pulsar to PostgreSQL.
 :::tip
 
 * Make sure you have Docker installed. If you do not have one, see [install Docker](https://docs.docker.com/docker-for-mac/install/).
+* The JDBC sink connector pulls messages from Pulsar topics and persists the messages to ClickHouse, MariaDB, PostgreSQL, or SQlite.
 
 :::
 
-The JDBC sink connector pulls messages from Pulsar topics and persists the messages to ClickHouse, MariaDB, PostgreSQL, or SQlite. 
 >For more information, see [JDBC sink connector](io-jdbc-sink).
 
 

--- a/site2/website/versioned_docs/version-2.7.4/io-quickstart.md
+++ b/site2/website/versioned_docs/version-2.7.4/io-quickstart.md
@@ -450,11 +450,10 @@ This section demonstrates how to connect Pulsar to PostgreSQL.
 :::tip
 
 * Make sure you have Docker installed. If you do not have one, see [install Docker](https://docs.docker.com/docker-for-mac/install/).
-* The JDBC sink connector pulls messages from Pulsar topics 
 
 :::
 
-and persists the messages to ClickHouse, MariaDB, PostgreSQL, or SQlite. 
+The JDBC sink connector pulls messages from Pulsar topics and persists the messages to ClickHouse, MariaDB, PostgreSQL, or SQlite. 
 >For more information, see [JDBC sink connector](io-jdbc-sink).
 
 

--- a/site2/website/versioned_docs/version-2.7.4/io-quickstart.md
+++ b/site2/website/versioned_docs/version-2.7.4/io-quickstart.md
@@ -450,10 +450,10 @@ This section demonstrates how to connect Pulsar to PostgreSQL.
 :::tip
 
 * Make sure you have Docker installed. If you do not have one, see [install Docker](https://docs.docker.com/docker-for-mac/install/).
+* The JDBC sink connector pulls messages from Pulsar topics and persists the messages to ClickHouse, MariaDB, PostgreSQL, or SQlite.
 
 :::
 
-The JDBC sink connector pulls messages from Pulsar topics and persists the messages to ClickHouse, MariaDB, PostgreSQL, or SQlite. 
 >For more information, see [JDBC sink connector](io-jdbc-sink).
 
 

--- a/site2/website/versioned_docs/version-2.8.0/io-quickstart.md
+++ b/site2/website/versioned_docs/version-2.8.0/io-quickstart.md
@@ -450,11 +450,10 @@ This section demonstrates how to connect Pulsar to PostgreSQL.
 :::tip
 
 * Make sure you have Docker installed. If you do not have one, see [install Docker](https://docs.docker.com/docker-for-mac/install/).
-* The JDBC sink connector pulls messages from Pulsar topics 
 
 :::
 
-and persists the messages to ClickHouse, MariaDB, PostgreSQL, or SQlite. 
+The JDBC sink connector pulls messages from Pulsar topics and persists the messages to ClickHouse, MariaDB, PostgreSQL, or SQlite. 
 >For more information, see [JDBC sink connector](io-jdbc-sink).
 
 

--- a/site2/website/versioned_docs/version-2.8.0/io-quickstart.md
+++ b/site2/website/versioned_docs/version-2.8.0/io-quickstart.md
@@ -450,10 +450,10 @@ This section demonstrates how to connect Pulsar to PostgreSQL.
 :::tip
 
 * Make sure you have Docker installed. If you do not have one, see [install Docker](https://docs.docker.com/docker-for-mac/install/).
+* The JDBC sink connector pulls messages from Pulsar topics and persists the messages to ClickHouse, MariaDB, PostgreSQL, or SQlite.
 
 :::
 
-The JDBC sink connector pulls messages from Pulsar topics and persists the messages to ClickHouse, MariaDB, PostgreSQL, or SQlite. 
 >For more information, see [JDBC sink connector](io-jdbc-sink).
 
 

--- a/site2/website/versioned_docs/version-2.8.1/io-quickstart.md
+++ b/site2/website/versioned_docs/version-2.8.1/io-quickstart.md
@@ -450,11 +450,10 @@ This section demonstrates how to connect Pulsar to PostgreSQL.
 :::tip
 
 * Make sure you have Docker installed. If you do not have one, see [install Docker](https://docs.docker.com/docker-for-mac/install/).
-* The JDBC sink connector pulls messages from Pulsar topics 
 
 :::
 
-and persists the messages to ClickHouse, MariaDB, PostgreSQL, or SQlite. 
+The JDBC sink connector pulls messages from Pulsar topics and persists the messages to ClickHouse, MariaDB, PostgreSQL, or SQlite. 
 >For more information, see [JDBC sink connector](io-jdbc-sink).
 
 

--- a/site2/website/versioned_docs/version-2.8.1/io-quickstart.md
+++ b/site2/website/versioned_docs/version-2.8.1/io-quickstart.md
@@ -450,10 +450,10 @@ This section demonstrates how to connect Pulsar to PostgreSQL.
 :::tip
 
 * Make sure you have Docker installed. If you do not have one, see [install Docker](https://docs.docker.com/docker-for-mac/install/).
+* The JDBC sink connector pulls messages from Pulsar topics and persists the messages to ClickHouse, MariaDB, PostgreSQL, or SQlite.
 
 :::
 
-The JDBC sink connector pulls messages from Pulsar topics and persists the messages to ClickHouse, MariaDB, PostgreSQL, or SQlite. 
 >For more information, see [JDBC sink connector](io-jdbc-sink).
 
 

--- a/site2/website/versioned_docs/version-2.8.2/io-quickstart.md
+++ b/site2/website/versioned_docs/version-2.8.2/io-quickstart.md
@@ -450,11 +450,10 @@ This section demonstrates how to connect Pulsar to PostgreSQL.
 :::tip
 
 * Make sure you have Docker installed. If you do not have one, see [install Docker](https://docs.docker.com/docker-for-mac/install/).
-* The JDBC sink connector pulls messages from Pulsar topics 
 
 :::
 
-and persists the messages to ClickHouse, MariaDB, PostgreSQL, or SQlite. 
+The JDBC sink connector pulls messages from Pulsar topics and persists the messages to ClickHouse, MariaDB, PostgreSQL, or SQlite. 
 >For more information, see [JDBC sink connector](io-jdbc-sink).
 
 

--- a/site2/website/versioned_docs/version-2.8.2/io-quickstart.md
+++ b/site2/website/versioned_docs/version-2.8.2/io-quickstart.md
@@ -450,10 +450,10 @@ This section demonstrates how to connect Pulsar to PostgreSQL.
 :::tip
 
 * Make sure you have Docker installed. If you do not have one, see [install Docker](https://docs.docker.com/docker-for-mac/install/).
+* The JDBC sink connector pulls messages from Pulsar topics and persists the messages to ClickHouse, MariaDB, PostgreSQL, or SQlite.
 
 :::
 
-The JDBC sink connector pulls messages from Pulsar topics and persists the messages to ClickHouse, MariaDB, PostgreSQL, or SQlite. 
 >For more information, see [JDBC sink connector](io-jdbc-sink).
 
 

--- a/site2/website/versioned_docs/version-2.8.3/io-quickstart.md
+++ b/site2/website/versioned_docs/version-2.8.3/io-quickstart.md
@@ -450,11 +450,10 @@ This section demonstrates how to connect Pulsar to PostgreSQL.
 :::tip
 
 * Make sure you have Docker installed. If you do not have one, see [install Docker](https://docs.docker.com/docker-for-mac/install/).
-* The JDBC sink connector pulls messages from Pulsar topics 
 
 :::
 
-and persists the messages to ClickHouse, MariaDB, PostgreSQL, or SQlite. 
+The JDBC sink connector pulls messages from Pulsar topics and persists the messages to ClickHouse, MariaDB, PostgreSQL, or SQlite. 
 >For more information, see [JDBC sink connector](io-jdbc-sink).
 
 

--- a/site2/website/versioned_docs/version-2.8.3/io-quickstart.md
+++ b/site2/website/versioned_docs/version-2.8.3/io-quickstart.md
@@ -450,10 +450,10 @@ This section demonstrates how to connect Pulsar to PostgreSQL.
 :::tip
 
 * Make sure you have Docker installed. If you do not have one, see [install Docker](https://docs.docker.com/docker-for-mac/install/).
+* The JDBC sink connector pulls messages from Pulsar topics and persists the messages to ClickHouse, MariaDB, PostgreSQL, or SQlite.
 
 :::
 
-The JDBC sink connector pulls messages from Pulsar topics and persists the messages to ClickHouse, MariaDB, PostgreSQL, or SQlite. 
 >For more information, see [JDBC sink connector](io-jdbc-sink).
 
 

--- a/site2/website/versioned_docs/version-2.9.0/io-quickstart.md
+++ b/site2/website/versioned_docs/version-2.9.0/io-quickstart.md
@@ -450,11 +450,10 @@ This section demonstrates how to connect Pulsar to PostgreSQL.
 :::tip
 
 * Make sure you have Docker installed. If you do not have one, see [install Docker](https://docs.docker.com/docker-for-mac/install/).
-* The JDBC sink connector pulls messages from Pulsar topics 
 
 :::
 
-and persists the messages to ClickHouse, MariaDB, PostgreSQL, or SQlite. 
+The JDBC sink connector pulls messages from Pulsar topics and persists the messages to ClickHouse, MariaDB, PostgreSQL, or SQlite. 
 >For more information, see [JDBC sink connector](io-jdbc-sink).
 
 

--- a/site2/website/versioned_docs/version-2.9.0/io-quickstart.md
+++ b/site2/website/versioned_docs/version-2.9.0/io-quickstart.md
@@ -450,10 +450,10 @@ This section demonstrates how to connect Pulsar to PostgreSQL.
 :::tip
 
 * Make sure you have Docker installed. If you do not have one, see [install Docker](https://docs.docker.com/docker-for-mac/install/).
+* The JDBC sink connector pulls messages from Pulsar topics and persists the messages to ClickHouse, MariaDB, PostgreSQL, or SQlite.
 
 :::
 
-The JDBC sink connector pulls messages from Pulsar topics and persists the messages to ClickHouse, MariaDB, PostgreSQL, or SQlite. 
 >For more information, see [JDBC sink connector](io-jdbc-sink).
 
 

--- a/site2/website/versioned_docs/version-2.9.1/io-quickstart.md
+++ b/site2/website/versioned_docs/version-2.9.1/io-quickstart.md
@@ -450,11 +450,10 @@ This section demonstrates how to connect Pulsar to PostgreSQL.
 :::tip
 
 * Make sure you have Docker installed. If you do not have one, see [install Docker](https://docs.docker.com/docker-for-mac/install/).
-* The JDBC sink connector pulls messages from Pulsar topics 
 
 :::
 
-and persists the messages to ClickHouse, MariaDB, PostgreSQL, or SQlite. 
+The JDBC sink connector pulls messages from Pulsar topics and persists the messages to ClickHouse, MariaDB, PostgreSQL, or SQlite. 
 >For more information, see [JDBC sink connector](io-jdbc-sink).
 
 

--- a/site2/website/versioned_docs/version-2.9.1/io-quickstart.md
+++ b/site2/website/versioned_docs/version-2.9.1/io-quickstart.md
@@ -450,10 +450,10 @@ This section demonstrates how to connect Pulsar to PostgreSQL.
 :::tip
 
 * Make sure you have Docker installed. If you do not have one, see [install Docker](https://docs.docker.com/docker-for-mac/install/).
+* The JDBC sink connector pulls messages from Pulsar topics and persists the messages to ClickHouse, MariaDB, PostgreSQL, or SQlite.
 
 :::
 
-The JDBC sink connector pulls messages from Pulsar topics and persists the messages to ClickHouse, MariaDB, PostgreSQL, or SQlite. 
 >For more information, see [JDBC sink connector](io-jdbc-sink).
 
 

--- a/site2/website/versioned_docs/version-2.9.2/io-quickstart.md
+++ b/site2/website/versioned_docs/version-2.9.2/io-quickstart.md
@@ -450,11 +450,10 @@ This section demonstrates how to connect Pulsar to PostgreSQL.
 :::tip
 
 * Make sure you have Docker installed. If you do not have one, see [install Docker](https://docs.docker.com/docker-for-mac/install/).
-* The JDBC sink connector pulls messages from Pulsar topics 
 
 :::
 
-and persists the messages to ClickHouse, MariaDB, PostgreSQL, or SQlite. 
+The JDBC sink connector pulls messages from Pulsar topics and persists the messages to ClickHouse, MariaDB, PostgreSQL, or SQlite. 
 >For more information, see [JDBC sink connector](io-jdbc-sink).
 
 

--- a/site2/website/versioned_docs/version-2.9.2/io-quickstart.md
+++ b/site2/website/versioned_docs/version-2.9.2/io-quickstart.md
@@ -450,10 +450,10 @@ This section demonstrates how to connect Pulsar to PostgreSQL.
 :::tip
 
 * Make sure you have Docker installed. If you do not have one, see [install Docker](https://docs.docker.com/docker-for-mac/install/).
+* The JDBC sink connector pulls messages from Pulsar topics and persists the messages to ClickHouse, MariaDB, PostgreSQL, or SQlite.
 
 :::
 
-The JDBC sink connector pulls messages from Pulsar topics and persists the messages to ClickHouse, MariaDB, PostgreSQL, or SQlite. 
 >For more information, see [JDBC sink connector](io-jdbc-sink).
 
 


### PR DESCRIPTION

### Motivation

* The tip section contained partial sentence  `The JDBC sink connector pulls messages from Pulsar topics `.  The rest of the sentence `and persists the messages to ClickHouse, MariaDB, PostgreSQL, or SQlite. ` was below the tip section.

### Modifications

* Moved partial sentence out to the tip section.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): no
  - The public API: no
  - The schema: no
  - The default values of configurations: no
  - The wire protocol: no
  - The rest endpoints: no
  - The admin cli options: no
  - Anything that affects deployment: no

### Documentation

Check the box below or label this PR directly.

Need to update docs? 

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)
  
- [ ] `doc-not-needed` 
(Please explain why)
  
- [x] `doc` 
This PR is documentation correction.

- [ ] `doc-complete`
(Docs have been already added)