### PR TITLE
[Branch-2.7][fix][client] Fix MaxQueueSize semaphore release leak in createOpSendMsg.

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/BatchMessageContainerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/BatchMessageContainerImpl.java
@@ -182,6 +182,7 @@ class BatchMessageContainerImpl extends AbstractBatchMessageContainer {
     public OpSendMsg createOpSendMsg() throws IOException {
         ByteBuf encryptedPayload = producer.encryptMessage(messageMetadata, getCompressedBatchMetadataAndPayload());
         if (encryptedPayload.readableBytes() > ClientCnx.getMaxMessageSize()) {
+            producer.getSemaphore().release(messages.size());
             discard(new PulsarClientException.InvalidMessageException(
                     "Message size is bigger than " + ClientCnx.getMaxMessageSize() + " bytes"));
             return null;


### PR DESCRIPTION
### Motivation

This PR is part of work of cherry-pick https://github.com/apache/pulsar/pull/16915 to branch 2.7
Release MaxQueueSize semaphore when invalid message.

### Modifications
1. add semaphore release;
2. add unit test;

### Documentation

- [X] `doc-not-needed` 
(Please explain why)