### PR TITLE
[fix][flaky-test] Delete assert availablePermits on testmulitiConsumeImpl

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/DynamicReceiverQueueSizeTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/DynamicReceiverQueueSizeTest.java
@@ -109,7 +109,6 @@ public class DynamicReceiverQueueSizeTest extends MockedPulsarServiceBaseTest {
             Assert.assertEquals(c.getCurrentReceiverQueueSize(), 5);
         }
         Awaitility.await().untilAsserted(() -> {
-            Assert.assertEquals(consumer.getAvailablePermits(), 0);
             Assert.assertTrue(consumer.getTotalIncomingMessages() >= 5);
             Assert.assertTrue(consumer.getTotalIncomingMessages() < 30);
         });


### PR DESCRIPTION
#16879 

### Motivation

When `MultiTopicConsumer` is incomingMessages is full, does not mean that all of its `consumers` is `AvailablePermits` must be 0.

The reason the current test sometimes passes is because, it just so happens that all consumer suspended after the last permit request was sent.


### Modifications

- Delete assert availablePermits on testmulitiConsumeImpl

### Documentation

- [x] `doc-not-needed` 
(Please explain why)
