### PR TITLE
[fix][flaky-test]BrokerServiceTest.testLookupThrottlingForClientByClient

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerServiceTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerServiceTest.java
@@ -969,7 +969,6 @@ public class BrokerServiceTest extends BrokerTestBase {
      */
     @Test
     public void testLookupThrottlingForClientByClient() throws Exception {
-        // Initialize rate limiter.
         final String topicName = "persistent://prop/ns-abc/newTopic";
         PulsarServiceNameResolver resolver = new PulsarServiceNameResolver();
         resolver.updateServiceUrl(pulsar.getBrokerServiceUrl());

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerServiceTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerServiceTest.java
@@ -972,24 +972,20 @@ public class BrokerServiceTest extends BrokerTestBase {
         final String topicName = "persistent://prop/ns-abc/newTopic";
         PulsarServiceNameResolver resolver = new PulsarServiceNameResolver();
         resolver.updateServiceUrl(pulsar.getBrokerServiceUrl());
-        ClientConfigurationData conf = new ClientConfigurationData();
+        final ClientConfigurationData conf = new ClientConfigurationData();
         conf.setConcurrentLookupRequest(1);
         conf.setMaxLookupRequest(2);
 
-        EventLoopGroup eventLoop = EventLoopUtil.newEventLoopGroup(20, false,
+        final EventLoopGroup eventLoop = EventLoopUtil.newEventLoopGroup(20, false,
                 new DefaultThreadFactory("test-pool", Thread.currentThread().isDaemon()));
         /**
          *  if the broker responds and client handle response quickly enough, there may never be concurrency in
          *  requests and this test will be flaky. So use {@link BlockLookupResponseClientCnx} to control the rate of
          *  response-handle.
          */
-        AtomicBoolean blockLookupResponseSignal = new AtomicBoolean(true);
-        Supplier<ClientCnx> blockLookupResponseClientCnxSupplier = new Supplier<ClientCnx>() {
-            @Override
-            public ClientCnx get() {
-                return new BlockLookupResponseClientCnx(conf, eventLoop, blockLookupResponseSignal);
-            }
-        };
+        final AtomicBoolean blockLookupResponseSignal = new AtomicBoolean(true);
+        Supplier<ClientCnx> blockLookupResponseClientCnxSupplier =
+                () -> new BlockLookupResponseClientCnx(conf, eventLoop, blockLookupResponseSignal);
 
         long reqId = 0xdeadbeef;
         try (ConnectionPool pool = new ConnectionPool(conf, eventLoop, blockLookupResponseClientCnxSupplier)) {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerServiceTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerServiceTest.java
@@ -980,8 +980,9 @@ public class BrokerServiceTest extends BrokerTestBase {
         EventLoopGroup eventLoop = EventLoopUtil.newEventLoopGroup(20, false,
                 new DefaultThreadFactory("test-pool", Thread.currentThread().isDaemon()));
         /**
-         * If the broker responds quickly enough, there may never be concurrency in requests. So we create a block-stat
-         * to control the rate of response-handle.
+         *  if the broker responds and client handle response quickly enough, there may never be concurrency in
+         *  requests and this test will be flaky. So use {@link BlockLookupResponseClientCnx} to control the rate of
+         *  response-handle.
          */
         AtomicBoolean blockLookupResponseSignal = new AtomicBoolean(true);
         Supplier<ClientCnx> blockLookupResponseClientCnxSupplier = new Supplier<ClientCnx>() {


### PR DESCRIPTION
Fixes #16521

Master Issue: #16521

### Motivation

![截屏2022-08-08 15 24 01](https://user-images.githubusercontent.com/25195800/183362626-03391383-4cbc-4c80-9d01-22bee00758a6.png)

this test is still flaky

In `BrokerServiceTest.testLookupThrottlingForClientByClient`, if the broker responds and client handle response quickly enough, this test will fail.

### Modifications

Add a signal to control the execution speed of "client handle response". The logic is almost like #16540

### Documentation

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)
  
- [x] `doc-not-needed` 
(Please explain why)
  
- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)