### PR TITLE
 [Branch-2.7][fix][client] Fix semaphore release duplicated in ProducerImpl.

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
@@ -1672,10 +1672,7 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
                 for (OpSendMsg opSendMsg : opSendMsgs) {
                     processOpSendMsg(opSendMsg);
                 }
-            } catch (PulsarClientException e) {
-                semaphore.release(batchMessageContainer.getNumMessagesInBatch());
             } catch (Throwable t) {
-                semaphore.release(batchMessageContainer.getNumMessagesInBatch());
                 log.warn("[{}] [{}] error while create opSendMsg by batch message container", topic, producerName, t);
             }
         }


### PR DESCRIPTION
### Motivation

This PR is part of work of cherry-pick https://github.com/apache/pulsar/pull/16837 to branch 2.7, and only contain the fix in duplicate semaphore release.
Avoid duplicate semaphore release in batchMessageAndSend.

### Modifications

1. delete duplicate semaphore release in batchMessageAndSend;
2. add unit test;

### Documentation

- [X] `doc-not-needed` 
(Please explain why)
  