### PR TITLE
[doc][improvement] enable geo-replication at topic level need extra config

### DIFF
--- a/site2/docs/administration-geo.md
+++ b/site2/docs/administration-geo.md
@@ -143,7 +143,7 @@ $ bin/pulsar-admin topics set-replication-clusters --clusters us-west,us-east,us
 
 - You can change the replication clusters for a namespace at any time, without disruption to ongoing traffic. Replication channels are immediately set up or stopped in all clusters as soon as the configuration changes.
 - Once you create a geo-replication namespace, any topics that producers or consumers create within that namespace are replicated across clusters. Typically, each application uses the `serviceUrl` for the local cluster.
-- To enable geo-replication at topic level, you need to change the following configurations in the `conf/broker.conf` or `conf/standalone.conf` file to enable system topics.
+- To enable geo-replication at topic level, you need to change the following configurations in the `conf/broker.conf` or `conf/standalone.conf` file to enable topic policies service.
 ```shell
 systemTopicEnabled=true
 topicLevelPoliciesEnabled=true

--- a/site2/docs/administration-geo.md
+++ b/site2/docs/administration-geo.md
@@ -143,7 +143,7 @@ $ bin/pulsar-admin topics set-replication-clusters --clusters us-west,us-east,us
 
 - You can change the replication clusters for a namespace at any time, without disruption to ongoing traffic. Replication channels are immediately set up or stopped in all clusters as soon as the configuration changes.
 - Once you create a geo-replication namespace, any topics that producers or consumers create within that namespace are replicated across clusters. Typically, each application uses the `serviceUrl` for the local cluster.
-- To enable geo-replication at topic level, you need to change the following configurations in the `conf/broker.conf` or `conf/standalone.conf` file to enable topic policies service.
+- If you are using Pulsar version `2.10.x`, to enable geo-replication at topic level, you need to change the following configurations in the `conf/broker.conf` or `conf/standalone.conf` file to enable topic policies service.
 ```shell
 systemTopicEnabled=true
 topicLevelPoliciesEnabled=true

--- a/site2/docs/administration-geo.md
+++ b/site2/docs/administration-geo.md
@@ -143,7 +143,11 @@ $ bin/pulsar-admin topics set-replication-clusters --clusters us-west,us-east,us
 
 - You can change the replication clusters for a namespace at any time, without disruption to ongoing traffic. Replication channels are immediately set up or stopped in all clusters as soon as the configuration changes.
 - Once you create a geo-replication namespace, any topics that producers or consumers create within that namespace are replicated across clusters. Typically, each application uses the `serviceUrl` for the local cluster.
-
+- To enable geo-replication at topic level, you need to change the following configurations in the `conf/broker.conf` or `conf/standalone.conf` file to enable system topics.
+```shell
+systemTopicEnabled=true
+topicLevelPoliciesEnabled=true
+```
 :::
 
 ### Use topics with geo-replication

--- a/site2/website/versioned_docs/version-2.10.0/administration-geo.md
+++ b/site2/website/versioned_docs/version-2.10.0/administration-geo.md
@@ -144,7 +144,11 @@ $ bin/pulsar-admin topics set-replication-clusters --clusters us-west,us-east,us
 
 - You can change the replication clusters for a namespace at any time, without disruption to ongoing traffic. Replication channels are immediately set up or stopped in all clusters as soon as the configuration changes.
 - Once you create a geo-replication namespace, any topics that producers or consumers create within that namespace are replicated across clusters. Typically, each application uses the `serviceUrl` for the local cluster.
-
+- If you are using Pulsar version `2.10.x`, to enable geo-replication at topic level, you need to change the following configurations in the `conf/broker.conf` or `conf/standalone.conf` file to enable topic policies service.
+```shell
+systemTopicEnabled=true
+topicLevelPoliciesEnabled=true
+```
 :::
 
 ### Use topics with geo-replication


### PR DESCRIPTION

### Motivation

i try to enable the topic level geo-replication in my cluster,
when i execute `./pulsar-admin topics set-replication-clusters public/default/repl-test --clusters standalone,aliyun-test`, i got error:

```java
2022-07-19T09:05:09,444+0000 [AsyncHttpClient-7-1] WARN  org.apache.pulsar.client.admin.internal.BaseResource - [http://localhost:8080/admin/v2/persistent/public/default/repl-test/replication] Failed to perform http post request: javax.ws.rs.NotAllowedException: HTTP 405 Topic level policies is disabled, to enable the topic level policy and retry.
Topic level policies is disabled, to enable the topic level policy and retry.

Reason: Topic level policies is disabled, to enable the topic level policy and retry.

```
after enable the topic error, try again, i got a `500` error:

```
2022-07-21T03:37:17,796+0000 [AsyncHttpClient-7-1] WARN  org.apache.pulsar.client.admin.internal.BaseResource - [http://localhost:8080/admin/v2/persistent/public/default/repl-test/replication] Failed to perform http post request: javax.ws.rs.InternalServerErrorException: HTTP 500 Topic policies service is disabled.

 --- An unexpected error occurred in the server ---

Message: Topic policies service is disabled.

Stacktrace:

java.lang.UnsupportedOperationException: Topic policies service is disabled.
	at org.apache.pulsar.broker.service.TopicPoliciesService$TopicPoliciesServiceDisabled.updateTopicPoliciesAsync(TopicPoliciesService.java:151)
	at org.apache.pulsar.broker.admin.impl.PersistentTopicsBase.lambda$internalSetReplicationClusters$215(PersistentTopicsBase.java:3119)
	at java.base/java.util.concurrent.CompletableFuture$UniCompose.tryFire(CompletableFuture.java:1072)
	at java.base/java.util.concurrent.CompletableFuture.postComplete(CompletableFuture.java:506)
	at java.base/java.util.concurrent.CompletableFuture.complete(CompletableFuture.java:2073)
	at org.apache.pulsar.client.util.RetryUtil.lambda$executeWithRetry$2(RetryUtil.java:62)
	at java.base/java.util.concurrent.CompletableFuture.uniWhenComplete(CompletableFuture.java:859)
	at java.base/java.util.concurrent.CompletableFuture.uniWhenCompleteStage(CompletableFuture.java:883)
	at java.base/java.util.concurrent.CompletableFuture.whenComplete(CompletableFuture.java:2251)
	at org.apache.pulsar.client.util.RetryUtil.executeWithRetry(RetryUtil.java:48)
	at org.apache.pulsar.client.util.RetryUtil.lambda$retryAsynchronously$0(RetryUtil.java:42)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base/java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:304)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
	at java.base/java.lang.Thread.run(Thread.java:829)
```

after search the doc, i could not found any information about the `Topic policies service`.
then i found these in code:
```java
// org.apache.pulsar.broker.PulsarService#start
            // Start topic level policies service
            if (config.isTopicLevelPoliciesEnabled() && config.isSystemTopicEnabled()) {
                this.topicPoliciesService = new SystemTopicBasedTopicPoliciesService(this);
            }
//     default value:
private TopicPoliciesService topicPoliciesService = TopicPoliciesService.DISABLED;

```
means i need to configure the `systemTopicEnabled` **too**,
the error msg is somewhat confuse.

i also think that we need more information about the `topic policy service` 


### Modifications

add necessary tips



### Documentation

Check the box below or label this PR directly.

Need to update docs? 
  
- [x] `doc` 
(Your PR contains doc changes)
