### PR TITLE
[Branch-2.9][fix][client] Fix MaxQueueSize semaphore release leak in createOpSendMsg. 

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/BatchMessageContainerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/BatchMessageContainerImpl.java
@@ -199,6 +199,7 @@ class BatchMessageContainerImpl extends AbstractBatchMessageContainer {
     public OpSendMsg createOpSendMsg() throws IOException {
         ByteBuf encryptedPayload = producer.encryptMessage(messageMetadata, getCompressedBatchMetadataAndPayload());
         if (encryptedPayload.readableBytes() > ClientCnx.getMaxMessageSize()) {
+            producer.semaphoreRelease(messages.size());
             discard(new PulsarClientException.InvalidMessageException(
                     "Message size is bigger than " + ClientCnx.getMaxMessageSize() + " bytes"));
             return null;


### PR DESCRIPTION
### Motivation
This PR is part of work of cherry-pick https://github.com/apache/pulsar/pull/16915 to branch 2.9
Release MaxQueueSize semaphore when invalid message.

### Modifications

1. add semaphore release;
2. fix unit test;


### Documentation
- [X] `doc-not-needed` 
(Please explain why)
