### PR TITLE
[fix][tests]Fix Flaky-test: ManagedLedgerBkTest.asyncMarkDeleteAndClose.

### DIFF
--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerBkTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerBkTest.java
@@ -330,10 +330,10 @@ public class ManagedLedgerBkTest extends BookKeeperClusterTestCase {
             }, null);
         }
 
+        counter.await();
+
         cursor.close();
         ledger.close();
-
-        counter.await();
 
         assertFalse(gotException.get());
     }


### PR DESCRIPTION

Fixes #16729

Master Issue: #16729

### Motivation
Close `cursor` after cursor delete position.


### Documentation

- [x] `doc-not-needed` 
(Please explain why)
