### PR TITLE
[improve][txn] PIP-160: Transaction buffered writer supports Timer

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/TransactionMetadataStoreService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/TransactionMetadataStoreService.java
@@ -35,7 +35,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedDeque;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
@@ -202,8 +201,8 @@ public class TransactionMetadataStoreService {
     }
 
     public CompletableFuture<TransactionMetadataStore> openTransactionMetadataStore(TransactionCoordinatorID tcId) {
-        final ScheduledExecutorService transactionLogBufferedWriteAsyncFlushTrigger =
-                pulsarService.getBrokerService().getTransactionTimer();
+        final Timer brokerClientSharedTimer =
+                pulsarService.getBrokerClientSharedTimer();
         final ServiceConfiguration serviceConfiguration = pulsarService.getConfiguration();
         final TxnLogBufferedWriterConfig txnLogBufferedWriterConfig = new TxnLogBufferedWriterConfig();
         txnLogBufferedWriterConfig.setBatchEnabled(serviceConfiguration.isTransactionLogBatchedWriteEnabled());
@@ -223,7 +222,7 @@ public class TransactionMetadataStoreService {
                                     .openStore(tcId, pulsarService.getManagedLedgerFactory(), v,
                                             timeoutTracker, recoverTracker,
                                             pulsarService.getConfig().getMaxActiveTransactionsPerCoordinator(),
-                                            txnLogBufferedWriterConfig, transactionLogBufferedWriteAsyncFlushTrigger);
+                                            txnLogBufferedWriterConfig, brokerClientSharedTimer);
                 });
     }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
@@ -224,9 +224,6 @@ public class BrokerService implements Closeable {
     @Getter
     private final ScheduledExecutorService backlogQuotaChecker;
 
-    @Getter
-    private final ScheduledExecutorService transactionTimer;
-
     protected final AtomicReference<Semaphore> lookupRequestSemaphore;
     protected final AtomicReference<Semaphore> topicLoadRequestSemaphore;
 
@@ -346,8 +343,6 @@ public class BrokerService implements Closeable {
                 new PublishRateLimiterMonitor("pulsar-broker-publish-rate-limiter-monitor");
         this.backlogQuotaManager = new BacklogQuotaManager(pulsar);
         this.backlogQuotaChecker = Executors
-                .newSingleThreadScheduledExecutor(new DefaultThreadFactory("pulsar-backlog-quota-checker"));
-        this.transactionTimer = Executors
                 .newSingleThreadScheduledExecutor(new DefaultThreadFactory("pulsar-backlog-quota-checker"));
         this.authenticationService = new AuthenticationService(pulsar.getConfiguration());
         this.blockedDispatchers =

--- a/pulsar-transaction/coordinator/src/main/java/org/apache/pulsar/transaction/coordinator/TransactionMetadataStoreProvider.java
+++ b/pulsar-transaction/coordinator/src/main/java/org/apache/pulsar/transaction/coordinator/TransactionMetadataStoreProvider.java
@@ -20,9 +20,9 @@ package org.apache.pulsar.transaction.coordinator;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import com.google.common.annotations.Beta;
+import io.netty.util.Timer;
 import java.io.IOException;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ScheduledExecutorService;
 import org.apache.bookkeeper.mledger.ManagedLedgerConfig;
 import org.apache.bookkeeper.mledger.ManagedLedgerFactory;
 import org.apache.pulsar.transaction.coordinator.impl.TxnLogBufferedWriterConfig;
@@ -71,5 +71,5 @@ public interface TransactionMetadataStoreProvider {
             TransactionCoordinatorID transactionCoordinatorId, ManagedLedgerFactory managedLedgerFactory,
             ManagedLedgerConfig managedLedgerConfig, TransactionTimeoutTracker timeoutTracker,
             TransactionRecoverTracker recoverTracker, long maxActiveTransactionsPerCoordinator,
-            TxnLogBufferedWriterConfig txnLogBufferedWriterConfig, ScheduledExecutorService scheduledExecutorService);
+            TxnLogBufferedWriterConfig txnLogBufferedWriterConfig, Timer timer);
 }

