### PR TITLE
[fix][doc] fix client-libraries table style

### DIFF
--- a/site2/docs/client-libraries.md
+++ b/site2/docs/client-libraries.md
@@ -6,15 +6,15 @@ sidebar_label: "Overview"
 
 Pulsar supports the following client libraries:
 
-|Language|Documentation|Release note|Code repo
-|---|---|---|---
-Java |- [User doc](client-libraries-java.md) <br /><br />- [API doc](/api/client/)|[Here](/release-notes/)|[Here](https://github.com/apache/pulsar/tree/master/pulsar-client) 
-C++ | - [User doc](client-libraries-cpp.md) <br /><br />- [API doc](/api/cpp/)|[Here](/release-notes/)|[Here](https://github.com/apache/pulsar/tree/master/pulsar-client-cpp) 
-Python | - [User doc](client-libraries-python.md) <br /><br />- [API doc](/api/python/)|[Here](/release-notes/)|[Here](https://github.com/apache/pulsar/tree/master/pulsar-client-cpp/python) 
-WebSocket| [User doc](client-libraries-websocket.md) | [Here](/release-notes/)|[Here](https://github.com/apache/pulsar/tree/master/pulsar-websocket) 
-Go client|[User doc](client-libraries-go.md)|[Here](https://github.com/apache/pulsar-client-go/blob/master/CHANGELOG) |[Here](https://github.com/apache/pulsar-client-go) 
-Node.js|[User doc](client-libraries-node.md)|[Here](https://github.com/apache/pulsar-client-node/releases) |[Here](https://github.com/apache/pulsar-client-node) 
-C# |[User doc](client-libraries-dotnet.md)| [Here](https://github.com/apache/pulsar-dotpulsar/blob/master/CHANGELOG)|[Here](https://github.com/apache/pulsar-dotpulsar) 
+| Language  | Documentation                                                                  | Release note                                                             | Code repo                                                                     |
+|-----------|--------------------------------------------------------------------------------|--------------------------------------------------------------------------|-------------------------------------------------------------------------------|
+| Java      | - [User doc](client-libraries-java.md) <br /><br />- [API doc](/api/client/)   | [Here](/release-notes/)                                                  | [Here](https://github.com/apache/pulsar/tree/master/pulsar-client)            |
+| C++       | - [User doc](client-libraries-cpp.md) <br /><br />- [API doc](/api/cpp/)       | [Here](/release-notes/)                                                  | [Here](https://github.com/apache/pulsar/tree/master/pulsar-client-cpp)        |
+| Python    | - [User doc](client-libraries-python.md) <br /><br />- [API doc](/api/python/) | [Here](/release-notes/)                                                  | [Here](https://github.com/apache/pulsar/tree/master/pulsar-client-cpp/python) |
+| WebSocket | [User doc](client-libraries-websocket.md)                                      | [Here](/release-notes/)                                                  | [Here](https://github.com/apache/pulsar/tree/master/pulsar-websocket)         |
+| Go client | [User doc](client-libraries-go.md)                                             | [Here](https://github.com/apache/pulsar-client-go/blob/master/CHANGELOG) | [Here](https://github.com/apache/pulsar-client-go)                            |
+| Node.js   | [User doc](client-libraries-node.md)                                           | [Here](https://github.com/apache/pulsar-client-node/releases)            | [Here](https://github.com/apache/pulsar-client-node)                          |
+| C#        | [User doc](client-libraries-dotnet.md)                                         | [Here](https://github.com/apache/pulsar-dotpulsar/blob/master/CHANGELOG) | [Here](https://github.com/apache/pulsar-dotpulsar)                            |
 
 :::note
 


### PR DESCRIPTION
### Motivation

The libraries table in the `client libraries Overview` documentation has the wrong format, so it does not render correctly on the site, this PR will fix it.

![image](https://user-images.githubusercontent.com/8078418/178279103-1cb128e6-ad1c-4d55-b5c9-e7b10e2002d4.png)

### Modifications

Modify Markdown formatting to render correctly. `site2/docs/client-libraries.md`

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): no
  - The public API: no
  - The schema: no
  - The default values of configurations: no
  - The wire protocol: no
  - The rest endpoints: no
  - The admin cli options: no
  - Anything that affects deployment: no

### Documentation

Check the box below or label this PR directly. 

Need to update docs? 

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)
  
- [ ] `doc-not-needed` 
(Please explain why)
  
- [x] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)