### PR TITLE
Bump prometheus client version from 0.15.0 to 0.16.0

### DIFF
--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -378,18 +378,18 @@ The Apache Software License, Version 2.0
     - io.netty-netty-tcnative-classes-2.0.52.Final.jar
  * Prometheus client
     - io.prometheus.jmx-collector-0.16.1.jar
-    - io.prometheus-simpleclient-0.15.0.jar
-    - io.prometheus-simpleclient_caffeine-0.15.0.jar
-    - io.prometheus-simpleclient_common-0.15.0.jar
-    - io.prometheus-simpleclient_hotspot-0.15.0.jar
-    - io.prometheus-simpleclient_httpserver-0.15.0.jar
-    - io.prometheus-simpleclient_jetty-0.15.0.jar
-    - io.prometheus-simpleclient_log4j2-0.15.0.jar
-    - io.prometheus-simpleclient_servlet-0.15.0.jar
-    - io.prometheus-simpleclient_servlet_common-0.15.0.jar
-    - io.prometheus-simpleclient_tracer_common-0.15.0.jar
-    - io.prometheus-simpleclient_tracer_otel-0.15.0.jar
-    - io.prometheus-simpleclient_tracer_otel_agent-0.15.0.jar
+    - io.prometheus-simpleclient-0.16.0.jar
+    - io.prometheus-simpleclient_caffeine-0.16.0.jar
+    - io.prometheus-simpleclient_common-0.16.0.jar
+    - io.prometheus-simpleclient_hotspot-0.16.0.jar
+    - io.prometheus-simpleclient_httpserver-0.16.0.jar
+    - io.prometheus-simpleclient_jetty-0.16.0.jar
+    - io.prometheus-simpleclient_log4j2-0.16.0.jar
+    - io.prometheus-simpleclient_servlet-0.16.0.jar
+    - io.prometheus-simpleclient_servlet_common-0.16.0.jar
+    - io.prometheus-simpleclient_tracer_common-0.16.0.jar
+    - io.prometheus-simpleclient_tracer_otel-0.16.0.jar
+    - io.prometheus-simpleclient_tracer_otel_agent-0.16.0.jar
  * Jakarta Bean Validation API
     - jakarta.validation-jakarta.validation-api-2.0.2.jar
     - javax.validation-validation-api-1.1.0.Final.jar
@@ -513,7 +513,7 @@ The Apache Software License, Version 2.0
     - io.dropwizard.metrics-metrics-jvm-4.1.12.1.jar
     - io.dropwizard.metrics-metrics-jmx-4.1.12.1.jar
   * Prometheus
-    - io.prometheus-simpleclient_httpserver-0.15.0.jar
+    - io.prometheus-simpleclient_httpserver-0.16.0.jar
   * Java JSON WebTokens
     - io.jsonwebtoken-jjwt-api-0.11.1.jar
     - io.jsonwebtoken-jjwt-impl-0.11.1.jar

--- a/pom.xml
+++ b/pom.xml
@@ -126,7 +126,7 @@ flexible messaging model and an intuitive client API.</description>
     <conscrypt.version>2.5.2</conscrypt.version>
     <jersey.version>2.34</jersey.version>
     <athenz.version>1.10.50</athenz.version>
-    <prometheus.version>0.15.0</prometheus.version>
+    <prometheus.version>0.16.0</prometheus.version>
     <vertx.version>3.9.8</vertx.version>
     <rocksdb.version>6.29.4.1</rocksdb.version>
     <slf4j.version>1.7.32</slf4j.version>

--- a/pulsar-sql/presto-distribution/LICENSE
+++ b/pulsar-sql/presto-distribution/LICENSE
@@ -419,14 +419,14 @@ The Apache Software License, Version 2.0
     - metrics-graphite-4.1.12.1.jar
     - metrics-jvm-4.1.12.1.jar
   * Prometheus
-    - simpleclient-0.15.0.jar
-    - simpleclient_common-0.15.0.jar
-    - simpleclient_hotspot-0.15.0.jar
-    - simpleclient_servlet-0.15.0.jar
-    - simpleclient_servlet_common-0.15.0.jar
-    - simpleclient_tracer_common-0.15.0.jar
-    - simpleclient_tracer_otel-0.15.0.jar
-    - simpleclient_tracer_otel_agent-0.15.0.jar
+    - simpleclient-0.16.0.jar
+    - simpleclient_common-0.16.0.jar
+    - simpleclient_hotspot-0.16.0.jar
+    - simpleclient_servlet-0.16.0.jar
+    - simpleclient_servlet_common-0.16.0.jar
+    - simpleclient_tracer_common-0.16.0.jar
+    - simpleclient_tracer_otel-0.16.0.jar
+    - simpleclient_tracer_otel_agent-0.16.0.jar
   * JCTools
     - jctools-core-2.1.2.jar
   * Asynchronous Http Client


### PR DESCRIPTION
### Motivation
prometheus client 0.16.0 contains some approvements that we can benefit from. Thanks for @dave2wave @michaeljmarshall  the reminder and pointing out.

> [ENHANCEMENT] Reduce the number of core threads in HTTPServer from 5 to 1. The HTTPServer will still start up to 5 threads on demand if there are parallel requests, but it will use only 1 thread as long as requests are sequential (https://github.com/prometheus/client_java/pull/786).
[ENHANCEMENT] Optimize metric name sanitization: Replace the regular expression with a hard-coded optimized algorithm to improve performance (https://github.com/prometheus/client_java/pull/777). Thanks @fwbrasil

See https://github.com/prometheus/client_java/releases

### Modifications

Bump prometheus client version from 0.15.0 to 0.16.0

### Documentation

Check the box below or label this PR directly.

Need to update docs? 
  
- [x] `doc-not-needed` 
dependency updates, no need doc