### PR TITLE
[improve] [admin] [PIP-179] Support the admin API to check unknown request parameters

### DIFF
--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/web/DynamicSkipUnknownPropertyHandler.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/web/DynamicSkipUnknownPropertyHandler.java
@@ -40,25 +40,17 @@ public class DynamicSkipUnknownPropertyHandler extends DeserializationProblemHan
     public boolean handleUnknownProperty(DeserializationContext deserializationContext, JsonParser p,
                                          JsonDeserializer<?> deserializer, Object beanOrClass,
                                          String propertyName) throws IOException {
+        Collection<Object> propIds = (deserializer == null) ? null : deserializer.getKnownPropertyNames();
+        UnrecognizedPropertyException unrecognizedPropertyException = UnrecognizedPropertyException
+                .from(p, beanOrClass, propertyName, propIds);
         if (skipUnknownProperty){
             if (log.isDebugEnabled()) {
-                StringBuilder warnLog = new StringBuilder();
-                warnLog.append("Deserialize json to [").append(beanOrClass.getClass().getName())
-                        .append("], found unknown property [").append(propertyName).append("] and skipped. ");
-                if (p.isExpectedStartArrayToken()){
-                    warnLog.append("The requested value is an array.");
-                } else if (p.isExpectedStartObjectToken()){
-                    warnLog.append("The requested value is an object.");
-                } else {
-                    warnLog.append("The requested value is [").append(p.getText()).append("].");
-                }
-                log.debug(warnLog.toString());
+                log.debug(unrecognizedPropertyException.getMessage());
             }
             p.skipChildren();
             return skipUnknownProperty;
         } else {
-            Collection<Object> propIds = (deserializer == null) ? null : deserializer.getKnownPropertyNames();
-            throw UnrecognizedPropertyException.from(p, beanOrClass, propertyName, propIds);
+            throw unrecognizedPropertyException;
         }
     }
 }

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/web/DynamicSkipUnknownPropertyHandler.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/web/DynamicSkipUnknownPropertyHandler.java
@@ -1,0 +1,62 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.web;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.deser.DeserializationProblemHandler;
+import com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException;
+import java.io.IOException;
+import java.util.Collection;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class DynamicSkipUnknownPropertyHandler extends DeserializationProblemHandler {
+
+    @Getter
+    @Setter
+    private boolean skipUnknownProperty = true;
+
+    @Override
+    public boolean handleUnknownProperty(DeserializationContext deserializationContext, JsonParser p,
+                                         JsonDeserializer<?> deserializer, Object beanOrClass,
+                                         String propertyName) throws IOException {
+        if (skipUnknownProperty){
+            StringBuilder warnLog = new StringBuilder();
+            warnLog.append("Deserialize json to [").append(beanOrClass.getClass().getName())
+                    .append("], found unknown property [").append(propertyName).append("] and skipped. ");
+            if (p.isExpectedStartArrayToken()){
+                warnLog.append("The requested value is an array.");
+            } else if (p.isExpectedStartObjectToken()){
+                warnLog.append("The requested value is an object.");
+            } else {
+                warnLog.append("The requested value is [").append(p.getText()).append("].");
+            }
+            log.warn(warnLog.toString());
+            p.skipChildren();
+            return skipUnknownProperty;
+        } else {
+            Collection<Object> propIds = (deserializer == null) ? null : deserializer.getKnownPropertyNames();
+            throw UnrecognizedPropertyException.from(p, beanOrClass, propertyName, propIds);
+        }
+    }
+}

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/web/DynamicSkipUnknownPropertyHandler.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/web/DynamicSkipUnknownPropertyHandler.java
@@ -41,17 +41,19 @@ public class DynamicSkipUnknownPropertyHandler extends DeserializationProblemHan
                                          JsonDeserializer<?> deserializer, Object beanOrClass,
                                          String propertyName) throws IOException {
         if (skipUnknownProperty){
-            StringBuilder warnLog = new StringBuilder();
-            warnLog.append("Deserialize json to [").append(beanOrClass.getClass().getName())
-                    .append("], found unknown property [").append(propertyName).append("] and skipped. ");
-            if (p.isExpectedStartArrayToken()){
-                warnLog.append("The requested value is an array.");
-            } else if (p.isExpectedStartObjectToken()){
-                warnLog.append("The requested value is an object.");
-            } else {
-                warnLog.append("The requested value is [").append(p.getText()).append("].");
+            if (log.isDebugEnabled()) {
+                StringBuilder warnLog = new StringBuilder();
+                warnLog.append("Deserialize json to [").append(beanOrClass.getClass().getName())
+                        .append("], found unknown property [").append(propertyName).append("] and skipped. ");
+                if (p.isExpectedStartArrayToken()){
+                    warnLog.append("The requested value is an array.");
+                } else if (p.isExpectedStartObjectToken()){
+                    warnLog.append("The requested value is an object.");
+                } else {
+                    warnLog.append("The requested value is [").append(p.getText()).append("].");
+                }
+                log.debug(warnLog.toString());
             }
-            log.warn(warnLog.toString());
             p.skipChildren();
             return skipUnknownProperty;
         } else {

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/web/JsonMapperProvider.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/web/JsonMapperProvider.java
@@ -18,7 +18,9 @@
  */
 package org.apache.pulsar.broker.web;
 
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.deser.DeserializationProblemHandler;
 import javax.ws.rs.ext.ContextResolver;
 import javax.ws.rs.ext.Provider;
 import org.apache.pulsar.common.util.ObjectMapperFactory;
@@ -26,6 +28,15 @@ import org.apache.pulsar.common.util.ObjectMapperFactory;
 @Provider
 public class JsonMapperProvider implements ContextResolver<ObjectMapper> {
     private final ObjectMapper mapper = ObjectMapperFactory.create();
+
+    public JsonMapperProvider(){
+
+    }
+
+    public JsonMapperProvider(DeserializationProblemHandler handler){
+        mapper.enable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
+        mapper.addHandler(handler);
+    }
 
     @Override
     public ObjectMapper getContext(Class<?> type) {

--- a/pulsar-broker-common/src/test/java/org/apache/pulsar/broker/web/DynamicSkipUnknownPropertyHandlerTest.java
+++ b/pulsar-broker-common/src/test/java/org/apache/pulsar/broker/web/DynamicSkipUnknownPropertyHandlerTest.java
@@ -26,6 +26,7 @@ import lombok.Data;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
+@Test(groups = "broker-admin-v2")
 public class DynamicSkipUnknownPropertyHandlerTest {
 
     @Test
@@ -117,7 +118,7 @@ public class DynamicSkipUnknownPropertyHandlerTest {
     }
 
     @Data
-    public static class TestBean {
+    private static class TestBean {
         private String name1;
         private String name;
         private String name2;

--- a/pulsar-broker-common/src/test/java/org/apache/pulsar/broker/web/DynamicSkipUnknownPropertyHandlerTest.java
+++ b/pulsar-broker-common/src/test/java/org/apache/pulsar/broker/web/DynamicSkipUnknownPropertyHandlerTest.java
@@ -26,7 +26,7 @@ import lombok.Data;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
-@Test(groups = "broker-admin-v2")
+@Test(groups = "broker-admin")
 public class DynamicSkipUnknownPropertyHandlerTest {
 
     @Test

--- a/pulsar-broker-common/src/test/java/org/apache/pulsar/broker/web/DynamicSkipUnknownPropertyHandlerTest.java
+++ b/pulsar-broker-common/src/test/java/org/apache/pulsar/broker/web/DynamicSkipUnknownPropertyHandlerTest.java
@@ -1,0 +1,125 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.web;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectReader;
+import com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException;
+import lombok.Data;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class DynamicSkipUnknownPropertyHandlerTest {
+
+    @Test
+    public void testHandleUnknownProperty() throws Exception{
+        DynamicSkipUnknownPropertyHandler handler = new DynamicSkipUnknownPropertyHandler();
+        handler.setSkipUnknownProperty(true);
+        // Case 1: initial ObjectMapper with "enable feature".
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.enable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
+        objectMapper.addHandler(handler);
+        ObjectReader objectReader = objectMapper.readerFor(TestBean.class);
+        // Assert skip unknown property and logging: objectMapper.
+        String json = "{\"name1\": \"James\",\"nm\":\"Paul\",\"name2\":\"Eric\"}";
+        TestBean testBean = objectMapper.readValue(json, TestBean.class);
+        Assert.assertNull(testBean.getName());
+        Assert.assertEquals(testBean.getName1(), "James");
+        Assert.assertEquals(testBean.getName2(), "Eric");
+        // Assert skip unknown property and logging: objectReader.
+        testBean = objectReader.readValue(json, TestBean.class);
+        Assert.assertNull(testBean.getName());
+        Assert.assertEquals(testBean.getName1(), "James");
+        Assert.assertEquals(testBean.getName2(), "Eric");
+        // Assert failure on unknown property.
+        handler.setSkipUnknownProperty(false);
+        try {
+            objectMapper.readValue(json, TestBean.class);
+            Assert.fail("Expect UnrecognizedPropertyException when set skipUnknownProperty false.");
+        } catch (UnrecognizedPropertyException e){
+
+        }
+        try {
+            objectReader.readValue(json, TestBean.class);
+            Assert.fail("Expect UnrecognizedPropertyException when set skipUnknownProperty false.");
+        } catch (UnrecognizedPropertyException e){
+
+        }
+        // Case 2: initial ObjectMapper with "disabled feature".
+        objectMapper = new ObjectMapper();
+        objectMapper.enable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
+        objectMapper.addHandler(handler);
+        objectReader = objectMapper.readerFor(TestBean.class);
+        // Assert failure on unknown property.
+        try {
+            objectMapper.readValue(json, TestBean.class);
+            Assert.fail("Expect UnrecognizedPropertyException when set skipUnknownProperty false.");
+        } catch (UnrecognizedPropertyException e){
+
+        }
+        try {
+            objectReader.readValue(json, TestBean.class);
+            Assert.fail("Expect UnrecognizedPropertyException when set skipUnknownProperty false.");
+        } catch (UnrecognizedPropertyException e){
+
+        }
+        // Assert skip unknown property and logging.
+        handler.setSkipUnknownProperty(true);
+        testBean = objectMapper.readValue(json, TestBean.class);
+        Assert.assertNull(testBean.getName());
+        Assert.assertEquals(testBean.getName1(), "James");
+        Assert.assertEquals(testBean.getName2(), "Eric");
+        testBean = objectReader.readValue(json, TestBean.class);
+        Assert.assertNull(testBean.getName());
+        Assert.assertEquals(testBean.getName1(), "James");
+        Assert.assertEquals(testBean.getName2(), "Eric");
+        // Case 3: unknown property deserialize by object json.
+        json = "{\"name1\": \"James\",\"nm\":{\"name\":\"Paul\",\"age\":18},\"name2\":\"Eric\"}";
+        // Assert skip unknown property and logging.
+        handler.setSkipUnknownProperty(true);
+        testBean = objectMapper.readValue(json, TestBean.class);
+        Assert.assertNull(testBean.getName());
+        Assert.assertEquals(testBean.getName1(), "James");
+        Assert.assertEquals(testBean.getName2(), "Eric");
+        testBean = objectReader.readValue(json, TestBean.class);
+        Assert.assertNull(testBean.getName());
+        Assert.assertEquals(testBean.getName1(), "James");
+        Assert.assertEquals(testBean.getName2(), "Eric");
+        // Case 4: unknown property deserialize by array json.
+        json = "{\"name1\": \"James\",\"nm\":[\"name\",\"Paul\"],\"name2\":\"Eric\"}";
+        // Assert skip unknown property and logging.
+        handler.setSkipUnknownProperty(true);
+        testBean = objectMapper.readValue(json, TestBean.class);
+        Assert.assertNull(testBean.getName());
+        Assert.assertEquals(testBean.getName1(), "James");
+        Assert.assertEquals(testBean.getName2(), "Eric");
+        testBean = objectReader.readValue(json, TestBean.class);
+        Assert.assertNull(testBean.getName());
+        Assert.assertEquals(testBean.getName1(), "James");
+        Assert.assertEquals(testBean.getName2(), "Eric");
+    }
+
+    @Data
+    public static class TestBean {
+        private String name1;
+        private String name;
+        private String name2;
+    }
+}

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
@@ -908,18 +908,18 @@ public class PulsarService implements AutoCloseable, ShutdownService {
 
         // Add admin rest resources
         webService.addRestResource("/",
-                false, vipAttributeMap, VipStatus.class);
+                false, vipAttributeMap, false, VipStatus.class);
         webService.addRestResources("/admin",
-                true, attributeMap, "org.apache.pulsar.broker.admin.v1");
+                true, attributeMap, false, "org.apache.pulsar.broker.admin.v1");
         webService.addRestResources("/admin/v2",
-                true, attributeMap, "org.apache.pulsar.broker.admin.v2");
+                true, attributeMap, true, "org.apache.pulsar.broker.admin.v2");
         webService.addRestResources("/admin/v3",
-                true, attributeMap, "org.apache.pulsar.broker.admin.v3");
+                true, attributeMap, true, "org.apache.pulsar.broker.admin.v3");
         webService.addRestResource("/lookup",
-                true, attributeMap, TopicLookup.class,
+                true, attributeMap, true,  TopicLookup.class,
                 org.apache.pulsar.broker.lookup.v2.TopicLookup.class);
         webService.addRestResource("/topics",
-                true, attributeMap, Topics.class);
+                true, attributeMap, true, Topics.class);
 
         // Add metrics servlet
         webService.addServlet("/metrics",

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/WebService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/WebService.java
@@ -77,7 +77,7 @@ public class WebService implements AutoCloseable {
     private JettyStatisticsCollector jettyStatisticsCollector;
 
     @Getter
-    private final DynamicSkipUnknownPropertyHandler sharedUnknownPropertyHandler =
+    private static final DynamicSkipUnknownPropertyHandler sharedUnknownPropertyHandler =
             new DynamicSkipUnknownPropertyHandler();
 
     public WebService(PulsarService pulsar) throws PulsarServerException {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/WebService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/WebService.java
@@ -77,7 +77,8 @@ public class WebService implements AutoCloseable {
     private JettyStatisticsCollector jettyStatisticsCollector;
 
     @Getter
-    private final DynamicSkipUnknownPropertyHandler sharedJsonMapperProvider = new DynamicSkipUnknownPropertyHandler();
+    private final DynamicSkipUnknownPropertyHandler sharedUnknownPropertyHandler =
+            new DynamicSkipUnknownPropertyHandler();
 
     public WebService(PulsarService pulsar) throws PulsarServerException {
         this.handlers = Lists.newArrayList();
@@ -174,7 +175,7 @@ public class WebService implements AutoCloseable {
     private void addResourceServlet(String basePath, boolean requiresAuthentication, Map<String, Object> attributeMap,
                                     ResourceConfig config, boolean useSharedJsonMapperProvider) {
         if (useSharedJsonMapperProvider){
-            JsonMapperProvider jsonMapperProvider = new JsonMapperProvider(sharedJsonMapperProvider);
+            JsonMapperProvider jsonMapperProvider = new JsonMapperProvider(sharedUnknownPropertyHandler);
             config.register(jsonMapperProvider);
         } else {
             config.register(JsonMapperProvider.class);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/WebService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/WebService.java
@@ -77,7 +77,7 @@ public class WebService implements AutoCloseable {
     private JettyStatisticsCollector jettyStatisticsCollector;
 
     @Getter
-    private DynamicSkipUnknownPropertyHandler sharedJsonMapperProvider = new DynamicSkipUnknownPropertyHandler();
+    private final DynamicSkipUnknownPropertyHandler sharedJsonMapperProvider = new DynamicSkipUnknownPropertyHandler();
 
     public WebService(PulsarService pulsar) throws PulsarServerException {
         this.handlers = Lists.newArrayList();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminRestTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminRestTest.java
@@ -1,2 +1,95 @@
-package org.apache.pulsar.broker.admin;public class AdminRestTest {
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.admin;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.pulsar.broker.auth.MockedPulsarServiceBaseTest;
+import org.apache.pulsar.common.policies.data.ClusterData;
+import org.apache.pulsar.common.policies.data.TenantInfoImpl;
+import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+@Slf4j
+public class AdminRestTest extends MockedPulsarServiceBaseTest {
+
+    private final String clusterName = "test";
+    private final String tenantName = "t-tenant";
+    private final String namespaceName = "t-tenant/test-namespace";
+    private final String topicNameSuffix = "t-rest-topic";
+    private final String topicName = "persistent://" + namespaceName + "/" + topicNameSuffix;
+
+    @Test
+    public void testRejectUnknownEntityProperties() throws Exception{
+        // Build request command.
+        int port = pulsar.getWebService().getListenPortHTTP().get();
+        Client client = ClientBuilder.newClient();
+        WebTarget target = client.target("http://127.0.0.1:" + port
+                + "/admin/v2/persistent/" + namespaceName + "/" + topicNameSuffix + "/retention");
+        Map<String,Object> data = new HashMap<>();
+        data.put("retention_size_in_mb", -1);
+        data.put("retention_time_in_minutes", 40320);
+        // Configuration default, response success.
+        Response response = target.request(MediaType.APPLICATION_JSON_TYPE).buildPost(Entity.json(data)).invoke();
+        Assert.assertTrue(response.getStatus() / 200 == 1);
+        // Enabled feature, bad request response.
+        pulsar.getWebService().getSharedUnknownPropertyHandler().setSkipUnknownProperty(false);
+        response = target.request(MediaType.APPLICATION_JSON_TYPE).buildPost(Entity.json(data)).invoke();
+        Assert.assertEquals(response.getStatus(), 400);
+        // Disabled feature, response success.
+        pulsar.getWebService().getSharedUnknownPropertyHandler().setSkipUnknownProperty(true);
+        response = target.request(MediaType.APPLICATION_JSON_TYPE).buildPost(Entity.json(data)).invoke();
+        Assert.assertTrue(response.getStatus() / 200 == 1);
+    }
+
+    @BeforeMethod
+    @Override
+    protected void setup() throws Exception {
+        resetConfig();
+        super.internalSetup();
+        // Create tenant, namespace, topic
+        admin.clusters().createCluster(clusterName, ClusterData.builder().serviceUrl(brokerUrl.toString()).build());
+        admin.tenants().createTenant(tenantName,
+                new TenantInfoImpl(Collections.singleton("a"), Collections.singleton(clusterName)));
+        admin.namespaces().createNamespace(namespaceName);
+        admin.topics().createNonPartitionedTopic(topicName);
+    }
+
+    @AfterMethod
+    @Override
+    protected void cleanup() throws Exception {
+        // cleanup.
+        admin.topics().delete(topicName);
+        admin.namespaces().deleteNamespace(namespaceName);
+        admin.tenants().deleteTenant(tenantName);
+        admin.clusters().deleteCluster(clusterName);
+        // super cleanup.
+        super.internalCleanup();
+    }
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminRestTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminRestTest.java
@@ -37,7 +37,7 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 @Slf4j
-@Test(groups = "broker-admin-v2")
+@Test(groups = "broker-admin")
 public class AdminRestTest extends MockedPulsarServiceBaseTest {
 
     private final String clusterName = "test";

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminRestTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminRestTest.java
@@ -1,0 +1,2 @@
+package org.apache.pulsar.broker.admin;public class AdminRestTest {
+}

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminRestTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminRestTest.java
@@ -37,6 +37,7 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 @Slf4j
+@Test(groups = "broker-admin-v2")
 public class AdminRestTest extends MockedPulsarServiceBaseTest {
 
     private final String clusterName = "test";

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/NamespacesV2Test.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/NamespacesV2Test.java
@@ -53,7 +53,7 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-@Test(groups = "broker-admin-v2")
+@Test(groups = "broker-admin")
 public class NamespacesV2Test extends MockedPulsarServiceBaseTest {
     private static final Logger log = LoggerFactory.getLogger(NamespacesV2Test.class);
 


### PR DESCRIPTION
Master Issue: #16135

### Motivation

see #16135

### Modifications

I will complete proposal #16135 with these pull requests( *current pull request is the step-1* ): 

1. Add A Jackson component `DynamicSkipUnknownPropertyHandler` that supports dynamically policy of rejecting unknown parameters. Prints warn log when it receives an unknown parameter.
2. Dynamic configuration.

### Documentation

- [ ] `doc-required` 
  
- [x] `doc-not-needed` 
  
- [ ] `doc` 

- [ ] `doc-complete`