### PR TITLE
[fix][test]Fix ManagedLedgerTest#avoidUseSameOpAddEntryBetweenDifferentLedger

### DIFF
--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerTest.java
@@ -3211,10 +3211,12 @@ public class ManagedLedgerTest extends MockedBookKeeperTestCase {
             if (i > 4) {
                 Assert.assertEquals(oldOp.getState(), OpAddEntry.State.CLOSED);
             } else {
-                Assert.assertEquals(oldOp.getState(), OpAddEntry.State.INITIATED);
+                Assert.assertTrue(oldOp.getState() == OpAddEntry.State.INITIATED
+                    || oldOp.getState() == OpAddEntry.State.COMPLETED);
             }
             OpAddEntry newOp = ledger.pendingAddEntries.poll();
-            Assert.assertEquals(newOp.getState(), OpAddEntry.State.INITIATED);
+            Assert.assertTrue(newOp.getState() == OpAddEntry.State.INITIATED
+                || newOp.getState() == OpAddEntry.State.COMPLETED);
             if (i > 4) {
                 Assert.assertNotSame(oldOp, newOp);
             } else {

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerTest.java
@@ -3211,6 +3211,9 @@ public class ManagedLedgerTest extends MockedBookKeeperTestCase {
             if (i > 4) {
                 Assert.assertEquals(oldOp.getState(), OpAddEntry.State.CLOSED);
             } else {
+                // When call `OpAddEntry#initiate`, which happens in `ledger.updateLedgersIdsComplete` above, the
+                // `OpAddEntry` state will be `INITIATED` if `ledger.asyncAddEntry` doesn't complete, otherwise, the
+                // state will be `COMPLETED`
                 Assert.assertTrue(oldOp.getState() == OpAddEntry.State.INITIATED
                     || oldOp.getState() == OpAddEntry.State.COMPLETED);
             }


### PR DESCRIPTION


### Motivation

* Fix https://github.com/apache/pulsar/issues/16665
* The root cause is that: When we called `ManagedLedgerImpl#updateLedgersIdsComplete` -> `OpAddEntry#initiate`, and then If `ledger.asyncAddEntry`(L140) callback successfully, the `OpAddEntry` state will be `COMPLETED` instead of `INITIATED`

https://github.com/apache/pulsar/blob/a1b8476e40b6a40e82062915d13e4dc9d7dff9cb/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/OpAddEntry.java#L125-L140

### Modifications

* Fix https://github.com/apache/pulsar/issues/16665

### Verifying this change

- [x] Make sure that the change passes the CI checks.


### Documentation

Check the box below or label this PR directly.

Need to update docs? 

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)
  
- [x] `doc-not-needed` 
(Please explain why)
  
- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)