### PR TITLE
[improve][authentication] Improve get the basic authentication config

### DIFF
--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -794,6 +794,13 @@ athenzDomainNames=
 # When this parameter is not empty, unauthenticated users perform as anonymousUserRole
 anonymousUserRole=
 
+## Configure the datasource of basic authenticate, supports the file and Base64 format.
+# file:
+# basicAuthConf=/path/my/.htpasswd
+# use Base64 to encode the contents of .htpasswd:
+# basicAuthConf=YOUR-BASE64-DATA
+basicAuthConf=
+
 ### --- Token Authentication Provider --- ###
 
 ## Symmetric key

--- a/conf/proxy.conf
+++ b/conf/proxy.conf
@@ -270,6 +270,13 @@ maxHttpServerConnections=2048
 # Max concurrent web requests
 maxConcurrentHttpRequests=1024
 
+## Configure the datasource of basic authenticate, supports the file and Base64 format.
+# file:
+# basicAuthConf=/path/my/.htpasswd
+# use Base64 to encode the contents of .htpasswd:
+# basicAuthConf=YOUR-BASE64-DATA
+basicAuthConf=
+
 ### --- Token Authentication Provider --- ###
 
 ## Symmetric key

--- a/conf/standalone.conf
+++ b/conf/standalone.conf
@@ -529,6 +529,12 @@ athenzDomainNames=
 # When this parameter is not empty, unauthenticated users perform as anonymousUserRole
 anonymousUserRole=
 
+## Configure the datasource of basic authenticate, supports the file and Base64 format.
+# file:
+# basicAuthConf=/path/my/.htpasswd
+# use Base64 to encode the contents of .htpasswd:
+# basicAuthConf=YOUR-BASE64-DATA
+basicAuthConf=
 
 ### --- Token Authentication Provider --- ###
 

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authentication/AuthenticationProviderBasic.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authentication/AuthenticationProviderBasic.java
@@ -23,6 +23,8 @@ import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
+import java.io.StringReader;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Base64;
 import java.util.HashMap;
