### PR TITLE
[improve][client] Add original principal and authentication data support

### DIFF
--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/ClientBuilder.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/ClientBuilder.java
@@ -566,4 +566,20 @@ public interface ClientBuilder extends Serializable, Cloneable {
      * @return
      */
     ClientBuilder socks5ProxyPassword(String socks5ProxyPassword);
+
+    /**
+     * When using the client as a proxy service, client can support the original principal.
+     *
+     * @param originalPrincipal
+     * @return the client builder instance
+     */
+    ClientBuilder originalPrincipal(String originalPrincipal);
+
+    /**
+     * When using the client as a proxy service, client can support the original authentication.
+     *
+     * @param originalAuthenticationData
+     * @return the client builder instance
+     */
+    ClientBuilder originalAuthentication(Authentication originalAuthenticationData);
 }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ClientBuilderImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ClientBuilderImpl.java
@@ -351,4 +351,16 @@ public class ClientBuilderImpl implements ClientBuilder {
         conf.setSocks5ProxyPassword(socks5ProxyPassword);
         return this;
     }
+
+    @Override
+    public ClientBuilder originalPrincipal(String originalPrincipal) {
+        conf.setOriginalPrincipal(originalPrincipal);
+        return this;
+    }
+
+    @Override
+    public ClientBuilder originalAuthentication(Authentication originalAuthentication) {
+        conf.setOriginalAuthentication(originalAuthentication);
+        return this;
+    }
 }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ClientConfigurationData.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ClientConfigurationData.java
@@ -328,6 +328,20 @@ public class ClientConfigurationData implements Serializable, Cloneable {
     @Secret
     private String socks5ProxyPassword;
 
+    @ApiModelProperty(
+            name = "originalPrincipal",
+            value = "Set the original principal."
+    )
+    @JsonIgnore
+    private String originalPrincipal;
+
+    @ApiModelProperty(
+            name = "originalAuthenticationData",
+            value = "Set the original authentication."
+    )
+    @JsonIgnore
+    private Authentication originalAuthentication;
+
     public Authentication getAuthentication() {
         if (authentication == null) {
             this.authentication = AuthenticationDisabled.INSTANCE;


### PR DESCRIPTION
Signed-off-by: Zixuan Liu <nodeces@gmail.com>

### Motivation

When the client as the proxy service to forward the request from other protocols, the client doesn't support setting the original principal and authentication data, the Pulsar Websocket is using this way of working. When the `proxyRoles` is enabled, the Pulsar needs to check the original principal and authentication data, but the client doesn't support setting that.

### Modifications

- Add set up the original principal and authentication data

### Documentation

Check the box below or label this PR directly.

Need to update docs? 

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)
  
- [x] `doc-not-needed` 
(Please explain why)
  
- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)