### PR TITLE
[fix][broker][branch-2.8] Fix potential to add duplicated consumer

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
@@ -976,34 +976,31 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
                                 consumerFuture);
 
                         if (existingConsumerFuture != null) {
-                            if (existingConsumerFuture.isDone() && !existingConsumerFuture.isCompletedExceptionally()) {
-                                Consumer consumer = existingConsumerFuture.getNow(null);
-                                log.info("[{}] Consumer with the same id is already created:"
-                                         + " consumerId={}, consumer={}",
-                                         remoteAddress, consumerId, consumer);
-                                commandSender.sendSuccessResponse(requestId);
-                                return null;
-                            } else {
-                                // There was an early request to create a consumer with same consumerId. This can happen
+                            if (!existingConsumerFuture.isDone()){
                                 // when
                                 // client timeout is lower the broker timeouts. We need to wait until the previous
                                 // consumer
                                 // creation request either complete or fails.
                                 log.warn("[{}][{}][{}] Consumer with id is already present on the connection,"
-                                         + " consumerId={}", remoteAddress, topicName, subscriptionName, consumerId);
-                                ServerError error = null;
-                                if (!existingConsumerFuture.isDone()) {
-                                    error = ServerError.ServiceNotReady;
-                                } else {
-                                    error = getErrorCode(existingConsumerFuture);
-                                    consumers.remove(consumerId, existingConsumerFuture);
-                                }
-                                commandSender.sendErrorResponse(requestId, error,
+                                        + " consumerId={}", remoteAddress, topicName, subscriptionName, consumerId);
+                                commandSender.sendErrorResponse(requestId, ServerError.ServiceNotReady,
                                         "Consumer is already present on the connection");
-                                return null;
+                            } else if (existingConsumerFuture.isCompletedExceptionally()){
+                                ServerError error = getErrorCodeWithErrorLog(existingConsumerFuture, true,
+                                        String.format("Consumer subscribe failure. remoteAddress: %s, subscription: %s",
+                                                remoteAddress, subscriptionName));
+                                consumers.remove(consumerId, existingConsumerFuture);
+                                commandSender.sendErrorResponse(requestId, error,
+                                        "Consumer that failed is already present on the connection");
+                            } else {
+                                Consumer consumer = existingConsumerFuture.getNow(null);
+                                log.info("[{}] Consumer with the same id is already created:"
+                                                + " consumerId={}, consumer={}",
+                                        remoteAddress, consumerId, consumer);
+                                commandSender.sendSuccessResponse(requestId);
                             }
+                            return null;
                         }
-
                         boolean createTopicIfDoesNotExist = forceTopicCreation
                                 && service.isAllowAutoTopicCreation(topicName.toString());
 
@@ -2486,12 +2483,22 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
     }
 
     private <T> ServerError getErrorCode(CompletableFuture<T> future) {
+        return getErrorCodeWithErrorLog(future, false, null);
+    }
+
+    private <T> ServerError getErrorCodeWithErrorLog(CompletableFuture<T> future, boolean logIfError,
+                                                     String errorMessageIfLog) {
         ServerError error = ServerError.UnknownError;
         try {
             future.getNow(null);
         } catch (Exception e) {
             if (e.getCause() instanceof BrokerServiceException) {
                 error = BrokerServiceException.getClientErrorCode(e.getCause());
+            }
+            if (logIfError){
+                String finalErrorMessage = StringUtils.isNotBlank(errorMessageIfLog)
+                        ? errorMessageIfLog : "Unknown Error";
+                log.error(finalErrorMessage, e);
             }
         }
         return error;


### PR DESCRIPTION
### Motivation

see #15051

There have conflicts when cherry-picking #15051 PR (branch 2.8 has no `mock static` support), so I created a separate PR to fix branch-2.8

### Modifications

Swap the execution order of duplicate validation and maximum validation

### Documentation

- [ ] `doc-required` 
  
- [x] `doc-not-needed` 
  
- [ ] `doc` 

- [ ] `doc-complete`