### PR TITLE
[improve][dep] Bump protoc version to 3.21.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -140,7 +140,7 @@ flexible messaging model and an intuitive client API.</description>
     <puppycrawl.checkstyle.version>8.37</puppycrawl.checkstyle.version>
     <dockerfile-maven.version>1.4.13</dockerfile-maven.version>
     <typetools.version>0.5.0</typetools.version>
-    <protobuf3.version>3.19.2</protobuf3.version>
+    <protobuf3.version>3.21.2</protobuf3.version>
     <protoc3.version>${protobuf3.version}</protoc3.version>
     <grpc.version>1.45.1</grpc.version>
     <google-http-client.version>1.41.0</google-http-client.version>


### PR DESCRIPTION
protoc 3.19.2 dists osx-aarch_64 binary as an alias to the osx-x86_64 one.

This cause the following exception on Apple M1 chip 2021:

```
[ERROR] Failed to execute goal org.xolstice.maven.plugins:protobuf-maven-plugin:0.6.1:compile (default) on project managed-ledger: An error occurred while invoking protoc: Error while executing process.: Cannot run program "/Users/chenzili/Workspace/pulsar/managed-ledger/target/protoc-plugins/protoc-3.19.2-osx-aarch_64.exe": error=86, Bad CPU type in executable -> [Help 1]
```

Bumping the version to 3.21.2 resolves the issue.

Signed-off-by: tison <wander4096@gmail.com>

Fixes #16639 

### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (yes)

### Documentation

- [x] `doc-not-needed` 

Internal change.