### PR TITLE
[improve][test] Improve the TransactionTest to reduce the execution time

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/intercept/CounterBrokerInterceptor.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/intercept/CounterBrokerInterceptor.java
@@ -61,6 +61,21 @@ public class CounterBrokerInterceptor implements BrokerInterceptor {
     int committedTxnCount = 0;
     int abortedTxnCount = 0;
 
+    public void reset() {
+        beforeSendCount = 0;
+        count = 0;
+        connectionCreationCount = 0;
+        producerCount = 0;
+        consumerCount = 0;
+        messageCount = 0;
+        messageDispatchCount = 0;
+        messageAckCount = 0;
+        handleAckCount = 0;
+        txnCount = 0;
+        committedTxnCount = 0;
+        abortedTxnCount = 0;
+    }
+
     private List<ResponseEvent> responseList = new ArrayList<>();
 
     @Data


### PR DESCRIPTION
### Motivation

The TransactionTest runs for over 3 minutes. To avoid starting a pulsar cluster for each test method.

```
 [INFO] Tests run: 24, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 186.322 s - in org.apache.pulsar.broker.transaction.TransactionTest
 ```

After this change, the execution time was reduced to under 1 minute on my laptop

### Documentation

Check the box below or label this PR directly.

Need to update docs? 

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)
  
- [x] `doc-not-needed` 
(Please explain why)
  
- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)