### PR TITLE
Rename Pulsar txn metrics to specify OpenMetrics

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/TransactionAggregator.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/TransactionAggregator.java
@@ -297,15 +297,15 @@ public class TransactionAggregator {
                                                  long coordinatorId) {
         metric(stream, cluster, "pulsar_txn_active_count",
                 stats.actives, coordinatorId);
-        metric(stream, cluster, "pulsar_txn_committed_count",
+        metric(stream, cluster, "pulsar_txn_committed_total",
                 stats.committedCount, coordinatorId);
-        metric(stream, cluster, "pulsar_txn_aborted_count",
+        metric(stream, cluster, "pulsar_txn_aborted_total",
                 stats.abortedCount, coordinatorId);
-        metric(stream, cluster, "pulsar_txn_created_count",
+        metric(stream, cluster, "pulsar_txn_created_total",
                 stats.createdCount, coordinatorId);
-        metric(stream, cluster, "pulsar_txn_timeout_count",
+        metric(stream, cluster, "pulsar_txn_timeout_total",
                 stats.timeoutCount, coordinatorId);
-        metric(stream, cluster, "pulsar_txn_append_log_count",
+        metric(stream, cluster, "pulsar_txn_append_log_total",
                 stats.appendLogCount, coordinatorId);
         long[] latencyBuckets = stats.executionLatency;
         metric(stream, cluster, "pulsar_txn_execution_latency_le_10", latencyBuckets[0], coordinatorId);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/TransactionMetricsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/TransactionMetricsTest.java
@@ -181,15 +181,15 @@ public class TransactionMetricsTest extends BrokerTestBase {
         String metricsStr = statsOut.toString();
         Multimap<String, PrometheusMetricsTest.Metric> metrics = parseMetrics(metricsStr);
 
-        Collection<PrometheusMetricsTest.Metric> metric = metrics.get("pulsar_txn_created_count");
+        Collection<PrometheusMetricsTest.Metric> metric = metrics.get("pulsar_txn_created_total");
         assertEquals(metric.size(), 1);
         metric.forEach(item -> assertEquals(item.value, txnCount));
 
-        metric = metrics.get("pulsar_txn_committed_count");
+        metric = metrics.get("pulsar_txn_committed_total");
         assertEquals(metric.size(), 1);
         metric.forEach(item -> assertEquals(item.value, txnCount / 2));
 
-        metric = metrics.get("pulsar_txn_aborted_count");
+        metric = metrics.get("pulsar_txn_aborted_total");
         assertEquals(metric.size(), 1);
         metric.forEach(item -> assertEquals(item.value, txnCount / 2));
 
@@ -211,11 +211,11 @@ public class TransactionMetricsTest extends BrokerTestBase {
         metricsStr = statsOut.toString();
         metrics = parseMetrics(metricsStr);
 
-        metric = metrics.get("pulsar_txn_timeout_count");
+        metric = metrics.get("pulsar_txn_timeout_total");
         assertEquals(metric.size(), 1);
         metric.forEach(item -> assertEquals(item.value, 1));
 
-        metric = metrics.get("pulsar_txn_append_log_count");
+        metric = metrics.get("pulsar_txn_append_log_total");
         assertEquals(metric.size(), 1);
         metric.forEach(item -> assertEquals(item.value, txnCount * 4 + 3));
 

--- a/site2/docs/reference-metrics.md
+++ b/site2/docs/reference-metrics.md
@@ -695,12 +695,12 @@ All the transaction metrics are labelled with the following labels:
 - *cluster*: `cluster=${pulsar_cluster}`. `${pulsar_cluster}` is the cluster name that you have configured in the `broker.conf` file.
 - *coordinator_id*: `coordinator_id=${coordinator_id}`. `${coordinator_id}` is the coordinator id.
 
-| Name | Type | Description |
-|---|---|---|
-| pulsar_txn_active_count | Gauge | Number of active transactions. |
-| pulsar_txn_created_count | Counter | Number of created transactions. |
-| pulsar_txn_committed_count | Counter | Number of committed transactions. |
-| pulsar_txn_aborted_count | Counter | Number of aborted transactions of this coordinator. |
-| pulsar_txn_timeout_count | Counter | Number of timeout transactions. |
-| pulsar_txn_append_log_count | Counter | Number of append transaction logs. |
+| Name                              | Type | Description |
+|-----------------------------------|---|---|
+| pulsar_txn_active_count           | Gauge | Number of active transactions. |
+| pulsar_txn_created_total          | Counter | Number of created transactions. |
+| pulsar_txn_committed_total        | Counter | Number of committed transactions. |
+| pulsar_txn_aborted_total          | Counter | Number of aborted transactions of this coordinator. |
+| pulsar_txn_timeout_total          | Counter | Number of timeout transactions. |
+| pulsar_txn_append_log_total       | Counter | Number of append transaction logs. |
 | pulsar_txn_execution_latency_le_* | Histogram | Transaction execution latency. <br /> Available latencies are as below: <br /><ul><li> latency="10" is TransactionExecutionLatency between (0ms, 10ms]</li> <li>latency="20" is TransactionExecutionLatency between (10ms, 20ms]</li><li>latency="50" is TransactionExecutionLatency between (20ms, 50ms]</li><li>latency="100" is TransactionExecutionLatency between (50ms, 100ms]</li><li>latency="500" is TransactionExecutionLatency between (100ms, 500ms]</li><li>latency="1000" is TransactionExecutionLatency between (500ms, 1000ms]</li><li>latency="5000" is TransactionExecutionLatency between (1s, 5s]</li><li>latency="15000" is TransactionExecutionLatency between (5s, 15s]</li><li>latency="30000" is TransactionExecutionLatency between (15s, 30s]</li><li>latency="60000" is TransactionExecutionLatency between (30s, 60s]</li><li>latency="300000" is TransactionExecutionLatency between (1m,5m]</li><li>latency="1500000" is TransactionExecutionLatency between (5m,15m]</li><li>latency="3000000" is TransactionExecutionLatency between (15m,30m]</li><li>latency="overflow" is TransactionExecutionLatency between (30m,∞]</li></ul>|


### PR DESCRIPTION
### Motivation
See https://github.com/OpenObservability/OpenMetrics/blob/main/specification/OpenMetrics.md
A COUNTER needs `metrics_name_total` or `metrics_name_created`

This PR contains metric name broken changes.

### Modifications
Rename counter's `_count` to `_total`

### metrics name broken changes
- rename `pulsar_txn_committed_count` to `pulsar_txn_committed_total`
- rename `pulsar_txn_aborted_count` to `pulsar_txn_aborted_total`
- rename `pulsar_txn_created_count` to `pulsar_txn_created_total`
- rename `pulsar_txn_timeout_count` to `pulsar_txn_timeout_total`
- rename `pulsar_txn_append_log_count` to `pulsar_txn_append_log_total`

### Documentation
  
- [X] `doc` 
As mentioned above, the metrics name has changed