### PR TITLE
Skip creating a subscription replication snapshot if no messages have been published after the topic gets activated on a broker

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/ReplicatedSubscriptionsController.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/ReplicatedSubscriptionsController.java
@@ -202,7 +202,8 @@ public class ReplicatedSubscriptionsController implements AutoCloseable, Topic.P
     private void startNewSnapshot() {
         cleanupTimedOutSnapshots();
 
-        if (topic.getLastDataMessagePublishedTimestamp() < lastCompletedSnapshotStartTime) {
+        if (topic.getLastDataMessagePublishedTimestamp() < lastCompletedSnapshotStartTime
+                || topic.getLastDataMessagePublishedTimestamp() == 0) {
             // There was no message written since the last snapshot, we can skip creating a new snapshot
             if (log.isDebugEnabled()) {
                 log.debug("[{}] There is no new data in topic. Skipping snapshot creation.", topic.getName());


### PR DESCRIPTION
### Motivation

There's a bug in replicated subscriptions snapshotting. Snapshots get continuously created after a topic gets activated and before new messages are published. This is a gap in the logic introduced in #11922.

### Additional context

The intention of the #10292 and #11922 changes were to pause replication snapshots when there are no new messages.
These changes were made to address #6437 and as an alternative to #7299 changes.

### Modifications

- Add condition to skip creating snapshots when the lastDataMessagePublishedTimestamp is 0.
- Modify existing test case `testReplicationSnapshotStopWhenNoTraffic` to verify that snapshots aren't published before messages have been published.
- [x] `doc-not-needed`
