### PR TITLE
Rename Pulsar lb metrics to specify OpenMetrics

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/ModularLoadManagerImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/ModularLoadManagerImpl.java
@@ -689,8 +689,8 @@ public class ModularLoadManagerImpl implements ModularLoadManager {
         dimensions.put("metric", "bundleUnloading");
 
         Metrics m = Metrics.create(dimensions);
-        m.put("brk_lb_unload_broker_count", unloadBrokerCount);
-        m.put("brk_lb_unload_bundle_count", unloadBundleCount);
+        m.put("brk_lb_unload_broker_total", unloadBrokerCount);
+        m.put("brk_lb_unload_bundle_total", unloadBundleCount);
         metrics.add(m);
         this.bundleUnloadMetrics.set(metrics);
     }
@@ -781,7 +781,7 @@ public class ModularLoadManagerImpl implements ModularLoadManager {
         dimensions.put("metric", "bundlesSplit");
 
         Metrics m = Metrics.create(dimensions);
-        m.put("brk_lb_bundles_split_count", bundleSplitCount);
+        m.put("brk_lb_bundles_split_total", bundleSplitCount);
         metrics.add(m);
         this.bundleSplitMetrics.set(metrics);
     }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/PrometheusMetricsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/PrometheusMetricsTest.java
@@ -490,7 +490,7 @@ public class PrometheusMetricsTest extends BrokerTestBase {
         assertTrue(metrics.containsKey("pulsar_lb_bandwidth_in_usage"));
         assertTrue(metrics.containsKey("pulsar_lb_bandwidth_out_usage"));
 
-        assertTrue(metrics.containsKey("pulsar_lb_bundles_split_count"));
+        assertTrue(metrics.containsKey("pulsar_lb_bundles_split_total"));
     }
 
     @Test

--- a/site2/docs/reference-metrics.md
+++ b/site2/docs/reference-metrics.md
@@ -381,19 +381,19 @@ All the bundleUnloading metrics are labelled with the following labels:
 - cluster: cluster=${pulsar_cluster}. ${pulsar_cluster} is the cluster name that you have configured in the `broker.conf` file.
 - metric: metric="bundleUnloading".
 
-| Name | Type | Description |
-| --- | --- | --- |
-| pulsar_lb_unload_broker_count | Counter | Unload broker count in this bundle unloading |
-| pulsar_lb_unload_bundle_count | Counter | Bundle unload count in this bundle unloading |
+| Name                          | Type    | Description                                  |
+|-------------------------------|---------|----------------------------------------------|
+| pulsar_lb_unload_broker_total | Counter | Unload broker count in this bundle unloading |
+| pulsar_lb_unload_bundle_total | Counter | Bundle unload count in this bundle unloading |
 
 #### BundleSplit metrics
 All the bundleUnloading metrics are labelled with the following labels:
 - cluster: cluster=${pulsar_cluster}. ${pulsar_cluster} is the cluster name that you have configured in the `broker.conf` file.
 - metric: metric="bundlesSplit".
 
-| Name | Type | Description |
-| --- | --- | --- |
-| pulsar_lb_bundles_split_count | Counter | bundle split count in this bundle splitting check interval |
+| Name                          | Type    | Description                                                |
+|-------------------------------|---------|------------------------------------------------------------|
+| pulsar_lb_bundles_split_total | Counter | bundle split count in this bundle splitting check interval |
 
 #### Bundle metrics
 All the bundle metrics are labelled with the following labels:


### PR DESCRIPTION
### Motivation
See https://github.com/OpenObservability/OpenMetrics/blob/main/specification/OpenMetrics.md
A COUNTER needs `metrics_name_total` or `metrics_name_created`

This PR contains metric name broken changes.

### Modifications
Rename counter's `_count` to `_total`

### metrics name broken changes
- rename `pulsar_lb_unload_broker_count` to `pulsar_lb_unload_broker_total`
- rename `pulsar_lb_unload_bundle_count` to `pulsar_lb_unload_bundle_total`
- rename `pulsar_lb_bundles_split_count` to `pulsar_lb_bundles_split_total`

### Documentation
  
- [X] `doc` 
As mentioned above, the metrics name has changed