### PR TITLE
[improve][broker]reduce lookup response meta exception while bundle is being unloaded

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/lookup/TopicLookupBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/lookup/TopicLookupBase.java
@@ -35,6 +35,7 @@ import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.broker.ServiceConfiguration;
 import org.apache.pulsar.broker.authentication.AuthenticationDataSource;
 import org.apache.pulsar.broker.namespace.LookupOptions;
+import org.apache.pulsar.broker.service.BrokerServiceException;
 import org.apache.pulsar.broker.web.PulsarWebResource;
 import org.apache.pulsar.broker.web.RestException;
 import org.apache.pulsar.common.api.proto.CommandLookupTopicResponse.LookupType;
@@ -324,7 +325,13 @@ public class TopicLookupBase extends PulsarWebResource {
             }
 
         }).exceptionally(ex -> {
-            if (ex instanceof CompletionException && ex.getCause() instanceof IllegalStateException) {
+            if (ex instanceof CompletionException
+                    && ex.getCause() instanceof BrokerServiceException.ServerMetadataException) {
+                log.warn("Failed to lookup {} for topic {} with error {}", clientAppId, topicName.toString(),
+                        ex.getCause().getMessage());
+                lookupfuture.complete(newLookupErrorResponse(ServerError.MetadataError, ex.getMessage(), requestId));
+                return null;
+            } else if (ex instanceof CompletionException && ex.getCause() instanceof IllegalStateException) {
                 log.info("Failed to lookup {} for topic {} with error {}", clientAppId, topicName.toString(),
                         ex.getCause().getMessage());
             } else {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/NamespaceService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/NamespaceService.java
@@ -56,6 +56,7 @@ import org.apache.pulsar.broker.loadbalance.LeaderElectionService;
 import org.apache.pulsar.broker.loadbalance.LoadManager;
 import org.apache.pulsar.broker.loadbalance.ResourceUnit;
 import org.apache.pulsar.broker.lookup.LookupResult;
+import org.apache.pulsar.broker.service.BrokerServiceException;
 import org.apache.pulsar.broker.service.BrokerServiceException.ServiceUnitNotReadyException;
 import org.apache.pulsar.broker.service.Topic;
 import org.apache.pulsar.broker.service.nonpersistent.NonPersistentTopic;
@@ -411,8 +412,8 @@ public class NamespaceService implements AutoCloseable {
                         });
                     }
                 } else if (nsData.get().isDisabled()) {
-                    future.completeExceptionally(
-                            new IllegalStateException(String.format("Namespace bundle %s is being unloaded", bundle)));
+                    future.completeExceptionally(new BrokerServiceException.ServerMetadataException(
+                            (String.format("Namespace bundle %s is being unloaded", bundle))));
                 } else {
                     if (LOG.isDebugEnabled()) {
                         LOG.debug("Namespace bundle {} already owned by {} ", bundle, nsData);


### PR DESCRIPTION
Fixed https://github.com/apache/pulsar/issues/12165

### Motivation
see https://github.com/apache/pulsar/issues/12165
The bundle unloading of one producer or consumer will not affect other producers and consumers which belong to the same client and share the same connection.

If the bundle is being unloaded when there is a lookup request coming, the server will send back error code `ServiceNotReady`. And the client will close the connection in `checkServerError`.
https://github.com/apache/pulsar/blob/5c09d536304e5873c4e1ceeb8353a1150b5d61f4/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ClientCnx.java#L1123-L1130

The other producers and consumers will be affected due to they share the same connection. The requests of the connection will be drop.

### Modifications
Add the error code `ServiceNotReady` with `ServerMetadata`. The client will not close the connection, and other producers and consumers will not be affected when the bundle is being unloaded.


### Verifying this change

- [x]  Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.
### Does this pull request potentially affect one of the following parts:

If `yes` was chosen, please highlight the changes

- Dependencies (does it add or upgrade a dependency): (no)
- The public API: (no)
- The schema: (no)
- The default values of configurations: (no)
- The wire protocol: (no)
- The rest endpoints: (no)
- The admin cli options: (no)
- Anything that affects deployment: (no)

### Documentation
Check the box below and label this PR (if you have committer privilege).

Need to update docs? 
- [x] `doc-not-needed` 
