### PR TITLE
[fix][rest] Fix swagger shows lookup API path error.

### DIFF
--- a/pulsar-broker/pom.xml
+++ b/pulsar-broker/pom.xml
@@ -690,7 +690,7 @@
                   <springmvc>false</springmvc>
                   <locations>org.apache.pulsar.broker.lookup.v2</locations>
                   <schemes>http,https</schemes>
-                  <basePath>/lookup/v2</basePath>
+                  <basePath>/lookup</basePath>
                   <info>
                     <title>Pulsar Lookup REST API</title>
                     <version>v2</version>


### PR DESCRIPTION
### Motivation

`Lookup API` has a superfluous v2 display address on the web page.


![image](https://user-images.githubusercontent.com/33416836/183608650-8444e4c1-d64c-4626-b353-8f4a403b6520.png)


### Modifications

- Change swagger base path.

### Documentation

- [x] `doc-not-needed` 

