### PR TITLE
[branch-2.7] Upgrade the BookKeeper version to 4.12.1

### DIFF
--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -395,32 +395,32 @@ The Apache Software License, Version 2.0
     - org.apache.logging.log4j-log4j-1.2-api-2.17.1.jar
  * Java Native Access JNA -- net.java.dev.jna-jna-4.2.0.jar
  * BookKeeper
-    - org.apache.bookkeeper-bookkeeper-common-4.12.0.jar
-    - org.apache.bookkeeper-bookkeeper-common-allocator-4.12.0.jar
-    - org.apache.bookkeeper-bookkeeper-proto-4.12.0.jar
-    - org.apache.bookkeeper-bookkeeper-server-4.12.0.jar
-    - org.apache.bookkeeper-bookkeeper-tools-framework-4.12.0.jar
-    - org.apache.bookkeeper-circe-checksum-4.12.0.jar
-    - org.apache.bookkeeper-cpu-affinity-4.12.0.jar
-    - org.apache.bookkeeper-statelib-4.12.0.jar
-    - org.apache.bookkeeper-stream-storage-api-4.12.0.jar
-    - org.apache.bookkeeper-stream-storage-common-4.12.0.jar
-    - org.apache.bookkeeper-stream-storage-java-client-4.12.0.jar
-    - org.apache.bookkeeper-stream-storage-java-client-base-4.12.0.jar
-    - org.apache.bookkeeper-stream-storage-proto-4.12.0.jar
-    - org.apache.bookkeeper-stream-storage-server-4.12.0.jar
-    - org.apache.bookkeeper-stream-storage-service-api-4.12.0.jar
-    - org.apache.bookkeeper-stream-storage-service-impl-4.12.0.jar
-    - org.apache.bookkeeper.http-http-server-4.12.0.jar
-    - org.apache.bookkeeper.http-vertx-http-server-4.12.0.jar
-    - org.apache.bookkeeper.stats-bookkeeper-stats-api-4.12.0.jar
-    - org.apache.bookkeeper.stats-prometheus-metrics-provider-4.12.0.jar
-    - org.apache.bookkeeper.tests-stream-storage-tests-common-4.12.0.jar
-    - org.apache.distributedlog-distributedlog-common-4.12.0.jar
-    - org.apache.distributedlog-distributedlog-core-4.12.0-tests.jar
-    - org.apache.distributedlog-distributedlog-core-4.12.0.jar
-    - org.apache.distributedlog-distributedlog-protocol-4.12.0.jar
-    - org.apache.bookkeeper.stats-codahale-metrics-provider-4.12.0.jar
+    - org.apache.bookkeeper-bookkeeper-common-4.12.1.jar
+    - org.apache.bookkeeper-bookkeeper-common-allocator-4.12.1.jar
+    - org.apache.bookkeeper-bookkeeper-proto-4.12.1.jar
+    - org.apache.bookkeeper-bookkeeper-server-4.12.1.jar
+    - org.apache.bookkeeper-bookkeeper-tools-framework-4.12.1.jar
+    - org.apache.bookkeeper-circe-checksum-4.12.1.jar
+    - org.apache.bookkeeper-cpu-affinity-4.12.1.jar
+    - org.apache.bookkeeper-statelib-4.12.1.jar
+    - org.apache.bookkeeper-stream-storage-api-4.12.1.jar
+    - org.apache.bookkeeper-stream-storage-common-4.12.1.jar
+    - org.apache.bookkeeper-stream-storage-java-client-4.12.1.jar
+    - org.apache.bookkeeper-stream-storage-java-client-base-4.12.1.jar
+    - org.apache.bookkeeper-stream-storage-proto-4.12.1.jar
+    - org.apache.bookkeeper-stream-storage-server-4.12.1.jar
+    - org.apache.bookkeeper-stream-storage-service-api-4.12.1.jar
+    - org.apache.bookkeeper-stream-storage-service-impl-4.12.1.jar
+    - org.apache.bookkeeper.http-http-server-4.12.1.jar
+    - org.apache.bookkeeper.http-vertx-http-server-4.12.1.jar
+    - org.apache.bookkeeper.stats-bookkeeper-stats-api-4.12.1.jar
+    - org.apache.bookkeeper.stats-prometheus-metrics-provider-4.12.1.jar
+    - org.apache.bookkeeper.tests-stream-storage-tests-common-4.12.1.jar
+    - org.apache.distributedlog-distributedlog-common-4.12.1.jar
+    - org.apache.distributedlog-distributedlog-core-4.12.1-tests.jar
+    - org.apache.distributedlog-distributedlog-core-4.12.1.jar
+    - org.apache.distributedlog-distributedlog-protocol-4.12.1.jar
+    - org.apache.bookkeeper.stats-codahale-metrics-provider-4.12.1.jar
   * Apache HTTP Client
     - org.apache.httpcomponents-httpclient-4.5.5.jar
     - org.apache.httpcomponents-httpcore-4.4.9.jar

