### PR TITLE
[fix][security] Upgrade to Jetty to 9.4.48.v20220622 to get rid of CVE-2022-2047

### DIFF
--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -429,25 +429,25 @@ The Apache Software License, Version 2.0
     - org.asynchttpclient-async-http-client-2.12.1.jar
     - org.asynchttpclient-async-http-client-netty-utils-2.12.1.jar
  * Jetty
-    - org.eclipse.jetty-jetty-client-9.4.44.v20210927.jar
-    - org.eclipse.jetty-jetty-continuation-9.4.44.v20210927.jar
-    - org.eclipse.jetty-jetty-http-9.4.44.v20210927.jar
-    - org.eclipse.jetty-jetty-io-9.4.44.v20210927.jar
-    - org.eclipse.jetty-jetty-proxy-9.4.44.v20210927.jar
-    - org.eclipse.jetty-jetty-security-9.4.44.v20210927.jar
-    - org.eclipse.jetty-jetty-server-9.4.44.v20210927.jar
-    - org.eclipse.jetty-jetty-servlet-9.4.44.v20210927.jar
-    - org.eclipse.jetty-jetty-servlets-9.4.44.v20210927.jar
-    - org.eclipse.jetty-jetty-util-9.4.44.v20210927.jar
-    - org.eclipse.jetty-jetty-util-ajax-9.4.44.v20210927.jar
-    - org.eclipse.jetty.websocket-javax-websocket-client-impl-9.4.44.v20210927.jar
-    - org.eclipse.jetty.websocket-websocket-api-9.4.44.v20210927.jar
-    - org.eclipse.jetty.websocket-websocket-client-9.4.44.v20210927.jar
-    - org.eclipse.jetty.websocket-websocket-common-9.4.44.v20210927.jar
-    - org.eclipse.jetty.websocket-websocket-server-9.4.44.v20210927.jar
-    - org.eclipse.jetty.websocket-websocket-servlet-9.4.44.v20210927.jar
-    - org.eclipse.jetty-jetty-alpn-conscrypt-server-9.4.44.v20210927.jar
-    - org.eclipse.jetty-jetty-alpn-server-9.4.44.v20210927.jar
+    - org.eclipse.jetty-jetty-client-9.4.48.v20220622.jar
+    - org.eclipse.jetty-jetty-continuation-9.4.48.v20220622.jar
+    - org.eclipse.jetty-jetty-http-9.4.48.v20220622.jar
+    - org.eclipse.jetty-jetty-io-9.4.48.v20220622.jar
+    - org.eclipse.jetty-jetty-proxy-9.4.48.v20220622.jar
+    - org.eclipse.jetty-jetty-security-9.4.48.v20220622.jar
+    - org.eclipse.jetty-jetty-server-9.4.48.v20220622.jar
+    - org.eclipse.jetty-jetty-servlet-9.4.48.v20220622.jar
+    - org.eclipse.jetty-jetty-servlets-9.4.48.v20220622.jar
+    - org.eclipse.jetty-jetty-util-9.4.48.v20220622.jar
+    - org.eclipse.jetty-jetty-util-ajax-9.4.48.v20220622.jar
+    - org.eclipse.jetty.websocket-javax-websocket-client-impl-9.4.48.v20220622.jar
+    - org.eclipse.jetty.websocket-websocket-api-9.4.48.v20220622.jar
+    - org.eclipse.jetty.websocket-websocket-client-9.4.48.v20220622.jar
+    - org.eclipse.jetty.websocket-websocket-common-9.4.48.v20220622.jar
+    - org.eclipse.jetty.websocket-websocket-server-9.4.48.v20220622.jar
+    - org.eclipse.jetty.websocket-websocket-servlet-9.4.48.v20220622.jar
+    - org.eclipse.jetty-jetty-alpn-conscrypt-server-9.4.48.v20220622.jar
+    - org.eclipse.jetty-jetty-alpn-server-9.4.48.v20220622.jar
  * SnakeYaml -- org.yaml-snakeyaml-1.30.jar
  * RocksDB - org.rocksdb-rocksdbjni-6.29.4.1.jar
  * Google Error Prone Annotations - com.google.errorprone-error_prone_annotations-2.5.1.jar

--- a/pom.xml
+++ b/pom.xml
@@ -122,7 +122,7 @@ flexible messaging model and an intuitive client API.</description>
     <curator.version>5.1.0</curator.version>
     <netty.version>4.1.77.Final</netty.version>
     <netty-tc-native.version>2.0.52.Final</netty-tc-native.version>
