### PR TITLE
[fix][client] Disable reconsumerLaster method  for non shared subscription

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/RetryTopicTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/RetryTopicTest.java
@@ -21,17 +21,14 @@ package org.apache.pulsar.client.api;
 import static org.junit.Assert.fail;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNull;
-import static org.testng.Assert.assertTrue;
 import com.google.common.collect.Sets;
 
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import lombok.Cleanup;
 import org.apache.pulsar.client.util.RetryMessageUtil;
-import org.apache.pulsar.transaction.coordinator.exceptions.CoordinatorException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.annotations.AfterMethod;

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBase.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBase.java
@@ -419,6 +419,9 @@ public abstract class ConsumerBase<T> extends HandlerState implements Consumer<T
         if (!conf.isRetryEnable()) {
             throw new PulsarClientException(RECONSUME_LATER_ERROR_MSG);
         }
+        if (conf.getSubscriptionType() != SubscriptionType.Shared) {
+            throw new PulsarClientException("reconsumeLater method not supported using non shared subscribe type.");
+        }
         try {
             reconsumeLaterAsync(message, customProperties, delayTime, unit).get();
         } catch (InterruptedException e) {
@@ -526,6 +529,10 @@ public abstract class ConsumerBase<T> extends HandlerState implements Consumer<T
             Message<?> message, Map<String, String> customProperties, long delayTime, TimeUnit unit) {
         if (!conf.isRetryEnable()) {
             return FutureUtil.failedFuture(new PulsarClientException(RECONSUME_LATER_ERROR_MSG));
+        }
+        if (conf.getSubscriptionType() != SubscriptionType.Shared) {
+            return FutureUtil.failedFuture(new PulsarClientException("reconsumeLater method not supported using non "
+                    + "shared subscribe type."));
         }
         try {
             validateMessageId(message);


### PR DESCRIPTION

### Motivation
The doc said `Currently, retry letter topic is enabled in Shared subscription types.`, But, We can use this method in non shared sub.
We should disable it to keep message order for non shared sub.  `reconsumeLaterCumulative` is recommended for non shared sub.

### Modifications
When we use `reconsumerLaster` in non shared sub, PulsarClientException will be thrown.

### Verifying this change

org.apache.pulsar.client.api.RetryTopicTest#testRetryTopicInNonSharedSub

### Documentation

Check the box below or label this PR directly.

Need to update docs? 

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)
  
- [x] `doc-not-needed` 
(Please explain why)
  
- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)
