### PR TITLE
[fix][doc] Fix sidebars.json syntax

### DIFF
--- a/site2/website/sidebars.json
+++ b/site2/website/sidebars.json
@@ -225,7 +225,7 @@
       "label": "Administration",
       "items": [
         "administration-zk-bk",
-        "administration-metadata-store"
+        "administration-metadata-store",
         "administration-geo",
         "administration-pulsar-manager",
         "administration-stats",


### PR DESCRIPTION
### Motivation
`sidebars.json` is broken, if you try to run the ´.start.sh´ command you get 
```
[ERROR] Sidebars file at "/Users/nicolo.boschi/dev/pulsar/site2/.preview/pulsar-site/site2/website-next/sidebars.js" failed to be loaded.
[ERROR] Loading of version failed for version current
[ERROR] SyntaxError: /Users/nicolo.boschi/dev/pulsar/site2/.preview/pulsar-site/site2/website-next/sidebars.json: Unexpected string in JSON at position 5924

```

### Modifications

Fix the json

- [x] `doc-not-needed` 