### PR TITLE
[fix][function] Fix load trust certificate

### DIFF
--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/PulsarWorkerService.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/PulsarWorkerService.java
@@ -127,51 +127,31 @@ public class PulsarWorkerService implements WorkerService {
             @Override
             public PulsarAdmin newPulsarAdmin(String pulsarServiceUrl, WorkerConfig workerConfig) {
                 // using isBrokerClientAuthenticationEnabled instead of isAuthenticationEnabled in function-worker
-                if (workerConfig.isBrokerClientAuthenticationEnabled()) {
-                    return WorkerUtils.getPulsarAdminClient(
+                return WorkerUtils.getPulsarAdminClient(
                         pulsarServiceUrl,
-                        workerConfig.getBrokerClientAuthenticationPlugin(),
-                        workerConfig.getBrokerClientAuthenticationParameters(),
+                        workerConfig.isBrokerClientAuthenticationEnabled()
+                                ? workerConfig.getBrokerClientAuthenticationPlugin() : null,
+                        workerConfig.isBrokerClientAuthenticationEnabled()
+                                ? workerConfig.getBrokerClientAuthenticationParameters() : null,
                         workerConfig.getBrokerClientTrustCertsFilePath(),
                         workerConfig.isTlsAllowInsecureConnection(),
                         workerConfig.isTlsEnableHostnameVerification(),
                         workerConfig);
-                } else {
-                    return WorkerUtils.getPulsarAdminClient(
-                            pulsarServiceUrl,
-                            null,
-                            null,
-                            null,
-                            workerConfig.isTlsAllowInsecureConnection(),
-                            workerConfig.isTlsEnableHostnameVerification(),
-                            workerConfig);
-                }
             }
 
             @Override
             public PulsarClient newPulsarClient(String pulsarServiceUrl, WorkerConfig workerConfig) {
                 // using isBrokerClientAuthenticationEnabled instead of isAuthenticationEnabled in function-worker
-                if (workerConfig.isBrokerClientAuthenticationEnabled()) {
-                    return WorkerUtils.getPulsarClient(
+                return WorkerUtils.getPulsarClient(
                         pulsarServiceUrl,
-                        workerConfig.getBrokerClientAuthenticationPlugin(),
-                        workerConfig.getBrokerClientAuthenticationParameters(),
-                        workerConfig.isUseTls(),
+                        workerConfig.isBrokerClientAuthenticationEnabled()
+                                ? workerConfig.getBrokerClientAuthenticationPlugin() : null,
+                        workerConfig.isBrokerClientAuthenticationEnabled()
+                                ? workerConfig.getBrokerClientAuthenticationParameters() : null,
                         workerConfig.getBrokerClientTrustCertsFilePath(),
                         workerConfig.isTlsAllowInsecureConnection(),
                         workerConfig.isTlsEnableHostnameVerification(),
                         workerConfig);
-                } else {
-                    return WorkerUtils.getPulsarClient(
-                            pulsarServiceUrl,
-                            null,
-                            null,
-                            null,
-                            null,
-                            workerConfig.isTlsAllowInsecureConnection(),
-                            workerConfig.isTlsEnableHostnameVerification(),
-                            workerConfig);
-                }
             }
         };
     }

--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/WorkerUtils.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/WorkerUtils.java
@@ -279,19 +279,19 @@ public final class WorkerUtils {
 
     public static PulsarClient getPulsarClient(String pulsarServiceUrl) {
         return getPulsarClient(pulsarServiceUrl, null, null, null,
-                null, null, null, null);
+                null, null, null);
     }
 
     public static PulsarClient getPulsarClient(String pulsarServiceUrl, String authPlugin, String authParams,
-                                               Boolean useTls, String tlsTrustCertsFilePath,
+                                               String tlsTrustCertsFilePath,
                                                Boolean allowTlsInsecureConnection,
                                                Boolean enableTlsHostnameVerificationEnable) {
-        return getPulsarClient(pulsarServiceUrl, authPlugin, authParams, useTls, tlsTrustCertsFilePath,
+        return getPulsarClient(pulsarServiceUrl, authPlugin, authParams, tlsTrustCertsFilePath,
                 allowTlsInsecureConnection, enableTlsHostnameVerificationEnable, null);
     }
 
     public static PulsarClient getPulsarClient(String pulsarServiceUrl, String authPlugin, String authParams,
-                                               Boolean useTls, String tlsTrustCertsFilePath,
+                                               String tlsTrustCertsFilePath,
                                                Boolean allowTlsInsecureConnection,
                                                Boolean enableTlsHostnameVerificationEnable,
                                                WorkerConfig workerConfig) {
@@ -311,9 +311,6 @@ public final class WorkerUtils {
             if (isNotBlank(authPlugin)
                     && isNotBlank(authParams)) {
                 clientBuilder.authentication(authPlugin, authParams);
-            }
-            if (useTls != null) {
-                clientBuilder.enableTls(useTls);
             }
             if (allowTlsInsecureConnection != null) {
                 clientBuilder.allowTlsInsecureConnection(allowTlsInsecureConnection);


### PR DESCRIPTION
Signed-off-by: Zixuan Liu <nodeces@gmail.com>

### Motivation

When `brokerClientAuthenticationEnabled=false`, the function worker doesn't load the trust certificate.

### Modifications

- Always load the trust certificate

### Documentation

Check the box below or label this PR directly.

Need to update docs? 

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)
  
- [x] `doc-not-needed` 
(Please explain why)
  
- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)