### PR TITLE
[improve] [admin] [PIP-179] Dynamic configuration for check unknown request parameters

### DIFF
--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -1488,6 +1488,13 @@ public class ServiceConfiguration implements PulsarConfiguration {
     private double httpRequestsMaxPerSecond = 100.0;
 
     @FieldContext(
+            category =  CATEGORY_HTTP,
+            dynamic = true,
+            doc = "Admin API fail on unknown request parameter in request-body. see PIP-178. Default false."
+        )
+    private boolean httpRequestsFailOnUnknownPropertiesEnabled = false;
+
+    @FieldContext(
         category = CATEGORY_SASL_AUTH,
         doc = "This is a regexp, which limits the range of possible ids which can connect to the Broker using SASL.\n"
             + " Default value is: \".*pulsar.*\", so only clients whose id contains 'pulsar' are allowed to connect."

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -1490,7 +1490,7 @@ public class ServiceConfiguration implements PulsarConfiguration {
     @FieldContext(
             category =  CATEGORY_HTTP,
             dynamic = true,
-            doc = "Admin API fail on unknown request parameter in request-body. see PIP-178. Default false."
+            doc = "Admin API fail on unknown request parameter in request-body. see PIP-179. Default false."
         )
     private boolean httpRequestsFailOnUnknownPropertiesEnabled = false;
 

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/web/UnrecognizedPropertyExceptionMapper.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/web/UnrecognizedPropertyExceptionMapper.java
@@ -1,0 +1,34 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.web;
+
+import com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+
+public class UnrecognizedPropertyExceptionMapper implements ExceptionMapper<UnrecognizedPropertyException> {
+
+    @Override
+    public Response toResponse(UnrecognizedPropertyException exception) {
+        String response = String.format("Unknown property %s, perhaps you want to use one of these: %s",
+                exception.getPropertyName(), String.valueOf(exception.getKnownPropertyIds()));
+        return Response.status(Response.Status.BAD_REQUEST).entity(response).type(MediaType.TEXT_PLAIN).build();
+    }
+}

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
@@ -2349,6 +2349,11 @@ public class BrokerService implements Closeable {
             this.updateMaxNumPartitionsPerPartitionedTopic((int) maxNumPartitions);
         });
 
+        // add listener to notify web service httpRequestsFailOnUnknownPropertiesEnabled changed.
+        registerConfigurationListener("httpRequestsFailOnUnknownPropertiesEnabled", enabled -> {
+            pulsar.getWebService().updateHttpRequestsFailOnUnknownPropertiesEnabled((boolean) enabled);
+        });
+
         // add more listeners here
     }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/WebService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/WebService.java
@@ -80,6 +80,11 @@ public class WebService implements AutoCloseable {
     private static final DynamicSkipUnknownPropertyHandler sharedUnknownPropertyHandler =
             new DynamicSkipUnknownPropertyHandler();
 
+    public void updateHttpRequestsFailOnUnknownPropertiesEnabled(boolean httpRequestsFailOnUnknownPropertiesEnabled){
+        sharedUnknownPropertyHandler
+                .setSkipUnknownProperty(!httpRequestsFailOnUnknownPropertiesEnabled);
+    }
+
     public WebService(PulsarService pulsar) throws PulsarServerException {
         this.handlers = Lists.newArrayList();
         this.pulsar = pulsar;
@@ -152,6 +157,8 @@ public class WebService implements AutoCloseable {
         server.setConnectors(connectors.toArray(new ServerConnector[connectors.size()]));
 
         filterInitializer = new FilterInitializer(pulsar);
+        // Whether to reject requests with unknown attributes.
+        sharedUnknownPropertyHandler.setSkipUnknownProperty(!config.isHttpRequestsFailOnUnknownPropertiesEnabled());
     }
 
     public void addRestResources(String basePath, boolean requiresAuthentication, Map<String, Object> attributeMap,
@@ -177,6 +184,7 @@ public class WebService implements AutoCloseable {
         if (useSharedJsonMapperProvider){
             JsonMapperProvider jsonMapperProvider = new JsonMapperProvider(sharedUnknownPropertyHandler);
             config.register(jsonMapperProvider);
+            config.register(UnrecognizedPropertyExceptionMapper.class);
         } else {
             config.register(JsonMapperProvider.class);
         }

--- a/site2/docs/reference-configuration.md
+++ b/site2/docs/reference-configuration.md
@@ -735,6 +735,7 @@ You can set the log level and configuration in the  [log4j2.yaml](https://github
 |transactionLogBatchedWriteEnabled| Provide a mechanism allowing the Transaction Log Store to aggregate multiple records into a batched record and persist into a single BK entry. This will make Pulsar transactions work more  efficiently, aka batched log. see: https://github.com/apache/pulsar/issues/15370  |false|
 |transactionLogBatchedWriteMaxRecords| If enabled the feature that transaction log batch, this attribute means maximum log records count in a batch  |512|
 |transactionLogBatchedWriteMaxSize| If enabled the feature that transaction log batch, this attribute means bytes size in a batch. |4m|
+|httpRequestsFailOnUnknownPropertiesEnabled| Admin API fail on unknown request parameter in request-body. |false|
 |transactionLogBatchedWriteMaxDelayInMillis| If enabled the feature that transaction log batch, this attribute means maximum wait time(in millis) for the first record in a batch |1|
 |transactionPendingAckBatchedWriteEnabled| Provide a mechanism allowing the Pending Ack Store to aggregate multiple records into a batched record and persist into a single BK entry. This will make Pulsar transactions work more efficiently, aka batched log. see: https://github.com/apache/pulsar/issues/15370 |false|
 |transactionPendingAckBatchedWriteMaxRecords| If enabled the feature that transaction pending ack log batch, this attribute means maximum log records count in a batch. |512|


### PR DESCRIPTION
Master Issue: #16135

### Motivation

see #16135

### Modifications

I will complete proposal #16135 with these pull requests( *current pull request is the step-2* ): 

1. Add A Jackson component `DynamicSkipUnknownPropertyHandler` that supports dynamically policy of rejecting unknown parameters. Prints warn log when it receives an unknown parameter.
2. Dynamic configuration.

### Documentation

- [ ] `doc-required` 
  
- [ ] `doc-not-needed` 
  
- [x] `doc` 

- [ ] `doc-complete`