### PR TITLE
[Python] Enable the schema tests in CI

### DIFF
--- a/pulsar-client-cpp/run-unit-tests.sh
+++ b/pulsar-client-cpp/run-unit-tests.sh
@@ -83,6 +83,10 @@ if [ $RES -eq 0 ]; then
     RES=$?
     echo "pulsar_test.py: $RES"
 
+    python3 schema_test.py
+    RES=$?
+    echo "schema_test.py: $RES"
+
     echo "---- Running Python Function Instance unit tests"
     bash $ROOT_DIR/pulsar-functions/instance/src/scripts/run_python_instance_tests.sh
     RES=$?


### PR DESCRIPTION
### Motivation

The schema related unit tests for Python client are not getting executed in the CI job. Fixing that.
- [x] `doc-not-needed`
