### PR TITLE
[pulsar-client] Get GettingAuthenticationDataException on Authentication Failure

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PulsarChannelInitializer.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PulsarChannelInitializer.java
@@ -127,6 +127,8 @@ public class PulsarChannelInitializer extends ChannelInitializer<SocketChannel> 
                                 conf.getTlsCiphers(),
                                 conf.getTlsProtocols());
                     }
+                } catch (PulsarClientException pulsarClientException) {
+                    throw new RuntimeException(pulsarClientException);
                 } catch (Exception e) {
                     throw new RuntimeException("Failed to create TLS context", e);
                 }


### PR DESCRIPTION
### Motivation
When a Consumer makes an authenticated connection (subscribe) and the connection fails due to incomplete authentication information, the application receives an `RuntimeException: Failed to create TLS context`.

In this case, `GettingAuthenticationDataException` is thrown by the following part, but the exception is not delivered to the application.
The reason is that `RuntimeException` is thrown in the catch statement.
https://github.com/apache/pulsar/blob/7d2f9b7184350c40778b0aa652283ef076f279b5/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PulsarChannelInitializer.java#L105-L132

Therefore, the application cannot know the cause of the authentication failure.

### Modifications
- Catch and throw PulsarClientException containing GettingAuthenticationDataException.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation
- [x] `doc-not-needed` 