### PR TITLE
[Branch-2.7] Fixed deadlock on metadata cache missing while doing checkReplication

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
@@ -1186,10 +1186,6 @@ public class BrokerService implements Closeable, ZooKeeperCacheListener<Policies
             NamespaceName namespace = topicName.getNamespaceObject();
             ServiceConfiguration serviceConfig = pulsar.getConfiguration();
 
-            // Get persistence policy for this topic
-            Optional<Policies> policies = Optional.empty();
-            Optional<LocalPolicies> localPolicies = Optional.empty();
-
             PersistencePolicies tmpPersistencePolicies = null;
             RetentionPolicies tmpRetentionPolicies = null;
             OffloadPolicies tmpTopicLevelOffloadPolicies = null;
@@ -1218,8 +1214,7 @@ public class BrokerService implements Closeable, ZooKeeperCacheListener<Policies
             String path = joinPath(LOCAL_POLICIES_ROOT, topicName.getNamespaceObject().toString());
             CompletableFuture<Optional<LocalPolicies>> localPoliciesFuture =
                     pulsar().getLocalZkCacheService().policiesCache().getAsync(path);
-
-            policiesFuture.thenCombine(localPoliciesFuture, (optPolicies, optLocalPolicies) -> {
+            policiesFuture.thenCombine(localPoliciesFuture, (policies, localPolicies) -> {
                 PersistencePolicies persistencePolicies = finalPersistencePolicies;
                 RetentionPolicies retentionPolicies = finalRetentionPolicies;
                 OffloadPolicies topicLevelOffloadPolicies = finalTopicLevelOffloadPolicies;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -157,6 +157,7 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
     @SuppressWarnings("unused")
     private volatile long usageCount = 0;
 
+
     static final String DEDUPLICATION_CURSOR_NAME = "pulsar.dedup";
 
     private static final double MESSAGE_EXPIRY_THRESHOLD = 1.5;
@@ -1155,68 +1156,72 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
             log.debug("[{}] Checking replication status", name);
         }
 
-        Policies policies = null;
-        try {
-            policies = brokerService.pulsar().getConfigurationCache().policiesCache()
-                    .get(AdminResource.path(POLICIES, name.getNamespace()))
-                    .orElseThrow(() -> new KeeperException.NoNodeException());
-        } catch (Exception e) {
-            CompletableFuture<Void> future = new CompletableFuture<>();
-            future.completeExceptionally(new ServerMetadataException(e));
-            return future;
-        }
-        //Ignore current broker's config for messageTTL for replication.
-        final int newMessageTTLinSeconds;
-        try {
-            newMessageTTLinSeconds = getMessageTTL();
-        } catch (Exception e) {
-            return FutureUtil.failedFuture(new ServerMetadataException(e));
-        }
+        return brokerService.pulsar().getConfigurationCache().policiesCache()
+                .getAsync(AdminResource.path(POLICIES, name.getNamespace()))
+                .thenCompose(optPolicies -> {
+                    if (!optPolicies.isPresent()) {
+                        return FutureUtil.failedFuture(
+                                new ServerMetadataException("Namespace not found: " + name.getNamespace()));
+                    }
 
-        Set<String> configuredClusters;
-        if (policies.replication_clusters != null) {
-            configuredClusters = Sets.newTreeSet(policies.replication_clusters);
-        } else {
-            configuredClusters = Collections.emptySet();
-        }
+                    Policies policies = optPolicies.get();
 
-        String localCluster = brokerService.pulsar().getConfiguration().getClusterName();
+                    //Ignore current broker's config for messageTTL for replication.
+                    final int newMessageTTLinSeconds;
+                    try {
+                        newMessageTTLinSeconds = getMessageTTL();
+                    } catch (Exception e) {
+                        return FutureUtil.failedFuture(new ServerMetadataException(e));
+                    }
 
-        // if local cluster is removed from global namespace cluster-list : then delete topic forcefully because pulsar
-        // doesn't serve global topic without local repl-cluster configured.
-        if (TopicName.get(topic).isGlobal() && !configuredClusters.contains(localCluster)) {
-            log.info("Deleting topic [{}] because local cluster is not part of global namespace repl list {}",
-                    topic, configuredClusters);
-            return deleteForcefully();
-        }
+                    Set<String> configuredClusters;
+                    if (policies.replication_clusters != null) {
+                        configuredClusters = Sets.newTreeSet(policies.replication_clusters);
+                    } else {
+                        configuredClusters = Collections.emptySet();
+                    }
 
-        List<CompletableFuture<Void>> futures = Lists.newArrayList();
+                    String localCluster = brokerService.pulsar().getConfiguration().getClusterName();
 
-        // Check for missing replicators
-        for (String cluster : configuredClusters) {
-            if (cluster.equals(localCluster)) {
-                continue;
-            }
+                    // if local cluster is removed from global namespace cluster-list : then delete topic forcefully
+                    // because pulsar
+                    // doesn't serve global topic without local repl-cluster configured.
+                    if (TopicName.get(topic).isGlobal() && !configuredClusters.contains(localCluster)) {
+                        log.info(
+                                "Deleting topic [{}] because local cluster is not part of global namespace repl list "
+                                        + "{}",
+                                topic, configuredClusters);
+                        return deleteForcefully();
+                    }
 
-            if (!replicators.containsKey(cluster)) {
-                futures.add(startReplicator(cluster));
-            }
-        }
+                    List<CompletableFuture<Void>> futures = Lists.newArrayList();
 
-        // Check for replicators to be stopped
-        replicators.forEach((cluster, replicator) -> {
-            // Update message TTL
-            ((PersistentReplicator) replicator).updateMessageTTL(newMessageTTLinSeconds);
+                    // Check for missing replicators
+                    for (String cluster : configuredClusters) {
+                        if (cluster.equals(localCluster)) {
+                            continue;
+                        }
 
-            if (!cluster.equals(localCluster)) {
-                if (!configuredClusters.contains(cluster)) {
-                    futures.add(removeReplicator(cluster));
-                }
-            }
+                        if (!replicators.containsKey(cluster)) {
+                            futures.add(startReplicator(cluster));
+                        }
+                    }
 
-        });
+                    // Check for replicators to be stopped
+                    replicators.forEach((cluster, replicator) -> {
+                        // Update message TTL
+                        ((PersistentReplicator) replicator).updateMessageTTL(newMessageTTLinSeconds);
 
-        return FutureUtil.waitForAll(futures);
+                        if (!cluster.equals(localCluster)) {
+                            if (!configuredClusters.contains(cluster)) {
+                                futures.add(removeReplicator(cluster));
+                            }
+                        }
+
+                    });
+
+                    return FutureUtil.waitForAll(futures);
+                });
     }
 
     @Override


### PR DESCRIPTION

### Motivation

The origin PR #12484 is merged into branch 2.7, but reverted in #16882 because Unit test `BrokerBookieIsolationTest#testBookieIsilationWithSecondaryGroup` fails.

The root cause is that `policies` and `localPolicies` are not updated after they are read from async process.

### Modifications

1. Cherry-pick PR #12484
2. Change `optPolicies, optLocalPolicies` to `policies, localPolicies` in 
https://github.com/merlimat/pulsar/blob/f53ddc13d7fb28f4c1bd73b23e7f3d8b7fc35591/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java#L1209

### Verifying this change

- [x] Make sure that the change passes the CI checks.



This change is already covered by existing tests, such as BrokerBookieIsolationTest#testBookieIsilationWithSecondaryGroup 


### Documentation

Check the box below or label this PR directly.

Need to update docs? 
  
- [x] `doc-not-needed` 
bug fix.
