### PR TITLE
[improve] Generate directory for distribution 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ test-results
 dependency-reduced-pom.xml
 logs
 /data
+build-target
 pulsar-broker/data/
 pulsar-broker/tmp.*
 pulsar-broker/src/test/resources/log4j2.yaml

--- a/distribution/offloaders/src/assemble/offloaders.xml
+++ b/distribution/offloaders/src/assemble/offloaders.xml
@@ -24,6 +24,7 @@
   <id>bin</id>
   <formats>
     <format>tar.gz</format>
+    <format>dir</format>
   </formats>
   <includeBaseDirectory>true</includeBaseDirectory>
   <files>

--- a/distribution/server/pom.xml
+++ b/distribution/server/pom.xml
@@ -378,5 +378,54 @@
         </dependency>
       </dependencies>
     </profile>
+    <profile>
+      <!-- Creates/Removes the 'build-target' symlink in the root directory (only Unix systems) -->
+      <id>symlink-build-target</id>
+      <activation>
+        <os>
+          <family>unix</family>
+        </os>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>exec-maven-plugin</artifactId>
+            <version>1.5.0</version>
+            <executions>
+              <execution>
+                <id>remove-build-target-link</id>
+                <phase>clean</phase>
+                <goals>
+                  <goal>exec</goal>
+                </goals>
+                <configuration>
+                  <executable>rm</executable>
+                  <arguments>
+                    <argument>-f</argument>
+                    <argument>${project.basedir}/../../build-target</argument>
+                  </arguments>
+                </configuration>
+              </execution>
+              <execution>
+                <id>create-build-target-link</id>
+                <phase>package</phase>
+                <goals>
+                  <goal>exec</goal>
+                </goals>
+                <configuration>
+                  <executable>ln</executable>
+                  <arguments>
+                    <argument>-sfn</argument>
+                    <argument>${project.basedir}/target/apache-pulsar-${project.version}-bin/apache-pulsar-${project.version}</argument>
+                    <argument>${project.basedir}/../../build-target</argument>
+                  </arguments>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
   </profiles>
 </project>

--- a/distribution/server/src/assemble/bin.xml
+++ b/distribution/server/src/assemble/bin.xml
@@ -24,6 +24,7 @@
   <id>bin</id>
   <formats>
     <format>tar.gz</format>
+    <format>dir</format>
   </formats>
   <includeBaseDirectory>true</includeBaseDirectory>
   <moduleSets>


### PR DESCRIPTION
### Motivation

When a developer wants to debug on the pulsar distribution on their branch, It's cumbersome to developers to extract the distribution for the tarball every time. Also, `distribution/server/target` is a deep level directory to work with.

This patch follows Flink's practice to add a `build-target` symbol link to the distribution directory, as well as firstly generate directory for Pulsar distribution - we currently generate only tarballs.

### Modifications

As described above.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

Please verify this change locally.

### Does this pull request potentially affect one of the following parts:

No.

### Documentation
  
- [x] `doc-not-needed` 

We don't need user doc for this change, but it would be better to write some dev doc later.