### PR TITLE
[improve] [txn] [PIP-160] Fix wrong doc(new doc is incorrectly written in version 2.3)

### DIFF
--- a/site2/docs/reference-configuration.md
+++ b/site2/docs/reference-configuration.md
@@ -732,6 +732,14 @@ You can set the log level and configuration in the  [log4j2.yaml](https://github
 |transactionBufferClientOperationTimeoutInMills| The transaction buffer client's operation timeout in milliseconds.|3000|
 |transactionBufferSnapshotMaxTransactionCount| Transaction buffer takes a snapshot after the number of transaction operations reaches this value.|1000|
 |transactionBufferSnapshotMinTimeInMillis| The interval between two snapshots that the transaction buffer takes (in milliseconds).|5000|
+|transactionLogBatchedWriteEnabled| Provide a mechanism allowing the Transaction Log Store to aggregate multiple records into a batched record and persist into a single BK entry. This will make Pulsar transactions work more  efficiently, aka batched log. see: https://github.com/apache/pulsar/issues/15370  |false|
+|transactionLogBatchedWriteMaxRecords| If enabled the feature that transaction log batch, this attribute means maximum log records count in a batch  |512|
+|transactionLogBatchedWriteMaxSize| If enabled the feature that transaction log batch, this attribute means bytes size in a batch. |4m|
+|transactionLogBatchedWriteMaxDelayInMillis| If enabled the feature that transaction log batch, this attribute means maximum wait time(in millis) for the first record in a batch |1|
+|transactionPendingAckBatchedWriteEnabled| Provide a mechanism allowing the Pending Ack Store to aggregate multiple records into a batched record and persist into a single BK entry. This will make Pulsar transactions work more efficiently, aka batched log. see: https://github.com/apache/pulsar/issues/15370 |false|
+|transactionPendingAckBatchedWriteMaxRecords| If enabled the feature that transaction pending ack log batch, this attribute means maximum log records count in a batch. |512|
+|transactionPendingAckBatchedWriteMaxSize| If enabled the feature that transaction pending ack log batch, this attribute means bytes size in a batch. |4m|
+|transactionPendingAckBatchedWriteMaxDelayInMillis| If enabled the feature that transaction pending ack log batch, this attribute means maximum wait time(in millis) for the first record in a batch |1|
 |defaultRetentionTimeInMinutes|   |0|
 |defaultRetentionSizeInMB|    |0|
 |keepAliveIntervalSeconds|    |30|

--- a/site2/website/versioned_docs/version-2.3.0/reference-configuration.md
+++ b/site2/website/versioned_docs/version-2.3.0/reference-configuration.md
@@ -215,14 +215,7 @@ Pulsar brokers are responsible for handling incoming messages from producers, di
 |s3ManagedLedgerOffloadServiceEndpoint| For Amazon S3 ledger offload, Alternative endpoint to connect to (useful for testing) ||
 |s3ManagedLedgerOffloadMaxBlockSizeInBytes| For Amazon S3 ledger offload, Max block size in bytes. (64MB by default, 5MB minimum) |67108864|
 |s3ManagedLedgerOffloadReadBufferSizeInBytes| For Amazon S3 ledger offload, Read buffer size in bytes (1MB by default)  |1048576|
-|transactionLogBatchedWriteEnabled| Provide a mechanism allowing the Transaction Log Store to aggregate multiple records into a batched record and persist into a single BK entry. This will make Pulsar transactions work more  efficiently, aka batched log. see: https://github.com/apache/pulsar/issues/15370  |false|
-|transactionLogBatchedWriteMaxRecords| If enabled the feature that transaction log batch, this attribute means maximum log records count in a batch  |512|
-|transactionLogBatchedWriteMaxSize| If enabled the feature that transaction log batch, this attribute means bytes size in a batch. |4m|
-|transactionLogBatchedWriteMaxDelayInMillis| If enabled the feature that transaction log batch, this attribute means maximum wait time(in millis) for the first record in a batch |1|
-|transactionPendingAckBatchedWriteEnabled| Provide a mechanism allowing the Pending Ack Store to aggregate multiple records into a batched record and persist into a single BK entry. This will make Pulsar transactions work more efficiently, aka batched log. see: https://github.com/apache/pulsar/issues/15370 |false|
-|transactionPendingAckBatchedWriteMaxRecords| If enabled the feature that transaction pending ack log batch, this attribute means maximum log records count in a batch. |512|
-|transactionPendingAckBatchedWriteMaxSize| If enabled the feature that transaction pending ack log batch, this attribute means bytes size in a batch. |4m|
-|transactionPendingAckBatchedWriteMaxDelayInMillis| If enabled the feature that transaction pending ack log batch, this attribute means maximum wait time(in millis) for the first record in a batch |1|
+
 
 
 


### PR DESCRIPTION
### Motivation

Doc of transaction batch incorrectly written in version 2.3.

### Modifications

Move the new doc to master

### Documentation

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)
  
- [ ] `doc-not-needed` 
(Please explain why)
  
- [x] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)