### PR TITLE
[refactor][test] Replace assertTrue with assertEquals in BrokerInterceptorTest

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/intercept/BrokerInterceptorTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/intercept/BrokerInterceptorTest.java
@@ -133,25 +133,25 @@ public class BrokerInterceptorTest extends ProducerConsumerBase {
         pulsarClient.newProducer(Schema.BOOL).topic("test").create();
         pulsarClient.newConsumer(Schema.STRING).topic("test1").subscriptionName("test-sub").subscribe();
         // single connection for both producer and consumer
-        Assert.assertTrue(((CounterBrokerInterceptor)listener).getConnectionCreationCount() == 1);
+        assertEquals(((CounterBrokerInterceptor) listener).getConnectionCreationCount(), 1);
     }
 
     @Test
     public void testProducerCreation() throws PulsarClientException {
         BrokerInterceptor listener = pulsar.getBrokerInterceptor();
         Assert.assertTrue(listener instanceof CounterBrokerInterceptor);
-        Assert.assertTrue(((CounterBrokerInterceptor)listener).getProducerCount() == 0);
+        assertEquals(((CounterBrokerInterceptor) listener).getProducerCount(), 0);
         pulsarClient.newProducer(Schema.BOOL).topic("test").create();
-        Assert.assertTrue(((CounterBrokerInterceptor)listener).getProducerCount() == 1);
+        assertEquals(((CounterBrokerInterceptor) listener).getProducerCount(), 1);
     }
 
     @Test
     public void testConsumerCreation() throws PulsarClientException {
         BrokerInterceptor listener = pulsar.getBrokerInterceptor();
         Assert.assertTrue(listener instanceof CounterBrokerInterceptor);
-        Assert.assertTrue(((CounterBrokerInterceptor)listener).getConsumerCount() == 0);
+        assertEquals(((CounterBrokerInterceptor) listener).getConsumerCount(), 0);
         pulsarClient.newConsumer(Schema.STRING).topic("test1").subscriptionName("test-sub").subscribe();
-        Assert.assertTrue(((CounterBrokerInterceptor)listener).getConsumerCount() == 1);
+        assertEquals(((CounterBrokerInterceptor) listener).getConsumerCount(), 1);
     }
 
     @Test


### PR DESCRIPTION
### Motivation

The `assertTrue` is hard to debug when the assert fails.

### Modifications

Replace assertTrue with assertEquals

### Documentation

Check the box below or label this PR directly.

Need to update docs? 

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)
  
- [x] `doc-not-needed` 
(Please explain why)
  
- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)