### PR TITLE
[cleanup][transaction] Add Maven Modernizer plugin in pulsar-transaction

### DIFF
--- a/pulsar-transaction/common/pom.xml
+++ b/pulsar-transaction/common/pom.xml
@@ -38,6 +38,23 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.gaul</groupId>
+                <artifactId>modernizer-maven-plugin</artifactId>
+                <configuration>
+                    <failOnViolations>true</failOnViolations>
+                    <javaVersion>8</javaVersion>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>modernizer</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>modernizer</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <groupId>com.github.spotbugs</groupId>
                 <artifactId>spotbugs-maven-plugin</artifactId>
                 <configuration>

--- a/pulsar-transaction/coordinator/pom.xml
+++ b/pulsar-transaction/coordinator/pom.xml
@@ -65,6 +65,23 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.gaul</groupId>
+                <artifactId>modernizer-maven-plugin</artifactId>
+                <configuration>
+                    <failOnViolations>true</failOnViolations>
+                    <javaVersion>8</javaVersion>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>modernizer</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>modernizer</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>properties-maven-plugin</artifactId>
                 <executions>

--- a/pulsar-transaction/coordinator/src/main/java/org/apache/pulsar/transaction/coordinator/TransactionSubscription.java
+++ b/pulsar-transaction/coordinator/src/main/java/org/apache/pulsar/transaction/coordinator/TransactionSubscription.java
@@ -18,7 +18,7 @@
  */
 package org.apache.pulsar.transaction.coordinator;
 
-import com.google.common.base.Objects;
+import java.util.Objects;
 import lombok.Builder;
 import lombok.Data;
 
@@ -34,7 +34,7 @@ public class TransactionSubscription implements Comparable<TransactionSubscripti
 
     @Override
     public int hashCode() {
-        return Objects.hashCode(topic, subscription);
+        return Objects.hash(topic, subscription);
     }
 
     @Override


### PR DESCRIPTION

### Motivation


Apply Maven Modernizer plugin to enforce we move away from legacy APIs.


### Modifications

Add Maven Modernizer plugin in pulsar-transaction module and fix violation.

### Verifying this change


This change is already covered by existing tests, such as *(please describe tests)*.




### Does this pull request potentially affect one of the following parts:


  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

- [x] `doc-not-needed` 
 