### PR TITLE
[Broker] Expose topic level storage write and read rate metrics

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/TopicStats.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/TopicStats.java
@@ -133,6 +133,10 @@ class TopicStats {
                 stats.managedLedgerStats.storageLogicalSize, splitTopicAndPartitionIndexLabel);
         metric(stream, cluster, namespace, topic, "pulsar_msg_backlog", stats.msgBacklog,
                 splitTopicAndPartitionIndexLabel);
+        metric(stream, cluster, namespace, topic, "pulsar_storage_write_rate",
+                stats.managedLedgerStats.storageWriteRate, splitTopicAndPartitionIndexLabel);
+        metric(stream, cluster, namespace, topic, "pulsar_storage_read_rate", stats.managedLedgerStats.storageReadRate,
+                splitTopicAndPartitionIndexLabel);
         metric(stream, cluster, namespace, topic, "pulsar_storage_backlog_size",
                 stats.managedLedgerStats.backlogSize, splitTopicAndPartitionIndexLabel);
         metric(stream, cluster, namespace, topic, "pulsar_publish_rate_limit_times", stats.publishRateLimitedTimes,


### PR DESCRIPTION
### Motivation

We collect metrics on storage read/write rate, but we do not expose it at the topic level. We already expose it at the namespace level.

### Modifications

* Expose `pulsar_storage_read_rate` and `pulsar_storage_write_rate` in topic level metrics

### Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

This change adds two new metrics.

### Documentation

- [x] `doc-not-needed` 

These two metrics are already documented for topic level stats: https://pulsar.apache.org/docs/next/reference-metrics.