### PR TITLE
[fix][broker]Fix ConcurrentModificationException when ModularLoadManagerImpl start

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/ModularLoadManagerImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/ModularLoadManagerImpl.java
@@ -197,7 +197,7 @@ public class ModularLoadManagerImpl implements ModularLoadManager {
     private long unloadBundleCount = 0;
 
     private final Lock lock = new ReentrantLock();
-    private Set<String> knownBrokers = new HashSet<>();
+    private Set<String> knownBrokers = ConcurrentHashMap.newKeySet();
 
     /**
      * Initializes fields which do not depend on PulsarService. initialize(PulsarService) should subsequently be called.


### PR DESCRIPTION


Fixes https://github.com/apache/pulsar/issues/16952

### Motivation

* Fix ConcurrentModificationException when ModularLoadManagerImpl start. The root cause is that `ModularLoadManagerImpl#knownBrokers` can be modified in multi-thread through `ModularLoadManagerImpl#updateAll`
     *  Thread-1 is line290:
     https://github.com/apache/pulsar/blob/5c09d536304e5873c4e1ceeb8353a1150b5d61f4/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/ModularLoadManagerImpl.java#L282-L292
     *  Thread-2 is line969
     https://github.com/apache/pulsar/blob/5c09d536304e5873c4e1ceeb8353a1150b5d61f4/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/ModularLoadManagerImpl.java#L938-L970

### Modifications

* Changing `ModularLoadManagerImpl#knownBrokers` to `ConcurrentHashMap.newKeySet()`

### Verifying this change

- [x] Make sure that the change passes the CI checks.


### Documentation

Check the box below or label this PR directly.

Need to update docs? 

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)
  
- [x] `doc-not-needed` 
(Please explain why)
  
- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)