### PR TITLE
[Pulsar Admin CLI Tool] Use NoSplitter for subscription properties

### DIFF
--- a/pulsar-client-tools-test/src/test/java/org/apache/pulsar/admin/cli/PulsarAdminToolTest.java
+++ b/pulsar-client-tools-test/src/test/java/org/apache/pulsar/admin/cli/PulsarAdminToolTest.java
@@ -1483,9 +1483,10 @@ public class PulsarAdminToolTest {
 
         // jcommander is stateful, you cannot parse the same command twice
         cmdTopics = new CmdTopics(() -> admin);
-        cmdTopics.run(split("create-subscription persistent://myprop/clust/ns1/ds1 -s sub1 --messageId earliest --property a=b"));
+        cmdTopics.run(split("create-subscription persistent://myprop/clust/ns1/ds1 -s sub1 --messageId earliest --property a=b -p x=y,z"));
         Map<String, String> props = new HashMap<>();
         props.put("a", "b");
+        props.put("x", "y,z");
         verify(mockTopics).createSubscription("persistent://myprop/clust/ns1/ds1", "sub1", MessageId.earliest, false, props);
 
         cmdTopics = new CmdTopics(() -> admin);
@@ -1504,7 +1505,8 @@ public class PulsarAdminToolTest {
         props = new HashMap<>();
         props.put("a", "b");
         props.put("c", "d");
-        cmdTopics.run(split("update-subscription-properties persistent://myprop/clust/ns1/ds1 -s sub1 -p a=b -p c=d"));
+        props.put("x", "y,z");
+        cmdTopics.run(split("update-subscription-properties persistent://myprop/clust/ns1/ds1 -s sub1 -p a=b -p c=d -p x=y,z"));
         verify(mockTopics).updateSubscriptionProperties("persistent://myprop/clust/ns1/ds1", "sub1", props);
 
         cmdTopics.run(split("create-partitioned-topic persistent://myprop/clust/ns1/ds1 --partitions 32"));
@@ -1900,10 +1902,11 @@ public class PulsarAdminToolTest {
         topics.run(split("expire-messages-all-subscriptions persistent://myprop/clust/ns1/ds1 -t 100"));
         verify(mockTopics).expireMessagesForAllSubscriptions("persistent://myprop/clust/ns1/ds1", 100);
 
-        topics.run(split("create-subscription persistent://myprop/clust/ns1/ds1 -s sub1 --messageId earliest -p a=b --property c=d"));
+        topics.run(split("create-subscription persistent://myprop/clust/ns1/ds1 -s sub1 --messageId earliest -p a=b --property c=d -p x=y,z"));
         Map<String, String> props = new HashMap<>();
         props.put("a", "b");
         props.put("c", "d");
+        props.put("x", "y,z");
         verify(mockTopics).createSubscription("persistent://myprop/clust/ns1/ds1", "sub1", MessageId.earliest, false, props);
 
         // jcommander is stateful, you cannot parse the same command twice

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdPersistentTopics.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdPersistentTopics.java
@@ -38,6 +38,7 @@ import org.apache.pulsar.client.admin.PulsarAdminException;
 import org.apache.pulsar.client.admin.Topics;
 import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.MessageId;
+import org.apache.pulsar.client.cli.NoSplitter;
 import org.apache.pulsar.client.impl.BatchMessageIdImpl;
 import org.apache.pulsar.client.impl.MessageIdImpl;
 import org.apache.pulsar.common.util.RelativeTimeUtil;
@@ -510,7 +511,7 @@ public class CmdPersistentTopics extends CmdBase {
         private String messageIdStr = "latest";
 
         @Parameter(names = {"--property", "-p"}, description = "key value pair properties(-p a=b -p c=d)",
-                required = false)
+                required = false, splitter = NoSplitter.class)
         private java.util.List<String> properties;
 
         @Override

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdTopics.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdTopics.java
@@ -55,6 +55,7 @@ import org.apache.pulsar.client.admin.Topics;
 import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.client.api.SubscriptionType;
+import org.apache.pulsar.client.cli.NoSplitter;
 import org.apache.pulsar.client.impl.BatchMessageIdImpl;
 import org.apache.pulsar.client.impl.MessageIdImpl;
 import org.apache.pulsar.client.impl.MessageImpl;
@@ -960,7 +961,7 @@ public class CmdTopics extends CmdBase {
         private boolean replicated = false;
 
         @Parameter(names = {"--property", "-p"}, description = "key value pair properties(-p a=b -p c=d)",
-                required = false)
+                required = false, splitter = NoSplitter.class)
         private java.util.List<String> properties;
 
         @Override
@@ -989,7 +990,7 @@ public class CmdTopics extends CmdBase {
         private String subscriptionName;
 
         @Parameter(names = {"--property", "-p"}, description = "key value pair properties(-p a=b -p c=d)",
-                required = false)
+                required = false, splitter = NoSplitter.class)
         private java.util.List<String> properties;
 
         @Parameter(names = {"--clear", "-c"}, description = "Remove all properties",


### PR DESCRIPTION
### Motivation

Subscription properties are a new feature coming in 2.11. The admin api will allow for properties with commas, but the admin cli tool splits parameters with commas into multiple properties. This PR switches the splitter for the `properties` field and makes it possible to specify any valid property with the cli tool.

Note: there are other properties fields that the CLI tool allows you to set, but because those have already been released, I am not updating those here.

### Modifications

* Use the `NoSplitter.class` as the `splitter` for the subscription `properties` parameter.
* Add test coverage for all changes.

### Verifying this change

This PR includes new test coverage.

### Does this pull request potentially affect one of the following parts:

This PR updates a CLI tool method that has not yet been released, so it does not break any existing functionality.

### Documentation

- [x] `doc-not-needed` 
