### PR TITLE
[improve] [broker] improve the restart broker can load bundle as one of the best brokers when selectBroker in LeastResourceUsageWithWeight

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/LeastResourceUsageWithWeight.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/LeastResourceUsageWithWeight.java
@@ -91,6 +91,11 @@ public class LeastResourceUsageWithWeight implements ModularLoadManagerStrategy 
                                                           ServiceConfiguration conf) {
         final double historyPercentage = conf.getLoadBalancerHistoryResourcePercentage();
         Double historyUsage = brokerAvgResourceUsageWithWeight.get(broker);
+        LocalBrokerData localData = brokerData.getLocalData();
+        // If the broker restarted or MsgRate is 0, should use current resourceUsage to cover the historyUsage
+        if (localData.getBundles().size() == 0 || (localData.getMsgRateIn() == 0 && localData.getMsgRateOut() == 0)){
+            historyUsage = null;
+        }
         double resourceUsage = brokerData.getLocalData().getMaxResourceUsageWithWeight(
                 conf.getLoadBalancerCPUResourceWeight(),
                 conf.getLoadBalancerMemoryResourceWeight(),

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/ModularLoadManagerStrategyTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/ModularLoadManagerStrategyTest.java
@@ -23,6 +23,7 @@ import static org.testng.Assert.assertEquals;
 import java.lang.reflect.Field;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
 
@@ -131,6 +132,16 @@ public class ModularLoadManagerStrategyTest {
         brokerDataMap.put("2", brokerData2);
         brokerDataMap.put("3", brokerData3);
         assertEquals(strategy.selectBroker(candidates, bundleData, loadData, conf), Optional.of("2"));
+
+        // test restart broker can load bundle as one of the best brokers.
+        brokerData1 = initBrokerData(35,100);
+        brokerData2 = initBrokerData(20,100);
+        brokerData3 = initBrokerData(0,100);
+        brokerData3.getLocalData().setBundles(Collections.emptySet());
+        brokerDataMap.put("1", brokerData1);
+        brokerDataMap.put("2", brokerData2);
+        brokerDataMap.put("3", brokerData3);
+        assertEquals(strategy.selectBroker(candidates, bundleData, loadData, conf), Optional.of("3"));
     }
 
     public void testLeastResourceUsageWithWeightWithArithmeticException()
@@ -180,6 +191,12 @@ public class ModularLoadManagerStrategyTest {
         localBrokerData.setDirectMemory(new ResourceUsage(usage, limit));
         localBrokerData.setBandwidthIn(new ResourceUsage(usage, limit));
         localBrokerData.setBandwidthOut(new ResourceUsage(usage, limit));
+        // add msgRate and bundle for update resource usage check.
+        localBrokerData.setMsgRateIn(100.00);
+        localBrokerData.setMsgRateOut(100.00);
+        Set<String> bundles = new HashSet<>();
+        bundles.add("0x00000000_0xffffffff");
+        localBrokerData.setBundles(bundles);
         BrokerData brokerData = new BrokerData(localBrokerData);
         TimeAverageBrokerData timeAverageBrokerData = new TimeAverageBrokerData();
         brokerData.setTimeAverageData(timeAverageBrokerData);


### PR DESCRIPTION
### Motivation

As the `brokerAvgResourceUsageWithWeight`  stored the broker's history resource usage, if a broker is high load before restart, after the broker restart always show a high load history resource usage, and `loadBalancerHistoryResourcePercentage = 0.9`, which will cause the first few  times the broker can not be select as best broker to load  bundles. Only when `selectBrokerForAssignment` invoke few time's ,  the `brokerAvgResourceUsageWithWeight` could be neutralized by the current resourceUsage.
But bundles unload is not a frequently operator if not disable `doLoadShedding`,it will wait a long time;  So if a broker restarted we can clean the brokers history resource usage to guaranty the no bundles or no msgRate broker can be select as the one of  best brokers.

https://github.com/apache/pulsar/blob/bc94643bc1a7f365dfb75e389ac3e1156770a119/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/LeastResourceUsageWithWeight.java#L99-L100

### Modifications
1. If the broker not own bundles or the msgRate is 0, use current resourceUsage to cover the historyUsage.
2. add some unit test.


### Documentation

- [X] `doc-not-needed` 
(Please explain why)


Matching PR in forked repository
PR in forked repository:https://github.com/Nicklee007/pulsar/pull/3
