### PR TITLE
[fix][flaky-test] Fix PersistentTopicStreamingDispatcherTest

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/PersistentTopicStreamingDispatcherTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/PersistentTopicStreamingDispatcherTest.java
@@ -29,7 +29,7 @@ import org.testng.annotations.Test;
 @Test(groups = "broker")
 public class PersistentTopicStreamingDispatcherTest extends PersistentTopicTest {
 
-    @BeforeMethod
+    @BeforeMethod(alwaysRun = true)
     public void setup() throws Exception {
         super.setup();
         pulsar.getConfiguration().setTopicLevelPoliciesEnabled(false);


### PR DESCRIPTION
Signed-off-by: Zixuan Liu <nodeces@gmail.com>

Fixes: https://github.com/apache/pulsar/issues/16666

### Motivation

Try add the `@BeforeMethod(alwaysRun = true)` to fix the `PersistentTopicStreamingDispatcherTest`.

### Documentation

Check the box below or label this PR directly.

Need to update docs? 

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)
  
- [x] `doc-not-needed` 
(Please explain why)
  
- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)