### PR TITLE
Revert minor part of #16968 to fix message redelivery

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumers.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumers.java
@@ -550,9 +550,12 @@ public class PersistentDispatcherMultipleConsumers extends AbstractDispatcherMul
         if (serviceConfig.isDispatcherDispatchMessagesInSubscriptionThread()) {
             // setting sendInProgress here, because sendMessagesToConsumers will be executed
             // in a separate thread, and we want to prevent more reads
+            sendInProgress = true;
             dispatchMessagesThread.execute(safeRun(() -> {
-                if (sendMessagesToConsumers(readType, entries)) {
-                    readMoreEntries();
+                synchronized (this) {
+                    if (sendMessagesToConsumers(readType, entries)) {
+                        readMoreEntries();
+                    }
                 }
             }));
         } else {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumers.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumers.java
@@ -93,7 +93,7 @@ public class PersistentDispatcherMultipleConsumers extends AbstractDispatcherMul
     protected volatile PositionImpl minReplayedPosition = null;
     protected boolean shouldRewindBeforeReadingOrReplaying = false;
     protected final String name;
-    protected volatile boolean sendInProgress;
+    protected boolean sendInProgress;
     protected static final AtomicIntegerFieldUpdater<PersistentDispatcherMultipleConsumers>
             TOTAL_AVAILABLE_PERMITS_UPDATER =
             AtomicIntegerFieldUpdater.newUpdater(PersistentDispatcherMultipleConsumers.class,

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumers.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumers.java
@@ -552,10 +552,8 @@ public class PersistentDispatcherMultipleConsumers extends AbstractDispatcherMul
             // in a separate thread, and we want to prevent more reads
             sendInProgress = true;
             dispatchMessagesThread.execute(safeRun(() -> {
-                synchronized (this) {
-                    if (sendMessagesToConsumers(readType, entries)) {
-                        readMoreEntries();
-                    }
+                if (sendMessagesToConsumers(readType, entries)) {
+                    readMoreEntries();
                 }
             }));
         } else {


### PR DESCRIPTION
Fixes https://github.com/apache/pulsar/issues/17028 https://github.com/apache/pulsar/issues/16830

### Motivation

In #16968, there was a change to remove some logic that appears necessary for certain message delivery guarantees. This PR fixes the minor regression introduced in that PR.

### Modifications

* Set `sendInProgress = true` before dispatching the read request.
* Remove `volatile` keyword from `sendInProgress`. It is only updated within `synchronized` blocks.

### Verifying this change

I verified that both `testDelayedDeliveryWithMultipleConcurrentReadEntries` and `testMessageRedelivery` pass consistently. Both were failing on my machine and stopped failing when I set `sendInProgress = true`. 

### Documentation
  
- [x] `doc-not-needed` 