### PR TITLE
[improve][broker] Add close function worker

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
@@ -409,6 +409,8 @@ public class PulsarService implements AutoCloseable, ShutdownService {
             LOG.info("Closing PulsarService");
             state = State.Closing;
 
+            functionWorkerService.ifPresent(WorkerService::stop);
+
             // close the service in reverse order v.s. in which they are started
             if (this.resourceUsageTransportManager != null) {
                 try {


### PR DESCRIPTION
Signed-off-by: Zixuan Liu <nodeces@gmail.com>

### Motivation

Miss close the function worker when the PulsarService close method is called, which introduces an [issue](https://github.com/apache/pulsar/issues/16538) in the test if we don't close the function worker.

We have a broker with function worker, when calling the PulsarService close method, the Pulsar needs to close some services and unload ns, it will break the function worker running, and when the function worker cannot work fine, it will call the PulsarService shutdownNow method, which will close the metadata store, and will affect the running close operation.

### Modifications

- Add close function worker to `org.apache.pulsar.broker.PulsarService#closeAsync`

### Documentation

Check the box below or label this PR directly.

Need to update docs? 

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)
  
- [x] `doc-not-needed` 
(Please explain why)
  
- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)