@@ -39,6 +41,7 @@ import org.apache.pulsar.broker.authentication.metrics.AuthenticationMetrics;
 public class AuthenticationProviderBasic implements AuthenticationProvider {
     private static final String HTTP_HEADER_NAME = "Authorization";
     private static final String CONF_SYSTEM_PROPERTY_KEY = "pulsar.auth.basic.conf";
+    private static final String CONF_PULSAR_PROPERTY_KEY = "basicAuthConf";
     private Map<String, String> users;
 
     @Override
@@ -48,14 +51,28 @@ public class AuthenticationProviderBasic implements AuthenticationProvider {
 
     @Override
     public void initialize(ServiceConfiguration config) throws IOException {
-        File confFile = new File(System.getProperty(CONF_SYSTEM_PROPERTY_KEY));
-        if (!confFile.exists()) {
-            throw new IOException("The password auth conf file does not exist");
-        } else if (!confFile.isFile()) {
-            throw new IOException("The path is not a file");
+        String data = config.getProperties().getProperty(CONF_PULSAR_PROPERTY_KEY);
+        if (StringUtils.isEmpty(data)) {
+            data = System.getProperty(CONF_SYSTEM_PROPERTY_KEY);
+        }
+        if (StringUtils.isEmpty(data)) {
+            throw new IOException("No basic authentication config provided");
         }
 
-        @Cleanup BufferedReader reader = new BufferedReader(new FileReader(confFile));
+        @Cleanup BufferedReader reader = null;
+        if (org.apache.commons.codec.binary.Base64.isBase64(data)) {
+            reader = new BufferedReader(new StringReader(new String(Base64.getDecoder().decode(data),
+                    StandardCharsets.UTF_8)));
+        } else {
+            File confFile = new File(data);
+            if (!confFile.exists()) {
+                throw new IOException("The password auth conf file does not exist");
+            } else if (!confFile.isFile()) {
+                throw new IOException("The path is not a file");
+            }
+            reader = new BufferedReader(new FileReader(confFile));
+        }
+
         users = new HashMap<>();
         for (String line : reader.lines().toArray(s -> new String[s])) {
             List<String> splitLine = Arrays.asList(line.split(":"));

--- a/pulsar-broker-common/src/test/java/org/apache/pulsar/broker/authentication/AuthenticationProviderBasicTest.java
+++ b/pulsar-broker-common/src/test/java/org/apache/pulsar/broker/authentication/AuthenticationProviderBasicTest.java
@@ -1,0 +1,90 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.authentication;
+
+import com.google.common.io.Resources;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Base64;
+import java.util.Properties;
+import lombok.Cleanup;
+import org.apache.pulsar.broker.ServiceConfiguration;
+import org.apache.pulsar.common.api.AuthData;
+import org.testng.annotations.Test;
+
+import javax.naming.AuthenticationException;
+
+public class AuthenticationProviderBasicTest {
+    private final String basicAuthConf = Resources.getResource("authentication/basic/.htpasswd").getPath();
+    private final String basicAuthConfBase64 = Base64.getEncoder().encodeToString(Files.readAllBytes(Path.of(basicAuthConf)));
+
+    public AuthenticationProviderBasicTest() throws IOException {
+    }
+
+    private void testAuthenticate(AuthenticationProviderBasic provider) throws AuthenticationException {
+        AuthData authData = AuthData.of("superUser2:superpassword".getBytes(StandardCharsets.UTF_8));
+        provider.newAuthState(authData, null, null);
+    }
+
+    @Test
+    public void testLoadFileFromPulsarProperties() throws Exception {
+        @Cleanup
+        AuthenticationProviderBasic provider = new AuthenticationProviderBasic();
+        ServiceConfiguration serviceConfiguration = new ServiceConfiguration();
+        Properties properties = new Properties();
+        properties.setProperty("basicAuthConf", basicAuthConf);
+        serviceConfiguration.setProperties(properties);
+        provider.initialize(serviceConfiguration);
+        testAuthenticate(provider);
+    }
+
+    @Test
+    public void testLoadBase64FromPulsarProperties() throws Exception {
+        @Cleanup
+        AuthenticationProviderBasic provider = new AuthenticationProviderBasic();
+        ServiceConfiguration serviceConfiguration = new ServiceConfiguration();
+        Properties properties = new Properties();
+        properties.setProperty("basicAuthConf", basicAuthConfBase64);
+        serviceConfiguration.setProperties(properties);
+        provider.initialize(serviceConfiguration);
+        testAuthenticate(provider);
+    }
+
+    @Test
+    public void testLoadFileFromSystemProperties() throws Exception {
+        @Cleanup
+        AuthenticationProviderBasic provider = new AuthenticationProviderBasic();
+        ServiceConfiguration serviceConfiguration = new ServiceConfiguration();
+        System.setProperty("pulsar.auth.basic.conf", basicAuthConf);
+        provider.initialize(serviceConfiguration);
+        testAuthenticate(provider);
+    }
+
+    @Test
+    public void testLoadBase64FromSystemProperties() throws Exception {
+        @Cleanup
+        AuthenticationProviderBasic provider = new AuthenticationProviderBasic();
+        ServiceConfiguration serviceConfiguration = new ServiceConfiguration();
+        System.setProperty("pulsar.auth.basic.conf", basicAuthConfBase64);
+        provider.initialize(serviceConfiguration);
+        testAuthenticate(provider);
+    }
+}

--- a/pulsar-broker-common/src/test/resources/authentication/basic/.htpasswd
+++ b/pulsar-broker-common/src/test/resources/authentication/basic/.htpasswd
@@ -1,0 +1,2 @@
+superUser:mQQQIsyvvKRtU
+superUser2:$apr1$foobarmq$kuSZlLgOITksCkRgl57ie/


### PR DESCRIPTION
Signed-off-by: Zixuan Liu <nodeces@gmail.com>

### Motivation

Right now the Pulsar only supports getting the basic authentication config from the system properties, I suggest reading it from the Pulsar config file.

### Modifications

- Add the `basicAuthConf` to the config file for use in reading the basic authentication config
- Add Base64 support for basic authentication config

### Documentation

- [x] `doc-required` 
Add `basicAuthConf` to Refrences page.
 