### PR TITLE
[improve][broker] Add `keyHashRangeIndex` to distinguish the same hashRanges with the same consumerName

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentSubscription.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentSubscription.java
@@ -1088,6 +1088,13 @@ public class PersistentSubscription extends AbstractSubscription implements Subs
                     consumerStats.keyHashRanges = consumerKeyHashRanges.get(consumer).stream()
                             .map(Range::toString)
                             .collect(Collectors.toList());
+                    long sameNameConsumerCount = consumerKeyHashRanges.keySet()
+                            .stream()
+                            .filter(c -> c.consumerName().equals(consumer.consumerName()))
+                            .count();
+                    if (sameNameConsumerCount > 1) {
+                        consumerStats.keyHashRangeIndex = (int) (consumer.consumerId() % sameNameConsumerCount);
+                    }
                 }
             });
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentTopicTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentTopicTest.java
@@ -2264,6 +2264,7 @@ public class PersistentTopicTest extends MockedBookKeeperTestCase {
         PersistentSubscription sub1 = new PersistentSubscription(topic, "key-shared-stats1", cursorMock, false);
         PersistentSubscription sub2 = new PersistentSubscription(topic, "key-shared-stats2", cursorMock, false);
         PersistentSubscription sub3 = new PersistentSubscription(topic, "key-shared-stats3", cursorMock, false);
+        PersistentSubscription sub4 = new PersistentSubscription(topic, "key-shared-stats4", cursorMock, false);
 
         Consumer consumer1 = new Consumer(sub1, SubType.Key_Shared, topic.getName(), 1, 0, "Cons1", true, serverCnx,
                 "myrole-1", Collections.emptyMap(), false,
@@ -2298,6 +2299,18 @@ public class PersistentTopicTest extends MockedBookKeeperTestCase {
         SubscriptionStatsImpl stats3 = sub3.getStats(false, false, false);
         assertEquals(stats3.keySharedMode, "STICKY");
         assertFalse(stats3.allowOutOfOrderDelivery);
+
+        KeySharedMeta ksm4 =  new KeySharedMeta().setKeySharedMode(KeySharedMode.AUTO_SPLIT).setAllowOutOfOrderDelivery(false);
+        Consumer consumer4 = new Consumer(sub4, SubType.Key_Shared, topic.getName(), 4, 0, "Cons4", true, serverCnx,
+                "myrole-1", Collections.emptyMap(), false, ksm4, MessageId.latest, DEFAULT_CONSUMER_EPOCH);
+        sub4.addConsumer(consumer4);
+        Consumer consumer5 = new Consumer(sub4, SubType.Key_Shared, topic.getName(), 5, 0, "Cons4", true, serverCnx,
+                "myrole-1", Collections.emptyMap(), false, ksm4, MessageId.latest, DEFAULT_CONSUMER_EPOCH);
+        sub4.addConsumer(consumer5);
+        SubscriptionStatsImpl stats4 = sub4.getStats(false, false, false);
+        assertEquals(stats4.getConsumers().size(), 2);
+        assertEquals(stats4.getConsumers().get(0).keyHashRangeIndex, Integer.valueOf(0));
+        assertEquals(stats4.getConsumers().get(1).keyHashRangeIndex, Integer.valueOf(1));
     }
 
     private ByteBuf getMessageWithMetadata(byte[] data) {

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/stats/ConsumerStatsImpl.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/stats/ConsumerStatsImpl.java
@@ -103,7 +103,7 @@ public class ConsumerStatsImpl implements ConsumerStats {
     /** Hash ranges assigned to this consumer if is Key_Shared sub mode. **/
     public List<String> keyHashRanges;
 
-    /** Hash range index if is Key_Shared sub mode. **/
+    /** Hash range index if is Key_Shared sub mode with the same consumer name. **/
     public Integer keyHashRangeIndex;
 
     /** Metadata (key/value strings) associated with this consumer. */

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/stats/ConsumerStatsImpl.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/stats/ConsumerStatsImpl.java
@@ -103,6 +103,9 @@ public class ConsumerStatsImpl implements ConsumerStats {
     /** Hash ranges assigned to this consumer if is Key_Shared sub mode. **/
     public List<String> keyHashRanges;
 
+    /** Hash range index if is Key_Shared sub mode. **/
+    public Integer keyHashRangeIndex;
+
     /** Metadata (key/value strings) associated with this consumer. */
     public Map<String, String> metadata;
 


### PR DESCRIPTION
Fixes #16654 

Master Issue: #16654 

### Motivation

Add `keyHashRangeIndex` to distinguish the same hashRanges with the same consumerName.

### Documentation

- [x] `doc-not-needed` 
