### PR TITLE
[cleanup][client] Reduce repetition in admin client

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiTest.java
@@ -57,7 +57,6 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
-import javax.ws.rs.client.InvocationCallback;
 import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.core.Response.Status;
 import lombok.Builder;
@@ -82,6 +81,7 @@ import org.apache.pulsar.client.admin.PulsarAdminException.ConflictException;
 import org.apache.pulsar.client.admin.PulsarAdminException.NotAuthorizedException;
 import org.apache.pulsar.client.admin.PulsarAdminException.NotFoundException;
 import org.apache.pulsar.client.admin.PulsarAdminException.PreconditionFailedException;
+import org.apache.pulsar.client.admin.internal.BaseResource.UnaryGetCallback;
 import org.apache.pulsar.client.admin.internal.LookupImpl;
 import org.apache.pulsar.client.admin.internal.TenantsImpl;
 import org.apache.pulsar.client.admin.internal.TopicsImpl;
@@ -2820,36 +2820,14 @@ public class AdminApiTest extends MockedPulsarServiceBaseTest {
         WebTarget persistentTopics = (WebTarget) field.get(persistent);
 
         // (1) Get PartitionedMetadata : with Url and Uri encoding
-        final CompletableFuture<PartitionedTopicMetadata> urlEncodedPartitionedMetadata = new CompletableFuture<>();
         // (a) Url encoding
-        persistent.asyncGetRequest(
-                persistentTopics.path("persistent").path(ns1).path(urlEncodedTopic).path("partitions"),
-                new InvocationCallback<PartitionedTopicMetadata>() {
-                    @Override
-                    public void completed(PartitionedTopicMetadata response) {
-                        urlEncodedPartitionedMetadata.complete(response);
-                    }
-
-                    @Override
-                    public void failed(Throwable e) {
-                        urlEncodedPartitionedMetadata.completeExceptionally(e);
-                    }
-                });
-        final CompletableFuture<PartitionedTopicMetadata> uriEncodedPartitionedMetadata = new CompletableFuture<>();
+        final CompletableFuture<PartitionedTopicMetadata> urlEncodedPartitionedMetadata = persistent
+                .asyncGetRequest(persistentTopics.path("persistent").path(ns1).path(urlEncodedTopic).path("partitions"),
+                        new UnaryGetCallback<>() {});
         // (b) Uri encoding
-        persistent.asyncGetRequest(
-                persistentTopics.path("persistent").path(ns1).path(uriEncodedTopic).path("partitions"),
-                new InvocationCallback<PartitionedTopicMetadata>() {
-                    @Override
-                    public void completed(PartitionedTopicMetadata response) {
-                        uriEncodedPartitionedMetadata.complete(response);
-                    }
-
-                    @Override
-                    public void failed(Throwable e) {
-                        uriEncodedPartitionedMetadata.completeExceptionally(e);
-                    }
-                });
+        final CompletableFuture<PartitionedTopicMetadata> uriEncodedPartitionedMetadata = persistent
+                .asyncGetRequest(persistentTopics.path("persistent").path(ns1).path(uriEncodedTopic).path("partitions"),
+                        new UnaryGetCallback<>() {});
         assertEquals(urlEncodedPartitionedMetadata.get().partitions, numOfPartitions);
         assertEquals(urlEncodedPartitionedMetadata.get().partitions, (uriEncodedPartitionedMetadata.get().partitions));
 
@@ -2874,35 +2852,14 @@ public class AdminApiTest extends MockedPulsarServiceBaseTest {
         assertEquals(numOfPartitions, lookupDataList.keySet().size());
 
         // (3) Get Topic Stats
-        final CompletableFuture<TopicStats> urlStats = new CompletableFuture<>();
         // (a) Url encoding
-        persistent.asyncGetRequest(persistentTopics.path("persistent").path(ns1).path(urlEncodedTopic + "-partition-1").path("stats"),
-                new InvocationCallback<TopicStats>() {
-                    @Override
-                    public void completed(TopicStats response) {
-                        urlStats.complete(response);
-                    }
-
-                    @Override
-                    public void failed(Throwable e) {
-                        urlStats.completeExceptionally(e);
-                    }
-                });
+        final CompletableFuture<TopicStats> urlStats = persistent
+                .asyncGetRequest(persistentTopics.path("persistent").path(ns1).path(urlEncodedTopic + "-partition-1").path("stats"),
+                        new UnaryGetCallback<>() {});
         // (b) Uri encoding
-        final CompletableFuture<TopicStats> uriStats = new CompletableFuture<>();
-        persistent.asyncGetRequest(
-                persistentTopics.path("persistent").path(ns1).path(uriEncodedTopic + "-partition-1").path("stats"),
-                new InvocationCallback<TopicStats>() {
-                    @Override
-                    public void completed(TopicStats response) {
-                        uriStats.complete(response);
-                    }
-
-                    @Override
-                    public void failed(Throwable e) {
-                        uriStats.completeExceptionally(e);
-                    }
-                });
+        final CompletableFuture<TopicStats> uriStats = persistent
+                .asyncGetRequest(persistentTopics.path("persistent").path(ns1).path(uriEncodedTopic + "-partition-1").path("stats"),
+                        new UnaryGetCallback<>() {});
         assertEquals(urlStats.get().getSubscriptions().size(), 1);
         assertEquals(uriStats.get().getSubscriptions().size(), 1);
     }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/v1/V1_AdminApiTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/v1/V1_AdminApiTest.java
@@ -47,7 +47,6 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
-import javax.ws.rs.client.InvocationCallback;
 import javax.ws.rs.client.WebTarget;
 import lombok.Builder;
 import lombok.Cleanup;
@@ -65,6 +64,7 @@ import org.apache.pulsar.client.admin.PulsarAdminException.ConflictException;
 import org.apache.pulsar.client.admin.PulsarAdminException.NotAuthorizedException;
 import org.apache.pulsar.client.admin.PulsarAdminException.NotFoundException;
 import org.apache.pulsar.client.admin.PulsarAdminException.PreconditionFailedException;
+import org.apache.pulsar.client.admin.internal.BaseResource.UnaryGetCallback;
 import org.apache.pulsar.client.admin.internal.LookupImpl;
 import org.apache.pulsar.client.admin.internal.TenantsImpl;
 import org.apache.pulsar.client.admin.internal.TopicsImpl;
@@ -1875,34 +1875,14 @@ public class V1_AdminApiTest extends MockedPulsarServiceBaseTest {
         WebTarget persistentTopics = ((WebTarget) field.get(persistent)).path("persistent");
 
         // (1) Get PartitionedMetadata : with Url and Uri encoding
-        final CompletableFuture<PartitionedTopicMetadata> urlEncodedPartitionedMetadata = new CompletableFuture<>();
         // (a) Url encoding
-        persistent.asyncGetRequest(persistentTopics.path(ns1).path(urlEncodedTopic).path("partitions"),
-                new InvocationCallback<PartitionedTopicMetadata>() {
-                    @Override
-                    public void completed(PartitionedTopicMetadata response) {
-                        urlEncodedPartitionedMetadata.complete(response);
-                    }
-
-                    @Override
-                    public void failed(Throwable e) {
-                        urlEncodedPartitionedMetadata.completeExceptionally(e);
-                    }
-                });
-        final CompletableFuture<PartitionedTopicMetadata> uriEncodedPartitionedMetadata = new CompletableFuture<>();
+        final CompletableFuture<PartitionedTopicMetadata> urlEncodedPartitionedMetadata = persistent
+                .asyncGetRequest(persistentTopics.path(ns1).path(urlEncodedTopic).path("partitions"),
+                        new UnaryGetCallback<>() {});
         // (b) Uri encoding
-        persistent.asyncGetRequest(persistentTopics.path(ns1).path(uriEncodedTopic).path("partitions"),
-                new InvocationCallback<PartitionedTopicMetadata>() {
-                    @Override
-                    public void completed(PartitionedTopicMetadata response) {
-                        uriEncodedPartitionedMetadata.complete(response);
-                    }
-
-                    @Override
-                    public void failed(Throwable e) {
-                        uriEncodedPartitionedMetadata.completeExceptionally(e);
-                    }
-                });
+        final CompletableFuture<PartitionedTopicMetadata> uriEncodedPartitionedMetadata = persistent
+                .asyncGetRequest(persistentTopics.path(ns1).path(uriEncodedTopic).path("partitions"),
+                        new UnaryGetCallback<>() {});
         assertEquals(urlEncodedPartitionedMetadata.get().partitions, numOfPartitions);
         assertEquals(urlEncodedPartitionedMetadata.get().partitions, (uriEncodedPartitionedMetadata.get().partitions));
 
@@ -1923,34 +1903,14 @@ public class V1_AdminApiTest extends MockedPulsarServiceBaseTest {
         assertEquals(urlEncodedLookupData.getBrokerUrl(), uriEncodedLookupData.getBrokerUrl());
 
         // (3) Get Topic Stats
-        final CompletableFuture<TopicStats> urlStats = new CompletableFuture<>();
         // (a) Url encoding
-        persistent.asyncGetRequest(persistentTopics.path(ns1).path(urlEncodedTopic + "-partition-1").path("stats"),
-                new InvocationCallback<TopicStats>() {
-                    @Override
-                    public void completed(TopicStats response) {
-                        urlStats.complete(response);
-                    }
-
-                    @Override
-                    public void failed(Throwable e) {
-                        urlStats.completeExceptionally(e);
-                    }
-                });
+        final CompletableFuture<TopicStats> urlStats = persistent
+                .asyncGetRequest(persistentTopics.path(ns1).path(urlEncodedTopic + "-partition-1").path("stats"),
+                        new UnaryGetCallback<>() {});
         // (b) Uri encoding
-        final CompletableFuture<TopicStats> uriStats = new CompletableFuture<>();
-        persistent.asyncGetRequest(persistentTopics.path(ns1).path(uriEncodedTopic + "-partition-1").path("stats"),
-                new InvocationCallback<TopicStats>() {
-                    @Override
-                    public void completed(TopicStats response) {
-                        uriStats.complete(response);
-                    }
-
-                    @Override
-                    public void failed(Throwable e) {
-                        uriStats.completeExceptionally(e);
-                    }
-                });
+        final CompletableFuture<TopicStats> uriStats = persistent
+                .asyncGetRequest(persistentTopics.path(ns1).path(uriEncodedTopic + "-partition-1").path("stats"),
+                        new UnaryGetCallback<>() {});
         assertEquals(urlStats.get().getSubscriptions().size(), 1);
         assertEquals(uriStats.get().getSubscriptions().size(), 1);
     }

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/BookiesImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/BookiesImpl.java
@@ -20,7 +20,6 @@ package org.apache.pulsar.client.admin.internal;
 
 import java.util.concurrent.CompletableFuture;
 import javax.ws.rs.client.Entity;
-import javax.ws.rs.client.InvocationCallback;
 import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.core.MediaType;
 import org.apache.pulsar.client.admin.Bookies;
@@ -46,20 +45,7 @@ public class BookiesImpl extends BaseResource implements Bookies {
     @Override
     public CompletableFuture<BookiesClusterInfo> getBookiesAsync() {
         WebTarget path = adminBookies.path("all");
-        final CompletableFuture<BookiesClusterInfo> future = new CompletableFuture<>();
-        asyncGetRequest(path,
-                new InvocationCallback<BookiesClusterInfo>() {
-                    @Override
-                    public void completed(BookiesClusterInfo bookies) {
-                        future.complete(bookies);
-                    }
-
-                    @Override
-                    public void failed(Throwable throwable) {
-                        future.completeExceptionally(getApiException(throwable.getCause()));
-                    }
-                });
-        return future;
+        return asyncGetRequest(path, new UnaryGetCallback<BookiesClusterInfo>() {});
     }
 
     @Override
@@ -70,20 +56,7 @@ public class BookiesImpl extends BaseResource implements Bookies {
     @Override
     public CompletableFuture<BookiesRackConfiguration> getBookiesRackInfoAsync() {
         WebTarget path = adminBookies.path("racks-info");
-        final CompletableFuture<BookiesRackConfiguration> future = new CompletableFuture<>();
-        asyncGetRequest(path,
-                new InvocationCallback<BookiesRackConfiguration>() {
-                    @Override
-                    public void completed(BookiesRackConfiguration bookiesRackConfiguration) {
-                        future.complete(bookiesRackConfiguration);
-                    }
-
-                    @Override
-                    public void failed(Throwable throwable) {
-                        future.completeExceptionally(getApiException(throwable.getCause()));
-                    }
-                });
-        return future;
+        return asyncGetRequest(path, new UnaryGetCallback<BookiesRackConfiguration>() {});
     }
 
     @Override
@@ -94,20 +67,7 @@ public class BookiesImpl extends BaseResource implements Bookies {
     @Override
     public CompletableFuture<BookieInfo> getBookieRackInfoAsync(String bookieAddress) {
         WebTarget path = adminBookies.path("racks-info").path(bookieAddress);
-        final CompletableFuture<BookieInfo> future = new CompletableFuture<>();
-        asyncGetRequest(path,
-                new InvocationCallback<BookieInfo>() {
-                    @Override
-                    public void completed(BookieInfo bookieInfo) {
-                        future.complete(bookieInfo);
-                    }
-
-                    @Override
-                    public void failed(Throwable throwable) {
-                        future.completeExceptionally(getApiException(throwable.getCause()));
-                    }
-                });
-        return future;
+        return asyncGetRequest(path, new UnaryGetCallback<BookieInfo>() {});
     }
 
     @Override

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/BrokerStatsImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/BrokerStatsImpl.java
@@ -21,7 +21,6 @@ package org.apache.pulsar.client.admin.internal;
 import com.google.gson.Gson;
 import com.google.gson.JsonObject;
 import java.util.concurrent.CompletableFuture;
-import javax.ws.rs.client.InvocationCallback;
 import javax.ws.rs.client.WebTarget;
 import org.apache.pulsar.client.admin.BrokerStats;
 import org.apache.pulsar.client.admin.PulsarAdminException;
@@ -53,20 +52,7 @@ public class BrokerStatsImpl extends BaseResource implements BrokerStats {
     @Override
     public CompletableFuture<String> getMetricsAsync() {
         WebTarget path = adminV2BrokerStats.path("/metrics");
-        final CompletableFuture<String> future = new CompletableFuture<>();
-        asyncGetRequest(path,
-                new InvocationCallback<String>() {
-                    @Override
-                    public void completed(String s) {
-                        future.complete(s);
-                    }
-
-                    @Override
-                    public void failed(Throwable throwable) {
-                        future.completeExceptionally(getApiException(throwable.getCause()));
-                    }
-                });
-        return future;
+        return asyncGetRequest(path, new UnaryGetCallback<String>() {});
     }
 
     @Override
@@ -77,20 +63,7 @@ public class BrokerStatsImpl extends BaseResource implements BrokerStats {
     @Override
     public CompletableFuture<AllocatorStats> getAllocatorStatsAsync(String allocatorName) {
         WebTarget path = adminV2BrokerStats.path("/allocator-stats").path(allocatorName);
-        final CompletableFuture<AllocatorStats> future = new CompletableFuture<>();
-        asyncGetRequest(path,
-                new InvocationCallback<AllocatorStats>() {
-                    @Override
-                    public void completed(AllocatorStats allocatorStats) {
-                        future.complete(allocatorStats);
-                    }
-
-                    @Override
-                    public void failed(Throwable throwable) {
-                        future.completeExceptionally(getApiException(throwable.getCause()));
-                    }
-                });
-        return future;
+        return asyncGetRequest(path, new UnaryGetCallback<AllocatorStats>() {});
     }
 
     @Override
@@ -101,20 +74,7 @@ public class BrokerStatsImpl extends BaseResource implements BrokerStats {
     @Override
     public CompletableFuture<String> getMBeansAsync() {
         WebTarget path = adminV2BrokerStats.path("/mbeans");
-        final CompletableFuture<String> future = new CompletableFuture<>();
-        asyncGetRequest(path,
-                new InvocationCallback<String>() {
-                    @Override
-                    public void completed(String s) {
-                        future.complete(s);
-                    }
-
-                    @Override
-                    public void failed(Throwable throwable) {
-                        future.completeExceptionally(getApiException(throwable.getCause()));
-                    }
-                });
-        return future;
+        return asyncGetRequest(path, new UnaryGetCallback<String>() {});
     }
 
     @Override
@@ -125,20 +85,7 @@ public class BrokerStatsImpl extends BaseResource implements BrokerStats {
     @Override
     public CompletableFuture<String> getTopicsAsync() {
         WebTarget path = adminV2BrokerStats.path("/topics");
-        final CompletableFuture<String> future = new CompletableFuture<>();
-        asyncGetRequest(path,
-                new InvocationCallback<String>() {
-                    @Override
-                    public void completed(String s) {
-                        future.complete(s);
-                    }
-
-                    @Override
-                    public void failed(Throwable throwable) {
-                        future.completeExceptionally(getApiException(throwable.getCause()));
-                    }
-                });
-        return future;
+        return asyncGetRequest(path, new UnaryGetCallback<String>() {});
     }
 
     @Override
@@ -149,20 +96,7 @@ public class BrokerStatsImpl extends BaseResource implements BrokerStats {
     @Override
     public CompletableFuture<LoadManagerReport> getLoadReportAsync() {
         WebTarget path = adminV2BrokerStats.path("/load-report");
-        final CompletableFuture<LoadManagerReport> future = new CompletableFuture<>();
-        asyncGetRequest(path,
-                new InvocationCallback<LoadManagerReport>() {
-                    @Override
-                    public void completed(LoadManagerReport loadManagerReport) {
-                        future.complete(loadManagerReport);
-                    }
-
-                    @Override
-                    public void failed(Throwable throwable) {
-                        future.completeExceptionally(getApiException(throwable.getCause()));
-                    }
-                });
-        return future;
+        return asyncGetRequest(path, new UnaryGetCallback<LoadManagerReport>() {});
     }
 
     @Override
@@ -173,20 +107,7 @@ public class BrokerStatsImpl extends BaseResource implements BrokerStats {
     @Override
     public CompletableFuture<String> getPendingBookieOpsStatsAsync() {
         WebTarget path = adminV2BrokerStats.path("/bookieops");
-        final CompletableFuture<String> future = new CompletableFuture<>();
-        asyncGetRequest(path,
-                new InvocationCallback<String>() {
-                    @Override
-                    public void completed(String s) {
-                        future.complete(s);
-                    }
-
-                    @Override
-                    public void failed(Throwable throwable) {
-                        future.completeExceptionally(getApiException(throwable.getCause()));
-                    }
-                });
-        return future;
+        return asyncGetRequest(path, new UnaryGetCallback<String>() {});
     }
 
     public JsonObject getBrokerResourceAvailability(String namespace) throws PulsarAdminException {

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/BrokersImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/BrokersImpl.java
@@ -22,7 +22,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import javax.ws.rs.client.Entity;
-import javax.ws.rs.client.InvocationCallback;
 import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.core.MediaType;
 import org.apache.pulsar.client.admin.Brokers;
@@ -60,44 +59,18 @@ public class BrokersImpl extends BaseResource implements Brokers {
     @Override
     public CompletableFuture<List<String>> getActiveBrokersAsync(String cluster) {
         WebTarget path = cluster == null ? adminBrokers : adminBrokers.path(cluster);
-        final CompletableFuture<List<String>> future = new CompletableFuture<>();
-        asyncGetRequest(path,
-                new InvocationCallback<List<String>>() {
-                    @Override
-                    public void completed(List<String> brokers) {
-                        future.complete(brokers);
-                    }
-
-                    @Override
-                    public void failed(Throwable throwable) {
-                        future.completeExceptionally(getApiException(throwable.getCause()));
-                    }
-                });
-        return future;
+        return asyncGetRequest(path, new UnaryGetCallback<List<String>>() {});
     }
 
     @Override
     public BrokerInfo getLeaderBroker() throws PulsarAdminException {
-        return sync(() -> getLeaderBrokerAsync());
+        return sync(this::getLeaderBrokerAsync);
     }
 
     @Override
     public CompletableFuture<BrokerInfo> getLeaderBrokerAsync() {
         WebTarget path = adminBrokers.path("leaderBroker");
-        final CompletableFuture<BrokerInfo> future = new CompletableFuture<>();
-        asyncGetRequest(path,
-                new InvocationCallback<BrokerInfo>() {
-                    @Override
-                    public void completed(BrokerInfo leaderBroker) {
-                        future.complete(leaderBroker);
-                    }
-
-                    @Override
-                    public void failed(Throwable throwable) {
-                        future.completeExceptionally(getApiException(throwable.getCause()));
-                    }
-                });
-        return future;
+        return asyncGetRequest(path, new UnaryGetCallback<BrokerInfo>() {});
     }
 
     @Override
@@ -110,20 +83,7 @@ public class BrokersImpl extends BaseResource implements Brokers {
     public CompletableFuture<Map<String, NamespaceOwnershipStatus>> getOwnedNamespacesAsync(
             String cluster, String brokerUrl) {
         WebTarget path = adminBrokers.path(cluster).path(brokerUrl).path("ownedNamespaces");
-        final CompletableFuture<Map<String, NamespaceOwnershipStatus>> future = new CompletableFuture<>();
-        asyncGetRequest(path,
-                new InvocationCallback<Map<String, NamespaceOwnershipStatus>>() {
-                    @Override
-                    public void completed(Map<String, NamespaceOwnershipStatus> ownedNamespaces) {
-                        future.complete(ownedNamespaces);
-                    }
-
-                    @Override
-                    public void failed(Throwable throwable) {
-                        future.completeExceptionally(getApiException(throwable.getCause()));
-                    }
-                });
-        return future;
+        return asyncGetRequest(path, new UnaryGetCallback<Map<String, NamespaceOwnershipStatus>>() {});
     }
 
     @Override
@@ -157,20 +117,7 @@ public class BrokersImpl extends BaseResource implements Brokers {
     @Override
     public CompletableFuture<Map<String, String>> getAllDynamicConfigurationsAsync() {
         WebTarget path = adminBrokers.path("configuration").path("values");
-        final CompletableFuture<Map<String, String>> future = new CompletableFuture<>();
-        asyncGetRequest(path,
-                new InvocationCallback<Map<String, String>>() {
-                    @Override
-                    public void completed(Map<String, String> allConfs) {
-                        future.complete(allConfs);
-                    }
-
-                    @Override
-                    public void failed(Throwable throwable) {
-                        future.completeExceptionally(getApiException(throwable.getCause()));
-                    }
-                });
-        return future;
+        return asyncGetRequest(path, new UnaryGetCallback<Map<String, String>>() {});
     }
 
     @Override
@@ -181,20 +128,7 @@ public class BrokersImpl extends BaseResource implements Brokers {
     @Override
     public CompletableFuture<List<String>> getDynamicConfigurationNamesAsync() {
         WebTarget path = adminBrokers.path("configuration");
-        final CompletableFuture<List<String>> future = new CompletableFuture<>();
-        asyncGetRequest(path,
-                new InvocationCallback<List<String>>() {
-                    @Override
-                    public void completed(List<String> confNames) {
-                        future.complete(confNames);
-                    }
-
-                    @Override
-                    public void failed(Throwable throwable) {
-                        future.completeExceptionally(getApiException(throwable.getCause()));
-                    }
-                });
-        return future;
+        return asyncGetRequest(path, new UnaryGetCallback<List<String>>() {});
     }
 
     @Override
@@ -205,20 +139,7 @@ public class BrokersImpl extends BaseResource implements Brokers {
     @Override
     public CompletableFuture<Map<String, String>> getRuntimeConfigurationsAsync() {
         WebTarget path = adminBrokers.path("configuration").path("runtime");
-        final CompletableFuture<Map<String, String>> future = new CompletableFuture<>();
-        asyncGetRequest(path,
-                new InvocationCallback<Map<String, String>>() {
-                    @Override
-                    public void completed(Map<String, String> runtimeConfs) {
-                        future.complete(runtimeConfs);
-                    }
-
-                    @Override
-                    public void failed(Throwable throwable) {
-                        future.completeExceptionally(getApiException(throwable.getCause()));
-                    }
-                });
-        return future;
+        return asyncGetRequest(path, new UnaryGetCallback<Map<String, String>>() {});
     }
 
     @Override
@@ -229,20 +150,7 @@ public class BrokersImpl extends BaseResource implements Brokers {
     @Override
     public CompletableFuture<InternalConfigurationData> getInternalConfigurationDataAsync() {
         WebTarget path = adminBrokers.path("internal-configuration");
-        final CompletableFuture<InternalConfigurationData> future = new CompletableFuture<>();
-        asyncGetRequest(path,
-                new InvocationCallback<InternalConfigurationData>() {
-                    @Override
-                    public void completed(InternalConfigurationData internalConfigurationData) {
-                        future.complete(internalConfigurationData);
-                    }
-
-                    @Override
-                    public void failed(Throwable throwable) {
-                        future.completeExceptionally(getApiException(throwable.getCause()));
-                    }
-                });
-        return future;
+        return asyncGetRequest(path, new UnaryGetCallback<InternalConfigurationData>() {});
     }
 
     @Override
@@ -253,19 +161,7 @@ public class BrokersImpl extends BaseResource implements Brokers {
     @Override
     public CompletableFuture<Void> backlogQuotaCheckAsync() {
         WebTarget path = adminBrokers.path("backlogQuotaCheck");
-        final CompletableFuture<Void> future = new CompletableFuture<>();
-        asyncGetRequest(path, new InvocationCallback<Void>() {
-            @Override
-            public void completed(Void unused) {
-                future.complete(null);
-            }
-
-            @Override
-            public void failed(Throwable throwable) {
-                future.completeExceptionally(throwable);
-            }
-        });
-        return future;
+        return asyncGetRequest(path, new GetCallback<Void, Void>((UnaryProcessor<Void>) __ -> null) {});
     }
 
     @Override
@@ -291,25 +187,12 @@ public class BrokersImpl extends BaseResource implements Brokers {
         if (topicVersion != null) {
             path = path.queryParam("topicVersion", topicVersion);
         }
-        final CompletableFuture<Void> future = new CompletableFuture<>();
-        asyncGetRequest(path,
-                new InvocationCallback<String>() {
-                    @Override
-                    public void completed(String result) {
-                        if (!"ok".equalsIgnoreCase(result.trim())) {
-                            future.completeExceptionally(
-                                    new PulsarAdminException("Healthcheck returned unexpected result: " + result));
-                        } else {
-                            future.complete(null);
-                        }
-                    }
-
-                    @Override
-                    public void failed(Throwable throwable) {
-                        future.completeExceptionally(getApiException(throwable.getCause()));
-                    }
-                });
-        return future;
+        return asyncGetRequest(path, new GetCallback<String, Void>(result -> {
+            if (!"ok".equalsIgnoreCase(result.trim())) {
+                throw new PulsarAdminException("Healthcheck returned unexpected result: " + result);
+            }
+            return null;
+        }) {});
     }
 
     @Override
@@ -328,19 +211,6 @@ public class BrokersImpl extends BaseResource implements Brokers {
 
     public CompletableFuture<String> getVersionAsync() {
         WebTarget path = adminBrokers.path("version");
-
-        final CompletableFuture<String> future = new CompletableFuture<>();
-        asyncGetRequest(path, new InvocationCallback<String>() {
-            @Override
-            public void completed(String version) {
-                future.complete(version);
-            }
-
-            @Override
-            public void failed(Throwable throwable) {
-                future.completeExceptionally(getApiException(throwable.getCause()));
-            }
-        });
-        return future;
+        return asyncGetRequest(path, new UnaryGetCallback<String>() {});
     }
 }

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/ClustersImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/ClustersImpl.java
@@ -26,20 +26,17 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import javax.ws.rs.client.Entity;
-import javax.ws.rs.client.InvocationCallback;
 import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.core.MediaType;
 import org.apache.pulsar.client.admin.Clusters;
 import org.apache.pulsar.client.admin.PulsarAdminException;
 import org.apache.pulsar.client.api.Authentication;
 import org.apache.pulsar.common.policies.data.BrokerNamespaceIsolationData;
-import org.apache.pulsar.common.policies.data.BrokerNamespaceIsolationDataImpl;
 import org.apache.pulsar.common.policies.data.ClusterData;
 import org.apache.pulsar.common.policies.data.ClusterDataImpl;
 import org.apache.pulsar.common.policies.data.FailureDomain;
 import org.apache.pulsar.common.policies.data.FailureDomainImpl;
 import org.apache.pulsar.common.policies.data.NamespaceIsolationData;
-import org.apache.pulsar.common.policies.data.NamespaceIsolationDataImpl;
 
 public class ClustersImpl extends BaseResource implements Clusters {
 
@@ -57,20 +54,7 @@ public class ClustersImpl extends BaseResource implements Clusters {
 
     @Override
     public CompletableFuture<List<String>> getClustersAsync() {
-        final CompletableFuture<List<String>> future = new CompletableFuture<>();
-        asyncGetRequest(adminClusters,
-                new InvocationCallback<List<String>>() {
-                    @Override
-                    public void completed(List<String> clusters) {
-                        future.complete(clusters);
-                    }
-
-                    @Override
-                    public void failed(Throwable throwable) {
-                        future.completeExceptionally(getApiException(throwable.getCause()));
-                    }
-                });
-        return future;
+        return asyncGetRequest(adminClusters, new UnaryGetCallback<List<String>>() {});
     }
 
     @Override
@@ -81,20 +65,7 @@ public class ClustersImpl extends BaseResource implements Clusters {
     @Override
     public CompletableFuture<ClusterData> getClusterAsync(String cluster) {
         WebTarget path = adminClusters.path(cluster);
-        final CompletableFuture<ClusterData> future = new CompletableFuture<>();
-        asyncGetRequest(path,
-                new InvocationCallback<ClusterDataImpl>() {
-                    @Override
-                    public void completed(ClusterDataImpl clusterData) {
-                        future.complete(clusterData);
-                    }
-
-                    @Override
-                    public void failed(Throwable throwable) {
-                        future.completeExceptionally(getApiException(throwable.getCause()));
-                    }
-                });
-        return future;
+        return asyncGetRequest(path, new UnaryGetCallback<ClusterData>() {});
     }
 
     @Override
@@ -132,7 +103,6 @@ public class ClustersImpl extends BaseResource implements Clusters {
     }
 
     @Override
-    @SuppressWarnings("unchecked")
     public Set<String> getPeerClusterNames(String cluster) throws PulsarAdminException {
         return sync(() -> getPeerClusterNamesAsync(cluster));
     }
@@ -140,20 +110,7 @@ public class ClustersImpl extends BaseResource implements Clusters {
     @Override
     public CompletableFuture<Set<String>> getPeerClusterNamesAsync(String cluster) {
         WebTarget path = adminClusters.path(cluster).path("peers");
-        final CompletableFuture<Set<String>> future = new CompletableFuture<>();
-        asyncGetRequest(path,
-                new InvocationCallback<Set<String>>() {
-                    @Override
-                    public void completed(Set<String> clusterNames) {
-                        future.complete(clusterNames);
-                    }
-
-                    @Override
-                    public void failed(Throwable throwable) {
-                        future.completeExceptionally(getApiException(throwable.getCause()));
-                    }
-                });
-        return future;
+        return asyncGetRequest(path, new UnaryGetCallback<Set<String>>() {});
     }
 
     @Override
@@ -177,22 +134,8 @@ public class ClustersImpl extends BaseResource implements Clusters {
     public CompletableFuture<Map<String, NamespaceIsolationData>> getNamespaceIsolationPoliciesAsync(
             String cluster) {
         WebTarget path = adminClusters.path(cluster).path("namespaceIsolationPolicies");
-        final CompletableFuture<Map<String, NamespaceIsolationData>> future = new CompletableFuture<>();
-        asyncGetRequest(path,
-                new InvocationCallback<Map<String, NamespaceIsolationDataImpl>>() {
-                    @Override
-                    public void completed(Map<String, NamespaceIsolationDataImpl> stringNamespaceIsolationDataMap) {
-                        Map<String, NamespaceIsolationData> result = new HashMap<>();
-                        stringNamespaceIsolationDataMap.forEach(result::put);
-                        future.complete(result);
-                    }
-
-                    @Override
-                    public void failed(Throwable throwable) {
-                        future.completeExceptionally(getApiException(throwable.getCause()));
-                    }
-                });
-        return future;
+        return asyncGetRequest(path, new UnaryGetCallback<Map<String, NamespaceIsolationData>>(HashMap::new) {
+        });
     }
 
     @Override
@@ -205,22 +148,7 @@ public class ClustersImpl extends BaseResource implements Clusters {
     public CompletableFuture<List<BrokerNamespaceIsolationData>> getBrokersWithNamespaceIsolationPolicyAsync(
             String cluster) {
         WebTarget path = adminClusters.path(cluster).path("namespaceIsolationPolicies").path("brokers");
-        final CompletableFuture<List<BrokerNamespaceIsolationData>> future = new CompletableFuture<>();
-        asyncGetRequest(path,
-                new InvocationCallback<List<BrokerNamespaceIsolationDataImpl>>() {
-                    @Override
-                    public void completed(List<BrokerNamespaceIsolationDataImpl> brokerNamespaceIsolationData) {
-                        List<BrokerNamespaceIsolationData> data =
-                                new ArrayList<>(brokerNamespaceIsolationData);
-                        future.complete(data);
-                    }
-
-                    @Override
-                    public void failed(Throwable throwable) {
-                        future.completeExceptionally(getApiException(throwable.getCause()));
-                    }
-                });
-        return future;
+        return asyncGetRequest(path, new UnaryGetCallback<List<BrokerNamespaceIsolationData>>(ArrayList::new) {});
     }
 
     @Override
@@ -233,20 +161,7 @@ public class ClustersImpl extends BaseResource implements Clusters {
     public CompletableFuture<BrokerNamespaceIsolationData> getBrokerWithNamespaceIsolationPolicyAsync(
             String cluster, String broker) {
         WebTarget path = adminClusters.path(cluster).path("namespaceIsolationPolicies").path("brokers").path(broker);
-        final CompletableFuture<BrokerNamespaceIsolationData> future = new CompletableFuture<>();
-        asyncGetRequest(path,
-                new InvocationCallback<BrokerNamespaceIsolationDataImpl>() {
-                    @Override
-                    public void completed(BrokerNamespaceIsolationDataImpl brokerNamespaceIsolationData) {
-                        future.complete(brokerNamespaceIsolationData);
-                    }
-
-                    @Override
-                    public void failed(Throwable throwable) {
-                        future.completeExceptionally(getApiException(throwable.getCause()));
-                    }
-                });
-        return future;
+        return asyncGetRequest(path, new UnaryGetCallback<BrokerNamespaceIsolationData>() {});
     }
 
     @Override
@@ -305,20 +220,7 @@ public class ClustersImpl extends BaseResource implements Clusters {
     public CompletableFuture<NamespaceIsolationData> getNamespaceIsolationPolicyAsync(
             String cluster, String policyName) {
         WebTarget path = adminClusters.path(cluster).path("namespaceIsolationPolicies").path(policyName);
-        final CompletableFuture<NamespaceIsolationData> future = new CompletableFuture<>();
-        asyncGetRequest(path,
-                new InvocationCallback<NamespaceIsolationDataImpl>() {
-                    @Override
-                    public void completed(NamespaceIsolationDataImpl namespaceIsolationData) {
-                        future.complete(namespaceIsolationData);
-                    }
-
-                    @Override
-                    public void failed(Throwable throwable) {
-                        future.completeExceptionally(getApiException(throwable.getCause()));
-                    }
-                });
-        return future;
+        return asyncGetRequest(path, new UnaryGetCallback<NamespaceIsolationData>() {});
     }
 
     @Override
@@ -364,21 +266,7 @@ public class ClustersImpl extends BaseResource implements Clusters {
     @Override
     public CompletableFuture<Map<String, FailureDomain>> getFailureDomainsAsync(String cluster) {
         WebTarget path = adminClusters.path(cluster).path("failureDomains");
-        final CompletableFuture<Map<String, FailureDomain>> future = new CompletableFuture<>();
-        asyncGetRequest(path,
-                new InvocationCallback<Map<String, FailureDomainImpl>>() {
-                    @Override
-                    public void completed(Map<String, FailureDomainImpl> failureDomains) {
-                        Map<String, FailureDomain> result = new HashMap<>(failureDomains);
-                        future.complete(result);
-                    }
-
-                    @Override
-                    public void failed(Throwable throwable) {
-                        future.completeExceptionally(getApiException(throwable.getCause()));
-                    }
-                });
-        return future;
+        return asyncGetRequest(path, new UnaryGetCallback<Map<String, FailureDomain>>(HashMap::new) {});
     }
 
     @Override
@@ -389,20 +277,7 @@ public class ClustersImpl extends BaseResource implements Clusters {
     @Override
     public CompletableFuture<FailureDomain> getFailureDomainAsync(String cluster, String domainName) {
         WebTarget path = adminClusters.path(cluster).path("failureDomains").path(domainName);
-        final CompletableFuture<FailureDomain> future = new CompletableFuture<>();
-        asyncGetRequest(path,
-                new InvocationCallback<FailureDomainImpl>() {
-                    @Override
-                    public void completed(FailureDomainImpl failureDomain) {
-                        future.complete(failureDomain);
-                    }
-
-                    @Override
-                    public void failed(Throwable throwable) {
-                        future.completeExceptionally(getApiException(throwable.getCause()));
-                    }
-                });
-        return future;
+        return asyncGetRequest(path, new UnaryGetCallback<FailureDomain>() {});
     }
 
     private void setDomain(String cluster, String domainName,

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/NamespacesImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/NamespacesImpl.java
@@ -47,7 +47,6 @@ import org.apache.pulsar.common.policies.data.DispatchRate;
 import org.apache.pulsar.common.policies.data.ErrorData;
 import org.apache.pulsar.common.policies.data.InactiveTopicPolicies;
 import org.apache.pulsar.common.policies.data.OffloadPolicies;
-import org.apache.pulsar.common.policies.data.OffloadPoliciesImpl;
 import org.apache.pulsar.common.policies.data.PersistencePolicies;
 import org.apache.pulsar.common.policies.data.Policies;
 import org.apache.pulsar.common.policies.data.PublishRate;
@@ -78,20 +77,7 @@ public class NamespacesImpl extends BaseResource implements Namespaces {
     @Override
     public CompletableFuture<List<String>> getNamespacesAsync(String tenant) {
         WebTarget path = adminV2Namespaces.path(tenant);
-        final CompletableFuture<List<String>> future = new CompletableFuture<>();
-        asyncGetRequest(path,
-                new InvocationCallback<List<String>>() {
-                    @Override
-                    public void completed(List<String> namespaces) {
-                        future.complete(namespaces);
-                    }
-
-                    @Override
-                    public void failed(Throwable throwable) {
-                        future.completeExceptionally(getApiException(throwable.getCause()));
-                    }
-                });
-        return future;
+        return asyncGetRequest(path, new UnaryGetCallback<List<String>>() {});
     }
 
     @Override
@@ -101,21 +87,7 @@ public class NamespacesImpl extends BaseResource implements Namespaces {
 
     public CompletableFuture<List<String>> getNamespacesAsync(String tenant, String cluster) {
         WebTarget path = adminNamespaces.path(tenant).path(cluster);
-        final CompletableFuture<List<String>> future = new CompletableFuture<>();
-        asyncGetRequest(path,
-                new InvocationCallback<List<String>>() {
-
-                    @Override
-                    public void completed(List<String> namespaces) {
-                        future.complete(namespaces);
-                    }
-
-                    @Override
-                    public void failed(Throwable throwable) {
-                        future.completeExceptionally(getApiException(throwable.getCause()));
-                    }
-                });
-        return future;
+        return asyncGetRequest(path, new UnaryGetCallback<List<String>>() {});
     }
 
     @Override
@@ -133,20 +105,7 @@ public class NamespacesImpl extends BaseResource implements Namespaces {
         NamespaceName ns = NamespaceName.get(namespace);
         String action = "bundles";
         WebTarget path = namespacePath(ns, action);
-        final CompletableFuture<BundlesData> future = new CompletableFuture<>();
-        asyncGetRequest(path,
-                new InvocationCallback<BundlesData>() {
-                    @Override
-                    public void completed(BundlesData bundles) {
-                        future.complete(bundles);
-                    }
-
-                    @Override
-                    public void failed(Throwable throwable) {
-                        future.completeExceptionally(getApiException(throwable.getCause()));
-                    }
-                });
-        return future;
+        return asyncGetRequest(path, new UnaryGetCallback<BundlesData>() {});
     }
 
     @Override
@@ -154,20 +113,7 @@ public class NamespacesImpl extends BaseResource implements Namespaces {
         NamespaceName ns = NamespaceName.get(namespace);
         String action = ns.isV2() ? "topics" : "destinations";
         WebTarget path = namespacePath(ns, action);
-        final CompletableFuture<List<String>> future = new CompletableFuture<>();
-        asyncGetRequest(path,
-                new InvocationCallback<List<String>>() {
-                    @Override
-                    public void completed(List<String> topics) {
-                        future.complete(topics);
-                    }
-
-                    @Override
-                    public void failed(Throwable throwable) {
-                        future.completeExceptionally(getApiException(throwable.getCause()));
-                    }
-                });
-        return future;
+        return asyncGetRequest(path, new UnaryGetCallback<List<String>>() {});
     }
 
     @Override
@@ -184,20 +130,7 @@ public class NamespacesImpl extends BaseResource implements Namespaces {
         path = path
                 .queryParam("mode", options.getMode())
                 .queryParam("includeSystemTopic", options.isIncludeSystemTopic());
-        final CompletableFuture<List<String>> future = new CompletableFuture<>();
-        asyncGetRequest(path,
-                new InvocationCallback<List<String>>() {
-                    @Override
-                    public void completed(List<String> topics) {
-                        future.complete(topics);
-                    }
-
-                    @Override
-                    public void failed(Throwable throwable) {
-                        future.completeExceptionally(getApiException(throwable.getCause()));
-                    }
-                });
-        return future;
+        return asyncGetRequest(path, new UnaryGetCallback<List<String>>() {});
     }
 
     @Override
@@ -209,20 +142,7 @@ public class NamespacesImpl extends BaseResource implements Namespaces {
     public CompletableFuture<Policies> getPoliciesAsync(String namespace) {
         NamespaceName ns = NamespaceName.get(namespace);
         WebTarget path = namespacePath(ns);
-        final CompletableFuture<Policies> future = new CompletableFuture<>();
-        asyncGetRequest(path,
-                new InvocationCallback<Policies>() {
-                    @Override
-                    public void completed(Policies policies) {
-                        future.complete(policies);
-                    }
-
-                    @Override
-                    public void failed(Throwable throwable) {
-                        future.completeExceptionally(getApiException(throwable.getCause()));
-                    }
-                });
-        return future;
+        return asyncGetRequest(path, new UnaryGetCallback<Policies>() {});
     }
 
     @Override
@@ -361,20 +281,7 @@ public class NamespacesImpl extends BaseResource implements Namespaces {
     public CompletableFuture<Map<String, Set<AuthAction>>> getPermissionsAsync(String namespace) {
         NamespaceName ns = NamespaceName.get(namespace);
         WebTarget path = namespacePath(ns, "permissions");
-        final CompletableFuture<Map<String, Set<AuthAction>>> future = new CompletableFuture<>();
-        asyncGetRequest(path,
-                new InvocationCallback<Map<String, Set<AuthAction>>>() {
-                    @Override
-                    public void completed(Map<String, Set<AuthAction>> permissions) {
-                        future.complete(permissions);
-                    }
-
-                    @Override
-                    public void failed(Throwable throwable) {
-                        future.completeExceptionally(getApiException(throwable.getCause()));
-                    }
-                });
-        return future;
+        return asyncGetRequest(path, new UnaryGetCallback<Map<String, Set<AuthAction>>>() {});
     }
 
     @Override
@@ -412,20 +319,7 @@ public class NamespacesImpl extends BaseResource implements Namespaces {
     public CompletableFuture<Map<String, Set<String>>> getPermissionOnSubscriptionAsync(String namespace) {
         NamespaceName ns = NamespaceName.get(namespace);
         WebTarget path = namespacePath(ns, "permissions", "subscription");
-        final CompletableFuture<Map<String, Set<String>>> future = new CompletableFuture<>();
-        asyncGetRequest(path,
-                new InvocationCallback<Map<String, Set<String>>>() {
-                    @Override
-                    public void completed(Map<String, Set<String>> permissions) {
-                        future.complete(permissions);
-                    }
-
-                    @Override
-                    public void failed(Throwable throwable) {
-                        future.completeExceptionally(getApiException(throwable.getCause()));
-                    }
-                });
-        return future;
+        return asyncGetRequest(path, new UnaryGetCallback<Map<String, Set<String>>>() {});
     }
 
     @Override
@@ -465,20 +359,7 @@ public class NamespacesImpl extends BaseResource implements Namespaces {
     public CompletableFuture<List<String>> getNamespaceReplicationClustersAsync(String namespace) {
         NamespaceName ns = NamespaceName.get(namespace);
         WebTarget path = namespacePath(ns, "replication");
-        final CompletableFuture<List<String>> future = new CompletableFuture<>();
-        asyncGetRequest(path,
-                new InvocationCallback<List<String>>() {
-                    @Override
-                    public void completed(List<String> clusters) {
-                        future.complete(clusters);
-                    }
-
-                    @Override
-                    public void failed(Throwable throwable) {
-                        future.completeExceptionally(getApiException(throwable.getCause()));
-                    }
-                });
-        return future;
+        return asyncGetRequest(path, new UnaryGetCallback<List<String>>() {});
     }
 
     @Override
@@ -502,20 +383,7 @@ public class NamespacesImpl extends BaseResource implements Namespaces {
     public CompletableFuture<Integer> getNamespaceMessageTTLAsync(String namespace) {
         NamespaceName ns = NamespaceName.get(namespace);
         WebTarget path = namespacePath(ns, "messageTTL");
-        final CompletableFuture<Integer> future = new CompletableFuture<>();
-        asyncGetRequest(path,
-                new InvocationCallback<Integer>() {
-                    @Override
-                    public void completed(Integer ttl) {
-                        future.complete(ttl);
-                    }
-
-                    @Override
-                    public void failed(Throwable throwable) {
-                        future.completeExceptionally(getApiException(throwable.getCause()));
-                    }
-                });
-        return future;
+        return asyncGetRequest(path, new UnaryGetCallback<Integer>() {});
     }
 
     @Override
@@ -551,19 +419,7 @@ public class NamespacesImpl extends BaseResource implements Namespaces {
     public CompletableFuture<Integer> getSubscriptionExpirationTimeAsync(String namespace) {
         NamespaceName ns = NamespaceName.get(namespace);
         WebTarget path = namespacePath(ns, "subscriptionExpirationTime");
-        final CompletableFuture<Integer> future = new CompletableFuture<>();
-        asyncGetRequest(path, new InvocationCallback<Integer>() {
-            @Override
-            public void completed(Integer expirationTime) {
-                future.complete(expirationTime);
-            }
-
-            @Override
-            public void failed(Throwable throwable) {
-                future.completeExceptionally(getApiException(throwable.getCause()));
-            }
-        });
-        return future;
+        return asyncGetRequest(path, new UnaryGetCallback<Integer>() {});
     }
 
     @Override
@@ -614,20 +470,7 @@ public class NamespacesImpl extends BaseResource implements Namespaces {
     public CompletableFuture<String> getNamespaceAntiAffinityGroupAsync(String namespace) {
         NamespaceName ns = NamespaceName.get(namespace);
         WebTarget path = namespacePath(ns, "antiAffinity");
-        final CompletableFuture<String> future = new CompletableFuture<>();
-        asyncGetRequest(path,
-                new InvocationCallback<String>() {
-                    @Override
-                    public void completed(String s) {
-                        future.complete(s);
-                    }
-
-                    @Override
-                    public void failed(Throwable throwable) {
-                        future.completeExceptionally(getApiException(throwable.getCause()));
-                    }
-                });
-        return future;
+        return asyncGetRequest(path, new UnaryGetCallback<String>() {});
     }
 
     @Override
@@ -641,20 +484,7 @@ public class NamespacesImpl extends BaseResource implements Namespaces {
             String tenant, String cluster, String namespaceAntiAffinityGroup) {
         WebTarget path = adminNamespaces.path(cluster)
                 .path("antiAffinity").path(namespaceAntiAffinityGroup).queryParam("property", tenant);
-        final CompletableFuture<List<String>> future = new CompletableFuture<>();
-        asyncGetRequest(path,
-                new InvocationCallback<List<String>>() {
-                    @Override
-                    public void completed(List<String> antiNamespaces) {
-                        future.complete(antiNamespaces);
-                    }
-
-                    @Override
-                    public void failed(Throwable throwable) {
-                        future.completeExceptionally(getApiException(throwable.getCause()));
-                    }
-                });
-        return future;
+        return asyncGetRequest(path, new UnaryGetCallback<List<String>>() {});
     }
 
     @Override
@@ -690,20 +520,7 @@ public class NamespacesImpl extends BaseResource implements Namespaces {
     public CompletableFuture<Boolean> getDeduplicationStatusAsync(String namespace) {
         NamespaceName ns = NamespaceName.get(namespace);
         WebTarget path = namespacePath(ns, "deduplication");
-        final CompletableFuture<Boolean> future = new CompletableFuture<>();
-        asyncGetRequest(path,
-                new InvocationCallback<Boolean>() {
-                    @Override
-                    public void completed(Boolean enabled) {
-                        future.complete(enabled);
-                    }
-
-                    @Override
-                    public void failed(Throwable throwable) {
-                        future.completeExceptionally(getApiException(throwable.getCause()));
-                    }
-                });
-        return future;
+        return asyncGetRequest(path, new UnaryGetCallback<Boolean>() {});
     }
 
     @Override
@@ -741,20 +558,7 @@ public class NamespacesImpl extends BaseResource implements Namespaces {
     public CompletableFuture<AutoTopicCreationOverride> getAutoTopicCreationAsync(String namespace) {
         NamespaceName ns = NamespaceName.get(namespace);
         WebTarget path = namespacePath(ns, "autoTopicCreation");
-        final CompletableFuture<AutoTopicCreationOverride> future = new CompletableFuture<>();
-        asyncGetRequest(path,
-                new InvocationCallback<AutoTopicCreationOverride>() {
-                    @Override
-                    public void completed(AutoTopicCreationOverride autoTopicCreationOverride) {
-                        future.complete(autoTopicCreationOverride);
-                    }
-
-                    @Override
-                    public void failed(Throwable throwable) {
-                        future.completeExceptionally(getApiException(throwable.getCause()));
-                    }
-                });
-        return future;
+        return asyncGetRequest(path, new UnaryGetCallback<AutoTopicCreationOverride>() {});
     }
 
     @Override
@@ -792,20 +596,7 @@ public class NamespacesImpl extends BaseResource implements Namespaces {
     public CompletableFuture<AutoSubscriptionCreationOverride> getAutoSubscriptionCreationAsync(String namespace) {
         NamespaceName ns = NamespaceName.get(namespace);
         WebTarget path = namespacePath(ns, "autoSubscriptionCreation");
-        final CompletableFuture<AutoSubscriptionCreationOverride> future = new CompletableFuture<>();
-        asyncGetRequest(path,
-                new InvocationCallback<AutoSubscriptionCreationOverride>() {
-                    @Override
-                    public void completed(AutoSubscriptionCreationOverride autoSubscriptionCreation) {
-                        future.complete(autoSubscriptionCreation);
-                    }
-
-                    @Override
-                    public void failed(Throwable throwable) {
-                        future.completeExceptionally(getApiException(throwable.getCause()));
-                    }
-                });
-        return future;
+        return asyncGetRequest(path, new UnaryGetCallback<AutoSubscriptionCreationOverride>() {});
     }
 
 
@@ -832,20 +623,7 @@ public class NamespacesImpl extends BaseResource implements Namespaces {
     public CompletableFuture<Set<SubscriptionType>> getSubscriptionTypesEnabledAsync(String namespace) {
         NamespaceName ns = NamespaceName.get(namespace);
         WebTarget path = namespacePath(ns, "subscriptionTypesEnabled");
-        final CompletableFuture<Set<SubscriptionType>> future = new CompletableFuture<>();
-        asyncGetRequest(path,
-                new InvocationCallback<Set<SubscriptionType>>() {
-                    @Override
-                    public void completed(Set<SubscriptionType> subscriptionTypesEnabled) {
-                        future.complete(subscriptionTypesEnabled);
-                    }
-
-                    @Override
-                    public void failed(Throwable throwable) {
-                        future.completeExceptionally(getApiException(throwable.getCause()));
-                    }
-                });
-        return future;
+        return asyncGetRequest(path, new UnaryGetCallback<Set<SubscriptionType>>() {});
     }
 
     @Override
@@ -881,20 +659,7 @@ public class NamespacesImpl extends BaseResource implements Namespaces {
     public CompletableFuture<Map<BacklogQuotaType, BacklogQuota>> getBacklogQuotaMapAsync(String namespace) {
         NamespaceName ns = NamespaceName.get(namespace);
         WebTarget path = namespacePath(ns, "backlogQuotaMap");
-        final CompletableFuture<Map<BacklogQuotaType, BacklogQuota>> future = new CompletableFuture<>();
-        asyncGetRequest(path,
-                new InvocationCallback<Map<BacklogQuotaType, BacklogQuota>>() {
-                    @Override
-                    public void completed(Map<BacklogQuotaType, BacklogQuota> quotaMap) {
-                        future.complete(quotaMap);
-                    }
-
-                    @Override
-                    public void failed(Throwable throwable) {
-                        future.completeExceptionally(getApiException(throwable.getCause()));
-                    }
-                });
-        return future;
+        return asyncGetRequest(path, new UnaryGetCallback<Map<BacklogQuotaType, BacklogQuota>>() {});
     }
 
     @Override
@@ -998,20 +763,7 @@ public class NamespacesImpl extends BaseResource implements Namespaces {
     public CompletableFuture<BookieAffinityGroupData> getBookieAffinityGroupAsync(String namespace) {
         NamespaceName ns = NamespaceName.get(namespace);
         WebTarget path = namespacePath(ns, "persistence", "bookieAffinity");
-        final CompletableFuture<BookieAffinityGroupData> future = new CompletableFuture<>();
-        asyncGetRequest(path,
-                new InvocationCallback<BookieAffinityGroupData>() {
-                    @Override
-                    public void completed(BookieAffinityGroupData bookieAffinityGroupData) {
-                        future.complete(bookieAffinityGroupData);
-                    }
-
-                    @Override
-                    public void failed(Throwable throwable) {
-                        future.completeExceptionally(getApiException(throwable.getCause()));
-                    }
-                });
-        return future;
+        return asyncGetRequest(path, new UnaryGetCallback<BookieAffinityGroupData>() {});
     }
 
     @Override
@@ -1023,20 +775,7 @@ public class NamespacesImpl extends BaseResource implements Namespaces {
     public CompletableFuture<PersistencePolicies> getPersistenceAsync(String namespace) {
         NamespaceName ns = NamespaceName.get(namespace);
         WebTarget path = namespacePath(ns, "persistence");
-        final CompletableFuture<PersistencePolicies> future = new CompletableFuture<>();
-        asyncGetRequest(path,
-                new InvocationCallback<PersistencePolicies>() {
-                    @Override
-                    public void completed(PersistencePolicies persistencePolicies) {
-                        future.complete(persistencePolicies);
-                    }
-
-                    @Override
-                    public void failed(Throwable throwable) {
-                        future.completeExceptionally(getApiException(throwable.getCause()));
-                    }
-                });
-        return future;
+        return asyncGetRequest(path, new UnaryGetCallback<PersistencePolicies>() {});
     }
 
     @Override
@@ -1072,20 +811,7 @@ public class NamespacesImpl extends BaseResource implements Namespaces {
     public CompletableFuture<RetentionPolicies> getRetentionAsync(String namespace) {
         NamespaceName ns = NamespaceName.get(namespace);
         WebTarget path = namespacePath(ns, "retention");
-        final CompletableFuture<RetentionPolicies> future = new CompletableFuture<>();
-        asyncGetRequest(path,
-                new InvocationCallback<RetentionPolicies>() {
-                    @Override
-                    public void completed(RetentionPolicies retentionPolicies) {
-                        future.complete(retentionPolicies);
-                    }
-
-                    @Override
-                    public void failed(Throwable throwable) {
-                        future.completeExceptionally(getApiException(throwable.getCause()));
-                    }
-                });
-        return future;
+        return asyncGetRequest(path, new UnaryGetCallback<RetentionPolicies>() {});
     }
 
     @Override
@@ -1109,20 +835,7 @@ public class NamespacesImpl extends BaseResource implements Namespaces {
     public CompletableFuture<String> getReplicationConfigVersionAsync(String namespace) {
         NamespaceName ns = NamespaceName.get(namespace);
         WebTarget path = namespacePath(ns, "configversion");
-        final CompletableFuture<String> future = new CompletableFuture<>();
-        asyncGetRequest(path,
-                new InvocationCallback<String>() {
-                    @Override
-                    public void completed(String s) {
-                        future.complete(s);
-                    }
-
-                    @Override
-                    public void failed(Throwable throwable) {
-                        future.completeExceptionally(getApiException(throwable.getCause()));
-                    }
-                });
-        return future;
+        return asyncGetRequest(path, new UnaryGetCallback<String>() {});
     }
 
     @Override
@@ -1185,20 +898,7 @@ public class NamespacesImpl extends BaseResource implements Namespaces {
         if (topics != null && topics.size() > 0) {
             path = path.queryParam("topics", topics.stream().map(Codec::encode).toArray());
         }
-        final CompletableFuture<TopicHashPositions> future = new CompletableFuture<>();
-        asyncGetRequest(path,
-                new InvocationCallback<TopicHashPositions>() {
-                    @Override
-                    public void completed(TopicHashPositions topicHashPositions) {
-                        future.complete(topicHashPositions);
-                    }
-
-                    @Override
-                    public void failed(Throwable throwable) {
-                        future.completeExceptionally(getApiException(throwable.getCause()));
-                    }
-                });
-        return future;
+        return asyncGetRequest(path, new UnaryGetCallback<TopicHashPositions>() {});
     }
 
     @Override
@@ -1234,20 +934,7 @@ public class NamespacesImpl extends BaseResource implements Namespaces {
     public CompletableFuture<PublishRate> getPublishRateAsync(String namespace) {
         NamespaceName ns = NamespaceName.get(namespace);
         WebTarget path = namespacePath(ns, "publishRate");
-        final CompletableFuture<PublishRate> future = new CompletableFuture<>();
-        asyncGetRequest(path,
-                new InvocationCallback<PublishRate>() {
-                    @Override
-                    public void completed(PublishRate publishRate) {
-                        future.complete(publishRate);
-                    }
-
-                    @Override
-                    public void failed(Throwable throwable) {
-                        future.completeExceptionally(getApiException(throwable.getCause()));
-                    }
-                });
-        return future;
+        return asyncGetRequest(path, new UnaryGetCallback<PublishRate>() {});
     }
 
     @Override
@@ -1283,20 +970,7 @@ public class NamespacesImpl extends BaseResource implements Namespaces {
     public CompletableFuture<DispatchRate> getDispatchRateAsync(String namespace) {
         NamespaceName ns = NamespaceName.get(namespace);
         WebTarget path = namespacePath(ns, "dispatchRate");
-        final CompletableFuture<DispatchRate> future = new CompletableFuture<>();
-        asyncGetRequest(path,
-                new InvocationCallback<DispatchRate>() {
-                    @Override
-                    public void completed(DispatchRate dispatchRate) {
-                        future.complete(dispatchRate);
-                    }
-
-                    @Override
-                    public void failed(Throwable throwable) {
-                        future.completeExceptionally(getApiException(throwable.getCause()));
-                    }
-                });
-        return future;
+        return asyncGetRequest(path, new UnaryGetCallback<DispatchRate>() {});
     }
 
     @Override
@@ -1332,20 +1006,7 @@ public class NamespacesImpl extends BaseResource implements Namespaces {
     public CompletableFuture<SubscribeRate> getSubscribeRateAsync(String namespace) {
         NamespaceName ns = NamespaceName.get(namespace);
         WebTarget path = namespacePath(ns, "subscribeRate");
-        final CompletableFuture<SubscribeRate> future = new CompletableFuture<>();
-        asyncGetRequest(path,
-                new InvocationCallback<SubscribeRate>() {
-                    @Override
-                    public void completed(SubscribeRate subscribeRate) {
-                        future.complete(subscribeRate);
-                    }
-
-                    @Override
-                    public void failed(Throwable throwable) {
-                        future.completeExceptionally(getApiException(throwable.getCause()));
-                    }
-                });
-        return future;
+        return asyncGetRequest(path, new UnaryGetCallback<SubscribeRate>() {});
     }
 
     @Override
@@ -1382,20 +1043,7 @@ public class NamespacesImpl extends BaseResource implements Namespaces {
     public CompletableFuture<DispatchRate> getSubscriptionDispatchRateAsync(String namespace) {
         NamespaceName ns = NamespaceName.get(namespace);
         WebTarget path = namespacePath(ns, "subscriptionDispatchRate");
-        final CompletableFuture<DispatchRate> future = new CompletableFuture<>();
-        asyncGetRequest(path,
-                new InvocationCallback<DispatchRate>() {
-                    @Override
-                    public void completed(DispatchRate dispatchRate) {
-                        future.complete(dispatchRate);
-                    }
-
-                    @Override
-                    public void failed(Throwable throwable) {
-                        future.completeExceptionally(getApiException(throwable.getCause()));
-                    }
-                });
-        return future;
+        return asyncGetRequest(path, new UnaryGetCallback<DispatchRate>() {});
     }
 
     @Override
@@ -1431,20 +1079,7 @@ public class NamespacesImpl extends BaseResource implements Namespaces {
     public CompletableFuture<DispatchRate> getReplicatorDispatchRateAsync(String namespace) {
         NamespaceName ns = NamespaceName.get(namespace);
         WebTarget path = namespacePath(ns, "replicatorDispatchRate");
-        final CompletableFuture<DispatchRate> future = new CompletableFuture<>();
-        asyncGetRequest(path,
-                new InvocationCallback<DispatchRate>() {
-                    @Override
-                    public void completed(DispatchRate dispatchRate) {
-                        future.complete(dispatchRate);
-                    }
-
-                    @Override
-                    public void failed(Throwable throwable) {
-                        future.completeExceptionally(getApiException(throwable.getCause()));
-                    }
-                });
-        return future;
+        return asyncGetRequest(path, new UnaryGetCallback<DispatchRate>() {});
     }
 
     @Override
@@ -1547,20 +1182,7 @@ public class NamespacesImpl extends BaseResource implements Namespaces {
     public CompletableFuture<SubscriptionAuthMode> getSubscriptionAuthModeAsync(String namespace) {
         NamespaceName ns = NamespaceName.get(namespace);
         WebTarget path = namespacePath(ns, "subscriptionAuthMode");
-        final CompletableFuture<SubscriptionAuthMode> future = new CompletableFuture<>();
-        asyncGetRequest(path,
-                new InvocationCallback<SubscriptionAuthMode>() {
-                    @Override
-                    public void completed(SubscriptionAuthMode subscriptionAuthMode) {
-                        future.complete(subscriptionAuthMode);
-                    }
-
-                    @Override
-                    public void failed(Throwable throwable) {
-                        future.completeExceptionally(getApiException(throwable.getCause()));
-                    }
-                });
-        return future;
+        return asyncGetRequest(path, new UnaryGetCallback<SubscriptionAuthMode>() {});
     }
 
     @Override
@@ -1584,20 +1206,7 @@ public class NamespacesImpl extends BaseResource implements Namespaces {
     public CompletableFuture<Boolean> getEncryptionRequiredStatusAsync(String namespace) {
         NamespaceName ns = NamespaceName.get(namespace);
         WebTarget path = namespacePath(ns, "encryptionRequired");
-        final CompletableFuture<Boolean> future = new CompletableFuture<>();
-        asyncGetRequest(path,
-                new InvocationCallback<Boolean>() {
-                    @Override
-                    public void completed(Boolean enabled) {
-                        future.complete(enabled);
-                    }
-
-                    @Override
-                    public void failed(Throwable throwable) {
-                        future.completeExceptionally(getApiException(throwable.getCause()));
-                    }
-                });
-        return future;
+        return asyncGetRequest(path, new UnaryGetCallback<Boolean>() {});
     }
 
     @Override
@@ -1609,20 +1218,7 @@ public class NamespacesImpl extends BaseResource implements Namespaces {
     public CompletableFuture<DelayedDeliveryPolicies> getDelayedDeliveryAsync(String namespace) {
         NamespaceName ns = NamespaceName.get(namespace);
         WebTarget path = namespacePath(ns, "delayedDelivery");
-        final CompletableFuture<DelayedDeliveryPolicies> future = new CompletableFuture<>();
-        asyncGetRequest(path,
-                new InvocationCallback<DelayedDeliveryPolicies>() {
-                    @Override
-                    public void completed(DelayedDeliveryPolicies delayedDeliveryPolicies) {
-                        future.complete(delayedDeliveryPolicies);
-                    }
-
-                    @Override
-                    public void failed(Throwable throwable) {
-                        future.completeExceptionally(getApiException(throwable.getCause()));
-                    }
-                });
-        return future;
+        return asyncGetRequest(path, new UnaryGetCallback<DelayedDeliveryPolicies>() {});
     }
 
     @Override
@@ -1660,19 +1256,7 @@ public class NamespacesImpl extends BaseResource implements Namespaces {
     public CompletableFuture<InactiveTopicPolicies> getInactiveTopicPoliciesAsync(String namespace) {
         NamespaceName ns = NamespaceName.get(namespace);
         WebTarget path = namespacePath(ns, "inactiveTopicPolicies");
-        final CompletableFuture<InactiveTopicPolicies> future = new CompletableFuture<>();
-        asyncGetRequest(path, new InvocationCallback<InactiveTopicPolicies>() {
-                    @Override
-                    public void completed(InactiveTopicPolicies inactiveTopicPolicies) {
-                        future.complete(inactiveTopicPolicies);
-                    }
-
-                    @Override
-                    public void failed(Throwable throwable) {
-                        future.completeExceptionally(getApiException(throwable.getCause()));
-                    }
-                });
-        return future;
+        return asyncGetRequest(path, new UnaryGetCallback<InactiveTopicPolicies>() {});
     }
 
     @Override
@@ -1698,20 +1282,7 @@ public class NamespacesImpl extends BaseResource implements Namespaces {
     public CompletableFuture<Integer> getDeduplicationSnapshotIntervalAsync(String namespace) {
         NamespaceName ns = NamespaceName.get(namespace);
         WebTarget path = namespacePath(ns, "deduplicationSnapshotInterval");
-        final CompletableFuture<Integer> future = new CompletableFuture<>();
-        asyncGetRequest(path,
-                new InvocationCallback<Integer>() {
-                    @Override
-                    public void completed(Integer interval) {
-                        future.complete(interval);
-                    }
-
-                    @Override
-                    public void failed(Throwable throwable) {
-                        future.completeExceptionally(getApiException(throwable.getCause()));
-                    }
-                });
-        return future;
+        return asyncGetRequest(path, new UnaryGetCallback<Integer>() {});
     }
 
     @Override
@@ -1745,20 +1316,7 @@ public class NamespacesImpl extends BaseResource implements Namespaces {
     public CompletableFuture<Integer> getMaxSubscriptionsPerTopicAsync(String namespace) {
         NamespaceName ns = NamespaceName.get(namespace);
         WebTarget path = namespacePath(ns, "maxSubscriptionsPerTopic");
-        final CompletableFuture<Integer> future = new CompletableFuture<>();
-        asyncGetRequest(path,
-                new InvocationCallback<Integer>() {
-                    @Override
-                    public void completed(Integer maxSubscriptionsPerTopic) {
-                        future.complete(maxSubscriptionsPerTopic);
-                    }
-
-                    @Override
-                    public void failed(Throwable throwable) {
-                        future.completeExceptionally(getApiException(throwable.getCause()));
-                    }
-                });
-        return future;
+        return asyncGetRequest(path, new UnaryGetCallback<Integer>() {});
     }
 
     @Override
@@ -1795,20 +1353,7 @@ public class NamespacesImpl extends BaseResource implements Namespaces {
     public CompletableFuture<Integer> getMaxProducersPerTopicAsync(String namespace) {
         NamespaceName ns = NamespaceName.get(namespace);
         WebTarget path = namespacePath(ns, "maxProducersPerTopic");
-        final CompletableFuture<Integer> future = new CompletableFuture<>();
-        asyncGetRequest(path,
-                new InvocationCallback<Integer>() {
-                    @Override
-                    public void completed(Integer max) {
-                        future.complete(max);
-                    }
-
-                    @Override
-                    public void failed(Throwable throwable) {
-                        future.completeExceptionally(getApiException(throwable.getCause()));
-                    }
-                });
-        return future;
+        return asyncGetRequest(path, new UnaryGetCallback<Integer>() {});
     }
 
     @Override
@@ -1844,20 +1389,7 @@ public class NamespacesImpl extends BaseResource implements Namespaces {
     public CompletableFuture<Integer> getMaxConsumersPerTopicAsync(String namespace) {
         NamespaceName ns = NamespaceName.get(namespace);
         WebTarget path = namespacePath(ns, "maxConsumersPerTopic");
-        final CompletableFuture<Integer> future = new CompletableFuture<>();
-        asyncGetRequest(path,
-                new InvocationCallback<Integer>() {
-                    @Override
-                    public void completed(Integer max) {
-                        future.complete(max);
-                    }
-
-                    @Override
-                    public void failed(Throwable throwable) {
-                        future.completeExceptionally(getApiException(throwable.getCause()));
-                    }
-                });
-        return future;
+        return asyncGetRequest(path, new UnaryGetCallback<Integer>() {});
     }
 
     @Override
@@ -1893,20 +1425,7 @@ public class NamespacesImpl extends BaseResource implements Namespaces {
     public CompletableFuture<Integer> getMaxConsumersPerSubscriptionAsync(String namespace) {
         NamespaceName ns = NamespaceName.get(namespace);
         WebTarget path = namespacePath(ns, "maxConsumersPerSubscription");
-        final CompletableFuture<Integer> future = new CompletableFuture<>();
-        asyncGetRequest(path,
-                new InvocationCallback<Integer>() {
-                    @Override
-                    public void completed(Integer max) {
-                        future.complete(max);
-                    }
-
-                    @Override
-                    public void failed(Throwable throwable) {
-                        future.completeExceptionally(getApiException(throwable.getCause()));
-                    }
-                });
-        return future;
+        return asyncGetRequest(path, new UnaryGetCallback<Integer>() {});
     }
 
     @Override
@@ -1946,20 +1465,7 @@ public class NamespacesImpl extends BaseResource implements Namespaces {
     public CompletableFuture<Integer> getMaxUnackedMessagesPerConsumerAsync(String namespace) {
         NamespaceName ns = NamespaceName.get(namespace);
         WebTarget path = namespacePath(ns, "maxUnackedMessagesPerConsumer");
-        final CompletableFuture<Integer> future = new CompletableFuture<>();
-        asyncGetRequest(path,
-                new InvocationCallback<Integer>() {
-                    @Override
-                    public void completed(Integer max) {
-                        future.complete(max);
-                    }
-
-                    @Override
-                    public void failed(Throwable throwable) {
-                        future.completeExceptionally(getApiException(throwable.getCause()));
-                    }
-                });
-        return future;
+        return asyncGetRequest(path, new UnaryGetCallback<Integer>() {});
     }
 
     @Override
@@ -1997,20 +1503,7 @@ public class NamespacesImpl extends BaseResource implements Namespaces {
     public CompletableFuture<Integer> getMaxUnackedMessagesPerSubscriptionAsync(String namespace) {
         NamespaceName ns = NamespaceName.get(namespace);
         WebTarget path = namespacePath(ns, "maxUnackedMessagesPerSubscription");
-        final CompletableFuture<Integer> future = new CompletableFuture<>();
-        asyncGetRequest(path,
-                new InvocationCallback<Integer>() {
-                    @Override
-                    public void completed(Integer max) {
-                        future.complete(max);
-                    }
-
-                    @Override
-                    public void failed(Throwable throwable) {
-                        future.completeExceptionally(getApiException(throwable.getCause()));
-                    }
-                });
-        return future;
+        return asyncGetRequest(path, new UnaryGetCallback<Integer>() {});
     }
 
     @Override
@@ -2050,20 +1543,7 @@ public class NamespacesImpl extends BaseResource implements Namespaces {
     public CompletableFuture<Long> getCompactionThresholdAsync(String namespace) {
         NamespaceName ns = NamespaceName.get(namespace);
         WebTarget path = namespacePath(ns, "compactionThreshold");
-        final CompletableFuture<Long> future = new CompletableFuture<>();
-        asyncGetRequest(path,
-                new InvocationCallback<Long>() {
-                    @Override
-                    public void completed(Long threshold) {
-                        future.complete(threshold);
-                    }
-
-                    @Override
-                    public void failed(Throwable throwable) {
-                        future.completeExceptionally(getApiException(throwable.getCause()));
-                    }
-                });
-        return future;
+        return asyncGetRequest(path, new UnaryGetCallback<Long>() {});
     }
 
     @Override
@@ -2099,20 +1579,7 @@ public class NamespacesImpl extends BaseResource implements Namespaces {
     public CompletableFuture<Long> getOffloadThresholdAsync(String namespace) {
         NamespaceName ns = NamespaceName.get(namespace);
         WebTarget path = namespacePath(ns, "offloadThreshold");
-        final CompletableFuture<Long> future = new CompletableFuture<>();
-        asyncGetRequest(path,
-                new InvocationCallback<Long>() {
-                    @Override
-                    public void completed(Long threshold) {
-                        future.complete(threshold);
-                    }
-
-                    @Override
-                    public void failed(Throwable throwable) {
-                        future.completeExceptionally(getApiException(throwable.getCause()));
-                    }
-                });
-        return future;
+        return asyncGetRequest(path, new UnaryGetCallback<Long>() {});
     }
 
     @Override
@@ -2136,20 +1603,7 @@ public class NamespacesImpl extends BaseResource implements Namespaces {
     public CompletableFuture<Long> getOffloadDeleteLagMsAsync(String namespace) {
         NamespaceName ns = NamespaceName.get(namespace);
         WebTarget path = namespacePath(ns, "offloadDeletionLagMs");
-        final CompletableFuture<Long> future = new CompletableFuture<>();
-        asyncGetRequest(path,
-                new InvocationCallback<Long>() {
-                    @Override
-                    public void completed(Long lag) {
-                        future.complete(lag);
-                    }
-
-                    @Override
-                    public void failed(Throwable throwable) {
-                        future.completeExceptionally(getApiException(throwable.getCause()));
-                    }
-                });
-        return future;
+        return asyncGetRequest(path, new UnaryGetCallback<Long>() {});
     }
 
     @Override
@@ -2224,20 +1678,7 @@ public class NamespacesImpl extends BaseResource implements Namespaces {
         NamespaceName ns = NamespaceName.get(namespace);
         WebTarget path = namespacePath(ns, "schemaValidationEnforced");
         path = path.queryParam("applied", applied);
-        final CompletableFuture<Boolean> future = new CompletableFuture<>();
-        asyncGetRequest(path,
-                new InvocationCallback<Boolean>() {
-                    @Override
-                    public void completed(Boolean enforced) {
-                        future.complete(enforced);
-                    }
-
-                    @Override
-                    public void failed(Throwable throwable) {
-                        future.completeExceptionally(getApiException(throwable.getCause()));
-                    }
-                });
-        return future;
+        return asyncGetRequest(path, new UnaryGetCallback<Boolean>() {});
     }
 
     @Override
@@ -2263,20 +1704,7 @@ public class NamespacesImpl extends BaseResource implements Namespaces {
     public CompletableFuture<SchemaCompatibilityStrategy> getSchemaCompatibilityStrategyAsync(String namespace) {
         NamespaceName ns = NamespaceName.get(namespace);
         WebTarget path = namespacePath(ns, "schemaCompatibilityStrategy");
-        final CompletableFuture<SchemaCompatibilityStrategy> future = new CompletableFuture<>();
-        asyncGetRequest(path,
-                new InvocationCallback<SchemaCompatibilityStrategy>() {
-                    @Override
-                    public void completed(SchemaCompatibilityStrategy schemaCompatibilityStrategy) {
-                        future.complete(schemaCompatibilityStrategy);
-                    }
-
-                    @Override
-                    public void failed(Throwable throwable) {
-                        future.completeExceptionally(getApiException(throwable.getCause()));
-                    }
-                });
-        return future;
+        return asyncGetRequest(path, new UnaryGetCallback<SchemaCompatibilityStrategy>() {});
     }
 
     @Override
@@ -2302,20 +1730,7 @@ public class NamespacesImpl extends BaseResource implements Namespaces {
     public CompletableFuture<Boolean> getIsAllowAutoUpdateSchemaAsync(String namespace) {
         NamespaceName ns = NamespaceName.get(namespace);
         WebTarget path = namespacePath(ns, "isAllowAutoUpdateSchema");
-        final CompletableFuture<Boolean> future = new CompletableFuture<>();
-        asyncGetRequest(path,
-                new InvocationCallback<Boolean>() {
-                    @Override
-                    public void completed(Boolean allowAutoUpdate) {
-                        future.complete(allowAutoUpdate);
-                    }
-
-                    @Override
-                    public void failed(Throwable throwable) {
-                        future.completeExceptionally(getApiException(throwable.getCause()));
-                    }
-                });
-        return future;
+        return asyncGetRequest(path, new UnaryGetCallback<Boolean>() {});
     }
 
     @Override
@@ -2365,20 +1780,7 @@ public class NamespacesImpl extends BaseResource implements Namespaces {
     public CompletableFuture<OffloadPolicies> getOffloadPoliciesAsync(String namespace) {
         NamespaceName ns = NamespaceName.get(namespace);
         WebTarget path = namespacePath(ns, "offloadPolicies");
-        final CompletableFuture<OffloadPolicies> future = new CompletableFuture<>();
-        asyncGetRequest(path,
-                new InvocationCallback<OffloadPoliciesImpl>() {
-                    @Override
-                    public void completed(OffloadPoliciesImpl offloadPolicies) {
-                        future.complete(offloadPolicies);
-                    }
-
-                    @Override
-                    public void failed(Throwable throwable) {
-                        future.completeExceptionally(getApiException(throwable.getCause()));
-                    }
-                });
-        return future;
+        return asyncGetRequest(path, new UnaryGetCallback<OffloadPolicies>() {});
     }
 
     @Override
@@ -2390,20 +1792,7 @@ public class NamespacesImpl extends BaseResource implements Namespaces {
     public CompletableFuture<Integer> getMaxTopicsPerNamespaceAsync(String namespace) {
         NamespaceName ns = NamespaceName.get(namespace);
         WebTarget path = namespacePath(ns, "maxTopicsPerNamespace");
-        final CompletableFuture<Integer> future = new CompletableFuture<>();
-        asyncGetRequest(path,
-                new InvocationCallback<Integer>() {
-                    @Override
-                    public void completed(Integer maxTopicsPerNamespace) {
-                        future.complete(maxTopicsPerNamespace);
-                    }
-
-                    @Override
-                    public void failed(Throwable throwable) {
-                        future.completeExceptionally(getApiException(throwable.getCause()));
-                    }
-                });
-        return future;
+        return asyncGetRequest(path, new UnaryGetCallback<Integer>() {});
     }
 
     @Override
@@ -2462,20 +1851,9 @@ public class NamespacesImpl extends BaseResource implements Namespaces {
     @Override
     public CompletableFuture<String> getPropertyAsync(String namespace, String key) {
         NamespaceName ns = NamespaceName.get(namespace);
-        final CompletableFuture<String> future = new CompletableFuture<>();
         WebTarget path = namespacePath(ns, "property", key);
-        asyncGetRequest(path, new InvocationCallback<String>() {
-            @Override
-            public void completed(String value) {
-                future.complete(StringUtils.isEmpty(value) ? null : value);
-            }
-
-            @Override
-            public void failed(Throwable throwable) {
-                future.completeExceptionally(getApiException(throwable.getCause()));
-            }
-        });
-        return future;
+        return asyncGetRequest(path, new UnaryGetCallback<String>(
+                value -> StringUtils.isEmpty(value) ? null : value) {});
     }
 
     @Override
@@ -2486,40 +1864,15 @@ public class NamespacesImpl extends BaseResource implements Namespaces {
     @Override
     public CompletableFuture<Map<String, String>> getPropertiesAsync(String namespace) {
         NamespaceName ns = NamespaceName.get(namespace);
-        final CompletableFuture<Map<String, String>> future = new CompletableFuture<>();
         WebTarget path = namespacePath(ns, "properties");
-        asyncGetRequest(path, new InvocationCallback<Map<String, String>>() {
-            @Override
-            public void completed(Map<String, String> value) {
-                future.complete(value);
-            }
-
-            @Override
-            public void failed(Throwable throwable) {
-                future.completeExceptionally(getApiException(throwable.getCause()));
-            }
-        });
-        return future;
+        return asyncGetRequest(path, new UnaryGetCallback<Map<String, String>>() {});
     }
 
     @Override
     public CompletableFuture<String> getNamespaceResourceGroupAsync(String namespace) {
         NamespaceName ns = NamespaceName.get(namespace);
         WebTarget path = namespacePath(ns, "resourcegroup");
-        final CompletableFuture<String> future = new CompletableFuture<>();
-        asyncGetRequest(path,
-                new InvocationCallback<String>() {
-                    @Override
-                    public void completed(String rgName) {
-                        future.complete(rgName);
-                    }
-
-                    @Override
-                    public void failed(Throwable throwable) {
-                        future.completeExceptionally(getApiException(throwable.getCause()));
-                    }
-                });
-        return future;
+        return asyncGetRequest(path, new UnaryGetCallback<String>() {});
     }
 
     @Override

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/NonPersistentTopicsImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/NonPersistentTopicsImpl.java
@@ -22,7 +22,6 @@ import static com.google.common.base.Preconditions.checkArgument;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import javax.ws.rs.client.Entity;
-import javax.ws.rs.client.InvocationCallback;
 import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.core.MediaType;
 import org.apache.pulsar.client.admin.NonPersistentTopics;
@@ -66,22 +65,8 @@ public class NonPersistentTopicsImpl extends BaseResource implements NonPersiste
     @Override
     public CompletableFuture<PartitionedTopicMetadata> getPartitionedTopicMetadataAsync(String topic) {
         TopicName topicName = validateTopic(topic);
-        final CompletableFuture<PartitionedTopicMetadata> future = new CompletableFuture<>();
         WebTarget path = topicPath(topicName, "partitions");
-        asyncGetRequest(path,
-                new InvocationCallback<PartitionedTopicMetadata>() {
-
-                    @Override
-                    public void completed(PartitionedTopicMetadata response) {
-                        future.complete(response);
-                    }
-
-                    @Override
-                    public void failed(Throwable throwable) {
-                        future.completeExceptionally(getApiException(throwable.getCause()));
-                    }
-                });
-        return future;
+        return asyncGetRequest(path, new UnaryGetCallback<PartitionedTopicMetadata>() {});
     }
 
     @Override
@@ -92,22 +77,8 @@ public class NonPersistentTopicsImpl extends BaseResource implements NonPersiste
     @Override
     public CompletableFuture<NonPersistentTopicStats> getStatsAsync(String topic) {
         TopicName topicName = validateTopic(topic);
-        final CompletableFuture<NonPersistentTopicStats> future = new CompletableFuture<>();
         WebTarget path = topicPath(topicName, "stats");
-        asyncGetRequest(path,
-                new InvocationCallback<NonPersistentTopicStats>() {
-
-                    @Override
-                    public void completed(NonPersistentTopicStats response) {
-                        future.complete(response);
-                    }
-
-                    @Override
-                    public void failed(Throwable throwable) {
-                        future.completeExceptionally(getApiException(throwable.getCause()));
-                    }
-                });
-        return future;
+        return asyncGetRequest(path, new UnaryGetCallback<NonPersistentTopicStats>() {});
     }
 
     @Override
@@ -118,22 +89,8 @@ public class NonPersistentTopicsImpl extends BaseResource implements NonPersiste
     @Override
     public CompletableFuture<PersistentTopicInternalStats> getInternalStatsAsync(String topic) {
         TopicName topicName = validateTopic(topic);
-        final CompletableFuture<PersistentTopicInternalStats> future = new CompletableFuture<>();
         WebTarget path = topicPath(topicName, "internalStats");
-        asyncGetRequest(path,
-                new InvocationCallback<PersistentTopicInternalStats>() {
-
-                    @Override
-                    public void completed(PersistentTopicInternalStats response) {
-                        future.complete(response);
-                    }
-
-                    @Override
-                    public void failed(Throwable throwable) {
-                        future.completeExceptionally(getApiException(throwable.getCause()));
-                    }
-                });
-        return future;
+        return asyncGetRequest(path, new UnaryGetCallback<PersistentTopicInternalStats>() {});
     }
 
     @Override
@@ -156,20 +113,8 @@ public class NonPersistentTopicsImpl extends BaseResource implements NonPersiste
     @Override
     public CompletableFuture<List<String>> getListInBundleAsync(String namespace, String bundleRange) {
         NamespaceName ns = NamespaceName.get(namespace);
-        final CompletableFuture<List<String>> future = new CompletableFuture<>();
         WebTarget path = namespacePath("non-persistent", ns, bundleRange);
-        asyncGetRequest(path,
-                new InvocationCallback<List<String>>() {
-                    @Override
-                    public void completed(List<String> response) {
-                        future.complete(response);
-                    }
-                    @Override
-                    public void failed(Throwable throwable) {
-                        future.completeExceptionally(getApiException(throwable.getCause()));
-                    }
-                });
-        return future;
+        return asyncGetRequest(path, new UnaryGetCallback<List<String>>() {});
     }
 
     @Override
@@ -180,21 +125,8 @@ public class NonPersistentTopicsImpl extends BaseResource implements NonPersiste
     @Override
     public CompletableFuture<List<String>> getListAsync(String namespace) {
         NamespaceName ns = NamespaceName.get(namespace);
-        final CompletableFuture<List<String>> future = new CompletableFuture<>();
         WebTarget path = namespacePath("non-persistent", ns);
-        asyncGetRequest(path,
-                new InvocationCallback<List<String>>() {
-                    @Override
-                    public void completed(List<String> response) {
-                        future.complete(response);
-                    }
-
-                    @Override
-                    public void failed(Throwable throwable) {
-                        future.completeExceptionally(getApiException(throwable.getCause()));
-                    }
-                });
-        return future;
+        return asyncGetRequest(path, new UnaryGetCallback<List<String>>() {});
     }
 
     /*

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/ResourceGroupsImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/ResourceGroupsImpl.java
@@ -21,7 +21,6 @@ package org.apache.pulsar.client.admin.internal;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import javax.ws.rs.client.Entity;
-import javax.ws.rs.client.InvocationCallback;
 import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.core.MediaType;
 import org.apache.pulsar.client.admin.PulsarAdminException;
@@ -40,25 +39,12 @@ public class ResourceGroupsImpl extends BaseResource implements ResourceGroups {
 
     @Override
     public List<String> getResourceGroups() throws PulsarAdminException {
-        return sync(() -> getResourceGroupsAsync());
+        return sync(this::getResourceGroupsAsync);
     }
 
     @Override
     public CompletableFuture<List<String>> getResourceGroupsAsync() {
-        final CompletableFuture<List<String>> future = new CompletableFuture<>();
-        asyncGetRequest(adminResourceGroups,
-                new InvocationCallback<List<String>>() {
-                    @Override
-                    public void completed(List<String> resourcegroups) {
-                        future.complete(resourcegroups);
-                    }
-
-                    @Override
-                    public void failed(Throwable throwable) {
-                        future.completeExceptionally(getApiException(throwable.getCause()));
-                    }
-                });
-        return future;
+        return asyncGetRequest(adminResourceGroups, new UnaryGetCallback<List<String>>() {});
     }
 
     @Override
@@ -69,20 +55,7 @@ public class ResourceGroupsImpl extends BaseResource implements ResourceGroups {
     @Override
     public CompletableFuture<ResourceGroup> getResourceGroupAsync(String name) {
         WebTarget path = adminResourceGroups.path(name);
-        final CompletableFuture<ResourceGroup> future = new CompletableFuture<>();
-        asyncGetRequest(path,
-                new InvocationCallback<ResourceGroup>() {
-                    @Override
-                    public void completed(ResourceGroup resourcegroup) {
-                        future.complete(resourcegroup);
-                    }
-
-                    @Override
-                    public void failed(Throwable throwable) {
-                        future.completeExceptionally(getApiException(throwable.getCause()));
-                    }
-                });
-        return future;
+        return asyncGetRequest(path, new UnaryGetCallback<ResourceGroup>() {});
     }
 
     @Override

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/ResourceQuotasImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/ResourceQuotasImpl.java
@@ -20,7 +20,6 @@ package org.apache.pulsar.client.admin.internal;
 
 import java.util.concurrent.CompletableFuture;
 import javax.ws.rs.client.Entity;
-import javax.ws.rs.client.InvocationCallback;
 import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.core.MediaType;
 import org.apache.pulsar.client.admin.PulsarAdminException;
@@ -42,25 +41,12 @@ public class ResourceQuotasImpl extends BaseResource implements ResourceQuotas {
 
     @Override
     public ResourceQuota getDefaultResourceQuota() throws PulsarAdminException {
-        return sync(() -> getDefaultResourceQuotaAsync());
+        return sync(this::getDefaultResourceQuotaAsync);
     }
 
     @Override
     public CompletableFuture<ResourceQuota> getDefaultResourceQuotaAsync() {
-        final CompletableFuture<ResourceQuota> future = new CompletableFuture<>();
-        asyncGetRequest(adminV2Quotas,
-                new InvocationCallback<ResourceQuota>() {
-                    @Override
-                    public void completed(ResourceQuota resourceQuota) {
-                        future.complete(resourceQuota);
-                    }
-
-                    @Override
-                    public void failed(Throwable throwable) {
-                        future.completeExceptionally(getApiException(throwable.getCause()));
-                    }
-                });
-        return future;
+        return asyncGetRequest(adminV2Quotas, new UnaryGetCallback<ResourceQuota>() {});
     }
 
     @Override
@@ -82,20 +68,7 @@ public class ResourceQuotasImpl extends BaseResource implements ResourceQuotas {
     public CompletableFuture<ResourceQuota> getNamespaceBundleResourceQuotaAsync(String namespace, String bundle) {
         NamespaceName ns = NamespaceName.get(namespace);
         WebTarget path = namespacePath(ns, bundle);
-        final CompletableFuture<ResourceQuota> future = new CompletableFuture<>();
-        asyncGetRequest(path,
-                new InvocationCallback<ResourceQuota>() {
-                    @Override
-                    public void completed(ResourceQuota resourceQuota) {
-                        future.complete(resourceQuota);
-                    }
-
-                    @Override
-                    public void failed(Throwable throwable) {
-                        future.completeExceptionally(getApiException(throwable.getCause()));
-                    }
-                });
-        return future;
+        return asyncGetRequest(path, new UnaryGetCallback<ResourceQuota>() {});
     }
 
     @Override

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/SchemasImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/SchemasImpl.java
@@ -60,20 +60,9 @@ public class SchemasImpl extends BaseResource implements Schemas {
     @Override
     public CompletableFuture<SchemaInfo> getSchemaInfoAsync(String topic) {
         TopicName tn = TopicName.get(topic);
-        final CompletableFuture<SchemaInfo> future = new CompletableFuture<>();
-        asyncGetRequest(schemaPath(tn),
-                new InvocationCallback<GetSchemaResponse>() {
-                    @Override
-                    public void completed(GetSchemaResponse response) {
-                        future.complete(convertGetSchemaResponseToSchemaInfo(tn, response));
-                    }
-
-                    @Override
-                    public void failed(Throwable throwable) {
-                        future.completeExceptionally(getApiException(throwable.getCause()));
-                    }
-                });
-        return future;
+        WebTarget path = schemaPath(tn);
+        return asyncGetRequest(path, new GetCallback<GetSchemaResponse, SchemaInfo>(response ->
+                        convertGetSchemaResponseToSchemaInfo(tn, response)) {});
     }
 
     @Override
@@ -84,20 +73,9 @@ public class SchemasImpl extends BaseResource implements Schemas {
     @Override
     public CompletableFuture<SchemaInfoWithVersion> getSchemaInfoWithVersionAsync(String topic) {
         TopicName tn = TopicName.get(topic);
-        final CompletableFuture<SchemaInfoWithVersion> future = new CompletableFuture<>();
-        asyncGetRequest(schemaPath(tn),
-                new InvocationCallback<GetSchemaResponse>() {
-                    @Override
-                    public void completed(GetSchemaResponse response) {
-                        future.complete(convertGetSchemaResponseToSchemaInfoWithVersion(tn, response));
-                    }
-
-                    @Override
-                    public void failed(Throwable throwable) {
-                        future.completeExceptionally(getApiException(throwable.getCause()));
-                    }
-                });
-        return future;
+        WebTarget path = schemaPath(tn);
+        return asyncGetRequest(path, new GetCallback<GetSchemaResponse, SchemaInfoWithVersion>(response ->
+                        convertGetSchemaResponseToSchemaInfoWithVersion(tn, response)) {});
     }
 
     @Override
@@ -109,20 +87,8 @@ public class SchemasImpl extends BaseResource implements Schemas {
     public CompletableFuture<SchemaInfo> getSchemaInfoAsync(String topic, long version) {
         TopicName tn = TopicName.get(topic);
         WebTarget path = schemaPath(tn).path(Long.toString(version));
-        final CompletableFuture<SchemaInfo> future = new CompletableFuture<>();
-        asyncGetRequest(path,
-                new InvocationCallback<GetSchemaResponse>() {
-                    @Override
-                    public void completed(GetSchemaResponse response) {
-                        future.complete(convertGetSchemaResponseToSchemaInfo(tn, response));
-                    }
-
-                    @Override
-                    public void failed(Throwable throwable) {
-                        future.completeExceptionally(getApiException(throwable.getCause()));
-                    }
-                });
-        return future;
+        return asyncGetRequest(path, new GetCallback<GetSchemaResponse, SchemaInfo>(response ->
+                        convertGetSchemaResponseToSchemaInfo(tn, response)) {});
     }
 
     @Override
@@ -305,24 +271,12 @@ public class SchemasImpl extends BaseResource implements Schemas {
     public CompletableFuture<List<SchemaInfo>> getAllSchemasAsync(String topic) {
         WebTarget path = schemasPath(TopicName.get(topic));
         TopicName topicName = TopicName.get(topic);
-        final CompletableFuture<List<SchemaInfo>> future = new CompletableFuture<>();
-        asyncGetRequest(path,
-                new InvocationCallback<GetAllVersionsSchemaResponse>() {
-                    @Override
-                    public void completed(GetAllVersionsSchemaResponse response) {
-                        future.complete(
-                                response.getGetSchemaResponses().stream()
-                                        .map(getSchemaResponse ->
-                                                convertGetSchemaResponseToSchemaInfo(topicName, getSchemaResponse))
-                                        .collect(Collectors.toList()));
-                    }
-
-                    @Override
-                    public void failed(Throwable throwable) {
-                        future.completeExceptionally(getApiException(throwable.getCause()));
-                    }
-                });
-        return future;
+        return asyncGetRequest(path, new GetCallback<GetAllVersionsSchemaResponse, List<SchemaInfo>>(
+                response -> response
+                        .getGetSchemaResponses().stream()
+                        .map(getSchemaResponse ->
+                                convertGetSchemaResponseToSchemaInfo(topicName, getSchemaResponse))
+                        .collect(Collectors.toList())) {});
     }
 
     private WebTarget schemaPath(TopicName topicName) {

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/TenantsImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/TenantsImpl.java
@@ -21,7 +21,6 @@ package org.apache.pulsar.client.admin.internal;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import javax.ws.rs.client.Entity;
-import javax.ws.rs.client.InvocationCallback;
 import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.core.MediaType;
 import org.apache.pulsar.client.admin.Properties;
@@ -42,25 +41,12 @@ public class TenantsImpl extends BaseResource implements Tenants, Properties {
 
     @Override
     public List<String> getTenants() throws PulsarAdminException {
-        return sync(() -> getTenantsAsync());
+        return sync(this::getTenantsAsync);
     }
 
     @Override
     public CompletableFuture<List<String>> getTenantsAsync() {
-        final CompletableFuture<List<String>> future = new CompletableFuture<>();
-        asyncGetRequest(adminTenants,
-                new InvocationCallback<List<String>>() {
-                    @Override
-                    public void completed(List<String> tenants) {
-                        future.complete(tenants);
-                    }
-
-                    @Override
-                    public void failed(Throwable throwable) {
-                        future.completeExceptionally(getApiException(throwable.getCause()));
-                    }
-                });
-        return future;
+        return asyncGetRequest(adminTenants, new UnaryGetCallback<List<String>>() {});
     }
 
     @Override
@@ -71,20 +57,7 @@ public class TenantsImpl extends BaseResource implements Tenants, Properties {
     @Override
     public CompletableFuture<TenantInfo> getTenantInfoAsync(String tenant) {
         WebTarget path = adminTenants.path(tenant);
-        final CompletableFuture<TenantInfo> future = new CompletableFuture<>();
-        asyncGetRequest(path,
-                new InvocationCallback<TenantInfoImpl>() {
-                    @Override
-                    public void completed(TenantInfoImpl tenantInfo) {
-                        future.complete(tenantInfo);
-                    }
-
-                    @Override
-                    public void failed(Throwable throwable) {
-                        future.completeExceptionally(getApiException(throwable.getCause()));
-                    }
-                });
-        return future;
+        return asyncGetRequest(path, new UnaryGetCallback<TenantInfo>() {});
     }
 
     @Override

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/TopicPoliciesImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/TopicPoliciesImpl.java
@@ -22,7 +22,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import javax.ws.rs.client.Entity;
-import javax.ws.rs.client.InvocationCallback;
 import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.core.GenericType;
 import javax.ws.rs.core.MediaType;
@@ -125,26 +124,13 @@ public class TopicPoliciesImpl extends BaseResource implements TopicPolicies {
         TopicName topicName = validateTopic(topic);
         WebTarget path = topicPath(topicName, "maxUnackedMessagesOnConsumer");
         path = path.queryParam("applied", applied);
-        final CompletableFuture<Integer> future = new CompletableFuture<>();
-        asyncGetRequest(path, new InvocationCallback<Integer>() {
-            @Override
-            public void completed(Integer maxNum) {
-                future.complete(maxNum);
-            }
-
-            @Override
-            public void failed(Throwable throwable) {
-                future.completeExceptionally(getApiException(throwable.getCause()));
-            }
-        });
-        return future;
+        return asyncGetRequest(path, new UnaryGetCallback<Integer>() {});
     }
 
     @Override
     public CompletableFuture<Void> setMaxUnackedMessagesOnConsumerAsync(String topic, int maxNum) {
         TopicName topicName = validateTopic(topic);
         WebTarget path = topicPath(topicName, "maxUnackedMessagesOnConsumer");
-
         return asyncPostRequest(path, Entity.entity(maxNum, MediaType.APPLICATION_JSON));
     }
 
@@ -175,19 +161,7 @@ public class TopicPoliciesImpl extends BaseResource implements TopicPolicies {
         TopicName topicName = validateTopic(topic);
         WebTarget path = topicPath(topicName, "inactiveTopicPolicies");
         path = path.queryParam("applied", applied);
-        final CompletableFuture<InactiveTopicPolicies> future = new CompletableFuture<>();
-        asyncGetRequest(path, new InvocationCallback<InactiveTopicPolicies>() {
-            @Override
-            public void completed(InactiveTopicPolicies inactiveTopicPolicies) {
-                future.complete(inactiveTopicPolicies);
-            }
-
-            @Override
-            public void failed(Throwable throwable) {
-                future.completeExceptionally(getApiException(throwable.getCause()));
-            }
-        });
-        return future;
+        return asyncGetRequest(path, new UnaryGetCallback<InactiveTopicPolicies>() {});
     }
 
     @Override
@@ -238,20 +212,7 @@ public class TopicPoliciesImpl extends BaseResource implements TopicPolicies {
         TopicName topicName = validateTopic(topic);
         WebTarget path = topicPath(topicName, "delayedDelivery");
         path = path.queryParam("applied", applied);
-
-        final CompletableFuture<DelayedDeliveryPolicies> future = new CompletableFuture<>();
-        asyncGetRequest(path, new InvocationCallback<DelayedDeliveryPolicies>() {
-            @Override
-            public void completed(DelayedDeliveryPolicies delayedDeliveryPolicies) {
-                future.complete(delayedDeliveryPolicies);
-            }
-
-            @Override
-            public void failed(Throwable throwable) {
-                future.completeExceptionally(getApiException(throwable.getCause()));
-            }
-        });
-        return future;
+        return asyncGetRequest(path, new UnaryGetCallback<DelayedDeliveryPolicies>() {});
     }
 
     @Override
@@ -310,19 +271,7 @@ public class TopicPoliciesImpl extends BaseResource implements TopicPolicies {
         TopicName topicName = validateTopic(topic);
         WebTarget path = topicPath(topicName, "deduplicationEnabled");
         path = path.queryParam("applied", applied);
-        final CompletableFuture<Boolean> future = new CompletableFuture<>();
-        asyncGetRequest(path, new InvocationCallback<Boolean>() {
-            @Override
-            public void completed(Boolean enabled) {
-                future.complete(enabled);
-            }
-
-            @Override
-            public void failed(Throwable throwable) {
-                future.completeExceptionally(getApiException(throwable.getCause()));
-            }
-        });
-        return future;
+        return asyncGetRequest(path, new UnaryGetCallback<Boolean>() {});
     }
 
     private CompletableFuture<Void> enableDeduplicationAsync(String topic, boolean enabled) {
@@ -375,19 +324,7 @@ public class TopicPoliciesImpl extends BaseResource implements TopicPolicies {
         TopicName topicName = validateTopic(topic);
         WebTarget path = topicPath(topicName, "offloadPolicies");
         path = path.queryParam("applied", applied);
-        final CompletableFuture<OffloadPolicies> future = new CompletableFuture<>();
-        asyncGetRequest(path, new InvocationCallback<OffloadPoliciesImpl>() {
-            @Override
-            public void completed(OffloadPoliciesImpl offloadPolicies) {
-                future.complete(offloadPolicies);
-            }
-
-            @Override
-            public void failed(Throwable throwable) {
-                future.completeExceptionally(getApiException(throwable.getCause()));
-            }
-        });
-        return future;
+        return asyncGetRequest(path, new UnaryGetCallback<OffloadPolicies>() {});
     }
 
     @Override
@@ -434,19 +371,7 @@ public class TopicPoliciesImpl extends BaseResource implements TopicPolicies {
         TopicName topicName = validateTopic(topic);
         WebTarget path = topicPath(topicName, "maxUnackedMessagesOnSubscription");
         path = path.queryParam("applied", applied);
-        final CompletableFuture<Integer> future = new CompletableFuture<>();
-        asyncGetRequest(path, new InvocationCallback<Integer>() {
-            @Override
-            public void completed(Integer maxNum) {
-                future.complete(maxNum);
-            }
-
-            @Override
-            public void failed(Throwable throwable) {
-                future.completeExceptionally(getApiException(throwable.getCause()));
-            }
-        });
-        return future;
+        return asyncGetRequest(path, new UnaryGetCallback<Integer>() {});
     }
 
     @Override
@@ -496,7 +421,7 @@ public class TopicPoliciesImpl extends BaseResource implements TopicPolicies {
             TopicName topicName = validateTopic(topic);
             WebTarget path = topicPath(topicName, "messageTTL");
             path = path.queryParam("applied", applied);
-            return request(path).get(new GenericType<Integer>() {});
+            return request(path).get(Integer.class);
         } catch (Exception e) {
             throw getApiException(e);
         }
@@ -545,20 +470,7 @@ public class TopicPoliciesImpl extends BaseResource implements TopicPolicies {
         TopicName tn = validateTopic(topic);
         WebTarget path = topicPath(tn, "retention");
         path = path.queryParam("applied", applied);
-        final CompletableFuture<RetentionPolicies> future = new CompletableFuture<>();
-        asyncGetRequest(path,
-                new InvocationCallback<RetentionPolicies>() {
-                    @Override
-                    public void completed(RetentionPolicies retentionPolicies) {
-                        future.complete(retentionPolicies);
-                    }
-
-                    @Override
-                    public void failed(Throwable throwable) {
-                        future.completeExceptionally(getApiException(throwable.getCause()));
-                    }
-                });
-        return future;
+        return asyncGetRequest(path, new UnaryGetCallback<RetentionPolicies>() {});
     }
 
     @Override
@@ -605,20 +517,7 @@ public class TopicPoliciesImpl extends BaseResource implements TopicPolicies {
         TopicName tn = validateTopic(topic);
         WebTarget path = topicPath(tn, "persistence");
         path = path.queryParam("applied", applied);
-        final CompletableFuture<PersistencePolicies> future = new CompletableFuture<>();
-        asyncGetRequest(path,
-                new InvocationCallback<PersistencePolicies>() {
-                    @Override
-                    public void completed(PersistencePolicies persistencePolicies) {
-                        future.complete(persistencePolicies);
-                    }
-
-                    @Override
-                    public void failed(Throwable throwable) {
-                        future.completeExceptionally(getApiException(throwable.getCause()));
-                    }
-                });
-        return future;
+        return asyncGetRequest(path, new UnaryGetCallback<PersistencePolicies>() {});
     }
 
     @Override
@@ -643,20 +542,7 @@ public class TopicPoliciesImpl extends BaseResource implements TopicPolicies {
         TopicName topicName = validateTopic(topic);
         WebTarget path = topicPath(topicName, "dispatchRate");
         path = path.queryParam("applied", applied);
-        final CompletableFuture<DispatchRate> future = new CompletableFuture<>();
-        asyncGetRequest(path,
-                new InvocationCallback<DispatchRate>() {
-                    @Override
-                    public void completed(DispatchRate dispatchRate) {
-                        future.complete(dispatchRate);
-                    }
-
-                    @Override
-                    public void failed(Throwable throwable) {
-                        future.completeExceptionally(getApiException(throwable.getCause()));
-                    }
-                });
-        return future;
+        return asyncGetRequest(path, new UnaryGetCallback<DispatchRate>() {});
     }
 
     @Override
@@ -703,20 +589,7 @@ public class TopicPoliciesImpl extends BaseResource implements TopicPolicies {
         TopicName topicName = validateTopic(topic);
         WebTarget path = topicPath(topicName, "subscriptionDispatchRate");
         path = path.queryParam("applied", applied);
-        final CompletableFuture<DispatchRate> future = new CompletableFuture<>();
-        asyncGetRequest(path,
-                new InvocationCallback<DispatchRate>() {
-                    @Override
-                    public void completed(DispatchRate dispatchRate) {
-                        future.complete(dispatchRate);
-                    }
-
-                    @Override
-                    public void failed(Throwable throwable) {
-                        future.completeExceptionally(getApiException(throwable.getCause()));
-                    }
-                });
-        return future;
+        return asyncGetRequest(path, new UnaryGetCallback<DispatchRate>() {});
     }
 
     @Override
@@ -779,20 +652,7 @@ public class TopicPoliciesImpl extends BaseResource implements TopicPolicies {
         TopicName topicName = validateTopic(topic);
         WebTarget path = topicPath(topicName, subscriptionName, "dispatchRate");
         path = path.queryParam("applied", applied);
-        final CompletableFuture<DispatchRate> future = new CompletableFuture<>();
-        asyncGetRequest(path,
-                new InvocationCallback<DispatchRate>() {
-                    @Override
-                    public void completed(DispatchRate dispatchRate) {
-                        future.complete(dispatchRate);
-                    }
-
-                    @Override
-                    public void failed(Throwable throwable) {
-                        future.completeExceptionally(getApiException(throwable.getCause()));
-                    }
-                });
-        return future;
+        return asyncGetRequest(path, new UnaryGetCallback<DispatchRate>() {});
     }
 
     @Override
@@ -837,20 +697,7 @@ public class TopicPoliciesImpl extends BaseResource implements TopicPolicies {
         TopicName topicName = validateTopic(topic);
         WebTarget path = topicPath(topicName, "compactionThreshold");
         path = path.queryParam("applied", applied);
-        final CompletableFuture<Long> future = new CompletableFuture<>();
-        asyncGetRequest(path,
-                new InvocationCallback<Long>() {
-                    @Override
-                    public void completed(Long compactionThreshold) {
-                        future.complete(compactionThreshold);
-                    }
-
-                    @Override
-                    public void failed(Throwable throwable) {
-                        future.completeExceptionally(getApiException(throwable.getCause()));
-                    }
-                });
-        return future;
+        return asyncGetRequest(path, new UnaryGetCallback<Long>() {});
     }
 
     @Override
@@ -886,20 +733,7 @@ public class TopicPoliciesImpl extends BaseResource implements TopicPolicies {
     public CompletableFuture<PublishRate> getPublishRateAsync(String topic) {
         TopicName topicName = validateTopic(topic);
         WebTarget path = topicPath(topicName, "publishRate");
-        final CompletableFuture<PublishRate> future = new CompletableFuture<>();
-        asyncGetRequest(path,
-                new InvocationCallback<PublishRate>() {
-                    @Override
-                    public void completed(PublishRate publishRate) {
-                        future.complete(publishRate);
-                    }
-
-                    @Override
-                    public void failed(Throwable throwable) {
-                        future.completeExceptionally(getApiException(throwable.getCause()));
-                    }
-                });
-        return future;
+        return asyncGetRequest(path, new UnaryGetCallback<PublishRate>() {});
     }
 
     @Override
@@ -935,20 +769,7 @@ public class TopicPoliciesImpl extends BaseResource implements TopicPolicies {
     public CompletableFuture<Integer> getMaxConsumersPerSubscriptionAsync(String topic) {
         TopicName topicName = validateTopic(topic);
         WebTarget path = topicPath(topicName, "maxConsumersPerSubscription");
-        final CompletableFuture<Integer> future = new CompletableFuture<>();
-        asyncGetRequest(path,
-                new InvocationCallback<Integer>() {
-                    @Override
-                    public void completed(Integer maxConsumersPerSubscription) {
-                        future.complete(maxConsumersPerSubscription);
-                    }
-
-                    @Override
-                    public void failed(Throwable throwable) {
-                        future.completeExceptionally(getApiException(throwable.getCause()));
-                    }
-                });
-        return future;
+        return asyncGetRequest(path, new UnaryGetCallback<Integer>() {});
     }
 
     @Override
@@ -996,20 +817,7 @@ public class TopicPoliciesImpl extends BaseResource implements TopicPolicies {
         TopicName tn = validateTopic(topic);
         WebTarget path = topicPath(tn, "maxProducers");
         path = path.queryParam("applied", applied);
-        final CompletableFuture<Integer> future = new CompletableFuture<>();
-        asyncGetRequest(path,
-                new InvocationCallback<Integer>() {
-                    @Override
-                    public void completed(Integer maxProducers) {
-                        future.complete(maxProducers);
-                    }
-
-                    @Override
-                    public void failed(Throwable throwable) {
-                        future.completeExceptionally(getApiException(throwable.getCause()));
-                    }
-                });
-        return future;
+        return asyncGetRequest(path, new UnaryGetCallback<Integer>() {});
     }
 
     @Override
@@ -1045,20 +853,7 @@ public class TopicPoliciesImpl extends BaseResource implements TopicPolicies {
     public CompletableFuture<Integer> getMaxSubscriptionsPerTopicAsync(String topic) {
         TopicName tn = validateTopic(topic);
         WebTarget path = topicPath(tn, "maxSubscriptionsPerTopic");
-        final CompletableFuture<Integer> future = new CompletableFuture<>();
-        asyncGetRequest(path,
-                new InvocationCallback<Integer>() {
-                    @Override
-                    public void completed(Integer maxSubscriptionsPerTopic) {
-                        future.complete(maxSubscriptionsPerTopic);
-                    }
-
-                    @Override
-                    public void failed(Throwable throwable) {
-                        future.completeExceptionally(getApiException(throwable.getCause()));
-                    }
-                });
-        return future;
+        return asyncGetRequest(path, new UnaryGetCallback<Integer>() {});
     }
 
     @Override
@@ -1094,20 +889,7 @@ public class TopicPoliciesImpl extends BaseResource implements TopicPolicies {
     public CompletableFuture<Integer> getMaxMessageSizeAsync(String topic) {
         TopicName tn = validateTopic(topic);
         WebTarget path = topicPath(tn, "maxMessageSize");
-        final CompletableFuture<Integer> future = new CompletableFuture<>();
-        asyncGetRequest(path,
-                new InvocationCallback<Integer>() {
-                    @Override
-                    public void completed(Integer maxMessageSize) {
-                        future.complete(maxMessageSize);
-                    }
-
-                    @Override
-                    public void failed(Throwable throwable) {
-                        future.completeExceptionally(getApiException(throwable.getCause()));
-                    }
-                });
-        return future;
+        return asyncGetRequest(path, new UnaryGetCallback<Integer>() {});
     }
 
     @Override
@@ -1154,20 +936,7 @@ public class TopicPoliciesImpl extends BaseResource implements TopicPolicies {
         TopicName tn = validateTopic(topic);
         WebTarget path = topicPath(tn, "maxConsumers");
         path = path.queryParam("applied", applied);
-        final CompletableFuture<Integer> future = new CompletableFuture<>();
-        asyncGetRequest(path,
-                new InvocationCallback<Integer>() {
-                    @Override
-                    public void completed(Integer maxProducers) {
-                        future.complete(maxProducers);
-                    }
-
-                    @Override
-                    public void failed(Throwable throwable) {
-                        future.completeExceptionally(getApiException(throwable.getCause()));
-                    }
-                });
-        return future;
+        return asyncGetRequest(path, new UnaryGetCallback<Integer>() {});
     }
 
     @Override
@@ -1204,20 +973,7 @@ public class TopicPoliciesImpl extends BaseResource implements TopicPolicies {
     public CompletableFuture<Integer> getDeduplicationSnapshotIntervalAsync(String topic) {
         TopicName topicName = validateTopic(topic);
         WebTarget path = topicPath(topicName, "deduplicationSnapshotInterval");
-        final CompletableFuture<Integer> future = new CompletableFuture<>();
-        asyncGetRequest(path,
-                new InvocationCallback<Integer>() {
-                    @Override
-                    public void completed(Integer interval) {
-                        future.complete(interval);
-                    }
-
-                    @Override
-                    public void failed(Throwable throwable) {
-                        future.completeExceptionally(getApiException(throwable.getCause()));
-                    }
-                });
-        return future;
+        return asyncGetRequest(path, new UnaryGetCallback<Integer>() {});
     }
 
     @Override
@@ -1268,20 +1024,7 @@ public class TopicPoliciesImpl extends BaseResource implements TopicPolicies {
     public CompletableFuture<Set<SubscriptionType>> getSubscriptionTypesEnabledAsync(String topic) {
         TopicName topicName = validateTopic(topic);
         WebTarget path = topicPath(topicName, "subscriptionTypesEnabled");
-        final CompletableFuture<Set<SubscriptionType>> future = new CompletableFuture<>();
-        asyncGetRequest(path,
-                new InvocationCallback<Set<SubscriptionType>>() {
-                    @Override
-                    public void completed(Set<SubscriptionType> subscriptionTypesEnabled) {
-                        future.complete(subscriptionTypesEnabled);
-                    }
-
-                    @Override
-                    public void failed(Throwable throwable) {
-                        future.completeExceptionally(getApiException(throwable.getCause()));
-                    }
-                });
-        return future;
+        return asyncGetRequest(path, new UnaryGetCallback<Set<SubscriptionType>>() {});
     }
 
     @Override
@@ -1316,20 +1059,7 @@ public class TopicPoliciesImpl extends BaseResource implements TopicPolicies {
         TopicName topicName = validateTopic(topic);
         WebTarget path = topicPath(topicName, "subscribeRate");
         path = path.queryParam("applied", applied);
-        final CompletableFuture<SubscribeRate> future = new CompletableFuture<>();
-        asyncGetRequest(path,
-                new InvocationCallback<SubscribeRate>() {
-                    @Override
-                    public void completed(SubscribeRate subscribeRate) {
-                        future.complete(subscribeRate);
-                    }
-
-                    @Override
-                    public void failed(Throwable throwable) {
-                        future.completeExceptionally(getApiException(throwable.getCause()));
-                    }
-                });
-        return future;
+        return asyncGetRequest(path, new UnaryGetCallback<SubscribeRate>() {});
     }
 
     @Override
@@ -1376,20 +1106,7 @@ public class TopicPoliciesImpl extends BaseResource implements TopicPolicies {
         TopicName topicName = validateTopic(topic);
         WebTarget path = topicPath(topicName, "replicatorDispatchRate");
         path = path.queryParam("applied", applied);
-        final CompletableFuture<DispatchRate> future = new CompletableFuture<>();
-        asyncGetRequest(path,
-                new InvocationCallback<DispatchRate>() {
-                    @Override
-                    public void completed(DispatchRate dispatchRate) {
-                        future.complete(dispatchRate);
-                    }
-
-                    @Override
-                    public void failed(Throwable throwable) {
-                        future.completeExceptionally(getApiException(throwable.getCause()));
-                    }
-                });
-        return future;
+        return asyncGetRequest(path, new UnaryGetCallback<DispatchRate>() {});
     }
 
     @Override
@@ -1428,21 +1145,7 @@ public class TopicPoliciesImpl extends BaseResource implements TopicPolicies {
         TopicName topicName = validateTopic(topic);
         WebTarget path = topicPath(topicName, "schemaCompatibilityStrategy");
         path = path.queryParam("applied", applied);
-        final CompletableFuture<SchemaCompatibilityStrategy> future = new CompletableFuture<>();
-        asyncGetRequest(path,
-                new InvocationCallback<SchemaCompatibilityStrategy>() {
-                    @Override
-                    public void completed(SchemaCompatibilityStrategy schemaCompatibilityStrategy) {
-                        future.complete(schemaCompatibilityStrategy);
-                    }
-
-                    @Override
-                    public void failed(Throwable throwable) {
-                        future.completeExceptionally(getApiException(throwable.getCause()));
-                    }
-                });
-
-        return future;
+        return asyncGetRequest(path, new UnaryGetCallback<SchemaCompatibilityStrategy>() {});
     }
 
     @Override

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/TransactionsImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/TransactionsImpl.java
@@ -23,7 +23,6 @@ import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import javax.ws.rs.client.Entity;
-import javax.ws.rs.client.InvocationCallback;
 import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.core.MediaType;
 import org.apache.pulsar.client.admin.PulsarAdminException;
@@ -53,20 +52,7 @@ public class TransactionsImpl extends BaseResource implements Transactions {
     public CompletableFuture<TransactionCoordinatorStats> getCoordinatorStatsByIdAsync(int coordinatorId) {
         WebTarget path = adminV3Transactions.path("coordinatorStats");
         path = path.queryParam("coordinatorId", coordinatorId);
-        final CompletableFuture<TransactionCoordinatorStats> future = new CompletableFuture<>();
-        asyncGetRequest(path,
-                new InvocationCallback<TransactionCoordinatorStats>() {
-                    @Override
-                    public void completed(TransactionCoordinatorStats stats) {
-                        future.complete(stats);
-                    }
-
-                    @Override
-                    public void failed(Throwable throwable) {
-                        future.completeExceptionally(getApiException(throwable.getCause()));
-                    }
-                });
-        return future;
+        return asyncGetRequest(path, new UnaryGetCallback<TransactionCoordinatorStats>() {});
     }
 
     @Override
@@ -77,25 +63,12 @@ public class TransactionsImpl extends BaseResource implements Transactions {
     @Override
     public CompletableFuture<Map<Integer, TransactionCoordinatorStats>> getCoordinatorStatsAsync() {
         WebTarget path = adminV3Transactions.path("coordinatorStats");
-        final CompletableFuture<Map<Integer, TransactionCoordinatorStats>> future = new CompletableFuture<>();
-        asyncGetRequest(path,
-                new InvocationCallback<Map<Integer, TransactionCoordinatorStats>>() {
-                    @Override
-                    public void completed(Map<Integer, TransactionCoordinatorStats> stats) {
-                        future.complete(stats);
-                    }
-
-                    @Override
-                    public void failed(Throwable throwable) {
-                        future.completeExceptionally(getApiException(throwable.getCause()));
-                    }
-                });
-        return future;
+        return asyncGetRequest(path, new UnaryGetCallback<Map<Integer, TransactionCoordinatorStats>>() {});
     }
 
     @Override
     public Map<Integer, TransactionCoordinatorStats> getCoordinatorStats() throws PulsarAdminException {
-        return sync(() -> getCoordinatorStatsAsync());
+        return sync(this::getCoordinatorStatsAsync);
     }
 
     @Override
@@ -105,20 +78,7 @@ public class TransactionsImpl extends BaseResource implements Transactions {
         path = path.path(topicName.getRestPath(false));
         path = path.path(txnID.getMostSigBits() + "");
         path = path.path(txnID.getLeastSigBits() + "");
-        final CompletableFuture<TransactionInBufferStats> future = new CompletableFuture<>();
-        asyncGetRequest(path,
-                new InvocationCallback<TransactionInBufferStats>() {
-                    @Override
-                    public void completed(TransactionInBufferStats stats) {
-                        future.complete(stats);
-                    }
-
-                    @Override
-                    public void failed(Throwable throwable) {
-                        future.completeExceptionally(getApiException(throwable.getCause()));
-                    }
-                });
-        return future;
+        return asyncGetRequest(path, new UnaryGetCallback<TransactionInBufferStats>() {});
     }
 
     @Override
@@ -135,20 +95,7 @@ public class TransactionsImpl extends BaseResource implements Transactions {
         path = path.path(subName);
         path = path.path(txnID.getMostSigBits() + "");
         path = path.path(txnID.getLeastSigBits() + "");
-        final CompletableFuture<TransactionInPendingAckStats> future = new CompletableFuture<>();
-        asyncGetRequest(path,
-                new InvocationCallback<TransactionInPendingAckStats>() {
-                    @Override
-                    public void completed(TransactionInPendingAckStats stats) {
-                        future.complete(stats);
-                    }
-
-                    @Override
-                    public void failed(Throwable throwable) {
-                        future.completeExceptionally(getApiException(throwable.getCause()));
-                    }
-                });
-        return future;
+        return asyncGetRequest(path, new UnaryGetCallback<TransactionInPendingAckStats>() {});
     }
 
     @Override
@@ -162,20 +109,7 @@ public class TransactionsImpl extends BaseResource implements Transactions {
         WebTarget path = adminV3Transactions.path("transactionMetadata");
         path = path.path(txnID.getMostSigBits() + "");
         path = path.path(txnID.getLeastSigBits() + "");
-        final CompletableFuture<TransactionMetadata> future = new CompletableFuture<>();
-        asyncGetRequest(path,
-                new InvocationCallback<TransactionMetadata>() {
-                    @Override
-                    public void completed(TransactionMetadata metadata) {
-                        future.complete(metadata);
-                    }
-
-                    @Override
-                    public void failed(Throwable throwable) {
-                        future.completeExceptionally(getApiException(throwable.getCause()));
-                    }
-                });
-        return future;
+        return asyncGetRequest(path, new UnaryGetCallback<TransactionMetadata>() {});
     }
 
     @Override
@@ -189,20 +123,7 @@ public class TransactionsImpl extends BaseResource implements Transactions {
         WebTarget path = adminV3Transactions.path("transactionBufferStats");
         path = path.path(TopicName.get(topic).getRestPath(false));
         path = path.queryParam("lowWaterMarks", lowWaterMarks);
-        final CompletableFuture<TransactionBufferStats> future = new CompletableFuture<>();
-        asyncGetRequest(path,
-                new InvocationCallback<TransactionBufferStats>() {
-                    @Override
-                    public void completed(TransactionBufferStats stats) {
-                        future.complete(stats);
-                    }
-
-                    @Override
-                    public void failed(Throwable throwable) {
-                        future.completeExceptionally(getApiException(throwable.getCause()));
-                    }
-                });
-        return future;
+        return asyncGetRequest(path, new UnaryGetCallback<TransactionBufferStats>() {});
     }
 
     @Override
@@ -218,20 +139,7 @@ public class TransactionsImpl extends BaseResource implements Transactions {
         path = path.path(TopicName.get(topic).getRestPath(false));
         path = path.path(subName);
         path = path.queryParam("lowWaterMarks", lowWaterMarks);
-        final CompletableFuture<TransactionPendingAckStats> future = new CompletableFuture<>();
-        asyncGetRequest(path,
-                new InvocationCallback<TransactionPendingAckStats>() {
-                    @Override
-                    public void completed(TransactionPendingAckStats stats) {
-                        future.complete(stats);
-                    }
-
-                    @Override
-                    public void failed(Throwable throwable) {
-                        future.completeExceptionally(getApiException(throwable.getCause()));
-                    }
-                });
-        return future;
+        return asyncGetRequest(path, new UnaryGetCallback<TransactionPendingAckStats>() {});
     }
 
     @Override
@@ -248,20 +156,7 @@ public class TransactionsImpl extends BaseResource implements Transactions {
         if (coordinatorId != null) {
             path = path.queryParam("coordinatorId", coordinatorId);
         }
-        final CompletableFuture<Map<String, TransactionMetadata>> future = new CompletableFuture<>();
-        asyncGetRequest(path,
-                new InvocationCallback<Map<String, TransactionMetadata>>() {
-                    @Override
-                    public void completed(Map<String, TransactionMetadata> metadataMap) {
-                        future.complete(metadataMap);
-                    }
-
-                    @Override
-                    public void failed(Throwable throwable) {
-                        future.completeExceptionally(getApiException(throwable.getCause()));
-                    }
-                });
-        return future;
+        return asyncGetRequest(path, new UnaryGetCallback<Map<String, TransactionMetadata>>() {});
     }
 
     @Override
@@ -290,20 +185,7 @@ public class TransactionsImpl extends BaseResource implements Transactions {
         WebTarget path = adminV3Transactions.path("coordinatorInternalStats");
         path = path.path(coordinatorId + "");
         path = path.queryParam("metadata", metadata);
-        final CompletableFuture<TransactionCoordinatorInternalStats> future = new CompletableFuture<>();
-        asyncGetRequest(path,
-                new InvocationCallback<TransactionCoordinatorInternalStats>() {
-                    @Override
-                    public void completed(TransactionCoordinatorInternalStats stats) {
-                        future.complete(stats);
-                    }
-
-                    @Override
-                    public void failed(Throwable throwable) {
-                        future.completeExceptionally(getApiException(throwable.getCause()));
-                    }
-                });
-        return future;
+        return asyncGetRequest(path, new UnaryGetCallback<TransactionCoordinatorInternalStats>() {});
     }
 
     @Override
@@ -322,20 +204,7 @@ public class TransactionsImpl extends BaseResource implements Transactions {
         path = path.path(tn.getRestPath(false));
         path = path.path(subName);
         path = path.queryParam("metadata", metadata);
-        final CompletableFuture<TransactionPendingAckInternalStats> future = new CompletableFuture<>();
-        asyncGetRequest(path,
-                new InvocationCallback<TransactionPendingAckInternalStats>() {
-                    @Override
-                    public void completed(TransactionPendingAckInternalStats stats) {
-                        future.complete(stats);
-                    }
-
-                    @Override
-                    public void failed(Throwable throwable) {
-                        future.completeExceptionally(getApiException(throwable.getCause()));
-                    }
-                });
-        return future;
+        return asyncGetRequest(path, new UnaryGetCallback<TransactionPendingAckInternalStats>() {});
     }
 
     @Override
@@ -371,20 +240,7 @@ public class TransactionsImpl extends BaseResource implements Transactions {
         path = path.path(ledgerId.toString());
         path = path.path(entryId.toString());
         path = path.queryParam("batchIndex", batchIndex);
-        final CompletableFuture<PositionInPendingAckStats> future = new CompletableFuture<>();
-        asyncGetRequest(path,
-                new InvocationCallback<PositionInPendingAckStats>() {
-                    @Override
-                    public void completed(PositionInPendingAckStats stats) {
-                        future.complete(stats);
-                    }
-
-                    @Override
-                    public void failed(Throwable throwable) {
-                        future.completeExceptionally(getApiException(throwable.getCause()));
-                    }
-                });
-        return future;
+        return asyncGetRequest(path, new UnaryGetCallback<PositionInPendingAckStats>() {});
     }
 
 

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/WorkerImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/WorkerImpl.java
@@ -22,9 +22,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
-import javax.ws.rs.ClientErrorException;
 import javax.ws.rs.client.Entity;
-import javax.ws.rs.client.InvocationCallback;
 import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.core.GenericType;
 import javax.ws.rs.core.MediaType;
@@ -51,147 +49,61 @@ public class WorkerImpl extends BaseResource implements Worker {
 
     @Override
     public List<WorkerFunctionInstanceStats> getFunctionsStats() throws PulsarAdminException {
-        return sync(() -> getFunctionsStatsAsync());
+        return sync(this::getFunctionsStatsAsync);
     }
 
     @Override
     public CompletableFuture<List<WorkerFunctionInstanceStats>> getFunctionsStatsAsync() {
         WebTarget path = workerStats.path("functionsmetrics");
-        final CompletableFuture<List<WorkerFunctionInstanceStats>> future = new CompletableFuture<>();
-        asyncGetRequest(path,
-                new InvocationCallback<Response>() {
-                    @Override
-                    public void completed(Response response) {
-                        if (response.getStatus() != Response.Status.OK.getStatusCode()) {
-                            future.completeExceptionally(new ClientErrorException(response));
-                        } else {
-                            List<WorkerFunctionInstanceStats> metricsList =
-                                    response.readEntity(new GenericType<List<WorkerFunctionInstanceStats>>() {});
-                            future.complete(metricsList);
-                        }
-                    }
-
-                    @Override
-                    public void failed(Throwable throwable) {
-                        future.completeExceptionally(getApiException(throwable.getCause()));
-                    }
-                });
-        return future;
+        return asyncGetRequest(path, new GetCallback<Response, List<WorkerFunctionInstanceStats>>(
+                processOkResponse(new GenericType<List<WorkerFunctionInstanceStats>>() {})) {});
     }
 
     @Override
     public Collection<Metrics> getMetrics() throws PulsarAdminException {
-        return sync(() -> getMetricsAsync());
+        return sync(this::getMetricsAsync);
     }
 
     @Override
     public CompletableFuture<Collection<Metrics>> getMetricsAsync() {
         WebTarget path = workerStats.path("metrics");
-        final CompletableFuture<Collection<Metrics>> future = new CompletableFuture<>();
-        asyncGetRequest(path,
-                new InvocationCallback<Response>() {
-                    @Override
-                    public void completed(Response response) {
-                        if (response.getStatus() != Response.Status.OK.getStatusCode()) {
-                            future.completeExceptionally(new ClientErrorException(response));
-                        } else {
-                            future.complete(response.readEntity(
-                                    new GenericType<List<Metrics>>() {}));
-                        }
-                    }
-
-                    @Override
-                    public void failed(Throwable throwable) {
-                        future.completeExceptionally(getApiException(throwable.getCause()));
-                    }
-                });
-        return future;
+        return asyncGetRequest(path, new GetCallback<Response, Collection<Metrics>>(
+                processOkResponse(new GenericType<Collection<Metrics>>() {})) {});
     }
 
     @Override
     public List<WorkerInfo> getCluster() throws PulsarAdminException {
-        return sync(() -> getClusterAsync());
+        return sync(this::getClusterAsync);
     }
 
     @Override
     public CompletableFuture<List<WorkerInfo>> getClusterAsync() {
         WebTarget path = worker.path("cluster");
-        final CompletableFuture<List<WorkerInfo>> future = new CompletableFuture<>();
-        asyncGetRequest(path,
-                new InvocationCallback<Response>() {
-
-                    @Override
-                    public void completed(Response response) {
-                        if (response.getStatus() != Response.Status.OK.getStatusCode()) {
-                            future.completeExceptionally(new ClientErrorException(response));
-                        } else {
-                            future.complete(response.readEntity(new GenericType<List<WorkerInfo>>() {}));
-                        }
-                    }
-
-                    @Override
-                    public void failed(Throwable throwable) {
-                        future.completeExceptionally(getApiException(throwable.getCause()));
-                    }
-                });
-        return future;
+        return asyncGetRequest(path, new GetCallback<Response, List<WorkerInfo>>(
+                processOkResponse(new GenericType<List<WorkerInfo>>() {})) {});
     }
 
     @Override
     public WorkerInfo getClusterLeader() throws PulsarAdminException {
-        return sync(() -> getClusterLeaderAsync());
+        return sync(this::getClusterLeaderAsync);
     }
 
     @Override
     public CompletableFuture<WorkerInfo> getClusterLeaderAsync() {
         WebTarget path = worker.path("cluster").path("leader");
-        final CompletableFuture<WorkerInfo> future = new CompletableFuture<>();
-        asyncGetRequest(path,
-                new InvocationCallback<Response>() {
-                    @Override
-                    public void completed(Response response) {
-                        if (response.getStatus() != Response.Status.OK.getStatusCode()) {
-                            future.completeExceptionally(new ClientErrorException(response));
-                        } else {
-                            future.complete(response.readEntity(new GenericType<WorkerInfo>(){}));
-                        }
-                    }
-
-                    @Override
-                    public void failed(Throwable throwable) {
-                        future.completeExceptionally(getApiException(throwable.getCause()));
-                    }
-                });
-        return future;
+        return asyncGetRequest(path, new GetCallback<Response, WorkerInfo>(processOkResponse(WorkerInfo.class)) {});
     }
 
     @Override
     public Map<String, Collection<String>> getAssignments() throws PulsarAdminException {
-        return sync(() -> getAssignmentsAsync());
+        return sync(this::getAssignmentsAsync);
     }
 
     @Override
     public CompletableFuture<Map<String, Collection<String>>> getAssignmentsAsync() {
         WebTarget path = worker.path("assignments");
-        final CompletableFuture<Map<String, Collection<String>>> future = new CompletableFuture<>();
-        asyncGetRequest(path,
-                new InvocationCallback<Response>() {
-                    @Override
-                    public void completed(Response response) {
-                        if (response.getStatus() != Response.Status.OK.getStatusCode()) {
-                            future.completeExceptionally(new ClientErrorException(response));
-                        } else {
-                            future.complete(response.readEntity(
-                                    new GenericType<Map<String, Collection<String>>>() {}));
-                        }
-                    }
-
-                    @Override
-                    public void failed(Throwable throwable) {
-                        future.completeExceptionally(getApiException(throwable.getCause()));
-                    }
-                });
-        return future;
+        return asyncGetRequest(path, new GetCallback<Response, Map<String, Collection<String>>>(
+                processOkResponse(new GenericType<Map<String, Collection<String>>>() {})) {});
     }
 
     @Override
@@ -202,6 +114,6 @@ public class WorkerImpl extends BaseResource implements Worker {
     @Override
     public CompletableFuture<Void> rebalanceAsync() {
         final WebTarget path = worker.path("rebalance");
-        return asyncPutRequest(path,  Entity.entity("", MediaType.APPLICATION_JSON));
+        return asyncPutRequest(path, Entity.entity("", MediaType.APPLICATION_JSON));
     }
 }


### PR DESCRIPTION
### Motivation

In the admin client, each GET request handler implements its own
`InvocationCallback` which it implements anonymously at the callsites.
Jersey requires a concrete implementation to get around type erasure
since it uses reflection to identify the generic type. However, there
are few variants of the `InvocationCallback` implementations in the
admin client and most are identical - handling the response/exception
into a `CompletableFuture`.

### Modifications

Refactor the admin client GET handlers to be more DRY by providing a
`GetCallback` abstract implementation of `InvocationCallback` that
handles the response/exception into a `CompletableFuture` result.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

Check the box below or label this PR directly.

Need to update docs? 

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)
  
- [x] `doc-not-needed` 
(Please explain why)
  
- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)