### PR TITLE
[fix][broker] remove exception log when access status.html

### DIFF
--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/common/configuration/VipStatus.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/common/configuration/VipStatus.java
@@ -26,10 +26,12 @@ import javax.ws.rs.Path;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.Response.Status;
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * Web resource used by the VIP service to check to availability of the service instance.
  */
+@Slf4j
 @Path("/status.html")
 public class VipStatus {
 
@@ -40,7 +42,6 @@ public class VipStatus {
     protected ServletContext servletContext;
 
     @GET
-    @Context
     public String checkStatus() {
         String statusFilePath = (String) servletContext.getAttribute(ATTRIBUTE_STATUS_FILE_PATH);
         @SuppressWarnings("unchecked")
@@ -54,6 +55,7 @@ public class VipStatus {
                 return "OK";
             }
         }
+        log.warn("Failed to access \"status.html\". The service is not ready");
         throw new WebApplicationException(Status.NOT_FOUND);
     }
 


### PR DESCRIPTION
Fixes #9201

Master Issue: #9201

### Motivation

If injection fails, Jersey print the error log, see:

https://github.com/javaee/jersey/blame/faa809da43538ce31076b50f969b4bd64caa5ac9/inject/hk2/src/main/java/org/glassfish/jersey/inject/hk2/JerseyErrorService.java#L89

### Modifications

- The method `checkStatus` is not an injection method, remove `@Context`. 
- Print warn log if service has not ready.


### Documentation

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)
  
- [x] `doc-not-needed` 
(Please explain why)
  
- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)