### PR TITLE
[improve][doc] Separate language-specific and language-agnostic clients

### DIFF
--- a/site2/docs/client-libraries-cpp.md
+++ b/site2/docs/client-libraries-cpp.md
@@ -12,8 +12,7 @@ All the methods in producer, consumer, and reader of a C++ client are thread-saf
 
 Pulsar C++ client is supported on **Linux** ,**MacOS** and **Windows** platforms.
 
-[Doxygen](http://www.doxygen.nl/)-generated API docs for the C++ client are available [here](/api/cpp).
-
+Doxygen-generated API docs for the C++ client are available [here](/api/cpp).
 
 ## Linux
 

--- a/site2/docs/client-libraries-python.md
+++ b/site2/docs/client-libraries-python.md
@@ -14,7 +14,7 @@ Pulsar Python client library is a wrapper over the existing [C++ client library]
 
 All the methods in producer, consumer, and reader of a Python client are thread-safe.
 
-[pdoc](https://github.com/BurntSushi/pdoc)-generated API docs for the Python client are available [here](/api/python).
+pdoc-generated API docs for the Python client are available [here](/api/python).
 
 ## Install
 

--- a/site2/docs/client-libraries.md
+++ b/site2/docs/client-libraries.md
@@ -6,14 +6,14 @@ sidebar_label: "Overview"
 
 Pulsar supports the following language specific client libraries:
 
-| Language  | Documentation                          | Release note                                                                      | Code repo                                                                        |
-| --------- | -------------------------------------- | --------------------------------------------------------------------------------- | -------------------------------------------------------------------------------- |
-| Java      | [User doc](client-libraries-java.md)   | [Bundled](/release-notes/)                                                        | [Bundled](https://github.com/apache/pulsar/tree/master/pulsar-client)            |
-| C++       | [User doc](client-libraries-cpp.md)    | [Bundled](/release-notes/)                                                        | [Bundled](https://github.com/apache/pulsar/tree/master/pulsar-client-cpp)        |
-| Python    | [User doc](client-libraries-python.md) | [Bundled](/release-notes/)                                                        | [Bundled](https://github.com/apache/pulsar/tree/master/pulsar-client-cpp/python) |
-| Go client | [User doc](client-libraries-go.md)     | [Standalone](https://github.com/apache/pulsar-client-go/releases)                 | [Standalone](https://github.com/apache/pulsar-client-go)                         |
-| Node.js   | [User doc](client-libraries-node.md)   | [Standalone](https://github.com/apache/pulsar-client-node/releases)               | [Standalone](https://github.com/apache/pulsar-client-node)                       |
-| C#        | [User doc](client-libraries-dotnet.md) | [Standalone](https://github.com/apache/pulsar-dotpulsar/blob/master/CHANGELOG.md) | [Standalone](https://github.com/apache/pulsar-dotpulsar)                         |
+| Language  | Documentation                                                        | Release note                                                                      | Code repo                                                                        |
+| --------- | -------------------------------------------------------------------- | --------------------------------------------------------------------------------- | -------------------------------------------------------------------------------- |
+| Java      | [User doc](client-libraries-java.md)   <br/> [API doc](/api/client/) | [Bundled](/release-notes/)                                                        | [Bundled](https://github.com/apache/pulsar/tree/master/pulsar-client)            |
+| C++       | [User doc](client-libraries-cpp.md)    <br/> [API doc](/api/cpp/)    | [Bundled](/release-notes/)                                                        | [Bundled](https://github.com/apache/pulsar/tree/master/pulsar-client-cpp)        |
+| Python    | [User doc](client-libraries-python.md) <br/> [API doc](/api/python/) | [Bundled](/release-notes/)                                                        | [Bundled](https://github.com/apache/pulsar/tree/master/pulsar-client-cpp/python) |
+| Go client | [User doc](client-libraries-go.md)                                   | [Standalone](https://github.com/apache/pulsar-client-go/releases)                 | [Standalone](https://github.com/apache/pulsar-client-go)                         |
+| Node.js   | [User doc](client-libraries-node.md)                                 | [Standalone](https://github.com/apache/pulsar-client-node/releases)               | [Standalone](https://github.com/apache/pulsar-client-node)                       |
+| C#        | [User doc](client-libraries-dotnet.md)                               | [Standalone](https://github.com/apache/pulsar-dotpulsar/blob/master/CHANGELOG.md) | [Standalone](https://github.com/apache/pulsar-dotpulsar)                         |
 
 Pulsar supports the following language-agnostic client libraries:
 

--- a/site2/docs/client-libraries.md
+++ b/site2/docs/client-libraries.md
@@ -32,7 +32,7 @@ Besides the official released clients, multiple projects on developing Pulsar cl
 
 > Want your repository listed here? Just submit a PR to the [pulsar repository](https://github.com/apache/pulsar/edit/master/site2/docs/client-libraries.md).
 
-### C#
+### .NET
 
 | Project                                                                    | Description                                     | License                                    | Star                                                                                                          |
 | -------------------------------------------------------------------------- | ----------------------------------------------- | ------------------------------------------ | ------------------------------------------------------------------------------------------------------------- |

--- a/site2/docs/client-libraries.md
+++ b/site2/docs/client-libraries.md
@@ -30,16 +30,48 @@ Pulsar client feature matrix for different languages is listed on [Pulsar Featur
 
 Besides the official released clients, multiple projects on developing Pulsar clients are available in different languages.
 
-> If you have developed a new Pulsar client, feel free to submit a pull request and add your client to the list below.
+> Want your repository listed here? Just submit a PR to the [pulsar repository](https://github.com/apache/pulsar/edit/master/site2/docs/client-libraries.md).
 
-| Language | Project                                                                       | Maintainer                                                                                                                                | License                                                                                                              | Description                                                          |
-| -------- | ----------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------- |
-| Go       | [pulsar-client-go](https://github.com/Comcast/pulsar-client-go)               | [Comcast](https://github.com/Comcast)                                                                                                     | [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0) | A native golang client                                               |
-| Go       | [go-pulsar](https://github.com/t2y/go-pulsar)                                 | [t2y](https://github.com/t2y)                                                                                                             | [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0) |                                                                      |
-| Haskell  | [supernova](https://github.com/cr-org/supernova)                              | [Chatroulette](https://github.com/cr-org)                                                                                                 | [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0) | Native Pulsar client for Haskell                                     |
-| Scala    | [neutron](https://github.com/cr-org/neutron)                                  | [Chatroulette](https://github.com/cr-org)                                                                                                 | [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0) | Purely functional Apache Pulsar client for Scala built on top of Fs2 |
-| Scala    | [pulsar4s](https://github.com/sksamuel/pulsar4s)                              | [sksamuel](https://github.com/sksamuel)                                                                                                   | [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0) | Idomatic, typesafe, and reactive Scala client for Apache Pulsar      |
-| Rust     | [pulsar-rs](https://github.com/wyyerd/pulsar-rs)                              | [Wyyerd Group](https://github.com/wyyerd)                                                                                                 | [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0) | Future-based Rust bindings for Apache Pulsar                         |
-| .NET     | [pulsar-client-dotnet](https://github.com/fsharplang-ru/pulsar-client-dotnet) | [Lanayx](https://github.com/Lanayx)                                                                                                       | [![GitHub](https://img.shields.io/badge/license-MIT-green.svg)](https://opensource.org/licenses/MIT)                 | Native .NET client for C#/F#/VB                                      |
-| Node.js  | [pulsar-flex](https://github.com/ayeo-flex-org/pulsar-flex)                   | [Daniel Sinai](https://github.com/danielsinai), [Ron Farkash](https://github.com/ronfarkash), [Gal Rosenberg](https://github.com/galrose) | [![GitHub](https://img.shields.io/badge/license-MIT-green.svg)](https://opensource.org/licenses/MIT)                 | Native Nodejs client                                                 |
-| PHP      | [pulsar-client-php](https://github.com/ikilobyte/pulsar-client-php)           | [ikilobyte](https://github.com/ikilobyte)                                                                                                 | [![GitHub](https://img.shields.io/badge/license-MIT-green.svg)](https://opensource.org/licenses/MIT)                 | Native PHP client                                                    |
+### C#
+
+| Project                                                                    | Description                                     | License                                    | Star                                                                                                          |
+| -------------------------------------------------------------------------- | ----------------------------------------------- | ------------------------------------------ | ------------------------------------------------------------------------------------------------------------- |
+| [pulsar-client-dotnet](https://github.com/fsprojects/pulsar-client-dotnet) | Apache Pulsar native client for .NET (C#/F#/VB) | [MIT](https://opensource.org/licenses/MIT) | ![GitHub Repo Stars](https://img.shields.io/github/stars/fsprojects/pulsar-client-dotnet?style=for-the-badge) |
+
+### Go
+
+| Project                                                         | Description                              | License                                                   | Star                                                                                                   |
+| --------------------------------------------------------------- | ---------------------------------------- | --------------------------------------------------------- | ------------------------------------------------------------------------------------------------------ |
+| [pulsar-client-go](https://github.com/Comcast/pulsar-client-go) | A Go client library for Apache Pulsar    | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) | ![GitHub Repo Stars](https://img.shields.io/github/stars/Comcast/pulsar-client-go?style=for-the-badge) |
+| [go-pulsar](https://github.com/t2y/go-pulsar)                   | go-pulsar is a client library for Pulsar | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) | ![GitHub Repo Stars](https://img.shields.io/github/stars/t2y/go-pulsar?style=for-the-badge)            |
+
+### Haskell
+
+| Project                                          | Description                      | License                                                   | Star                                                                                           |
+| ------------------------------------------------ | -------------------------------- | --------------------------------------------------------- | ---------------------------------------------------------------------------------------------- |
+| [supernova](https://github.com/cr-org/supernova) | Apache Pulsar client for Haskell | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) | ![GitHub Repo Stars](https://img.shields.io/github/stars/cr-org/supernova?style=for-the-badge) |
+
+### Node.js
+
+| Project                                          | Description                      | License                                                   | Star                                                                                           |
+| ------------------------------------------------ | -------------------------------- | --------------------------------------------------------- | ---------------------------------------------------------------------------------------------- |
+| [pulsar-flex](https://github.com/ayeo-flex-org/pulsar-flex) | Pulsar Flex is a modern Apache Pulsar client for Node.js, developed to be independent of C++. | [MIT](https://opensource.org/licenses/MIT) | ![GitHub Repo Stars](https://img.shields.io/github/stars/ayeo-flex-org/pulsar-flex?style=for-the-badge) |
+
+### PHP
+
+| Project                                          | Description                      | License                                                   | Star                                                                                           |
+| ------------------------------------------------ | -------------------------------- | --------------------------------------------------------- | ---------------------------------------------------------------------------------------------- |
+| [pulsar-client-php](https://github.com/ikilobyte/pulsar-client-php) | PHP Native Client library for Apache Pulsar | [MIT](https://opensource.org/licenses/MIT) | ![GitHub Repo Stars](https://img.shields.io/github/stars/ikilobyte/pulsar-client-php?style=for-the-badge) |
+
+### Rust
+
+| Project                                                | Description                           | License                                                   | Star                                                                                                 |
+| ------------------------------------------------------ | ------------------------------------- | --------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
+| [pulsar-rs](https://github.com/streamnative/pulsar-rs) | Rust Client library for Apache Pulsar | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) | ![GitHub Repo Stars](https://img.shields.io/github/stars/streamnative/pulsar-rs?style=for-the-badge) |
+
+### Scala
+
+| Project                                             | Description                                                          | License                                                   | Star                                                                                               |
+| --------------------------------------------------- | -------------------------------------------------------------------- | --------------------------------------------------------- | -------------------------------------------------------------------------------------------------- |
+| [pulsar4s](https://github.com/CleverCloud/pulsar4s) | Idiomatic, typesafe, and reactive Scala client for Apache Pulsar     | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) | ![GitHub Repo Stars](https://img.shields.io/github/stars/CleverCloud/pulsar4s?style=for-the-badge) |
+| [neutron](https://github.com/cr-org/neutron)        | Purely functional Apache Pulsar client for Scala built on top of Fs2 | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) | ![GitHub Repo Stars](https://img.shields.io/github/stars/cr-org/neutron?style=for-the-badge)       |

--- a/site2/docs/client-libraries.md
+++ b/site2/docs/client-libraries.md
@@ -4,26 +4,26 @@ title: Pulsar client libraries
 sidebar_label: "Overview"
 ---
 
-Pulsar supports the following client libraries:
+Pulsar supports the following language specific client libraries:
 
-| Language  | Documentation                                                                 | Release note                                                             | Code repo                                                                     |
-|-----------|-------------------------------------------------------------------------------|--------------------------------------------------------------------------|-------------------------------------------------------------------------------|
-| Java      | - [User doc](client-libraries-java.md) <br/><br/> - [API doc](/api/client/)   | [Here](/release-notes/)                                                  | [Here](https://github.com/apache/pulsar/tree/master/pulsar-client)            |
-| C++       | - [User doc](client-libraries-cpp.md) <br/><br/> - [API doc](/api/cpp/)       | [Here](/release-notes/)                                                  | [Here](https://github.com/apache/pulsar/tree/master/pulsar-client-cpp)        |
-| Python    | - [User doc](client-libraries-python.md) <br/><br/> - [API doc](/api/python/) | [Here](/release-notes/)                                                  | [Here](https://github.com/apache/pulsar/tree/master/pulsar-client-cpp/python) |
-| WebSocket | [User doc](client-libraries-websocket.md)                                     | [Here](/release-notes/)                                                  | [Here](https://github.com/apache/pulsar/tree/master/pulsar-websocket)         |
-| Go client | [User doc](client-libraries-go.md)                                            | [Here](https://github.com/apache/pulsar-client-go/blob/master/CHANGELOG) | [Here](https://github.com/apache/pulsar-client-go)                            |
-| Node.js   | [User doc](client-libraries-node.md)                                          | [Here](https://github.com/apache/pulsar-client-node/releases)            | [Here](https://github.com/apache/pulsar-client-node)                          |
-| C#        | [User doc](client-libraries-dotnet.md)                                        | [Here](https://github.com/apache/pulsar-dotpulsar/blob/master/CHANGELOG) | [Here](https://github.com/apache/pulsar-dotpulsar)                            |
+| Language  | Documentation                          | Release note                                                                   | Code repo                                                                        |
+| --------- | -------------------------------------- | ------------------------------------------------------------------------------ | -------------------------------------------------------------------------------- |
+| Java      | [User doc](client-libraries-java.md)   | [Bundled](/release-notes/)                                                     | [Bundled](https://github.com/apache/pulsar/tree/master/pulsar-client)            |
+| C++       | [User doc](client-libraries-cpp.md)    | [Bundled](/release-notes/)                                                     | [Bundled](https://github.com/apache/pulsar/tree/master/pulsar-client-cpp)        |
+| Python    | [User doc](client-libraries-python.md) | [Bundled](/release-notes/)                                                     | [Bundled](https://github.com/apache/pulsar/tree/master/pulsar-client-cpp/python) |
+| Go client | [User doc](client-libraries-go.md)     | [Standalone](https://github.com/apache/pulsar-client-go/blob/master/CHANGELOG) | [Standalone](https://github.com/apache/pulsar-client-go)                         |
+| Node.js   | [User doc](client-libraries-node.md)   | [Standalone](https://github.com/apache/pulsar-client-node/releases)            | [Standalone](https://github.com/apache/pulsar-client-node)                       |
+| C#        | [User doc](client-libraries-dotnet.md) | [Standalone](https://github.com/apache/pulsar-dotpulsar/blob/master/CHANGELOG) | [Standalone](https://github.com/apache/pulsar-dotpulsar)                         |
 
-:::note
+Pulsar supports the following language-agnostic client libraries:
 
-- The code repos of **Java, C++, Python,** and **WebSocket** clients are hosted in the [Pulsar main repo](https://github.com/apache/pulsar) and these clients are released with Pulsar, so their release notes are parts of [Pulsar release note](/release-notes/).
-- The code repos of **Go, Node.js,** and **C#** clients are hosted outside of the [Pulsar main repo](https://github.com/apache/pulsar) and these clients are not released with Pulsar, so they have independent release notes.
-
-:::
+| Interface | Documentation                             | Release note               | Code repo                                                                |
+| --------- | ----------------------------------------- | -------------------------- | ------------------------------------------------------------------------ |
+| REST      | [User doc](client-libraries-rest.md)      | [Bundled](/release-notes/) | [Bundled](https://github.com/apache/pulsar/tree/master/pulsar-broker)    |
+| WebSocket | [User doc](client-libraries-websocket.md) | [Bundled](/release-notes/) | [Bundled](https://github.com/apache/pulsar/tree/master/pulsar-websocket) |
 
 ## Feature matrix
+
 Pulsar client feature matrix for different languages is listed on [Pulsar Feature Matrix (Client and Function)](https://docs.google.com/spreadsheets/d/1YHYTkIXR8-Ql103u-IMI18TXLlGStK8uJjDsOOA0T20/edit#gid=1784579914) page.
 
 ## Third-party clients
@@ -32,14 +32,14 @@ Besides the official released clients, multiple projects on developing Pulsar cl
 
 > If you have developed a new Pulsar client, feel free to submit a pull request and add your client to the list below.
 
-| Language | Project | Maintainer | License | Description |
-|----------|---------|------------|---------|-------------|
-| Go | [pulsar-client-go](https://github.com/Comcast/pulsar-client-go) | [Comcast](https://github.com/Comcast) | [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0) | A native golang client |
-| Go | [go-pulsar](https://github.com/t2y/go-pulsar) | [t2y](https://github.com/t2y) | [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0) | 
-| Haskell | [supernova](https://github.com/cr-org/supernova) | [Chatroulette](https://github.com/cr-org) | [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0) | Native Pulsar client for Haskell | 
-| Scala | [neutron](https://github.com/cr-org/neutron) | [Chatroulette](https://github.com/cr-org) | [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0) | Purely functional Apache Pulsar client for Scala built on top of Fs2 |
-| Scala | [pulsar4s](https://github.com/sksamuel/pulsar4s) | [sksamuel](https://github.com/sksamuel) | [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0) | Idomatic, typesafe, and reactive Scala client for Apache Pulsar |
-| Rust | [pulsar-rs](https://github.com/wyyerd/pulsar-rs) | [Wyyerd Group](https://github.com/wyyerd) | [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0) | Future-based Rust bindings for Apache Pulsar |
-| .NET | [pulsar-client-dotnet](https://github.com/fsharplang-ru/pulsar-client-dotnet) | [Lanayx](https://github.com/Lanayx) | [![GitHub](https://img.shields.io/badge/license-MIT-green.svg)](https://opensource.org/licenses/MIT) | Native .NET client for C#/F#/VB |
-| Node.js | [pulsar-flex](https://github.com/ayeo-flex-org/pulsar-flex) | [Daniel Sinai](https://github.com/danielsinai), [Ron Farkash](https://github.com/ronfarkash), [Gal Rosenberg](https://github.com/galrose)| [![GitHub](https://img.shields.io/badge/license-MIT-green.svg)](https://opensource.org/licenses/MIT) | Native Nodejs client |
-| PHP | [pulsar-client-php](https://github.com/ikilobyte/pulsar-client-php) | [ikilobyte](https://github.com/ikilobyte) | [![GitHub](https://img.shields.io/badge/license-MIT-green.svg)](https://opensource.org/licenses/MIT) | Native PHP client |
+| Language | Project                                                                       | Maintainer                                                                                                                                | License                                                                                                              | Description                                                          |
+| -------- | ----------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------- |
+| Go       | [pulsar-client-go](https://github.com/Comcast/pulsar-client-go)               | [Comcast](https://github.com/Comcast)                                                                                                     | [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0) | A native golang client                                               |
+| Go       | [go-pulsar](https://github.com/t2y/go-pulsar)                                 | [t2y](https://github.com/t2y)                                                                                                             | [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0) |                                                                      |
+| Haskell  | [supernova](https://github.com/cr-org/supernova)                              | [Chatroulette](https://github.com/cr-org)                                                                                                 | [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0) | Native Pulsar client for Haskell                                     |
+| Scala    | [neutron](https://github.com/cr-org/neutron)                                  | [Chatroulette](https://github.com/cr-org)                                                                                                 | [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0) | Purely functional Apache Pulsar client for Scala built on top of Fs2 |
+| Scala    | [pulsar4s](https://github.com/sksamuel/pulsar4s)                              | [sksamuel](https://github.com/sksamuel)                                                                                                   | [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0) | Idomatic, typesafe, and reactive Scala client for Apache Pulsar      |
+| Rust     | [pulsar-rs](https://github.com/wyyerd/pulsar-rs)                              | [Wyyerd Group](https://github.com/wyyerd)                                                                                                 | [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0) | Future-based Rust bindings for Apache Pulsar                         |
+| .NET     | [pulsar-client-dotnet](https://github.com/fsharplang-ru/pulsar-client-dotnet) | [Lanayx](https://github.com/Lanayx)                                                                                                       | [![GitHub](https://img.shields.io/badge/license-MIT-green.svg)](https://opensource.org/licenses/MIT)                 | Native .NET client for C#/F#/VB                                      |
+| Node.js  | [pulsar-flex](https://github.com/ayeo-flex-org/pulsar-flex)                   | [Daniel Sinai](https://github.com/danielsinai), [Ron Farkash](https://github.com/ronfarkash), [Gal Rosenberg](https://github.com/galrose) | [![GitHub](https://img.shields.io/badge/license-MIT-green.svg)](https://opensource.org/licenses/MIT)                 | Native Nodejs client                                                 |
+| PHP      | [pulsar-client-php](https://github.com/ikilobyte/pulsar-client-php)           | [ikilobyte](https://github.com/ikilobyte)                                                                                                 | [![GitHub](https://img.shields.io/badge/license-MIT-green.svg)](https://opensource.org/licenses/MIT)                 | Native PHP client                                                    |

--- a/site2/docs/client-libraries.md
+++ b/site2/docs/client-libraries.md
@@ -6,14 +6,14 @@ sidebar_label: "Overview"
 
 Pulsar supports the following language specific client libraries:
 
-| Language  | Documentation                          | Release note                                                                   | Code repo                                                                        |
-| --------- | -------------------------------------- | ------------------------------------------------------------------------------ | -------------------------------------------------------------------------------- |
-| Java      | [User doc](client-libraries-java.md)   | [Bundled](/release-notes/)                                                     | [Bundled](https://github.com/apache/pulsar/tree/master/pulsar-client)            |
-| C++       | [User doc](client-libraries-cpp.md)    | [Bundled](/release-notes/)                                                     | [Bundled](https://github.com/apache/pulsar/tree/master/pulsar-client-cpp)        |
-| Python    | [User doc](client-libraries-python.md) | [Bundled](/release-notes/)                                                     | [Bundled](https://github.com/apache/pulsar/tree/master/pulsar-client-cpp/python) |
-| Go client | [User doc](client-libraries-go.md)     | [Standalone](https://github.com/apache/pulsar-client-go/blob/master/CHANGELOG) | [Standalone](https://github.com/apache/pulsar-client-go)                         |
-| Node.js   | [User doc](client-libraries-node.md)   | [Standalone](https://github.com/apache/pulsar-client-node/releases)            | [Standalone](https://github.com/apache/pulsar-client-node)                       |
-| C#        | [User doc](client-libraries-dotnet.md) | [Standalone](https://github.com/apache/pulsar-dotpulsar/blob/master/CHANGELOG) | [Standalone](https://github.com/apache/pulsar-dotpulsar)                         |
+| Language  | Documentation                          | Release note                                                                      | Code repo                                                                        |
+| --------- | -------------------------------------- | --------------------------------------------------------------------------------- | -------------------------------------------------------------------------------- |
+| Java      | [User doc](client-libraries-java.md)   | [Bundled](/release-notes/)                                                        | [Bundled](https://github.com/apache/pulsar/tree/master/pulsar-client)            |
+| C++       | [User doc](client-libraries-cpp.md)    | [Bundled](/release-notes/)                                                        | [Bundled](https://github.com/apache/pulsar/tree/master/pulsar-client-cpp)        |
+| Python    | [User doc](client-libraries-python.md) | [Bundled](/release-notes/)                                                        | [Bundled](https://github.com/apache/pulsar/tree/master/pulsar-client-cpp/python) |
+| Go client | [User doc](client-libraries-go.md)     | [Standalone](https://github.com/apache/pulsar-client-go/releases)                 | [Standalone](https://github.com/apache/pulsar-client-go)                         |
+| Node.js   | [User doc](client-libraries-node.md)   | [Standalone](https://github.com/apache/pulsar-client-node/releases)               | [Standalone](https://github.com/apache/pulsar-client-node)                       |
+| C#        | [User doc](client-libraries-dotnet.md) | [Standalone](https://github.com/apache/pulsar-dotpulsar/blob/master/CHANGELOG.md) | [Standalone](https://github.com/apache/pulsar-dotpulsar)                         |
 
 Pulsar supports the following language-agnostic client libraries:
 
@@ -53,14 +53,14 @@ Besides the official released clients, multiple projects on developing Pulsar cl
 
 ### Node.js
 
-| Project                                          | Description                      | License                                                   | Star                                                                                           |
-| ------------------------------------------------ | -------------------------------- | --------------------------------------------------------- | ---------------------------------------------------------------------------------------------- |
+| Project                                                     | Description                                                                                   | License                                    | Star                                                                                                    |
+| ----------------------------------------------------------- | --------------------------------------------------------------------------------------------- | ------------------------------------------ | ------------------------------------------------------------------------------------------------------- |
 | [pulsar-flex](https://github.com/ayeo-flex-org/pulsar-flex) | Pulsar Flex is a modern Apache Pulsar client for Node.js, developed to be independent of C++. | [MIT](https://opensource.org/licenses/MIT) | ![GitHub Repo Stars](https://img.shields.io/github/stars/ayeo-flex-org/pulsar-flex?style=for-the-badge) |
 
 ### PHP
 
-| Project                                          | Description                      | License                                                   | Star                                                                                           |
-| ------------------------------------------------ | -------------------------------- | --------------------------------------------------------- | ---------------------------------------------------------------------------------------------- |
+| Project                                                             | Description                                 | License                                    | Star                                                                                                      |
+| ------------------------------------------------------------------- | ------------------------------------------- | ------------------------------------------ | --------------------------------------------------------------------------------------------------------- |
 | [pulsar-client-php](https://github.com/ikilobyte/pulsar-client-php) | PHP Native Client library for Apache Pulsar | [MIT](https://opensource.org/licenses/MIT) | ![GitHub Repo Stars](https://img.shields.io/github/stars/ikilobyte/pulsar-client-php?style=for-the-badge) |
 
 ### Rust


### PR DESCRIPTION
Related to https://github.com/apache/pulsar-site/issues/146.

### Motivation

* Websocket is not a language but a language-agnostic interface.

### Modifications

1. Separate language-specific and language-agnostic clients.
2. Improve third-party client libraries display - show stars, grouped by languages.
3. Avoid redundant links to doc tools, it's not what users care.

### Preview

<img width="1250" alt="image" src="https://user-images.githubusercontent.com/18818196/183602362-61d22da2-c127-4463-abff-91fc49c4b4d4.png">

<img width="1237" alt="image" src="https://user-images.githubusercontent.com/18818196/183602541-cbbb75a9-bde9-4663-9803-054ab7e6f903.png">


### Documentation
  
- [x] `doc` 

cc @Anonymitaet @momo-jun @shibd @RobertIndie 