### PR TITLE
[branch-2.9] Fix `MockStatic` method caused the  exception

### DIFF
--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedCursorTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedCursorTest.java
@@ -97,17 +97,27 @@ import org.apache.pulsar.metadata.api.MetadataStoreException;
 import org.apache.pulsar.metadata.api.Stat;
 import org.apache.pulsar.common.api.proto.IntRange;
 import org.awaitility.Awaitility;
-import org.mockito.MockedStatic;
-import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.Assert;
+import org.testng.IObjectFactory;
 import org.testng.annotations.DataProvider;
+import org.testng.annotations.ObjectFactory;
 import org.testng.annotations.Test;
 
+@PrepareForTest({
+        OpReadEntry.class
+})
 public class ManagedCursorTest extends MockedBookKeeperTestCase {
+
+    @ObjectFactory
+    public IObjectFactory getObjectFactory() {
+        return new org.powermock.modules.testng.PowerMockObjectFactory();
+    }
 
     private static final Charset Encoding = Charsets.UTF_8;
 
@@ -3769,8 +3779,8 @@ public class ManagedCursorTest extends MockedBookKeeperTestCase {
             return mockedOpReadEntry;
         };
 
-        @Cleanup final MockedStatic<OpReadEntry> mockedStaticOpReadEntry = Mockito.mockStatic(OpReadEntry.class);
-        mockedStaticOpReadEntry.when(() -> OpReadEntry.create(any(), any(), anyInt(), any(), any(), any()))
+        PowerMockito.mockStatic(OpReadEntry.class);
+        PowerMockito.when(OpReadEntry.create(any(), any(), anyInt(), any(), any(), any()))
                 .thenAnswer(__ -> createOpReadEntry.get());
 
         final ManagedLedgerConfig ledgerConfig = new ManagedLedgerConfig();

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedCursorTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedCursorTest.java
@@ -100,6 +100,7 @@ import org.awaitility.Awaitility;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -112,6 +113,7 @@ import org.testng.annotations.Test;
 @PrepareForTest({
         OpReadEntry.class
 })
+@PowerMockIgnore({"org.apache.logging.log4j.*"})
 public class ManagedCursorTest extends MockedBookKeeperTestCase {
 
     @ObjectFactory


### PR DESCRIPTION
### Motivation

Fix `MockStatic` method caused the exception.

```
The used MockMaker PowerMockMaker does not support the creation of static mocks
[3197](https://github.com/apache/pulsar/runs/7358126340?check_suite_focus=true#step:8:3198)
[3198](https://github.com/apache/pulsar/runs/7358126340?check_suite_focus=true#step:8:3199)
Mockito's inline mock maker supports static mocks based on the Instrumentation API.
[3199](https://github.com/apache/pulsar/runs/7358126340?check_suite_focus=true#step:8:3200)
You can simply enable this mock mode, by placing the 'mockito-inline' artifact where you are currently using 'mockito-core'.
[3200](https://github.com/apache/pulsar/runs/7358126340?check_suite_focus=true#step:8:3201)
Note that Mockito's inline mock maker is not supported on Android.
[3201](https://github.com/apache/pulsar/runs/7358126340?check_suite_focus=true#step:8:3202)
	at org.apache.bookkeeper.mledger.impl.ManagedCursorTest.testOpReadEntryRecycle(ManagedCursorTest.java:3772)
[3202](https://github.com/apache/pulsar/runs/7358126340?check_suite_focus=true#step:8:3203)
	at org.testng.internal.MethodInvocationHelper.invokeMethod(MethodInvocationHelper.java:132)
[3203](https://github.com/apache/pulsar/runs/7358126340?check_suite_focus=true#step:8:3204)
	at org.testng.internal.InvokeMethodRunnable.runOne(InvokeMethodRunnable.java:45)
[3204](https://github.com/apache/pulsar/runs/7358126340?check_suite_focus=true#step:8:3205)
	at org.testng.internal.InvokeMethodRunnable.call(InvokeMethodRunnable.java:73)
[3205](https://github.com/apache/pulsar/runs/7358126340?check_suite_focus=true#step:8:3206)
	at org.testng.internal.InvokeMethodRunnable.call(InvokeMethodRunnable.java:11)
[3206](https://github.com/apache/pulsar/runs/7358126340?check_suite_focus=true#step:8:3207)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
[3207](https://github.com/apache/pulsar/runs/7358126340?check_suite_focus=true#step:8:3208)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
[3208](https://github.com/apache/pulsar/runs/7358126340?check_suite_focus=true#step:8:3209)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
[3209](https://github.com/apache/pulsar/runs/7358126340?check_suite_focus=true#step:8:3210)
	at java.base/java.lang.Thread.run(Thread.java:829)
```

### Modification

- Use `PowerMockito` to support it.