### PR TITLE
[fix][broker] Avoid IllegalStateException while client_version is not set

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
@@ -19,6 +19,7 @@
 package org.apache.pulsar.broker.service;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static org.apache.commons.lang3.StringUtils.EMPTY;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import static org.apache.pulsar.broker.admin.impl.PersistentTopicsBase.unsafeGetPartitionedTopicMetadataAsync;
 import static org.apache.pulsar.broker.lookup.TopicLookupBase.lookupTopicAsync;
@@ -916,7 +917,8 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
 
         try {
             AuthData clientData = AuthData.of(authResponse.getResponse().getAuthData());
-            doAuthentication(clientData, authResponse.getProtocolVersion(), authResponse.getClientVersion());
+            doAuthentication(clientData, authResponse.getProtocolVersion(),
+                    authResponse.hasClientVersion() ? authResponse.getClientVersion() : EMPTY);
         } catch (AuthenticationException e) {
             service.getPulsarStats().recordConnectionCreateFail();
             log.warn("[{}] Authentication failed: {} ", remoteAddress, e.getMessage());

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ServerCnxTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ServerCnxTest.java
@@ -23,11 +23,15 @@ import static org.apache.pulsar.broker.auth.MockedPulsarServiceBaseTest.createMo
 import static org.apache.pulsar.broker.auth.MockedPulsarServiceBaseTest.createMockZooKeeper;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.CALLS_REAL_METHODS;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.matches;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
@@ -92,6 +96,7 @@ import org.apache.pulsar.common.api.proto.AuthMethod;
 import org.apache.pulsar.common.api.proto.BaseCommand;
 import org.apache.pulsar.common.api.proto.BaseCommand.Type;
 import org.apache.pulsar.common.api.proto.CommandAck.AckType;
+import org.apache.pulsar.common.api.proto.CommandAuthResponse;
 import org.apache.pulsar.common.api.proto.CommandConnected;
 import org.apache.pulsar.common.api.proto.CommandError;
 import org.apache.pulsar.common.api.proto.CommandGetTopicsOfNamespace;
@@ -2129,5 +2134,23 @@ public class ServerCnxTest {
             assertTrue(channel.isOpen());
             channel.finish();
         }
+    }
+
+    @Test
+    public void testHandleAuthResponseWithoutClientVersion() {
+        ServerCnx cnx = mock(ServerCnx.class, CALLS_REAL_METHODS);
+        CommandAuthResponse authResponse = mock(CommandAuthResponse.class);
+        org.apache.pulsar.common.api.proto.AuthData authData = mock(org.apache.pulsar.common.api.proto.AuthData.class);
+        when(authResponse.getResponse()).thenReturn(authData);
+        when(authResponse.hasResponse()).thenReturn(true);
+        when(authResponse.getResponse().hasAuthMethodName()).thenReturn(true);
+        when(authResponse.getResponse().hasAuthData()).thenReturn(true);
+        when(authResponse.hasClientVersion()).thenReturn(false);
+        try {
+            cnx.handleAuthResponse(authResponse);
+        } catch (Exception ignore) {
+        }
+        verify(authResponse, times(1)).hasClientVersion();
+        verify(authResponse, times(0)).getClientVersion();
     }
 }


### PR DESCRIPTION
### Motivation

Avoid IllegalStateException while client_version is not set

