### PR TITLE
[improve][security] Upgrade aws-java-sdk-s3 to 1.12.261

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -153,7 +153,7 @@ flexible messaging model and an intuitive client API.</description>
     <aerospike-client.version>4.4.20</aerospike-client.version>
     <kafka-client.version>2.7.2</kafka-client.version>
     <rabbitmq-client.version>5.5.3</rabbitmq-client.version>
-    <aws-sdk.version>1.11.774</aws-sdk.version>
+    <aws-sdk.version>1.12.262</aws-sdk.version>
     <avro.version>1.10.2</avro.version>
     <joda.version>2.10.5</joda.version>
     <jclouds.version>2.5.0</jclouds.version>


### PR DESCRIPTION
### Motivation

This fixes CVE-2022-31159. Failure reports at https://github.com/apache/pulsar/runs/7410813199?check_suite_focus=true.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (yes, to fix CVE)

### Documentation

- [x] `doc-not-needed` 