### PR TITLE
[fix][proxy] Fix client service url

### DIFF
--- a/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/ProxyConnection.java
+++ b/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/ProxyConnection.java
@@ -565,8 +565,10 @@ public class ProxyConnection extends PulsarHandler {
 
     ClientConfigurationData createClientConfiguration() {
         ClientConfigurationData initialConf = new ClientConfigurationData();
-        initialConf.setServiceUrl(service.getServiceUrl());
         ProxyConfiguration proxyConfig = service.getConfiguration();
+        initialConf.setServiceUrl(
+                proxyConfig.isTlsEnabledWithBroker() ? service.getServiceUrlTls() : service.getServiceUrl());
+
         // Apply all arbitrary configuration. This must be called before setting any fields annotated as
         // @Secret on the ClientConfigurationData object because of the way they are serialized.
         // See https://github.com/apache/pulsar/issues/8509 for more information.

--- a/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyConnectionTest.java
+++ b/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyConnectionTest.java
@@ -18,8 +18,12 @@
  */
 package org.apache.pulsar.proxy.server;
 
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
+import org.apache.pulsar.client.impl.conf.ClientConfigurationData;
 import org.testng.annotations.Test;
 
 public class ProxyConnectionTest {
@@ -34,5 +38,25 @@ public class ProxyConnectionTest {
                 .matchesHostAndPort("pulsar://", "pulsar://1.2.3.4:12345", "5.6.7.8:1234"));
         assertFalse(ProxyConnection
                 .matchesHostAndPort("pulsar://", "pulsar://1.2.3.4:12345", "1.2.3.4:1234"));
+    }
+    @Test
+    public void testCreateClientConfiguration() {
+        ProxyConfiguration proxyConfiguration = new ProxyConfiguration();
+        proxyConfiguration.setTlsEnabledWithBroker(true);
+        String proxyUrlTls = "pulsar+ssl://proxy:6651";
+        String proxyUrl = "pulsar://proxy:6650";
+
+        ProxyService proxyService = mock(ProxyService.class);
+        doReturn(proxyConfiguration).when(proxyService).getConfiguration();
+        doReturn(proxyUrlTls).when(proxyService).getServiceUrlTls();
+        doReturn(proxyUrl).when(proxyService).getServiceUrl();
+
+        ProxyConnection proxyConnection = new ProxyConnection(proxyService, null);
+        ClientConfigurationData clientConfiguration = proxyConnection.createClientConfiguration();
+        assertEquals(clientConfiguration.getServiceUrl(), proxyUrlTls);
+
+        proxyConfiguration.setTlsEnabledWithBroker(false);
+        clientConfiguration = proxyConnection.createClientConfiguration();
+        assertEquals(clientConfiguration.getServiceUrl(), proxyUrl);
     }
 }


### PR DESCRIPTION
Signed-off-by: Zixuan Liu <nodeces@gmail.com>

### Motivation

When the TLS is enabled, the client always uses the non-TLS URL.

### Modifications

- Add check whether using the TLS URL

### Documentation

Check the box below or label this PR directly.

Need to update docs? 

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)
  
- [x] `doc-not-needed` 
(Please explain why)
  
- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)