### PR TITLE
[fix][flaky-test] Fix BacklogQuotaManagerTest.testConsumerBacklogEvictionTimeQuotaWithEmptyLedge

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BacklogQuotaManagerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BacklogQuotaManagerTest.java
@@ -541,30 +541,27 @@ public class BacklogQuotaManagerTest {
         consumer.receive();
 
         admin.topics().unload(topic);
-        Awaitility.await().until(consumer::isConnected);
-        PersistentTopicInternalStats internalStats = admin.topics().getInternalStats(topic);
-        assertEquals(internalStats.ledgers.size(), 2);
-        assertEquals(internalStats.ledgers.get(1).entries, 0);
+
+        Awaitility.await().untilAsserted(() -> {
+            PersistentTopicInternalStats internalStats = admin.topics().getInternalStats(topic);
+            assertEquals(internalStats.ledgers.size(), 2);
+            assertEquals(internalStats.ledgers.get(1).entries, 0);
+        });
 
         TopicStats stats = getTopicStats(topic);
         assertEquals(stats.getSubscriptions().get(subName).getMsgBacklog(), 1);
 
-        TimeUnit.SECONDS.sleep(TIME_TO_CHECK_BACKLOG_QUOTA);
+        rolloverStats();
 
-        Awaitility.await()
-                .pollInterval(Duration.ofSeconds(1))
-                .atMost(Duration.ofSeconds(TIME_TO_CHECK_BACKLOG_QUOTA))
-                .untilAsserted(() -> {
-                    rolloverStats();
-
-                    // Cause the last ledger is empty, it is not possible to skip first ledger,
-                    // so the number of ledgers will keep unchanged, and backlog is clear
-                    PersistentTopicInternalStats latestInternalStats = admin.topics().getInternalStats(topic);
-                    assertEquals(latestInternalStats.ledgers.size(), 2);
-                    assertEquals(latestInternalStats.ledgers.get(1).entries, 0);
-                    TopicStats latestStats = getTopicStats(topic);
-                    assertEquals(latestStats.getSubscriptions().get(subName).getMsgBacklog(), 0);
-                });
+        Awaitility.await().untilAsserted(() -> {
+            // Cause the last ledger is empty, it is not possible to skip first ledger,
+            // so the number of ledgers will keep unchanged, and backlog is clear
+            PersistentTopicInternalStats latestInternalStats = admin.topics().getInternalStats(topic);
+            assertEquals(latestInternalStats.ledgers.size(), 2);
+            assertEquals(latestInternalStats.ledgers.get(1).entries, 0);
+            TopicStats latestStats = getTopicStats(topic);
+            assertEquals(latestStats.getSubscriptions().get(subName).getMsgBacklog(), 0);
+        });
 
         client.close();
     }


### PR DESCRIPTION
Fixes #16733 

### Motivation

This is a flaky test, which looks have the incorrect condition.

### Documentation

Check the box below or label this PR directly.

Need to update docs? 

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)
  
- [x] `doc-not-needed` 
(Please explain why)
  
- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)