### PR TITLE
[fix][cookbooks-compaction][docs] - Updated consumer config section

### DIFF
--- a/site2/docs/cookbooks-compaction.md
+++ b/site2/docs/cookbooks-compaction.md
@@ -84,7 +84,7 @@ How often you [trigger compaction](#triggering-compaction-manually) will vary wi
 
 ## Consumer configuration
 
-Pulsar consumers and readers need to be configured to read from compacted topics. The sections below show you how to enable compacted topic reads for Pulsar's language clients. If the
+Pulsar consumers and readers need to be configured to read from compacted topics. The sections below show you how to enable compacted topic reads for Pulsar's language clients.
 
 ### Java
 

--- a/site2/website/versioned_docs/version-2.1.0-incubating/cookbooks-compaction.md
+++ b/site2/website/versioned_docs/version-2.1.0-incubating/cookbooks-compaction.md
@@ -85,7 +85,7 @@ How often you [trigger compaction](#trigger) will vary widely based on the use c
 
 ## Consumer configuration {#config}
 
-Pulsar consumers and readers need to be configured to read from compacted topics. The sections below show you how to enable compacted topic reads for Pulsar's language clients. If the
+Pulsar consumers and readers need to be configured to read from compacted topics. The sections below show you how to enable compacted topic reads for Pulsar's language clients.
 
 
 > #### Java only

--- a/site2/website/versioned_docs/version-2.1.1-incubating/cookbooks-compaction.md
+++ b/site2/website/versioned_docs/version-2.1.1-incubating/cookbooks-compaction.md
@@ -84,7 +84,7 @@ How often you [trigger compaction](#triggering-compaction-manually) will vary wi
 
 ## Consumer configuration
 
-Pulsar consumers and readers need to be configured to read from compacted topics. The sections below show you how to enable compacted topic reads for Pulsar's language clients. If the
+Pulsar consumers and readers need to be configured to read from compacted topics. The sections below show you how to enable compacted topic reads for Pulsar's language clients.
 
 ### Java
 

--- a/site2/website/versioned_docs/version-2.10.0/cookbooks-compaction.md
+++ b/site2/website/versioned_docs/version-2.10.0/cookbooks-compaction.md
@@ -85,7 +85,7 @@ How often you [trigger compaction](#triggering-compaction-manually) will vary wi
 
 ## Consumer configuration
 
-Pulsar consumers and readers need to be configured to read from compacted topics. The sections below show you how to enable compacted topic reads for Pulsar's language clients. If the
+Pulsar consumers and readers need to be configured to read from compacted topics. The sections below show you how to enable compacted topic reads for Pulsar's language clients.
 
 ### Java
 

--- a/site2/website/versioned_docs/version-2.10.1/cookbooks-compaction.md
+++ b/site2/website/versioned_docs/version-2.10.1/cookbooks-compaction.md
@@ -85,7 +85,7 @@ How often you [trigger compaction](#triggering-compaction-manually) will vary wi
 
 ## Consumer configuration
 
-Pulsar consumers and readers need to be configured to read from compacted topics. The sections below show you how to enable compacted topic reads for Pulsar's language clients. If the
+Pulsar consumers and readers need to be configured to read from compacted topics. The sections below show you how to enable compacted topic reads for Pulsar's language clients.
 
 ### Java
 

--- a/site2/website/versioned_docs/version-2.2.0/cookbooks-compaction.md
+++ b/site2/website/versioned_docs/version-2.2.0/cookbooks-compaction.md
@@ -84,7 +84,7 @@ How often you [trigger compaction](#triggering-compaction-manually) will vary wi
 
 ## Consumer configuration
 
-Pulsar consumers and readers need to be configured to read from compacted topics. The sections below show you how to enable compacted topic reads for Pulsar's language clients. If the
+Pulsar consumers and readers need to be configured to read from compacted topics. The sections below show you how to enable compacted topic reads for Pulsar's language clients.
 
 ### Java
 

--- a/site2/website/versioned_docs/version-2.2.1/cookbooks-compaction.md
+++ b/site2/website/versioned_docs/version-2.2.1/cookbooks-compaction.md
@@ -84,7 +84,7 @@ How often you [trigger compaction](#triggering-compaction-manually) will vary wi
 
 ## Consumer configuration
 
-Pulsar consumers and readers need to be configured to read from compacted topics. The sections below show you how to enable compacted topic reads for Pulsar's language clients. If the
+Pulsar consumers and readers need to be configured to read from compacted topics. The sections below show you how to enable compacted topic reads for Pulsar's language clients.
 
 ### Java
 

--- a/site2/website/versioned_docs/version-2.3.0/cookbooks-compaction.md
+++ b/site2/website/versioned_docs/version-2.3.0/cookbooks-compaction.md
@@ -84,7 +84,7 @@ How often you [trigger compaction](#triggering-compaction-manually) will vary wi
 
 ## Consumer configuration
 
-Pulsar consumers and readers need to be configured to read from compacted topics. The sections below show you how to enable compacted topic reads for Pulsar's language clients. If the
+Pulsar consumers and readers need to be configured to read from compacted topics. The sections below show you how to enable compacted topic reads for Pulsar's language clients.
 
 ### Java
 

--- a/site2/website/versioned_docs/version-2.3.1/cookbooks-compaction.md
+++ b/site2/website/versioned_docs/version-2.3.1/cookbooks-compaction.md
@@ -84,7 +84,7 @@ How often you [trigger compaction](#triggering-compaction-manually) will vary wi
 
 ## Consumer configuration
 
-Pulsar consumers and readers need to be configured to read from compacted topics. The sections below show you how to enable compacted topic reads for Pulsar's language clients. If the
+Pulsar consumers and readers need to be configured to read from compacted topics. The sections below show you how to enable compacted topic reads for Pulsar's language clients.
 
 ### Java
 

--- a/site2/website/versioned_docs/version-2.3.2/cookbooks-compaction.md
+++ b/site2/website/versioned_docs/version-2.3.2/cookbooks-compaction.md
@@ -84,7 +84,7 @@ How often you [trigger compaction](#triggering-compaction-manually) will vary wi
 
 ## Consumer configuration
 
-Pulsar consumers and readers need to be configured to read from compacted topics. The sections below show you how to enable compacted topic reads for Pulsar's language clients. If the
+Pulsar consumers and readers need to be configured to read from compacted topics. The sections below show you how to enable compacted topic reads for Pulsar's language clients.
 
 ### Java
 

--- a/site2/website/versioned_docs/version-2.4.0/cookbooks-compaction.md
+++ b/site2/website/versioned_docs/version-2.4.0/cookbooks-compaction.md
@@ -85,7 +85,7 @@ How often you [trigger compaction](#trigger) will vary widely based on the use c
 
 ## Consumer configuration {#config}
 
-Pulsar consumers and readers need to be configured to read from compacted topics. The sections below show you how to enable compacted topic reads for Pulsar's language clients. If the
+Pulsar consumers and readers need to be configured to read from compacted topics. The sections below show you how to enable compacted topic reads for Pulsar's language clients.
 
 
 > #### Java only

--- a/site2/website/versioned_docs/version-2.4.1/cookbooks-compaction.md
+++ b/site2/website/versioned_docs/version-2.4.1/cookbooks-compaction.md
@@ -85,7 +85,7 @@ How often you [trigger compaction](#trigger) will vary widely based on the use c
 
 ## Consumer configuration
 
-Pulsar consumers and readers need to be configured to read from compacted topics. The sections below show you how to enable compacted topic reads for Pulsar's language clients. If the
+Pulsar consumers and readers need to be configured to read from compacted topics. The sections below show you how to enable compacted topic reads for Pulsar's language clients.
 
 ### Java
 

--- a/site2/website/versioned_docs/version-2.4.2/cookbooks-compaction.md
+++ b/site2/website/versioned_docs/version-2.4.2/cookbooks-compaction.md
@@ -85,7 +85,7 @@ How often you [trigger compaction](#trigger) will vary widely based on the use c
 
 ## Consumer configuration
 
-Pulsar consumers and readers need to be configured to read from compacted topics. The sections below show you how to enable compacted topic reads for Pulsar's language clients. If the
+Pulsar consumers and readers need to be configured to read from compacted topics. The sections below show you how to enable compacted topic reads for Pulsar's language clients.
 
 ### Java
 

--- a/site2/website/versioned_docs/version-2.5.0/cookbooks-compaction.md
+++ b/site2/website/versioned_docs/version-2.5.0/cookbooks-compaction.md
@@ -84,7 +84,7 @@ How often you [trigger compaction](#triggering-compaction-manually) will vary wi
 
 ## Consumer configuration
 
-Pulsar consumers and readers need to be configured to read from compacted topics. The sections below show you how to enable compacted topic reads for Pulsar's language clients. If the
+Pulsar consumers and readers need to be configured to read from compacted topics. The sections below show you how to enable compacted topic reads for Pulsar's language clients.
 
 ### Java
 

--- a/site2/website/versioned_docs/version-2.5.1/cookbooks-compaction.md
+++ b/site2/website/versioned_docs/version-2.5.1/cookbooks-compaction.md
@@ -85,7 +85,7 @@ How often you [trigger compaction](#triggering-compaction-manually) will vary wi
 
 ## Consumer configuration
 
-Pulsar consumers and readers need to be configured to read from compacted topics. The sections below show you how to enable compacted topic reads for Pulsar's language clients. If the
+Pulsar consumers and readers need to be configured to read from compacted topics. The sections below show you how to enable compacted topic reads for Pulsar's language clients.
 
 ### Java
 

--- a/site2/website/versioned_docs/version-2.5.2/cookbooks-compaction.md
+++ b/site2/website/versioned_docs/version-2.5.2/cookbooks-compaction.md
@@ -85,7 +85,7 @@ How often you [trigger compaction](#triggering-compaction-manually) will vary wi
 
 ## Consumer configuration
 
-Pulsar consumers and readers need to be configured to read from compacted topics. The sections below show you how to enable compacted topic reads for Pulsar's language clients. If the
+Pulsar consumers and readers need to be configured to read from compacted topics. The sections below show you how to enable compacted topic reads for Pulsar's language clients.
 
 ### Java
 

--- a/site2/website/versioned_docs/version-2.6.0/cookbooks-compaction.md
+++ b/site2/website/versioned_docs/version-2.6.0/cookbooks-compaction.md
@@ -85,7 +85,7 @@ How often you [trigger compaction](#triggering-compaction-manually) will vary wi
 
 ## Consumer configuration
 
-Pulsar consumers and readers need to be configured to read from compacted topics. The sections below show you how to enable compacted topic reads for Pulsar's language clients. If the
+Pulsar consumers and readers need to be configured to read from compacted topics. The sections below show you how to enable compacted topic reads for Pulsar's language clients.
 
 ### Java
 

--- a/site2/website/versioned_docs/version-2.6.1/cookbooks-compaction.md
+++ b/site2/website/versioned_docs/version-2.6.1/cookbooks-compaction.md
@@ -85,7 +85,7 @@ How often you [trigger compaction](#triggering-compaction-manually) will vary wi
 
 ## Consumer configuration
 
-Pulsar consumers and readers need to be configured to read from compacted topics. The sections below show you how to enable compacted topic reads for Pulsar's language clients. If the
+Pulsar consumers and readers need to be configured to read from compacted topics. The sections below show you how to enable compacted topic reads for Pulsar's language clients.
 
 ### Java
 

--- a/site2/website/versioned_docs/version-2.6.2/cookbooks-compaction.md
+++ b/site2/website/versioned_docs/version-2.6.2/cookbooks-compaction.md
@@ -85,7 +85,7 @@ How often you [trigger compaction](#triggering-compaction-manually) will vary wi
 
 ## Consumer configuration
 
-Pulsar consumers and readers need to be configured to read from compacted topics. The sections below show you how to enable compacted topic reads for Pulsar's language clients. If the
+Pulsar consumers and readers need to be configured to read from compacted topics. The sections below show you how to enable compacted topic reads for Pulsar's language clients.
 
 ### Java
 

--- a/site2/website/versioned_docs/version-2.6.3/cookbooks-compaction.md
+++ b/site2/website/versioned_docs/version-2.6.3/cookbooks-compaction.md
@@ -85,7 +85,7 @@ How often you [trigger compaction](#triggering-compaction-manually) will vary wi
 
 ## Consumer configuration
 
-Pulsar consumers and readers need to be configured to read from compacted topics. The sections below show you how to enable compacted topic reads for Pulsar's language clients. If the
+Pulsar consumers and readers need to be configured to read from compacted topics. The sections below show you how to enable compacted topic reads for Pulsar's language clients.
 
 ### Java
 

--- a/site2/website/versioned_docs/version-2.6.4/cookbooks-compaction.md
+++ b/site2/website/versioned_docs/version-2.6.4/cookbooks-compaction.md
@@ -85,7 +85,7 @@ How often you [trigger compaction](#triggering-compaction-manually) will vary wi
 
 ## Consumer configuration
 
-Pulsar consumers and readers need to be configured to read from compacted topics. The sections below show you how to enable compacted topic reads for Pulsar's language clients. If the
+Pulsar consumers and readers need to be configured to read from compacted topics. The sections below show you how to enable compacted topic reads for Pulsar's language clients.
 
 ### Java
 

--- a/site2/website/versioned_docs/version-2.7.0/cookbooks-compaction.md
+++ b/site2/website/versioned_docs/version-2.7.0/cookbooks-compaction.md
@@ -85,7 +85,7 @@ How often you [trigger compaction](#triggering-compaction-manually) will vary wi
 
 ## Consumer configuration
 
-Pulsar consumers and readers need to be configured to read from compacted topics. The sections below show you how to enable compacted topic reads for Pulsar's language clients. If the
+Pulsar consumers and readers need to be configured to read from compacted topics. The sections below show you how to enable compacted topic reads for Pulsar's language clients.
 
 ### Java
 

--- a/site2/website/versioned_docs/version-2.7.1/cookbooks-compaction.md
+++ b/site2/website/versioned_docs/version-2.7.1/cookbooks-compaction.md
@@ -85,7 +85,7 @@ How often you [trigger compaction](#triggering-compaction-manually) will vary wi
 
 ## Consumer configuration
 
-Pulsar consumers and readers need to be configured to read from compacted topics. The sections below show you how to enable compacted topic reads for Pulsar's language clients. If the
+Pulsar consumers and readers need to be configured to read from compacted topics. The sections below show you how to enable compacted topic reads for Pulsar's language clients.
 
 ### Java
 

--- a/site2/website/versioned_docs/version-2.7.2/cookbooks-compaction.md
+++ b/site2/website/versioned_docs/version-2.7.2/cookbooks-compaction.md
@@ -85,7 +85,7 @@ How often you [trigger compaction](#triggering-compaction-manually) will vary wi
 
 ## Consumer configuration
 
-Pulsar consumers and readers need to be configured to read from compacted topics. The sections below show you how to enable compacted topic reads for Pulsar's language clients. If the
+Pulsar consumers and readers need to be configured to read from compacted topics. The sections below show you how to enable compacted topic reads for Pulsar's language clients.
 
 ### Java
 

--- a/site2/website/versioned_docs/version-2.7.3/cookbooks-compaction.md
+++ b/site2/website/versioned_docs/version-2.7.3/cookbooks-compaction.md
@@ -85,7 +85,7 @@ How often you [trigger compaction](#triggering-compaction-manually) will vary wi
 
 ## Consumer configuration
 
-Pulsar consumers and readers need to be configured to read from compacted topics. The sections below show you how to enable compacted topic reads for Pulsar's language clients. If the
+Pulsar consumers and readers need to be configured to read from compacted topics. The sections below show you how to enable compacted topic reads for Pulsar's language clients.
 
 ### Java
 

--- a/site2/website/versioned_docs/version-2.7.4/cookbooks-compaction.md
+++ b/site2/website/versioned_docs/version-2.7.4/cookbooks-compaction.md
@@ -85,7 +85,7 @@ How often you [trigger compaction](#triggering-compaction-manually) will vary wi
 
 ## Consumer configuration
 
-Pulsar consumers and readers need to be configured to read from compacted topics. The sections below show you how to enable compacted topic reads for Pulsar's language clients. If the
+Pulsar consumers and readers need to be configured to read from compacted topics. The sections below show you how to enable compacted topic reads for Pulsar's language clients.
 
 ### Java
 

--- a/site2/website/versioned_docs/version-2.8.0/cookbooks-compaction.md
+++ b/site2/website/versioned_docs/version-2.8.0/cookbooks-compaction.md
@@ -85,7 +85,7 @@ How often you [trigger compaction](#triggering-compaction-manually) will vary wi
 
 ## Consumer configuration
 
-Pulsar consumers and readers need to be configured to read from compacted topics. The sections below show you how to enable compacted topic reads for Pulsar's language clients. If the
+Pulsar consumers and readers need to be configured to read from compacted topics. The sections below show you how to enable compacted topic reads for Pulsar's language clients.
 
 ### Java
 

--- a/site2/website/versioned_docs/version-2.8.1/cookbooks-compaction.md
+++ b/site2/website/versioned_docs/version-2.8.1/cookbooks-compaction.md
@@ -85,7 +85,7 @@ How often you [trigger compaction](#triggering-compaction-manually) will vary wi
 
 ## Consumer configuration
 
-Pulsar consumers and readers need to be configured to read from compacted topics. The sections below show you how to enable compacted topic reads for Pulsar's language clients. If the
+Pulsar consumers and readers need to be configured to read from compacted topics. The sections below show you how to enable compacted topic reads for Pulsar's language clients.
 
 ### Java
 

--- a/site2/website/versioned_docs/version-2.8.2/cookbooks-compaction.md
+++ b/site2/website/versioned_docs/version-2.8.2/cookbooks-compaction.md
@@ -85,7 +85,7 @@ How often you [trigger compaction](#triggering-compaction-manually) will vary wi
 
 ## Consumer configuration
 
-Pulsar consumers and readers need to be configured to read from compacted topics. The sections below show you how to enable compacted topic reads for Pulsar's language clients. If the
+Pulsar consumers and readers need to be configured to read from compacted topics. The sections below show you how to enable compacted topic reads for Pulsar's language clients.
 
 ### Java
 

--- a/site2/website/versioned_docs/version-2.8.3/cookbooks-compaction.md
+++ b/site2/website/versioned_docs/version-2.8.3/cookbooks-compaction.md
@@ -85,7 +85,7 @@ How often you [trigger compaction](#triggering-compaction-manually) will vary wi
 
 ## Consumer configuration
 
-Pulsar consumers and readers need to be configured to read from compacted topics. The sections below show you how to enable compacted topic reads for Pulsar's language clients. If the
+Pulsar consumers and readers need to be configured to read from compacted topics. The sections below show you how to enable compacted topic reads for Pulsar's language clients.
 
 ### Java
 

--- a/site2/website/versioned_docs/version-2.9.0/cookbooks-compaction.md
+++ b/site2/website/versioned_docs/version-2.9.0/cookbooks-compaction.md
@@ -85,7 +85,7 @@ How often you [trigger compaction](#triggering-compaction-manually) will vary wi
 
 ## Consumer configuration
 
-Pulsar consumers and readers need to be configured to read from compacted topics. The sections below show you how to enable compacted topic reads for Pulsar's language clients. If the
+Pulsar consumers and readers need to be configured to read from compacted topics. The sections below show you how to enable compacted topic reads for Pulsar's language clients.
 
 ### Java
 

--- a/site2/website/versioned_docs/version-2.9.1/cookbooks-compaction.md
+++ b/site2/website/versioned_docs/version-2.9.1/cookbooks-compaction.md
@@ -85,7 +85,7 @@ How often you [trigger compaction](#triggering-compaction-manually) will vary wi
 
 ## Consumer configuration
 
-Pulsar consumers and readers need to be configured to read from compacted topics. The sections below show you how to enable compacted topic reads for Pulsar's language clients. If the
+Pulsar consumers and readers need to be configured to read from compacted topics. The sections below show you how to enable compacted topic reads for Pulsar's language clients.
 
 ### Java
 

--- a/site2/website/versioned_docs/version-2.9.2/cookbooks-compaction.md
+++ b/site2/website/versioned_docs/version-2.9.2/cookbooks-compaction.md
@@ -85,7 +85,7 @@ How often you [trigger compaction](#triggering-compaction-manually) will vary wi
 
 ## Consumer configuration
 
-Pulsar consumers and readers need to be configured to read from compacted topics. The sections below show you how to enable compacted topic reads for Pulsar's language clients. If the
+Pulsar consumers and readers need to be configured to read from compacted topics. The sections below show you how to enable compacted topic reads for Pulsar's language clients.
 
 ### Java
 

--- a/site2/website/versioned_docs/version-2.9.3/cookbooks-compaction.md
+++ b/site2/website/versioned_docs/version-2.9.3/cookbooks-compaction.md
@@ -85,7 +85,7 @@ How often you [trigger compaction](#triggering-compaction-manually) will vary wi
 
 ## Consumer configuration
 
-Pulsar consumers and readers need to be configured to read from compacted topics. The sections below show you how to enable compacted topic reads for Pulsar's language clients. If the
+Pulsar consumers and readers need to be configured to read from compacted topics. The sections below show you how to enable compacted topic reads for Pulsar's language clients.
 
 ### Java
 


### PR DESCRIPTION

### Motivation

* The consumer config section has extra words `If the`

### Modifications

* Removed extra words 

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): no
  - The public API: no
  - The schema: no 
  - The default values of configurations: no
  - The wire protocol: no
  - The rest endpoints: no
  - The admin cli options: no
  - Anything that affects deployment: no 

### Documentation

Check the box below or label this PR directly.

Need to update docs? 

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)
  
- [ ] `doc-not-needed` 
(Please explain why)
  
- [x] `doc` 
This is a doc update

- [ ] `doc-complete`
(Docs have been already added)