### PR TITLE
[refactor][c++ client] Enable client memory limit controller by default.

### DIFF
--- a/pulsar-client-cpp/.gitignore
+++ b/pulsar-client-cpp/.gitignore
@@ -50,6 +50,7 @@ lib*.so*
 
 # Files generated from templates by CMAKE
 include/pulsar/Version.h
+.cmake
 
 # IDE generated files
 .csettings

--- a/pulsar-client-cpp/include/pulsar/ClientConfiguration.h
+++ b/pulsar-client-cpp/include/pulsar/ClientConfiguration.h
@@ -36,6 +36,7 @@ class PULSAR_PUBLIC ClientConfiguration {
     /**
      * Configure a limit on the amount of memory that will be allocated by this client instance.
      * Setting this to 0 will disable the limit. By default this is disabled.
+     * default: 64MB, The 64M default can guarantee a high producer throughput.
      *
      * @param memoryLimitBytes the memory limit
      */

--- a/pulsar-client-cpp/include/pulsar/ProducerConfiguration.h
+++ b/pulsar-client-cpp/include/pulsar/ProducerConfiguration.h
@@ -180,7 +180,7 @@ class PULSAR_PUBLIC ProducerConfiguration {
      * would fail unless blockIfQueueFull is set to true. Use {@link #setBlockIfQueueFull} to change the
      * blocking behavior.
      *
-     * Default: 1000
+     * Default: 0, disable the pending messages check.
      *
      * @param maxPendingMessages max number of pending messages.
      * @return
@@ -198,7 +198,7 @@ class PULSAR_PUBLIC ProducerConfiguration {
      * This setting will be used to lower the max pending messages for each partition
      * ({@link #setMaxPendingMessages(int)}), if the total exceeds the configured value.
      *
-     * Default: 50000
+     * Default: 0, disable the pending messages across partitions check.
      *
      * @param maxPendingMessagesAcrossPartitions
      */

--- a/pulsar-client-cpp/lib/ClientConfigurationImpl.h
+++ b/pulsar-client-cpp/lib/ClientConfigurationImpl.h
@@ -25,7 +25,7 @@ namespace pulsar {
 
 struct ClientConfigurationImpl {
     AuthenticationPtr authenticationPtr{AuthFactory::Disabled()};
-    uint64_t memoryLimit{0ull};
+    uint64_t memoryLimit{64 * 1024 *1024};
     int ioThreads{1};
     int operationTimeoutSeconds{30};
     int messageListenerThreads{1};

--- a/pulsar-client-cpp/lib/ClientConfigurationImpl.h
+++ b/pulsar-client-cpp/lib/ClientConfigurationImpl.h
@@ -25,7 +25,7 @@ namespace pulsar {
 
 struct ClientConfigurationImpl {
     AuthenticationPtr authenticationPtr{AuthFactory::Disabled()};
-    uint64_t memoryLimit{64 * 1024 *1024};
+    uint64_t memoryLimit{64 * 1024 * 1024};
     int ioThreads{1};
     int operationTimeoutSeconds{30};
     int messageListenerThreads{1};

--- a/pulsar-client-cpp/lib/ProducerConfigurationImpl.h
+++ b/pulsar-client-cpp/lib/ProducerConfigurationImpl.h
@@ -32,8 +32,8 @@ struct ProducerConfigurationImpl {
     Optional<int64_t> initialSequenceId;
     int sendTimeoutMs{30000};
     CompressionType compressionType{CompressionNone};
-    int maxPendingMessages{1000};
-    int maxPendingMessagesAcrossPartitions{50000};
+    int maxPendingMessages{0};
+    int maxPendingMessagesAcrossPartitions{0};
     ProducerConfiguration::PartitionsRoutingMode routingMode{ProducerConfiguration::UseSinglePartition};
     MessageRoutingPolicyPtr messageRouter;
     ProducerConfiguration::HashingScheme hashingScheme{ProducerConfiguration::BoostHash};

--- a/pulsar-client-cpp/tests/ClientConfigurationTest.cc
+++ b/pulsar-client-cpp/tests/ClientConfigurationTest.cc
@@ -1,0 +1,38 @@
+/**
+* Licensed to the Apache Software Foundation (ASF) under one
+* or more contributor license agreements.  See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership.  The ASF licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License.  You may obtain a copy of the License at
+*
+*   http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+#include <gtest/gtest.h>
+#include <pulsar/ClientConfiguration.h>
+
+using namespace pulsar;
+
+TEST(ClientConfigurationTest, testDefaultConfig) {
+    ClientConfiguration conf;
+    ASSERT_EQ(conf.getMemoryLimit(), 64 * 1024 * 1024);
+    ASSERT_EQ(conf.getIOThreads(), 1);
+    ASSERT_EQ(conf.getOperationTimeoutSeconds(), 30);
+    ASSERT_EQ(conf.getMessageListenerThreads(), 1);
+    ASSERT_EQ(conf.getConcurrentLookupRequest(), 50000);
+    ASSERT_EQ(conf.getLogConfFilePath(), "");
+    ASSERT_EQ(conf.isUseTls(), false);
+    ASSERT_EQ(conf.getTlsTrustCertsFilePath(), "");
+    ASSERT_EQ(conf.getStatsIntervalInSeconds(), 600);
+    ASSERT_EQ(conf.isValidateHostName(), false);
+    ASSERT_EQ(conf.getPartitionsUpdateInterval(), 60);
+    ASSERT_EQ(conf.getConnectionTimeout(), 10000);
+}

--- a/pulsar-client-cpp/tests/ClientConfigurationTest.cc
+++ b/pulsar-client-cpp/tests/ClientConfigurationTest.cc
@@ -1,21 +1,21 @@
 /**
-* Licensed to the Apache Software Foundation (ASF) under one
-* or more contributor license agreements.  See the NOTICE file
-* distributed with this work for additional information
-* regarding copyright ownership.  The ASF licenses this file
-* to you under the Apache License, Version 2.0 (the
-* "License"); you may not use this file except in compliance
-* with the License.  You may obtain a copy of the License at
-*
-*   http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing,
-* software distributed under the License is distributed on an
-* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-* KIND, either express or implied.  See the License for the
-* specific language governing permissions and limitations
-* under the License.
-*/
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 #include <gtest/gtest.h>
 #include <pulsar/ClientConfiguration.h>
 

--- a/pulsar-client-cpp/tests/ProducerConfigurationTest.cc
+++ b/pulsar-client-cpp/tests/ProducerConfigurationTest.cc
@@ -30,8 +30,8 @@ TEST(ProducerConfigurationTest, testDefaultConfig) {
     ASSERT_EQ(conf.getSendTimeout(), 30000);
     ASSERT_EQ(conf.getInitialSequenceId(), -1ll);
     ASSERT_EQ(conf.getCompressionType(), CompressionType::CompressionNone);
-    ASSERT_EQ(conf.getMaxPendingMessages(), 1000);
-    ASSERT_EQ(conf.getMaxPendingMessagesAcrossPartitions(), 50000);
+    ASSERT_EQ(conf.getMaxPendingMessages(), 0);
+    ASSERT_EQ(conf.getMaxPendingMessagesAcrossPartitions(), 0);
     ASSERT_EQ(conf.getPartitionsRoutingMode(), ProducerConfiguration::UseSinglePartition);
     ASSERT_EQ(conf.getMessageRouterPtr(), MessageRoutingPolicyPtr{});
     ASSERT_EQ(conf.getHashingScheme(), ProducerConfiguration::BoostHash);


### PR DESCRIPTION
### Motivation

#13306

### Modifications

- Enable C++ client memory limit controller by default.
- Git ignore `.cmake` folder

### Documentation

- [x] `doc-not-needed` 
(Please explain why)
 