--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -476,9 +476,9 @@ The Apache Software License, Version 2.0
     - org.apache.avro-avro-1.9.1.jar
     - org.apache.avro-avro-protobuf-1.9.1.jar
   * Apache Curator
-    - org.apache.curator-curator-client-4.0.1.jar
-    - org.apache.curator-curator-framework-4.0.1.jar
-    - org.apache.curator-curator-recipes-4.0.1.jar
+    - org.apache.curator-curator-client-5.1.0.jar
+    - org.apache.curator-curator-framework-5.1.0.jar
+    - org.apache.curator-curator-recipes-5.1.0.jar
   * Apache Yetus
     - org.apache.yetus-audience-annotations-0.5.0.jar
   * @FreeBuilder

--- a/pom.xml
+++ b/pom.xml
@@ -98,7 +98,7 @@ flexible messaging model and an intuitive client API.</description>
     <!-- apache commons -->
     <commons-compress.version>1.21</commons-compress.version>
 
-    <bookkeeper.version>4.12.0</bookkeeper.version>
+    <bookkeeper.version>4.12.1</bookkeeper.version>
     <zookeeper.version>3.5.9</zookeeper.version>
     <netty.version>4.1.68.Final</netty.version>
     <netty-tc-native.version>2.0.42.Final</netty-tc-native.version>

--- a/pulsar-sql/presto-distribution/LICENSE
+++ b/pulsar-sql/presto-distribution/LICENSE
@@ -411,18 +411,18 @@ The Apache Software License, Version 2.0
     - async-http-client-2.12.1.jar
     - async-http-client-netty-utils-2.12.1.jar
   * Apache Bookkeeper
-    - bookkeeper-common-4.12.0.jar
-    - bookkeeper-common-allocator-4.12.0.jar
-    - bookkeeper-proto-4.12.0.jar
-    - bookkeeper-server-4.12.0.jar
-    - bookkeeper-stats-api-4.12.0.jar
-    - bookkeeper-tools-framework-4.12.0.jar
-    - circe-checksum-4.12.0.jar
-    - codahale-metrics-provider-4.12.0jar
-    - cpu-affinity-4.12.0.jar
-    - http-server-4.12.0.jar
-    - prometheus-metrics-provider-4.12.0.jar
-    - codahale-metrics-provider-4.12.0.jar
+    - bookkeeper-common-4.12.1.jar
+    - bookkeeper-common-allocator-4.12.1.jar
+    - bookkeeper-proto-4.12.1.jar
+    - bookkeeper-server-4.12.1.jar
+    - bookkeeper-stats-api-4.12.1.jar
+    - bookkeeper-tools-framework-4.12.1.jar
+    - circe-checksum-4.12.1.jar
+    - codahale-metrics-provider-4.12.1.jar
+    - cpu-affinity-4.12.1.jar
+    - http-server-4.12.1.jar
+    - prometheus-metrics-provider-4.12.1.jar
+    - codahale-metrics-provider-4.12.1.jar
   * Apache Commons
     - commons-cli-1.2.jar
     - commons-codec-1.10.jar


### PR DESCRIPTION
### Motivation
When running `bin/bookkeeper shell cookie_update` command, we get the following exception.
```
$ bin/bookkeeper shell cookie_update -h
JMX enabled by default
Exception in thread "main" java.lang.NoSuchMethodError: com.beust.jcommander.JCommander.usage(Ljava/lang/StringBuilder;)V
  at org.apache.bookkeeper.tools.framework.Cli.setupCli(Cli.java:142)
  at org.apache.bookkeeper.tools.framework.Cli.<init>(Cli.java:53)
  at org.apache.bookkeeper.tools.framework.Cli.runCli(Cli.java:243)
  at org.apache.bookkeeper.tools.common.BKCommand.apply(BKCommand.java:64)
  at org.apache.bookkeeper.tools.cli.helpers.BookieShellCommand.runCmd(BookieShellCommand.java:46)
  at org.apache.bookkeeper.bookie.BookieShell.run(BookieShell.java:2235)
  at org.apache.bookkeeper.bookie.BookieShell.main(BookieShell.java:2326)
```

The reason is that in BookKeeper 4.12.0, it depends on the `com.beust. commander` version `1.48`, however, in Pulsar, we depend on the `com.beust. commander` version `1.78`. The Pulsar depends version overrides the BookKeeper's depends version.  

However, `com.beust. commander` 1.78 version's interface has been changed, which leads to the BookKeeper shell command can't be executed.

In BookKeeper 4.12.1, it upgrades the `com.beust. commander` version to 1.78 in https://github.com/apache/bookkeeper/pull/2523. So we can upgrade BookKeeper dependency from 4.12.0 to 4.12.1 to solve this bug.

### Modification
Upgrade the BookKeeper version from 4.12.0 to 4.12.1



### Documentation

Check the box below or label this PR directly.

Need to update docs? 

- [x] `doc-required` 
(Your PR needs to update docs and you will update later)
  
- [ ] `doc-not-needed` 
(Please explain why)
  
- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)