### PR TITLE
[improve][workflow] Add a workflow to delete old workflow runs

### DIFF
--- a/.github/workflows/delete-workflow.yaml
+++ b/.github/workflows/delete-workflow.yaml
@@ -1,0 +1,44 @@
+name: Delete old workflow runs
+on:
+  workflow_dispatch:
+    inputs:
+      days:
+        description: "Number of days."
+        required: true
+        default: 30
+      minimum_runs:
+        description: "The minimum runs to keep for each workflow."
+        required: true
+        default: 6
+      delete_workflow_pattern:
+        description: "The name or filename of the workflow. if not set then it will target all workflows."
+        required: false
+      delete_workflow_by_state_pattern:
+        description: "Remove workflow by state: active, deleted, disabled_fork, disabled_inactivity, disabled_manually"
+        required: true
+        default: "All"
+        type: choice
+        options:
+          - "All"
+          - active
+          - deleted
+          - disabled_inactivity
+          - disabled_manually
+      dry_run:
+        description: "Only log actions, do not perform any delete operations."
+        required: false
+
+jobs:
+  del_runs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Delete workflow runs
+        uses: Mattraks/delete-workflow-runs@v2
+        with:
+          token: ${{ github.token }}
+          repository: ${{ github.repository }}
+          retain_days: ${{ github.event.inputs.days }}
+          keep_minimum_runs: ${{ github.event.inputs.minimum_runs }}
+          delete_workflow_pattern: ${{ github.event.inputs.delete_workflow_pattern }}
+          delete_workflow_by_state_pattern: ${{ github.event.inputs.delete_workflow_by_state_pattern }}
+          dry_run: ${{ github.event.inputs.dry_run }}


### PR DESCRIPTION
Fixes #16439 

### Motivation

To delete stale workflows.

### Modifications

Add a new workflow that can delete specific stale workflows with one click. It can be set to run periodically, but is currently set to be manually triggered to prevent unexpected deletions. It can also be configured to specify the workflows to delete, so that all 3 issues in #16439 can be fixed with proper settings.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API: no
  - The schema: no
  - The default values of configurations: no
  - The wire protocol: no
  - The rest endpoints: no
  - The admin cli options: no
  - Anything that affects deployment: no

### Documentation

Check the box below or label this PR directly.

Need to update docs? 

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)
  
- [x] `doc-not-needed` 
(Please explain why: This PR only changes GitHub Actions workflow)
  
- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)