### PR TITLE
[improve][broker] Support start multiple bookies for BKCluster

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/EndToEndMetadataTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/EndToEndMetadataTest.java
@@ -60,7 +60,7 @@ public class EndToEndMetadataTest extends BaseMetadataStoreTest {
         @Cleanup
         EmbeddedPulsarCluster epc = EmbeddedPulsarCluster.builder()
                 .numBrokers(1)
-                .numBookies(1)
+                .numBookies(2)
                 .metadataStoreUrl(urlSupplier.get())
                 .dataDir(tempDir.getAbsolutePath())
                 .clearOldData(true)

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/bookkeeper/BKCluster.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/bookkeeper/BKCluster.java
@@ -172,7 +172,7 @@ public class BKCluster implements AutoCloseable {
 
         // Create Bookie Servers (B1, B2, B3)
         for (int i = 0; i < numBookies; i++) {
-            startNewBookie();
+            startNewBookie(i);
         }
     }
 
@@ -197,13 +197,13 @@ public class BKCluster implements AutoCloseable {
         }
     }
 
-    private ServerConfiguration newServerConfiguration() throws Exception {
+    private ServerConfiguration newServerConfiguration(int index) throws Exception {
         File dataDir;
         if (clusterConf.dataDir != null) {
             dataDir = new File(clusterConf.dataDir);
         } else {
             // Use temp dir and clean it up later
-            dataDir = createTempDir("bookie", "test");
+            dataDir = createTempDir("bookie", index + "test");
         }
 
         if (clusterConf.clearOldData) {
@@ -259,12 +259,12 @@ public class BKCluster implements AutoCloseable {
      * Helper method to startup a new bookie server with the indicated port
      * number. Also, starts the auto recovery process, if the
      * isAutoRecoveryEnabled is set true.
-     *
+     * @param index Bookie index
      * @throws IOException
      */
-    public int startNewBookie()
+    public int startNewBookie(int index)
             throws Exception {
-        ServerConfiguration conf = newServerConfiguration();
+        ServerConfiguration conf = newServerConfiguration(index);
         bsConfs.add(conf);
         log.info("Starting new bookie on port: {}", conf.getBookiePort());
         LifecycleComponentStack server = startBookie(conf);

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/bookkeeper/BKCluster.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/bookkeeper/BKCluster.java
@@ -203,7 +203,7 @@ public class BKCluster implements AutoCloseable {
             dataDir = new File(clusterConf.dataDir);
         } else {
             // Use temp dir and clean it up later
-            dataDir = createTempDir("bookie", index + "test");
+            dataDir = createTempDir("bookie",  "test-" + index);
         }
 
         if (clusterConf.clearOldData) {


### PR DESCRIPTION
Fixes #16846

### Motivation

The dataDir conflict when starting multiple bookies in the BKCluster.

### Modifications

Add index suffix for per bookie dataDir.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change is already covered by existing tests, such as *EndToEndMetadataTest.java*.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API: (yes / no)
  - The schema: (yes / no / don't know)
  - The default values of configurations: (yes / no)
  - The wire protocol: (yes / no)
  - The rest endpoints: (yes / no)
  - The admin cli options: (yes / no)
  - Anything that affects deployment: (yes / no / don't know)

### Documentation

Check the box below or label this PR directly.

Need to update docs? 

- [x] `doc-not-needed` 
(Please explain why)