### PR TITLE
[improve][workflow] Add a job in document bot to auto generate config docs

### DIFF
--- a/.github/workflows/ci-documentbot.yml
+++ b/.github/workflows/ci-documentbot.yml
@@ -69,13 +69,29 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v2
       
-      - name: Set up Java
-        uses: actions/setup-java@v3
+      - name: Tune Runner VM
+        uses: ./.github/actions/tune-runner-vm
+      
+      - name: Cache Maven dependencies
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.m2/repository/*/*/*
+            !~/.m2/repository/org/apache/pulsar
+          key: ${{ runner.os }}-m2-dependencies-all-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-m2-dependencies-all-
+      
+      - name: Set up JDK 17
+        uses: actions/setup-java@v2
         with:
           distribution: 'temurin'
           java-version: 17
+      
+      - name: Build package
+        run: mvn -B clean install -DskipTests
 
       - name: Generate config docs
         run: site2/tools/generate-config-docs.sh

--- a/.github/workflows/ci-documentbot.yml
+++ b/.github/workflows/ci-documentbot.yml
@@ -22,7 +22,7 @@ name: Documentation Bot
 on:
   push:
     branches:
-      - master
+      - config-gen-workflow
     paths:
       - pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
       - pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ClientConfigurationData.java

--- a/.github/workflows/ci-documentbot.yml
+++ b/.github/workflows/ci-documentbot.yml
@@ -68,5 +68,14 @@ jobs:
     if: ${{ github.event_name == 'push' }}
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      
+      - name: Set up Java
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: 17
+
       - name: Generate config docs
         run: site2/tools/generate-config-docs.sh

--- a/.github/workflows/ci-documentbot.yml
+++ b/.github/workflows/ci-documentbot.yml
@@ -20,6 +20,14 @@
 name: Documentation Bot
 
 on:
+  push:
+    branches:
+      - master
+    paths:
+      - pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+      - pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ClientConfigurationData.java
+      - pulsar-websocket/src/main/java/org/apache/pulsar/websocket/service/WebSocketProxyConfiguration.java
+      - pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/ProxyConfiguration.java
   pull_request_target :
     types:
       - opened
@@ -33,7 +41,7 @@ concurrency:
 
 jobs:
   label:
-    if: ${{ github.repository == 'apache/pulsar' }}
+    if: ${{ github.event_name == 'pull_request' && github.repository == 'apache/pulsar' }}
     permissions:
       pull-requests: write 
     runs-on: ubuntu-latest
@@ -55,3 +63,10 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           LABEL_WATCH_LIST: 'doc,doc-required,doc-not-needed,doc-complete'
           LABEL_MISSING: 'doc-label-missing'
