### PR TITLE
[test]Fix test org.apache.pulsar.broker.admin.PersistentTopicsTest#testUnlo…

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/PersistentTopicsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/PersistentTopicsTest.java
@@ -639,8 +639,11 @@ public class PersistentTopicsTest extends MockedPulsarServiceBaseTest {
         // 2) create non partitioned topic and unload
         response = mock(AsyncResponse.class);
         persistentTopics.createNonPartitionedTopic(response, testTenant, testNamespace, topicName, true, null);
-        persistentTopics.unloadTopic(response, testTenant, testNamespace, topicName, true);
         ArgumentCaptor<Response> responseCaptor = ArgumentCaptor.forClass(Response.class);
+        verify(response, timeout(5000).times(1)).resume(responseCaptor.capture());
+        Assert.assertEquals(responseCaptor.getValue().getStatus(), Response.Status.NO_CONTENT.getStatusCode());
+        persistentTopics.unloadTopic(response, testTenant, testNamespace, topicName, true);
+        responseCaptor = ArgumentCaptor.forClass(Response.class);
         verify(response, timeout(5000).times(1)).resume(responseCaptor.capture());
         Assert.assertEquals(responseCaptor.getValue().getStatus(), Response.Status.NO_CONTENT.getStatusCode());
 


### PR DESCRIPTION

### Motivation

Fixes https://github.com/apache/pulsar/issues/16698

The root cause is that `response` was called twice in L641 and L642.  The method is async, so this test may run sucessfully sometimes and  fails sporadically :

https://github.com/apache/pulsar/blob/42fe0603518be7db7a14802eb4274b6ea22b0c9a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/PersistentTopicsTest.java#L639-L644

### Modifications

See https://github.com/apache/pulsar/issues/16698

### Verifying this change

- [x] Make sure that the change passes the CI checks.


### Documentation

Check the box below or label this PR directly.

Need to update docs? 

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)
  
- [x] `doc-not-needed` 
(Please explain why)
  
- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)