### PR TITLE
[fix][client] Fix subscription topic name error.

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/PatternTopicsConsumerImplTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/PatternTopicsConsumerImplTest.java
@@ -525,8 +525,6 @@ public class PatternTopicsConsumerImplTest extends ProducerConsumerBase {
                 .receiverQueueSize(4)
                 .subscribe();
 
-
-
         // 1. create partition
         String topicName = "persistent://my-property/my-ns/pattern-topic-1-" + key;
         TenantInfoImpl tenantInfo = createDefaultTenantInfo();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/PatternTopicsConsumerImplTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/PatternTopicsConsumerImplTest.java
@@ -539,6 +539,8 @@ public class PatternTopicsConsumerImplTest extends ProducerConsumerBase {
             assertEquals(((PatternMultiTopicsConsumerImpl<?>) consumer).getConsumers().size(), 4);
             assertEquals(((PatternMultiTopicsConsumerImpl<?>) consumer).getPartitionedTopics().size(), 1);
         });
+
+        consumer.close();
     }
 
     // simulate subscribe a pattern which has 3 topics, but then matched topic added in.

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/PatternTopicsConsumerImplTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/PatternTopicsConsumerImplTest.java
@@ -469,11 +469,6 @@ public class PatternTopicsConsumerImplTest extends ProducerConsumerBase {
             .messageRoutingMode(org.apache.pulsar.client.api.MessageRoutingMode.RoundRobinPartition)
             .create();
 
-        List<String> topicNames = Lists.newArrayList(topicName1, topicName2, topicName3);
-        NamespaceService nss = pulsar.getNamespaceService();
-        doReturn(CompletableFuture.completedFuture(topicNames)).when(nss)
-                .getListOfPersistentTopics(NamespaceName.get("my-property/my-ns"));
-
         // 5. call recheckTopics to subscribe each added topics above
         log.debug("recheck topics change");
         PatternMultiTopicsConsumerImpl<byte[]> consumer1 = ((PatternMultiTopicsConsumerImpl<byte[]>) consumer);
@@ -589,11 +584,6 @@ public class PatternTopicsConsumerImplTest extends ProducerConsumerBase {
             .enableBatching(false)
             .messageRoutingMode(org.apache.pulsar.client.api.MessageRoutingMode.RoundRobinPartition)
             .create();
-
-        List<String> topicNames = Lists.newArrayList(topicName1, topicName2, topicName3, topicName4);
-        NamespaceService nss = pulsar.getNamespaceService();
-        doReturn(CompletableFuture.completedFuture(topicNames)).when(nss)
-                .getListOfPersistentTopics(NamespaceName.get("my-property/my-ns"));
 
         // 7. call recheckTopics to subscribe each added topics above, verify topics number: 10=1+2+3+4
         log.debug("recheck topics change");

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiTopicsConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiTopicsConsumerImpl.java
@@ -934,7 +934,7 @@ public class MultiTopicsConsumerImpl<T> extends ConsumerBase<T> {
 
         client.getPartitionedTopicMetadata(topicName)
                 .thenAccept(metadata -> subscribeTopicPartitions(subscribeResult, fullTopicName, metadata.partitions,
-                        createTopicIfDoesNotExist))
+                    createTopicIfDoesNotExist))
                 .exceptionally(ex1 -> {
                     log.warn("[{}] Failed to get partitioned topic metadata: {}", fullTopicName, ex1.getMessage());
                     subscribeResult.completeExceptionally(ex1);

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiTopicsConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiTopicsConsumerImpl.java
@@ -932,10 +932,9 @@ public class MultiTopicsConsumerImpl<T> extends ConsumerBase<T> {
 
         CompletableFuture<Void> subscribeResult = new CompletableFuture<>();
 
-        client.getPartitionedTopicMetadata(topicNameInstance.getPartitionedTopicName())
-                .thenAccept(metadata -> subscribeTopicPartitions(subscribeResult,
-                        topicNameInstance.getPartitionedTopicName(),
-                        metadata.partitions, createTopicIfDoesNotExist))
+        client.getPartitionedTopicMetadata(topicName)
+                .thenAccept(metadata -> subscribeTopicPartitions(subscribeResult, fullTopicName, metadata.partitions,
+                        createTopicIfDoesNotExist))
                 .exceptionally(ex1 -> {
                     log.warn("[{}] Failed to get partitioned topic metadata: {}", fullTopicName, ex1.getMessage());
                     subscribeResult.completeExceptionally(ex1);

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiTopicsConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiTopicsConsumerImpl.java
@@ -932,9 +932,10 @@ public class MultiTopicsConsumerImpl<T> extends ConsumerBase<T> {
 
         CompletableFuture<Void> subscribeResult = new CompletableFuture<>();
 
-        client.getPartitionedTopicMetadata(topicName)
-                .thenAccept(metadata -> subscribeTopicPartitions(subscribeResult, fullTopicName, metadata.partitions,
-                    createTopicIfDoesNotExist))
+        client.getPartitionedTopicMetadata(topicNameInstance.getPartitionedTopicName())
+                .thenAccept(metadata -> subscribeTopicPartitions(subscribeResult,
+                        topicNameInstance.getPartitionedTopicName(),
+                        metadata.partitions, createTopicIfDoesNotExist))
                 .exceptionally(ex1 -> {
                     log.warn("[{}] Failed to get partitioned topic metadata: {}", fullTopicName, ex1.getMessage());
                     subscribeResult.completeExceptionally(ex1);

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PatternMultiTopicsConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PatternMultiTopicsConsumerImpl.java
@@ -210,7 +210,7 @@ public class PatternMultiTopicsConsumerImpl<T> extends MultiTopicsConsumerImpl<T
                     .collect(Collectors.toSet());
 
             List<CompletableFuture<Void>> futures = Lists.newArrayListWithExpectedSize(partitionedTopics.size());
-            addTopicPartitionedName.stream().forEach(partitionedTopic -> futures.add(
+            addTopicPartitionedName.forEach(partitionedTopic -> futures.add(
                     subscribeAsync(partitionedTopic,
                             false /* createTopicIfDoesNotExist */)));
             FutureUtil.waitForAll(futures)

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PatternMultiTopicsConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PatternMultiTopicsConsumerImpl.java
@@ -28,9 +28,11 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 import org.apache.pulsar.client.api.Consumer;
 import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.client.impl.conf.ConsumerConfigurationData;
@@ -203,9 +205,14 @@ public class PatternMultiTopicsConsumerImpl<T> extends MultiTopicsConsumerImpl<T
                 return addFuture;
             }
 
+            Set<String> addTopicPartitionedName = addedTopics.stream()
+                    .map(addTopicName -> TopicName.get(addTopicName).getPartitionedTopicName())
+                    .collect(Collectors.toSet());
+
             List<CompletableFuture<Void>> futures = Lists.newArrayListWithExpectedSize(partitionedTopics.size());
-            addedTopics.stream().forEach(topic -> futures.add(
-                    subscribeAsync(topic, false /* createTopicIfDoesNotExist */)));
+            addTopicPartitionedName.stream().forEach(partitionedTopic -> futures.add(
+                    subscribeAsync(partitionedTopic,
+                            false /* createTopicIfDoesNotExist */)));
             FutureUtil.waitForAll(futures)
                 .thenAccept(finalFuture -> addFuture.complete(null))
                 .exceptionally(ex -> {


### PR DESCRIPTION
#16374  #16556 #16375 #16599

### Motivation

This is a bug, after [[PIP-145](https://github.com/apache/pulsar/pull/16062)],  `PatternMultiTopicsConsumer` can receive  `CommandWatchTopicUpdate` from broker to subscribe new topic.

But this topic name is with the partition index(case: public/default/test-topic-partition-0), This will produce unexpected behavior when executing the following subscribe method.

https://github.com/apache/pulsar/blob/9c93ab45af80dbeb116bfe9b63ff579ac4e22ce6/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiTopicsConsumerImpl.java#L935-L942


The reasons for these failed unit tests are:

When the client receives the `CommandWatchTopicUpdate` command, it will enter the logic of processing non-partitions, then only process the [consumer](https://github.com/apache/pulsar/blob/9c93ab45af80dbeb116bfe9b63ff579ac4e22ce6/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiTopicsConsumerImpl.java#L79) collection and not the [partitionedTopics](https://github.com/apache/pulsar/blob/9c93ab45af80dbeb116bfe9b63ff579ac4e22ce6/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiTopicsConsumerImpl.java#L82) collection

https://github.com/apache/pulsar/blob/9c93ab45af80dbeb116bfe9b63ff579ac4e22ce6/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiTopicsConsumerImpl.java#L1068-L1094

Then, when we execute the `consumer1.run(consumer1.getRecheckPatternTimeout())` to trigger the update subscription on the unit test, By executing the following logic, will cause `topic-4` to be removed and added at the same time. ultimately destabilizes unit tests (maybe deletes will be executed after additions)

https://github.com/apache/pulsar/blob/9c93ab45af80dbeb116bfe9b63ff579ac4e22ce6/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PatternMultiTopicsConsumerImpl.java#L115-L121

Print log here:
<img width="1332" alt="image" src="https://user-images.githubusercontent.com/33416836/180206241-db6daeea-727e-422f-9861-74f9f16b1525.png">

Can See:

```
2022-07-21T19:43:35,883 - INFO  - [pulsar-client-io-397-1:PatternMultiTopicsConsumerImpl@154] - debug add: [persistent://my-property/my-ns/pattern-topic-4-AutoSubscribePatternConsumer]
2022-07-21T19:43:35,883 - INFO  - [pulsar-client-io-397-1:PatternMultiTopicsConsumerImpl@155] - debug remove: [persistent://my-property/my-ns/pattern-topic-4-AutoSubscribePatternConsumer-partition-0, persistent://my-property/my-ns/pattern-topic-4-AutoSubscribePatternConsumer-partition-1, persistent://my-property/my-ns/pattern-topic-4-AutoSubscribePatternConsumer-partition-2, persistent://my-property/my-ns/pattern-topic-4-AutoSubscribePatternConsumer-partition-3]

```

### Modifications

- Change subscribe logic, use the `getPartitionedTopicName()`.


### Documentation

- [x] `doc-not-needed` 
(Please explain why)
