### PR TITLE
[doc][client] Specify the gtest version for C++ client compilation under Mac

### DIFF
--- a/pulsar-client-cpp/README.md
+++ b/pulsar-client-cpp/README.md
@@ -162,6 +162,7 @@ brew install protobuf boost boost-python log4cxx jsoncpp
 cd $HOME
 git clone https://github.com/google/googletest.git
 cd googletest
+git checkout release-1.12.1
 cmake .
 make install
 # Refer gtest documentation in case you get stuck somewhere

--- a/pulsar-client-cpp/docs/MainPage.md
+++ b/pulsar-client-cpp/docs/MainPage.md
@@ -93,6 +93,7 @@ $ brew install log4cxx
 # Google Test installation
 $ git clone https://github.com/google/googletest.git
 $ cd googletest
+$ git checkout release-1.12.1
 $ cmake .
 $ make install
 ```

--- a/site2/docs/client-libraries-cpp.md
+++ b/site2/docs/client-libraries-cpp.md
@@ -270,6 +270,7 @@ $ brew install protobuf boost boost-python log4cxx
 # Google Test installation
 $ git clone https://github.com/google/googletest.git
 $ cd googletest
+$ git checkout release-1.12.1
 $ cmake .
 $ make install
 

--- a/site2/website/versioned_docs/version-2.1.0-incubating/develop-cpp.md
+++ b/site2/website/versioned_docs/version-2.1.0-incubating/develop-cpp.md
@@ -97,6 +97,7 @@ $ brew install log4cxx
 # Google Test installation
 $ git clone https://github.com/google/googletest.git
 $ cd googletest
+$ git checkout release-1.12.1
 $ cmake .
 $ make install
 

--- a/site2/website/versioned_docs/version-2.1.1-incubating/develop-cpp.md
+++ b/site2/website/versioned_docs/version-2.1.1-incubating/develop-cpp.md
@@ -97,6 +97,7 @@ $ brew install log4cxx
 # Google Test installation
 $ git clone https://github.com/google/googletest.git
 $ cd googletest
+$ git checkout release-1.12.1
 $ cmake .
 $ make install
 

--- a/site2/website/versioned_docs/version-2.10.0/client-libraries-cpp.md
+++ b/site2/website/versioned_docs/version-2.10.0/client-libraries-cpp.md
@@ -271,6 +271,7 @@ $ brew install protobuf boost boost-python log4cxx
 # Google Test installation
 $ git clone https://github.com/google/googletest.git
 $ cd googletest
+$ git checkout release-1.12.1
 $ cmake .
 $ make install
 

--- a/site2/website/versioned_docs/version-2.10.1/client-libraries-cpp.md
+++ b/site2/website/versioned_docs/version-2.10.1/client-libraries-cpp.md
@@ -271,6 +271,7 @@ $ brew install protobuf boost boost-python log4cxx
 # Google Test installation
 $ git clone https://github.com/google/googletest.git
 $ cd googletest
+$ git checkout release-1.12.1
 $ cmake .
 $ make install
 

--- a/site2/website/versioned_docs/version-2.2.0/develop-cpp.md
+++ b/site2/website/versioned_docs/version-2.2.0/develop-cpp.md
@@ -97,6 +97,7 @@ $ brew install log4cxx
 # Google Test installation
 $ git clone https://github.com/google/googletest.git
 $ cd googletest
+$ git checkout release-1.12.1
 $ cmake .
 $ make install
 

--- a/site2/website/versioned_docs/version-2.2.1/client-libraries-cpp.md
+++ b/site2/website/versioned_docs/version-2.2.1/client-libraries-cpp.md
@@ -270,6 +270,7 @@ $ brew install protobuf boost boost-python log4cxx
 # Google Test installation
 $ git clone https://github.com/google/googletest.git
 $ cd googletest
+$ git checkout release-1.12.1
 $ cmake .
 $ make install
 

--- a/site2/website/versioned_docs/version-2.2.1/develop-cpp.md
+++ b/site2/website/versioned_docs/version-2.2.1/develop-cpp.md
@@ -97,6 +97,7 @@ $ brew install log4cxx
 # Google Test installation
 $ git clone https://github.com/google/googletest.git
 $ cd googletest
+$ git checkout release-1.12.1
 $ cmake .
 $ make install
 

--- a/site2/website/versioned_docs/version-2.3.0/develop-cpp.md
+++ b/site2/website/versioned_docs/version-2.3.0/develop-cpp.md
@@ -97,6 +97,7 @@ $ brew install log4cxx
 # Google Test installation
 $ git clone https://github.com/google/googletest.git
 $ cd googletest
+$ git checkout release-1.12.1
 $ cmake .
 $ make install
 

--- a/site2/website/versioned_docs/version-2.3.1/develop-cpp.md
+++ b/site2/website/versioned_docs/version-2.3.1/develop-cpp.md
@@ -97,6 +97,7 @@ $ brew install log4cxx
 # Google Test installation
 $ git clone https://github.com/google/googletest.git
 $ cd googletest
+$ git checkout release-1.12.1
 $ cmake .
 $ make install
 

--- a/site2/website/versioned_docs/version-2.3.2/client-libraries-cpp.md
+++ b/site2/website/versioned_docs/version-2.3.2/client-libraries-cpp.md
@@ -270,6 +270,7 @@ $ brew install protobuf boost boost-python log4cxx
 # Google Test installation
 $ git clone https://github.com/google/googletest.git
 $ cd googletest
+$ git checkout release-1.12.1
 $ cmake .
 $ make install
 

--- a/site2/website/versioned_docs/version-2.3.2/develop-cpp.md
+++ b/site2/website/versioned_docs/version-2.3.2/develop-cpp.md
@@ -97,6 +97,7 @@ $ brew install log4cxx
 # Google Test installation
 $ git clone https://github.com/google/googletest.git
 $ cd googletest
+$ git checkout release-1.12.1
 $ cmake .
 $ make install
 

--- a/site2/website/versioned_docs/version-2.4.0/client-libraries-cpp.md
+++ b/site2/website/versioned_docs/version-2.4.0/client-libraries-cpp.md
@@ -270,6 +270,7 @@ $ brew install protobuf boost boost-python log4cxx
 # Google Test installation
 $ git clone https://github.com/google/googletest.git
 $ cd googletest
+$ git checkout release-1.12.1
 $ cmake .
 $ make install
 

--- a/site2/website/versioned_docs/version-2.4.0/develop-cpp.md
+++ b/site2/website/versioned_docs/version-2.4.0/develop-cpp.md
@@ -97,6 +97,7 @@ $ brew install log4cxx
 # Google Test installation
 $ git clone https://github.com/google/googletest.git
 $ cd googletest
+$ git checkout release-1.12.1
 $ cmake .
 $ make install
 

--- a/site2/website/versioned_docs/version-2.4.1/client-libraries-cpp.md
+++ b/site2/website/versioned_docs/version-2.4.1/client-libraries-cpp.md
@@ -270,6 +270,7 @@ $ brew install protobuf boost boost-python log4cxx
 # Google Test installation
 $ git clone https://github.com/google/googletest.git
 $ cd googletest
+$ git checkout release-1.12.1
 $ cmake .
 $ make install
 

--- a/site2/website/versioned_docs/version-2.4.1/develop-cpp.md
+++ b/site2/website/versioned_docs/version-2.4.1/develop-cpp.md
@@ -97,6 +97,7 @@ $ brew install log4cxx
 # Google Test installation
 $ git clone https://github.com/google/googletest.git
 $ cd googletest
+$ git checkout release-1.12.1
 $ cmake .
 $ make install
 

--- a/site2/website/versioned_docs/version-2.4.2/client-libraries-cpp.md
+++ b/site2/website/versioned_docs/version-2.4.2/client-libraries-cpp.md
@@ -270,6 +270,7 @@ $ brew install protobuf boost boost-python log4cxx
 # Google Test installation
 $ git clone https://github.com/google/googletest.git
 $ cd googletest
+$ git checkout release-1.12.1
 $ cmake .
 $ make install
 

--- a/site2/website/versioned_docs/version-2.4.2/develop-cpp.md
+++ b/site2/website/versioned_docs/version-2.4.2/develop-cpp.md
@@ -97,6 +97,7 @@ $ brew install log4cxx
 # Google Test installation
 $ git clone https://github.com/google/googletest.git
 $ cd googletest
+$ git checkout release-1.12.1
 $ cmake .
 $ make install
 

--- a/site2/website/versioned_docs/version-2.5.0/develop-cpp.md
+++ b/site2/website/versioned_docs/version-2.5.0/develop-cpp.md
@@ -97,6 +97,7 @@ $ brew install log4cxx
 # Google Test installation
 $ git clone https://github.com/google/googletest.git
 $ cd googletest
+$ git checkout release-1.12.1
 $ cmake .
 $ make install
 

--- a/site2/website/versioned_docs/version-2.5.1/develop-cpp.md
+++ b/site2/website/versioned_docs/version-2.5.1/develop-cpp.md
@@ -97,6 +97,7 @@ $ brew install log4cxx
 # Google Test installation
 $ git clone https://github.com/google/googletest.git
 $ cd googletest
+$ git checkout release-1.12.1
 $ cmake .
 $ make install
 

--- a/site2/website/versioned_docs/version-2.5.2/develop-cpp.md
+++ b/site2/website/versioned_docs/version-2.5.2/develop-cpp.md
@@ -97,6 +97,7 @@ $ brew install log4cxx
 # Google Test installation
 $ git clone https://github.com/google/googletest.git
 $ cd googletest
+$ git checkout release-1.12.1
 $ cmake .
 $ make install
 

--- a/site2/website/versioned_docs/version-2.6.0/develop-cpp.md
+++ b/site2/website/versioned_docs/version-2.6.0/develop-cpp.md
@@ -97,6 +97,7 @@ $ brew install log4cxx
 # Google Test installation
 $ git clone https://github.com/google/googletest.git
 $ cd googletest
+$ git checkout release-1.12.1
 $ cmake .
 $ make install
 

--- a/site2/website/versioned_docs/version-2.6.1/develop-cpp.md
+++ b/site2/website/versioned_docs/version-2.6.1/develop-cpp.md
@@ -97,6 +97,7 @@ $ brew install log4cxx
 # Google Test installation
 $ git clone https://github.com/google/googletest.git
 $ cd googletest
+$ git checkout release-1.12.1
 $ cmake .
 $ make install
 

--- a/site2/website/versioned_docs/version-2.6.2/develop-cpp.md
+++ b/site2/website/versioned_docs/version-2.6.2/develop-cpp.md
@@ -97,6 +97,7 @@ $ brew install log4cxx
 # Google Test installation
 $ git clone https://github.com/google/googletest.git
 $ cd googletest
+$ git checkout release-1.12.1
 $ cmake .
 $ make install
 

--- a/site2/website/versioned_docs/version-2.6.3/develop-cpp.md
+++ b/site2/website/versioned_docs/version-2.6.3/develop-cpp.md
@@ -97,6 +97,7 @@ $ brew install log4cxx
 # Google Test installation
 $ git clone https://github.com/google/googletest.git
 $ cd googletest
+$ git checkout release-1.12.1
 $ cmake .
 $ make install
 

--- a/site2/website/versioned_docs/version-2.6.4/develop-cpp.md
+++ b/site2/website/versioned_docs/version-2.6.4/develop-cpp.md
@@ -97,6 +97,7 @@ $ brew install log4cxx
 # Google Test installation
 $ git clone https://github.com/google/googletest.git
 $ cd googletest
+$ git checkout release-1.12.1
 $ cmake .
 $ make install
 

--- a/site2/website/versioned_docs/version-2.7.0/develop-cpp.md
+++ b/site2/website/versioned_docs/version-2.7.0/develop-cpp.md
@@ -97,6 +97,7 @@ $ brew install log4cxx
 # Google Test installation
 $ git clone https://github.com/google/googletest.git
 $ cd googletest
+$ git checkout release-1.12.1
 $ cmake .
 $ make install
 

--- a/site2/website/versioned_docs/version-2.7.1/develop-cpp.md
+++ b/site2/website/versioned_docs/version-2.7.1/develop-cpp.md
@@ -97,6 +97,7 @@ $ brew install log4cxx
 # Google Test installation
 $ git clone https://github.com/google/googletest.git
 $ cd googletest
+$ git checkout release-1.12.1
 $ cmake .
 $ make install
 

--- a/site2/website/versioned_docs/version-2.7.2/develop-cpp.md
+++ b/site2/website/versioned_docs/version-2.7.2/develop-cpp.md
@@ -97,6 +97,7 @@ $ brew install log4cxx
 # Google Test installation
 $ git clone https://github.com/google/googletest.git
 $ cd googletest
+$ git checkout release-1.12.1
 $ cmake .
 $ make install
 

--- a/site2/website/versioned_docs/version-2.7.3/develop-cpp.md
+++ b/site2/website/versioned_docs/version-2.7.3/develop-cpp.md
@@ -97,6 +97,7 @@ $ brew install log4cxx
 # Google Test installation
 $ git clone https://github.com/google/googletest.git
 $ cd googletest
+$ git checkout release-1.12.1
 $ cmake .
 $ make install
 

--- a/site2/website/versioned_docs/version-2.7.4/develop-cpp.md
+++ b/site2/website/versioned_docs/version-2.7.4/develop-cpp.md
@@ -97,6 +97,7 @@ $ brew install log4cxx
 # Google Test installation
 $ git clone https://github.com/google/googletest.git
 $ cd googletest
+$ git checkout release-1.12.1
 $ cmake .
 $ make install
 

--- a/site2/website/versioned_docs/version-2.8.0/client-libraries-cpp.md
+++ b/site2/website/versioned_docs/version-2.8.0/client-libraries-cpp.md
@@ -244,6 +244,7 @@ $ brew install log4cxx
 # Google Test installation
 $ git clone https://github.com/google/googletest.git
 $ cd googletest
+$ git checkout release-1.12.1
 $ cmake .
 $ make install
 

--- a/site2/website/versioned_docs/version-2.8.1/client-libraries-cpp.md
+++ b/site2/website/versioned_docs/version-2.8.1/client-libraries-cpp.md
@@ -248,6 +248,7 @@ $ brew install protobuf boost boost-python log4cxx
 # Google Test installation
 $ git clone https://github.com/google/googletest.git
 $ cd googletest
+$ git checkout release-1.12.1
 $ cmake .
 $ make install
 

--- a/site2/website/versioned_docs/version-2.8.2/client-libraries-cpp.md
+++ b/site2/website/versioned_docs/version-2.8.2/client-libraries-cpp.md
@@ -244,6 +244,7 @@ $ brew install log4cxx
 # Google Test installation
 $ git clone https://github.com/google/googletest.git
 $ cd googletest
+$ git checkout release-1.12.1
 $ cmake .
 $ make install
 

--- a/site2/website/versioned_docs/version-2.8.3/client-libraries-cpp.md
+++ b/site2/website/versioned_docs/version-2.8.3/client-libraries-cpp.md
@@ -244,6 +244,7 @@ $ brew install log4cxx
 # Google Test installation
 $ git clone https://github.com/google/googletest.git
 $ cd googletest
+$ git checkout release-1.12.1
 $ cmake .
 $ make install
 

--- a/site2/website/versioned_docs/version-2.9.0/client-libraries-cpp.md
+++ b/site2/website/versioned_docs/version-2.9.0/client-libraries-cpp.md
@@ -248,6 +248,7 @@ $ brew install protobuf boost boost-python log4cxx
 # Google Test installation
 $ git clone https://github.com/google/googletest.git
 $ cd googletest
+$ git checkout release-1.12.1
 $ cmake .
 $ make install
 

--- a/site2/website/versioned_docs/version-2.9.1/client-libraries-cpp.md
+++ b/site2/website/versioned_docs/version-2.9.1/client-libraries-cpp.md
@@ -248,6 +248,7 @@ $ brew install protobuf boost boost-python log4cxx
 # Google Test installation
 $ git clone https://github.com/google/googletest.git
 $ cd googletest
+$ git checkout release-1.12.1
 $ cmake .
 $ make install
 

--- a/site2/website/versioned_docs/version-2.9.2/client-libraries-cpp.md
+++ b/site2/website/versioned_docs/version-2.9.2/client-libraries-cpp.md
@@ -248,6 +248,7 @@ $ brew install protobuf boost boost-python log4cxx
 # Google Test installation
 $ git clone https://github.com/google/googletest.git
 $ cd googletest
+$ git checkout release-1.12.1
 $ cmake .
 $ make install
 

--- a/site2/website/versioned_docs/version-2.9.3/client-libraries-cpp.md
+++ b/site2/website/versioned_docs/version-2.9.3/client-libraries-cpp.md
@@ -248,6 +248,7 @@ $ brew install protobuf boost boost-python log4cxx
 # Google Test installation
 $ git clone https://github.com/google/googletest.git
 $ cd googletest
+$ git checkout release-1.12.1
 $ cmake .
 $ make install
 


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://docs.google.com/document/d/1d8Pw6ZbWk-_pCKdOmdvx9rnhPiyuxwq60_TrD68d7BA/edit#heading=h.trs9rsex3xom)*. 

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.

**(The sections below can be removed for hotfixes of typos)**
-->


### Motivation

As discussed with @BewareMyPower and @shibd . Currently, compiling the C++ client does not support using the latest main branch of [gtest](https://github.com/google/googletest). It's not stable to use the main branch code of the gtest.
The following error will occur:

```
In file included from /Users/aaronrobert/codebase/pulsar/pulsar-client-cpp/tests/AuthPluginTest.cc:20:
In file included from /usr/local/include/gtest/gtest.h:60:
In file included from /usr/local/include/gtest/gtest-death-test.h:43:
In file included from /usr/local/include/gtest/internal/gtest-death-test-internal.h:46:
In file included from /usr/local/include/gtest/gtest-matchers.h:48:
In file included from /usr/local/include/gtest/gtest-printers.h:114:
/usr/local/include/gtest/internal/gtest-internal.h:635:54: error: too few template arguments for class template 'less'
  typedef ::std::map<std::string, CodeLocation, std::less<>> RegisteredTestsMap;
                                                     ^
