### PR TITLE
[fix][load-balancer] skip mis-configured resource usage(>100%) in load balancer

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/LeastResourceUsageWithWeight.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/LeastResourceUsageWithWeight.java
@@ -90,7 +90,7 @@ public class LeastResourceUsageWithWeight implements ModularLoadManagerStrategy 
                                                           ServiceConfiguration conf) {
         final double historyPercentage = conf.getLoadBalancerHistoryResourcePercentage();
         Double historyUsage = brokerAvgResourceUsageWithWeight.get(broker);
-        double resourceUsage = brokerData.getLocalData().getMaxResourceUsageWithWeight(
+        double resourceUsage = brokerData.getLocalData().getMaxResourceUsageWithWeightWithinLimit(
                 conf.getLoadBalancerCPUResourceWeight(),
                 conf.getLoadBalancerMemoryResourceWeight(),
                 conf.getLoadBalancerDirectMemoryResourceWeight(),

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/ModularLoadManagerImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/ModularLoadManagerImpl.java
@@ -448,8 +448,9 @@ public class ModularLoadManagerImpl implements ModularLoadManager {
         long timeSinceLastReportWrittenToStore = System.currentTimeMillis() - localData.getLastUpdate();
         if (timeSinceLastReportWrittenToStore > updateMaxIntervalMillis) {
             log.info("Writing local data to metadata store because time since last"
-                            + " update exceeded threshold of {} minutes",
-                    conf.getLoadBalancerReportUpdateMaxIntervalMinutes());
+                            + " update exceeded threshold of {} minutes. ResourceUsage:[{}]",
+                    conf.getLoadBalancerReportUpdateMaxIntervalMinutes(),
+                    localData.printResourceUsage());
             // Always update after surpassing the maximum interval.
             return true;
         }
@@ -463,9 +464,10 @@ public class ModularLoadManagerImpl implements ModularLoadManager {
                                         percentChange(lastData.getNumBundles(), localData.getNumBundles()))));
         if (maxChange > conf.getLoadBalancerReportUpdateThresholdPercentage()) {
             log.info("Writing local data to metadata store because maximum change {}% exceeded threshold {}%; "
-                            + "time since last report written is {} seconds", maxChange,
+                            + "time since last report written is {} seconds. ResourceUsage:[{}]", maxChange,
                     conf.getLoadBalancerReportUpdateThresholdPercentage(),
-                    timeSinceLastReportWrittenToStore / 1000.0);
+                    timeSinceLastReportWrittenToStore / 1000.0,
+                    localData.printResourceUsage());
             return true;
         }
         return false;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/ThresholdShedder.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/ThresholdShedder.java