--- a/pulsar-transaction/coordinator/src/main/java/org/apache/pulsar/transaction/coordinator/impl/InMemTransactionMetadataStoreProvider.java
+++ b/pulsar-transaction/coordinator/src/main/java/org/apache/pulsar/transaction/coordinator/impl/InMemTransactionMetadataStoreProvider.java
@@ -18,8 +18,8 @@
  */
 package org.apache.pulsar.transaction.coordinator.impl;
 
+import io.netty.util.Timer;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ScheduledExecutorService;
 import org.apache.bookkeeper.mledger.ManagedLedgerConfig;
 import org.apache.bookkeeper.mledger.ManagedLedgerFactory;
 import org.apache.pulsar.transaction.coordinator.TransactionCoordinatorID;
@@ -41,7 +41,7 @@ public class InMemTransactionMetadataStoreProvider implements TransactionMetadat
                                                                  TransactionRecoverTracker recoverTracker,
                                                                  long maxActiveTransactionsPerCoordinator,
                                                                  TxnLogBufferedWriterConfig txnLogBufferedWriterConfig,
-                                                                 ScheduledExecutorService scheduledExecutorService) {
+                                                                 Timer timer) {
         return CompletableFuture.completedFuture(
             new InMemTransactionMetadataStore(transactionCoordinatorId));
     }

--- a/pulsar-transaction/coordinator/src/main/java/org/apache/pulsar/transaction/coordinator/impl/MLTransactionMetadataStoreProvider.java
+++ b/pulsar-transaction/coordinator/src/main/java/org/apache/pulsar/transaction/coordinator/impl/MLTransactionMetadataStoreProvider.java
@@ -18,8 +18,8 @@
  */
 package org.apache.pulsar.transaction.coordinator.impl;
 
+import io.netty.util.Timer;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ScheduledExecutorService;
 import org.apache.bookkeeper.mledger.ManagedLedgerConfig;
 import org.apache.bookkeeper.mledger.ManagedLedgerFactory;
 import org.apache.pulsar.transaction.coordinator.TransactionCoordinatorID;
@@ -45,11 +45,11 @@ public class MLTransactionMetadataStoreProvider implements TransactionMetadataSt
                                                                  TransactionRecoverTracker recoverTracker,
                                                                  long maxActiveTransactionsPerCoordinator,
                                                                  TxnLogBufferedWriterConfig txnLogBufferedWriterConfig,
-                                                                 ScheduledExecutorService scheduledExecutorService) {
+                                                                 Timer timer) {
         MLTransactionSequenceIdGenerator mlTransactionSequenceIdGenerator = new MLTransactionSequenceIdGenerator();
         managedLedgerConfig.setManagedLedgerInterceptor(mlTransactionSequenceIdGenerator);
         MLTransactionLogImpl txnLog = new MLTransactionLogImpl(transactionCoordinatorId,
-                managedLedgerFactory, managedLedgerConfig, txnLogBufferedWriterConfig, scheduledExecutorService);
+                managedLedgerFactory, managedLedgerConfig, txnLogBufferedWriterConfig, timer);
 
         // MLTransactionLogInterceptor will init sequenceId and update the sequenceId to managedLedger properties.
         return txnLog.initialize().thenCompose(__ ->

--- a/pulsar-transaction/coordinator/src/main/java/org/apache/pulsar/transaction/coordinator/impl/TxnLogBufferedWriter.java
+++ b/pulsar-transaction/coordinator/src/main/java/org/apache/pulsar/transaction/coordinator/impl/TxnLogBufferedWriter.java
@@ -151,7 +151,12 @@ public class TxnLogBufferedWriter<T> implements AsyncCallbacks.AddEntryCallback,
         }
     }
 
-    private final TimerTask timingFlush = timeout -> trigFlush(false, true);
+    private final TimerTask timingFlush = (timeout) -> {
+        if (timeout.isCancelled()) {
+            return;
+        }
+        trigFlush(false, true);
+    };
 
     /***
      * Why not use {@link ScheduledExecutorService#scheduleAtFixedRate(Runnable, long, long, TimeUnit)} ?

--- a/pulsar-transaction/coordinator/src/main/java/org/apache/pulsar/transaction/coordinator/impl/TxnLogBufferedWriter.java
+++ b/pulsar-transaction/coordinator/src/main/java/org/apache/pulsar/transaction/coordinator/impl/TxnLogBufferedWriter.java
@@ -28,7 +28,6 @@ import java.util.ArrayList;
 import java.util.UUID;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 import lombok.Getter;
@@ -76,8 +75,6 @@ public class TxnLogBufferedWriter<T> implements AsyncCallbacks.AddEntryCallback,
 
     private final ManagedLedger managedLedger;
 
-    private ScheduledExecutorService scheduledExecutorService;
-
     private Timer timer;
 
     /** All write operation will be executed on single thread. **/