-    <jetty.version>9.4.44.v20210927</jetty.version>
+    <jetty.version>9.4.48.v20220622</jetty.version>
     <conscrypt.version>2.5.2</conscrypt.version>
     <jersey.version>2.34</jersey.version>
     <athenz.version>1.10.50</athenz.version>

--- a/pulsar-sql/presto-distribution/LICENSE
+++ b/pulsar-sql/presto-distribution/LICENSE
@@ -274,22 +274,22 @@ The Apache Software License, Version 2.0
     - joda-time-2.10.5.jar
     - failsafe-2.4.4.jar
   * Jetty
-    - http2-client-9.4.44.v20210927.jar
-    - http2-common-9.4.44.v20210927.jar
-    - http2-hpack-9.4.44.v20210927.jar
-    - http2-http-client-transport-9.4.44.v20210927.jar
-    - jetty-alpn-client-9.4.44.v20210927.jar
-    - http2-server-9.4.44.v20210927.jar
-    - jetty-alpn-java-client-9.4.44.v20210927.jar
-    - jetty-client-9.4.44.v20210927.jar
-    - jetty-http-9.4.44.v20210927.jar
-    - jetty-io-9.4.44.v20210927.jar
-    - jetty-jmx-9.4.44.v20210927.jar
-    - jetty-security-9.4.44.v20210927.jar
-    - jetty-server-9.4.44.v20210927.jar
-    - jetty-servlet-9.4.44.v20210927.jar
-    - jetty-util-9.4.44.v20210927.jar
-    - jetty-util-ajax-9.4.44.v20210927.jar
+    - http2-client-9.4.48.v20220622.jar
+    - http2-common-9.4.48.v20220622.jar
+    - http2-hpack-9.4.48.v20220622.jar
+    - http2-http-client-transport-9.4.48.v20220622.jar
+    - jetty-alpn-client-9.4.48.v20220622.jar
+    - http2-server-9.4.48.v20220622.jar
+    - jetty-alpn-java-client-9.4.48.v20220622.jar
+    - jetty-client-9.4.48.v20220622.jar
+    - jetty-http-9.4.48.v20220622.jar
+    - jetty-io-9.4.48.v20220622.jar
+    - jetty-jmx-9.4.48.v20220622.jar
+    - jetty-security-9.4.48.v20220622.jar
+    - jetty-server-9.4.48.v20220622.jar
+    - jetty-servlet-9.4.48.v20220622.jar
+    - jetty-util-9.4.48.v20220622.jar
+    - jetty-util-ajax-9.4.48.v20220622.jar
   * Apache BVal
     - bval-jsr-2.0.0.jar
   * Bytecode

--- a/src/owasp-dependency-check-false-positives.xml
+++ b/src/owasp-dependency-check-false-positives.xml
@@ -158,4 +158,13 @@
     <sha1>1a754a5dd672218a2ac667d7ff2b28df7a5a240e</sha1>
     <cve>CVE-2022-25647</cve>
   </suppress>
+
+  <!-- 9.4.x is not affected https://github.com/eclipse/jetty.project/issues/8161#issuecomment-1178728623-->
+  <suppress>
+    <notes><![CDATA[
+   file name: jetty-io-9.4.48.v20220622.jar
+   ]]></notes>
+    <sha1>b09b55209d0a304e542f779750a01f6914dc55e7</sha1>
+    <vulnerabilityName>CVE-2022-2191</vulnerabilityName>
+  </suppress>
 </suppressions>

--- a/src/owasp-dependency-check-false-positives.xml
+++ b/src/owasp-dependency-check-false-positives.xml
@@ -158,13 +158,4 @@
     <sha1>1a754a5dd672218a2ac667d7ff2b28df7a5a240e</sha1>
     <cve>CVE-2022-25647</cve>
   </suppress>
-
-  <!-- 9.4.x is not affected https://github.com/eclipse/jetty.project/issues/8161#issuecomment-1178728623-->
-  <suppress>
-    <notes><![CDATA[
-   file name: jetty-io-9.4.48.v20220622.jar
-   ]]></notes>
-    <sha1>b09b55209d0a304e542f779750a01f6914dc55e7</sha1>
-    <vulnerabilityName>CVE-2022-2191</vulnerabilityName>
-  </suppress>
 </suppressions>


### PR DESCRIPTION
### Motivation

Owasp check fails because jetty 9.4.44 is marked as vulnerable due to [CVE-2022-2047](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-2047)

Note that Jetty 9.4.x is EOL after `9.4.48.v20220622` 

### Modifications

* Upgrade to latest 9.4.x (9.4.48.v20220622)
(see https://github.com/eclipse/jetty.project/releases)

- [x] `doc-not-needed` 