### PR TITLE
[improve][doc] improve descriptions of configuring end-to-end encryption for Python and Node.js Client

### DIFF
--- a/site2/docs/client-libraries-node.md
+++ b/site2/docs/client-libraries-node.md
@@ -480,7 +480,7 @@ The following static methods are available for the message id object:
 
 ### Configuration
 
-If you want to use the end-to-end encryption feature in the Node.js client, you need to configure `publicKeyPath` and `privateKeyPath` for both producer and consumer.
+If you want to use the end-to-end encryption feature in the Node.js client, you need to configure `publicKeyPath` for producer and `privateKeyPath` for consumer.
 
 ```
 
@@ -531,7 +531,6 @@ This section provides step-by-step instructions on how to use the end-to-end enc
        sendTimeoutMs: 30000,
        batchingEnabled: true,
        publicKeyPath: "./public.pem",
-       privateKeyPath: "./private.pem",
        encryptionKey: "encryption-key"
      });
 
@@ -573,7 +572,6 @@ This section provides step-by-step instructions on how to use the end-to-end enc
        subscription: 'sub1',
        subscriptionType: 'Shared',
        ackTimeoutMs: 10000,
-       publicKeyPath: "./public.pem",
        privateKeyPath: "./private.pem"
      });
 

--- a/site2/docs/client-libraries-python.md
+++ b/site2/docs/client-libraries-python.md
@@ -542,7 +542,7 @@ consumer = client.subscribe(
 
 ### Configuration
 
-To use the end-to-end encryption feature in the Python client, you need to configure `publicKeyPath` and `privateKeyPath` for both producer and consumer.
+To use the end-to-end encryption feature in the Python client, you need to configure `publicKeyPath` for producer and `privateKeyPath` for consumer.
 
 ```
 
@@ -581,7 +581,7 @@ This section provides step-by-step instructions on how to use the end-to-end enc
    import pulsar
 
    publicKeyPath = "./public.pem"
-   privateKeyPath = "./private.pem"
+   privateKeyPath = ""
    crypto_key_reader = pulsar.CryptoKeyReader(publicKeyPath, privateKeyPath)
    client = pulsar.Client('pulsar://localhost:6650')
    producer = client.create_producer(topic='encryption', encryption_key='encryption', crypto_key_reader=crypto_key_reader)
@@ -600,7 +600,7 @@ This section provides step-by-step instructions on how to use the end-to-end enc
    
    import pulsar
 
-   publicKeyPath = "./public.pem"
+   publicKeyPath = ""
    privateKeyPath = "./private.pem"
    crypto_key_reader = pulsar.CryptoKeyReader(publicKeyPath, privateKeyPath)
    client = pulsar.Client('pulsar://localhost:6650')


### PR DESCRIPTION
### Motivation
The documentation for end-to-end encryption says that producer and consumer need both public and private keys.
However, it is sufficient to set the public key for producer and the private key for consumer.

### Modifications
- fix description
- improve code in tutorial

### Documentation
- [ ] `doc-required` 
  
- [ ] `doc-not-needed` 
  
- [x] `doc` 

- [ ] `doc-complete`