### PR TITLE
[fix][broker] Fix misleading -c option in pulsar standalone

### DIFF
--- a/bin/pulsar
+++ b/bin/pulsar
@@ -371,7 +371,7 @@ elif [ $COMMAND == "functions-worker" ]; then
     exec $JAVA $OPTS -Dpulsar.log.file=$PULSAR_LOG_FILE org.apache.pulsar.functions.worker.FunctionWorkerStarter -c $PULSAR_WORKER_CONF $@
 elif [ $COMMAND == "standalone" ]; then
     PULSAR_LOG_FILE=${PULSAR_LOG_FILE:-"pulsar-standalone.log"}
-    exec $JAVA $LOG4J2_SHUTDOWN_HOOK_DISABLED $OPTS ${ZK_OPTS} -Dpulsar.log.file=$PULSAR_LOG_FILE org.apache.pulsar.PulsarStandaloneStarter --config $PULSAR_STANDALONE_CONF $@
+    exec $JAVA $LOG4J2_SHUTDOWN_HOOK_DISABLED $OPTS ${ZK_OPTS} -Dpulsar.log.file=$PULSAR_LOG_FILE -Dpulsar.config.file=$PULSAR_STANDALONE_CONF org.apache.pulsar.PulsarStandaloneStarter $@
 elif [ ${COMMAND} == "autorecovery" ]; then
     PULSAR_LOG_FILE=${PULSAR_LOG_FILE:-"pulsar-autorecovery.log"}
     exec $JAVA $OPTS -Dpulsar.log.file=$PULSAR_LOG_FILE org.apache.bookkeeper.replication.AutoRecoveryMain --conf $PULSAR_BOOKKEEPER_CONF $@

--- a/pulsar-broker/src/main/java/org/apache/pulsar/PulsarStandalone.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/PulsarStandalone.java
@@ -210,7 +210,7 @@ public class PulsarStandalone implements AutoCloseable {
         return help;
     }
 
-    @Parameter(names = { "-c", "--config" }, description = "Configuration file path", required = true)
+    @Parameter(names = { "-c", "--config" }, description = "Configuration file path")
     private String configFile;
 
     @Parameter(names = { "--wipe-data" }, description = "Clean up previous ZK/BK data")

--- a/pulsar-broker/src/main/java/org/apache/pulsar/PulsarStandaloneStarter.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/PulsarStandaloneStarter.java
@@ -21,6 +21,7 @@ package org.apache.pulsar;
 import static org.apache.commons.lang3.StringUtils.isBlank;
 import com.beust.jcommander.JCommander;
 import com.beust.jcommander.Parameter;
+import com.google.common.base.Strings;
 import java.io.FileInputStream;
 import java.util.Arrays;
 import lombok.extern.slf4j.Slf4j;
@@ -32,6 +33,9 @@ import org.apache.pulsar.common.util.CmdGenerateDocs;
 
 @Slf4j
 public class PulsarStandaloneStarter extends PulsarStandalone {
+
+    private static final String PULSAR_CONFIG_FILE = "pulsar.config.file";
+
     @Parameter(names = {"-g", "--generate-docs"}, description = "Generate docs")
     private boolean generateDocs = false;
 
@@ -41,9 +45,18 @@ public class PulsarStandaloneStarter extends PulsarStandalone {
         try {
             jcommander.addObject(this);
             jcommander.parse(args);
-            if (this.isHelp() || isBlank(this.getConfigFile())) {
+            if (this.isHelp()) {
                 jcommander.usage();
-                return;
+                System.exit(0);
+            }
+            if (Strings.isNullOrEmpty(this.getConfigFile())) {
+                String configFile = System.getProperty(PULSAR_CONFIG_FILE);
+                if (Strings.isNullOrEmpty(configFile)) {
+                    throw new IllegalArgumentException(
+                            "Config file not specified. Please use -c, --config-file or -Dpulsar.config.file to "
+                                    + "specify the config file.");
+                }
+                this.setConfigFile(configFile);
             }
             if (this.generateDocs) {
                 CmdGenerateDocs cmd = new CmdGenerateDocs("pulsar");
@@ -60,7 +73,7 @@ public class PulsarStandaloneStarter extends PulsarStandalone {
         } catch (Exception e) {
             jcommander.usage();
             log.error(e.getMessage());
-            return;
+            System.exit(1);
         }
 
         try (FileInputStream inputStream = new FileInputStream(this.getConfigFile())) {


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://docs.google.com/document/d/1d8Pw6ZbWk-_pCKdOmdvx9rnhPiyuxwq60_TrD68d7BA/edit#heading=h.trs9rsex3xom)*. 

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.

**(The sections below can be removed for hotfixes of typos)**
-->

Fixes #16800

### Motivation

The -c option offered in the standalone is missleading.
An error occurs when passing --config to the pulsar standalone:
```
2022-07-26T15:11:40,180+0200 [main] ERROR org.apache.pulsar.PulsarStandaloneStarter - Can only specify option -c once.
```

### Modifications

* Add `-Dpulsar.config.file` to specify the pulsar standalone config file
* The priority for config file loading: using `-c or --config` > using `-Dpulsar.config.file`
* Fix the standalone still execute after the argument check fails.

This PR will not change the existing behavior.

### Verifying this change

Execute `bin/pulsar standalone` and `bin/pulsar standalone -c {your-config-file}` to verify this change.

### Documentation

Check the box below or label this PR directly.

Need to update docs? 

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)
  
- [x] `doc-not-needed` 
(Please explain why)
  
- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)