### PR TITLE
Rename Pulsar schema metrics to specify OpenMetrics

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/SchemaRegistryStats.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/SchemaRegistryStats.java
@@ -59,16 +59,16 @@ class SchemaRegistryStats implements AutoCloseable, Runnable {
     }
 
     private SchemaRegistryStats(ScheduledExecutorService scheduler) {
-        this.deleteOpsFailedCounter = Counter.build("pulsar_schema_del_ops_failed_count", "-")
+        this.deleteOpsFailedCounter = Counter.build("pulsar_schema_del_ops_failed_total", "-")
                 .labelNames(NAMESPACE).create().register();
-        this.getOpsFailedCounter = Counter.build("pulsar_schema_get_ops_failed_count", "-")
+        this.getOpsFailedCounter = Counter.build("pulsar_schema_get_ops_failed_total", "-")
                 .labelNames(NAMESPACE).create().register();
-        this.putOpsFailedCounter = Counter.build("pulsar_schema_put_ops_failed_count", "-")
+        this.putOpsFailedCounter = Counter.build("pulsar_schema_put_ops_failed_total", "-")
                 .labelNames(NAMESPACE).create().register();
 
-        this.compatibleCounter = Counter.build("pulsar_schema_compatible_count", "-")
+        this.compatibleCounter = Counter.build("pulsar_schema_compatible_total", "-")
                 .labelNames(NAMESPACE).create().register();
-        this.incompatibleCounter = Counter.build("pulsar_schema_incompatible_count", "-")
+        this.incompatibleCounter = Counter.build("pulsar_schema_incompatible_total", "-")
                 .labelNames(NAMESPACE).create().register();
 
         this.deleteOpsLatency = this.buildSummary("pulsar_schema_del_ops_latency", "-");

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/schema/SchemaServiceTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/schema/SchemaServiceTest.java
@@ -116,11 +116,11 @@ public class SchemaServiceTest extends MockedPulsarServiceBaseTest {
         String metricsStr = output.toString(StandardCharsets.UTF_8);
         Multimap<String, PrometheusMetricsTest.Metric> metrics = PrometheusMetricsTest.parseMetrics(metricsStr);
 
-        Collection<PrometheusMetricsTest.Metric> delMetrics = metrics.get("pulsar_schema_del_ops_failed_count");
+        Collection<PrometheusMetricsTest.Metric> delMetrics = metrics.get("pulsar_schema_del_ops_failed_total");
         Assert.assertEquals(delMetrics.size(), 0);
-        Collection<PrometheusMetricsTest.Metric> getMetrics = metrics.get("pulsar_schema_get_ops_failed_count");
+        Collection<PrometheusMetricsTest.Metric> getMetrics = metrics.get("pulsar_schema_get_ops_failed_total");
         Assert.assertEquals(getMetrics.size(), 0);
-        Collection<PrometheusMetricsTest.Metric> putMetrics = metrics.get("pulsar_schema_put_ops_failed_count");
+        Collection<PrometheusMetricsTest.Metric> putMetrics = metrics.get("pulsar_schema_put_ops_failed_total");
         Assert.assertEquals(putMetrics.size(), 0);
 
         Collection<PrometheusMetricsTest.Metric> deleteLatency = metrics.get("pulsar_schema_del_ops_latency_count");

--- a/site2/docs/reference-metrics.md
+++ b/site2/docs/reference-metrics.md
@@ -533,16 +533,16 @@ All the schema metrics are labelled with the following labels:
 
 - *cluster*: `cluster=${pulsar_cluster}`. `${pulsar_cluster}` is the cluster name that you have configured in the `broker.conf` file.
 
-| Name | Type | Description |
-|---|---|---|
-| pulsar_schema_del_ops_failed_count | Counter | Number of failed operations to delete schemas. |
-| pulsar_schema_get_ops_failed_count | Counter | Number of failed operations to get schemas. |
-| pulsar_schema_put_ops_failed_count | Counter | Number of failed operations to send schemas. |
-| pulsar_schema_compatible_count | Counter | Number of compatible schemas. |
-| pulsar_schema_incompatible_count | Counter | Number of incompatible schemas. |
-| pulsar_schema_del_ops_latency | Summary | Latency of successful operations to delete schemas. |
-| pulsar_schema_get_ops_latency | Summary | Latency of successful operations to get schemas. |
-| pulsar_schema_put_ops_latency | Summary | Latency of successful operations to send schemas. |
+| Name                               | Type    | Description                                         |
+|------------------------------------|---------|-----------------------------------------------------|
+| pulsar_schema_del_ops_failed_total | Counter | Number of failed operations to delete schemas.      |
+| pulsar_schema_get_ops_failed_total | Counter | Number of failed operations to get schemas.         |
+| pulsar_schema_put_ops_failed_total | Counter | Number of failed operations to send schemas.        |
+| pulsar_schema_compatible_total     | Counter | Number of compatible schemas.                       |
+| pulsar_schema_incompatible_total   | Counter | Number of incompatible schemas.                     |
+| pulsar_schema_del_ops_latency      | Summary | Latency of successful operations to delete schemas. |
+| pulsar_schema_get_ops_latency      | Summary | Latency of successful operations to get schemas.    |
+| pulsar_schema_put_ops_latency      | Summary | Latency of successful operations to send schemas.   |
 
 ### Offload metrics
 


### PR DESCRIPTION
### Motivation
See https://github.com/OpenObservability/OpenMetrics/blob/main/specification/OpenMetrics.md
A COUNTER needs `metrics_name_total` or `metrics_name_created`

This PR contains metric name broken changes.

### Modifications
Rename counter's `_count` to `_total`

### metrics name broken changes
- rename `pulsar_schema_del_ops_failed_count` to `pulsar_schema_del_ops_failed_total`
- rename `pulsar_schema_get_ops_failed_count` to `pulsar_schema_get_ops_failed_total`
- rename `pulsar_schema_put_ops_failed_count` to `pulsar_schema_put_ops_failed_total`
- rename `pulsar_schema_compatible_count ` to `pulsar_schema_compatible_total`
- rename `pulsar_schema_incompatible_count ` to `pulsar_schema_incompatible_total`

### Documentation
  
- [X] `doc` 
As mentioned above, the metrics name has changed