/Library/Developer/CommandLineTools/SDKs/MacOSX12.1.sdk/usr/include/c++/v1/__functional_base:50:29: note: template is declared here
struct _LIBCPP_TEMPLATE_VIS less : binary_function<_Tp, _Tp, bool>
                            ^
In file included from /Users/aaronrobert/codebase/pulsar/pulsar-client-cpp/tests/AuthPluginTest.cc:20:
In file included from /usr/local/include/gtest/gtest.h:60:
In file included from /usr/local/include/gtest/gtest-death-test.h:43:
In file included from /usr/local/include/gtest/internal/gtest-death-test-internal.h:46:
In file included from /usr/local/include/gtest/gtest-matchers.h:48:
In file included from /usr/local/include/gtest/gtest-printers.h:114:
/usr/local/include/gtest/internal/gtest-internal.h:612:22: error: member reference base type 'testing::internal::TypedTestSuitePState::RegisteredTestsMap' (aka 'int') is not a structure or union
    registered_tests_.insert(
    ~~~~~~~~~~~~~~~~~^~~~~~~
/usr/local/include/gtest/internal/gtest-internal.h:618:29: error: member reference base type 'const testing::internal::TypedTestSuitePState::RegisteredTestsMap' (aka 'const int') is not a structure or union
    return registered_tests_.count(test_name) > 0;
           ~~~~~~~~~~~~~~~~~^~~~~~
/usr/local/include/gtest/internal/gtest-internal.h:622:5: error: 'testing::internal::TypedTestSuitePState::RegisteredTestsMap' (aka 'int') is not a class, namespace, or enumeration
    RegisteredTestsMap::const_iterator it = registered_tests_.find(test_name);
    ^
/usr/local/include/gtest/internal/gtest-internal.h:622:62: error: member reference base type 'const testing::internal::TypedTestSuitePState::RegisteredTestsMap' (aka 'const int') is not a structure or union
    RegisteredTestsMap::const_iterator it = registered_tests_.find(test_name);
                                            ~~~~~~~~~~~~~~~~~^~~~~
/usr/local/include/gtest/internal/gtest-internal.h:623:41: error: member reference base type 'const testing::internal::TypedTestSuitePState::RegisteredTestsMap' (aka 'const int') is not a structure or union
    GTEST_CHECK_(it != registered_tests_.end());
                       ~~~~~~~~~~~~~~~~~^~~~
/usr/local/include/gtest/internal/gtest-port.h:1005:35: note: expanded from macro 'GTEST_CHECK_'
  if (::testing::internal::IsTrue(condition)) \
                                  ^~~~~~~~~
6 errors generated.
make[2]: *** [tests/CMakeFiles/main.dir/AuthPluginTest.cc.o] Error 1
make[1]: *** [tests/CMakeFiles/main.dir/all] Error 2
make: *** [all] Error 2
```
We need to use the released gtest version like 1.12.1 to compile the c++ client tests.

### Modifications

* Use gtest 1.12.1 to compile the c++ client.

### Documentation

Check the box below or label this PR directly.

Need to update docs? 

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)
  
- [ ] `doc-not-needed` 
(Please explain why)
  
- [x] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)