### PR TITLE
[doc][broker][monitoring] Add doc for per-subscription EntryFilter metrics

### DIFF
--- a/site2/docs/admin-api-topics.md
+++ b/site2/docs/admin-api-topics.md
@@ -415,7 +415,15 @@ You can check the following statistics of a given non-partitioned topic.
 
           -   **nonContiguousDeletedMessagesRanges**: The number of non-contiguous deleted messages ranges.
 
-          -   **nonContiguousDeletedMessagesRangesSerializedSize**: The serialized size of non-contiguous deleted messages ranges. 
+          -   **nonContiguousDeletedMessagesRangesSerializedSize**: The serialized size of non-contiguous deleted messages ranges.
+              
+          -   **throughEntryFilterMsgs**: The number of messages passes through `EntryFilter`.
+              
+          -   **entryFilterAccepted**: The number of messages accepted by `EntryFilter`.
+              
+          -   **entryFilterRejected**: The number of messages rejected by `EntryFilter`.
+              
+          -   **entryFilterRescheduled**: The number of messages rescheduled by `EntryFilter`.
 
           -   **consumers**: The list of connected consumers for this subscription.
 

--- a/site2/docs/admin-api-topics.md
+++ b/site2/docs/admin-api-topics.md
@@ -549,6 +549,10 @@ The following is an example of a topic status.
       "lastConsumedTimestamp" : 1623230583946,
       "lastAckedTimestamp" : 1623230584033,
       "lastMarkDeleteAdvancedTimestamp" : 1623230584033,
+      "throughEntryFilterMsgs": 100,
+      "entryFilterAccepted": 100,
+      "entryFilterRejected": 0,
+      "entryFilterRescheduled": 0,
       "consumers" : [ {
         "msgRateOut" : 0.0,
         "msgThroughputOut" : 0.0,

--- a/site2/docs/reference-metrics.md
+++ b/site2/docs/reference-metrics.md
@@ -444,6 +444,10 @@ All the subscription metrics are labelled with the following labels:
 | pulsar_subscription_total_msg_expired | Gauge | The total number of messages expired on this subscription. |
 | pulsar_subscription_msg_drop_rate | Gauge | The rate of messages dropped on this subscription (message per second). |
 | pulsar_subscription_consumers_count | Gauge | The number of connected consumers on this subscription. |
+| pulsar_subscription_through_filter_msg_count | Counter | The number of messages passes through `EntryFilter`. |
+| pulsar_subscription_filter_accepted_msg_count | Counter | The number of messages accepted by `EntryFilter`. |
+| pulsar_subscription_filter_rejected_msg_count | Counter | The number of messages rejected by `EntryFilter`. |
+| pulsar_subscription_filter_rescheduled_msg_count | Counter | The number of messages rescheduled by `EntryFilter`. |
 
 ### Consumer metrics
 


### PR DESCRIPTION
### Motivation

add reference-metrics doc and admin-api doc for https://github.com/apache/pulsar/pull/16932

### Documentation

Check the box below or label this PR directly.

Need to update docs? 

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)
  
- [ ] `doc-not-needed` 
(Please explain why)
  
- [x] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)