### PR TITLE
[fix][broker] ManagedCursor: mark delete no callback when create meta-ledger fail

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
@@ -1874,7 +1874,7 @@ public class ManagedCursorImpl implements ManagedCursor {
                         // Create ledger failure, execute "callback.fail".
                         mdEntry.callback.markDeleteFailed((ManagedLedgerException) ex, mdEntry.ctx);
                     } else {
-                        // Create ledger and already set ledger-state to "Open" success, so goto the case: State.open.
+                        // Create ledger and already set state to "Open" success, so goto the case: State.open.
                         internalAsyncMarkDelete(newPosition, properties, callback, ctx);
                     }
                 });


### PR DESCRIPTION
Fixes: #16711

### Motivation

If the meta-ledger fails to be initialized when mark delete is executed, the callback of mark delete will not execute anymore. this case will occur in 1/1000 probability. You can reproduce it by doing this: "Run unit test `ManagedCursorTest.markDeleteWithZKErrors` 1000 times".

This problem also makes unit test `ManagedCursorTest.markDeleteWithZKErrors` flaky. #16711

When the problem occurs, the actual execution process is as follows:

#### Flow-1. The process we expect

| Time | `cursor mark deleted` | `meta thread` |
| -----------  | ----------- | ----------- |
| 1 | synchronized `pendingMarkDeleteOps` | |
| 2 | check meta-ledger state | |
| 3 | do create ledger |  |
| 4 | append to pending requests queue  |  |
| 4 |  | synchronized `pendingMarkDeleteOps`( <strong>High light</strong> ) |
| 5 |  | create ledger fail |
| 6 |  | loop pending requests, and fail callback | 

#### Flow-2. The process we did not expect. However, Thread `cursor mark deleted` and `meta thread` may be assigned to the same thread,  the actual maybe execution process is as follows:


| Time | `cursor mark deleted`/`meta thread` |
| -----------  | ----------- |
| 1 | synchronized `pendingMarkDeleteOps` |
| 2 | check meta-ledger state |
| 3 | do create ledger |
| 4 |  synchronized `pendingMarkDeleteOps` ( <strong>High light</strong> ) reentrant lock by the same thread, which we did not expect |
| 5 |  create ledger fail |
| 6 |  loop pending requests, and fail callback | 
| 7 | append to pending requests queue |
| 8 |  waiting callback...  |
| 9 |  waiting callback...  |


- Each column means the individual threads.
- Column Time is used only to indicate the order of each step, not the actual time.
- The important steps are explained below:

step-4: If the ledger fails to be created, will trigger a "fail back" for the pending requests, and the requests that have not been queued will be ignored.

https://github.com/apache/pulsar/blob/c217b8f559292fd34c6a4fb4b30aab213720d962/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java#L2570-L2577

step-5 ( <strong>High light</strong> ): If the meta ledger needs to be created, create ledger will be triggered first and the current request will be put into the `pending requests queue`. It is possible that `create ledger fail` has been completed before the request is put into the queue, so this request will not get the callback anymore( see flow2 above ).

https://github.com/apache/pulsar/blob/c217b8f559292fd34c6a4fb4b30aab213720d962/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java#L1870-L1876

### Modifications

- Selected plain ( <strong>High light</strong> )
   Makes `put request into the pending queue` executed before `create ledger`. 

- Rejected plan 
   Makes `put request into the pending queue` and `create ledger` execute serially. Why rejected this plan? Because plan-1 fewer changes.

### Documentation

Check the box below or label this PR directly.

Need to update docs? 

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)
  
- [x] `doc-not-needed` 
(Please explain why)
  
- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)