### PR TITLE
WIP: Upgrade Mockito to 4.6.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -234,7 +234,7 @@ flexible messaging model and an intuitive client API.</description>
     <docker-java.version>3.2.13</docker-java.version>
     <kerby.version>1.1.1</kerby.version>
     <testng.version>7.3.0</testng.version>
-    <mockito.version>3.12.4</mockito.version>
+    <mockito.version>4.6.1</mockito.version>
     <powermock.version>2.0.9</powermock.version>
     <javassist.version>3.25.0-GA</javassist.version>
     <skyscreamer.version>1.5.0</skyscreamer.version>


### PR DESCRIPTION
### Motivation

We have been seeing several weird test errors involving mock objects failure to construct. Updating to latest Mockito version to pick up all the new fixes and improvements.
- [x] `doc-not-needed`