+
+  docs-gen:
+    if: ${{ github.event_name == 'push' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate config docs
+        run: site2/tools/generate-config-docs.sh

--- a/.github/workflows/ci-documentbot.yml
+++ b/.github/workflows/ci-documentbot.yml
@@ -20,14 +20,6 @@
 name: Documentation Bot
 
 on:
-  push:
-    branches:
-      - config-gen-workflow
-    paths:
-      - pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
-      - pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ClientConfigurationData.java
-      - pulsar-websocket/src/main/java/org/apache/pulsar/websocket/service/WebSocketProxyConfiguration.java
-      - pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/ProxyConfiguration.java
   pull_request_target :
     types:
       - opened
@@ -41,7 +33,7 @@ concurrency:
 
 jobs:
   label:
-    if: ${{ github.event_name == 'pull_request' && github.repository == 'apache/pulsar' }}
+    if: ${{ github.repository == 'apache/pulsar' }}
     permissions:
       pull-requests: write 
     runs-on: ubuntu-latest
@@ -63,35 +55,3 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           LABEL_WATCH_LIST: 'doc,doc-required,doc-not-needed,doc-complete'
           LABEL_MISSING: 'doc-label-missing'
-
-  docs-gen:
-    if: ${{ github.event_name == 'push' }}
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      
-      - name: Tune Runner VM
-        uses: ./.github/actions/tune-runner-vm
-      
-      - name: Cache Maven dependencies
-        uses: actions/cache@v2
-        with:
-          path: |
-            ~/.m2/repository/*/*/*
-            !~/.m2/repository/org/apache/pulsar
-          key: ${{ runner.os }}-m2-dependencies-all-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-m2-dependencies-all-
-      
-      - name: Set up JDK 17
-        uses: actions/setup-java@v2
-        with:
-          distribution: 'temurin'
-          java-version: 17
-      
-      - name: Build package
-        run: mvn -B clean install -DskipTests
-
-      - name: Generate config docs
-        run: site2/tools/generate-config-docs.sh

--- a/.github/workflows/doc-auto-gen.yml
+++ b/.github/workflows/doc-auto-gen.yml
@@ -1,0 +1,74 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+name: Documentation Generation
+
+on:
+  push:
+    branches:
+      - config-gen-workflow
+    paths:
+      - pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+      - pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ClientConfigurationData.java
+      - pulsar-websocket/src/main/java/org/apache/pulsar/websocket/service/WebSocketProxyConfiguration.java
+      - pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/ProxyConfiguration.java
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  docs-gen:
+    if: ${{ github.event_name == 'push' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      
+      - name: Tune Runner VM
+        uses: ./.github/actions/tune-runner-vm
+      
+      - name: Cache Maven dependencies
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.m2/repository/*/*/*
+            !~/.m2/repository/org/apache/pulsar
+          key: ${{ runner.os }}-m2-dependencies-all-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-m2-dependencies-all-
+      
+      - name: Set up JDK 17
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'temurin'
+          java-version: 17
+      
+      - name: Build package
+        run: mvn -B clean install -DskipTests
+
+      - name: Generate config docs
+        run: site2/tools/generate-config-docs.sh
+      
+      - name: Commit changes
+        run: |
+          git config --global user.name 'pulsar-bot'
+          git config --global user.email 'pulsar-bot@users.noreply.github.com'
+          git commit -am "Auto update configuration docs"
+          git push

--- a/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/ProxyConfiguration.java
+++ b/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/ProxyConfiguration.java
@@ -115,7 +115,7 @@ public class ProxyConfiguration implements PulsarConfiguration {
     @FieldContext(
             category = CATEGORY_BROKER_DISCOVERY,
             required = false,
-            doc = "The metadata store URL for the configuration data. If empty, we fall back to use metadataStoreUrl"
+            doc = "The metadata store URL for the configuration data. If empty, we fall back to use metadataStoreUrl."
     )
     private String configurationMetadataStoreUrl;
 

--- a/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/ProxyConfiguration.java
+++ b/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/ProxyConfiguration.java
@@ -115,7 +115,7 @@ public class ProxyConfiguration implements PulsarConfiguration {
     @FieldContext(
             category = CATEGORY_BROKER_DISCOVERY,
             required = false,
-            doc = "The metadata store URL for the configuration data. If empty, we fall back to use metadataStoreUrl."
+            doc = "The metadata store URL for the configuration data. If empty, we fall back to use metadataStoreUrl"
     )
     private String configurationMetadataStoreUrl;
 

--- a/site2/tools/generate-config-docs.sh
+++ b/site2/tools/generate-config-docs.sh
@@ -29,7 +29,7 @@ DOCS_DIR=site2/docs
 
 cd ${ROOT_DIR}
 
-$JAVA -cp `cat "${f}"` $GEN_DOCS_BROKER -c org.apache.pulsar.broker.ServiceConfiguration > $DOCS_DIR/reference-configuration-broker.md
-$JAVA -cp `cat "${f}"` $GEN_DOCS_BROKER -c org.apache.pulsar.client.impl.conf.ClientConfigurationData > $DOCS_DIR/reference-configuration-client.md
-$JAVA -cp `cat "${f}"` $GEN_DOCS_BROKER -c org.apache.pulsar.websocket.service.WebSocketProxyConfiguration > $DOCS_DIR/reference-configuration-websocket.md
-$JAVA -cp `cat "${f}"` $GEN_DOCS_PROXY -c org.apache.pulsar.proxy.server.ProxyConfiguration > $DOCS_DIR/reference-configuration-pulsar-proxy.md
+exec $JAVA -cp `cat "${f}"` $GEN_DOCS_BROKER -c org.apache.pulsar.broker.ServiceConfiguration > $DOCS_DIR/reference-configuration-broker.md
+exec $JAVA -cp `cat "${f}"` $GEN_DOCS_BROKER -c org.apache.pulsar.client.impl.conf.ClientConfigurationData > $DOCS_DIR/reference-configuration-client.md
+exec $JAVA -cp `cat "${f}"` $GEN_DOCS_BROKER -c org.apache.pulsar.websocket.service.WebSocketProxyConfiguration > $DOCS_DIR/reference-configuration-websocket.md
+exec $JAVA -cp `cat "${f}"` $GEN_DOCS_PROXY -c org.apache.pulsar.proxy.server.ProxyConfiguration > $DOCS_DIR/reference-configuration-pulsar-proxy.md


### PR DESCRIPTION
Fix #13453

### Motivation

In #16627, we can now generate config docs by manually running a script after changing specific code files that contains annotations. This PR adds a job in the existing document bot to automate this step.

### Modifications

~A new job `doc-gen` is added in `ci-documentbot.yml`~ A new workflow `doc-auto-gen` is added which will only trigger when there're new pushes to `master` updating the 4 code files that contains configuration annotations.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API: no
  - The schema: no
  - The default values of configurations: no
  - The wire protocol: no
  - The rest endpoints: no
  - The admin cli options: no
  - Anything that affects deployment: no

### Documentation

Check the box below or label this PR directly.

Need to update docs? 

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)
  
- [ ] `doc-not-needed` 
(Please explain why)

CI adjustment.

- [x] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)