### PR TITLE
[improve][tool] Able to set maxLookupRequest for pulsar-perf

### DIFF
--- a/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerfClientUtils.java
+++ b/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerfClientUtils.java
@@ -74,7 +74,8 @@ public class PerfClientUtils {
                 .statsInterval(arguments.statsIntervalSeconds, TimeUnit.SECONDS)
                 .enableBusyWait(arguments.enableBusyWait)
                 .listenerThreads(arguments.listenerThreads)
-                .tlsTrustCertsFilePath(arguments.tlsTrustCertsFilePath);
+                .tlsTrustCertsFilePath(arguments.tlsTrustCertsFilePath)
+                .maxLookupRequests(arguments.maxLookupRequest);
 
         if (isNotBlank(arguments.authPluginClassName)) {
             clientBuilder.authentication(arguments.authPluginClassName, arguments.authParams);

--- a/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceBaseArguments.java
+++ b/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceBaseArguments.java
@@ -81,6 +81,10 @@ public abstract class PerformanceBaseArguments {
             + " to be used for message listeners")
     public int listenerThreads = 1;
 
+    @Parameter(names = {"-mlr", "--max-lookup-request"}, description = "Maximum number of lookup requests allowed "
+            + "on each broker connection to prevent overloading a broker")
+    public int maxLookupRequest = 50000;
+
     public abstract void fillArgumentsFromProperties(Properties prop);
 
     @SneakyThrows

--- a/pulsar-testclient/src/test/java/org/apache/pulsar/testclient/PerfClientUtilsTest.java
+++ b/pulsar-testclient/src/test/java/org/apache/pulsar/testclient/PerfClientUtilsTest.java
@@ -70,6 +70,7 @@ public class PerfClientUtilsTest {
         args.serviceURL = "pulsar+ssl://my-pulsar:6651";
         args.tlsTrustCertsFilePath = "path";
         args.tlsAllowInsecureConnection = true;
+        args.maxLookupRequest = 100000;
 
         final ClientBuilderImpl builder = (ClientBuilderImpl)PerfClientUtils.createClientBuilderFromArguments(args);
         final ClientConfigurationData conf = builder.getClientConfigurationData();
@@ -86,6 +87,7 @@ public class PerfClientUtilsTest {
         Assert.assertEquals(conf.getServiceUrl(), "pulsar+ssl://my-pulsar:6651");
         Assert.assertEquals(conf.getTlsTrustCertsFilePath(), "path");
         Assert.assertTrue(conf.isTlsAllowInsecureConnection());
+        Assert.assertEquals(conf.getMaxLookupRequest(), 100000);
 
     }
 }


### PR DESCRIPTION
### Motivation

Expose the maxLookupRequest configuration for pulsar-perf.
Without this configuration, run the pulsar-perf for over 50000 topics will
get exception like followings:

```
2022-08-07T10:31:28,317+0800 [pulsar-timer-7-1] WARN  org.apache.pulsar.client.impl.ConnectionHandler - [persistent://public/default/p100k-partition-50393] [standalone-6-0] Could not get connection to broker: org.apache.pulsar.client.api.PulsarClientException$TooManyRequestsException: Requests number out of config: There are {0} lookup requests outstanding and {45000} requests pending. -- Will try again in 0.798 s
```

### Documentation

Check the box below or label this PR directly.

Need to update docs? 

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)
  
- [x] `doc-not-needed` 
(Please explain why)
  
- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)