### PR TITLE
[improve][cli] Add a separate TLS transport encryption configuration

### DIFF
--- a/conf/client.conf
+++ b/conf/client.conf
@@ -56,6 +56,12 @@ tlsEnableHostnameVerification=false
 # fails, then the cert is untrusted and the connection is dropped.
 tlsTrustCertsFilePath=
 
+# Path for the TLS certificate file
+tlsCertificateFilePath=
+
+# Path for the TLS private key file
+tlsKeyFilePath=
+
 # Enable TLS with KeyStore type configuration in broker.
 useKeyStoreTls=false
 
@@ -67,6 +73,15 @@ tlsTrustStorePath=
 
 # TLS TrustStore password
 tlsTrustStorePassword=
+
+# TLS KeyStore type configuration: JKS, PKCS12
+tlsKeyStoreType=JKS
+
+# TLS TrustStore path
+tlsKeyStorePath=
+
+# TLS TrustStore password
+tlsKeyStorePassword=
 
 # Set up TLS provider for web service
 # When TLS authentication with CACert is used, the valid value is either OPENSSL or JDK.

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/PulsarAdminTool.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/PulsarAdminTool.java
@@ -108,6 +108,12 @@ public class PulsarAdminTool {
         String tlsTrustStoreType = properties.getProperty("tlsTrustStoreType", "JKS");
         String tlsTrustStorePath = properties.getProperty("tlsTrustStorePath");
         String tlsTrustStorePassword = properties.getProperty("tlsTrustStorePassword");
+        String tlsKeyStoreType = properties.getProperty("tlsKeyStoreType", "JKS");
+        String tlsKeyStorePath = properties.getProperty("tlsKeyStorePath");
+        String tlsKeyStorePassword = properties.getProperty("tlsKeyStorePassword");
+        String tlsKeyFilePath = properties.getProperty("tlsKeyFilePath");
+        String tlsCertificateFilePath = properties.getProperty("tlsCertificateFilePath");
+
         boolean tlsAllowInsecureConnection = this.rootParams.tlsAllowInsecureConnection != null
                 ? this.rootParams.tlsAllowInsecureConnection
                 : Boolean.parseBoolean(properties.getProperty("tlsAllowInsecureConnection", "false"));
@@ -125,7 +131,12 @@ public class PulsarAdminTool {
                 .useKeyStoreTls(useKeyStoreTls)
                 .tlsTrustStoreType(tlsTrustStoreType)
                 .tlsTrustStorePath(tlsTrustStorePath)
-                .tlsTrustStorePassword(tlsTrustStorePassword);
+                .tlsTrustStorePassword(tlsTrustStorePassword)
+                .tlsKeyStoreType(tlsKeyStoreType)
+                .tlsKeyStorePath(tlsKeyStorePath)
+                .tlsKeyStorePassword(tlsKeyStorePassword)
+                .tlsKeyFilePath(tlsKeyFilePath)
+                .tlsCertificateFilePath(tlsCertificateFilePath);
     }
 
     protected void initRootParamsFromProperties(Properties properties) {

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/client/cli/PulsarClientTool.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/client/cli/PulsarClientTool.java
@@ -78,12 +78,17 @@ public class PulsarClientTool {
     boolean tlsAllowInsecureConnection;
     boolean tlsEnableHostnameVerification;
     String tlsTrustCertsFilePath;
+    String tlsKeyFilePath;
+    String tlsCertificateFilePath;
 
     // for tls with keystore type config
     boolean useKeyStoreTls;
     String tlsTrustStoreType;
     String tlsTrustStorePath;
     String tlsTrustStorePassword;
+    String tlsKeyStoreType;
+    String tlsKeyStorePath;
+    String tlsKeyStorePassword;
 
     protected JCommander jcommander;
     IUsageFormatter usageFormatter;
@@ -105,6 +110,12 @@ public class PulsarClientTool {
         this.tlsTrustStoreType = properties.getProperty("tlsTrustStoreType", "JKS");
         this.tlsTrustStorePath = properties.getProperty("tlsTrustStorePath");
         this.tlsTrustStorePassword = properties.getProperty("tlsTrustStorePassword");
+
+        this.tlsKeyStoreType = properties.getProperty("tlsKeyStoreType", "JKS");
+        this.tlsKeyStorePath = properties.getProperty("tlsKeyStorePath");
+        this.tlsKeyStorePassword = properties.getProperty("tlsKeyStorePassword");
+        this.tlsKeyFilePath = properties.getProperty("tlsKeyFilePath");
+        this.tlsCertificateFilePath = properties.getProperty("tlsCertificateFilePath");
 
         initJCommander();
     }
@@ -146,14 +157,20 @@ public class PulsarClientTool {
             clientBuilder.listenerName(this.rootParams.listenerName);
         }
         clientBuilder.allowTlsInsecureConnection(this.tlsAllowInsecureConnection);
-        clientBuilder.tlsTrustCertsFilePath(this.tlsTrustCertsFilePath);
         clientBuilder.enableTlsHostnameVerification(this.tlsEnableHostnameVerification);
         clientBuilder.serviceUrl(rootParams.serviceURL);
+
+        clientBuilder.tlsTrustCertsFilePath(this.tlsTrustCertsFilePath)
+                .tlsKeyFilePath(tlsKeyFilePath)
+                .tlsCertificateFilePath(tlsCertificateFilePath);
 
         clientBuilder.useKeyStoreTls(useKeyStoreTls)
                 .tlsTrustStoreType(tlsTrustStoreType)
                 .tlsTrustStorePath(tlsTrustStorePath)
-                .tlsTrustStorePassword(tlsTrustStorePassword);
+                .tlsTrustStorePassword(tlsTrustStorePassword)
+                .tlsKeyStoreType(tlsKeyStoreType)
+                .tlsKeyStorePath(tlsKeyStorePath)
+                .tlsKeyStorePassword(tlsKeyStorePassword);
 
         if (isNotBlank(rootParams.proxyServiceURL)) {
             if (rootParams.proxyProtocol == null) {


### PR DESCRIPTION
Signed-off-by: Zixuan Liu <nodeces@gmail.com>

### Motivation

We have implemented independent TLS transport encryption configuration on the Admin and Client, now let's support this in the cli.

### Documentation

Check the box below or label this PR directly.

Need to update docs? 

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)
  
- [ ] `doc-not-needed` 
(Please explain why)
  
- [ ] `doc` 
(Your PR contains doc changes)

- [x] `doc-complete` - https://github.com/apache/pulsar/pull/16924