### PR TITLE
[improve] Always generate package-info.class file

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1413,6 +1413,7 @@ flexible messaging model and an intuitive client API.</description>
             <arg>-Xlint:-serial</arg>
             <arg>-Xlint:-classfile</arg>
             <arg>-Xlint:-processing</arg>
+            <arg>-Xpkginfo:always</arg>
           </compilerArgs>
         </configuration>
       </plugin>


### PR DESCRIPTION
This suppresses the annoying waring about package-info.class file not found.

Reference:

* https://bugs.java.com/bugdatabase/view_bug.do?bug_id=6960424
* https://github.com/checkstyle/checkstyle/pull/11663

- [x] `doc-not-needed` 