### PR TITLE
[Java Client] fix PatternTopicsChangedListener blocked when topic removed

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiTopicsConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiTopicsConsumerImpl.java
@@ -1208,7 +1208,9 @@ public class MultiTopicsConsumerImpl<T> extends ConsumerBase<T> {
                     });
 
                     removeTopic(topicName);
-                    ((UnAckedTopicMessageTracker) unAckedMessageTracker).removeTopicMessages(topicName);
+                    if (unAckedMessageTracker instanceof UnAckedTopicMessageTracker) {
+                        ((UnAckedTopicMessageTracker) unAckedMessageTracker).removeTopicMessages(topicName);
+                    }
 
                     unsubscribeFuture.complete(null);
                     log.info("[{}] [{}] [{}] Unsubscribed Topics Consumer, allTopicPartitionsNumber: {}",
@@ -1256,7 +1258,9 @@ public class MultiTopicsConsumerImpl<T> extends ConsumerBase<T> {
                     });
 
                     removeTopic(topicName);
-                    ((UnAckedTopicMessageTracker) unAckedMessageTracker).removeTopicMessages(topicName);
+                    if (unAckedMessageTracker instanceof UnAckedTopicMessageTracker) {
+                        ((UnAckedTopicMessageTracker) unAckedMessageTracker).removeTopicMessages(topicName);
+                    }
 
                     unsubscribeFuture.complete(null);
                     log.info("[{}] [{}] [{}] Removed Topics Consumer, allTopicPartitionsNumber: {}",


### PR DESCRIPTION
Fixes #16839

### Modifications
When `PatternTopicsChangedListener#onTopicsRemoved` triggered,  `removeConsumerAsync` will throw ClassCastException.
When ackTimeoutMillis = 0 (default value), `unAckedMessageTracker` is created with `UnAckedMessageTracker.UNACKED_MESSAGE_TRACKER_DISABLED`

### Verifying this change
This change is a trivial rework / code cleanup without any test coverage.

### Documentation

Check the box below or label this PR directly.
- [x] `doc-not-needed` 