### PR TITLE
[fix][doc] Fix wording in Tiered Storage

### DIFF
--- a/site2/docs/concepts-tiered-storage.md
+++ b/site2/docs/concepts-tiered-storage.md
@@ -12,6 +12,6 @@ One way to alleviate this cost is to use Tiered Storage. With tiered storage, ol
 
 > Data written to BookKeeper is replicated to 3 physical machines by default. However, once a segment is sealed in BookKeeper it becomes immutable and can be copied to long term storage. Long term storage can achieve cost savings by using mechanisms such as [Reed-Solomon error correction](https://en.wikipedia.org/wiki/Reed%E2%80%93Solomon_error_correction) to require fewer physical copies of data.
 
-Pulsar currently supports S3, Google Cloud Storage (GCS), and filesystem for [long term store](cookbooks-tiered-storage.md). Offloading to long term storage triggered via a Rest API or command line interface. The user passes in the amount of topic data they wish to retain on BookKeeper, and the broker will copy the backlog data to long term storage. The original data will then be deleted from BookKeeper after a configured delay (4 hours by default).
+Pulsar currently supports S3, Google Cloud Storage (GCS), and filesystem for [long term storage](cookbooks-tiered-storage.md). Offloading to long term storage is triggered via a Rest API or command line interface. The user passes in the amount of topic data they wish to retain on BookKeeper, and the broker will copy the backlog data to long term storage. The original data will then be deleted from BookKeeper after a configured delay (4 hours by default).
 
 > For a guide for setting up tiered storage, see the [Tiered storage cookbook](cookbooks-tiered-storage.md).


### PR DESCRIPTION
### Motivation


The Concepts->Tiered Storage page is missing some words. This is a hotfix to improve readability.

### Modifications

Fixed grammar on the Tiered Storage page.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.


This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API: (yes / **no**)
  - The schema: (yes / **no** / don't know)
  - The default values of configurations: (yes / **no**)
  - The wire protocol: (yes / **no**)
  - The rest endpoints: (yes / **no**)
  - The admin cli options: (yes / **no**)
  - Anything that affects deployment: (yes / **no** / don't know)

### Documentation

Check the box below or label this PR directly.

Need to update docs? 

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)
  
- [ ] `doc-not-needed` 
(Please explain why)
  
- [x] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)