### PR TITLE
[clean up][broker] delete unused method in Commands

### DIFF
--- a/pulsar-common/src/main/java/org/apache/pulsar/common/protocol/Commands.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/protocol/Commands.java
@@ -1612,11 +1612,6 @@ public class Commands {
     }
 
     public static ByteBuf addBrokerEntryMetadata(ByteBuf headerAndPayload,
-                                                 Set<BrokerEntryMetadataInterceptor> interceptors) {
-        return addBrokerEntryMetadata(headerAndPayload, interceptors, -1);
-    }
-
-    public static ByteBuf addBrokerEntryMetadata(ByteBuf headerAndPayload,
                                                  Set<BrokerEntryMetadataInterceptor> brokerInterceptors,
                                                  int numberOfMessages) {
         //   | BROKER_ENTRY_METADATA_MAGIC_NUMBER | BROKER_ENTRY_METADATA_SIZE |         BROKER_ENTRY_METADATA         |


### PR DESCRIPTION
### Motivation


*Explain here the context, and why you're making that change. What is the problem you're trying to solve.*

### Modifications

delete `addBrokerEntryMetadata(ByteBuf headerAndPayload, Set<BrokerEntryMetadataInterceptor> interceptors)` in Commands

### Documentation

Check the box below or label this PR directly.

Need to update docs? 
  
- [x] `doc-not-needed` 
clean up, no need doc