### PR TITLE
[Branch 2.7] Avoid potentially blocking calls to metadata in PersistentTopic#getMessageTTL

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/NamespacesBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/NamespacesBase.java
@@ -829,7 +829,6 @@ public abstract class NamespacesBase extends AdminResource {
             // Write back the new policies into zookeeper
             globalZk().setData(path(POLICIES, namespaceName.toString()),
                     jsonMapper().writeValueAsBytes(policiesNode.getKey()), policiesNode.getValue().getVersion());
-            policiesCache().invalidate(path(POLICIES, namespaceName.toString()));
 
             log.info("[{}] Successfully updated the message TTL on namespace {}", clientAppId(), namespaceName);
         } catch (KeeperException.NoNodeException e) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -2480,8 +2480,11 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
         TopicName name = TopicName.get(topic);
         TopicPolicies topicPolicies = getTopicPolicies(name);
         Policies policies = brokerService.pulsar().getConfigurationCache().policiesCache()
-                .get(AdminResource.path(POLICIES, TopicName.get(topic).getNamespace()))
-                .orElseThrow(() -> new KeeperException.NoNodeException());
+                .getDataIfPresent(AdminResource.path(POLICIES, name.getNamespace()));
+        if (policies == null) {
+            log.error("policies is null in getMessageTTL");
+            throw new KeeperException.NoNodeException();
+        }
         if (topicPolicies != null && topicPolicies.isMessageTTLSet()) {
             return topicPolicies.getMessageTTLInSeconds();
         }


### PR DESCRIPTION
### Motivation

This PR is part of work of cherry-pick #12340 to branch 2.7

There is a concurrent issue when updating namespace TTL, causing `AdminApiTest#testTopicStatsLastExpireTimestampForSubscription` fails periodically.

The root cause is that in `NamespacesBase#internalSetNamespaceMessageTTL`:
- Step A, we write new namespace policy data to zk
- Step B, we call `policiesCache().invalidate` to disable the cache.

But between Step A and B, `ZooKeeperDataCache` will receive a data change event, and new data of `policiesCache` will be reloaded in `ZooKeeperDataCache#reloadCache`. So this reloaded data will invalidated in Step B. 

And in `PersistentTopic#onPoliciesUpdate` (triggered by Step A) won't be able to get policy data with `policiesCache().getDataIfPresent`, so `checkMessageExpiry` is skipped and results in `AdminApiTest#testTopicStatsLastExpireTimestampForSubscription` failure. 


### Modifications

Remove `policiesCache().invalidate` in Step B.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Documentation

Check the box below or label this PR directly.

- [x] `doc-not-needed` 

Bug fix
