### PR TITLE
[improve][doc] Improve defaultRetentionTimeInMinutes and defaultRetentionSizeInMB doc

### DIFF
--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -1310,11 +1310,11 @@ replicatorPrefix=pulsar.repl
 replicationPolicyCheckDurationSeconds=600
 
 # Default message retention time.
-# Value of 0 means the retention is disabled, -1 means the data will not be removed by time quota.
+# 0 means retention is disabled. -1 means data is not removed by time quota.
 defaultRetentionTimeInMinutes=0
 
 # Default retention size.
-# Value of 0 means the retention is disabled, -1 means the data will not be removed by size quota.
+# 0 means retention is disabled. -1 means data is not removed by size quota.
 defaultRetentionSizeInMB=0
 
 # How often to check whether the connections are still alive

--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -1310,13 +1310,11 @@ replicatorPrefix=pulsar.repl
 replicationPolicyCheckDurationSeconds=600
 
 # Default message retention time.
-# The default value is 0, which means the data is removed after all the subscriptions are consumed.
-# Value less than 0 means messages never expire.
+# Value of 0 means the retention is disabled, -1 means the data will not be removed by time quota.
 defaultRetentionTimeInMinutes=0
 
 # Default retention size.
-# The default value is 0, which means the data is removed after all the subscriptions are consumed.
-# Value less than 0 means no infinite size quota.
+# Value of 0 means the retention is disabled, -1 means the data will not be removed by size quota.
 defaultRetentionSizeInMB=0
 
 # How often to check whether the connections are still alive

--- a/conf/standalone.conf
+++ b/conf/standalone.conf
@@ -918,10 +918,10 @@ replicationProducerQueueSize=1000
 # due to missing ZooKeeper watch (disable with value 0)
 replicationPolicyCheckDurationSeconds=600
 
-# Default message retention time
+# Default message retention time. Value of 0 means the retention is disabled, -1 means the data will not be removed by time quota
 defaultRetentionTimeInMinutes=0
 
-# Default retention size
+# Default retention size. Value of 0 means the retention is disabled, -1 means the data will not be removed by size quota
 defaultRetentionSizeInMB=0
 
 # How often to check whether the connections are still alive

--- a/conf/standalone.conf
+++ b/conf/standalone.conf
@@ -918,10 +918,10 @@ replicationProducerQueueSize=1000
 # due to missing ZooKeeper watch (disable with value 0)
 replicationPolicyCheckDurationSeconds=600
 
-# Default message retention time. Value of 0 means the retention is disabled, -1 means the data will not be removed by time quota
+# Default message retention time. 0 means retention is disabled. -1 means data is not removed by time quota
 defaultRetentionTimeInMinutes=0
 
-# Default retention size. Value of 0 means the retention is disabled, -1 means the data will not be removed by size quota
+# Default retention size. 0 means retention is disabled. -1 means data is not removed by size quota
 defaultRetentionSizeInMB=0
 
 # How often to check whether the connections are still alive

--- a/deployment/terraform-ansible/templates/broker.conf
+++ b/deployment/terraform-ansible/templates/broker.conf
@@ -993,10 +993,10 @@ replicatorPrefix=pulsar.repl
 # due to missing ZooKeeper watch (disable with value 0)
 replicatioPolicyCheckDurationSeconds=600
 
-# Default message retention time. Value of 0 means the retention is disabled, -1 means the data will not be removed by time quota
+# Default message retention time. 0 means retention is disabled. -1 means data is not removed by time quota
 defaultRetentionTimeInMinutes=0
 
-# Default retention size. Value of 0 means the retention is disabled, -1 means the data will not be removed by size quota
+# Default retention size. 0 means retention is disabled. -1 means data is not removed by size quota
 defaultRetentionSizeInMB=0
 
 # How often to check whether the connections are still alive

--- a/deployment/terraform-ansible/templates/broker.conf
+++ b/deployment/terraform-ansible/templates/broker.conf
@@ -993,10 +993,10 @@ replicatorPrefix=pulsar.repl
 # due to missing ZooKeeper watch (disable with value 0)
 replicatioPolicyCheckDurationSeconds=600
 
-# Default message retention time
+# Default message retention time. Value of 0 means the retention is disabled, -1 means the data will not be removed by time quota
 defaultRetentionTimeInMinutes=0
 
