### PR TITLE
[fix][test] Fix `PersistentStreamingDispatcherSingleActiveConsumer#testAddRemoveConsumer`

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentDispatcherFailoverConsumerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentDispatcherFailoverConsumerTest.java
@@ -402,8 +402,12 @@ public class PersistentDispatcherFailoverConsumerTest {
         consumers = pdfc.getConsumers();
         assertSame(pdfc.getActiveConsumer().consumerName(), consumer1.consumerName());
         assertEquals(3, consumers.size());
-        // not consumer group changes
-        assertNull(consumerChanges.poll());
+        change = consumerChanges.take();
+        verifyActiveConsumerChange(change, 0, false);
+        change = consumerChanges.take();
+        verifyActiveConsumerChange(change, 1, true);
+        change = consumerChanges.take();
+        verifyActiveConsumerChange(change, 1, true);
 
         // 8. Verify if we cannot unsubscribe when more than one consumer is connected
         assertFalse(pdfc.canUnsubscribe(consumer0));
@@ -414,11 +418,8 @@ public class PersistentDispatcherFailoverConsumerTest {
         assertSame(pdfc.getActiveConsumer().consumerName(), consumer1.consumerName());
         assertEquals(2, consumers.size());
 
-        // the remaining consumers will receive notifications
-        change = consumerChanges.take();
-        verifyActiveConsumerChange(change, 1, true);
-        change = consumerChanges.take();
-        verifyActiveConsumerChange(change, 1, true);
+        // not consumer group changes
+        assertNull(consumerChanges.poll());
 
         // 10. Attempt to remove already removed consumer
         String cause = "";


### PR DESCRIPTION

### Motivation

Fix flaky test `PersistentStreamingDispatcherSingleActiveConsumer#testAddRemoveConsumer`. 

### Modifications

- Fix the wrong logic when test `testAddRemoveConsumer `

### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API: (yes / no)
  - The schema: (yes / no / don't know)
  - The default values of configurations: (yes / no)
  - The wire protocol: (yes / no)
  - The rest endpoints: (yes / no)
  - The admin cli options: (yes / no)
  - Anything that affects deployment: (yes / no / don't know)

### Documentation

Check the box below or label this PR directly.

Need to update docs? 

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)
  
- [x] `doc-not-needed` 
(Please explain why)
  
- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)