### PR TITLE
[fix][client-c++] Close `messages_` when PartitionedConsumer is closed

### DIFF
--- a/pulsar-client-cpp/lib/ConsumerImpl.cc
+++ b/pulsar-client-cpp/lib/ConsumerImpl.cc
@@ -826,11 +826,9 @@ Result ConsumerImpl::receiveHelper(Message& msg, int timeout) {
         messageProcessed(msg);
         return ResultOk;
     } else {
-        {
-            Lock lock(mutex_);
-            if (state_ != Ready) {
-                return ResultAlreadyClosed;
-            }
+        Lock lock(mutex_);
+        if (state_ != Ready) {
+            return ResultAlreadyClosed;
         }
         return ResultTimeout;
     }

--- a/pulsar-client-cpp/lib/ConsumerImpl.cc
+++ b/pulsar-client-cpp/lib/ConsumerImpl.cc
@@ -826,6 +826,12 @@ Result ConsumerImpl::receiveHelper(Message& msg, int timeout) {
         messageProcessed(msg);
         return ResultOk;
     } else {
+        {
+            Lock lock(mutex_);
+            if (state_ != Ready) {
+                return ResultAlreadyClosed;
+            }
+        }
         return ResultTimeout;
     }
 }

--- a/pulsar-client-cpp/lib/MultiTopicsConsumerImpl.cc
+++ b/pulsar-client-cpp/lib/MultiTopicsConsumerImpl.cc
@@ -493,6 +493,12 @@ Result MultiTopicsConsumerImpl::receive(Message& msg, int timeout) {
         unAckedMessageTrackerPtr_->add(msg.getMessageId());
         return ResultOk;
     } else {
+        {
+            lock.lock();
+            if (state_ != Ready) {
+                return ResultAlreadyClosed;
+            }
+        }
         return ResultTimeout;
     }
 }

