### PR TITLE
Set notifications section with correct level

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -20,12 +20,6 @@
 github:
   description: "Apache Pulsar - distributed pub-sub messaging system"
   homepage: https://pulsar.apache.org/
-  notifications:
-    commits:      commits@pulsar.apache.org
-    issues:       commits@pulsar.apache.org
-    pullrequests: commits@pulsar.apache.org
-    discussions:  dev@pulsar.apache.org
-    jira_options: link label
   labels:
     - pulsar
     - pubsub
@@ -115,3 +109,10 @@ github:
     branch-2.8: {}
     branch-2.9: {}
     branch-2.10: {}
+
+notifications:
+  commits:      commits@pulsar.apache.org
+  issues:       commits@pulsar.apache.org
+  pullrequests: commits@pulsar.apache.org
+  discussions:  dev@pulsar.apache.org
+  jira_options: link label


### PR DESCRIPTION
I notice that GitHub Discussions activities aren't redirected to the mailing list and it's because the yaml section in a wrong indent level.

See also https://cwiki.apache.org/confluence/display/INFRA/Git+-+.asf.yaml+features#Git.asf.yamlfeatures-Notificationsettingsforrepositories.

- [x] `doc-not-needed` 
