### PR TITLE
[improve] clean the empty topicAuthenticationMap in zk when revoke permission

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
@@ -359,7 +359,13 @@ public class PersistentTopicsBase extends AdminResource {
                     }
                     // Write the new policies to metadata store
                     return namespaceResources().setPoliciesAsync(namespaceName, p -> {
-                        p.auth_policies.getTopicAuthentication().get(topicUri).remove(role);
+                        p.auth_policies.getTopicAuthentication().computeIfPresent(topicUri, (k, roles) -> {
+                            roles.remove(role);
+                            if (roles.isEmpty()) {
+                                return null;
+                            }
+                            return roles;
+                        });
                         return p;
                     }).thenAccept(__ ->
                             log.info("[{}] Successfully revoke access for role {} - topic {}", clientAppId(), role,


### PR DESCRIPTION
### Motivation
Steps to reproduce:
1. grant permission for role1 on topic  "persistent://public/default/test"
2. revoke permission for role1 on topic "persistent://public/default/test"
3. zk remain empty record, as shown in the picture
 
![企业微信截图_2725005a-a13e-4f07-b27a-112986e1b856](https://user-images.githubusercontent.com/13505225/181196420-99233345-16ba-4904-a4b7-c08a1b969b2a.png)

### Modifications

If the topic has no roles after revoke permission, remove topicKey from TopicAuthenticationMap 

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change is already covered by existing tests, such as *PersistentTopicsTest*.


### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): no
  - The public API: no
  - The schema: no
  - The default values of configurations: no
  - The wire protocol: no
  - The rest endpoints: no
  - The admin cli options: no
  - Anything that affects deployment: no

### Documentation

Check the box below or label this PR directly.

Need to update docs? 

  
- [x] `doc-not-needed` 
(Please explain why)
  

