### PR TITLE
[improve][authentication] Adapt basic authentication configuration with prefix

### DIFF
--- a/pulsar-broker-common/src/test/java/org/apache/pulsar/broker/authentication/AuthenticationProviderBasicTest.java
+++ b/pulsar-broker-common/src/test/java/org/apache/pulsar/broker/authentication/AuthenticationProviderBasicTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pulsar.broker.authentication;
 
+import static org.testng.Assert.assertEquals;
 import com.google.common.io.Resources;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -25,12 +26,11 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Base64;
 import java.util.Properties;
+import javax.naming.AuthenticationException;
 import lombok.Cleanup;
 import org.apache.pulsar.broker.ServiceConfiguration;
 import org.apache.pulsar.common.api.AuthData;
 import org.testng.annotations.Test;
-
-import javax.naming.AuthenticationException;
 
 public class AuthenticationProviderBasicTest {
     private final String basicAuthConf = Resources.getResource("authentication/basic/.htpasswd").getPath();
@@ -86,5 +86,19 @@ public class AuthenticationProviderBasicTest {
         System.setProperty("pulsar.auth.basic.conf", basicAuthConfBase64);
         provider.initialize(serviceConfiguration);
         testAuthenticate(provider);
+    }
+
+    @Test
+    public void testReadData() throws Exception {
+        byte[] data = Files.readAllBytes(Path.of(basicAuthConf));
+        String base64Data = Base64.getEncoder().encodeToString(data);
+
+        // base64 format
+        assertEquals(AuthenticationProviderBasic.readData("data:;base64," + base64Data), data);
+        assertEquals(AuthenticationProviderBasic.readData(base64Data), data);
+
+        // file format
+        assertEquals(AuthenticationProviderBasic.readData("file://" + basicAuthConf), data);
+        assertEquals(AuthenticationProviderBasic.readData(basicAuthConf), data);
     }
 }


### PR DESCRIPTION
Signed-off-by: Zixuan Liu <nodeces@gmail.com>

### Motivation

Fix https://github.com/apache/pulsar/pull/16526#discussion_r920269032, which supports the following config:
```
basicAuthConf=data:;base64,YOUR-BASE64
basicAuthConf=file:///my/basic.conf
basicAuthConf=YOUR-BASE64
basicAuthConf=/my/basic.conf
```

### Documentation

Check the box below or label this PR directly.

Need to update docs? 

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)
  
- [ ] `doc-not-needed` 
(Please explain why)
  
- [ ] `doc` 
(Your PR contains doc changes)

- [x] `doc-complete` - https://github.com/apache/pulsar/pull/16941