@@ -85,8 +82,6 @@ public class TxnLogBufferedWriter<T> implements AsyncCallbacks.AddEntryCallback,
 
     /** The serializer for the object which called by {@link #asyncAddData}. **/
     private final DataSerializer<T> dataSerializer;
-
-    private ScheduledFuture<?> scheduledFuture;
 
     private Timeout timeout;
 
@@ -131,41 +126,9 @@ public class TxnLogBufferedWriter<T> implements AsyncCallbacks.AddEntryCallback,
      * @param batchedWriteMaxDelayInMillis Maximum delay for writing to bookie for the earliest request in the batch.
      * @param batchEnabled Enable or disabled the batch feature, will use Managed Ledger directly and without batching
      *                    when disabled.
-     */
-    public TxnLogBufferedWriter(ManagedLedger managedLedger, OrderedExecutor orderedExecutor,
-                                ScheduledExecutorService scheduledExecutorService, DataSerializer<T> dataSerializer,
-                                int batchedWriteMaxRecords, int batchedWriteMaxSize, int batchedWriteMaxDelayInMillis,
-                                boolean batchEnabled){
-        this(managedLedger, orderedExecutor, dataSerializer, batchedWriteMaxRecords, batchedWriteMaxSize,
-                batchedWriteMaxDelayInMillis, batchEnabled);
-        this.scheduledExecutorService = scheduledExecutorService;
-        // scheduler task.
-        if (this.batchEnabled) {
-            nextTimingTrigger();
-        }
-    }
-
-    /**
-     * see also above constructor: {@link #TxnLogBufferedWriter}.
      * @param timer Used for periodic flush.
      */
