### PR TITLE
[improve][admin] Expose the last consumed flow timestamp for consumer stats

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Consumer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Consumer.java
@@ -88,6 +88,7 @@ public class Consumer {
 
     private long lastConsumedTimestamp;
     private long lastAckedTimestamp;
+    private long lastConsumedFlowTimestamp;
     private Rate chunkedMessageRate;
 
     // Represents how many messages we can safely send to the consumer without
@@ -681,6 +682,7 @@ public class Consumer {
 
     public void flowPermits(int additionalNumberOfMessages) {
         checkArgument(additionalNumberOfMessages > 0);
+        this.lastConsumedFlowTimestamp = System.currentTimeMillis();
 
         // block shared consumer when unacked-messages reaches limit
         if (shouldBlockConsumerOnUnackMsgs() && unackedMessages >= getMaxUnackedMessages()) {
@@ -773,6 +775,7 @@ public class Consumer {
         msgOut.recordMultipleEvents(consumerStats.msgOutCounter, consumerStats.bytesOutCounter);
         lastAckedTimestamp = consumerStats.lastAckedTimestamp;
         lastConsumedTimestamp = consumerStats.lastConsumedTimestamp;
+        lastConsumedFlowTimestamp = consumerStats.lastConsumedFlowTimestamp;
         MESSAGE_PERMITS_UPDATER.set(this, consumerStats.availablePermits);
         if (log.isDebugEnabled()) {
             log.debug("[{}-{}] Setting broker.service.Consumer's messagePermits to {} for consumer {}", topicName,
@@ -788,6 +791,7 @@ public class Consumer {
         stats.bytesOutCounter = bytesOutCounter.longValue();
         stats.lastAckedTimestamp = lastAckedTimestamp;
         stats.lastConsumedTimestamp = lastConsumedTimestamp;
+        stats.lastConsumedFlowTimestamp = lastConsumedFlowTimestamp;
         stats.availablePermits = getAvailablePermits();
         stats.unackedMessages = unackedMessages;
         stats.blockedConsumerOnUnackedMsgs = blockedConsumerOnUnackedMsgs;

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/ConsumerStatsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/ConsumerStatsTest.java
@@ -207,6 +207,7 @@ public class ConsumerStatsTest extends ProducerConsumerBase {
                 "readPositionWhenJoining",
                 "lastAckedTimestamp",
                 "lastConsumedTimestamp",
+                "lastConsumedFlowTimestamp",
                 "keyHashRanges",
                 "metadata",
                 "address",
@@ -224,8 +225,10 @@ public class ConsumerStatsTest extends ProducerConsumerBase {
 
         TopicStats stats = admin.topics().getStats(topicName);
         ObjectMapper mapper = ObjectMapperFactory.create();
-        JsonNode node = mapper.readTree(mapper.writer().writeValueAsString(stats.getSubscriptions()
-                .get(subName).getConsumers().get(0)));
+        ConsumerStats consumerStats = stats.getSubscriptions()
+                .get(subName).getConsumers().get(0);
+        Assert.assertTrue(consumerStats.getLastConsumedFlowTimestamp() > 0);
+        JsonNode node = mapper.readTree(mapper.writer().writeValueAsString(consumerStats));
         Iterator<String> itr = node.fieldNames();
         while (itr.hasNext()) {
             String field = itr.next();

--- a/pulsar-client-admin-api/src/main/java/org/apache/pulsar/common/policies/data/ConsumerStats.java
+++ b/pulsar-client-admin-api/src/main/java/org/apache/pulsar/common/policies/data/ConsumerStats.java
@@ -83,6 +83,7 @@ public interface ConsumerStats {
 
     long getLastAckedTimestamp();
     long getLastConsumedTimestamp();
+    long getLastConsumedFlowTimestamp();
 
     /** Hash ranges assigned to this consumer if is Key_Shared sub mode. **/
     List<String> getKeyHashRanges();

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/stats/ConsumerStatsImpl.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/stats/ConsumerStatsImpl.java
@@ -98,6 +98,8 @@ public class ConsumerStatsImpl implements ConsumerStats {
     public long lastAckedTimestamp;
     public long lastConsumedTimestamp;
 
+    public long lastConsumedFlowTimestamp;
+
     /** Hash ranges assigned to this consumer if is Key_Shared sub mode. **/
     public List<String> keyHashRanges;
 


### PR DESCRIPTION
### Motivation

Expose the last consumed flow timestamp for consumer stats.
Currently, we only have `lastConsumedFlowTimestamp` for the subscription.
If a subscription has multiple consumers or the consumers sent flow permits are disconnected.
It is not able to know if the active consumer has sent the flow permits or not.

### Documentation

Check the box below or label this PR directly.

Need to update docs? 

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)
  
- [x] `doc-not-needed` 
(Please explain why)
  
- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)