### PR TITLE
Enable GitHub Discussions Notifications

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -20,6 +20,12 @@
 github:
   description: "Apache Pulsar - distributed pub-sub messaging system"
   homepage: https://pulsar.apache.org/
+  notifications:
+    commits:      commits@pulsar.apache.org
+    issues:       commits@pulsar.apache.org
+    pullrequests: commits@pulsar.apache.org
+    discussions:  dev@pulsar.apache.org
+    jira_options: link label
   labels:
     - pulsar
     - pubsub


### PR DESCRIPTION
Notify discussions to dev@pulsar mailing list

Fixes #16275 

### Motivation

Make sure that GitHub Discussions are seen on the dev@pulsar mailing list.

### Modifications

Added the notifications section to `.asf.yaml` with the current setup from https://gitbox.apache.org/schemas.cgi?pulsar and then add a `discussions` section.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

### Documentation

Check the box below or label this PR directly.

Need to update docs? 

- [X] `doc-not-needed` 
It's a repository configuration
