### PR TITLE
[doc][client] Add timestamp format description for seek method of the Consumer and Reader.

### DIFF
--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/Consumer.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/Consumer.java
@@ -708,6 +708,7 @@ public interface Consumer<T> extends Closeable {
      *
      * @param timestamp
      *            the message publish time where to reposition the subscription
+     *            The timestamp format should be Unix time in milliseconds.
      */
     void seek(long timestamp) throws PulsarClientException;
 
@@ -765,6 +766,7 @@ public interface Consumer<T> extends Closeable {
      *
      * @param timestamp
      *            the message publish time where to reposition the subscription
+     *            The timestamp format should be Unix time in milliseconds.
      * @return a future to track the completion of the seek operation
      */
     CompletableFuture<Void> seekAsync(long timestamp);

--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/Reader.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/Reader.java
@@ -153,6 +153,7 @@ public interface Reader<T> extends Closeable {
      * the seek() on the individual partitions.
      *
      * @param timestamp the message publish time where to reposition the reader
+     *                  The timestamp format should be Unix time in milliseconds.
      */
     void seek(long timestamp) throws PulsarClientException;
 
@@ -212,6 +213,7 @@ public interface Reader<T> extends Closeable {
      *
      * @param timestamp
      *            the message publish time where to position the reader
+     *            The timestamp format should be Unix time in milliseconds.
      * @return a future to track the completion of the seek operation
      */
     CompletableFuture<Void> seekAsync(long timestamp);


### PR DESCRIPTION

<!--
### Contribution Checklist
  
  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://docs.google.com/document/d/1d8Pw6ZbWk-_pCKdOmdvx9rnhPiyuxwq60_TrD68d7BA/edit#heading=h.trs9rsex3xom)*. 

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.

**(The sections below can be removed for hotfixes of typos)**
-->


### Motivation

There are many timestamp formats, we need to specify the required timestamp format for the seek method of the Consumer and Reader.

### Modifications
* Add a description requiring the timestamp format should be Unix Time in milliseconds for the seek method of the Consumer and Reader.

### Documentation


- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)
  
- [ ] `doc-not-needed` 
(Please explain why)
  
- [x] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)