### PR TITLE
[fix][broker]fix the zero value as denominator cause ArithmeticException when selectBroker use LeastResourceUsageWithWeight

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/LeastResourceUsageWithWeight.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/LeastResourceUsageWithWeight.java
@@ -125,6 +125,11 @@ public class LeastResourceUsageWithWeight implements ModularLoadManagerStrategy 
     @Override
     public Optional<String> selectBroker(Set<String> candidates, BundleData bundleToAssign, LoadData loadData,
                                          ServiceConfiguration conf) {
+        if (candidates.isEmpty()) {
+            log.error("There are no available brokers as candidates at this point for bundle: {}", bundleToAssign);
+            return Optional.empty();
+        }
+
         bestBrokers.clear();
         // Maintain of list of all the best scoring brokers and then randomly
         // select one of them at the end.
@@ -148,12 +153,6 @@ public class LeastResourceUsageWithWeight implements ModularLoadManagerStrategy 
             // Assign randomly as all brokers are overloaded.
             log.warn("Assign randomly as all {} brokers are overloaded.", candidates.size());
             bestBrokers.addAll(candidates);
-        }
-
-        if (bestBrokers.isEmpty()) {
-            // If still, it means there are no available brokers at this point.
-            log.error("There are no available brokers as candidates at this point for bundle: {}", bundleToAssign);
-            return Optional.empty();
         }
 
         if (log.isDebugEnabled()) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/LeastResourceUsageWithWeight.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/LeastResourceUsageWithWeight.java
@@ -126,7 +126,7 @@ public class LeastResourceUsageWithWeight implements ModularLoadManagerStrategy 
     public Optional<String> selectBroker(Set<String> candidates, BundleData bundleToAssign, LoadData loadData,
                                          ServiceConfiguration conf) {
         if (candidates.isEmpty()) {
-            log.error("There are no available brokers as candidates at this point for bundle: {}", bundleToAssign);
+            log.info("There are no available brokers as candidates at this point for bundle: {}", bundleToAssign);
             return Optional.empty();
         }
 


### PR DESCRIPTION
### Motivation

Fix the zero value as denominator when after `applyNamespacePolicies`  the `candidates` is empty,  then `selectBroker` use `LeastResourceUsageWithWeight`, which will cause `ArithmeticException`

**the cause exception point** 
https://github.com/apache/pulsar/blob/9f7021909486ac97590b17a6c245367900ab989c/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/LeastResourceUsageWithWeight.java#L138

### Modifications
1. add  `candidates` empty check;
2. after add `candidates` empty check, remove some unused check;

### Documentation

- [X] `doc-not-needed` 
