### PR TITLE
[fix][broker] PulsarLedgerManager to pass correct error code to BK client

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerFactoryImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerFactoryImpl.java
@@ -894,11 +894,12 @@ public class ManagedLedgerFactoryImpl implements ManagedLedgerFactory {
         Futures.waitForAll(info.ledgers.stream()
                 .filter(li -> !li.isOffloaded)
                 .map(li -> bkc.newDeleteLedgerOp().withLedgerId(li.ledgerId).execute()
-                        .handleAsync((result, ex) -> {
+                        .handle((result, ex) -> {
                             if (ex != null) {
                                 int rc = BKException.getExceptionCode(ex);
                                 if (rc == BKException.Code.NoSuchLedgerExistsOnMetadataServerException
                                     || rc == BKException.Code.NoSuchLedgerExistsException) {
+                                    log.info("Ledger {} does not exist, ignoring", li.ledgerId);
                                     return null;
                                 }
                                 throw new CompletionException(ex);
@@ -934,11 +935,12 @@ public class ManagedLedgerFactoryImpl implements ManagedLedgerFactory {
         if (cursor.cursorsLedgerId != -1) {
             cursorLedgerDeleteFuture = bkc.newDeleteLedgerOp().withLedgerId(cursor.cursorsLedgerId)
                     .execute()
-                    .handleAsync((result, ex) -> {
+                    .handle((result, ex) -> {
                         if (ex != null) {
                             int rc = BKException.getExceptionCode(ex);
                             if (rc == BKException.Code.NoSuchLedgerExistsOnMetadataServerException
                                     || rc == BKException.Code.NoSuchLedgerExistsException) {
+                                log.info("Ledger {} does not exist, ignoring", cursor.cursorsLedgerId);
                                 return null;
                             }
                             throw new CompletionException(ex);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerBkEnsemblesTests.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerBkEnsemblesTests.java
@@ -245,7 +245,7 @@ public class BrokerBkEnsemblesTests extends BkEnsemblesTestBase {
                 try {
                     bookKeeper.deleteLedger(entry.getKey());
                 } catch (Exception e) {
-                    e.printStackTrace();
+                    log.warn("failed to delete ledger {}", entry.getKey(), e);
                 }
             }
         });
@@ -359,7 +359,7 @@ public class BrokerBkEnsemblesTests extends BkEnsemblesTestBase {
                 try {
                     bookKeeper.deleteLedger(entry.getKey());
                 } catch (Exception e) {
-                    e.printStackTrace();
+                    log.warn("failed to delete ledger {}", entry.getKey(), e);
                 }
             }
         });

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerBkEnsemblesTests.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerBkEnsemblesTests.java
@@ -20,6 +20,7 @@ package org.apache.pulsar.broker.service;
 
 import static org.apache.pulsar.broker.auth.MockedPulsarServiceBaseTest.retryStrategically;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotEquals;
 import static org.testng.Assert.fail;
 
 import java.lang.reflect.Field;
@@ -31,9 +32,13 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 
+import com.google.common.collect.Sets;
 import lombok.Cleanup;
 
+import lombok.extern.slf4j.Slf4j;
+import org.apache.bookkeeper.client.BKException;
 import org.apache.bookkeeper.client.BookKeeper;
+import org.apache.bookkeeper.client.api.LedgerMetadata;
 import org.apache.bookkeeper.mledger.ManagedLedgerConfig;
 import org.apache.bookkeeper.mledger.impl.ManagedCursorImpl;
 import org.apache.bookkeeper.mledger.impl.ManagedLedgerFactoryImpl;
@@ -47,12 +52,14 @@ import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.Producer;
 import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.client.api.Schema;
+import org.apache.pulsar.common.policies.data.TenantInfoImpl;
 import org.apache.zookeeper.ZooKeeper;
 import org.awaitility.Awaitility;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
 @Test(groups = "broker")
+@Slf4j
 public class BrokerBkEnsemblesTests extends BkEnsemblesTestBase {
 
     public BrokerBkEnsemblesTests() {
@@ -277,6 +284,147 @@ public class BrokerBkEnsemblesTests extends BkEnsemblesTestBase {
 
         producer.close();
         consumer.close();
+    }
+
+    @Test
+    public void testTruncateCorruptDataLedger() throws Exception {
+        // Ensure intended state for autoSkipNonRecoverableData
+        admin.brokers().updateDynamicConfiguration("autoSkipNonRecoverableData", "false");
+
+        @Cleanup
+        PulsarClient client = PulsarClient.builder()
+                .serviceUrl(pulsar.getWebServiceAddress())
+                .statsInterval(0, TimeUnit.SECONDS)
+                .build();
+
+        final int totalMessages = 100;
+        final int totalDataLedgers = 5;
+        final int entriesPerLedger = totalMessages / totalDataLedgers;
+
+        final String tenant = "prop";
+        try {
+            admin.tenants().createTenant(tenant, new TenantInfoImpl(Sets.newHashSet("role1", "role2"),
+                    Sets.newHashSet(config.getClusterName())));
+        } catch (Exception e) {
+
+        }
+        final String ns1 = tenant + "/crash-broker";
+        try {
+            admin.namespaces().createNamespace(ns1, Sets.newHashSet(config.getClusterName()));
+        } catch (Exception e) {
+
+        }
+
+        final String topic1 = "persistent://" + ns1 + "/my-topic-" + System.currentTimeMillis();
+
+        // Create subscription
+        Consumer<byte[]> consumer = client.newConsumer().topic(topic1).subscriptionName("my-subscriber-name")
+                .receiverQueueSize(5).subscribe();
+
+        PersistentTopic topic = (PersistentTopic) pulsar.getBrokerService().getOrCreateTopic(topic1).get();
+        ManagedLedgerImpl ml = (ManagedLedgerImpl) topic.getManagedLedger();
+        ManagedCursorImpl cursor = (ManagedCursorImpl) ml.getCursors().iterator().next();
+        Field configField = ManagedCursorImpl.class.getDeclaredField("config");
+        configField.setAccessible(true);
+        // Create multiple data-ledger
+        ManagedLedgerConfig config = (ManagedLedgerConfig) configField.get(cursor);
+        config.setMaxEntriesPerLedger(entriesPerLedger);
+        config.setMinimumRolloverTime(1, TimeUnit.MILLISECONDS);
+        // bookkeeper client
+        Field bookKeeperField = ManagedLedgerImpl.class.getDeclaredField("bookKeeper");
+        bookKeeperField.setAccessible(true);
+        // Create multiple data-ledger
+        BookKeeper bookKeeper = (BookKeeper) bookKeeperField.get(ml);
+
+        // (1) publish messages in 10 data-ledgers each with 20 entries under managed-ledger
+        Producer<byte[]> producer = client.newProducer().topic(topic1).create();
+        for (int i = 0; i < totalMessages; i++) {
+            String message = "my-message-" + i;
+            producer.send(message.getBytes());
+        }
+
+        // validate: consumer is able to consume msg and close consumer after reading 1 entry
+        Assert.assertNotNull(consumer.receive(1, TimeUnit.SECONDS));
+        consumer.close();
+
+        NavigableMap<Long, LedgerInfo> ledgerInfo = ml.getLedgersInfo();
+        Assert.assertEquals(ledgerInfo.size(), totalDataLedgers);
+        Entry<Long, LedgerInfo> lastLedger = ledgerInfo.lastEntry();
+        long firstLedgerToDelete = lastLedger.getKey();
+
+        // (2) delete first 4 data-ledgers
+        ledgerInfo.entrySet().forEach(entry -> {
+            if (!entry.equals(lastLedger)) {
+                assertEquals(entry.getValue().getEntries(), entriesPerLedger);
+                try {
+                    bookKeeper.deleteLedger(entry.getKey());
+                } catch (Exception e) {
+                    e.printStackTrace();
+                }
+            }
+        });
+
+        // create 5 more ledgers
+        for (int i = 0; i < totalMessages; i++) {
+            String message = "my-message2-" + i;
+            producer.send(message.getBytes());
+        }
+
+        ml.delete();
+
+        // Admin should be able to truncate the topic
+        admin.topics().truncate(topic1);
+
+        ledgerInfo.entrySet().forEach(entry -> {
+            log.warn("found ledger: {}", entry.getKey());
+            assertNotEquals(firstLedgerToDelete, entry.getKey());
+        });
+
+        // Currently, ledger deletion is async and failed deletion
+        // does not actually fail truncation but logs an exception
+        // and creates scheduled task to retry
+        Awaitility.await().atMost(30, TimeUnit.SECONDS).untilAsserted(() -> {
+            LedgerMetadata meta = bookKeeper
+                    .getLedgerMetadata(firstLedgerToDelete)
+                    .exceptionally(e -> null)
+                    .get();
+            assertEquals(null, meta, "ledger should be deleted " + firstLedgerToDelete);
+            });
+
+        // Should not throw, deleting absent ledger must be a noop
+        // unless PulsarManager returned a wrong error which
+        // got translated to BKUnexpectedConditionException
+        try {
+            bookKeeper.deleteLedger(firstLedgerToDelete);
+        } catch (BKException.BKNoSuchLedgerExistsOnMetadataServerException bke) {
+            // pass
+        }
+
+        producer.close();
+        consumer.close();
+    }
+
+    @Test
+    public void testDeleteLedgerFactoryCorruptLedger() throws Exception {
+        ManagedLedgerFactoryImpl factory = (ManagedLedgerFactoryImpl) pulsar.getManagedLedgerFactory();
+        ManagedLedgerImpl ml = (ManagedLedgerImpl) factory.open("test");
+
+        // bookkeeper client
+        Field bookKeeperField = ManagedLedgerImpl.class.getDeclaredField("bookKeeper");
+        bookKeeperField.setAccessible(true);
+        // Create multiple data-ledger
+        BookKeeper bookKeeper = (BookKeeper) bookKeeperField.get(ml);
+
+        ml.addEntry("dummy-entry-1".getBytes());
+
+        NavigableMap<Long, LedgerInfo> ledgerInfo = ml.getLedgersInfo();
+        long lastLedger = ledgerInfo.lastEntry().getKey();
+
+        ml.close();
+        bookKeeper.deleteLedger(lastLedger);
+
+        // BK ledger is deleted, factory should not throw on delete
+        factory.delete("test");
     }
 
     @Test(timeOut = 20000)

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/api/MetadataStoreException.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/api/MetadataStoreException.java
@@ -28,9 +28,9 @@ import org.apache.bookkeeper.client.BKException;
  */
 public class MetadataStoreException extends IOException {
 
-    private static Throwable makeBkFriendlyException(int code, Throwable cause) {
+    private static Throwable makeBkFriendlyException(BKException bkException, Throwable cause) {
         if (cause == null) {
-            return BKException.create(code);
+            return bkException;
         }
 
         Throwable lastCause = cause;
@@ -46,7 +46,6 @@ public class MetadataStoreException extends IOException {
             lastCause = lastCause.getCause();
         }
 
-        BKException bkException = BKException.create(code);
         lastCause.initCause(bkException);
         return cause;
     }
@@ -84,19 +83,19 @@ public class MetadataStoreException extends IOException {
      * Key not found in store.
      */
     public static class NotFoundException extends MetadataStoreException {
+        private static final BKException bkEx =
+                BKException.create(BKException.Code.NoSuchLedgerExistsOnMetadataServerException);
+
         public NotFoundException() {
-            super(makeBkFriendlyException(
-                    BKException.Code.NoSuchLedgerExistsOnMetadataServerException, null));
+            super(makeBkFriendlyException(bkEx, null));
         }
 
         public NotFoundException(Throwable t) {
-            super(makeBkFriendlyException(
-                    BKException.Code.NoSuchLedgerExistsOnMetadataServerException, t));
+            super(makeBkFriendlyException(bkEx, t));
         }
 
         public NotFoundException(String msg) {
-            super(msg, makeBkFriendlyException(
-                    BKException.Code.NoSuchLedgerExistsOnMetadataServerException, null));
+            super(msg, makeBkFriendlyException(bkEx, null));
         }
     }
 
@@ -104,14 +103,14 @@ public class MetadataStoreException extends IOException {
      * Key was already in store.
      */
     public static class AlreadyExistsException extends MetadataStoreException {
+        private static final BKException bkEx = BKException.create(BKException.Code.LedgerExistException);
+
         public AlreadyExistsException(Throwable t) {
-            super(makeBkFriendlyException(
-                    BKException.Code.LedgerExistException, t));
+            super(makeBkFriendlyException(bkEx, t));
         }
 
         public AlreadyExistsException(String msg) {
-            super(msg, makeBkFriendlyException(
-                    BKException.Code.LedgerExistException, null));
+            super(msg, makeBkFriendlyException(bkEx, null));
         }
     }
 
@@ -119,14 +118,14 @@ public class MetadataStoreException extends IOException {
      * Unsuccessful update due to mismatched expected version.
      */
     public static class BadVersionException extends MetadataStoreException {
+        private static final BKException bkEx = BKException.create(BKException.Code.MetadataVersionException);
+
         public BadVersionException(Throwable t) {
-            super(makeBkFriendlyException(
-                    BKException.Code.MetadataVersionException, t));
+            super(makeBkFriendlyException(bkEx, t));
         }
 
         public BadVersionException(String msg) {
-            super(msg, makeBkFriendlyException(
-                    BKException.Code.MetadataVersionException, null));
+            super(msg, makeBkFriendlyException(bkEx, null));
         }
     }
 
@@ -168,14 +167,14 @@ public class MetadataStoreException extends IOException {
      * The store was already closed.
      */
     public static class AlreadyClosedException extends MetadataStoreException {
+        private static final BKException bkEx = BKException.create(BKException.Code.LedgerClosedException);
+
         public AlreadyClosedException(Throwable t) {
-            super(makeBkFriendlyException(
-                    BKException.Code.LedgerClosedException, t));
+            super(makeBkFriendlyException(bkEx, t));
         }
 
         public AlreadyClosedException(String msg) {
-            super(msg, makeBkFriendlyException(
-                    BKException.Code.LedgerClosedException, null));
+            super(msg, makeBkFriendlyException(bkEx, null));
         }
     }
 


### PR DESCRIPTION
### Motivation

In some situations it is possible to encounter case when deletion of a ManagedLedger deals with cases of already deleted bookie ledgers. 
Such cases currently handled as errors even though they are safe to ignore.
Currently, it is impossible to handle these cases because PulsarManagedLedger returns error that's not mappable into the BK error code end the end user ends up with obscure `UnexpectedConditionException` (error code -999) that cannot be distinguished from ledger already deleted case.

### Modifications

1. Made PulsarManagedLedger compatible with BK erros so BK client has a chance to return correct error. I didn't do this for all MetadataStoreException, just for the ones where it made sense.
2. Ignored NoSuchLedgerExistsOnMetadataServerException on delete as it is safe there 

### Verifying this change

This change added tests and can be verified as follows:

  - Added unit tests

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

Nothing that I can think of.
BK Error codes can change (on purpose) for the internal components to become more specific but MetadataStoreException's type didn't change.

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API: (yes / no)
  - The schema: (yes / no / don't know)
  - The default values of configurations: (yes / no)
  - The wire protocol: (yes / no)
  - The rest endpoints: (yes / no)
  - The admin cli options: (yes / no)
  - Anything that affects deployment: (yes / no / don't know)

### Documentation

Check the box below or label this PR directly.

Need to update docs? 

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)
  
- [x] `doc-not-needed` 
(Please explain why)
  
- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)