### PR TITLE
[fix] PulsarLedgerManager: add missed return statement

### DIFF
--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/bookkeeper/PulsarLedgerManager.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/bookkeeper/PulsarLedgerManager.java
@@ -161,6 +161,7 @@ public class PulsarLedgerManager implements LedgerManager {
                             log.debug("No such ledger: {} at path {}", ledgerId, ledgerPath);
                         }
                         promise.completeExceptionally(new BKException.BKNoSuchLedgerExistsOnMetadataServerException());
+                        return;
                     }
 
                     Stat stat = optRes.get().getStat();


### PR DESCRIPTION
### Motivation

I observed the following error log in the bookkeeper:

> 2022-07-13T23:42:21,390+0000 [main-EventThread] ERROR org.apache.pulsar.metadata.bookkeeper.PulsarLedgerManager - Could not read metadata for ledger: 154498: java.util.NoSuchElementException: No value present

In looking closer, the error happens because there is a missing return statement after completing a promise.

The bug is cosmetic because the promise is completed with the correct error.

### Modifications

* Add a return statement after completing the promise.

### Verifying this change

No tests are needed since the effect of this bug is only a confusing log line.

### Does this pull request potentially affect one of the following parts:

This is not a breaking change.

### Documentation

- [x] `doc-not-needed` 