### PR TITLE
[fix][tests] Fix Flaky-test: PartitionedProducerConsumerTest.testPartitionedTopicInterceptor

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/PartitionedProducerConsumerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/PartitionedProducerConsumerTest.java
@@ -1025,6 +1025,8 @@ public class PartitionedProducerConsumerTest extends ProducerConsumerBase {
         assertEquals(newProducerPartitions.get(), newPartitions);
         assertEquals(newConsumerPartitions.get(), newPartitions);
 
+        Awaitility.await().untilAsserted(() -> consumer.isConnected());
+
         producer.close();
         consumer.unsubscribe();
         consumer.close();


### PR DESCRIPTION
Fixes #16710

Master Issue: #16710

### Motivation

When the partition updates, the internal consumer may not connect to the broker(you can see `onPartitionsChange ` is before `startReceivingMessages`), so `unsubscribe` will throw the exception.
https://github.com/apache/pulsar/blob/bdd87794a0ad6a775a911e9cb27cf6fbaf02d9e8/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiTopicsConsumerImpl.java#L1415-L1425

PartitionedProducerConsumerTest#testPartitionedTopicInterceptor tests for updating the partition, another way to fix is that deleting `consumer.unsubscribe()` at line 1029.

### Documentation

- [x] `doc-not-needed` 
(Please explain why)
