### PR TITLE
[fix] [txn] [PIP-160] Avoid timing task burdens the ledger thread and leads to an avalanche

### DIFF
--- a/pulsar-transaction/coordinator/src/main/java/org/apache/pulsar/transaction/coordinator/impl/TxnLogBufferedWriter.java
+++ b/pulsar-transaction/coordinator/src/main/java/org/apache/pulsar/transaction/coordinator/impl/TxnLogBufferedWriter.java
@@ -159,7 +159,7 @@ public class TxnLogBufferedWriter<T> implements AsyncCallbacks.AddEntryCallback,
                 return;
             }
             scheduledFuture = scheduledExecutorService.schedule(() -> trigFlush(false, true),
-                    batchedWriteMaxDelayInMillis, TimeUnit.MICROSECONDS);
+                    batchedWriteMaxDelayInMillis, TimeUnit.MILLISECONDS);
         } catch (Exception e){
             log.error("Start timing flush trigger failed."
                     + " managedLedger: " + managedLedger.getName(), e);

--- a/pulsar-transaction/coordinator/src/main/java/org/apache/pulsar/transaction/coordinator/impl/TxnLogBufferedWriter.java
+++ b/pulsar-transaction/coordinator/src/main/java/org/apache/pulsar/transaction/coordinator/impl/TxnLogBufferedWriter.java
@@ -267,8 +267,12 @@ public class TxnLogBufferedWriter<T> implements AsyncCallbacks.AddEntryCallback,
                 doFlush();
                 return;
             }
+            if (byScheduleThreads) {
+                doFlush();
+                return;
+            }
             AsyncAddArgs firstAsyncAddArgs = flushContext.asyncAddArgsList.get(0);
