### PR TITLE
[fix][doc] remove unnecessary option from helm install

### DIFF
--- a/site2/docs/getting-started-helm.md
+++ b/site2/docs/getting-started-helm.md
@@ -104,17 +104,10 @@ We use [Minikube](https://minikube.sigs.k8s.io/docs/start/) in this quick start 
 
 4. Use the Pulsar Helm chart to install a Pulsar cluster to Kubernetes. 
 
-   :::note
-
-   You need to specify `--set initialize=true` when installing Pulsar the first time. This command installs and starts Apache Pulsar.
-
-   :::
-
    ```bash
    
    helm install \
        --values examples/values-minikube.yaml \
-       --set initialize=true \
        --namespace pulsar \
        pulsar-mini apache/pulsar
    

--- a/site2/docs/helm-deploy.md
+++ b/site2/docs/helm-deploy.md
@@ -396,16 +396,9 @@ helm repo add apache https://pulsar.apache.org/charts
 helm repo update
 helm install pulsar apache/pulsar \
     --timeout 10m \
-    --set initialize=true \
     --set [your configuration options]
 
 ```
-
-:::note
-
-For the first deployment, add `--set initialize=true` option to initialize bookie and Pulsar cluster metadata.
-
-:::
 
 You can also use the `--version <installation version>` option if you want to install a specific version of Pulsar Helm chart.
 

--- a/site2/docs/kubernetes-helm.md
+++ b/site2/docs/kubernetes-helm.md
@@ -98,17 +98,10 @@ We use [Minikube](https://minikube.sigs.k8s.io/docs/start/) in this quick start 
 
 4. Use the Pulsar Helm chart to install a Pulsar cluster to Kubernetes. 
 
-   :::note
-
-   You need to specify `--set initialize=true` when installing Pulsar the first time. This command installs and starts Apache Pulsar.
-
-   :::
-
    ```bash
    
    helm install \
        --values examples/values-minikube.yaml \
-       --set initialize=true \
        --namespace pulsar \
        pulsar-mini apache/pulsar
    


### PR DESCRIPTION
The helm option `--set initialize=true` is no longer needed.
See: https://github.com/apache/pulsar-helm-chart/pull/138

Signed-off-by: Paul Gier <paul.gier@datastax.com>

### Motivation

Minor simplification to the docs based on prior improvements to the helm charts.

### Modifications

Just removed some config from the site docs that is no longer needed.

### Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

### Documentation
  
- [ X ] `doc` 
(Your PR contains doc changes)
