### PR TITLE
[feature][function] add the ability to customize logging level for Go & Python functions

### DIFF
--- a/pulsar-function-go/logutil/log.go
+++ b/pulsar-function-go/logutil/log.go
@@ -32,6 +32,7 @@ import (
 )
 
 const (
+	logLevelEnvName      = "LOGGING_LEVEL"
 	defaultLogLevel      = log.InfoLevel
 	defaultLogTimeFormat = "2006/01/02 15:04:05.000"
 )
@@ -175,6 +176,12 @@ func (f *TextFormatter) Format(entry *log.Entry) ([]byte, error) {
 
 func init() {
 	log.SetLevel(defaultLogLevel)
+	// lookup and parse the logLevel variable
+	if logLevelStr, exist := os.LookupEnv(logLevelEnvName); exist {
+		if logLevel, err := log.ParseLevel(logLevelStr); err == nil {
+			log.SetLevel(logLevel)
+		}
+	}
 	log.AddHook(&contextHook{})
 	log.SetFormatter(&TextFormatter{})
 }

--- a/pulsar-functions/instance/src/main/python/log.py
+++ b/pulsar-functions/instance/src/main/python/log.py
@@ -90,7 +90,10 @@ def init_logger(level, logfile, logging_config_file):
   os.environ['LOG_FILE'] = logfile
   logging.config.fileConfig(logging_config_file)
   Log = logging.getLogger()
-  Log.setLevel(level)
+  if level is not None:
+    Log.setLevel(level)
+    for h in Log.handlers:
+      h.setLevel(level)
 
   # set print to redirect to logger
   class StreamToLogger(object):

--- a/pulsar-functions/instance/src/main/python/python_instance_main.py
+++ b/pulsar-functions/instance/src/main/python/python_instance_main.py
@@ -78,6 +78,7 @@ def main():
   parser.add_argument('--max_buffered_tuples', required=True, help='Maximum number of Buffered tuples')
   parser.add_argument('--logging_directory', required=True, help='Logging Directory')
   parser.add_argument('--logging_file', required=True, help='Log file name')
+  parser.add_argument('--logging_level', required=False, help='Logging level')
   parser.add_argument('--logging_config_file', required=True, help='Config file for logging')
   parser.add_argument('--expected_healthcheck_interval', required=True, help='Expected time in seconds between health checks', type=int)
   parser.add_argument('--secrets_provider', required=False, help='The classname of the secrets provider')
@@ -154,7 +155,15 @@ def main():
   log_file = os.path.join(args.logging_directory,
                           util.getFullyQualifiedFunctionName(function_details.tenant, function_details.namespace, function_details.name),
                           "%s-%s.log" % (args.logging_file, args.instance_id))
-  log.init_logger(logging.INFO, log_file, args.logging_config_file)
+  logging_level = {"notset": logging.NOTSET,
+                   "debug": logging.DEBUG,
+                   "info": logging.INFO,
+                   "warn": logging.WARNING,
+                   "warning": logging.WARNING,
+                   "error": logging.ERROR,
+                   "critical": logging.CRITICAL,
+                   "fatal": logging.CRITICAL}.get(args.logging_level, None)
+  log.init_logger(logging_level, log_file, args.logging_config_file)
 
   Log.info("Starting Python instance with %s" % str(args))
 


### PR DESCRIPTION
Signed-off-by: laminar <[tpiperatgod@gmail.com](mailto:tpiperatgod@gmail.com)>

<!--

### Contribution Checklist

  - PR title format should be *[[type](https://github.com/apache/pulsar/compare/master...tpiperatgod:pulsar:issue-16928?expand=1#)][component] summary*. For details, see *[[Guideline - Pulsar PR Naming Convention](https://docs.google.com/document/d/1d8Pw6ZbWk-_pCKdOmdvx9rnhPiyuxwq60_TrD68d7BA/edit#heading=h.trs9rsex3xom)](https://docs.google.com/document/d/1d8Pw6ZbWk-_pCKdOmdvx9rnhPiyuxwq60_TrD68d7BA/edit#heading=h.trs9rsex3xom)*. 

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Each pull request should address only one issue, not mix up code from multiple issues.

  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.

**(The sections below can be removed for hotfixes of typos)**
-->

*(If this PR fixes a github issue, please add `Fixes #<xyz>`.)*

Fixes #16928 

*(or if this PR is one task of a github issue, please add `Master Issue: #<xyz>` to link to the master issue.)*

Master Issue: #<xyz>

### Motivation

*Currently, if the user wants to output more logging level logs other than INFO, it should provide the log settings for different pulsar function runtimes.*

### Modifications

- modifications to Go functions

  Pass in the logging level via environment variable, such as setting `LOGGING_LEVEL`, then add parsing of the `LOGGING_LEVEL` environment variable in `log.go`, , and finally set the logging level.

  ```go
  const (
  	// environment variable for custom logging level
  	logLevelEnvName      = "LOGGING_LEVEL"
  	defaultLogLevel      = log.InfoLevel
  	defaultLogTimeFormat = "2006/01/02 15:04:05.000"
  )
  
  func init() {
  	log.SetLevel(defaultLogLevel)
  	// lookup and parse the logLevel variable
  	if logLevelStr, exist := os.LookupEnv(logLevelEnvName); exist {
  		if logLevel, err := log.ParseLevel(logLevelStr); err == nil {
  			log.SetLevel(logLevel)
  		}
  	}
  	log.AddHook(&contextHook{})
  	log.SetFormatter(&TextFormatter{})
  }
  ```

- modifications to Python functions

  Add the `--logging_level` argument to `python_instance_main.py` to pass in the logging level, and add the following handle logic to `log.py` to set the logging level for each handlers.

  ```python
  def init_logger(level, logfile, logging_config_file):
      global Log
      # get log file location for function instance
      os.environ['LOG_FILE'] = logfile
      logging.config.fileConfig(logging_config_file)
      Log = logging.getLogger()
      # the priority of `level` is higher than `logging_config_file`
      if level != "":
          Log.setLevel(level)
          # set logging level for each handler
          for h in Log.handlers:
              h.setLevel(level)
  ```

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*

  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API: (yes / **no**)
  - The schema: (yes / **no** / don't know)
  - The default values of configurations: (yes / **no**)
  - The wire protocol: (yes / **no**)
  - The rest endpoints: (yes / **no**)
  - The admin cli options: (yes / **no**)
  - Anything that affects deployment: (yes / **no** / don't know)

### Documentation

Check the box below or label this PR directly.

Need to update docs? 

- [x] `doc-required` 
  (Your PR needs to update docs and you will update later)

- [ ] `doc-not-needed` 
  (Please explain why)

- [ ] `doc` 
  (Your PR contains doc changes)

- [ ] `doc-complete`
  (Docs have been already added)

[component]: