### PR TITLE
[fix][client] Make DeadLetterPolicy deserializable

### DIFF
--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/DeadLetterPolicy.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/DeadLetterPolicy.java
@@ -18,8 +18,10 @@
  */
 package org.apache.pulsar.client.api;
 
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 import org.apache.pulsar.common.classification.InterfaceAudience;
 import org.apache.pulsar.common.classification.InterfaceStability;
 
@@ -30,6 +32,8 @@ import org.apache.pulsar.common.classification.InterfaceStability;
  */
 @Builder
 @Data
+@NoArgsConstructor
+@AllArgsConstructor
 @InterfaceAudience.Public
 @InterfaceStability.Stable
 public class DeadLetterPolicy {


### PR DESCRIPTION

Fixes #16487


### Motivation

DeadLetterPolicy can't deserialization, the root cause is DeadLetterPolicy without a No-argument constructor.

### Modifications

Add `@NoArgsConstructor` and `@AllArgsConstructor` annotates for DeadLetterPolicy.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change is already covered by existing tests, such as `testDeadLetterPolicyDeserialize`.

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API: (yes / no)
  - The schema: (yes / no / don't know)
  - The default values of configurations: (yes / no)
  - The wire protocol: (yes / no)
  - The rest endpoints: (yes / no)
  - The admin cli options: (yes / no)
  - Anything that affects deployment: (yes / no / don't know)

### Documentation

Check the box below or label this PR directly.

Need to update docs? 

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)
  
- [x] `doc-not-needed` 
(Please explain why)
  
- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)