### PR TITLE
[Branch 2.7][Fix][broker] Fix NPE when ledger id not found in `OpReadEntry` (#15837)

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
@@ -1969,14 +1969,9 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
         }
     }
 
-    PositionImpl startReadOperationOnLedger(PositionImpl position, OpReadEntry opReadEntry) {
+    PositionImpl startReadOperationOnLedger(PositionImpl position) {
         Long ledgerId = ledgers.ceilingKey(position.getLedgerId());
-        if (null == ledgerId) {
-            opReadEntry.readEntriesFailed(new ManagedLedgerException.NoMoreEntriesToReadException("The ceilingKey(K key) method is used to return the " +
-                    "least key greater than or equal to the given key, or null if there is no such key"), null);
-        }
-
-        if (ledgerId != position.getLedgerId()) {
+        if (ledgerId != null && ledgerId != position.getLedgerId()) {
             // The ledger pointed by this position does not exist anymore. It was deleted because it was empty. We need
             // to skip on the next available ledger
             position = new PositionImpl(ledgerId, 0);

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/OpReadEntry.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/OpReadEntry.java
@@ -47,7 +47,7 @@ class OpReadEntry implements ReadEntriesCallback {
     public static OpReadEntry create(ManagedCursorImpl cursor, PositionImpl readPositionRef, int count,
             ReadEntriesCallback callback, Object ctx) {
         OpReadEntry op = RECYCLER.get();
-        op.readPosition = cursor.ledger.startReadOperationOnLedger(readPositionRef, op);
+        op.readPosition = cursor.ledger.startReadOperationOnLedger(readPositionRef);
         op.cursor = cursor;
         op.count = count;
         op.callback = callback;
@@ -132,7 +132,7 @@ class OpReadEntry implements ReadEntriesCallback {
         if (entries.size() < count && cursor.hasMoreEntries()) {
             // We still have more entries to read from the next ledger, schedule a new async operation
             cursor.ledger.getExecutor().execute(safeRun(() -> {
-                readPosition = cursor.ledger.startReadOperationOnLedger(nextReadPosition, OpReadEntry.this);
+                readPosition = cursor.ledger.startReadOperationOnLedger(nextReadPosition);
                 cursor.ledger.asyncReadEntries(OpReadEntry.this);
             }));
         } else {

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerTest.java
@@ -49,6 +49,8 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.NavigableMap;
+import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
@@ -407,6 +409,31 @@ public class ManagedLedgerTest extends MockedBookKeeperTestCase {
         assertFalse(cursor.hasMoreEntries());
 
         ledger.close();
+    }
+
+    @Test
+    public void testStartReadOperationOnLedgerWithEmptyLedgers() throws ManagedLedgerException, InterruptedException {
+        ManagedLedger ledger = factory.open("my_test_ledger_1");
+        ManagedLedgerImpl ledgerImpl = (ManagedLedgerImpl) ledger;
+        NavigableMap<Long, LedgerInfo> ledgers = ledgerImpl.getLedgersInfo();
+        LedgerInfo ledgerInfo = ledgers.firstEntry().getValue();
+        ledgers.clear();
+        ManagedCursor c1 = ledger.openCursor("c1");
+        PositionImpl position = new PositionImpl(ledgerInfo.getLedgerId(), 0);
+        OpReadEntry opReadEntry = OpReadEntry.create((ManagedCursorImpl) c1, position, 20,
+                new ReadEntriesCallback() {
+
+                    @Override
+                    public void readEntriesComplete(List<Entry> entries, Object ctx) {
+
+                    }
+
+                    @Override
+                    public void readEntriesFailed(ManagedLedgerException exception, Object ctx) {
+
+                    }
+                }, null);
+        Assert.assertEquals(opReadEntry.readPosition, position);
     }
 
     @Test(timeOut = 20000)


### PR DESCRIPTION
(cherry picked from commit 7a3ad611f51511afca4bcaa1de299517a1907e8e)

### Motivation

In current implementation, We have more than one potential NPE relate `ManagedLedgerImpl#startReadOperationOnLedger` method.

**1. Unbox NPE**

https://github.com/apache/pulsar/blob/b13d15c4d6d795f33c6ed23f920fabbb3eeaf745/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java#L2230-L2244


According to this code, we can know that when the ledger id is null, we will fail `OpReadEntry`. However, there is no direct return here after failure. NPE will be thrown on line 2238. Because we want to unbox `null`.

**2. null `OpReadEntry` context**

According to the code above, we can see when we fail `OpReadEntry`, we pass a null value as context(line 2235). there is an NPE when the dispatcher gets the callback.

https://github.com/apache/pulsar/blob/0975cdc2489739b7518ee7acc78bbc6e8c8e2e4d/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherSingleActiveConsumer.java#L478-L484

**3. `OpReadEntry#create`**

https://github.com/apache/pulsar/blob/93761284b9f6875da0403f5fedb6ccbfbbcd7315/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/OpReadEntry.java#L48-L63

When we create `OpReadEntry` and then call `ManagedCursor#startReadOperationOnLedger` , assuming the ledger id is equal to null. At this point, we will fail this `OpReadEntry`. But at the current time, other parameters are not initialized. When we call `OpReadEntry#readEntriesFailed`. The cursor will be null and the NPE will be thrown.

https://github.com/apache/pulsar/blob/93761284b9f6875da0403f5fedb6ccbfbbcd7315/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/OpReadEntry.java#L90-L94


### Modifications

- Remove fail `OpReadEntry` logic in `ManagedCursor#startReadOperationOnLedger`, when ledger id equals null, we can return the original value. the `ManagedLedger` will validate if this operation is legal.

From the perspective of the overall design, the `OpReadEntry` is just a middle state object, that may have illegal value, we have to check this `OpReadEntry` is valid in `ManagedLedger#asyncReadEntries`(Current we already do that).

### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Documentation

- [x] `doc-not-needed` 
(Please explain why)
