### PR TITLE
[fix][broker]avoid the bestBroker choice broker exceed candidates when selectBroker in LeastResourceUsageWithWeight

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/LeastResourceUsageWithWeight.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/LeastResourceUsageWithWeight.java
@@ -138,9 +138,9 @@ public class LeastResourceUsageWithWeight implements ModularLoadManagerStrategy 
         final double avgUsage = totalUsage / candidates.size();
         final double diffThreshold =
                 conf.getLoadBalancerAverageResourceUsageDifferenceThresholdPercentage() / 100.0;
-        brokerAvgResourceUsageWithWeight.forEach((broker, avgResUsage) -> {
-            if ((avgResUsage + diffThreshold <= avgUsage)
-                    && candidates.contains(broker)) {
+        candidates.forEach(broker -> {
+            Double avgResUsage = brokerAvgResourceUsageWithWeight.getOrDefault(broker, Double.MAX_VALUE);
+            if ((avgResUsage + diffThreshold <= avgUsage)) {
                 bestBrokers.add(broker);
             }
         });

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/LeastResourceUsageWithWeight.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/LeastResourceUsageWithWeight.java
@@ -139,7 +139,8 @@ public class LeastResourceUsageWithWeight implements ModularLoadManagerStrategy 
         final double diffThreshold =
                 conf.getLoadBalancerAverageResourceUsageDifferenceThresholdPercentage() / 100.0;
         brokerAvgResourceUsageWithWeight.forEach((broker, avgResUsage) -> {
-            if (avgResUsage + diffThreshold <= avgUsage) {
+            if ((avgResUsage + diffThreshold <= avgUsage)
+                    && candidates.contains(broker)) {
                 bestBrokers.add(broker);
             }
         });

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/ModularLoadManagerStrategyTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/ModularLoadManagerStrategyTest.java
@@ -20,10 +20,12 @@ package org.apache.pulsar.broker.loadbalance;
 
 import static org.testng.Assert.assertEquals;
 
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Optional;
 
 
+import java.util.Set;
 import org.apache.pulsar.broker.ServiceConfiguration;
 import org.apache.pulsar.broker.loadbalance.impl.LeastLongTermMessageRate;
 import org.apache.pulsar.broker.loadbalance.impl.LeastResourceUsageWithWeight;
@@ -66,11 +68,14 @@ public class ModularLoadManagerStrategyTest {
         BrokerData brokerData1 = initBrokerData(10, 100);
         BrokerData brokerData2 = initBrokerData(30, 100);
         BrokerData brokerData3 = initBrokerData(60, 100);
+        BrokerData brokerData4 = initBrokerData(5, 100);
         LoadData loadData = new LoadData();
         Map<String, BrokerData> brokerDataMap = loadData.getBrokerData();
         brokerDataMap.put("1", brokerData1);
         brokerDataMap.put("2", brokerData2);
         brokerDataMap.put("3", brokerData3);
+        brokerDataMap.put("4", brokerData4);
+
         ServiceConfiguration conf = new ServiceConfiguration();
         conf.setLoadBalancerCPUResourceWeight(1.0);
         conf.setLoadBalancerMemoryResourceWeight(0.1);
@@ -81,7 +86,17 @@ public class ModularLoadManagerStrategyTest {
         conf.setLoadBalancerAverageResourceUsageDifferenceThresholdPercentage(5);
 
         ModularLoadManagerStrategy strategy = new LeastResourceUsageWithWeight();
-        assertEquals(strategy.selectBroker(brokerDataMap.keySet(), bundleData, loadData, conf), Optional.of("1"));
+
+        // Make brokerAvgResourceUsageWithWeight contain broker4.
+        strategy.selectBroker(brokerDataMap.keySet(), bundleData, loadData, conf);
+
+        // Should choice broker from broker1 2 3.
+        Set<String> candidates = new HashSet<>();
+        candidates.add("1");
+        candidates.add("2");
+        candidates.add("3");
+
+        assertEquals(strategy.selectBroker(candidates, bundleData, loadData, conf), Optional.of("1"));
 
         brokerData1 = initBrokerData(20,100);
         brokerData2 = initBrokerData(30,100);
@@ -89,7 +104,7 @@ public class ModularLoadManagerStrategyTest {
         brokerDataMap.put("1", brokerData1);
         brokerDataMap.put("2", brokerData2);
         brokerDataMap.put("3", brokerData3);
-        assertEquals(strategy.selectBroker(brokerDataMap.keySet(), bundleData, loadData, conf), Optional.of("1"));
+        assertEquals(strategy.selectBroker(candidates, bundleData, loadData, conf), Optional.of("1"));
 
         brokerData1 = initBrokerData(30,100);
         brokerData2 = initBrokerData(30,100);
@@ -97,7 +112,7 @@ public class ModularLoadManagerStrategyTest {
         brokerDataMap.put("1", brokerData1);
         brokerDataMap.put("2", brokerData2);
         brokerDataMap.put("3", brokerData3);
-        assertEquals(strategy.selectBroker(brokerDataMap.keySet(), bundleData, loadData, conf), Optional.of("1"));
+        assertEquals(strategy.selectBroker(candidates, bundleData, loadData, conf), Optional.of("1"));
 
         brokerData1 = initBrokerData(30,100);
         brokerData2 = initBrokerData(30,100);
@@ -105,7 +120,7 @@ public class ModularLoadManagerStrategyTest {
         brokerDataMap.put("1", brokerData1);
         brokerDataMap.put("2", brokerData2);
         brokerDataMap.put("3", brokerData3);
-        assertEquals(strategy.selectBroker(brokerDataMap.keySet(), bundleData, loadData, conf), Optional.of("1"));
+        assertEquals(strategy.selectBroker(candidates, bundleData, loadData, conf), Optional.of("1"));
 
         brokerData1 = initBrokerData(35,100);
         brokerData2 = initBrokerData(20,100);
@@ -113,7 +128,7 @@ public class ModularLoadManagerStrategyTest {
         brokerDataMap.put("1", brokerData1);
         brokerDataMap.put("2", brokerData2);
         brokerDataMap.put("3", brokerData3);
-        assertEquals(strategy.selectBroker(brokerDataMap.keySet(), bundleData, loadData, conf), Optional.of("2"));
+        assertEquals(strategy.selectBroker(candidates, bundleData, loadData, conf), Optional.of("2"));
     }
 
     private BrokerData initBrokerData(double usage, double limit) {


### PR DESCRIPTION
### Motivation

Avoid the bestBroker choice broker exceed candidates when selectBroker in LeastResourceUsageWithWeight.
When loadManager leader running a period of time,   `brokerAvgResourceUsageWithWeight` will contain almost all brokers, the judge will cause we selected broker exceed candidates, it's out of expectation.

### Modifications

1. check if `candidates` contain the broker before add the broker to `bestBrokers`.


### Documentation

- [X] `doc-not-needed` 
(Please explain why)
  