### PR TITLE
[improve][admin-cli] Add TLS provider support

### DIFF
--- a/conf/client.conf
+++ b/conf/client.conf
@@ -67,3 +67,8 @@ tlsTrustStorePath=
 
 # TLS TrustStore password
 tlsTrustStorePassword=
+
+# Set up TLS provider for web service
+# When TLS authentication with CACert is used, the valid value is either OPENSSL or JDK.
+# When TLS authentication with KeyStore is used, available options can be SunJSSE, Conscrypt and so on.
+webserviceTlsProvider=

--- a/pulsar-client-tools/src/test/java/org/apache/pulsar/admin/cli/TestRunMain.java
+++ b/pulsar-client-tools/src/test/java/org/apache/pulsar/admin/cli/TestRunMain.java
@@ -18,12 +18,11 @@
  */
 package org.apache.pulsar.admin.cli;
 
-import org.testng.annotations.Test;
-
+import static org.testng.Assert.assertEquals;
 import java.nio.file.Files;
 import java.nio.file.Path;
-
-import static org.testng.Assert.assertEquals;
+import java.util.Properties;
+import org.testng.annotations.Test;
 
 public class TestRunMain {
 
@@ -40,7 +39,40 @@ public class TestRunMain {
         PulsarAdminTool.resetLastExitCode();
         PulsarAdminTool.setAllowSystemExit(false);
         Path dummyEmptyFile = Files.createTempFile("test", ".conf");
-        PulsarAdminTool.main(new String[] {dummyEmptyFile.toAbsolutePath().toString()});
+        PulsarAdminTool.main(new String[]{dummyEmptyFile.toAbsolutePath().toString()});
         assertEquals(PulsarAdminTool.getLastExitCode(), 1);
+    }
+
+    @Test
+    public void testRunWithTlsProviderFlag() throws Exception {
+        var pulsarAdminTool = new PulsarAdminTool(new Properties());
+        pulsarAdminTool.run(new String[]{
+                "--admin-url", "https://localhost:8081",
+                "--tls-provider", "JDK",
+                "tenants"});
+        assertEquals(pulsarAdminTool.rootParams.tlsProvider, "JDK");
+    }
+
+    @Test
+    public void testRunWithTlsProviderConfigFile() throws Exception {
+        Properties properties = new Properties();
+        properties.setProperty("webserviceTlsProvider", "JDK");
+        var pulsarAdminTool = new PulsarAdminTool(properties);
+        pulsarAdminTool.run(new String[]{
+                "--admin-url", "https://localhost:8081",
+                "tenants"});
+        assertEquals(pulsarAdminTool.rootParams.tlsProvider, "JDK");
+    }
+
+    @Test
+    public void testRunWithTlsProviderFlagWithConfigFile() throws Exception {
+        Properties properties = new Properties();
+        properties.setProperty("webserviceTlsProvider", "JDK");
+        var pulsarAdminTool = new PulsarAdminTool(properties);
+        pulsarAdminTool.run(new String[]{
+                "--admin-url", "https://localhost:8081",
+                "--tls-provider", "OPENSSL",
+                "tenants"});
+        assertEquals(pulsarAdminTool.rootParams.tlsProvider, "OPENSSL");
     }
 }

--- a/site2/docs/reference-configuration.md
+++ b/site2/docs/reference-configuration.md
@@ -443,11 +443,7 @@ You can use the [`pulsar-client`](reference-cli-tools.md#pulsar-client) CLI tool
 | tlsTrustStoreType | TLS TrustStore type configuration. <li>JKS </li><li>PKCS12 </li>|JKS|
 | tlsTrustStore | TLS TrustStore path. | |
 | tlsTrustStorePassword | TLS TrustStore password. | |
-
-
-
-
-
+| webserviceTlsProvider | The TLS provider for the web service. <br />When TLS authentication with CACert is used, the valid value is either `OPENSSL` or `JDK`.<br />When TLS authentication with KeyStore is used, available options can be `SunJSSE`, `Conscrypt` and so on. | N/A |
 
 ## Log4j
 

--- a/site2/website/versioned_docs/version-2.10.1/reference-configuration.md
+++ b/site2/website/versioned_docs/version-2.10.1/reference-configuration.md
@@ -428,11 +428,7 @@ You can use the [`pulsar-client`](reference-cli-tools.md#pulsar-client) CLI tool
 | tlsTrustStoreType | TLS TrustStore type configuration. <li>JKS </li><li>PKCS12 </li>|JKS|
 | tlsTrustStore | TLS TrustStore path. | |
 | tlsTrustStorePassword | TLS TrustStore password. | |
-
-
-
-
-
+| webserviceTlsProvider | The TLS provider for the web service. <br />When TLS authentication with CACert is used, the valid value is either `OPENSSL` or `JDK`.<br />When TLS authentication with KeyStore is used, available options can be `SunJSSE`, `Conscrypt` and so on. | N/A |
 
 ## Log4j
 

--- a/site2/website/versioned_docs/version-2.8.3/reference-configuration.md
+++ b/site2/website/versioned_docs/version-2.8.3/reference-configuration.md
@@ -376,7 +376,7 @@ You can use the [`pulsar-client`](reference-cli-tools.md#pulsar-client) CLI tool
 | tlsTrustStoreType | TLS TrustStore type configuration. <li>JKS </li><li>PKCS12 </li>|JKS|
 | tlsTrustStore | TLS TrustStore path. | |
 | tlsTrustStorePassword | TLS TrustStore password. | |
-
+| webserviceTlsProvider | The TLS provider for the web service. <br />When TLS authentication with CACert is used, the valid value is either `OPENSSL` or `JDK`.<br />When TLS authentication with KeyStore is used, available options can be `SunJSSE`, `Conscrypt` and so on. | N/A |
 
 ## Service discovery
 

--- a/site2/website/versioned_docs/version-2.9.3/reference-configuration.md
+++ b/site2/website/versioned_docs/version-2.9.3/reference-configuration.md
@@ -377,11 +377,7 @@ You can use the [`pulsar-client`](reference-cli-tools.md#pulsar-client) CLI tool
 | tlsTrustStoreType | TLS TrustStore type configuration. <li>JKS </li><li>PKCS12 </li>|JKS|
 | tlsTrustStore | TLS TrustStore path. | |
 | tlsTrustStorePassword | TLS TrustStore password. | |
-
-
-
-
-
+| webserviceTlsProvider | The TLS provider for the web service. <br />When TLS authentication with CACert is used, the valid value is either `OPENSSL` or `JDK`.<br />When TLS authentication with KeyStore is used, available options can be `SunJSSE`, `Conscrypt` and so on. | N/A |
 
 ## Log4j
 


### PR DESCRIPTION
Signed-off-by: Zixuan Liu <nodeces@gmail.com>

### Motivation

The `pulsar-admin` doesn't support setting the TLS provider. 

Default to OpenSSL implement, which doesn't support the switch to JDK implement, now we add support for this.

### Modifications

- Add `webserviceTlsProvider` to `client.conf` file
- Add setting the TLS provider in `PulsarAdminTool.java`

### Documentation

Check the box below or label this PR directly.

Need to update docs? 

- [x] `doc-required` 
Add setting the `webserviceTlsProvider` to `reference-configuration#client` section.
  
- [ ] `doc-not-needed` 
(Please explain why)
  
- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)