-    public TxnLogBufferedWriter(ManagedLedger managedLedger, OrderedExecutor orderedExecutor,
-                                Timer timer, DataSerializer<T> dataSerializer,
-                                int batchedWriteMaxRecords, int batchedWriteMaxSize, int batchedWriteMaxDelayInMillis,
-                                boolean batchEnabled){
-        this(managedLedger, orderedExecutor, dataSerializer, batchedWriteMaxRecords, batchedWriteMaxSize,
-                batchedWriteMaxDelayInMillis, batchEnabled);
-        this.timer = timer;
-        // scheduler task.
-        if (this.batchEnabled) {
-            nextTimingTrigger();
-        }
-    }
-
-    /**
-     * see also above constructor: {@link #TxnLogBufferedWriter}.
-     */
-    public TxnLogBufferedWriter(ManagedLedger managedLedger, OrderedExecutor orderedExecutor,
+    public TxnLogBufferedWriter(ManagedLedger managedLedger, OrderedExecutor orderedExecutor, Timer timer,
                                 DataSerializer<T> dataSerializer,
                                 int batchedWriteMaxRecords, int batchedWriteMaxSize, int batchedWriteMaxDelayInMillis,
                                 boolean batchEnabled){
@@ -180,6 +143,11 @@ public class TxnLogBufferedWriter<T> implements AsyncCallbacks.AddEntryCallback,
         this.flushContext = FlushContext.newInstance();
         this.dataArray = new ArrayList<>();
         this.state = State.OPEN;
+        this.timer = timer;
+        // scheduler task.
+        if (this.batchEnabled) {
+            nextTimingTrigger();
+        }
     }
 
     /***
@@ -193,13 +161,8 @@ public class TxnLogBufferedWriter<T> implements AsyncCallbacks.AddEntryCallback,
             if (state == State.CLOSING || state == State.CLOSED){
                 return;
             }
-            if (scheduledExecutorService != null) {
-                scheduledFuture = scheduledExecutorService.schedule(() -> trigFlush(false, true),
-                        batchedWriteMaxDelayInMillis, TimeUnit.MILLISECONDS);
-            } else {
-                timeout = timer.newTimeout(timeout -> trigFlush(false, true),
-                        batchedWriteMaxDelayInMillis, TimeUnit.MILLISECONDS);
-            }
+            timeout = timer.newTimeout(timeout -> trigFlush(false, true),
+                    batchedWriteMaxDelayInMillis, TimeUnit.MILLISECONDS);
         } catch (Exception e){
             log.error("Start timing flush trigger failed."
                     + " managedLedger: " + managedLedger.getName(), e);
@@ -409,36 +372,19 @@ public class TxnLogBufferedWriter<T> implements AsyncCallbacks.AddEntryCallback,
             // If some request has been flushed, Bookie triggers the callback.
             failureCallbackByContextAndRecycle(this.flushContext, BUFFERED_WRITER_CLOSED_EXCEPTION);
             // Cancel task that schedule at fixed rate trig flush.
-            if (scheduledExecutorService != null) {
-                if (scheduledFuture == null){
-                    log.error("Cancel scheduled-task that schedule at fixed rate trig flush failure. The"
-                            + " field-scheduledFuture is null. managedLedger: " + managedLedger.getName());
-                } else if (scheduledFuture.isCancelled() || scheduledFuture.isDone()){
-                    this.state = State.CLOSED;
-                } else {
-                    if (this.scheduledFuture.cancel(false)) {
-                        this.state = State.CLOSED;
-                    } else {
-                        // Cancel task failure, The state will stay at CLOSING.
-                        log.error("Cancel scheduled-task that schedule at fixed rate trig flush failure. The state will"
-                                + " stay at CLOSING. managedLedger: " + managedLedger.getName());
-                    }
-                }
+            if (timeout == null){
+                log.error("Cancel timeout-task that schedule at fixed rate trig flush failure. The field-timeout"
+                        + " is null. managedLedger: " + managedLedger.getName());
+            } else if (timeout.isCancelled()){
+                // TODO How decisions the timer-task has been finished ?
+                this.state = State.CLOSED;
             } else {
-                if (timeout == null){
-                    log.error("Cancel timeout-task that schedule at fixed rate trig flush failure. The field-timeout"
-                            + " is null. managedLedger: " + managedLedger.getName());
-                } else if (timeout.isCancelled()){
-                    // TODO How decisions the timer-task has been finished ?
+                if (this.timeout.cancel()) {
                     this.state = State.CLOSED;
                 } else {
-                    if (this.timeout.cancel()) {
-                        this.state = State.CLOSED;
-                    } else {
-                        // Cancel task failure, The state will stay at CLOSING.
-                        log.error("Cancel timeout-task that schedule at fixed rate trig flush failure. The state will"
-                                + " stay at CLOSING. managedLedger: " + managedLedger.getName());
-                    }
+                    // Cancel task failure, The state will stay at CLOSING.
+                    log.error("Cancel timeout-task that schedule at fixed rate trig flush failure. The state will"
+                            + " stay at CLOSING. managedLedger: " + managedLedger.getName());
                 }
             }
         });

--- a/pulsar-transaction/coordinator/src/test/java/org/apache/pulsar/transaction/coordinator/impl/TxnLogBufferedWriterTest.java
+++ b/pulsar-transaction/coordinator/src/test/java/org/apache/pulsar/transaction/coordinator/impl/TxnLogBufferedWriterTest.java
@@ -155,8 +155,8 @@ public class TxnLogBufferedWriterTest extends MockedBookKeeperTestCase {
          *  - scheduledExecutorService
          *  - dataSerializer
          */
-        ManagedLedger managedLedger = factory.open("tx_test_ledger");
-        ManagedCursor managedCursor = managedLedger.openCursor("tx_test_cursor");
+        ManagedLedger managedLedger = factory.open("txn_test_ledger");
+        ManagedCursor managedCursor = managedLedger.openCursor("txn_test_cursor");
         if (BookieErrorType.ALWAYS_ERROR == bookieErrorType){
             managedLedger = Mockito.spy(managedLedger);
             managedCursor = Mockito.spy(managedCursor);
@@ -166,7 +166,7 @@ public class TxnLogBufferedWriterTest extends MockedBookKeeperTestCase {
             metadataStore.setAlwaysFail(new MetadataStoreException.BadVersionException(""));
         }
         OrderedExecutor orderedExecutor =  OrderedExecutor.newBuilder()
-                .numThreads(5).name("tx-threads").build();
+                .numThreads(5).name("txn-threads").build();
         JsonDataSerializer dataSerializer = new JsonDataSerializer(eachDataBytesLen);
         /**
          * Execute test task.
@@ -177,7 +177,7 @@ public class TxnLogBufferedWriterTest extends MockedBookKeeperTestCase {
         HashedWheelTimer transactionTimer = new HashedWheelTimer(new DefaultThreadFactory("transaction-timer"),
                 1, TimeUnit.MILLISECONDS);
         ScheduledExecutorService transactionScheduledService =
-                Executors.newSingleThreadScheduledExecutor(new DefaultThreadFactory("tx-scheduler-threads"));
+                Executors.newSingleThreadScheduledExecutor(new DefaultThreadFactory("txn-scheduler-threads"));
         TxnLogBufferedWriter txnLogBufferedWriter = null;
         if (useTimer){
             txnLogBufferedWriter = new TxnLogBufferedWriter<Integer>(
@@ -377,11 +377,11 @@ public class TxnLogBufferedWriterTest extends MockedBookKeeperTestCase {
         String managedLedgerName = "-";
         ManagedLedger managedLedger = Mockito.mock(ManagedLedger.class);
         Mockito.when(managedLedger.getName()).thenReturn(managedLedgerName);
-        OrderedExecutor orderedExecutor =  OrderedExecutor.newBuilder().numThreads(5).name("tx-topic-threads").build();
+        OrderedExecutor orderedExecutor =  OrderedExecutor.newBuilder().numThreads(5).name("txn-topic-threads").build();
         HashedWheelTimer transactionTimer = new HashedWheelTimer(new DefaultThreadFactory("transaction-timer"),
                 1, TimeUnit.MILLISECONDS);
         ScheduledExecutorService scheduledExecutorService =
-                Executors.newSingleThreadScheduledExecutor(new DefaultThreadFactory("tx-scheduler-threads"));
+                Executors.newSingleThreadScheduledExecutor(new DefaultThreadFactory("txn-scheduler-threads"));
         SumStrDataSerializer dataSerializer = new SumStrDataSerializer();
         // Cache the data flush to Bookie for Asserts.
         List<Integer> dataArrayFlushedToBookie = new ArrayList<>();
@@ -416,7 +416,7 @@ public class TxnLogBufferedWriterTest extends MockedBookKeeperTestCase {
         TxnLogBufferedWriter txnLogBufferedWriter1 = new TxnLogBufferedWriter<>(managedLedger, orderedExecutor,
                 transactionTimer, dataSerializer, 32, 1024 * 4, 100, true);
         txnLogBufferedWriter1.asyncAddData(100, callback, 100);
-        Thread.sleep(70);
+        Thread.sleep(90);
         // Verify does not refresh ahead of time.
         Assert.assertEquals(dataArrayFlushedToBookie.size(), 1);
         Awaitility.await().atMost(2, TimeUnit.SECONDS).until(() -> dataArrayFlushedToBookie.size() == 2);
@@ -481,7 +481,7 @@ public class TxnLogBufferedWriterTest extends MockedBookKeeperTestCase {
         HashedWheelTimer transactionTimer = new HashedWheelTimer(new DefaultThreadFactory("transaction-timer"),
                 1, TimeUnit.MILLISECONDS);
         ScheduledExecutorService scheduledExecutorService =
-                Executors.newSingleThreadScheduledExecutor(new DefaultThreadFactory("tx-scheduler-threads"));
+                Executors.newSingleThreadScheduledExecutor(new DefaultThreadFactory("txn-scheduler-threads"));
         SumStrDataSerializer dataSerializer = new SumStrDataSerializer();
         // Count the number of tasks that have been submitted to bookie for later validation.
         AtomicInteger completeFlushTaskCounter = new AtomicInteger();


### PR DESCRIPTION
Master Issue: #15370

### Motivation

see #15370

### Modifications

In the original design of the transaction buffered writer, we use a scheduled executor to execute timed tasks. There are no scheduled executors that match this scenario, and It's a little expensive to have a new scheduled executor with 1 millis tick time.
The `PulsarService.brokerClientSharedTimer` is very match to this scenario, so we should reuse it instead to create a new scheduled executor.

So we should make transaction buffered writer supports `io.netty.Timer`.


### Documentation


- [ ] `doc-required` 
  
- [x] `doc-not-needed` 
  
- [ ] `doc` 

- [ ] `doc-complete`