### PR TITLE
[fix][connector]IOConfigUtils support required and defaultValue annotations.

### DIFF
--- a/pulsar-io/common/src/test/java/org/apache/pulsar/io/common/IOConfigUtilsTest.java
+++ b/pulsar-io/common/src/test/java/org/apache/pulsar/io/common/IOConfigUtilsTest.java
@@ -44,6 +44,73 @@ import java.util.concurrent.CompletableFuture;
 public class IOConfigUtilsTest {
 
     @Data
+    static class TestDefaultConfig {
+        @FieldDoc(
+                required = false,
+                defaultValue = "defaultStr",
+                sensitive = false,
+                help = "defaultStr"
+        )
+        protected String defaultStr;
+
+        @FieldDoc(
+                required = true,
+                defaultValue = "",
+                sensitive = true,
+                help = "testRequired"
+        )
+        protected String testRequired;
+
+        @FieldDoc(
+                required = false,
+                defaultValue = "true",
+                sensitive = false,
+                help = "defaultBool"
+        )
+        protected boolean defaultBool;
+
+        @FieldDoc(
+                required = false,
+                defaultValue = "100",
+                sensitive = false,
+                help = "defaultInt"
+        )
+        protected int defaultInt;
+
+        @FieldDoc(
+                required = false,
+                defaultValue = "100",
+                sensitive = false,
+                help = "defaultLong"
+        )
+        protected long defaultLong;
+
+        @FieldDoc(
+                required = false,
+                defaultValue = "100.12",
+                sensitive = false,
+                help = "defaultDouble"
+        )
+        protected double defaultDouble;
+
+        @FieldDoc(
+                required = false,
+                defaultValue = "100.10",
+                sensitive = false,
+                help = "defaultFloat"
+        )
+        protected float defaultFloat;
+
+        @FieldDoc(
+                required = false,
+                defaultValue = "",
+                sensitive = false,
+                help = "noDefault"
+        )
+        protected int noDefault;
+    }
+
+    @Data
     static class TestConfig {
         @FieldDoc(
                 required = true,
@@ -216,6 +283,28 @@ public class IOConfigUtilsTest {
         public PulsarClient getPulsarClient() {
             return null;
         }
+    }
+
+    @Test
+    public void testDefaultValue() {
+
+        // test required field.
+        Assert.expectThrows(IllegalArgumentException.class,
+                () -> IOConfigUtils.loadWithSecrets(new HashMap<>(), TestDefaultConfig.class, new TestSinkContext()));
+
+
+        // test all default value.
+        Map<String, Object> configMap = new HashMap<>();
+        configMap.put("testRequired", "test");
+        TestDefaultConfig testDefaultConfig =
+                IOConfigUtils.loadWithSecrets(configMap, TestDefaultConfig.class, new TestSinkContext());
+        Assert.assertEquals(testDefaultConfig.getDefaultStr(), "defaultStr");
+        Assert.assertEquals(testDefaultConfig.isDefaultBool(), true);
+        Assert.assertEquals(testDefaultConfig.getDefaultInt(), 100);
+        Assert.assertEquals(testDefaultConfig.getDefaultLong(), 100);
+        Assert.assertEquals(testDefaultConfig.getDefaultDouble(), 100.12,0.00001);
+        Assert.assertEquals(testDefaultConfig.getDefaultFloat(), 100.10,0.00001);
+        Assert.assertEquals(testDefaultConfig.getNoDefault(), 0);
     }
 
     @Test

--- a/pulsar-io/common/src/test/java/org/apache/pulsar/io/common/IOConfigUtilsTest.java
+++ b/pulsar-io/common/src/test/java/org/apache/pulsar/io/common/IOConfigUtilsTest.java
@@ -45,13 +45,6 @@ public class IOConfigUtilsTest {
 
     @Data
     static class TestDefaultConfig {
-        @FieldDoc(
-                required = false,
-                defaultValue = "defaultStr",
-                sensitive = false,
-                help = "defaultStr"
-        )
-        protected String defaultStr;
 
         @FieldDoc(
                 required = true,
@@ -60,6 +53,14 @@ public class IOConfigUtilsTest {
                 help = "testRequired"
         )
         protected String testRequired;
+
+        @FieldDoc(
+                required = false,
+                defaultValue = "defaultStr",
+                sensitive = false,
+                help = "defaultStr"
+        )
+        protected String defaultStr;
 
         @FieldDoc(
                 required = false,
@@ -113,7 +114,7 @@ public class IOConfigUtilsTest {
     @Data
     static class TestConfig {
         @FieldDoc(
-                required = true,
+                required = false,
                 defaultValue = "",
                 sensitive = true,
                 help = "password"
@@ -132,7 +133,7 @@ public class IOConfigUtilsTest {
          * Non-string secrets are not supported at this moment
          */
         @FieldDoc(
-                required = true,
+                required = false,
                 defaultValue = "",
                 sensitive = true,
                 help = ""

--- a/pulsar-io/kinesis/src/main/java/org/apache/pulsar/io/kinesis/KinesisSinkConfig.java
+++ b/pulsar-io/kinesis/src/main/java/org/apache/pulsar/io/kinesis/KinesisSinkConfig.java
@@ -49,7 +49,7 @@ public class KinesisSinkConfig extends BaseKinesisConfig implements Serializable
     private Boolean skipCertificateValidation = false;
 
     @FieldDoc(
-        required = true,
+        required = false,
         defaultValue = "ONLY_RAW_PAYLOAD",
         help = "Message format in which kinesis sink converts pulsar messages and publishes to kinesis streams.\n"
             + "  #\n"


### PR DESCRIPTION
### Motivation

Currently, `FieldDoc` annotation has `required` and `defaultValue` config. But `IOConfigUtils` didn't deal with those.

The connector we implemented deserialized the configuration using `IOConfigUtils.loadWithSecrets()`


### Modifications

- IOConfigUtils support required and defaultValue annotations.


### Documentation

- [x] `doc-not-needed` 

  