-            if (System.currentTimeMillis() - firstAsyncAddArgs.addedTime > batchedWriteMaxDelayInMillis) {
+            if (System.currentTimeMillis() - firstAsyncAddArgs.addedTime >= batchedWriteMaxDelayInMillis) {
                 doFlush();
                 return;
             }

--- a/pulsar-transaction/coordinator/src/main/java/org/apache/pulsar/transaction/coordinator/impl/TxnLogBufferedWriter.java
+++ b/pulsar-transaction/coordinator/src/main/java/org/apache/pulsar/transaction/coordinator/impl/TxnLogBufferedWriter.java
@@ -151,6 +151,7 @@ public class TxnLogBufferedWriter<T> implements AsyncCallbacks.AddEntryCallback,
      * Why not use {@link ScheduledExecutorService#scheduleAtFixedRate(Runnable, long, long, TimeUnit)} ?
      * Because: when the {@link #singleThreadExecutorForWrite} thread processes slowly, the scheduleAtFixedRate task
      * will continue to append tasks to the ledger thread, this burdens the ledger thread and leads to an avalanche.
+     * see: https://github.com/apache/pulsar/pull/16679.
      */
     private void nextTimingTrigger(){
         try {

--- a/pulsar-transaction/coordinator/src/main/java/org/apache/pulsar/transaction/coordinator/impl/TxnLogBufferedWriter.java
+++ b/pulsar-transaction/coordinator/src/main/java/org/apache/pulsar/transaction/coordinator/impl/TxnLogBufferedWriter.java
@@ -73,6 +73,8 @@ public class TxnLogBufferedWriter<T> implements AsyncCallbacks.AddEntryCallback,
 
     private final ManagedLedger managedLedger;
 
+    private final ScheduledExecutorService scheduledExecutorService;
+
     /** All write operation will be executed on single thread. **/
     private final ExecutorService singleThreadExecutorForWrite;
 
@@ -137,13 +139,33 @@ public class TxnLogBufferedWriter<T> implements AsyncCallbacks.AddEntryCallback,
         this.batchedWriteMaxDelayInMillis = batchedWriteMaxDelayInMillis;
         this.flushContext = FlushContext.newInstance();
         this.dataArray = new ArrayList<>();
+        this.scheduledExecutorService = scheduledExecutorService;
         // scheduler task.
-        if (batchEnabled) {
-            this.scheduledFuture = scheduledExecutorService.scheduleAtFixedRate(() -> trigFlush(false),
-                    batchedWriteMaxDelayInMillis, batchedWriteMaxDelayInMillis, TimeUnit.MICROSECONDS);
+        if (this.batchEnabled) {
+            nextTimingTrigger();
         }
         this.state = State.OPEN;
     }
+
+    /***
+     * Why not use {@link ScheduledExecutorService#scheduleAtFixedRate(Runnable, long, long, TimeUnit)} ?
+     * Because: when the {@link #singleThreadExecutorForWrite} thread processes slowly, the scheduleAtFixedRate task
+     * will continue to append tasks to the ledger thread, this burdens the ledger thread and leads to an avalanche.
+     */
+    private void nextTimingTrigger(){
+        try {
+            if (state == State.CLOSING || state == State.CLOSED){
+                return;
+            }
+            scheduledFuture = scheduledExecutorService.schedule(() -> trigFlush(false, true),
+                    batchedWriteMaxDelayInMillis, TimeUnit.MICROSECONDS);
+        } catch (Exception e){
+            log.error("Start timing flush trigger failed."
+                    + " managedLedger: " + managedLedger.getName(), e);
+        }
+    }
+
+
 
     /**
      * Append a new entry to the end of a managed ledger. All writes will be performed in the same thread. Callbacks are
@@ -178,7 +200,7 @@ public class TxnLogBufferedWriter<T> implements AsyncCallbacks.AddEntryCallback,
         int len = dataSerializer.getSerializedSize(data);
         if (len >= batchedWriteMaxSize){
             if (!flushContext.asyncAddArgsList.isEmpty()) {
-                doTrigFlush(true);
+                doTrigFlush(true, false);
             }
             ByteBuf byteBuf = dataSerializer.serialize(data);
             managedLedger.asyncAddEntry(byteBuf, DisabledBatchCallback.INSTANCE,
@@ -193,7 +215,7 @@ public class TxnLogBufferedWriter<T> implements AsyncCallbacks.AddEntryCallback,
         // Calculate bytes-size.
         this.bytesSize += len;
         // trig flush.
-        doTrigFlush(false);
+        doTrigFlush(false, false);
     }
 
     /***
@@ -231,29 +253,35 @@ public class TxnLogBufferedWriter<T> implements AsyncCallbacks.AddEntryCallback,
     /**
      * Trigger write to bookie once, If the conditions are not met, nothing will be done.
      */
-    public void trigFlush(final boolean force){
-        singleThreadExecutorForWrite.execute(() -> doTrigFlush(force));
+    public void trigFlush(final boolean force, boolean byScheduleThreads){
+        singleThreadExecutorForWrite.execute(() -> doTrigFlush(force, byScheduleThreads));
     }
 
-    private void doTrigFlush(boolean force){
-        if (flushContext.asyncAddArgsList.isEmpty()) {
-            return;
-        }
-        if (force){
-            doFlush();
-            return;
-        }
-        AsyncAddArgs firstAsyncAddArgs = flushContext.asyncAddArgsList.get(0);
-        if (System.currentTimeMillis() - firstAsyncAddArgs.addedTime > batchedWriteMaxDelayInMillis){
-            doFlush();
-            return;
-        }
-        if (this.flushContext.asyncAddArgsList.size() >= batchedWriteMaxRecords){
-            doFlush();
-            return;
-        }
-        if (this.bytesSize >= batchedWriteMaxSize){
-            doFlush();
+    private void doTrigFlush(boolean force, boolean byScheduleThreads){
+        try {
+            if (flushContext.asyncAddArgsList.isEmpty()) {
+                return;
+            }
+            if (force) {
+                doFlush();
+                return;
+            }
+            AsyncAddArgs firstAsyncAddArgs = flushContext.asyncAddArgsList.get(0);
+            if (System.currentTimeMillis() - firstAsyncAddArgs.addedTime > batchedWriteMaxDelayInMillis) {
+                doFlush();
+                return;
+            }
+            if (this.flushContext.asyncAddArgsList.size() >= batchedWriteMaxRecords) {
+                doFlush();
+                return;
+            }
+            if (this.bytesSize >= batchedWriteMaxSize) {
+                doFlush();
+            }
+        } finally {
+            if (byScheduleThreads) {
+                nextTimingTrigger();
+            }
         }
     }
 

--- a/pulsar-transaction/coordinator/src/test/java/org/apache/pulsar/transaction/coordinator/impl/TxnLogBufferedWriterTest.java
+++ b/pulsar-transaction/coordinator/src/test/java/org/apache/pulsar/transaction/coordinator/impl/TxnLogBufferedWriterTest.java
@@ -388,7 +388,10 @@ public class TxnLogBufferedWriterTest extends MockedBookKeeperTestCase {
         TxnLogBufferedWriter.AddDataCallback callback = Mockito.mock(TxnLogBufferedWriter.AddDataCallback.class);
         // Test threshold: writeMaxDelayInMillis.
         txnLogBufferedWriter.asyncAddData(100, callback, 100);
-        Thread.sleep(101);
+        Thread.sleep(90);
+        // Verify does not refresh ahead of time.
+        Assert.assertEquals(dataArrayFlushedToBookie.size(), 0);
+        Thread.sleep(11);
         // Test threshold: batchedWriteMaxRecords.
         for (int i = 0; i < 32; i++){
             txnLogBufferedWriter.asyncAddData(1, callback, 1);

--- a/pulsar-transaction/coordinator/src/test/java/org/apache/pulsar/transaction/coordinator/impl/TxnLogBufferedWriterTest.java
+++ b/pulsar-transaction/coordinator/src/test/java/org/apache/pulsar/transaction/coordinator/impl/TxnLogBufferedWriterTest.java
@@ -207,7 +207,7 @@ public class TxnLogBufferedWriterTest extends MockedBookKeeperTestCase {
             txnLogBufferedWriter.asyncAddData(i, callback, i);
             // Ensure flush at least once before close buffered writer.
             if (closeBufferedWriter && i == 0){
-                txnLogBufferedWriter.trigFlush(true);
+                txnLogBufferedWriter.trigFlush(true, false);
             }
             if (closeBufferedWriter && bufferedWriteCloseAtIndex == i){
                 // Wait for any complete callback, avoid unstable.

--- a/pulsar-transaction/coordinator/src/test/java/org/apache/pulsar/transaction/coordinator/impl/TxnLogBufferedWriterTest.java
+++ b/pulsar-transaction/coordinator/src/test/java/org/apache/pulsar/transaction/coordinator/impl/TxnLogBufferedWriterTest.java
@@ -407,6 +407,8 @@ public class TxnLogBufferedWriterTest extends MockedBookKeeperTestCase {
         // Assert all resources released
         dataSerializer.assertAllByteBufHasBeenReleased();
         // clean up.
+        txnLogBufferedWriter.close();
+        txnLogBufferedWriter2.close();
         dataSerializer.cleanup();
         scheduledExecutorService.shutdown();
         orderedExecutor.shutdown();
@@ -510,6 +512,7 @@ public class TxnLogBufferedWriterTest extends MockedBookKeeperTestCase {
         // Assert the timing task count. The above calculation is not accurate, so leave a margin.
         Assert.assertTrue(workQueue.size() - maxCountOfRemainingTasks < 10);
         // clean up.
+        txnLogBufferedWriter.close();
         dataSerializer.cleanup();
         threadPoolExecutor.shutdown();
         scheduledExecutorService.shutdown();

--- a/pulsar-transaction/coordinator/src/test/java/org/apache/pulsar/transaction/coordinator/impl/TxnLogBufferedWriterTest.java
+++ b/pulsar-transaction/coordinator/src/test/java/org/apache/pulsar/transaction/coordinator/impl/TxnLogBufferedWriterTest.java
@@ -390,6 +390,7 @@ public class TxnLogBufferedWriterTest extends MockedBookKeeperTestCase {
         Thread.sleep(90);
         // Verify does not refresh ahead of time.
         Assert.assertEquals(dataArrayFlushedToBookie.size(), 0);
+        // Scheduled task maybe execute slowly than expected, so we wait a long time.
         Thread.sleep(111);
         Awaitility.await().atMost(2, TimeUnit.SECONDS).until(() -> dataArrayFlushedToBookie.size() == 1);
         Assert.assertEquals(dataArrayFlushedToBookie.get(0).intValue(), 100);

--- a/pulsar-transaction/coordinator/src/test/java/org/apache/pulsar/transaction/coordinator/impl/TxnLogBufferedWriterTest.java
+++ b/pulsar-transaction/coordinator/src/test/java/org/apache/pulsar/transaction/coordinator/impl/TxnLogBufferedWriterTest.java
@@ -390,8 +390,6 @@ public class TxnLogBufferedWriterTest extends MockedBookKeeperTestCase {
         Thread.sleep(90);
         // Verify does not refresh ahead of time.
         Assert.assertEquals(dataArrayFlushedToBookie.size(), 0);
-        // Scheduled task maybe execute slowly than expected, so we wait a long time.
-        Thread.sleep(111);
         Awaitility.await().atMost(2, TimeUnit.SECONDS).until(() -> dataArrayFlushedToBookie.size() == 1);
         Assert.assertEquals(dataArrayFlushedToBookie.get(0).intValue(), 100);
         txnLogBufferedWriter1.close();


### PR DESCRIPTION
Master Issue: #15370

### Motivation

see #15370

### Modifications

####  Managed Ledger I/O thread gets busier and busier.

In origin implementation, `TxnLogBufferedWriter` has two thread pools:

- `ExecutorService singleThreadExecutorForWrite` is A single-threaded actuator, used to perform Managed Ledger I/O operations. Includes the following tasks:
  - `internalAsyncAddData` Each execution of the `asyncAddData` adds a task.
  - `doFlush` The execution of `trigFlush` sometimes add a task, and there is also a scheduled task that adds tasks.
- `ScheduledExecutorService scheduledExecutorService` is used to periodically add `doFlush` tasks to the `singleThreadExecutorForWrite`, whether the `singleThreadExecutorForWrite` is idle or not.

If `singleThreadExecutorForWrite` is busy for a period of time, `scheduledExecutorService` will keep adding `doFlush` tasks during that period. Then `singleThreadExecutorForWrite` will be busy with the newly added `doFlush` tasks and allocate fewer resources to `internalAsyncAddData` while `scheduledExecutorService` is adding `doFlush` tasks, which will cause `singleThreadExecutorForWrite` to accumulate more and more tasks, even if that the `doFlush` task appended by `scheduledExecutorService` possible only triggers the check and does nothing else. The net result is that `singleThreadExecutorForWrite` gets busier and busier.

#### Imprecise timing task
If new data is added immediately after a scheduled task is executed, the data cannot be flushed in the next scheduled task. Aka. we set the max delay time to 1 min, the scheduled tasks and new data tasks are executed in the following sequence: 

```
1. scheduled task running at 12:00:00.000
2. scheduled task running at 12:00:01.000
3. add data at 12:00:01.005
4. scheduled task running at 12:00:02.000
```
In the step-4, the flush task will not flush the data to the bookie, because the result of expression `System.currentTimeMillis() - firstAsyncAddArgs.addedTime >= batchedWriteMaxDelayInMillis` is `false`, this data will actually flushed at next scheduled task `12:00:03.000`


### Changes:  

####  Managed Ledger I/O thread gets busier and busier.

Since all C tasks are executed in the same thread, we can change that "after a scheduled task is executed, then add the next one". This reduces the density of `doFlush trig by timer` task execution, thereby somewhat losing timing accuracy (the original implementation was not completely accurate either).

This change can only avoid the task accumulation in `TxnLogBufferedWriter` caused by too many scheduled tasks, but cannot improve the write performance of Managed Ledger.

#### Imprecise timing task
Flush triggered by the scheduled task no longer determines whether the time of the first node reaches the condition. To avoid imprecise scheduled task execution time, the maximum delay time is still checked and flushed in the Flush task triggered by the `asyncAddData`.

### Documentation

- [ ] `doc-required` 
  
- [x] `doc-not-needed` 
  
- [ ] `doc` 

- [ ] `doc-complete`