### PR TITLE
[test]Fix Flaky-test: BrokerServiceTest.testLookupThrottlingForClientByClient

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerServiceTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerServiceTest.java
@@ -1051,7 +1051,7 @@ public class BrokerServiceTest extends BrokerTestBase {
             f2.get();
             try {
                 f3.get();
-                fail("f3 one should fail");
+                fail("At least one should fail");
             } catch (ExecutionException e) {
                 Throwable rootCause = e;
                 while (rootCause instanceof ExecutionException) {
@@ -1110,7 +1110,7 @@ public class BrokerServiceTest extends BrokerTestBase {
             f2.get();
             try {
                 f3.get();
-                fail("f3 should fail");
+                fail("At least one should fail");
             } catch (ExecutionException e) {
                 Throwable rootCause = e;
                 while (rootCause instanceof ExecutionException) {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerServiceTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerServiceTest.java
@@ -981,8 +981,7 @@ public class BrokerServiceTest extends BrokerTestBase {
         EventLoopGroup eventLoop = EventLoopUtil.newEventLoopGroup(20, false,
                 new DefaultThreadFactory("test-pool", Thread.currentThread().isDaemon()));
         long reqId = 0xdeadbeef;
-
-        // using an AtomicReference in order to reset a new CountDownLatch
+        // Using an AtomicReference in order to reset a new CountDownLatch
         AtomicReference<CountDownLatch> latchRef = new AtomicReference<>();
         latchRef.set(new CountDownLatch(1));
         try (ConnectionPool pool = new ConnectionPool(conf, eventLoop, () -> new ClientCnx(conf, eventLoop) {
@@ -1027,9 +1026,7 @@ public class BrokerServiceTest extends BrokerTestBase {
             f2.get();
 
             // 3 lookup will fail
-
             latchRef.set(new CountDownLatch(1));
-            assertEquals(latchRef.get().getCount(), 1);
             long reqId3 = reqId++;
             ByteBuf request3 = Commands.newPartitionMetadataRequest(topicName, reqId3);
             f1 = pool.getConnection(resolver.resolveHost())
@@ -1068,9 +1065,7 @@ public class BrokerServiceTest extends BrokerTestBase {
 
             // for Lookup
             // 2 lookup will succeed
-
             latchRef.set(new CountDownLatch(1));
-            assertEquals(latchRef.get().getCount(), 1);
             long reqId6 = reqId++;
             ByteBuf request6 = Commands.newLookup(topicName, true, reqId6);
             f1 = pool.getConnection(resolver.resolveHost())
@@ -1090,9 +1085,7 @@ public class BrokerServiceTest extends BrokerTestBase {
             f2.get();
 
             // 3 lookup will fail
-
             latchRef.set(new CountDownLatch(1));
-            assertEquals(latchRef.get().getCount(), 1);
             long reqId8 = reqId++;
             ByteBuf request8 = Commands.newLookup(topicName, true, reqId8);
             f1 = pool.getConnection(resolver.resolveHost())

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerServiceTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerServiceTest.java
@@ -1047,11 +1047,11 @@ public class BrokerServiceTest extends BrokerTestBase {
                     return future;
                     });
 
+            f1.get();
+            f2.get();
             try {
-                f1.get();
-                f2.get();
                 f3.get();
-                fail("At least one should fail");
+                fail("f3 one should fail");
             } catch (ExecutionException e) {
                 Throwable rootCause = e;
                 while (rootCause instanceof ExecutionException) {
@@ -1106,11 +1106,11 @@ public class BrokerServiceTest extends BrokerTestBase {
                     return future;
                 });
 
+            f1.get();
+            f2.get();
             try {
-                f1.get();
-                f2.get();
                 f3.get();
-                fail("At least one should fail");
+                fail("f3 should fail");
             } catch (ExecutionException e) {
                 Throwable rootCause = e;
                 while (rootCause instanceof ExecutionException) {


### PR DESCRIPTION

Master Issue: https://github.com/apache/pulsar/issues/16521

### Motivation

- Fixes https://github.com/apache/pulsar/issues/16521

- If the broker responds quickly enough, there may never be concurrency in requests, so we use a `Semaphore` to block the response.

### Modifications

Fix UT  `BrokerServiceTest.testLookupThrottlingForClientByClient`

### Verifying this change

- [x] Make sure that the change passes the CI checks.



### Documentation

Check the box below or label this PR directly.

Need to update docs? 

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)
  
- [x] `doc-not-needed` 
(Please explain why)
  
- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)