@@ -53,16 +53,38 @@ public class ThresholdShedder implements LoadSheddingStrategy {
     private final Multimap<String, String> selectedBundlesCache = ArrayListMultimap.create();
     private static final double ADDITIONAL_THRESHOLD_PERCENT_MARGIN = 0.05;
     private static final double MB = 1024 * 1024;
+
+    private static final long LOAD_LOG_SAMPLE_DELAY_IN_SEC = 5 * 60; // 5 mins
     private final Map<String, Double> brokerAvgResourceUsage = new HashMap<>();
+    private long lastSampledLoadLogTS = 0;
+
+
+    private static int toPercentage(double usage) {
+        return (int) (usage * 100);
+    }
+
+    private boolean canSampleLog() {
+        long now = System.currentTimeMillis() / 1000;
+        boolean sampleLog = now - lastSampledLoadLogTS >= LOAD_LOG_SAMPLE_DELAY_IN_SEC;
+        if (sampleLog) {
+            lastSampledLoadLogTS = now;
+        }
+        return sampleLog;
+    }
 
     @Override
     public Multimap<String, String> findBundlesForUnloading(final LoadData loadData, final ServiceConfiguration conf) {
         selectedBundlesCache.clear();
+        boolean sampleLog = canSampleLog();
         final double threshold = conf.getLoadBalancerBrokerThresholdShedderPercentage() / 100.0;
         final Map<String, Long> recentlyUnloadedBundles = loadData.getRecentlyUnloadedBundles();
         final double minThroughputThreshold = conf.getLoadBalancerBundleUnloadMinThroughputThreshold() * MB;
 
-        final double avgUsage = getBrokerAvgUsage(loadData, conf.getLoadBalancerHistoryResourcePercentage(), conf);
+        final double avgUsage = getBrokerAvgUsage(
+                loadData, conf.getLoadBalancerHistoryResourcePercentage(), conf, sampleLog);
+        if (sampleLog) {
+            log.info("brokers' resource avgUsage:{}%", toPercentage(avgUsage));
+        }
 
         if (avgUsage == 0) {
             log.warn("average max resource usage is 0");
@@ -74,8 +96,9 @@ public class ThresholdShedder implements LoadSheddingStrategy {
             final double currentUsage = brokerAvgResourceUsage.getOrDefault(broker, 0.0);
 
             if (currentUsage < avgUsage + threshold) {
-                if (log.isDebugEnabled()) {
-                    log.debug("[{}] broker is not overloaded, ignoring at this point", broker);
+                if (sampleLog) {
+                    log.info("[{}] broker is not overloaded, ignoring at this point, currentUsage:{}%",
+                            broker, toPercentage(currentUsage));
                 }
                 return;
             }
@@ -86,14 +109,13 @@ public class ThresholdShedder implements LoadSheddingStrategy {
             double minimumThroughputToOffload = brokerCurrentThroughput * percentOfTrafficToOffload;
 
             if (minimumThroughputToOffload < minThroughputThreshold) {
-                if (log.isDebugEnabled()) {
-                    log.debug("[{}] broker is planning to shed throughput {} MByte/s less than "
+                if (sampleLog) {
+                    log.info("[{}] broker is planning to shed throughput {} MByte/s less than "
                                     + "minimumThroughputThreshold {} MByte/s, skipping bundle unload.",
                             broker, minimumThroughputToOffload / MB, minThroughputThreshold / MB);
                 }
                 return;
             }
-
             log.info(
                     "Attempting to shed load on {}, which has max resource usage above avgUsage  and threshold {}%"
                             + " > {}% + {}% -- Offloading at least {} MByte/s of traffic, left throughput {} MByte/s",
@@ -139,14 +161,14 @@ public class ThresholdShedder implements LoadSheddingStrategy {
     }
 
     private double getBrokerAvgUsage(final LoadData loadData, final double historyPercentage,
-                                     final ServiceConfiguration conf) {
+                                     final ServiceConfiguration conf, boolean sampleLog) {
         double totalUsage = 0.0;
         int totalBrokers = 0;
 
         for (Map.Entry<String, BrokerData> entry : loadData.getBrokerData().entrySet()) {
             LocalBrokerData localBrokerData = entry.getValue().getLocalData();
             String broker = entry.getKey();
-            totalUsage += updateAvgResourceUsage(broker, localBrokerData, historyPercentage, conf);
+            totalUsage += updateAvgResourceUsage(broker, localBrokerData, historyPercentage, conf, sampleLog);
             totalBrokers++;
         }
 
@@ -154,7 +176,8 @@ public class ThresholdShedder implements LoadSheddingStrategy {
     }
 
     private double updateAvgResourceUsage(String broker, LocalBrokerData localBrokerData,
-                                          final double historyPercentage, final ServiceConfiguration conf) {
+                                          final double historyPercentage, final ServiceConfiguration conf,
+                                          boolean sampleLog) {
         Double historyUsage =
                 brokerAvgResourceUsage.get(broker);
         double resourceUsage = localBrokerData.getMaxResourceUsageWithWeight(
@@ -162,6 +185,41 @@ public class ThresholdShedder implements LoadSheddingStrategy {
                 conf.getLoadBalancerMemoryResourceWeight(), conf.getLoadBalancerDirectMemoryResourceWeight(),
                 conf.getLoadBalancerBandwithInResourceWeight(),
                 conf.getLoadBalancerBandwithOutResourceWeight());
+
+        if (sampleLog) {
+            log.info("{} broker load: historyUsage={}%, resourceUsage={}%",
+                    broker,
+                    historyUsage == null ? 0 : toPercentage(historyUsage),
+                    toPercentage(resourceUsage));
+        }
+
+        // wrap if resourceUsage is bigger than 1.0
+        if (resourceUsage > 1.0) {
+            log.error("{} broker resourceUsage is bigger than 100%. "
+                            + "Some of the resource limits are mis-configured. "
+                            + "Try to disable the error resource signals by setting their weights to zero "
+                            + "or fix the resource limit configurations. "
+                            + "Ref:https://pulsar.apache.org/docs/administration-load-balance/#thresholdshedder "
+                            + "ResourceUsage:[{}], "
+                            + "CPUResourceWeight:{}, MemoryResourceWeight:{}, DirectMemoryResourceWeight:{}, "
+                            + "BandwithInResourceWeight:{}, BandwithOutResourceWeight:{}",
+                    broker,
+                    localBrokerData.printResourceUsage(),
+                    conf.getLoadBalancerCPUResourceWeight(),
+                    conf.getLoadBalancerMemoryResourceWeight(),
+                    conf.getLoadBalancerDirectMemoryResourceWeight(),
+                    conf.getLoadBalancerBandwithInResourceWeight(),
+                    conf.getLoadBalancerBandwithOutResourceWeight());
+
+            resourceUsage = localBrokerData.getMaxResourceUsageWithWeightWithinLimit(
+                    conf.getLoadBalancerCPUResourceWeight(),
+                    conf.getLoadBalancerMemoryResourceWeight(), conf.getLoadBalancerDirectMemoryResourceWeight(),
+                    conf.getLoadBalancerBandwithInResourceWeight(),
+                    conf.getLoadBalancerBandwithOutResourceWeight());
+
+            log.warn("{} broker recomputed max resourceUsage={}%. Skipped usage signals bigger than 100%",
+                    broker, toPercentage(resourceUsage));
+        }
         historyUsage = historyUsage == null
                 ? resourceUsage : historyUsage * historyPercentage + (1 - historyPercentage) * resourceUsage;
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/impl/ThresholdShedderTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/impl/ThresholdShedderTest.java
@@ -73,6 +73,9 @@ public class ThresholdShedderTest {
         LoadData loadData = new LoadData();
 
         LocalBrokerData broker1 = new LocalBrokerData();
+        broker1.setCpu(new ResourceUsage(1000, 100));
+        broker1.setMemory(new ResourceUsage(5000, 100));
+        broker1.setDirectMemory(new ResourceUsage(5000, 100));
         broker1.setBandwidthIn(new ResourceUsage(500, 1000));
         broker1.setBandwidthOut(new ResourceUsage(500, 1000));
         broker1.setBundles(Sets.newHashSet("bundle-1"));
@@ -115,6 +118,9 @@ public class ThresholdShedderTest {
         LoadData loadData = new LoadData();
         
         LocalBrokerData broker1 = new LocalBrokerData();
+        broker1.setCpu(new ResourceUsage(1000, 100));
+        broker1.setMemory(new ResourceUsage(5000, 100));
+        broker1.setDirectMemory(new ResourceUsage(5000, 100));
         broker1.setBandwidthIn(new ResourceUsage(999, 1000));
         broker1.setBandwidthOut(new ResourceUsage(999, 1000));
 

--- a/pulsar-common/src/main/java/org/apache/pulsar/policies/data/loadbalancer/LocalBrokerData.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/policies/data/loadbalancer/LocalBrokerData.java
@@ -255,6 +255,16 @@ public class LocalBrokerData implements LoadManagerReport {
                 bandwidthOut.percentUsage() * bandwidthOutWeight) / 100;
     }
 
+    public double getMaxResourceUsageWithWeightWithinLimit(final double cpuWeight, final double memoryWeight,
+                                                           final double directMemoryWeight,
+                                                           final double bandwidthInWeight,
+                                                           final double bandwidthOutWeight) {
+        return maxWithinLimit(100.0d,
+                cpu.percentUsage() * cpuWeight, memory.percentUsage() * memoryWeight,
+                directMemory.percentUsage() * directMemoryWeight, bandwidthIn.percentUsage() * bandwidthInWeight,
+                bandwidthOut.percentUsage() * bandwidthOutWeight) / 100;
+    }
+
     private static double max(double... args) {
         double max = Double.NEGATIVE_INFINITY;
 
@@ -276,6 +286,16 @@ public class LocalBrokerData implements LoadManagerReport {
             }
         }
 
+        return max;
+    }
+
+    private static double maxWithinLimit(double limit, double...args) {
+        double max = 0.0;
+        for (double d : args) {
+            if (d > max && d <= limit) {
+                max = d;
+            }
+        }
         return max;
     }
 


### PR DESCRIPTION


<!--
### Contribution Checklist
  
  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://docs.google.com/document/d/1d8Pw6ZbWk-_pCKdOmdvx9rnhPiyuxwq60_TrD68d7BA/edit#heading=h.trs9rsex3xom)*. 

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.

**(The sections below can be removed for hotfixes of typos)**
-->


### Motivation
Incorrectly scaled resource load usage(cpu, memory, network usages bigger than 100%) can harm the load computation in the load balancer logics, as the load balancer computation expects all resource usages are normalized to the 100% scale. 

Also, we need more logs to debug load balance issues in the production. For example, we need more logs to investigate why the load balancer does not unload the bundles to the underloaded brokers and etc.

### Modifications
- Added a fall-back logic to ignore any incorrectly scaled resource usage in the load balance computation from ThresholdShedder. 
- Also updated LeastResourceUsageWithWeight.java (used for broker assignment) to ignore such invalid resource usages. 
- Added more logs in load balance logics(ThresholdShedder and Load Report) for better debugging.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change is already covered by existing tests, such as ThresholdShedderTest


### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API: (yes / **no**)
  - The schema: (yes / **no** / don't know)
  - The default values of configurations: (yes / **no**)
  - The wire protocol: (yes / **no**)
  - The rest endpoints: (yes / **no**)
  - The admin cli options: (yes / **no**)
  - Anything that affects deployment: (yes / **no** / don't know)

### Documentation

Check the box below or label this PR directly.

Need to update docs? 

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)
  
- [x] `doc-not-needed` 
(Please explain why) This fix covers the load computation edge case from the Load Balancer.
  
- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)