### PR TITLE
[feature][broker] Support cgroup v2 for by using `jdk.internal.platform.Metrics` in Pulsar Loadbalancer

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -98,6 +98,7 @@ flexible messaging model and an intuitive client API.</description>
       --add-opens java.base/java.io=ALL-UNNAMED <!--Bookkeeper NativeIO -->
       --add-opens java.base/sun.net=ALL-UNNAMED <!--netty.DnsResolverUtil-->
       --add-opens java.management/sun.management=ALL-UNNAMED <!--JvmDefaultGCMetricsLogger-->
+      --add-opens java.base/jdk.internal.platform=ALL-UNNAMED <!--LinuxInfoUtils-->
     </test.additional.args>
     <testReuseFork>true</testReuseFork>
     <testForkCount>4</testForkCount>

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/SimpleBrokerStartTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/SimpleBrokerStartTest.java
@@ -21,14 +21,21 @@ package org.apache.pulsar.broker.loadbalance;
 import static org.mockito.Mockito.spy;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
+import com.google.common.base.Charsets;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Optional;
 import lombok.Cleanup;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.SystemUtils;
 import org.apache.pulsar.broker.PulsarServerException;
 import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.broker.ServiceConfiguration;
 import org.apache.pulsar.broker.loadbalance.impl.SimpleLoadManagerImpl;
 import org.apache.pulsar.zookeeper.LocalBookkeeperEnsemble;
+import org.testng.Assert;
 import org.testng.annotations.Test;
 
 @Slf4j
@@ -96,5 +103,39 @@ public class SimpleBrokerStartTest {
         }
     }
 
+
+    @Test
+    public void testCGroupMetrics() throws IOException {
+        if (!SystemUtils.IS_OS_LINUX) {
+            return;
+        }
+
+        boolean existsCGroup = Files.exists(Paths.get("/sys/fs/cgroup/cpu/cpuacct.usage"));
+        boolean cGroupEnabled = LinuxInfoUtils.isCGroupEnabled();
+        Assert.assertEquals(cGroupEnabled, existsCGroup);
+
+        double totalCpuLimit = LinuxInfoUtils.getTotalCpuLimit(cGroupEnabled);
+        double expectTotalCpuLimit = getTotalCpuLimit(cGroupEnabled);
+        Assert.assertEquals(totalCpuLimit, expectTotalCpuLimit);
+
+        if (cGroupEnabled) {
+            double cpuUsageForCGroup = LinuxInfoUtils.getCpuUsageForCGroup();
+            log.info("cpuUsageForCGroup: {}", cpuUsageForCGroup);
+        }
+    }
+
+    public static double getTotalCpuLimit(boolean isCGroupsEnabled) throws IOException {
+        if (isCGroupsEnabled) {
+            long quota = Long.parseLong(
+                    Files.readString(Path.of("/sys/fs/cgroup/cpu/cpu.cfs_quota_us"), Charsets.UTF_8).trim());
+            long period = Long.parseLong(
+                    Files.readString(Path.of("/sys/fs/cgroup/cpu/cpu.cfs_period_us"), Charsets.UTF_8).trim());
+            if (quota > 0) {
+                return 100.0 * quota / period;
+            }
+        }
+        // Fallback to JVM reported CPU quota
+        return 100 * Runtime.getRuntime().availableProcessors();
+    }
 
 }


### PR DESCRIPTION
Master Issue: #16601

### Motivation

The Pulsar loadbalancer detects CPU limits using cgroup v1 API, and the `jdk.internal.platform.Metrics` already support cgroup (V1, v2) so we should use `jdk.internal.platform.Metrics` to get the cgroup metrics.

### Modifications

Use `jdk.internal.platform.Metrics` to get the cgroup metrics in Pulsar Loadbalancer.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change is already covered by existing tests, such as *testCGroupMetrics*.

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API: (yes / no)
  - The schema: (yes / no / don't know)
  - The default values of configurations: (yes / no)
  - The wire protocol: (yes / no)
  - The rest endpoints: (yes / no)
  - The admin cli options: (yes / no)
  - Anything that affects deployment: (yes / no / don't know)

### Documentation

Check the box below or label this PR directly.

Need to update docs? 

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)
  
- [x] `doc-not-needed` 
(Please explain why)
  
- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)