### PR TITLE
Update .asf.yaml to protect branch-2.11

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -109,6 +109,7 @@ github:
     branch-2.8: {}
     branch-2.9: {}
     branch-2.10: {}
+    branch-2.11: {}
 
 notifications:
   commits:      commits@pulsar.apache.org


### PR DESCRIPTION
### Motivation

See #14226 for original context.

### Modifications

* Add `branch-2.11` to the list of protected branches

### Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

### Documentation
  
- [x] `doc-not-needed` 