```
[pod/prod-broker-1/pulsar-broker] 2022-07-25T07:56:43.083238692Z 2022-07-25T07:56:43,082+0000 [pulsar-io-4-1] WARN  org.apache.pulsar.broker.service.ServerCnx - [/10.80.10.151:48010] Unable to handleAuthResponse
[pod/prod-broker-1/pulsar-broker] 2022-07-25T07:56:43.083275432Z java.lang.IllegalStateException: Field 'client_version' is not set
[pod/prod-broker-1/pulsar-broker] 2022-07-25T07:56:43.083278245Z        at org.apache.pulsar.common.api.proto.CommandAuthResponse.getClientVersion(CommandAuthResponse.java:16) ~[io.streamnative-pulsar-common-2.9.2.18.jar:2.9.2.18]
[pod/prod-broker-1/pulsar-broker] 2022-07-25T07:56:43.083281031Z        at org.apache.pulsar.broker.service.ServerCnx.handleAuthResponse(ServerCnx.java:899) [io.streamnative-pulsar-broker-2.9.2.18.jar:2.9.2.18]
[pod/prod-broker-1/pulsar-broker] 2022-07-25T07:56:43.083283517Z        at org.apache.pulsar.common.protocol.PulsarDecoder.channelRead(PulsarDecoder.java:362) [io.streamnative-pulsar-common-2.9.2.18.jar:2.9.2.18]
[pod/prod-broker-1/pulsar-broker] 2022-07-25T07:56:43.083285174Z        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379) [io.netty-netty-transport-4.1.77.Final.jar:4.1.77.Final]
[pod/prod-broker-1/pulsar-broker] 2022-07-25T07:56:43.083286765Z        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365) [io.netty-netty-transport-4.1.77.Final.jar:4.1.77.Final]
[pod/prod-broker-1/pulsar-broker] 2022-07-25T07:56:43.083288574Z        at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357) [io.netty-netty-transport-4.1.77.Final.jar:4.1.77.Final]
[pod/prod-broker-1/pulsar-broker] 2022-07-25T07:56:43.083290125Z        at io.netty.handler.flow.FlowControlHandler.dequeue(FlowControlHandler.java:200) [io.netty-netty-handler-4.1.77.Final.jar:4.1.77.Final]
[pod/prod-broker-1/pulsar-broker] 2022-07-25T07:56:43.083291658Z        at io.netty.handler.flow.FlowControlHandler.channelRead(FlowControlHandler.java:162) [io.netty-netty-handler-4.1.77.Final.jar:4.1.77.Final]
[pod/prod-broker-1/pulsar-broker] 2022-07-25T07:56:43.083293190Z        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379) [io.netty-netty-transport-4.1.77.Final.jar:4.1.77.Final]
[pod/prod-broker-1/pulsar-broker] 2022-07-25T07:56:43.083294719Z        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365) [io.netty-netty-transport-4.1.77.Final.jar:4.1.77.Final]
[pod/prod-broker-1/pulsar-broker] 2022-07-25T07:56:43.083296232Z        at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357) [io.netty-netty-transport-4.1.77.Final.jar:4.1.77.Final]
[pod/prod-broker-1/pulsar-broker] 2022-07-25T07:56:43.083298698Z        at io.netty.handler.codec.ByteToMessageDecoder.fireChannelRead(ByteToMessageDecoder.java:327) [io.netty-netty-codec-4.1.77.Final.jar:4.1.77.Final]
[pod/prod-broker-1/pulsar-broker] 2022-07-25T07:56:43.083300354Z        at io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:299) [io.netty-netty-codec-4.1.77.Final.jar:4.1.77.Final]
[pod/prod-broker-1/pulsar-broker] 2022-07-25T07:56:43.083301807Z        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379) [io.netty-netty-transport-4.1.77.Final.jar:4.1.77.Final]
[pod/prod-broker-1/pulsar-broker] 2022-07-25T07:56:43.083303276Z        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365) [io.netty-netty-transport-4.1.77.Final.jar:4.1.77.Final]
[pod/prod-broker-1/pulsar-broker] 2022-07-25T07:56:43.083304772Z        at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357) [io.netty-netty-transport-4.1.77.Final.jar:4.1.77.Final]
[pod/prod-broker-1/pulsar-broker] 2022-07-25T07:56:43.083306338Z        at io.netty.channel.DefaultChannelPipeline$HeadContext.channelRead(DefaultChannelPipeline.java:1410) [io.netty-netty-transport-4.1.77.Final.jar:4.1.77.Final]
[pod/prod-broker-1/pulsar-broker] 2022-07-25T07:56:43.083309181Z        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379) [io.netty-netty-transport-4.1.77.Final.jar:4.1.77.Final]
[pod/prod-broker-1/pulsar-broker] 2022-07-25T07:56:43.083310669Z        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365) [io.netty-netty-transport-4.1.77.Final.jar:4.1.77.Final]
[pod/prod-broker-1/pulsar-broker] 2022-07-25T07:56:43.083312121Z        at io.netty.channel.DefaultChannelPipeline.fireChannelRead(DefaultChannelPipeline.java:919) [io.netty-netty-transport-4.1.77.Final.jar:4.1.77.Final]
[pod/prod-broker-1/pulsar-broker] 2022-07-25T07:56:43.083313645Z        at io.netty.channel.epoll.AbstractEpollStreamChannel$EpollStreamUnsafe.epollInReady(AbstractEpollStreamChannel.java:800) [io.netty-netty-transport-classes-epoll-4.1.77.Final.jar:4.1.77.Final]
[pod/prod-broker-1/pulsar-broker] 2022-07-25T07:56:43.083315384Z        at io.netty.channel.epoll.AbstractEpollChannel$AbstractEpollUnsafe$1.run(AbstractEpollChannel.java:425) [io.netty-netty-transport-classes-epoll-4.1.77.Final.jar:4.1.77.Final]
[pod/prod-broker-1/pulsar-broker] 2022-07-25T07:56:43.083317412Z        at io.netty.util.concurrent.AbstractEventExecutor.runTask(AbstractEventExecutor.java:174) [io.netty-netty-common-4.1.77.Final.jar:4.1.77.Final]
[pod/prod-broker-1/pulsar-broker] 2022-07-25T07:56:43.083319534Z        at io.netty.util.concurrent.AbstractEventExecutor.safeExecute(AbstractEventExecutor.java:167) [io.netty-netty-common-4.1.77.Final.jar:4.1.77.Final]
[pod/prod-broker-1/pulsar-broker] 2022-07-25T07:56:43.083322163Z        at io.netty.util.concurrent.SingleThreadEventExecutor.runAllTasks(SingleThreadEventExecutor.java:470) [io.netty-netty-common-4.1.77.Final.jar:4.1.77.Final]
[pod/prod-broker-1/pulsar-broker] 2022-07-25T07:56:43.083324661Z        at io.netty.channel.epoll.EpollEventLoop.run(EpollEventLoop.java:391) [io.netty-netty-transport-classes-epoll-4.1.77.Final.jar:4.1.77.Final]
[pod/prod-broker-1/pulsar-broker] 2022-07-25T07:56:43.083326706Z        at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:995) [io.netty-netty-common-4.1.77.Final.jar:4.1.77.Final]
[pod/prod-broker-1/pulsar-broker] 2022-07-25T07:56:43.083328701Z        at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74) [io.netty-netty-common-4.1.77.Final.jar:4.1.77.Final]
[pod/prod-broker-1/pulsar-broker] 2022-07-25T07:56:43.083330790Z        at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30) [io.netty-netty-common-4.1.77.Final.jar:4.1.77.Final]
[pod/prod-broker-1/pulsar-broker] 2022-07-25T07:56:43.083332843Z        at java.lang.Thread.run(Thread.java:829) [?:?]
[pod/prod-broker-1/pulsar-broker] 2022-07-25T07:56:43.083334783Z 2022-07-25T07:56:43,083+0000 [pulsar-io-4-1] INFO  org.apache.pulsar.broker.service.ServerCnx - Closed connection from /10.80.10.151:48010
[pod/prod-broker-1/pulsar-broker] 2022-07-25T07:56:43.406671403Z 2022-07-25T07:56:43,406+0000 [pulsar-io-4-1] INFO  org.apache.pulsar.broker.service.ServerCnx - New connection from /10.80.11.50:43230
```

### Documentation

Check the box below or label this PR directly.

Need to update docs? 

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)
  
- [x] `doc-not-needed` 
(Please explain why)
  
- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)