-# Default retention size
+# Default retention size. Value of 0 means the retention is disabled, -1 means the data will not be removed by size quota
 defaultRetentionSizeInMB=0
 
 # How often to check whether the connections are still alive

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -2378,14 +2378,14 @@ public class ServiceConfiguration implements PulsarConfiguration {
     private boolean replicationTlsEnabled = false;
     @FieldContext(
         category = CATEGORY_POLICIES,
-        doc = "Default message retention time. The default value is 0, which means the data is removed after all the "
-                + "subscriptions are consumed. Value less than 0 means messages never expire."
+        doc = "Default message retention time."
+            + " Value of 0 means the retention is disabled, -1 means the data will not be removed by time quota"
     )
     private int defaultRetentionTimeInMinutes = 0;
     @FieldContext(
         category = CATEGORY_POLICIES,
-        doc = "Default retention size. The default value is 0, which means the data is removed after all the "
-                + "subscriptions are consumed. Value less than 0 means no infinite size quota."
+        doc = "Default retention size."
+            + " Value of 0 means the retention is disabled, -1 means the data will not be removed by size quota"
     )
     private int defaultRetentionSizeInMB = 0;
     @FieldContext(

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -2379,13 +2379,13 @@ public class ServiceConfiguration implements PulsarConfiguration {
     @FieldContext(
         category = CATEGORY_POLICIES,
         doc = "Default message retention time."
-            + " Value of 0 means the retention is disabled, -1 means the data will not be removed by time quota"
+            + " 0 means retention is disabled. -1 means data is not removed by time quota"
     )
     private int defaultRetentionTimeInMinutes = 0;
     @FieldContext(
         category = CATEGORY_POLICIES,
         doc = "Default retention size."
-            + " Value of 0 means the retention is disabled, -1 means the data will not be removed by size quota"
+            + " 0 means retention is disabled. -1 means data is not removed by size quota"
     )
     private int defaultRetentionSizeInMB = 0;
     @FieldContext(

--- a/pulsar-client-cpp/test-conf/standalone-ssl.conf
+++ b/pulsar-client-cpp/test-conf/standalone-ssl.conf
@@ -276,10 +276,10 @@ replicationConnectionsPerBroker=16
 # Replicator producer queue size
 replicationProducerQueueSize=1000
 
-# Default message retention time. Value of 0 means the retention is disabled, -1 means the data will not be removed by time quota
+# Default message retention time. 0 means retention is disabled. -1 means data is not removed by time quota
 defaultRetentionTimeInMinutes=0
 
-# Default retention size. Value of 0 means the retention is disabled, -1 means the data will not be removed by size quota
+# Default retention size. 0 means retention is disabled. -1 means data is not removed by size quota
 defaultRetentionSizeInMB=0
 
 # How often to check whether the connections are still alive

--- a/pulsar-client-cpp/test-conf/standalone-ssl.conf
+++ b/pulsar-client-cpp/test-conf/standalone-ssl.conf
@@ -276,10 +276,10 @@ replicationConnectionsPerBroker=16
 # Replicator producer queue size
 replicationProducerQueueSize=1000
 
-# Default message retention time
+# Default message retention time. Value of 0 means the retention is disabled, -1 means the data will not be removed by time quota
 defaultRetentionTimeInMinutes=0
 
-# Default retention size
+# Default retention size. Value of 0 means the retention is disabled, -1 means the data will not be removed by size quota
 defaultRetentionSizeInMB=0
 
 # How often to check whether the connections are still alive

--- a/pulsar-client-cpp/test-conf/standalone.conf
+++ b/pulsar-client-cpp/test-conf/standalone.conf
@@ -264,10 +264,10 @@ replicationConnectionsPerBroker=16
 # Replicator producer queue size
 replicationProducerQueueSize=1000
 
-# Default message retention time
+# Default message retention time. Value of 0 means the retention is disabled, -1 means the data will not be removed by time quota
 defaultRetentionTimeInMinutes=0
 
-# Default retention size
+# Default retention size. Value of 0 means the retention is disabled, -1 means the data will not be removed by size quota
 defaultRetentionSizeInMB=0
 
 # How often to check whether the connections are still alive

--- a/pulsar-client-cpp/test-conf/standalone.conf
+++ b/pulsar-client-cpp/test-conf/standalone.conf
@@ -264,10 +264,10 @@ replicationConnectionsPerBroker=16
 # Replicator producer queue size
 replicationProducerQueueSize=1000
 
-# Default message retention time. Value of 0 means the retention is disabled, -1 means the data will not be removed by time quota
+# Default message retention time. 0 means retention is disabled. -1 means data is not removed by time quota
 defaultRetentionTimeInMinutes=0
 
-# Default retention size. Value of 0 means the retention is disabled, -1 means the data will not be removed by size quota
+# Default retention size. 0 means retention is disabled. -1 means data is not removed by size quota
 defaultRetentionSizeInMB=0
 
 # How often to check whether the connections are still alive

--- a/pulsar-client-cpp/tests/authentication.conf
+++ b/pulsar-client-cpp/tests/authentication.conf
@@ -270,10 +270,10 @@ replicationConnectionsPerBroker=16
 # Replicator producer queue size
 replicationProducerQueueSize=1000
 
-# Default message retention time
+# Default message retention time. Value of 0 means the retention is disabled, -1 means the data will not be removed by time quota
 defaultRetentionTimeInMinutes=0
 
-# Default retention size
+# Default retention size. Value of 0 means the retention is disabled, -1 means the data will not be removed by size quota
 defaultRetentionSizeInMB=0
 
 # How often to check whether the connections are still alive

--- a/pulsar-client-cpp/tests/authentication.conf
+++ b/pulsar-client-cpp/tests/authentication.conf
@@ -270,10 +270,10 @@ replicationConnectionsPerBroker=16
 # Replicator producer queue size
 replicationProducerQueueSize=1000
 
-# Default message retention time. Value of 0 means the retention is disabled, -1 means the data will not be removed by time quota
+# Default message retention time. 0 means retention is disabled. -1 means data is not removed by time quota
 defaultRetentionTimeInMinutes=0
 
-# Default retention size. Value of 0 means the retention is disabled, -1 means the data will not be removed by size quota
+# Default retention size. 0 means retention is disabled. -1 means data is not removed by size quota
 defaultRetentionSizeInMB=0
 
 # How often to check whether the connections are still alive

--- a/pulsar-client-cpp/tests/standalone.conf
+++ b/pulsar-client-cpp/tests/standalone.conf
@@ -262,10 +262,10 @@ replicationConnectionsPerBroker=16
 # Replicator producer queue size
 replicationProducerQueueSize=1000
 
-# Default message retention time
+# Default message retention time. Value of 0 means the retention is disabled, -1 means the data will not be removed by time quota
 defaultRetentionTimeInMinutes=0
 
-# Default retention size
+# Default retention size. Value of 0 means the retention is disabled, -1 means the data will not be removed by size quota
 defaultRetentionSizeInMB=0
 
 # How often to check whether the connections are still alive

--- a/pulsar-client-cpp/tests/standalone.conf
+++ b/pulsar-client-cpp/tests/standalone.conf
@@ -262,10 +262,10 @@ replicationConnectionsPerBroker=16
 # Replicator producer queue size
 replicationProducerQueueSize=1000
 
-# Default message retention time. Value of 0 means the retention is disabled, -1 means the data will not be removed by time quota
+# Default message retention time. 0 means retention is disabled. -1 means data is not removed by time quota
 defaultRetentionTimeInMinutes=0
 
-# Default retention size. Value of 0 means the retention is disabled, -1 means the data will not be removed by size quota
+# Default retention size. 0 means retention is disabled. -1 means data is not removed by size quota
 defaultRetentionSizeInMB=0
 
 # How often to check whether the connections are still alive

--- a/site2/docs/reference-configuration-broker.md
+++ b/site2/docs/reference-configuration-broker.md
@@ -1109,7 +1109,7 @@ When a namespace is created without specifying the number of bundle, this value 
 **Category**: Policies
 
 ### defaultRetentionSizeInMB
-Default retention size. Value of 0 means the retention is disabled, -1 means the data will not be removed by size quota
+Default retention size. 0 means retention is disabled. -1 means data is not removed by size quota
 
 **Default**: `0`
 
@@ -1118,7 +1118,7 @@ Default retention size. Value of 0 means the retention is disabled, -1 means the
 **Category**: Policies
 
 ### defaultRetentionTimeInMinutes
-Default message retention time. Value of 0 means the retention is disabled, -1 means the data will not be removed by time quota
+Default message retention time. 0 means retention is disabled. -1 means data is not removed by time quota
 
 **Default**: `0`
 

--- a/site2/docs/reference-configuration-broker.md
+++ b/site2/docs/reference-configuration-broker.md
@@ -1109,7 +1109,7 @@ When a namespace is created without specifying the number of bundle, this value 
 **Category**: Policies
 
 ### defaultRetentionSizeInMB
-Default retention size
+Default retention size. Value of 0 means the retention is disabled, -1 means the data will not be removed by size quota
 
 **Default**: `0`
 
@@ -1118,7 +1118,7 @@ Default retention size
 **Category**: Policies
 
 ### defaultRetentionTimeInMinutes
-Default message retention time
+Default message retention time. Value of 0 means the retention is disabled, -1 means the data will not be removed by time quota
 
 **Default**: `0`
 

--- a/site2/website/versioned_docs/version-2.1.0-incubating/reference-configuration.md
+++ b/site2/website/versioned_docs/version-2.1.0-incubating/reference-configuration.md
@@ -195,8 +195,8 @@ Pulsar brokers are responsible for handling incoming messages from producers, di
 |replicationProducerQueueSize|  Replicator producer queue size  |1000|
 |replicatorPrefix|  Replicator prefix used for replicator producer name and cursor name pulsar.repl||
 |replicationTlsEnabled| Enable TLS when talking with other clusters to replicate messages |false|
-|defaultRetentionTimeInMinutes| Default message retention time. Value of 0 means the retention is disabled, -1 means the data will not be removed by time quota  ||
-|defaultRetentionSizeInMB|  Default retention size. Value of 0 means the retention is disabled, -1 means the data will not be removed by size quota  |0|
+|defaultRetentionTimeInMinutes| Default message retention time. 0 means retention is disabled. -1 means data is not removed by time quota  ||
+|defaultRetentionSizeInMB|  Default retention size. 0 means retention is disabled. -1 means data is not removed by size quota  |0|
 |keepAliveIntervalSeconds|  How often to check whether the connections are still alive  |30|
 |brokerServicePurgeInactiveFrequencyInSeconds|  How often broker checks for inactive topics to be deleted (topics with no subscriptions and no one connected) |60|
 |loadManagerClassName|  Name of load manager to use |org.apache.pulsar.broker.loadbalance.impl.SimpleLoadManagerImpl|

--- a/site2/website/versioned_docs/version-2.1.0-incubating/reference-configuration.md
+++ b/site2/website/versioned_docs/version-2.1.0-incubating/reference-configuration.md
@@ -195,8 +195,8 @@ Pulsar brokers are responsible for handling incoming messages from producers, di
 |replicationProducerQueueSize|  Replicator producer queue size  |1000|
 |replicatorPrefix|  Replicator prefix used for replicator producer name and cursor name pulsar.repl||
 |replicationTlsEnabled| Enable TLS when talking with other clusters to replicate messages |false|
-|defaultRetentionTimeInMinutes| Default message retention time  ||
-|defaultRetentionSizeInMB|  Default retention size  |0|
+|defaultRetentionTimeInMinutes| Default message retention time. Value of 0 means the retention is disabled, -1 means the data will not be removed by time quota  ||
+|defaultRetentionSizeInMB|  Default retention size. Value of 0 means the retention is disabled, -1 means the data will not be removed by size quota  |0|
 |keepAliveIntervalSeconds|  How often to check whether the connections are still alive  |30|
 |brokerServicePurgeInactiveFrequencyInSeconds|  How often broker checks for inactive topics to be deleted (topics with no subscriptions and no one connected) |60|
 |loadManagerClassName|  Name of load manager to use |org.apache.pulsar.broker.loadbalance.impl.SimpleLoadManagerImpl|

--- a/site2/website/versioned_docs/version-2.1.1-incubating/reference-configuration.md
+++ b/site2/website/versioned_docs/version-2.1.1-incubating/reference-configuration.md
@@ -195,8 +195,8 @@ Pulsar brokers are responsible for handling incoming messages from producers, di
 |replicationProducerQueueSize|  Replicator producer queue size  |1000|
 |replicatorPrefix|  Replicator prefix used for replicator producer name and cursor name pulsar.repl||
 |replicationTlsEnabled| Enable TLS when talking with other clusters to replicate messages |false|
-|defaultRetentionTimeInMinutes| Default message retention time. Value of 0 means the retention is disabled, -1 means the data will not be removed by time quota  ||
-|defaultRetentionSizeInMB|  Default retention size. Value of 0 means the retention is disabled, -1 means the data will not be removed by size quota  |0|
+|defaultRetentionTimeInMinutes| Default message retention time. 0 means retention is disabled. -1 means data is not removed by time quota  ||
+|defaultRetentionSizeInMB|  Default retention size. 0 means retention is disabled. -1 means data is not removed by size quota  |0|
 |keepAliveIntervalSeconds|  How often to check whether the connections are still alive  |30|
 |brokerServicePurgeInactiveFrequencyInSeconds|  How often broker checks for inactive topics to be deleted (topics with no subscriptions and no one connected) |60|
 |loadManagerClassName|  Name of load manager to use |org.apache.pulsar.broker.loadbalance.impl.SimpleLoadManagerImpl|

--- a/site2/website/versioned_docs/version-2.1.1-incubating/reference-configuration.md
+++ b/site2/website/versioned_docs/version-2.1.1-incubating/reference-configuration.md
@@ -195,8 +195,8 @@ Pulsar brokers are responsible for handling incoming messages from producers, di
 |replicationProducerQueueSize|  Replicator producer queue size  |1000|
 |replicatorPrefix|  Replicator prefix used for replicator producer name and cursor name pulsar.repl||
 |replicationTlsEnabled| Enable TLS when talking with other clusters to replicate messages |false|
-|defaultRetentionTimeInMinutes| Default message retention time  ||
-|defaultRetentionSizeInMB|  Default retention size  |0|
+|defaultRetentionTimeInMinutes| Default message retention time. Value of 0 means the retention is disabled, -1 means the data will not be removed by time quota  ||
+|defaultRetentionSizeInMB|  Default retention size. Value of 0 means the retention is disabled, -1 means the data will not be removed by size quota  |0|
 |keepAliveIntervalSeconds|  How often to check whether the connections are still alive  |30|
 |brokerServicePurgeInactiveFrequencyInSeconds|  How often broker checks for inactive topics to be deleted (topics with no subscriptions and no one connected) |60|
 |loadManagerClassName|  Name of load manager to use |org.apache.pulsar.broker.loadbalance.impl.SimpleLoadManagerImpl|

--- a/site2/website/versioned_docs/version-2.10.0-deprecated/reference-configuration.md
+++ b/site2/website/versioned_docs/version-2.10.0-deprecated/reference-configuration.md
@@ -329,8 +329,8 @@ brokerServiceCompactionThresholdInBytes|If the estimated backlog size is greater
 |replicatorPrefix|  Replicator prefix used for replicator producer name and cursor name pulsar.repl||
 |transactionCoordinatorEnabled|Whether to enable transaction coordinator in broker.|true|
 |transactionMetadataStoreProviderClassName| |org.apache.pulsar.transaction.coordinator.impl.InMemTransactionMetadataStoreProvider|
-|defaultRetentionTimeInMinutes| Default message retention time. Value of 0 means the retention is disabled, -1 means the data will not be removed by time quota  |0|
-|defaultRetentionSizeInMB|  Default retention size. Value of 0 means the retention is disabled, -1 means the data will not be removed by size quota  |0|
+|defaultRetentionTimeInMinutes| Default message retention time. 0 means retention is disabled. -1 means data is not removed by time quota  |0|
+|defaultRetentionSizeInMB|  Default retention size. 0 means retention is disabled. -1 means data is not removed by size quota  |0|
 |keepAliveIntervalSeconds|  How often to check whether the connections are still alive  |30|
 |bootstrapNamespaces| The bootstrap name. | N/A |
 |loadManagerClassName|  Name of load manager to use |org.apache.pulsar.broker.loadbalance.impl.SimpleLoadManagerImpl|

--- a/site2/website/versioned_docs/version-2.10.0-deprecated/reference-configuration.md
+++ b/site2/website/versioned_docs/version-2.10.0-deprecated/reference-configuration.md
@@ -329,8 +329,8 @@ brokerServiceCompactionThresholdInBytes|If the estimated backlog size is greater
 |replicatorPrefix|  Replicator prefix used for replicator producer name and cursor name pulsar.repl||
 |transactionCoordinatorEnabled|Whether to enable transaction coordinator in broker.|true|
 |transactionMetadataStoreProviderClassName| |org.apache.pulsar.transaction.coordinator.impl.InMemTransactionMetadataStoreProvider|
-|defaultRetentionTimeInMinutes| Default message retention time  |0|
-|defaultRetentionSizeInMB|  Default retention size  |0|
+|defaultRetentionTimeInMinutes| Default message retention time. Value of 0 means the retention is disabled, -1 means the data will not be removed by time quota  |0|
+|defaultRetentionSizeInMB|  Default retention size. Value of 0 means the retention is disabled, -1 means the data will not be removed by size quota  |0|
 |keepAliveIntervalSeconds|  How often to check whether the connections are still alive  |30|
 |bootstrapNamespaces| The bootstrap name. | N/A |
 |loadManagerClassName|  Name of load manager to use |org.apache.pulsar.broker.loadbalance.impl.SimpleLoadManagerImpl|

--- a/site2/website/versioned_docs/version-2.10.1-deprecated/reference-configuration.md
+++ b/site2/website/versioned_docs/version-2.10.1-deprecated/reference-configuration.md
@@ -329,8 +329,8 @@ brokerServiceCompactionThresholdInBytes|If the estimated backlog size is greater
 |replicatorPrefix|  Replicator prefix used for replicator producer name and cursor name pulsar.repl||
 |transactionCoordinatorEnabled|Whether to enable transaction coordinator in broker.|true|
 |transactionMetadataStoreProviderClassName| |org.apache.pulsar.transaction.coordinator.impl.InMemTransactionMetadataStoreProvider|
-|defaultRetentionTimeInMinutes| Default message retention time. Value of 0 means the retention is disabled, -1 means the data will not be removed by time quota  |0|
-|defaultRetentionSizeInMB|  Default retention size. Value of 0 means the retention is disabled, -1 means the data will not be removed by size quota  |0|
+|defaultRetentionTimeInMinutes| Default message retention time. 0 means retention is disabled. -1 means data is not removed by time quota  |0|
+|defaultRetentionSizeInMB|  Default retention size. 0 means retention is disabled. -1 means data is not removed by size quota  |0|
 |keepAliveIntervalSeconds|  How often to check whether the connections are still alive  |30|
 |bootstrapNamespaces| The bootstrap name. | N/A |
 |loadManagerClassName|  Name of load manager to use |org.apache.pulsar.broker.loadbalance.impl.SimpleLoadManagerImpl|

--- a/site2/website/versioned_docs/version-2.10.1-deprecated/reference-configuration.md
+++ b/site2/website/versioned_docs/version-2.10.1-deprecated/reference-configuration.md
@@ -329,8 +329,8 @@ brokerServiceCompactionThresholdInBytes|If the estimated backlog size is greater
 |replicatorPrefix|  Replicator prefix used for replicator producer name and cursor name pulsar.repl||
 |transactionCoordinatorEnabled|Whether to enable transaction coordinator in broker.|true|
 |transactionMetadataStoreProviderClassName| |org.apache.pulsar.transaction.coordinator.impl.InMemTransactionMetadataStoreProvider|
-|defaultRetentionTimeInMinutes| Default message retention time  |0|
-|defaultRetentionSizeInMB|  Default retention size  |0|
+|defaultRetentionTimeInMinutes| Default message retention time. Value of 0 means the retention is disabled, -1 means the data will not be removed by time quota  |0|
+|defaultRetentionSizeInMB|  Default retention size. Value of 0 means the retention is disabled, -1 means the data will not be removed by size quota  |0|
 |keepAliveIntervalSeconds|  How often to check whether the connections are still alive  |30|
 |bootstrapNamespaces| The bootstrap name. | N/A |
 |loadManagerClassName|  Name of load manager to use |org.apache.pulsar.broker.loadbalance.impl.SimpleLoadManagerImpl|

--- a/site2/website/versioned_docs/version-2.2.0/reference-configuration.md
+++ b/site2/website/versioned_docs/version-2.2.0/reference-configuration.md
@@ -195,8 +195,8 @@ Pulsar brokers are responsible for handling incoming messages from producers, di
 |replicationProducerQueueSize|  Replicator producer queue size  |1000|
 |replicatorPrefix|  Replicator prefix used for replicator producer name and cursor name pulsar.repl||
 |replicationTlsEnabled| Enable TLS when talking with other clusters to replicate messages |false|
-|defaultRetentionTimeInMinutes| Default message retention time. Value of 0 means the retention is disabled, -1 means the data will not be removed by time quota  ||
-|defaultRetentionSizeInMB|  Default retention size. Value of 0 means the retention is disabled, -1 means the data will not be removed by size quota  |0|
+|defaultRetentionTimeInMinutes| Default message retention time. 0 means retention is disabled. -1 means data is not removed by time quota  ||
+|defaultRetentionSizeInMB|  Default retention size. 0 means retention is disabled. -1 means data is not removed by size quota  |0|
 |keepAliveIntervalSeconds|  How often to check whether the connections are still alive  |30|
 |brokerServicePurgeInactiveFrequencyInSeconds|  How often broker checks for inactive topics to be deleted (topics with no subscriptions and no one connected) |60|
 |loadManagerClassName|  Name of load manager to use |org.apache.pulsar.broker.loadbalance.impl.SimpleLoadManagerImpl|

--- a/site2/website/versioned_docs/version-2.2.0/reference-configuration.md
+++ b/site2/website/versioned_docs/version-2.2.0/reference-configuration.md
@@ -195,8 +195,8 @@ Pulsar brokers are responsible for handling incoming messages from producers, di
 |replicationProducerQueueSize|  Replicator producer queue size  |1000|
 |replicatorPrefix|  Replicator prefix used for replicator producer name and cursor name pulsar.repl||
 |replicationTlsEnabled| Enable TLS when talking with other clusters to replicate messages |false|
-|defaultRetentionTimeInMinutes| Default message retention time  ||
-|defaultRetentionSizeInMB|  Default retention size  |0|
+|defaultRetentionTimeInMinutes| Default message retention time. Value of 0 means the retention is disabled, -1 means the data will not be removed by time quota  ||
+|defaultRetentionSizeInMB|  Default retention size. Value of 0 means the retention is disabled, -1 means the data will not be removed by size quota  |0|
 |keepAliveIntervalSeconds|  How often to check whether the connections are still alive  |30|
 |brokerServicePurgeInactiveFrequencyInSeconds|  How often broker checks for inactive topics to be deleted (topics with no subscriptions and no one connected) |60|
 |loadManagerClassName|  Name of load manager to use |org.apache.pulsar.broker.loadbalance.impl.SimpleLoadManagerImpl|

--- a/site2/website/versioned_docs/version-2.2.1/reference-configuration.md
+++ b/site2/website/versioned_docs/version-2.2.1/reference-configuration.md
@@ -201,8 +201,8 @@ Pulsar brokers are responsible for handling incoming messages from producers, di
 |replicationProducerQueueSize|  Replicator producer queue size  |1000|
 |replicatorPrefix|  Replicator prefix used for replicator producer name and cursor name pulsar.repl||
 |replicationTlsEnabled| Enable TLS when talking with other clusters to replicate messages |false|
-|defaultRetentionTimeInMinutes| Default message retention time  ||
-|defaultRetentionSizeInMB|  Default retention size  |0|
+|defaultRetentionTimeInMinutes| Default message retention time. Value of 0 means the retention is disabled, -1 means the data will not be removed by time quota  ||
+|defaultRetentionSizeInMB|  Default retention size. Value of 0 means the retention is disabled, -1 means the data will not be removed by size quota  |0|
 |keepAliveIntervalSeconds|  How often to check whether the connections are still alive  |30|
 |brokerServicePurgeInactiveFrequencyInSeconds|  How often broker checks for inactive topics to be deleted (topics with no subscriptions and no one connected) |60|
 |loadManagerClassName|  Name of load manager to use |org.apache.pulsar.broker.loadbalance.impl.SimpleLoadManagerImpl|

--- a/site2/website/versioned_docs/version-2.2.1/reference-configuration.md
+++ b/site2/website/versioned_docs/version-2.2.1/reference-configuration.md
@@ -201,8 +201,8 @@ Pulsar brokers are responsible for handling incoming messages from producers, di
 |replicationProducerQueueSize|  Replicator producer queue size  |1000|
 |replicatorPrefix|  Replicator prefix used for replicator producer name and cursor name pulsar.repl||
 |replicationTlsEnabled| Enable TLS when talking with other clusters to replicate messages |false|
-|defaultRetentionTimeInMinutes| Default message retention time. Value of 0 means the retention is disabled, -1 means the data will not be removed by time quota  ||
-|defaultRetentionSizeInMB|  Default retention size. Value of 0 means the retention is disabled, -1 means the data will not be removed by size quota  |0|
+|defaultRetentionTimeInMinutes| Default message retention time. 0 means retention is disabled. -1 means data is not removed by time quota  ||
+|defaultRetentionSizeInMB|  Default retention size. 0 means retention is disabled. -1 means data is not removed by size quota  |0|
 |keepAliveIntervalSeconds|  How often to check whether the connections are still alive  |30|
 |brokerServicePurgeInactiveFrequencyInSeconds|  How often broker checks for inactive topics to be deleted (topics with no subscriptions and no one connected) |60|
 |loadManagerClassName|  Name of load manager to use |org.apache.pulsar.broker.loadbalance.impl.SimpleLoadManagerImpl|

--- a/site2/website/versioned_docs/version-2.3.0/reference-configuration.md
+++ b/site2/website/versioned_docs/version-2.3.0/reference-configuration.md
@@ -203,8 +203,8 @@ Pulsar brokers are responsible for handling incoming messages from producers, di
 |replicationProducerQueueSize|  Replicator producer queue size  |1000|
 |replicatorPrefix|  Replicator prefix used for replicator producer name and cursor name pulsar.repl||
 |replicationTlsEnabled| Enable TLS when talking with other clusters to replicate messages |false|
-|defaultRetentionTimeInMinutes| Default message retention time. Value of 0 means the retention is disabled, -1 means the data will not be removed by time quota  ||
-|defaultRetentionSizeInMB|  Default retention size. Value of 0 means the retention is disabled, -1 means the data will not be removed by size quota  |0|
+|defaultRetentionTimeInMinutes| Default message retention time. 0 means retention is disabled. -1 means data is not removed by time quota  ||
+|defaultRetentionSizeInMB|  Default retention size. 0 means retention is disabled. -1 means data is not removed by size quota  |0|
 |keepAliveIntervalSeconds|  How often to check whether the connections are still alive  |30|
 |brokerServicePurgeInactiveFrequencyInSeconds|  How often broker checks for inactive topics to be deleted (topics with no subscriptions and no one connected) |60|
 |loadManagerClassName|  Name of load manager to use |org.apache.pulsar.broker.loadbalance.impl.SimpleLoadManagerImpl|

--- a/site2/website/versioned_docs/version-2.3.0/reference-configuration.md
+++ b/site2/website/versioned_docs/version-2.3.0/reference-configuration.md
@@ -203,8 +203,8 @@ Pulsar brokers are responsible for handling incoming messages from producers, di
 |replicationProducerQueueSize|  Replicator producer queue size  |1000|
 |replicatorPrefix|  Replicator prefix used for replicator producer name and cursor name pulsar.repl||
 |replicationTlsEnabled| Enable TLS when talking with other clusters to replicate messages |false|
-|defaultRetentionTimeInMinutes| Default message retention time  ||
-|defaultRetentionSizeInMB|  Default retention size  |0|
+|defaultRetentionTimeInMinutes| Default message retention time. Value of 0 means the retention is disabled, -1 means the data will not be removed by time quota  ||
+|defaultRetentionSizeInMB|  Default retention size. Value of 0 means the retention is disabled, -1 means the data will not be removed by size quota  |0|
 |keepAliveIntervalSeconds|  How often to check whether the connections are still alive  |30|
 |brokerServicePurgeInactiveFrequencyInSeconds|  How often broker checks for inactive topics to be deleted (topics with no subscriptions and no one connected) |60|
 |loadManagerClassName|  Name of load manager to use |org.apache.pulsar.broker.loadbalance.impl.SimpleLoadManagerImpl|

--- a/site2/website/versioned_docs/version-2.3.1/reference-configuration.md
+++ b/site2/website/versioned_docs/version-2.3.1/reference-configuration.md
@@ -204,8 +204,8 @@ Pulsar brokers are responsible for handling incoming messages from producers, di
 |replicationProducerQueueSize|  Replicator producer queue size  |1000|
 |replicatorPrefix|  Replicator prefix used for replicator producer name and cursor name pulsar.repl||
 |replicationTlsEnabled| Enable TLS when talking with other clusters to replicate messages |false|
-|defaultRetentionTimeInMinutes| Default message retention time  ||
-|defaultRetentionSizeInMB|  Default retention size  |0|
+|defaultRetentionTimeInMinutes| Default message retention time. Value of 0 means the retention is disabled, -1 means the data will not be removed by time quota  ||
+|defaultRetentionSizeInMB|  Default retention size. Value of 0 means the retention is disabled, -1 means the data will not be removed by size quota  |0|
 |keepAliveIntervalSeconds|  How often to check whether the connections are still alive  |30|
 |brokerServicePurgeInactiveFrequencyInSeconds|  How often broker checks for inactive topics to be deleted (topics with no subscriptions and no one connected) |60|
 |loadManagerClassName|  Name of load manager to use |org.apache.pulsar.broker.loadbalance.impl.SimpleLoadManagerImpl|

--- a/site2/website/versioned_docs/version-2.3.1/reference-configuration.md
+++ b/site2/website/versioned_docs/version-2.3.1/reference-configuration.md
@@ -204,8 +204,8 @@ Pulsar brokers are responsible for handling incoming messages from producers, di
 |replicationProducerQueueSize|  Replicator producer queue size  |1000|
 |replicatorPrefix|  Replicator prefix used for replicator producer name and cursor name pulsar.repl||
 |replicationTlsEnabled| Enable TLS when talking with other clusters to replicate messages |false|
-|defaultRetentionTimeInMinutes| Default message retention time. Value of 0 means the retention is disabled, -1 means the data will not be removed by time quota  ||
-|defaultRetentionSizeInMB|  Default retention size. Value of 0 means the retention is disabled, -1 means the data will not be removed by size quota  |0|
+|defaultRetentionTimeInMinutes| Default message retention time. 0 means retention is disabled. -1 means data is not removed by time quota  ||
+|defaultRetentionSizeInMB|  Default retention size. 0 means retention is disabled. -1 means data is not removed by size quota  |0|
 |keepAliveIntervalSeconds|  How often to check whether the connections are still alive  |30|
 |brokerServicePurgeInactiveFrequencyInSeconds|  How often broker checks for inactive topics to be deleted (topics with no subscriptions and no one connected) |60|
 |loadManagerClassName|  Name of load manager to use |org.apache.pulsar.broker.loadbalance.impl.SimpleLoadManagerImpl|

--- a/site2/website/versioned_docs/version-2.3.2/reference-configuration.md
+++ b/site2/website/versioned_docs/version-2.3.2/reference-configuration.md
@@ -210,8 +210,8 @@ Pulsar brokers are responsible for handling incoming messages from producers, di
 |replicationProducerQueueSize|  Replicator producer queue size  |1000|
 |replicatorPrefix|  Replicator prefix used for replicator producer name and cursor name pulsar.repl||
 |replicationTlsEnabled| Enable TLS when talking with other clusters to replicate messages |false|
-|defaultRetentionTimeInMinutes| Default message retention time  ||
-|defaultRetentionSizeInMB|  Default retention size  |0|
+|defaultRetentionTimeInMinutes| Default message retention time. Value of 0 means the retention is disabled, -1 means the data will not be removed by time quota  ||
+|defaultRetentionSizeInMB|  Default retention size. Value of 0 means the retention is disabled, -1 means the data will not be removed by size quota  |0|
 |keepAliveIntervalSeconds|  How often to check whether the connections are still alive  |30|
 |brokerServicePurgeInactiveFrequencyInSeconds|  How often broker checks for inactive topics to be deleted (topics with no subscriptions and no one connected) |60|
 |loadManagerClassName|  Name of load manager to use |org.apache.pulsar.broker.loadbalance.impl.SimpleLoadManagerImpl|

--- a/site2/website/versioned_docs/version-2.3.2/reference-configuration.md
+++ b/site2/website/versioned_docs/version-2.3.2/reference-configuration.md
@@ -210,8 +210,8 @@ Pulsar brokers are responsible for handling incoming messages from producers, di
 |replicationProducerQueueSize|  Replicator producer queue size  |1000|
 |replicatorPrefix|  Replicator prefix used for replicator producer name and cursor name pulsar.repl||
 |replicationTlsEnabled| Enable TLS when talking with other clusters to replicate messages |false|
-|defaultRetentionTimeInMinutes| Default message retention time. Value of 0 means the retention is disabled, -1 means the data will not be removed by time quota  ||
-|defaultRetentionSizeInMB|  Default retention size. Value of 0 means the retention is disabled, -1 means the data will not be removed by size quota  |0|
+|defaultRetentionTimeInMinutes| Default message retention time. 0 means retention is disabled. -1 means data is not removed by time quota  ||
+|defaultRetentionSizeInMB|  Default retention size. 0 means retention is disabled. -1 means data is not removed by size quota  |0|
 |keepAliveIntervalSeconds|  How often to check whether the connections are still alive  |30|
 |brokerServicePurgeInactiveFrequencyInSeconds|  How often broker checks for inactive topics to be deleted (topics with no subscriptions and no one connected) |60|
 |loadManagerClassName|  Name of load manager to use |org.apache.pulsar.broker.loadbalance.impl.SimpleLoadManagerImpl|

--- a/site2/website/versioned_docs/version-2.4.0/reference-configuration.md
+++ b/site2/website/versioned_docs/version-2.4.0/reference-configuration.md
@@ -218,8 +218,8 @@ Pulsar brokers are responsible for handling incoming messages from producers, di
 |replicationProducerQueueSize|  Replicator producer queue size  |1000|
 |replicatorPrefix|  Replicator prefix used for replicator producer name and cursor name pulsar.repl||
 |replicationTlsEnabled| Enable TLS when talking with other clusters to replicate messages |false|
-|defaultRetentionTimeInMinutes| Default message retention time. Value of 0 means the retention is disabled, -1 means the data will not be removed by time quota  ||
-|defaultRetentionSizeInMB|  Default retention size. Value of 0 means the retention is disabled, -1 means the data will not be removed by size quota  |0|
+|defaultRetentionTimeInMinutes| Default message retention time. 0 means retention is disabled. -1 means data is not removed by time quota  ||
+|defaultRetentionSizeInMB|  Default retention size. 0 means retention is disabled. -1 means data is not removed by size quota  |0|
 |keepAliveIntervalSeconds|  How often to check whether the connections are still alive  |30|
 |loadManagerClassName|  Name of load manager to use |org.apache.pulsar.broker.loadbalance.impl.SimpleLoadManagerImpl|
 |managedLedgerOffloadDriver|  Driver to use to offload old data to long term storage (Possible values: S3)  ||

--- a/site2/website/versioned_docs/version-2.4.0/reference-configuration.md
+++ b/site2/website/versioned_docs/version-2.4.0/reference-configuration.md
@@ -218,8 +218,8 @@ Pulsar brokers are responsible for handling incoming messages from producers, di
 |replicationProducerQueueSize|  Replicator producer queue size  |1000|
 |replicatorPrefix|  Replicator prefix used for replicator producer name and cursor name pulsar.repl||
 |replicationTlsEnabled| Enable TLS when talking with other clusters to replicate messages |false|
-|defaultRetentionTimeInMinutes| Default message retention time  ||
-|defaultRetentionSizeInMB|  Default retention size  |0|
+|defaultRetentionTimeInMinutes| Default message retention time. Value of 0 means the retention is disabled, -1 means the data will not be removed by time quota  ||
+|defaultRetentionSizeInMB|  Default retention size. Value of 0 means the retention is disabled, -1 means the data will not be removed by size quota  |0|
 |keepAliveIntervalSeconds|  How often to check whether the connections are still alive  |30|
 |loadManagerClassName|  Name of load manager to use |org.apache.pulsar.broker.loadbalance.impl.SimpleLoadManagerImpl|
 |managedLedgerOffloadDriver|  Driver to use to offload old data to long term storage (Possible values: S3)  ||

--- a/site2/website/versioned_docs/version-2.4.1/reference-configuration.md
+++ b/site2/website/versioned_docs/version-2.4.1/reference-configuration.md
@@ -218,8 +218,8 @@ Pulsar brokers are responsible for handling incoming messages from producers, di
 |replicationProducerQueueSize|  Replicator producer queue size  |1000|
 |replicatorPrefix|  Replicator prefix used for replicator producer name and cursor name pulsar.repl||
 |replicationTlsEnabled| Enable TLS when talking with other clusters to replicate messages |false|
-|defaultRetentionTimeInMinutes| Default message retention time. Value of 0 means the retention is disabled, -1 means the data will not be removed by time quota  ||
-|defaultRetentionSizeInMB|  Default retention size. Value of 0 means the retention is disabled, -1 means the data will not be removed by size quota  |0|
+|defaultRetentionTimeInMinutes| Default message retention time. 0 means retention is disabled. -1 means data is not removed by time quota  ||
+|defaultRetentionSizeInMB|  Default retention size. 0 means retention is disabled. -1 means data is not removed by size quota  |0|
 |keepAliveIntervalSeconds|  How often to check whether the connections are still alive  |30|
 |loadManagerClassName|  Name of load manager to use |org.apache.pulsar.broker.loadbalance.impl.SimpleLoadManagerImpl|
 |managedLedgerOffloadDriver|  Driver to use to offload old data to long term storage (Possible values: S3)  ||

--- a/site2/website/versioned_docs/version-2.4.1/reference-configuration.md
+++ b/site2/website/versioned_docs/version-2.4.1/reference-configuration.md
@@ -218,8 +218,8 @@ Pulsar brokers are responsible for handling incoming messages from producers, di
 |replicationProducerQueueSize|  Replicator producer queue size  |1000|
 |replicatorPrefix|  Replicator prefix used for replicator producer name and cursor name pulsar.repl||
 |replicationTlsEnabled| Enable TLS when talking with other clusters to replicate messages |false|
-|defaultRetentionTimeInMinutes| Default message retention time  ||
-|defaultRetentionSizeInMB|  Default retention size  |0|
+|defaultRetentionTimeInMinutes| Default message retention time. Value of 0 means the retention is disabled, -1 means the data will not be removed by time quota  ||
+|defaultRetentionSizeInMB|  Default retention size. Value of 0 means the retention is disabled, -1 means the data will not be removed by size quota  |0|
 |keepAliveIntervalSeconds|  How often to check whether the connections are still alive  |30|
 |loadManagerClassName|  Name of load manager to use |org.apache.pulsar.broker.loadbalance.impl.SimpleLoadManagerImpl|
 |managedLedgerOffloadDriver|  Driver to use to offload old data to long term storage (Possible values: S3)  ||

--- a/site2/website/versioned_docs/version-2.4.2/reference-configuration.md
+++ b/site2/website/versioned_docs/version-2.4.2/reference-configuration.md
@@ -218,8 +218,8 @@ Pulsar brokers are responsible for handling incoming messages from producers, di
 |replicationProducerQueueSize|  Replicator producer queue size  |1000|
 |replicatorPrefix|  Replicator prefix used for replicator producer name and cursor name pulsar.repl||
 |replicationTlsEnabled| Enable TLS when talking with other clusters to replicate messages |false|
-|defaultRetentionTimeInMinutes| Default message retention time. Value of 0 means the retention is disabled, -1 means the data will not be removed by time quota  ||
-|defaultRetentionSizeInMB|  Default retention size. Value of 0 means the retention is disabled, -1 means the data will not be removed by size quota  |0|
+|defaultRetentionTimeInMinutes| Default message retention time. 0 means retention is disabled. -1 means data is not removed by time quota  ||
+|defaultRetentionSizeInMB|  Default retention size. 0 means retention is disabled. -1 means data is not removed by size quota  |0|
 |keepAliveIntervalSeconds|  How often to check whether the connections are still alive  |30|
 |loadManagerClassName|  Name of load manager to use |org.apache.pulsar.broker.loadbalance.impl.SimpleLoadManagerImpl|
 |managedLedgerOffloadDriver|  Driver to use to offload old data to long term storage (Possible values: S3)  ||

--- a/site2/website/versioned_docs/version-2.4.2/reference-configuration.md
+++ b/site2/website/versioned_docs/version-2.4.2/reference-configuration.md
@@ -218,8 +218,8 @@ Pulsar brokers are responsible for handling incoming messages from producers, di
 |replicationProducerQueueSize|  Replicator producer queue size  |1000|
 |replicatorPrefix|  Replicator prefix used for replicator producer name and cursor name pulsar.repl||
 |replicationTlsEnabled| Enable TLS when talking with other clusters to replicate messages |false|
-|defaultRetentionTimeInMinutes| Default message retention time  ||
-|defaultRetentionSizeInMB|  Default retention size  |0|
+|defaultRetentionTimeInMinutes| Default message retention time. Value of 0 means the retention is disabled, -1 means the data will not be removed by time quota  ||
+|defaultRetentionSizeInMB|  Default retention size. Value of 0 means the retention is disabled, -1 means the data will not be removed by size quota  |0|
 |keepAliveIntervalSeconds|  How often to check whether the connections are still alive  |30|
 |loadManagerClassName|  Name of load manager to use |org.apache.pulsar.broker.loadbalance.impl.SimpleLoadManagerImpl|
 |managedLedgerOffloadDriver|  Driver to use to offload old data to long term storage (Possible values: S3)  ||

--- a/site2/website/versioned_docs/version-2.5.0/reference-configuration.md
+++ b/site2/website/versioned_docs/version-2.5.0/reference-configuration.md
@@ -216,8 +216,8 @@ Pulsar brokers are responsible for handling incoming messages from producers, di
 |replicationProducerQueueSize|  Replicator producer queue size  |1000|
 |replicatorPrefix|  Replicator prefix used for replicator producer name and cursor name pulsar.repl||
 |replicationTlsEnabled| Enable TLS when talking with other clusters to replicate messages |false|
-|defaultRetentionTimeInMinutes| Default message retention time  ||
-|defaultRetentionSizeInMB|  Default retention size  |0|
+|defaultRetentionTimeInMinutes| Default message retention time. Value of 0 means the retention is disabled, -1 means the data will not be removed by time quota  ||
+|defaultRetentionSizeInMB|  Default retention size. Value of 0 means the retention is disabled, -1 means the data will not be removed by size quota  |0|
 |keepAliveIntervalSeconds|  How often to check whether the connections are still alive  |30|
 |loadManagerClassName|  Name of load manager to use |org.apache.pulsar.broker.loadbalance.impl.SimpleLoadManagerImpl|
 |managedLedgerOffloadDriver|  Driver to use to offload old data to long term storage (Possible values: S3)  ||

--- a/site2/website/versioned_docs/version-2.5.0/reference-configuration.md
+++ b/site2/website/versioned_docs/version-2.5.0/reference-configuration.md
@@ -216,8 +216,8 @@ Pulsar brokers are responsible for handling incoming messages from producers, di
 |replicationProducerQueueSize|  Replicator producer queue size  |1000|
 |replicatorPrefix|  Replicator prefix used for replicator producer name and cursor name pulsar.repl||
 |replicationTlsEnabled| Enable TLS when talking with other clusters to replicate messages |false|
-|defaultRetentionTimeInMinutes| Default message retention time. Value of 0 means the retention is disabled, -1 means the data will not be removed by time quota  ||
-|defaultRetentionSizeInMB|  Default retention size. Value of 0 means the retention is disabled, -1 means the data will not be removed by size quota  |0|
+|defaultRetentionTimeInMinutes| Default message retention time. 0 means retention is disabled. -1 means data is not removed by time quota  ||
+|defaultRetentionSizeInMB|  Default retention size. 0 means retention is disabled. -1 means data is not removed by size quota  |0|
 |keepAliveIntervalSeconds|  How often to check whether the connections are still alive  |30|
 |loadManagerClassName|  Name of load manager to use |org.apache.pulsar.broker.loadbalance.impl.SimpleLoadManagerImpl|
 |managedLedgerOffloadDriver|  Driver to use to offload old data to long term storage (Possible values: S3)  ||

--- a/site2/website/versioned_docs/version-2.5.1/reference-configuration.md
+++ b/site2/website/versioned_docs/version-2.5.1/reference-configuration.md
@@ -223,8 +223,8 @@ Pulsar brokers are responsible for handling incoming messages from producers, di
 |replicationProducerQueueSize|  Replicator producer queue size  |1000|
 |replicatorPrefix|  Replicator prefix used for replicator producer name and cursor name pulsar.repl||
 |replicationTlsEnabled| Enable TLS when talking with other clusters to replicate messages |false|
-|defaultRetentionTimeInMinutes| Default message retention time. Value of 0 means the retention is disabled, -1 means the data will not be removed by time quota  ||
-|defaultRetentionSizeInMB|  Default retention size. Value of 0 means the retention is disabled, -1 means the data will not be removed by size quota  |0|
+|defaultRetentionTimeInMinutes| Default message retention time. 0 means retention is disabled. -1 means data is not removed by time quota  ||
+|defaultRetentionSizeInMB|  Default retention size. 0 means retention is disabled. -1 means data is not removed by size quota  |0|
 |keepAliveIntervalSeconds|  How often to check whether the connections are still alive  |30|
 |loadManagerClassName|  Name of load manager to use |org.apache.pulsar.broker.loadbalance.impl.SimpleLoadManagerImpl|
 |supportedNamespaceBundleSplitAlgorithms| Supported algorithms name for namespace bundle split |[range_equally_divide,topic_count_equally_divide]|

--- a/site2/website/versioned_docs/version-2.5.1/reference-configuration.md
+++ b/site2/website/versioned_docs/version-2.5.1/reference-configuration.md
@@ -223,8 +223,8 @@ Pulsar brokers are responsible for handling incoming messages from producers, di
 |replicationProducerQueueSize|  Replicator producer queue size  |1000|
 |replicatorPrefix|  Replicator prefix used for replicator producer name and cursor name pulsar.repl||
 |replicationTlsEnabled| Enable TLS when talking with other clusters to replicate messages |false|
-|defaultRetentionTimeInMinutes| Default message retention time  ||
-|defaultRetentionSizeInMB|  Default retention size  |0|
+|defaultRetentionTimeInMinutes| Default message retention time. Value of 0 means the retention is disabled, -1 means the data will not be removed by time quota  ||
+|defaultRetentionSizeInMB|  Default retention size. Value of 0 means the retention is disabled, -1 means the data will not be removed by size quota  |0|
 |keepAliveIntervalSeconds|  How often to check whether the connections are still alive  |30|
 |loadManagerClassName|  Name of load manager to use |org.apache.pulsar.broker.loadbalance.impl.SimpleLoadManagerImpl|
 |supportedNamespaceBundleSplitAlgorithms| Supported algorithms name for namespace bundle split |[range_equally_divide,topic_count_equally_divide]|

--- a/site2/website/versioned_docs/version-2.5.2/reference-configuration.md
+++ b/site2/website/versioned_docs/version-2.5.2/reference-configuration.md
@@ -224,8 +224,8 @@ Pulsar brokers are responsible for handling incoming messages from producers, di
 |replicationProducerQueueSize|  Replicator producer queue size  |1000|
 |replicatorPrefix|  Replicator prefix used for replicator producer name and cursor name pulsar.repl||
 |replicationTlsEnabled| Enable TLS when talking with other clusters to replicate messages |false|
-|defaultRetentionTimeInMinutes| Default message retention time  ||
-|defaultRetentionSizeInMB|  Default retention size  |0|
+|defaultRetentionTimeInMinutes| Default message retention time. Value of 0 means the retention is disabled, -1 means the data will not be removed by time quota  ||
+|defaultRetentionSizeInMB|  Default retention size. Value of 0 means the retention is disabled, -1 means the data will not be removed by size quota  |0|
 |keepAliveIntervalSeconds|  How often to check whether the connections are still alive  |30|
 |loadManagerClassName|  Name of load manager to use |org.apache.pulsar.broker.loadbalance.impl.SimpleLoadManagerImpl|
 |supportedNamespaceBundleSplitAlgorithms| Supported algorithms name for namespace bundle split |[range_equally_divide,topic_count_equally_divide]|

--- a/site2/website/versioned_docs/version-2.5.2/reference-configuration.md
+++ b/site2/website/versioned_docs/version-2.5.2/reference-configuration.md
@@ -224,8 +224,8 @@ Pulsar brokers are responsible for handling incoming messages from producers, di
 |replicationProducerQueueSize|  Replicator producer queue size  |1000|
 |replicatorPrefix|  Replicator prefix used for replicator producer name and cursor name pulsar.repl||
 |replicationTlsEnabled| Enable TLS when talking with other clusters to replicate messages |false|
-|defaultRetentionTimeInMinutes| Default message retention time. Value of 0 means the retention is disabled, -1 means the data will not be removed by time quota  ||
-|defaultRetentionSizeInMB|  Default retention size. Value of 0 means the retention is disabled, -1 means the data will not be removed by size quota  |0|
+|defaultRetentionTimeInMinutes| Default message retention time. 0 means retention is disabled. -1 means data is not removed by time quota  ||
+|defaultRetentionSizeInMB|  Default retention size. 0 means retention is disabled. -1 means data is not removed by size quota  |0|
 |keepAliveIntervalSeconds|  How often to check whether the connections are still alive  |30|
 |loadManagerClassName|  Name of load manager to use |org.apache.pulsar.broker.loadbalance.impl.SimpleLoadManagerImpl|
 |supportedNamespaceBundleSplitAlgorithms| Supported algorithms name for namespace bundle split |[range_equally_divide,topic_count_equally_divide]|

--- a/site2/website/versioned_docs/version-2.6.0/reference-configuration.md
+++ b/site2/website/versioned_docs/version-2.6.0/reference-configuration.md
@@ -246,8 +246,8 @@ Pulsar brokers are responsible for handling incoming messages from producers, di
 |replicationProducerQueueSize|  Replicator producer queue size  |1000|
 |replicatorPrefix|  Replicator prefix used for replicator producer name and cursor name pulsar.repl||
 |replicationTlsEnabled| Enable TLS when talking with other clusters to replicate messages |false|
-|defaultRetentionTimeInMinutes| Default message retention time  ||
-|defaultRetentionSizeInMB|  Default retention size  |0|
+|defaultRetentionTimeInMinutes| Default message retention time. Value of 0 means the retention is disabled, -1 means the data will not be removed by time quota  ||
+|defaultRetentionSizeInMB|  Default retention size. Value of 0 means the retention is disabled, -1 means the data will not be removed by size quota  |0|
 |keepAliveIntervalSeconds|  How often to check whether the connections are still alive  |30|
 |loadManagerClassName|  Name of load manager to use |org.apache.pulsar.broker.loadbalance.impl.SimpleLoadManagerImpl|
 |supportedNamespaceBundleSplitAlgorithms| Supported algorithms name for namespace bundle split |[range_equally_divide,topic_count_equally_divide]|

--- a/site2/website/versioned_docs/version-2.6.0/reference-configuration.md
+++ b/site2/website/versioned_docs/version-2.6.0/reference-configuration.md
@@ -246,8 +246,8 @@ Pulsar brokers are responsible for handling incoming messages from producers, di
 |replicationProducerQueueSize|  Replicator producer queue size  |1000|
 |replicatorPrefix|  Replicator prefix used for replicator producer name and cursor name pulsar.repl||
 |replicationTlsEnabled| Enable TLS when talking with other clusters to replicate messages |false|
-|defaultRetentionTimeInMinutes| Default message retention time. Value of 0 means the retention is disabled, -1 means the data will not be removed by time quota  ||
-|defaultRetentionSizeInMB|  Default retention size. Value of 0 means the retention is disabled, -1 means the data will not be removed by size quota  |0|
+|defaultRetentionTimeInMinutes| Default message retention time. 0 means retention is disabled. -1 means data is not removed by time quota  ||
+|defaultRetentionSizeInMB|  Default retention size. 0 means retention is disabled. -1 means data is not removed by size quota  |0|
 |keepAliveIntervalSeconds|  How often to check whether the connections are still alive  |30|
 |loadManagerClassName|  Name of load manager to use |org.apache.pulsar.broker.loadbalance.impl.SimpleLoadManagerImpl|
 |supportedNamespaceBundleSplitAlgorithms| Supported algorithms name for namespace bundle split |[range_equally_divide,topic_count_equally_divide]|

--- a/site2/website/versioned_docs/version-2.6.1/reference-configuration.md
+++ b/site2/website/versioned_docs/version-2.6.1/reference-configuration.md
@@ -246,8 +246,8 @@ Pulsar brokers are responsible for handling incoming messages from producers, di
 |replicationProducerQueueSize|  Replicator producer queue size  |1000|
 |replicatorPrefix|  Replicator prefix used for replicator producer name and cursor name pulsar.repl||
 |replicationTlsEnabled| Enable TLS when talking with other clusters to replicate messages |false|
-|defaultRetentionTimeInMinutes| Default message retention time  ||
-|defaultRetentionSizeInMB|  Default retention size  |0|
+|defaultRetentionTimeInMinutes| Default message retention time. Value of 0 means the retention is disabled, -1 means the data will not be removed by time quota  ||
+|defaultRetentionSizeInMB|  Default retention size. Value of 0 means the retention is disabled, -1 means the data will not be removed by size quota  |0|
 |keepAliveIntervalSeconds|  How often to check whether the connections are still alive  |30|
 |loadManagerClassName|  Name of load manager to use |org.apache.pulsar.broker.loadbalance.impl.SimpleLoadManagerImpl|
 |supportedNamespaceBundleSplitAlgorithms| Supported algorithms name for namespace bundle split |[range_equally_divide,topic_count_equally_divide]|

--- a/site2/website/versioned_docs/version-2.6.1/reference-configuration.md
+++ b/site2/website/versioned_docs/version-2.6.1/reference-configuration.md
@@ -246,8 +246,8 @@ Pulsar brokers are responsible for handling incoming messages from producers, di
 |replicationProducerQueueSize|  Replicator producer queue size  |1000|
 |replicatorPrefix|  Replicator prefix used for replicator producer name and cursor name pulsar.repl||
 |replicationTlsEnabled| Enable TLS when talking with other clusters to replicate messages |false|
-|defaultRetentionTimeInMinutes| Default message retention time. Value of 0 means the retention is disabled, -1 means the data will not be removed by time quota  ||
-|defaultRetentionSizeInMB|  Default retention size. Value of 0 means the retention is disabled, -1 means the data will not be removed by size quota  |0|
+|defaultRetentionTimeInMinutes| Default message retention time. 0 means retention is disabled. -1 means data is not removed by time quota  ||
+|defaultRetentionSizeInMB|  Default retention size. 0 means retention is disabled. -1 means data is not removed by size quota  |0|
 |keepAliveIntervalSeconds|  How often to check whether the connections are still alive  |30|
 |loadManagerClassName|  Name of load manager to use |org.apache.pulsar.broker.loadbalance.impl.SimpleLoadManagerImpl|
 |supportedNamespaceBundleSplitAlgorithms| Supported algorithms name for namespace bundle split |[range_equally_divide,topic_count_equally_divide]|

--- a/site2/website/versioned_docs/version-2.6.2/reference-configuration.md
+++ b/site2/website/versioned_docs/version-2.6.2/reference-configuration.md
@@ -247,8 +247,8 @@ Pulsar brokers are responsible for handling incoming messages from producers, di
 |replicationProducerQueueSize|  Replicator producer queue size  |1000|
 |replicatorPrefix|  Replicator prefix used for replicator producer name and cursor name pulsar.repl||
 |replicationTlsEnabled| Enable TLS when talking with other clusters to replicate messages |false|
-|defaultRetentionTimeInMinutes| Default message retention time  ||
-|defaultRetentionSizeInMB|  Default retention size  |0|
+|defaultRetentionTimeInMinutes| Default message retention time. Value of 0 means the retention is disabled, -1 means the data will not be removed by time quota  ||
+|defaultRetentionSizeInMB|  Default retention size. Value of 0 means the retention is disabled, -1 means the data will not be removed by size quota  |0|
 |keepAliveIntervalSeconds|  How often to check whether the connections are still alive  |30|
 |loadManagerClassName|  Name of load manager to use |org.apache.pulsar.broker.loadbalance.impl.SimpleLoadManagerImpl|
 |supportedNamespaceBundleSplitAlgorithms| Supported algorithms name for namespace bundle split |[range_equally_divide,topic_count_equally_divide]|

--- a/site2/website/versioned_docs/version-2.6.2/reference-configuration.md
+++ b/site2/website/versioned_docs/version-2.6.2/reference-configuration.md
@@ -247,8 +247,8 @@ Pulsar brokers are responsible for handling incoming messages from producers, di
 |replicationProducerQueueSize|  Replicator producer queue size  |1000|
 |replicatorPrefix|  Replicator prefix used for replicator producer name and cursor name pulsar.repl||
 |replicationTlsEnabled| Enable TLS when talking with other clusters to replicate messages |false|
-|defaultRetentionTimeInMinutes| Default message retention time. Value of 0 means the retention is disabled, -1 means the data will not be removed by time quota  ||
-|defaultRetentionSizeInMB|  Default retention size. Value of 0 means the retention is disabled, -1 means the data will not be removed by size quota  |0|
+|defaultRetentionTimeInMinutes| Default message retention time. 0 means retention is disabled. -1 means data is not removed by time quota  ||
+|defaultRetentionSizeInMB|  Default retention size. 0 means retention is disabled. -1 means data is not removed by size quota  |0|
 |keepAliveIntervalSeconds|  How often to check whether the connections are still alive  |30|
 |loadManagerClassName|  Name of load manager to use |org.apache.pulsar.broker.loadbalance.impl.SimpleLoadManagerImpl|
 |supportedNamespaceBundleSplitAlgorithms| Supported algorithms name for namespace bundle split |[range_equally_divide,topic_count_equally_divide]|

--- a/site2/website/versioned_docs/version-2.6.3/reference-configuration.md
+++ b/site2/website/versioned_docs/version-2.6.3/reference-configuration.md
@@ -247,8 +247,8 @@ Pulsar brokers are responsible for handling incoming messages from producers, di
 |replicationProducerQueueSize|  Replicator producer queue size  |1000|
 |replicatorPrefix|  Replicator prefix used for replicator producer name and cursor name pulsar.repl||
 |replicationTlsEnabled| Enable TLS when talking with other clusters to replicate messages |false|
-|defaultRetentionTimeInMinutes| Default message retention time  ||
-|defaultRetentionSizeInMB|  Default retention size  |0|
+|defaultRetentionTimeInMinutes| Default message retention time. Value of 0 means the retention is disabled, -1 means the data will not be removed by time quota  ||
+|defaultRetentionSizeInMB|  Default retention size. Value of 0 means the retention is disabled, -1 means the data will not be removed by size quota  |0|
 |keepAliveIntervalSeconds|  How often to check whether the connections are still alive  |30|
 |loadManagerClassName|  Name of load manager to use |org.apache.pulsar.broker.loadbalance.impl.SimpleLoadManagerImpl|
 |supportedNamespaceBundleSplitAlgorithms| Supported algorithms name for namespace bundle split |[range_equally_divide,topic_count_equally_divide]|

--- a/site2/website/versioned_docs/version-2.6.3/reference-configuration.md
+++ b/site2/website/versioned_docs/version-2.6.3/reference-configuration.md
@@ -247,8 +247,8 @@ Pulsar brokers are responsible for handling incoming messages from producers, di
 |replicationProducerQueueSize|  Replicator producer queue size  |1000|
 |replicatorPrefix|  Replicator prefix used for replicator producer name and cursor name pulsar.repl||
 |replicationTlsEnabled| Enable TLS when talking with other clusters to replicate messages |false|
-|defaultRetentionTimeInMinutes| Default message retention time. Value of 0 means the retention is disabled, -1 means the data will not be removed by time quota  ||
-|defaultRetentionSizeInMB|  Default retention size. Value of 0 means the retention is disabled, -1 means the data will not be removed by size quota  |0|
+|defaultRetentionTimeInMinutes| Default message retention time. 0 means retention is disabled. -1 means data is not removed by time quota  ||
+|defaultRetentionSizeInMB|  Default retention size. 0 means retention is disabled. -1 means data is not removed by size quota  |0|
 |keepAliveIntervalSeconds|  How often to check whether the connections are still alive  |30|
 |loadManagerClassName|  Name of load manager to use |org.apache.pulsar.broker.loadbalance.impl.SimpleLoadManagerImpl|
 |supportedNamespaceBundleSplitAlgorithms| Supported algorithms name for namespace bundle split |[range_equally_divide,topic_count_equally_divide]|

--- a/site2/website/versioned_docs/version-2.6.4/reference-configuration.md
+++ b/site2/website/versioned_docs/version-2.6.4/reference-configuration.md
@@ -244,8 +244,8 @@ subscriptionExpirationTimeMinutes | How long to delete inactive subscriptions fr
 |replicationProducerQueueSize|  Replicator producer queue size  |1000|
 |replicatorPrefix|  Replicator prefix used for replicator producer name and cursor name pulsar.repl||
 |replicationTlsEnabled| Enable TLS when talking with other clusters to replicate messages |false|
-|defaultRetentionTimeInMinutes| Default message retention time. Value of 0 means the retention is disabled, -1 means the data will not be removed by time quota  ||
-|defaultRetentionSizeInMB|  Default retention size. Value of 0 means the retention is disabled, -1 means the data will not be removed by size quota  |0|
+|defaultRetentionTimeInMinutes| Default message retention time. 0 means retention is disabled. -1 means data is not removed by time quota  ||
+|defaultRetentionSizeInMB|  Default retention size. 0 means retention is disabled. -1 means data is not removed by size quota  |0|
 |keepAliveIntervalSeconds|  How often to check whether the connections are still alive  |30|
 |loadManagerClassName|  Name of load manager to use |org.apache.pulsar.broker.loadbalance.impl.SimpleLoadManagerImpl|
 |supportedNamespaceBundleSplitAlgorithms| Supported algorithms name for namespace bundle split |[range_equally_divide,topic_count_equally_divide]|

--- a/site2/website/versioned_docs/version-2.6.4/reference-configuration.md
+++ b/site2/website/versioned_docs/version-2.6.4/reference-configuration.md
@@ -244,8 +244,8 @@ subscriptionExpirationTimeMinutes | How long to delete inactive subscriptions fr
 |replicationProducerQueueSize|  Replicator producer queue size  |1000|
 |replicatorPrefix|  Replicator prefix used for replicator producer name and cursor name pulsar.repl||
 |replicationTlsEnabled| Enable TLS when talking with other clusters to replicate messages |false|
-|defaultRetentionTimeInMinutes| Default message retention time  ||
-|defaultRetentionSizeInMB|  Default retention size  |0|
+|defaultRetentionTimeInMinutes| Default message retention time. Value of 0 means the retention is disabled, -1 means the data will not be removed by time quota  ||
+|defaultRetentionSizeInMB|  Default retention size. Value of 0 means the retention is disabled, -1 means the data will not be removed by size quota  |0|
 |keepAliveIntervalSeconds|  How often to check whether the connections are still alive  |30|
 |loadManagerClassName|  Name of load manager to use |org.apache.pulsar.broker.loadbalance.impl.SimpleLoadManagerImpl|
 |supportedNamespaceBundleSplitAlgorithms| Supported algorithms name for namespace bundle split |[range_equally_divide,topic_count_equally_divide]|

--- a/site2/website/versioned_docs/version-2.7.0/reference-configuration.md
+++ b/site2/website/versioned_docs/version-2.7.0/reference-configuration.md
@@ -310,8 +310,8 @@ Pulsar brokers are responsible for handling incoming messages from producers, di
 |brokerServicePurgeInactiveFrequencyInSeconds|Deprecated. Use `brokerDeleteInactiveTopicsFrequencySeconds`.|60|
 |transactionCoordinatorEnabled|Whether to enable transaction coordinator in broker.|true|
 |transactionMetadataStoreProviderClassName| |org.apache.pulsar.transaction.coordinator.impl.InMemTransactionMetadataStoreProvider|
-|defaultRetentionTimeInMinutes| Default message retention time  |0|
-|defaultRetentionSizeInMB|  Default retention size  |0|
+|defaultRetentionTimeInMinutes| Default message retention time. Value of 0 means the retention is disabled, -1 means the data will not be removed by time quota  |0|
+|defaultRetentionSizeInMB|  Default retention size. Value of 0 means the retention is disabled, -1 means the data will not be removed by size quota  |0|
 |keepAliveIntervalSeconds|  How often to check whether the connections are still alive  |30|
 |bootstrapNamespaces| The bootstrap name. | N/A |
 |loadManagerClassName|  Name of load manager to use |org.apache.pulsar.broker.loadbalance.impl.SimpleLoadManagerImpl|

--- a/site2/website/versioned_docs/version-2.7.0/reference-configuration.md
+++ b/site2/website/versioned_docs/version-2.7.0/reference-configuration.md
@@ -310,8 +310,8 @@ Pulsar brokers are responsible for handling incoming messages from producers, di
 |brokerServicePurgeInactiveFrequencyInSeconds|Deprecated. Use `brokerDeleteInactiveTopicsFrequencySeconds`.|60|
 |transactionCoordinatorEnabled|Whether to enable transaction coordinator in broker.|true|
 |transactionMetadataStoreProviderClassName| |org.apache.pulsar.transaction.coordinator.impl.InMemTransactionMetadataStoreProvider|
-|defaultRetentionTimeInMinutes| Default message retention time. Value of 0 means the retention is disabled, -1 means the data will not be removed by time quota  |0|
-|defaultRetentionSizeInMB|  Default retention size. Value of 0 means the retention is disabled, -1 means the data will not be removed by size quota  |0|
+|defaultRetentionTimeInMinutes| Default message retention time. 0 means retention is disabled. -1 means data is not removed by time quota  |0|
+|defaultRetentionSizeInMB|  Default retention size. 0 means retention is disabled. -1 means data is not removed by size quota  |0|
 |keepAliveIntervalSeconds|  How often to check whether the connections are still alive  |30|
 |bootstrapNamespaces| The bootstrap name. | N/A |
 |loadManagerClassName|  Name of load manager to use |org.apache.pulsar.broker.loadbalance.impl.SimpleLoadManagerImpl|

--- a/site2/website/versioned_docs/version-2.7.1/reference-configuration.md
+++ b/site2/website/versioned_docs/version-2.7.1/reference-configuration.md
@@ -310,8 +310,8 @@ Pulsar brokers are responsible for handling incoming messages from producers, di
 |brokerServicePurgeInactiveFrequencyInSeconds|Deprecated. Use `brokerDeleteInactiveTopicsFrequencySeconds`.|60|
 |transactionCoordinatorEnabled|Whether to enable transaction coordinator in broker.|true|
 |transactionMetadataStoreProviderClassName| |org.apache.pulsar.transaction.coordinator.impl.InMemTransactionMetadataStoreProvider|
-|defaultRetentionTimeInMinutes| Default message retention time  |0|
-|defaultRetentionSizeInMB|  Default retention size  |0|
+|defaultRetentionTimeInMinutes| Default message retention time. Value of 0 means the retention is disabled, -1 means the data will not be removed by time quota  |0|
+|defaultRetentionSizeInMB|  Default retention size. Value of 0 means the retention is disabled, -1 means the data will not be removed by size quota  |0|
 |keepAliveIntervalSeconds|  How often to check whether the connections are still alive  |30|
 |bootstrapNamespaces| The bootstrap name. | N/A |
 |loadManagerClassName|  Name of load manager to use |org.apache.pulsar.broker.loadbalance.impl.SimpleLoadManagerImpl|

--- a/site2/website/versioned_docs/version-2.7.1/reference-configuration.md
+++ b/site2/website/versioned_docs/version-2.7.1/reference-configuration.md
@@ -310,8 +310,8 @@ Pulsar brokers are responsible for handling incoming messages from producers, di
 |brokerServicePurgeInactiveFrequencyInSeconds|Deprecated. Use `brokerDeleteInactiveTopicsFrequencySeconds`.|60|
 |transactionCoordinatorEnabled|Whether to enable transaction coordinator in broker.|true|
 |transactionMetadataStoreProviderClassName| |org.apache.pulsar.transaction.coordinator.impl.InMemTransactionMetadataStoreProvider|
-|defaultRetentionTimeInMinutes| Default message retention time. Value of 0 means the retention is disabled, -1 means the data will not be removed by time quota  |0|
-|defaultRetentionSizeInMB|  Default retention size. Value of 0 means the retention is disabled, -1 means the data will not be removed by size quota  |0|
+|defaultRetentionTimeInMinutes| Default message retention time. 0 means retention is disabled. -1 means data is not removed by time quota  |0|
+|defaultRetentionSizeInMB|  Default retention size. 0 means retention is disabled. -1 means data is not removed by size quota  |0|
 |keepAliveIntervalSeconds|  How often to check whether the connections are still alive  |30|
 |bootstrapNamespaces| The bootstrap name. | N/A |
 |loadManagerClassName|  Name of load manager to use |org.apache.pulsar.broker.loadbalance.impl.SimpleLoadManagerImpl|

--- a/site2/website/versioned_docs/version-2.7.2/reference-configuration.md
+++ b/site2/website/versioned_docs/version-2.7.2/reference-configuration.md
@@ -310,8 +310,8 @@ Pulsar brokers are responsible for handling incoming messages from producers, di
 |brokerServicePurgeInactiveFrequencyInSeconds|Deprecated. Use `brokerDeleteInactiveTopicsFrequencySeconds`.|60|
 |transactionCoordinatorEnabled|Whether to enable transaction coordinator in broker.|true|
 |transactionMetadataStoreProviderClassName| |org.apache.pulsar.transaction.coordinator.impl.InMemTransactionMetadataStoreProvider|
-|defaultRetentionTimeInMinutes| Default message retention time  |0|
-|defaultRetentionSizeInMB|  Default retention size  |0|
+|defaultRetentionTimeInMinutes| Default message retention time. Value of 0 means the retention is disabled, -1 means the data will not be removed by time quota  |0|
+|defaultRetentionSizeInMB|  Default retention size. Value of 0 means the retention is disabled, -1 means the data will not be removed by size quota  |0|
 |keepAliveIntervalSeconds|  How often to check whether the connections are still alive  |30|
 |bootstrapNamespaces| The bootstrap name. | N/A |
 |loadManagerClassName|  Name of load manager to use |org.apache.pulsar.broker.loadbalance.impl.SimpleLoadManagerImpl|

--- a/site2/website/versioned_docs/version-2.7.2/reference-configuration.md
+++ b/site2/website/versioned_docs/version-2.7.2/reference-configuration.md
@@ -310,8 +310,8 @@ Pulsar brokers are responsible for handling incoming messages from producers, di
 |brokerServicePurgeInactiveFrequencyInSeconds|Deprecated. Use `brokerDeleteInactiveTopicsFrequencySeconds`.|60|
 |transactionCoordinatorEnabled|Whether to enable transaction coordinator in broker.|true|
 |transactionMetadataStoreProviderClassName| |org.apache.pulsar.transaction.coordinator.impl.InMemTransactionMetadataStoreProvider|
-|defaultRetentionTimeInMinutes| Default message retention time. Value of 0 means the retention is disabled, -1 means the data will not be removed by time quota  |0|
-|defaultRetentionSizeInMB|  Default retention size. Value of 0 means the retention is disabled, -1 means the data will not be removed by size quota  |0|
+|defaultRetentionTimeInMinutes| Default message retention time. 0 means retention is disabled. -1 means data is not removed by time quota  |0|
+|defaultRetentionSizeInMB|  Default retention size. 0 means retention is disabled. -1 means data is not removed by size quota  |0|
 |keepAliveIntervalSeconds|  How often to check whether the connections are still alive  |30|
 |bootstrapNamespaces| The bootstrap name. | N/A |
 |loadManagerClassName|  Name of load manager to use |org.apache.pulsar.broker.loadbalance.impl.SimpleLoadManagerImpl|

--- a/site2/website/versioned_docs/version-2.7.3/reference-configuration.md
+++ b/site2/website/versioned_docs/version-2.7.3/reference-configuration.md
@@ -310,8 +310,8 @@ Pulsar brokers are responsible for handling incoming messages from producers, di
 |brokerServicePurgeInactiveFrequencyInSeconds|Deprecated. Use `brokerDeleteInactiveTopicsFrequencySeconds`.|60|
 |transactionCoordinatorEnabled|Whether to enable transaction coordinator in broker.|true|
 |transactionMetadataStoreProviderClassName| |org.apache.pulsar.transaction.coordinator.impl.InMemTransactionMetadataStoreProvider|
-|defaultRetentionTimeInMinutes| Default message retention time  |0|
-|defaultRetentionSizeInMB|  Default retention size  |0|
+|defaultRetentionTimeInMinutes| Default message retention time. Value of 0 means the retention is disabled, -1 means the data will not be removed by time quota  |0|
+|defaultRetentionSizeInMB|  Default retention size. Value of 0 means the retention is disabled, -1 means the data will not be removed by size quota  |0|
 |keepAliveIntervalSeconds|  How often to check whether the connections are still alive  |30|
 |bootstrapNamespaces| The bootstrap name. | N/A |
 |loadManagerClassName|  Name of load manager to use |org.apache.pulsar.broker.loadbalance.impl.SimpleLoadManagerImpl|

--- a/site2/website/versioned_docs/version-2.7.3/reference-configuration.md
+++ b/site2/website/versioned_docs/version-2.7.3/reference-configuration.md
@@ -310,8 +310,8 @@ Pulsar brokers are responsible for handling incoming messages from producers, di
 |brokerServicePurgeInactiveFrequencyInSeconds|Deprecated. Use `brokerDeleteInactiveTopicsFrequencySeconds`.|60|
 |transactionCoordinatorEnabled|Whether to enable transaction coordinator in broker.|true|
 |transactionMetadataStoreProviderClassName| |org.apache.pulsar.transaction.coordinator.impl.InMemTransactionMetadataStoreProvider|
-|defaultRetentionTimeInMinutes| Default message retention time. Value of 0 means the retention is disabled, -1 means the data will not be removed by time quota  |0|
-|defaultRetentionSizeInMB|  Default retention size. Value of 0 means the retention is disabled, -1 means the data will not be removed by size quota  |0|
+|defaultRetentionTimeInMinutes| Default message retention time. 0 means retention is disabled. -1 means data is not removed by time quota  |0|
+|defaultRetentionSizeInMB|  Default retention size. 0 means retention is disabled. -1 means data is not removed by size quota  |0|
 |keepAliveIntervalSeconds|  How often to check whether the connections are still alive  |30|
 |bootstrapNamespaces| The bootstrap name. | N/A |
 |loadManagerClassName|  Name of load manager to use |org.apache.pulsar.broker.loadbalance.impl.SimpleLoadManagerImpl|

--- a/site2/website/versioned_docs/version-2.7.4/reference-configuration.md
+++ b/site2/website/versioned_docs/version-2.7.4/reference-configuration.md
@@ -308,8 +308,8 @@ Pulsar brokers are responsible for handling incoming messages from producers, di
 |brokerServicePurgeInactiveFrequencyInSeconds|Deprecated. Use `brokerDeleteInactiveTopicsFrequencySeconds`.|60|
 |transactionCoordinatorEnabled|Whether to enable transaction coordinator in broker.|true|
 |transactionMetadataStoreProviderClassName| |org.apache.pulsar.transaction.coordinator.impl.InMemTransactionMetadataStoreProvider|
-|defaultRetentionTimeInMinutes| Default message retention time. Value of 0 means the retention is disabled, -1 means the data will not be removed by time quota  |0|
-|defaultRetentionSizeInMB|  Default retention size. Value of 0 means the retention is disabled, -1 means the data will not be removed by size quota  |0|
+|defaultRetentionTimeInMinutes| Default message retention time. 0 means retention is disabled. -1 means data is not removed by time quota  |0|
+|defaultRetentionSizeInMB|  Default retention size. 0 means retention is disabled. -1 means data is not removed by size quota  |0|
 |keepAliveIntervalSeconds|  How often to check whether the connections are still alive  |30|
 |bootstrapNamespaces| The bootstrap name. | N/A |
 |loadManagerClassName|  Name of load manager to use |org.apache.pulsar.broker.loadbalance.impl.SimpleLoadManagerImpl|

--- a/site2/website/versioned_docs/version-2.7.4/reference-configuration.md
+++ b/site2/website/versioned_docs/version-2.7.4/reference-configuration.md
@@ -308,8 +308,8 @@ Pulsar brokers are responsible for handling incoming messages from producers, di
 |brokerServicePurgeInactiveFrequencyInSeconds|Deprecated. Use `brokerDeleteInactiveTopicsFrequencySeconds`.|60|
 |transactionCoordinatorEnabled|Whether to enable transaction coordinator in broker.|true|
 |transactionMetadataStoreProviderClassName| |org.apache.pulsar.transaction.coordinator.impl.InMemTransactionMetadataStoreProvider|
-|defaultRetentionTimeInMinutes| Default message retention time  |0|
-|defaultRetentionSizeInMB|  Default retention size  |0|
+|defaultRetentionTimeInMinutes| Default message retention time. Value of 0 means the retention is disabled, -1 means the data will not be removed by time quota  |0|
+|defaultRetentionSizeInMB|  Default retention size. Value of 0 means the retention is disabled, -1 means the data will not be removed by size quota  |0|
 |keepAliveIntervalSeconds|  How often to check whether the connections are still alive  |30|
 |bootstrapNamespaces| The bootstrap name. | N/A |
 |loadManagerClassName|  Name of load manager to use |org.apache.pulsar.broker.loadbalance.impl.SimpleLoadManagerImpl|

--- a/site2/website/versioned_docs/version-2.8.0-deprecated/reference-configuration.md
+++ b/site2/website/versioned_docs/version-2.8.0-deprecated/reference-configuration.md
@@ -313,8 +313,8 @@ brokerServiceCompactionThresholdInBytes|If the estimated backlog size is greater
 |brokerServicePurgeInactiveFrequencyInSeconds|Deprecated. Use `brokerDeleteInactiveTopicsFrequencySeconds`.|60|
 |transactionCoordinatorEnabled|Whether to enable transaction coordinator in broker.|true|
 |transactionMetadataStoreProviderClassName| |org.apache.pulsar.transaction.coordinator.impl.InMemTransactionMetadataStoreProvider|
-|defaultRetentionTimeInMinutes| Default message retention time  |0|
-|defaultRetentionSizeInMB|  Default retention size  |0|
+|defaultRetentionTimeInMinutes| Default message retention time. Value of 0 means the retention is disabled, -1 means the data will not be removed by time quota  |0|
+|defaultRetentionSizeInMB|  Default retention size. Value of 0 means the retention is disabled, -1 means the data will not be removed by size quota  |0|
 |keepAliveIntervalSeconds|  How often to check whether the connections are still alive  |30|
 |bootstrapNamespaces| The bootstrap name. | N/A |
 |loadManagerClassName|  Name of load manager to use |org.apache.pulsar.broker.loadbalance.impl.SimpleLoadManagerImpl|

--- a/site2/website/versioned_docs/version-2.8.0-deprecated/reference-configuration.md
+++ b/site2/website/versioned_docs/version-2.8.0-deprecated/reference-configuration.md
@@ -313,8 +313,8 @@ brokerServiceCompactionThresholdInBytes|If the estimated backlog size is greater
 |brokerServicePurgeInactiveFrequencyInSeconds|Deprecated. Use `brokerDeleteInactiveTopicsFrequencySeconds`.|60|
 |transactionCoordinatorEnabled|Whether to enable transaction coordinator in broker.|true|
 |transactionMetadataStoreProviderClassName| |org.apache.pulsar.transaction.coordinator.impl.InMemTransactionMetadataStoreProvider|
-|defaultRetentionTimeInMinutes| Default message retention time. Value of 0 means the retention is disabled, -1 means the data will not be removed by time quota  |0|
-|defaultRetentionSizeInMB|  Default retention size. Value of 0 means the retention is disabled, -1 means the data will not be removed by size quota  |0|
+|defaultRetentionTimeInMinutes| Default message retention time. 0 means retention is disabled. -1 means data is not removed by time quota  |0|
+|defaultRetentionSizeInMB|  Default retention size. 0 means retention is disabled. -1 means data is not removed by size quota  |0|
 |keepAliveIntervalSeconds|  How often to check whether the connections are still alive  |30|
 |bootstrapNamespaces| The bootstrap name. | N/A |
 |loadManagerClassName|  Name of load manager to use |org.apache.pulsar.broker.loadbalance.impl.SimpleLoadManagerImpl|

--- a/site2/website/versioned_docs/version-2.8.1-deprecated/reference-configuration.md
+++ b/site2/website/versioned_docs/version-2.8.1-deprecated/reference-configuration.md
@@ -313,8 +313,8 @@ brokerServiceCompactionThresholdInBytes|If the estimated backlog size is greater
 |brokerServicePurgeInactiveFrequencyInSeconds|Deprecated. Use `brokerDeleteInactiveTopicsFrequencySeconds`.|60|
 |transactionCoordinatorEnabled|Whether to enable transaction coordinator in broker.|true|
 |transactionMetadataStoreProviderClassName| |org.apache.pulsar.transaction.coordinator.impl.InMemTransactionMetadataStoreProvider|
-|defaultRetentionTimeInMinutes| Default message retention time  |0|
-|defaultRetentionSizeInMB|  Default retention size  |0|
+|defaultRetentionTimeInMinutes| Default message retention time. Value of 0 means the retention is disabled, -1 means the data will not be removed by time quota  |0|
+|defaultRetentionSizeInMB|  Default retention size. Value of 0 means the retention is disabled, -1 means the data will not be removed by size quota  |0|
 |keepAliveIntervalSeconds|  How often to check whether the connections are still alive  |30|
 |bootstrapNamespaces| The bootstrap name. | N/A |
 |loadManagerClassName|  Name of load manager to use |org.apache.pulsar.broker.loadbalance.impl.SimpleLoadManagerImpl|

--- a/site2/website/versioned_docs/version-2.8.1-deprecated/reference-configuration.md
+++ b/site2/website/versioned_docs/version-2.8.1-deprecated/reference-configuration.md
@@ -313,8 +313,8 @@ brokerServiceCompactionThresholdInBytes|If the estimated backlog size is greater
 |brokerServicePurgeInactiveFrequencyInSeconds|Deprecated. Use `brokerDeleteInactiveTopicsFrequencySeconds`.|60|
 |transactionCoordinatorEnabled|Whether to enable transaction coordinator in broker.|true|
 |transactionMetadataStoreProviderClassName| |org.apache.pulsar.transaction.coordinator.impl.InMemTransactionMetadataStoreProvider|
-|defaultRetentionTimeInMinutes| Default message retention time. Value of 0 means the retention is disabled, -1 means the data will not be removed by time quota  |0|
-|defaultRetentionSizeInMB|  Default retention size. Value of 0 means the retention is disabled, -1 means the data will not be removed by size quota  |0|
+|defaultRetentionTimeInMinutes| Default message retention time. 0 means retention is disabled. -1 means data is not removed by time quota  |0|
+|defaultRetentionSizeInMB|  Default retention size. 0 means retention is disabled. -1 means data is not removed by size quota  |0|
 |keepAliveIntervalSeconds|  How often to check whether the connections are still alive  |30|
 |bootstrapNamespaces| The bootstrap name. | N/A |
 |loadManagerClassName|  Name of load manager to use |org.apache.pulsar.broker.loadbalance.impl.SimpleLoadManagerImpl|

--- a/site2/website/versioned_docs/version-2.8.2-deprecated/reference-configuration.md
+++ b/site2/website/versioned_docs/version-2.8.2-deprecated/reference-configuration.md
@@ -314,8 +314,8 @@ brokerServiceCompactionThresholdInBytes|If the estimated backlog size is greater
 |brokerServicePurgeInactiveFrequencyInSeconds|Deprecated. Use `brokerDeleteInactiveTopicsFrequencySeconds`.|60|
 |transactionCoordinatorEnabled|Whether to enable transaction coordinator in broker.|true|
 |transactionMetadataStoreProviderClassName| |org.apache.pulsar.transaction.coordinator.impl.InMemTransactionMetadataStoreProvider|
-|defaultRetentionTimeInMinutes| Default message retention time. Value of 0 means the retention is disabled, -1 means the data will not be removed by time quota  |0|
-|defaultRetentionSizeInMB|  Default retention size. Value of 0 means the retention is disabled, -1 means the data will not be removed by size quota  |0|
+|defaultRetentionTimeInMinutes| Default message retention time. 0 means retention is disabled. -1 means data is not removed by time quota  |0|
+|defaultRetentionSizeInMB|  Default retention size. 0 means retention is disabled. -1 means data is not removed by size quota  |0|
 |keepAliveIntervalSeconds|  How often to check whether the connections are still alive  |30|
 |bootstrapNamespaces| The bootstrap name. | N/A |
 |loadManagerClassName|  Name of load manager to use |org.apache.pulsar.broker.loadbalance.impl.SimpleLoadManagerImpl|

--- a/site2/website/versioned_docs/version-2.8.2-deprecated/reference-configuration.md
+++ b/site2/website/versioned_docs/version-2.8.2-deprecated/reference-configuration.md
@@ -314,8 +314,8 @@ brokerServiceCompactionThresholdInBytes|If the estimated backlog size is greater
 |brokerServicePurgeInactiveFrequencyInSeconds|Deprecated. Use `brokerDeleteInactiveTopicsFrequencySeconds`.|60|
 |transactionCoordinatorEnabled|Whether to enable transaction coordinator in broker.|true|
 |transactionMetadataStoreProviderClassName| |org.apache.pulsar.transaction.coordinator.impl.InMemTransactionMetadataStoreProvider|
-|defaultRetentionTimeInMinutes| Default message retention time  |0|
-|defaultRetentionSizeInMB|  Default retention size  |0|
+|defaultRetentionTimeInMinutes| Default message retention time. Value of 0 means the retention is disabled, -1 means the data will not be removed by time quota  |0|
+|defaultRetentionSizeInMB|  Default retention size. Value of 0 means the retention is disabled, -1 means the data will not be removed by size quota  |0|
 |keepAliveIntervalSeconds|  How often to check whether the connections are still alive  |30|
 |bootstrapNamespaces| The bootstrap name. | N/A |
 |loadManagerClassName|  Name of load manager to use |org.apache.pulsar.broker.loadbalance.impl.SimpleLoadManagerImpl|

--- a/site2/website/versioned_docs/version-2.8.3-deprecated/reference-configuration.md
+++ b/site2/website/versioned_docs/version-2.8.3-deprecated/reference-configuration.md
@@ -314,8 +314,8 @@ brokerServiceCompactionThresholdInBytes|If the estimated backlog size is greater
 |brokerServicePurgeInactiveFrequencyInSeconds|Deprecated. Use `brokerDeleteInactiveTopicsFrequencySeconds`.|60|
 |transactionCoordinatorEnabled|Whether to enable transaction coordinator in broker.|true|
 |transactionMetadataStoreProviderClassName| |org.apache.pulsar.transaction.coordinator.impl.InMemTransactionMetadataStoreProvider|
-|defaultRetentionTimeInMinutes| Default message retention time. Value of 0 means the retention is disabled, -1 means the data will not be removed by time quota  |0|
-|defaultRetentionSizeInMB|  Default retention size. Value of 0 means the retention is disabled, -1 means the data will not be removed by size quota  |0|
+|defaultRetentionTimeInMinutes| Default message retention time. 0 means retention is disabled. -1 means data is not removed by time quota  |0|
+|defaultRetentionSizeInMB|  Default retention size. 0 means retention is disabled. -1 means data is not removed by size quota  |0|
 |keepAliveIntervalSeconds|  How often to check whether the connections are still alive  |30|
 |bootstrapNamespaces| The bootstrap name. | N/A |
 |loadManagerClassName|  Name of load manager to use |org.apache.pulsar.broker.loadbalance.impl.SimpleLoadManagerImpl|

--- a/site2/website/versioned_docs/version-2.8.3-deprecated/reference-configuration.md
+++ b/site2/website/versioned_docs/version-2.8.3-deprecated/reference-configuration.md
@@ -314,8 +314,8 @@ brokerServiceCompactionThresholdInBytes|If the estimated backlog size is greater
 |brokerServicePurgeInactiveFrequencyInSeconds|Deprecated. Use `brokerDeleteInactiveTopicsFrequencySeconds`.|60|
 |transactionCoordinatorEnabled|Whether to enable transaction coordinator in broker.|true|
 |transactionMetadataStoreProviderClassName| |org.apache.pulsar.transaction.coordinator.impl.InMemTransactionMetadataStoreProvider|
-|defaultRetentionTimeInMinutes| Default message retention time  |0|
-|defaultRetentionSizeInMB|  Default retention size  |0|
+|defaultRetentionTimeInMinutes| Default message retention time. Value of 0 means the retention is disabled, -1 means the data will not be removed by time quota  |0|
+|defaultRetentionSizeInMB|  Default retention size. Value of 0 means the retention is disabled, -1 means the data will not be removed by size quota  |0|
 |keepAliveIntervalSeconds|  How often to check whether the connections are still alive  |30|
 |bootstrapNamespaces| The bootstrap name. | N/A |
 |loadManagerClassName|  Name of load manager to use |org.apache.pulsar.broker.loadbalance.impl.SimpleLoadManagerImpl|

--- a/site2/website/versioned_docs/version-2.9.0-deprecated/reference-configuration.md
+++ b/site2/website/versioned_docs/version-2.9.0-deprecated/reference-configuration.md
@@ -313,8 +313,8 @@ brokerServiceCompactionThresholdInBytes|If the estimated backlog size is greater
 |brokerServicePurgeInactiveFrequencyInSeconds|Deprecated. Use `brokerDeleteInactiveTopicsFrequencySeconds`.|60|
 |transactionCoordinatorEnabled|Whether to enable transaction coordinator in broker.|true|
 |transactionMetadataStoreProviderClassName| |org.apache.pulsar.transaction.coordinator.impl.InMemTransactionMetadataStoreProvider|
-|defaultRetentionTimeInMinutes| Default message retention time  |0|
-|defaultRetentionSizeInMB|  Default retention size  |0|
+|defaultRetentionTimeInMinutes| Default message retention time. Value of 0 means the retention is disabled, -1 means the data will not be removed by time quota  |0|
+|defaultRetentionSizeInMB|  Default retention size. Value of 0 means the retention is disabled, -1 means the data will not be removed by size quota  |0|
 |keepAliveIntervalSeconds|  How often to check whether the connections are still alive  |30|
 |bootstrapNamespaces| The bootstrap name. | N/A |
 |loadManagerClassName|  Name of load manager to use |org.apache.pulsar.broker.loadbalance.impl.SimpleLoadManagerImpl|

--- a/site2/website/versioned_docs/version-2.9.0-deprecated/reference-configuration.md
+++ b/site2/website/versioned_docs/version-2.9.0-deprecated/reference-configuration.md
@@ -313,8 +313,8 @@ brokerServiceCompactionThresholdInBytes|If the estimated backlog size is greater
 |brokerServicePurgeInactiveFrequencyInSeconds|Deprecated. Use `brokerDeleteInactiveTopicsFrequencySeconds`.|60|
 |transactionCoordinatorEnabled|Whether to enable transaction coordinator in broker.|true|
 |transactionMetadataStoreProviderClassName| |org.apache.pulsar.transaction.coordinator.impl.InMemTransactionMetadataStoreProvider|
-|defaultRetentionTimeInMinutes| Default message retention time. Value of 0 means the retention is disabled, -1 means the data will not be removed by time quota  |0|
-|defaultRetentionSizeInMB|  Default retention size. Value of 0 means the retention is disabled, -1 means the data will not be removed by size quota  |0|
+|defaultRetentionTimeInMinutes| Default message retention time. 0 means retention is disabled. -1 means data is not removed by time quota  |0|
+|defaultRetentionSizeInMB|  Default retention size. 0 means retention is disabled. -1 means data is not removed by size quota  |0|
 |keepAliveIntervalSeconds|  How often to check whether the connections are still alive  |30|
 |bootstrapNamespaces| The bootstrap name. | N/A |
 |loadManagerClassName|  Name of load manager to use |org.apache.pulsar.broker.loadbalance.impl.SimpleLoadManagerImpl|

--- a/site2/website/versioned_docs/version-2.9.1-deprecated/reference-configuration.md
+++ b/site2/website/versioned_docs/version-2.9.1-deprecated/reference-configuration.md
@@ -313,8 +313,8 @@ brokerServiceCompactionThresholdInBytes|If the estimated backlog size is greater
 |brokerServicePurgeInactiveFrequencyInSeconds|Deprecated. Use `brokerDeleteInactiveTopicsFrequencySeconds`.|60|
 |transactionCoordinatorEnabled|Whether to enable transaction coordinator in broker.|true|
 |transactionMetadataStoreProviderClassName| |org.apache.pulsar.transaction.coordinator.impl.InMemTransactionMetadataStoreProvider|
-|defaultRetentionTimeInMinutes| Default message retention time  |0|
-|defaultRetentionSizeInMB|  Default retention size  |0|
+|defaultRetentionTimeInMinutes| Default message retention time. Value of 0 means the retention is disabled, -1 means the data will not be removed by time quota  |0|
+|defaultRetentionSizeInMB|  Default retention size. Value of 0 means the retention is disabled, -1 means the data will not be removed by size quota  |0|
 |keepAliveIntervalSeconds|  How often to check whether the connections are still alive  |30|
 |bootstrapNamespaces| The bootstrap name. | N/A |
 |loadManagerClassName|  Name of load manager to use |org.apache.pulsar.broker.loadbalance.impl.SimpleLoadManagerImpl|

--- a/site2/website/versioned_docs/version-2.9.1-deprecated/reference-configuration.md
+++ b/site2/website/versioned_docs/version-2.9.1-deprecated/reference-configuration.md
@@ -313,8 +313,8 @@ brokerServiceCompactionThresholdInBytes|If the estimated backlog size is greater
 |brokerServicePurgeInactiveFrequencyInSeconds|Deprecated. Use `brokerDeleteInactiveTopicsFrequencySeconds`.|60|
 |transactionCoordinatorEnabled|Whether to enable transaction coordinator in broker.|true|
 |transactionMetadataStoreProviderClassName| |org.apache.pulsar.transaction.coordinator.impl.InMemTransactionMetadataStoreProvider|
-|defaultRetentionTimeInMinutes| Default message retention time. Value of 0 means the retention is disabled, -1 means the data will not be removed by time quota  |0|
-|defaultRetentionSizeInMB|  Default retention size. Value of 0 means the retention is disabled, -1 means the data will not be removed by size quota  |0|
+|defaultRetentionTimeInMinutes| Default message retention time. 0 means retention is disabled. -1 means data is not removed by time quota  |0|
+|defaultRetentionSizeInMB|  Default retention size. 0 means retention is disabled. -1 means data is not removed by size quota  |0|
 |keepAliveIntervalSeconds|  How often to check whether the connections are still alive  |30|
 |bootstrapNamespaces| The bootstrap name. | N/A |
 |loadManagerClassName|  Name of load manager to use |org.apache.pulsar.broker.loadbalance.impl.SimpleLoadManagerImpl|

--- a/site2/website/versioned_docs/version-2.9.2-deprecated/reference-configuration.md
+++ b/site2/website/versioned_docs/version-2.9.2-deprecated/reference-configuration.md
@@ -313,8 +313,8 @@ brokerServiceCompactionThresholdInBytes|If the estimated backlog size is greater
 |brokerServicePurgeInactiveFrequencyInSeconds|Deprecated. Use `brokerDeleteInactiveTopicsFrequencySeconds`.|60|
 |transactionCoordinatorEnabled|Whether to enable transaction coordinator in broker.|true|
 |transactionMetadataStoreProviderClassName| |org.apache.pulsar.transaction.coordinator.impl.InMemTransactionMetadataStoreProvider|
-|defaultRetentionTimeInMinutes| Default message retention time  |0|
-|defaultRetentionSizeInMB|  Default retention size  |0|
+|defaultRetentionTimeInMinutes| Default message retention time. Value of 0 means the retention is disabled, -1 means the data will not be removed by time quota  |0|
+|defaultRetentionSizeInMB|  Default retention size. Value of 0 means the retention is disabled, -1 means the data will not be removed by size quota  |0|
 |keepAliveIntervalSeconds|  How often to check whether the connections are still alive  |30|
 |bootstrapNamespaces| The bootstrap name. | N/A |
 |loadManagerClassName|  Name of load manager to use |org.apache.pulsar.broker.loadbalance.impl.SimpleLoadManagerImpl|

--- a/site2/website/versioned_docs/version-2.9.2-deprecated/reference-configuration.md
+++ b/site2/website/versioned_docs/version-2.9.2-deprecated/reference-configuration.md
@@ -313,8 +313,8 @@ brokerServiceCompactionThresholdInBytes|If the estimated backlog size is greater
 |brokerServicePurgeInactiveFrequencyInSeconds|Deprecated. Use `brokerDeleteInactiveTopicsFrequencySeconds`.|60|
 |transactionCoordinatorEnabled|Whether to enable transaction coordinator in broker.|true|
 |transactionMetadataStoreProviderClassName| |org.apache.pulsar.transaction.coordinator.impl.InMemTransactionMetadataStoreProvider|
-|defaultRetentionTimeInMinutes| Default message retention time. Value of 0 means the retention is disabled, -1 means the data will not be removed by time quota  |0|
-|defaultRetentionSizeInMB|  Default retention size. Value of 0 means the retention is disabled, -1 means the data will not be removed by size quota  |0|
+|defaultRetentionTimeInMinutes| Default message retention time. 0 means retention is disabled. -1 means data is not removed by time quota  |0|
+|defaultRetentionSizeInMB|  Default retention size. 0 means retention is disabled. -1 means data is not removed by size quota  |0|
 |keepAliveIntervalSeconds|  How often to check whether the connections are still alive  |30|
 |bootstrapNamespaces| The bootstrap name. | N/A |
 |loadManagerClassName|  Name of load manager to use |org.apache.pulsar.broker.loadbalance.impl.SimpleLoadManagerImpl|

--- a/site2/website/versioned_docs/version-2.9.3-deprecated/reference-configuration.md
+++ b/site2/website/versioned_docs/version-2.9.3-deprecated/reference-configuration.md
@@ -313,8 +313,8 @@ brokerServiceCompactionThresholdInBytes|If the estimated backlog size is greater
 |brokerServicePurgeInactiveFrequencyInSeconds|Deprecated. Use `brokerDeleteInactiveTopicsFrequencySeconds`.|60|
 |transactionCoordinatorEnabled|Whether to enable transaction coordinator in broker.|true|
 |transactionMetadataStoreProviderClassName| |org.apache.pulsar.transaction.coordinator.impl.InMemTransactionMetadataStoreProvider|
-|defaultRetentionTimeInMinutes| Default message retention time  |0|
-|defaultRetentionSizeInMB|  Default retention size  |0|
+|defaultRetentionTimeInMinutes| Default message retention time. Value of 0 means the retention is disabled, -1 means the data will not be removed by time quota  |0|
+|defaultRetentionSizeInMB|  Default retention size. Value of 0 means the retention is disabled, -1 means the data will not be removed by size quota  |0|
 |keepAliveIntervalSeconds|  How often to check whether the connections are still alive  |30|
 |bootstrapNamespaces| The bootstrap name. | N/A |
 |loadManagerClassName|  Name of load manager to use |org.apache.pulsar.broker.loadbalance.impl.SimpleLoadManagerImpl|

--- a/site2/website/versioned_docs/version-2.9.3-deprecated/reference-configuration.md
+++ b/site2/website/versioned_docs/version-2.9.3-deprecated/reference-configuration.md
@@ -313,8 +313,8 @@ brokerServiceCompactionThresholdInBytes|If the estimated backlog size is greater
 |brokerServicePurgeInactiveFrequencyInSeconds|Deprecated. Use `brokerDeleteInactiveTopicsFrequencySeconds`.|60|
 |transactionCoordinatorEnabled|Whether to enable transaction coordinator in broker.|true|
 |transactionMetadataStoreProviderClassName| |org.apache.pulsar.transaction.coordinator.impl.InMemTransactionMetadataStoreProvider|
-|defaultRetentionTimeInMinutes| Default message retention time. Value of 0 means the retention is disabled, -1 means the data will not be removed by time quota  |0|
-|defaultRetentionSizeInMB|  Default retention size. Value of 0 means the retention is disabled, -1 means the data will not be removed by size quota  |0|
+|defaultRetentionTimeInMinutes| Default message retention time. 0 means retention is disabled. -1 means data is not removed by time quota  |0|
+|defaultRetentionSizeInMB|  Default retention size. 0 means retention is disabled. -1 means data is not removed by size quota  |0|
 |keepAliveIntervalSeconds|  How often to check whether the connections are still alive  |30|
 |bootstrapNamespaces| The bootstrap name. | N/A |
 |loadManagerClassName|  Name of load manager to use |org.apache.pulsar.broker.loadbalance.impl.SimpleLoadManagerImpl|


### PR DESCRIPTION
### Motivation

 There is only a simple word `Default message retention time/size`  on  `defaultRetentionTimeInMinutes=0` and `defaultRetentionSizeInMB=0` in broker.conf. 
 
 I think it is not clear for users because `0` and `-1` are both special numbers but have different meaning here.  It is easliy that new users maybe mistaken thought a value of `0` means limit as "infinite" size quota , but in fact direct opposite.

### Modifications

* Improve `defaultRetentionTimeInMinutes` and `defaultRetentionSizeInMB` doc  on *.conf  and *.md and `ServiceConfiguration.java`

### Verifying this change

- [x] Make sure that the change passes the CI checks.


### Documentation

Check the box below or label this PR directly.

Need to update docs? 

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)
  
- [ ] `doc-not-needed` 
(Please explain why)
  
- [x] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)