### PR TITLE
[fix][flaky-test]TxnLogBufferedWriterTest.testMainProcess

### DIFF
--- a/pulsar-transaction/coordinator/src/test/java/org/apache/pulsar/transaction/coordinator/impl/TxnLogBufferedWriterTest.java
+++ b/pulsar-transaction/coordinator/src/test/java/org/apache/pulsar/transaction/coordinator/impl/TxnLogBufferedWriterTest.java
@@ -248,8 +248,6 @@ public class TxnLogBufferedWriterTest extends MockedBookKeeperTestCase {
         int exceptionCallbackCount = exceptionArrayOfCallback.size();
         int positionCallbackCount = (int) positionsOfCallback.values().stream().flatMap(l -> l.stream()).count();
         if (BookieErrorType.SOMETIMES_ERROR == bookieErrorType ||  closeBufferedWriter){
-            Assert.assertTrue(exceptionCallbackCount > 0);
-            Assert.assertTrue(positionCallbackCount > 0);
             Assert.assertEquals(exceptionCallbackCount + positionCallbackCount, writeCmdExecuteCount);
         } else if (BookieErrorType.NO_ERROR == bookieErrorType){
             Assert.assertEquals(positionCallbackCount, writeCmdExecuteCount);

--- a/pulsar-transaction/coordinator/src/test/java/org/apache/pulsar/transaction/coordinator/impl/TxnLogBufferedWriterTest.java
+++ b/pulsar-transaction/coordinator/src/test/java/org/apache/pulsar/transaction/coordinator/impl/TxnLogBufferedWriterTest.java
@@ -233,7 +233,8 @@ public class TxnLogBufferedWriterTest extends MockedBookKeeperTestCase {
         // Assert callback count.
         Awaitility.await().until(() -> contextArrayOfCallback.size() == writeCmdExecuteCount);
         // Assert callback param-context, verify that all callbacks are executed in strict order.
-        if (closeBufferedWriter){
+        // If exception occurs, the failure callback be executed earlier. So sorted contextArrayOfCallback.
+        if (closeBufferedWriter || bookieErrorType == BookieErrorType.SOMETIMES_ERROR){
             Collections.sort(contextArrayOfCallback);
         }
         Assert.assertEquals(contextArrayOfCallback.size(), writeCmdExecuteCount);

--- a/pulsar-transaction/coordinator/src/test/java/org/apache/pulsar/transaction/coordinator/impl/TxnLogBufferedWriterTest.java
+++ b/pulsar-transaction/coordinator/src/test/java/org/apache/pulsar/transaction/coordinator/impl/TxnLogBufferedWriterTest.java
@@ -29,6 +29,7 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Random;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.ExecutorService;
@@ -179,9 +180,9 @@ public class TxnLogBufferedWriterTest extends MockedBookKeeperTestCase {
                     dataSerializer, batchedWriteMaxRecords, batchedWriteMaxSize,
                     batchedWriteMaxDelayInMillis, batchEnabled);
         // Store the param-context, param-position, param-exception of callback function and complete-count for verify.
-        ArrayList<Integer> contextArrayOfCallback = new ArrayList<>();
-        ArrayList<ManagedLedgerException> exceptionArrayOfCallback = new ArrayList<>();
-        LinkedHashMap<PositionImpl, ArrayList<Position>> positionsOfCallback = new LinkedHashMap<>();
+        List<Integer> contextArrayOfCallback = Collections.synchronizedList(new ArrayList<>());
+        List<ManagedLedgerException> exceptionArrayOfCallback = Collections.synchronizedList(new ArrayList<>());
+        Map<PositionImpl, List<Position>> positionsOfCallback = Collections.synchronizedMap(new LinkedHashMap<>());
         AtomicBoolean anyFlushCompleted = new AtomicBoolean();
         TxnLogBufferedWriter.AddDataCallback callback = new TxnLogBufferedWriter.AddDataCallback(){
             @Override
@@ -192,7 +193,8 @@ public class TxnLogBufferedWriterTest extends MockedBookKeeperTestCase {
                 }
                 contextArrayOfCallback.add((int)ctx);
                 PositionImpl lightPosition = PositionImpl.get(position.getLedgerId(), position.getEntryId());
-                positionsOfCallback.computeIfAbsent(lightPosition, p -> new ArrayList<>());
+                positionsOfCallback.computeIfAbsent(lightPosition,
+                        p -> Collections.synchronizedList(new ArrayList<>()));
                 positionsOfCallback.get(lightPosition).add(position);
             }
             @Override
@@ -256,13 +258,13 @@ public class TxnLogBufferedWriterTest extends MockedBookKeeperTestCase {
         }
         // if enabled batch-feature, will verify the attributes (batchSize, batchIndex) of callback param-position.
         if (exactlyBatched && BookieErrorType.ALWAYS_ERROR != bookieErrorType){
-            Iterator<ArrayList<Position>> callbackPositionIterator = positionsOfCallback.values().iterator();
+            Iterator<List<Position>> callbackPositionIterator = positionsOfCallback.values().iterator();
             List<String> exactlyFlushedDataArray = dataSerializer.getGeneratedJsonArray();
             for (int batchedEntryIndex = 0; batchedEntryIndex < exactlyFlushedDataArray.size() - exceptionCallbackCount;
                  batchedEntryIndex++) {
                 String json = exactlyFlushedDataArray.get(batchedEntryIndex);
                 List<Integer> batchedData = JsonDataSerializer.deserializeMergedData(json);
-                ArrayList<Position> innerPositions = callbackPositionIterator.next();
+                List<Position> innerPositions = callbackPositionIterator.next();
                 for (int i = 0; i < batchedData.size(); i++) {
                     TxnBatchedPositionImpl innerPosition =
                             (TxnBatchedPositionImpl) innerPositions.get(i);
@@ -368,7 +370,7 @@ public class TxnLogBufferedWriterTest extends MockedBookKeeperTestCase {
                 1, TimeUnit.MILLISECONDS);
         SumStrDataSerializer dataSerializer = new SumStrDataSerializer();
         // Cache the data flush to Bookie for Asserts.
-        List<Integer> dataArrayFlushedToBookie = new ArrayList<>();
+        List<Integer> dataArrayFlushedToBookie = Collections.synchronizedList(new ArrayList<>());
         Mockito.doAnswer(new Answer() {
             @Override
             public Object answer(InvocationOnMock invocation) throws Throwable {
@@ -531,10 +533,10 @@ public class TxnLogBufferedWriterTest extends MockedBookKeeperTestCase {
 
         private static ObjectMapper objectMapper = new ObjectMapper();
 
-        private ArrayList<ByteBuf> generatedByteBufArray = new ArrayList<>();
+        private List<ByteBuf> generatedByteBufArray = Collections.synchronizedList(new ArrayList<>());
 
         @Getter
-        private ArrayList<String> generatedJsonArray = new ArrayList<>();
+        private List<String> generatedJsonArray = Collections.synchronizedList(new ArrayList<>());
 
         private int eachDataBytesLen = 4;
 
@@ -590,8 +592,8 @@ public class TxnLogBufferedWriterTest extends MockedBookKeeperTestCase {
 
         protected void cleanup(){
             // Just for GC.
-            generatedByteBufArray = new ArrayList<>();
-            generatedJsonArray = new ArrayList<>();
+            generatedByteBufArray = Collections.synchronizedList(new ArrayList<>());
+            generatedJsonArray = Collections.synchronizedList(new ArrayList<>());
         }
 
         protected void assertAllByteBufHasBeenReleased(){


### PR DESCRIPTION
Fixes #16989, #16723

Master Issue: #16989, #16723

### Motivation

- #16989: We mocked a BK error, but if an exception occurs, the failure callback will be executed earlier. So the results of the callbacks will be out of order, and mismatch occur.
- #16723: I'm sorry, but after PR #16982 I found another reason makes unit test flaky, Multi threads access to `ArrayList` causes the 'list.size()' to return incorrect results, leading to `Awaitility.await().until(() -> contextArrayOfCallback.size() == writeCmdExecuteCount)` cannot end.


### Modifications

- #16989: If we mocked BK errors, sort the callback results.
- #16723: Make collection objects to thread safety.
- Remove unstable assertions. I will rewrite these two cases after PR #16758, because that PR has really changed a lot
```java
Assert.assertTrue(exceptionCallbackCount > 0);
Assert.assertTrue(positionCallbackCount > 0);
```

### Documentation

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)
  
- [x] `doc-not-needed` 
(Please explain why)
  
- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)