### PR TITLE
[fix][broker] The configuration loadBalancerNamespaceMaximumBundles is invalid

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/NamespacesBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/NamespacesBase.java
@@ -1158,6 +1158,11 @@ public abstract class NamespacesBase extends AdminResource {
                         }));
     }
 
+    /**
+     * 内部拆分命名空间包
+     * asyncResponse: 异步response
+     */
+
     @SuppressWarnings("deprecation")
     protected void internalSplitNamespaceBundle(AsyncResponse asyncResponse, String bundleName, boolean authoritative,
                                                 boolean unload, String splitAlgorithmName, List<Long> splitBoundaries) {
@@ -1165,6 +1170,7 @@ public abstract class NamespacesBase extends AdminResource {
         checkNotNull(bundleName, "BundleRange should not be null");
         log.info("[{}] Split namespace bundle {}/{}", clientAppId(), namespaceName, bundleName);
 
+        // 检查要split的范围
         String bundleRange = getBundleRange(bundleName);
 
         Policies policies = getNamespacePolicies(namespaceName);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/NamespacesBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/NamespacesBase.java
@@ -1158,11 +1158,6 @@ public abstract class NamespacesBase extends AdminResource {
                         }));
     }
 
-    /**
-     * 内部拆分命名空间包
-     * asyncResponse: 异步response
-     */
-
     @SuppressWarnings("deprecation")
     protected void internalSplitNamespaceBundle(AsyncResponse asyncResponse, String bundleName, boolean authoritative,
                                                 boolean unload, String splitAlgorithmName, List<Long> splitBoundaries) {
@@ -1170,7 +1165,6 @@ public abstract class NamespacesBase extends AdminResource {
         checkNotNull(bundleName, "BundleRange should not be null");
         log.info("[{}] Split namespace bundle {}/{}", clientAppId(), namespaceName, bundleName);
 
-        // 检查要split的范围
         String bundleRange = getBundleRange(bundleName);
 
         Policies policies = getNamespacePolicies(namespaceName);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/BundleSplitterTask.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/BundleSplitterTask.java
@@ -93,7 +93,7 @@ public class BundleSplitterTask implements BundleSplitStrategy {
                     try {
                         final int bundleCount = pulsar.getNamespaceService()
                                 .getBundleCount(NamespaceName.get(namespace));
-                        if (bundleCount < maxBundleCount) {
+                        if ((bundleCount + bundleCache.size()) < maxBundleCount) {
                             bundleCache.add(bundle);
                         } else {
                             if (log.isDebugEnabled()) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/BundleSplitterTask.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/BundleSplitterTask.java
@@ -100,7 +100,8 @@ public class BundleSplitterTask implements BundleSplitStrategy {
                     try {
                         final int bundleCount = pulsar.getNamespaceService()
                                 .getBundleCount(NamespaceName.get(namespace));
-                        if ((bundleCount + namespaceBundleCount.get(namespace)) < maxBundleCount) {
+                        if ((bundleCount + namespaceBundleCount.getOrDefault(namespace, 0))
+                                < maxBundleCount) {
                             bundleCache.add(bundle);
                             int bundleNum = namespaceBundleCount.getOrDefault(namespace, 0);
                             namespaceBundleCount.put(namespace, bundleNum + 1);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/BundleSplitterTask.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/BundleSplitterTask.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pulsar.broker.loadbalance.impl;
 
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
@@ -39,12 +40,16 @@ public class BundleSplitterTask implements BundleSplitStrategy {
     private static final Logger log = LoggerFactory.getLogger(BundleSplitStrategy.class);
     private final Set<String> bundleCache;
 
+    private final Map<String, Integer> namespaceBundleCount;
+
+
     /**
      * Construct a BundleSplitterTask.
      *
      */
     public BundleSplitterTask() {
         bundleCache = new HashSet<>();
+        namespaceBundleCount = new HashMap<>();
     }
 
     /**
@@ -61,12 +66,14 @@ public class BundleSplitterTask implements BundleSplitStrategy {
     @Override
     public Set<String> findBundlesToSplit(final LoadData loadData, final PulsarService pulsar) {
         bundleCache.clear();
+        namespaceBundleCount.clear();
         final ServiceConfiguration conf = pulsar.getConfiguration();
         int maxBundleCount = conf.getLoadBalancerNamespaceMaximumBundles();
         long maxBundleTopics = conf.getLoadBalancerNamespaceBundleMaxTopics();
         long maxBundleSessions = conf.getLoadBalancerNamespaceBundleMaxSessions();
         long maxBundleMsgRate = conf.getLoadBalancerNamespaceBundleMaxMsgRate();
         long maxBundleBandwidth = conf.getLoadBalancerNamespaceBundleMaxBandwidthMbytes() * LoadManagerShared.MIBI;
+
         loadData.getBrokerData().forEach((broker, brokerData) -> {
             LocalBrokerData localData = brokerData.getLocalData();
             for (final Map.Entry<String, NamespaceBundleStats> entry : localData.getLastStats().entrySet()) {
@@ -93,8 +100,10 @@ public class BundleSplitterTask implements BundleSplitStrategy {
                     try {
                         final int bundleCount = pulsar.getNamespaceService()
                                 .getBundleCount(NamespaceName.get(namespace));
-                        if ((bundleCount + bundleCache.size()) < maxBundleCount) {
+                        if ((bundleCount + namespaceBundleCount.get(namespace)) < maxBundleCount) {
                             bundleCache.add(bundle);
+                            int bundleNum = namespaceBundleCount.getOrDefault(namespace, 0);
+                            namespaceBundleCount.put(namespace, bundleNum + 1);
                         } else {
                             if (log.isDebugEnabled()) {
                                 log.debug(

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/impl/BundleSplitterTaskTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/impl/BundleSplitterTaskTest.java
@@ -97,7 +97,7 @@ public class BundleSplitterTaskTest {
     }
 
     @Test
-    public void testLoadBalancerNamespaceMaximumBundles() {
+    public void testLoadBalancerNamespaceMaximumBundles() throws Exception {
         pulsar.getConfiguration().setLoadBalancerNamespaceMaximumBundles(3);
 
         final BundleSplitterTask bundleSplitterTask = new BundleSplitterTask();
@@ -141,14 +141,10 @@ public class BundleSplitterTaskTest {
         bundleData3.setLongTermData(averageMessageData3);
         loadData.getBundleData().put("ten/ns/0x40000000_0x60000000", bundleData3);
 
-        try {
-            int currentBundleCount = pulsar.getNamespaceService().getBundleCount(NamespaceName.get("ten/ns"));
-            final Set<String> bundlesToSplit = bundleSplitterTask.findBundlesToSplit(loadData, pulsar);
-            Assert.assertEquals(bundlesToSplit.size() + currentBundleCount,
-                    pulsar.getConfiguration().getLoadBalancerNamespaceMaximumBundles());
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
+        int currentBundleCount = pulsar.getNamespaceService().getBundleCount(NamespaceName.get("ten/ns"));
+        final Set<String> bundlesToSplit = bundleSplitterTask.findBundlesToSplit(loadData, pulsar);
+        Assert.assertEquals(bundlesToSplit.size() + currentBundleCount,
+                pulsar.getConfiguration().getLoadBalancerNamespaceMaximumBundles());
     }
 
 


### PR DESCRIPTION
### Motivation
The configuration loadBalancerNamespaceMaximumBundles is invalid.


example to illustrate:
1. Configure loadBalancerNamespaceMaximumBundles=128
1. The current number of bundles in the namespace is 120
2. According to the current logic, after executing the method findBundlesToSplit, 40 bundles may be found that need to be split;
3. After these bundles, the number of bundles in the namespace will become 120+40=160 > loadBalancerNamespaceMaximumBundles=128


modified logic：
1. When judging whether the number of bundles exceeds the configuration, it is necessary to add the already selected bundles：

<img width="928" alt="image" src="https://user-images.githubusercontent.com/19296967/179136866-93005313-35ea-4ced-a8fa-83ea5c7dec53.png">


### Documentation

Check the box below or label this PR directly.

Need to update docs? 

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)
  
- [x] `doc-not-needed` 
(Please explain why)
  
- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)