### PR TITLE
[fix][broker] Fix the managed ledger factory shutdown stuck due to scheduled executor shutdown first

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerFactoryImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerFactoryImpl.java
@@ -570,9 +570,6 @@ public class ManagedLedgerFactoryImpl implements ManagedLedgerFactory {
             } else {
                 bookkeeperFuture.complete(null);
             }
-            //wait for tasks in scheduledExecutor executed.
-            scheduledExecutor.shutdown();
-
             if (!ledgers.isEmpty()) {
                 log.info("Force closing {} ledgers.", ledgers.size());
                 //make sure all callbacks is called.
@@ -596,7 +593,10 @@ public class ManagedLedgerFactoryImpl implements ManagedLedgerFactory {
             }
         }));
         entryCacheManager.clear();
-        return FutureUtil.waitForAll(futures);
+        return FutureUtil.waitForAll(futures).thenAccept(__ -> {
+            //wait for tasks in scheduledExecutor executed.
+            scheduledExecutor.shutdown();
+        });
     }
 
     @Override

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerTest.java
@@ -3193,7 +3193,7 @@ public class ManagedLedgerTest extends MockedBookKeeperTestCase {
 
         @Cleanup("shutdown")
         ManagedLedgerFactoryImpl factory = new ManagedLedgerFactoryImpl(metadataStore, bkc, config);
-        ManagedLedgerImpl ledger = (ManagedLedgerImpl) factory.open("avoidUseSameOpAddEntryBetweenDifferentLedger");
+        ManagedLedgerImpl ledger = (ManagedLedgerImpl) factory.open("my_test_ledger");
 
         List<OpAddEntry> oldOps = new ArrayList<>();
         for (int i = 0; i < 10; i++) {

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerTest.java
@@ -3193,7 +3193,7 @@ public class ManagedLedgerTest extends MockedBookKeeperTestCase {
 
         @Cleanup("shutdown")
         ManagedLedgerFactoryImpl factory = new ManagedLedgerFactoryImpl(metadataStore, bkc, config);
-        ManagedLedgerImpl ledger = (ManagedLedgerImpl) factory.open("my_test_ledger");
+        ManagedLedgerImpl ledger = (ManagedLedgerImpl) factory.open("avoidUseSameOpAddEntryBetweenDifferentLedger");
 
         List<OpAddEntry> oldOps = new ArrayList<>();
         for (int i = 0; i < 10; i++) {


### PR DESCRIPTION
### Motivation

Fix the managed ledger factory shutdown stuck due to scheduled executor shutdown first

```
2022-07-18T14:03:01,708 - ERROR - [main:MockedBookKeeperTestCase@107] - tearDown Error
java.util.concurrent.TimeoutException: null
	at java.util.concurrent.CompletableFuture.timedGet(CompletableFuture.java:1960) ~[?:?]
	at java.util.concurrent.CompletableFuture.get(CompletableFuture.java:2095) ~[?:?]
	at org.apache.bookkeeper.test.MockedBookKeeperTestCase.tearDown(MockedBookKeeperTestCase.java:101) ~[test-classes/:?]
	at jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[?:?]
	at jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77) ~[?:?]
	at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:?]
	at java.lang.reflect.Method.invoke(Method.java:568) ~[?:?]
	at org.testng.internal.MethodInvocationHelper.invokeMethod(MethodInvocationHelper.java:132) ~[testng-7.3.0.jar:?]
	at org.testng.internal.MethodInvocationHelper.invokeMethodConsideringTimeout(MethodInvocationHelper.java:61) ~[testng-7.3.0.jar:?]
	at org.testng.internal.ConfigInvoker.invokeConfigurationMethod(ConfigInvoker.java:366) ~[testng-7.3.0.jar:?]
	at org.testng.internal.ConfigInvoker.invokeConfigurations(ConfigInvoker.java:320) ~[testng-7.3.0.jar:?]
	at org.testng.internal.TestInvoker.runConfigMethods(TestInvoker.java:701) ~[testng-7.3.0.jar:?]
	at org.testng.internal.TestInvoker.runAfterGroupsConfigurations(TestInvoker.java:677) ~[testng-7.3.0.jar:?]
	at org.testng.internal.TestInvoker.invokeMethod(TestInvoker.java:661) ~[testng-7.3.0.jar:?]
	at org.testng.internal.TestInvoker.invokeTestMethod(TestInvoker.java:174) ~[testng-7.3.0.jar:?]
	at org.testng.internal.MethodRunner.runInSequence(MethodRunner.java:46) ~[testng-7.3.0.jar:?]
	at org.testng.internal.TestInvoker$MethodInvocationAgent.invoke(TestInvoker.java:822) ~[testng-7.3.0.jar:?]
	at org.testng.internal.TestInvoker.invokeTestMethods(TestInvoker.java:147) ~[testng-7.3.0.jar:?]
	at org.testng.internal.TestMethodWorker.invokeTestMethods(TestMethodWorker.java:146) ~[testng-7.3.0.jar:?]
	at org.testng.internal.TestMethodWorker.run(TestMethodWorker.java:128) ~[testng-7.3.0.jar:?]
	at java.util.ArrayList.forEach(ArrayList.java:1511) [?:?]
	at org.testng.TestRunner.privateRun(TestRunner.java:764) [testng-7.3.0.jar:?]
	at org.testng.TestRunner.run(TestRunner.java:585) [testng-7.3.0.jar:?]
	at org.testng.SuiteRunner.runTest(SuiteRunner.java:384) [testng-7.3.0.jar:?]
	at org.testng.SuiteRunner.runSequentially(SuiteRunner.java:378) [testng-7.3.0.jar:?]
	at org.testng.SuiteRunner.privateRun(SuiteRunner.java:337) [testng-7.3.0.jar:?]
	at org.testng.SuiteRunner.run(SuiteRunner.java:286) [testng-7.3.0.jar:?]
	at org.testng.SuiteRunnerWorker.runSuite(SuiteRunnerWorker.java:53) [testng-7.3.0.jar:?]
	at org.testng.SuiteRunnerWorker.run(SuiteRunnerWorker.java:96) [testng-7.3.0.jar:?]
	at org.testng.TestNG.runSuitesSequentially(TestNG.java:1218) [testng-7.3.0.jar:?]
	at org.testng.TestNG.runSuitesLocally(TestNG.java:1140) [testng-7.3.0.jar:?]
	at org.testng.TestNG.runSuites(TestNG.java:1069) [testng-7.3.0.jar:?]
	at org.testng.TestNG.run(TestNG.java:1037) [testng-7.3.0.jar:?]
	at org.apache.maven.surefire.testng.TestNGExecutor.run(TestNGExecutor.java:135) [surefire-testng-3.0.0-M3.jar:3.0.0-M3]
	at org.apache.maven.surefire.testng.TestNGDirectoryTestSuite.executeSingleClass(TestNGDirectoryTestSuite.java:112) [surefire-testng-3.0.0-M3.jar:3.0.0-M3]
	at org.apache.maven.surefire.testng.TestNGDirectoryTestSuite.executeLazy(TestNGDirectoryTestSuite.java:123) [surefire-testng-3.0.0-M3.jar:3.0.0-M3]
	at org.apache.maven.surefire.testng.TestNGDirectoryTestSuite.execute(TestNGDirectoryTestSuite.java:90) [surefire-testng-3.0.0-M3.jar:3.0.0-M3]
	at org.apache.maven.surefire.testng.TestNGProvider.invoke(TestNGProvider.java:146) [surefire-testng-3.0.0-M3.jar:3.0.0-M3]
	at org.apache.maven.surefire.booter.ForkedBooter.invokeProviderInSameClassLoader(ForkedBooter.java:384) [surefire-booter-3.0.0-M3.jar:3.0.0-M3]
	at org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:345) [surefire-booter-3.0.0-M3.jar:3.0.0-M3]
	at org.apache.maven.surefire.booter.ForkedBooter.execute(ForkedBooter.java:126) [surefire-booter-3.0.0-M3.jar:3.0.0-M3]
	at org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:418) [surefire-booter-3.0.0-M3.jar:3.0.0-M3]
2022-07-18T14:03:01,710 - INFO  - [main:MockedBookKeeperTestCase@70] - >>>>>> starting public void org.apache.bookkeeper.mledger.impl.ManagedLedgerTest.avoidUseSameOpAddEntryBetweenDifferentLedger() throws java.lang.Exception
```
The root cause is the scheduled executor shutdown before all the ledgers closed. The close ledger operation will be stuck due to the scheduled executor being shut down.

https://github.com/apache/pulsar/blob/c60e063fcab18a2da9757ca5f13479e268e0681d/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/MetaStoreImpl.java#L241

### Modification

Shut down the scheduled executor after all the ledgers and cursors are closed.

### Documentation

Check the box below or label this PR directly.

Need to update docs? 

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)
  
- [x] `doc-not-needed` 
(Please explain why)
  
- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)