### PR TITLE
[Improve][Broker]Reduce PartitionedStats local REST call

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
@@ -39,7 +39,6 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiConsumer;
@@ -1344,7 +1343,6 @@ public class PersistentTopicsBase extends AdminResource {
             }
             PartitionedTopicStatsImpl stats = new PartitionedTopicStatsImpl(partitionMetadata);
             List<CompletableFuture<TopicStats>> topicStatsFutureList = new ArrayList<>(partitionMetadata.partitions);
-            AtomicBoolean exceptionFlag = new AtomicBoolean(false);
             for (int i = 0; i < partitionMetadata.partitions; i++) {
                 TopicName partition = topicName.getPartition(i);
                 topicStatsFutureList.add(
@@ -1363,16 +1361,12 @@ public class PersistentTopicsBase extends AdminResource {
                                         partition.toString(), getPreciseBacklog, subscriptionBacklogSize,
                                         getEarliestTimeInBacklog);
                                 } catch (PulsarServerException e) {
-                                    exceptionFlag.set(true);
                                     restFuture.completeExceptionally(e);
                                 }
                                 return restFuture;
                             }
                         })
                 );
-                if (exceptionFlag.get()) {
-                    break;
-                }
             }
 
             FutureUtil.waitForAll(topicStatsFutureList).handle((result, exception) -> {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
@@ -1355,15 +1355,13 @@ public class PersistentTopicsBase extends AdminResource {
                                         ref.getStats(getPreciseBacklog, subscriptionBacklogSize,
                                             getEarliestTimeInBacklog));
                             } else {
-                                CompletableFuture<TopicStats> restFuture = new CompletableFuture<>();
                                 try {
-                                    restFuture = pulsar().getAdminClient().topics().getStatsAsync(
+                                    return pulsar().getAdminClient().topics().getStatsAsync(
                                         partition.toString(), getPreciseBacklog, subscriptionBacklogSize,
                                         getEarliestTimeInBacklog);
                                 } catch (PulsarServerException e) {
-                                    restFuture.completeExceptionally(e);
+                                    return FutureUtil.failedFuture(e);
                                 }
-                                return restFuture;
                             }
                         })
                 );


### PR DESCRIPTION
### Motivation


* Reduce local REST calll for `org.apache.pulsar.broker.admin.impl.PersistentTopicsBase#internalGetPartitionedStats`

### Modifications

* Call local method if partition is owned by this broker,  or call REST api usng internal `AdminClient`

### Verifying this change

- [x] Make sure that the change passes the CI checks.


### Documentation

Check the box below or label this PR directly.

Need to update docs? 

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)
  
- [x] `doc-not-needed` 
(Please explain why)
  
- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)