### PR TITLE
[Pulsar Client CLI] Fix incorrect description for producing messages

### DIFF
--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/client/cli/CmdProduce.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/client/cli/CmdProduce.java
@@ -85,7 +85,7 @@ public class CmdProduce {
     private List<String> mainOptions;
 
     @Parameter(names = { "-m", "--messages" },
-               description = "Messages to send, either -m or -f must be specified. The default separator is comma",
+               description = "Messages to send, either -m or -f must be specified. Specify -m for each message.",
                splitter = NoSplitter.class)
     private List<String> messages = new ArrayList<>();
 


### PR DESCRIPTION
### Motivation

Fix a misleading (incorrect) description for the `--message` parameter of the `pulsar-client produce` command. The description currently states that messages can be comma delimited. However, the splitter on the field is `NoSplitter`, and that means different messages need to be passed as different arguments (e.g. `-m message1 -m message2`).

### Modifications

* Update description.

### Verifying this change

This is a documentation update.

### Does this pull request potentially affect one of the following parts:

This is not a breaking change. It simply makes the documentation align with the implementation.

### Documentation
  
- [x] `doc` 
