### PR TITLE
[Branch 2.7] Fix license check failure

### DIFF
--- a/pulsar-sql/presto-distribution/pom.xml
+++ b/pulsar-sql/presto-distribution/pom.xml
@@ -38,6 +38,7 @@
         <presto.version>332</presto.version>
         <jersey.version>2.31</jersey.version>
         <airlift.version>0.170</airlift.version>
+        <aircompressor.version>0.20</aircompressor.version>
         <objenesis.version>2.6</objenesis.version>
         <objectsize.version>0.0.12</objectsize.version>
         <guice.version>4.2.0</guice.version>
@@ -134,6 +135,18 @@
             <groupId>io.prestosql</groupId>
             <artifactId>presto-cli</artifactId>
             <version>${presto.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>aircompressor</artifactId>
+            <version>${aircompressor.version}</version>
+            <exclusions>
+              <exclusion>
+                <groupId>org.openjdk.jol</groupId>
+                <artifactId>jol-core</artifactId>
+              </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://docs.google.com/document/d/1d8Pw6ZbWk-_pCKdOmdvx9rnhPiyuxwq60_TrD68d7BA/edit#heading=h.trs9rsex3xom)*. 

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.

**(The sections below can be removed for hotfixes of typos)**
-->

### Motivation


After cherry-pick #11790 to branch 2.7, there is a license check issue:

> aircompressor-0.16.jar unaccounted for in lib/presto/LICENSE

The root cause is that in branch 2.7, `pulsar-presto-distribution` is not a child of Pulsar main project. So the version changes in main `pom.xml` is not applied to lib/presto/LICENSE.


### Modifications

Add dependency of aircompressor-0.20 in `pulsar-sql/presto-distribution/pom.xml`.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.


This change is already covered by existing tests, such as CI license check.



### Documentation

Check the box below or label this PR directly.

Need to update docs? 

  
- [x] `doc-not-needed` 
bug fix
  
