### PR TITLE
[fix][broker] Run sendMessagesToConsumers in the same thread by default

### DIFF
--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -407,7 +407,7 @@ dispatchThrottlingOnNonBacklogConsumerEnabled=true
 dispatcherMaxReadBatchSize=100
 
 # Dispatch messages and execute broker side filters in a per-subscription thread
-dispatcherDispatchMessagesInSubscriptionThread=true
+dispatcherDispatchMessagesInSubscriptionThread=false
 
 # Max size in bytes of entries to read from bookkeeper. By default it is 5MB.
 dispatcherMaxReadSizeBytes=5242880

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -995,7 +995,7 @@ public class ServiceConfiguration implements PulsarConfiguration {
             category = CATEGORY_SERVER,
             doc = "Dispatch messages and execute broker side filters in a per-subscription thread"
     )
-    private boolean dispatcherDispatchMessagesInSubscriptionThread = true;
+    private boolean dispatcherDispatchMessagesInSubscriptionThread = false;
 
     // <-- dispatcher read settings -->
     @FieldContext(


### PR DESCRIPTION
### Motivation

See https://github.com/apache/pulsar/issues/16802 and the discussion in
https://github.com/apache/pulsar/pull/16803. Before reverting #16603,
disabling the `dispatcherDispatchMessagesInSubscriptionThread` option
first.

### Modifications

Change the default value of
`dispatcherDispatchMessagesInSubscriptionThread` to false.

### Documentation

Check the box below or label this PR directly.

Need to update docs? 

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)
  
- [x] `doc-not-needed` 
(Please explain why)
  
- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)