### PR TITLE
[fix][flaky-test] NonPersistentTopicE2ETest.testGC

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/NonPersistentTopicE2ETest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/NonPersistentTopicE2ETest.java
@@ -199,7 +199,9 @@ public class NonPersistentTopicE2ETest extends BrokerTestBase {
 
         assertTrue(pulsar.getBrokerService().getTopicReference(topicName).isPresent());
         runGC();
-        assertFalse(pulsar.getBrokerService().getTopicReference(topicName).isPresent());
+        Awaitility.await().untilAsserted(() ->
+                assertFalse(pulsar.getBrokerService().getTopicReference(topicName).isPresent())
+        );
 
         // 2. Topic is not GCed with live connection
         String subName = "sub1";


### PR DESCRIPTION

### Motivation

Stack Trace
```
Error:  Tests run: 10, Failures: 1, Errors: 0, Skipped: 9, Time elapsed: 65.361 s <<< FAILURE! - in org.apache.pulsar.broker.service.NonPersistentTopicE2ETest
  Error:  testGC(org.apache.pulsar.broker.service.NonPersistentTopicE2ETest)  Time elapsed: 0.403 s  <<< FAILURE!
  java.lang.AssertionError: expected [false] but found [true]
  	at org.testng.Assert.fail(Assert.java:99)
  	at org.testng.Assert.failNotEquals(Assert.java:1037)
  	at org.testng.Assert.assertFalse(Assert.java:67)
  	at org.testng.Assert.assertFalse(Assert.java:77)
  	at org.apache.pulsar.broker.service.NonPersistentTopicE2ETest.testGC(NonPersistentTopicE2ETest.java:202)
  	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
  	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
  	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
  	at java.base/java.lang.reflect.Method.invoke(Method.java:568)
  	at org.testng.internal.MethodInvocationHelper.invokeMethod(MethodInvocationHelper.java:132)
  	at org.testng.internal.InvokeMethodRunnable.runOne(InvokeMethodRunnable.java:45)
  	at org.testng.internal.InvokeMethodRunnable.call(InvokeMethodRunnable.java:73)
  	at org.testng.internal.InvokeMethodRunnable.call(InvokeMethodRunnable.java:11)
  	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
  	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
  	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
  	at java.base/java.lang.Thread.run(Thread.java:833)</summary>
```



### Documentation

Check the box below or label this PR directly.

Need to update docs? 

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)
  
- [x] `doc-not-needed` 
(Please explain why)
  
- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)