### PR TITLE
[fix][broker] Fix memory leak if entry exists in cache

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/OpAddEntry.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/OpAddEntry.java
@@ -211,6 +211,8 @@ public class OpAddEntry extends SafeRunnable implements AddCallback, CloseCallba
         if (ml.hasActiveCursors()) {
             // Avoid caching entries if no cursor has been created
             EntryImpl entry = EntryImpl.create(ledger.getId(), entryId, data);
+            // EntryCache.insert: duplicates entry by allocating new entry and data. so, recycle entry after calling
+            // insert
             ml.entryCache.insert(entry);
             entry.release();
         }

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/OpAddEntry.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/OpAddEntry.java
@@ -211,13 +211,8 @@ public class OpAddEntry extends SafeRunnable implements AddCallback, CloseCallba
         if (ml.hasActiveCursors()) {
             // Avoid caching entries if no cursor has been created
             EntryImpl entry = EntryImpl.create(ledger.getId(), entryId, data);
-            // EntryCache.insert: duplicates entry by allocating new entry and data. so, recycle entry after calling
-            // insert
-            // Entry cache doesn't copy the data if entry already exist into the cache.
-            // Backlog read tries to add entry into cache which can try to add duplicate entry into cache.
-            if (ml.entryCache.insert(entry)) {
-                entry.release();
-            }
+            ml.entryCache.insert(entry);
+            entry.release();
         }
 
         PositionImpl lastEntry = PositionImpl.get(ledger.getId(), entryId);

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/protocol/Commands.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/protocol/Commands.java
@@ -1850,9 +1850,10 @@ public class Commands {
             long consumerId) {
         try {
             // save the reader index and restore after parsing
-            metadataAndPayload.markReaderIndex();
+            int readerIdx = metadataAndPayload.readerIndex();
             MessageMetadata metadata = Commands.parseMessageMetadata(metadataAndPayload);
-            metadataAndPayload.resetReaderIndex();
+            metadataAndPayload.readerIndex(readerIdx);
+
             return metadata;
         } catch (Throwable t) {
             log.error("[{}] [{}] Failed to parse message metadata", subscription, consumerId, t);

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/protocol/Commands.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/protocol/Commands.java
@@ -1850,10 +1850,9 @@ public class Commands {
             long consumerId) {
         try {
             // save the reader index and restore after parsing
-            int readerIdx = metadataAndPayload.readerIndex();
+            metadataAndPayload.markReaderIndex();
             MessageMetadata metadata = Commands.parseMessageMetadata(metadataAndPayload);
-            metadataAndPayload.readerIndex(readerIdx);
-
+            metadataAndPayload.resetReaderIndex();
             return metadata;
         } catch (Throwable t) {
             log.error("[{}] [{}] Failed to parse message metadata", subscription, consumerId, t);


### PR DESCRIPTION
Master Issue: #16979

### Motivation

PR https://github.com/apache/pulsar/pull/12258 made changes to OpAddEntry which causes a memory leak when the entry is already in the cache.

### Modifications

Modifications: Revert PR https://github.com/apache/pulsar/pull/12258 changes to OpAddEntry

### Documentation

- [x] `doc-not-needed` 
