### PR TITLE
Avoid tracking the delays of all the message when we detect that they are fixed

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/delayed/DelayedDeliveryTracker.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/delayed/DelayedDeliveryTracker.java
@@ -55,6 +55,11 @@ public interface DelayedDeliveryTracker extends AutoCloseable {
      */
     Set<PositionImpl> getScheduledMessages(int maxMessages);
 
+    /**
+     * Tells whether the dispatcher should pause any message deliveries, until the DelayedDeliveryTracker has
+     * more messages available.
+     */
+    boolean shouldPauseAllDeliveries();
 
     /**
      *  Reset tick time use zk policies cache.

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/delayed/InMemoryDelayedDeliveryTracker.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/delayed/InMemoryDelayedDeliveryTracker.java
@@ -55,6 +55,20 @@ public class InMemoryDelayedDeliveryTracker implements DelayedDeliveryTracker, T
 
     private final boolean isDelayedDeliveryDeliverAtTimeStrict;
 
+    // If we detect that all messages have fixed delay time, such that the delivery is
+    // always going to be in FIFO order, then we can avoid pulling all the messages in
+    // tracker. Instead, we use the lookahead for detection and pause the read from
+    // the cursor if the delays are fixed.
+    public static final long DETECT_FIXED_DELAY_LOOKAHEAD_MESSAGES = 50_000;
+
+    // This is the timestamp of the message with the highest delivery time
+    // If new added messages are lower than this, it means the delivery is requested
+    // to be out-of-order. It gets reset to 0, once the tracker is emptied.
+    private long highestDeliveryTimeTracked = 0;
+
+    // Track whether we have seen all messages with fixed delay so far.
+    private boolean messagesHaveFixedDelay = true;
+
     InMemoryDelayedDeliveryTracker(PersistentDispatcherMultipleConsumers dispatcher, Timer timer, long tickTimeMillis,
                                    boolean isDelayedDeliveryDeliverAtTimeStrict) {
         this(dispatcher, timer, tickTimeMillis, Clock.systemUTC(), isDelayedDeliveryDeliverAtTimeStrict);
@@ -86,16 +100,26 @@ public class InMemoryDelayedDeliveryTracker implements DelayedDeliveryTracker, T
 
     @Override
     public boolean addMessage(long ledgerId, long entryId, long deliverAt) {
+        if (deliverAt < 0 || deliverAt <= getCutoffTime()) {
+            messagesHaveFixedDelay = false;
+            return false;
+        }
+
         if (log.isDebugEnabled()) {
             log.debug("[{}] Add message {}:{} -- Delivery in {} ms ", dispatcher.getName(), ledgerId, entryId,
                     deliverAt - clock.millis());
         }
-        if (deliverAt <= getCutoffTime()) {
-            return false;
-        }
+
 
         priorityQueue.add(deliverAt, ledgerId, entryId);
         updateTimer();
+
+        if (deliverAt < highestDeliveryTimeTracked) {
+            messagesHaveFixedDelay = false;
+        }
+
+        highestDeliveryTimeTracked = Math.max(highestDeliveryTimeTracked, deliverAt);
+
         return true;
     }
 
@@ -137,6 +161,13 @@ public class InMemoryDelayedDeliveryTracker implements DelayedDeliveryTracker, T
         if (log.isDebugEnabled()) {
             log.debug("[{}] Get scheduled messages - found {}", dispatcher.getName(), positions.size());
         }
+
+        if (priorityQueue.isEmpty()) {
+            // Reset to initial state
+            highestDeliveryTimeTracked = 0;
+            messagesHaveFixedDelay = true;
+        }
+
         updateTimer();
         return positions;
     }
@@ -240,5 +271,13 @@ public class InMemoryDelayedDeliveryTracker implements DelayedDeliveryTracker, T
         if (timeout != null) {
             timeout.cancel();
         }
+    }
+
+    @Override
+    public boolean shouldPauseAllDeliveries() {
+        // Pause deliveries if we know all delays are fixed within the lookahead window
+        return messagesHaveFixedDelay
+                && priorityQueue.size() >= DETECT_FIXED_DELAY_LOOKAHEAD_MESSAGES
+                && !hasMessageAvailable();
     }
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/delayed/InMemoryDelayedDeliveryTracker.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/delayed/InMemoryDelayedDeliveryTracker.java
@@ -114,7 +114,9 @@ public class InMemoryDelayedDeliveryTracker implements DelayedDeliveryTracker, T
         priorityQueue.add(deliverAt, ledgerId, entryId);
         updateTimer();
 
-        if (deliverAt < highestDeliveryTimeTracked) {
+        // Check that new delivery time comes after the current highest, or at
+        // least within a single tick time interval of 1 second.
+        if (deliverAt < (highestDeliveryTimeTracked - tickTimeMillis)) {
             messagesHaveFixedDelay = false;
         }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractBaseDispatcher.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractBaseDispatcher.java
@@ -177,8 +177,7 @@ public abstract class AbstractBaseDispatcher implements Dispatcher {
                 entry.release();
                 individualAcknowledgeMessageIfNeeded(pos, Collections.emptyMap());
                 continue;
-            } else if (msgMetadata.hasDeliverAtTime()
-                    && trackDelayedDelivery(entry.getLedgerId(), entry.getEntryId(), msgMetadata)) {
+            } else if (trackDelayedDelivery(entry.getLedgerId(), entry.getEntryId(), msgMetadata)) {
                 // The message is marked for delayed delivery. Ignore for now.
                 entries.set(i, null);
                 entry.release();


### PR DESCRIPTION
### Motivation

If all the messages in a topic have the same fixed delay, then there is no reason to track the entire set of messages in the priority queue, since the messages will have to be delivered in FIFO order. 

If we identify that this is the case, we need to switch into a different mode, where we pause the scanning of the topic and instead we just rely on the timer task from the delay-tracker which will get triggered for the 1st message to be delivered.


- [x] `doc-not-needed`
