### PR TITLE
[improve][connector] add reader config to `pulsar-io-debezium` and `pulsar-io-kafka-connect-adaptor`

### DIFF
--- a/pulsar-io/common/src/main/java/org/apache/pulsar/io/common/IOConfigUtils.java
+++ b/pulsar-io/common/src/main/java/org/apache/pulsar/io/common/IOConfigUtils.java
@@ -24,6 +24,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Field;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Function;
@@ -49,7 +50,7 @@ public class IOConfigUtils {
             return mapper.readValue(config, new TypeReference<Map<String, Object>>() {
             });
         } else {
-            return new HashMap<>();
+            return Collections.emptyMap();
         }
     }
 

--- a/pulsar-io/common/src/main/java/org/apache/pulsar/io/common/IOConfigUtils.java
+++ b/pulsar-io/common/src/main/java/org/apache/pulsar/io/common/IOConfigUtils.java
@@ -18,6 +18,9 @@
  */
 package org.apache.pulsar.io.common;
 
+import static org.apache.commons.lang.StringUtils.isBlank;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Field;
@@ -40,6 +43,15 @@ public class IOConfigUtils {
         return loadWithSecrets(map, clazz, secretName -> sinkContext.getSecret(secretName));
     }
 
+    public static Map<String, Object> loadConfigFromJsonString(String config) throws JsonProcessingException {
+        if (!isBlank(config)) {
+            ObjectMapper mapper = new ObjectMapper();
+            return mapper.readValue(config, new TypeReference<Map<String, Object>>() {
+            });
+        } else {
+            return new HashMap<>();
+        }
+    }
 
     private static <T> T loadWithSecrets(Map<String, Object> map, Class<T> clazz,
                                          Function<String, String> secretsGetter) {

--- a/pulsar-io/debezium/core/src/main/java/org/apache/pulsar/io/debezium/PulsarDatabaseHistory.java
+++ b/pulsar-io/debezium/core/src/main/java/org/apache/pulsar/io/debezium/PulsarDatabaseHistory.java
@@ -21,7 +21,6 @@ package org.apache.pulsar.io.debezium;
 import static org.apache.commons.lang.StringUtils.isBlank;
 import static org.apache.pulsar.io.common.IOConfigUtils.loadConfigFromJsonString;
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.core.type.TypeReference;
 import io.debezium.annotation.ThreadSafe;
 import io.debezium.config.Configuration;
 import io.debezium.config.Field;
@@ -49,7 +48,6 @@ import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.api.Reader;
 import org.apache.pulsar.client.api.Schema;
-import org.apache.pulsar.common.util.ObjectMapperFactory;
 
 /**
  * A {@link DatabaseHistory} implementation that records schema changes as normal pulsar messages on the specified

--- a/pulsar-io/debezium/core/src/test/java/org/apache/pulsar/io/debezium/PulsarDatabaseHistoryTest.java
+++ b/pulsar-io/debezium/core/src/test/java/org/apache/pulsar/io/debezium/PulsarDatabaseHistoryTest.java
@@ -34,6 +34,7 @@ import io.debezium.util.Collect;
 import java.io.ByteArrayOutputStream;
 import java.io.ObjectOutputStream;
 import java.util.Base64;
+import java.util.List;
 import java.util.Map;
 
 import org.apache.pulsar.client.api.ClientBuilder;
@@ -74,7 +75,7 @@ public class PulsarDatabaseHistoryTest extends ProducerConsumerBase {
         super.internalCleanup();
     }
 
-    private void testHistoryTopicContent(boolean skipUnparseableDDL, boolean testWithClientBuilder) throws Exception {
+    private void testHistoryTopicContent(boolean skipUnparseableDDL, boolean testWithClientBuilder, boolean testWithReaderConfig) throws Exception {
         Configuration.Builder configBuidler = Configuration.create()
                 .with(PulsarDatabaseHistory.TOPIC, topicName)
                 .with(DatabaseHistory.NAME, "my-db-history")
@@ -91,6 +92,10 @@ public class PulsarDatabaseHistoryTest extends ProducerConsumerBase {
             }
         } else {
             configBuidler.with(PulsarDatabaseHistory.SERVICE_URL, brokerUrl.toString());
+        }
+
+        if (testWithReaderConfig) {
+            configBuidler.with(PulsarDatabaseHistory.READER_CONFIG, "{\"subscriptionName\":\"my-subscription\"}");
         }
 
         // Start up the history ...
@@ -122,8 +127,8 @@ public class PulsarDatabaseHistoryTest extends ProducerConsumerBase {
         // Now record schema changes, which writes out to kafka but doesn't actually change the Tables ...
         setLogPosition(10);
         ddl = "CREATE TABLE foo ( first VARCHAR(22) NOT NULL ); \n" +
-            "CREATE TABLE customers ( id INTEGER NOT NULL PRIMARY KEY, name VARCHAR(100) NOT NULL ); \n" +
-            "CREATE TABLE products ( productId INTEGER NOT NULL PRIMARY KEY, description VARCHAR(255) NOT NULL ); \n";
+                "CREATE TABLE customers ( id INTEGER NOT NULL PRIMARY KEY, name VARCHAR(100) NOT NULL ); \n" +
+                "CREATE TABLE products ( productId INTEGER NOT NULL PRIMARY KEY, description VARCHAR(255) NOT NULL ); \n";
         history.record(source, position, "db1", ddl);
 
         // Parse the DDL statement 3x and each time update a different Tables object ...
@@ -179,6 +184,10 @@ public class PulsarDatabaseHistoryTest extends ProducerConsumerBase {
         setLogPosition(100000010);
         history.recover(source, position, recoveredTables, recoveryParser);
         assertEquals(recoveredTables, tables3);
+    }
+
+    private void testHistoryTopicContent(boolean skipUnparseableDDL, boolean testWithClientBuilder) throws Exception {
+        testHistoryTopicContent(skipUnparseableDDL, testWithClientBuilder, false);
     }
 
     protected void setLogPosition(int index) {
@@ -238,5 +247,14 @@ public class PulsarDatabaseHistoryTest extends ProducerConsumerBase {
 
         // dummytopic should not exist yet
         assertFalse(history.exists());
+    }
+
+    @Test
+    public void testSubscriptionName() throws Exception {
+        // happy path
+        testHistoryTopicContent(true, false, true);
+        assertTrue(history.exists());
+        List<String> subscriptions = admin.topics().getSubscriptions("persistent://my-property/my-ns/substopic");
+        assertTrue(subscriptions.contains("my-subscription"));
     }
 }

--- a/pulsar-io/debezium/core/src/test/java/org/apache/pulsar/io/debezium/PulsarDatabaseHistoryTest.java
+++ b/pulsar-io/debezium/core/src/test/java/org/apache/pulsar/io/debezium/PulsarDatabaseHistoryTest.java
@@ -254,7 +254,7 @@ public class PulsarDatabaseHistoryTest extends ProducerConsumerBase {
         // happy path
         testHistoryTopicContent(true, false, true);
         assertTrue(history.exists());
-        List<String> subscriptions = admin.topics().getSubscriptions("persistent://my-property/my-ns/substopic");
+        List<String> subscriptions = admin.topics().getSubscriptions(topicName);
         assertTrue(subscriptions.contains("my-subscription"));
     }
 }

--- a/pulsar-io/kafka-connect-adaptor/pom.xml
+++ b/pulsar-io/kafka-connect-adaptor/pom.xml
@@ -39,6 +39,12 @@
     </dependency>
 
     <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>pulsar-io-common</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <dependency>
       <groupId>org.apache.kafka</groupId>
       <artifactId>kafka_${scala.binary.version}</artifactId>
       <version>${kafka-client.version}</version>

--- a/pulsar-io/kafka-connect-adaptor/src/main/java/org/apache/pulsar/io/kafka/connect/PulsarKafkaWorkerConfig.java
+++ b/pulsar-io/kafka-connect-adaptor/src/main/java/org/apache/pulsar/io/kafka/connect/PulsarKafkaWorkerConfig.java
@@ -43,6 +43,14 @@ public class PulsarKafkaWorkerConfig extends WorkerConfig {
     public static final String TOPIC_NAMESPACE_CONFIG = "topic.namespace";
     private static final String TOPIC_NAMESPACE_CONFIG_DOC = "namespace of topic name to store the output topics";
 
+    /**
+     * <code>offset.storage.reader.config</code>.
+     */
+    public static final String OFFSET_STORAGE_READER_CONFIG = "offset.storage.reader.config";
+    private static final String OFFSET_STORAGE_READER_CONFIG_DOC = "The configs of the reader for the "
+            + "kafka connector offsets topic, in the form of a JSON string with key-value pairs";
+
+
     static {
         CONFIG = new ConfigDef()
             .define(OFFSET_STORAGE_TOPIC_CONFIG,
@@ -53,7 +61,12 @@ public class PulsarKafkaWorkerConfig extends WorkerConfig {
                 Type.STRING,
                 "public/default",
                 Importance.HIGH,
-                TOPIC_NAMESPACE_CONFIG_DOC);
+                TOPIC_NAMESPACE_CONFIG_DOC)
+            .define(OFFSET_STORAGE_READER_CONFIG,
+                    Type.STRING,
+                    null,
+                    Importance.HIGH,
+                    OFFSET_STORAGE_READER_CONFIG_DOC);
     }
 
     public PulsarKafkaWorkerConfig(Map<String, String> props) {

--- a/pulsar-io/kafka-connect-adaptor/src/main/java/org/apache/pulsar/io/kafka/connect/PulsarOffsetBackingStore.java
+++ b/pulsar-io/kafka-connect-adaptor/src/main/java/org/apache/pulsar/io/kafka/connect/PulsarOffsetBackingStore.java
@@ -21,6 +21,8 @@ package org.apache.pulsar.io.kafka.connect;
 import static com.google.common.base.Preconditions.checkArgument;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.commons.lang.StringUtils.isBlank;
+import static org.apache.pulsar.io.common.IOConfigUtils.loadConfigFromJsonString;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufUtil;
 import io.netty.buffer.Unpooled;
@@ -54,6 +56,7 @@ public class PulsarOffsetBackingStore implements OffsetBackingStore {
     private final Map<ByteBuffer, ByteBuffer> data = new ConcurrentHashMap<>();
     private PulsarClient client;
     private String topic;
+    private Map<String, Object> readerConfigMap = new HashMap<>();
     private Producer<byte[]> producer;
     private Reader<byte[]> reader;
     private volatile CompletableFuture<Void> outstandingReadToEnd = null;
@@ -67,6 +70,13 @@ public class PulsarOffsetBackingStore implements OffsetBackingStore {
     public void configure(WorkerConfig workerConfig) {
         this.topic = workerConfig.getString(PulsarKafkaWorkerConfig.OFFSET_STORAGE_TOPIC_CONFIG);
         checkArgument(!isBlank(topic), "Offset storage topic must be specified");
+        try {
+            this.readerConfigMap = loadConfigFromJsonString(
+                    workerConfig.getString(PulsarKafkaWorkerConfig.OFFSET_STORAGE_READER_CONFIG));
+        } catch (JsonProcessingException exception) {
+            log.warn("The provided reader configs are invalid, "
+                    + "will not passing any extra config to the reader builder.", exception);
+        }
 
         log.info("Configure offset backing store on pulsar topic {}", topic);
     }
@@ -148,6 +158,7 @@ public class PulsarOffsetBackingStore implements OffsetBackingStore {
             reader = client.newReader(Schema.BYTES)
                     .topic(topic)
                     .startMessageId(MessageId.earliest)
+                    .loadConf(readerConfigMap)
                 .create();
             log.info("Successfully created reader to replay updates from topic {}", topic);
 


### PR DESCRIPTION
Fixes #16674

### Motivation

Allow user customize the reader configs in pulsar-io-debezium and pulsar-io-kafka-connect-adaptor.

### Modifications

- add `offset.storage.reader.config` to `PulsarKafkaWorkerConfig`
- add `pulsar.reader.config` to `PulsarDatabaseHistory`
- add utils to pulsar-io-common
- add pulsar-io-common dependency to pulsar-io-kafka-connect-adaptor
- add tests

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API: (yes / no)
  - The schema: (yes / no / don't know)
  - The default values of configurations: (yes / no)
  - The wire protocol: (yes / no)
  - The rest endpoints: (yes / no)
  - The admin cli options: (yes / no)
  - Anything that affects deployment: (yes / no / don't know)

### Documentation

Check the box below or label this PR directly.

Need to update docs? 

- [x] `doc-required` 
(Your PR needs to update docs and you will update later)
  
- [ ] `doc-not-needed` 
(Please explain why)
  
- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)