--- a/pulsar-client-cpp/lib/MultiTopicsConsumerImpl.cc
+++ b/pulsar-client-cpp/lib/MultiTopicsConsumerImpl.cc
@@ -493,11 +493,9 @@ Result MultiTopicsConsumerImpl::receive(Message& msg, int timeout) {
         unAckedMessageTrackerPtr_->add(msg.getMessageId());
         return ResultOk;
     } else {
-        {
-            lock.lock();
-            if (state_ != Ready) {
-                return ResultAlreadyClosed;
-            }
+        lock.lock();
+        if (state_ != Ready) {
+            return ResultAlreadyClosed;
         }
         return ResultTimeout;
     }

--- a/pulsar-client-cpp/lib/PartitionedConsumerImpl.cc
+++ b/pulsar-client-cpp/lib/PartitionedConsumerImpl.cc
@@ -106,11 +106,9 @@ Result PartitionedConsumerImpl::receive(Message& msg, int timeout) {
         unAckedMessageTrackerPtr_->add(msg.getMessageId());
         return ResultOk;
     } else {
-        {
-            lock.lock();
-            if (state_ != Ready) {
-                return ResultAlreadyClosed;
-            }
+        lock.lock();
+        if (state_ != Ready) {
+            return ResultAlreadyClosed;
         }
         return ResultTimeout;
     }

--- a/pulsar-client-cpp/lib/PartitionedConsumerImpl.cc
+++ b/pulsar-client-cpp/lib/PartitionedConsumerImpl.cc
@@ -106,6 +106,9 @@ Result PartitionedConsumerImpl::receive(Message& msg, int timeout) {
         unAckedMessageTrackerPtr_->add(msg.getMessageId());
         return ResultOk;
     } else {
+        if (state_ != Ready) {
+            return ResultAlreadyClosed;
+        }
         return ResultTimeout;
     }
 }
@@ -427,6 +430,9 @@ void PartitionedConsumerImpl::messageReceived(Consumer consumer, const Message& 
 
 void PartitionedConsumerImpl::failPendingReceiveCallback() {
     Message msg;
+
+    messages_.close();
+
     Lock lock(pendingReceiveMutex_);
     while (!pendingReceives_.empty()) {
         ReceiveCallback callback = pendingReceives_.front();

--- a/pulsar-client-cpp/lib/PartitionedConsumerImpl.cc
+++ b/pulsar-client-cpp/lib/PartitionedConsumerImpl.cc
@@ -106,8 +106,11 @@ Result PartitionedConsumerImpl::receive(Message& msg, int timeout) {
         unAckedMessageTrackerPtr_->add(msg.getMessageId());
         return ResultOk;
     } else {
-        if (state_ != Ready) {
-            return ResultAlreadyClosed;
+        {
+            lock.lock();
+            if (state_ != Ready) {
+                return ResultAlreadyClosed;
+            }
         }
         return ResultTimeout;
     }

--- a/pulsar-client-cpp/tests/ConsumerTest.cc
+++ b/pulsar-client-cpp/tests/ConsumerTest.cc
@@ -722,8 +722,7 @@ TEST(ConsumerTest, testIsConnected) {
 
 TEST(ConsumerTest, testPartitionsWithCloseUnblock) {
     Client client(lookupUrl);
-    const std::string partitionedTopic =
-        "testPartitionsWithCloseUnblock" + std::to_string(time(nullptr));
+    const std::string partitionedTopic = "testPartitionsWithCloseUnblock" + std::to_string(time(nullptr));
     constexpr int numPartitions = 2;
 
     int res =
@@ -758,7 +757,7 @@ TEST(ConsumerTest, testPartitionsWithCloseUnblock) {
 
     consumer.close();
 
-    bool wasUnblocked = latch.wait(std::chrono::milliseconds (100));
+    bool wasUnblocked = latch.wait(std::chrono::milliseconds(100));
 
     ASSERT_TRUE(wasUnblocked);
     thread.join();

--- a/pulsar-client-cpp/tests/ConsumerTest.cc
+++ b/pulsar-client-cpp/tests/ConsumerTest.cc
@@ -720,4 +720,48 @@ TEST(ConsumerTest, testIsConnected) {
     ASSERT_FALSE(consumer.isConnected());
 }
 
+TEST(ConsumerTest, testPartitionsWithCloseUnblock) {
+    Client client(lookupUrl);
+    const std::string partitionedTopic =
+        "testPartitionsWithCloseUnblock" + std::to_string(time(nullptr));
+    constexpr int numPartitions = 2;
+
+    int res =
+        makePutRequest(adminUrl + "admin/v2/persistent/public/default/" + partitionedTopic + "/partitions",
+                       std::to_string(numPartitions));
+    ASSERT_TRUE(res == 204 || res == 409) << "res: " << res;
+
+    Consumer consumer;
+    ConsumerConfiguration consumerConfig;
+    ASSERT_EQ(ResultOk, client.subscribe(partitionedTopic, "SubscriptionName", consumerConfig, consumer));
+
+    // send messages
+    ProducerConfiguration producerConfig;
+    Producer producer;
+    ASSERT_EQ(ResultOk, client.createProducer(partitionedTopic, producerConfig, producer));
+    Message msg = MessageBuilder().setContent("message").build();
+    ASSERT_EQ(ResultOk, producer.send(msg));
+
+    producer.close();
+
+    // receive message on another thread
+    pulsar::Latch latch(1);
+    auto thread = std::thread([&]() {
+        Message msg;
+        ASSERT_EQ(ResultOk, consumer.receive(msg, 10 * 1000));
+        consumer.acknowledge(msg.getMessageId());
+        ASSERT_EQ(ResultAlreadyClosed, consumer.receive(msg, 10 * 1000));
+        latch.countdown();
+    });
+
+    std::this_thread::sleep_for(std::chrono::seconds(1));
+
+    consumer.close();
+
+    bool wasUnblocked = latch.wait(std::chrono::milliseconds (100));
+
+    ASSERT_TRUE(wasUnblocked);
+    thread.join();
+}
+
 }  // namespace pulsar


### PR DESCRIPTION
Fixes #16567 

### Motivation

When PartitionedConsumer is closed, it forgets to close `messages_` leading to the PartitionedConsumer blocking operations can't be interrupted.
Also, we should return `ResultAlreadyClosed` rather than `ResultTimeout` when `state_ != Ready` after `message_.pop()` failed.

### Modifications

* Close `messages_` when PartitionedConsumer is closed.
* Return `ResultAlreadyClosed` when `state_ != Ready` after `message_.pop()` failed.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change is already covered by existing tests, such as *testPartitionsWithCloseUnblock*.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API: (yes / no)
  - The schema: (yes / no / don't know)
  - The default values of configurations: (yes / no)
  - The wire protocol: (yes / no)
  - The rest endpoints: (yes / no)
  - The admin cli options: (yes / no)
  - Anything that affects deployment: (yes / no / don't know)

### Documentation

Check the box below or label this PR directly.

Need to update docs? 

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)
  
- [x] `doc-not-needed` 
(Please explain why)
  
- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)