### PR TITLE
rename pulsar env variables for pulsar tools

### DIFF
--- a/conf/pulsar_tools_env.sh
+++ b/conf/pulsar_tools_env.sh
@@ -42,10 +42,10 @@
 # PULSAR_GLOBAL_ZK_CONF=
 
 # Extra options to be passed to the jvm
-PULSAR_TOOL_MEM=${PULSAR_MEM:-"-Xmx128m -XX:MaxDirectMemorySize=128m"}
+PULSAR_TOOL_MEM=${PULSAR_TOOL_MEM:-"-Xmx128m -XX:MaxDirectMemorySize=128m"}
 
 # Garbage collection options
-PULSAR_TOOL_GC=${PULSAR_GC:-" -client "}
+PULSAR_TOOL_GC=${PULSAR_TOOL_GC:-" -client "}
 
 # Extra options to be passed to the jvm
 PULSAR_EXTRA_OPTS="${PULSAR_TOOL_MEM} ${PULSAR_TOOL_GC} ${PULSAR_GC_LOG} -Dio.netty.leakDetectionLevel=disabled ${PULSAR_EXTRA_OPTS}"

--- a/conf/pulsar_tools_env.sh
+++ b/conf/pulsar_tools_env.sh
@@ -42,13 +42,13 @@
 # PULSAR_GLOBAL_ZK_CONF=
 
 # Extra options to be passed to the jvm
-PULSAR_MEM=${PULSAR_MEM:-"-Xmx128m -XX:MaxDirectMemorySize=128m"}
+PULSAR_TOOL_MEM=${PULSAR_MEM:-"-Xmx128m -XX:MaxDirectMemorySize=128m"}
 
 # Garbage collection options
-PULSAR_GC=${PULSAR_GC:-" -client "}
+PULSAR_TOOL_GC=${PULSAR_GC:-" -client "}
 
 # Extra options to be passed to the jvm
-PULSAR_EXTRA_OPTS="${PULSAR_MEM} ${PULSAR_GC} ${PULSAR_GC_LOG} -Dio.netty.leakDetectionLevel=disabled ${PULSAR_EXTRA_OPTS}"
+PULSAR_EXTRA_OPTS="${PULSAR_TOOL_MEM} ${PULSAR_TOOL_GC} ${PULSAR_GC_LOG} -Dio.netty.leakDetectionLevel=disabled ${PULSAR_EXTRA_OPTS}"
 
 # Add extra paths to the bookkeeper classpath
 # PULSAR_EXTRA_CLASSPATH=


### PR DESCRIPTION
### Motivation

As #4105, we could config pulsar in container environments through environment variables.
Current, both broker and pulsar tools (admin, client, perf) use `PULSAR_MEM` to config jvm memory.
Consider we create a pod for broker through kubernetes, we set `containers.resources.limits.memory` to 25Gi, set env `PULSAR_MEM` to `-Xms10g -Xmx10g -XX:MaxDirectMemorySize=10g`, broker will start with this jvm memory config.
When we run pulsar-admin or pulsar-client in this pod, they will start with broker's jvm memory config since `PULSAR_MEM` was already set, that will cause pod's total memory exceed the limit.

### Modifications
Rename `PULSAR_MEM` to `PULSAR_TOOL_MEM` for pulsar tools, we could set `PULSAR_TOOL_MEM` through environment variables for pulsar tools, or just use the default jvm memory setting.

### Verifying this change

This change is a trivial rework

### Documentation
  
- [x] `doc-not-needed` 