### PR TITLE
[fix][broker]stage 1: check the cursor status when handling flowPermits

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
@@ -3290,4 +3290,13 @@ public class ManagedCursorImpl implements ManagedCursor {
     public ManagedLedgerConfig getConfig() {
         return config;
     }
+
+    /**
+     * check cursor reset status
+     *
+     * @return true if the cursor reset in progress
+     */
+    public boolean resetCursorInProgress() {
+        return RESET_CURSOR_IN_PROGRESS_UPDATER.get(this) == TRUE;
+    }
 }

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
@@ -3296,7 +3296,7 @@ public class ManagedCursorImpl implements ManagedCursor {
      *
      * @return true if the cursor reset in progress
      */
-    public boolean resetCursorInProgress() {
+    public boolean isResetCursorInProgress() {
         return RESET_CURSOR_IN_PROGRESS_UPDATER.get(this) == TRUE;
     }
 }

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
@@ -3292,7 +3292,7 @@ public class ManagedCursorImpl implements ManagedCursor {
     }
 
     /**
-     * check cursor reset status
+     * check cursor reset status.
      *
      * @return true if the cursor reset in progress
      */

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherSingleActiveConsumer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherSingleActiveConsumer.java
@@ -35,6 +35,7 @@ import org.apache.bookkeeper.mledger.ManagedLedgerException;
 import org.apache.bookkeeper.mledger.ManagedLedgerException.ConcurrentWaitCallbackException;
 import org.apache.bookkeeper.mledger.ManagedLedgerException.NoMoreEntriesToReadException;
 import org.apache.bookkeeper.mledger.ManagedLedgerException.TooManyRequestsException;
+import org.apache.bookkeeper.mledger.impl.ManagedCursorImpl;
 import org.apache.bookkeeper.mledger.impl.PositionImpl;
 import org.apache.bookkeeper.mledger.util.SafeRun;
 import org.apache.commons.lang3.tuple.Pair;
@@ -278,6 +279,11 @@ public class PersistentDispatcherSingleActiveConsumer extends AbstractDispatcher
             if (log.isDebugEnabled()) {
                 log.debug("[{}-{}] Ignoring flow control message since consumer is waiting for cursor to be rewinded",
                         name, consumer);
+            }
+        } else if (((ManagedCursorImpl) cursor).resetCursorInProgress()) {
+            if (log.isDebugEnabled()) {
+                log.debug("[{}-{}] Ignoring flow control message since cursor reset in progress - cursor {}",
+                        name, consumer, cursor.getName());
             }
         } else {
             if (log.isDebugEnabled()) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherSingleActiveConsumer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherSingleActiveConsumer.java
@@ -280,7 +280,7 @@ public class PersistentDispatcherSingleActiveConsumer extends AbstractDispatcher
                 log.debug("[{}-{}] Ignoring flow control message since consumer is waiting for cursor to be rewinded",
                         name, consumer);
             }
-        } else if (((ManagedCursorImpl) cursor).resetCursorInProgress()) {
+        } else if (((ManagedCursorImpl) cursor).isResetCursorInProgress()) {
             if (log.isDebugEnabled()) {
                 log.debug("[{}-{}] Ignoring flow control message since cursor reset in progress - cursor {}",
                         name, consumer, cursor.getName());


### PR DESCRIPTION
Fixes #16757 

### Motivation
also fixes #14559

`Reader` belongs to exclusive subscription type, and it uses `nonDurable` cursor. After receiving messages, `Reader` will ack cumulatively immediately.
The `flowPermits` are triggered in multiple scenarios from the client side and it is isolated from `seek` of `Consumer`. Therefore, it is possibile that `flowPermits` will execute after `seek` from the client side, like the following flow chart. 

<img width="613" alt="image" src="https://user-images.githubusercontent.com/4970972/178506611-b02a1127-c8d8-40df-be61-7645deb5f48e.png">

When `handleSeek` processing is delay from the server side, the `MarkDelete position` is modified in a wrong way.
The expected result is that `Reader`can re-consume messages from `mark delete:(1,1)` after `seek`. But it doesn't work.

### Modifications
- stage 1: It is necessary to check the current cursor status when handling `flowPermits` from the server side.
- stage 2: check the seek status before ack in `ConsumerImpl`, in which prevent an in-process entry reading operation after  the seek position
@codelipenghui 

### Verifying this change

- [x]  Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.
### Does this pull request potentially affect one of the following parts:

If `yes` was chosen, please highlight the changes

- Dependencies (does it add or upgrade a dependency): (no)
- The public API: (no)
- The schema: (no)
- The default values of configurations: (no)
- The wire protocol: (no)
- The rest endpoints: (no)
- The admin cli options: (no)
- Anything that affects deployment: (no)

### Documentation
Check the box below and label this PR (if you have committer privilege).

Need to update docs? 
- [x] `doc-not-needed` 
