### PR TITLE
[fix][broker] Fix delivery the message that has been acknowledged

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Consumer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Consumer.java
@@ -336,7 +336,7 @@ public class Consumer {
         }
         incrementUnackedMessages(unackedMessages);
         Future<Void> writeAndFlushPromise =
-                cnx.getCommandSender().sendMessagesToConsumer(consumerId, topicName, subscription, partitionIdx,
+                cnx.getCommandSender().sendMessagesToConsumer(this, topicName, subscription, partitionIdx,
                         entries, batchSizes, batchIndexesAcks, redeliveryTracker, epoch);
         writeAndFlushPromise.addListener(status -> {
             // only increment counters after the messages have been successfully written to the TCP/IP connection

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/PulsarCommandSender.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/PulsarCommandSender.java
@@ -77,7 +77,7 @@ public interface PulsarCommandSender {
 
     void sendReachedEndOfTopic(long consumerId);
 
-    Future<Void> sendMessagesToConsumer(long consumerId, String topicName, Subscription subscription,
+    Future<Void> sendMessagesToConsumer(Consumer consumer, String topicName, Subscription subscription,
                                         int partitionIdx, List<? extends Entry> entries, EntryBatchSizes batchSizes,
                                         EntryBatchIndexesAcks batchIndexesAcks,
                                         RedeliveryTracker redeliveryTracker, long epoch);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/PulsarCommandSenderImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/PulsarCommandSenderImpl.java
@@ -223,16 +223,18 @@ public class PulsarCommandSenderImpl implements PulsarCommandSender {
     }
 
     @Override
-    public ChannelPromise sendMessagesToConsumer(long consumerId, String topicName, Subscription subscription,
+    public ChannelPromise sendMessagesToConsumer(Consumer consumer, String topicName, Subscription subscription,
                                                  int partitionIdx, List<? extends Entry> entries,
                                                  EntryBatchSizes batchSizes, EntryBatchIndexesAcks batchIndexesAcks,
                                                  RedeliveryTracker redeliveryTracker, long epoch) {
         final ChannelHandlerContext ctx = cnx.ctx();
         final ChannelPromise writePromise = ctx.newPromise();
+        final long consumerId = consumer.consumerId();
         ctx.channel().eventLoop().execute(() -> {
             ManagedCursorImpl cursor = null;
             if (subscription instanceof PersistentSubscription persistentSubscription
-                    && !(subscription instanceof CompactorSubscription)) {
+                    && !(subscription instanceof CompactorSubscription)
+                    && !consumer.readCompacted()) {
                 cursor = (ManagedCursorImpl) persistentSubscription.getCursor();
             }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/PulsarCommandSenderImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/PulsarCommandSenderImpl.java
@@ -244,7 +244,7 @@ public class PulsarCommandSenderImpl implements PulsarCommandSender {
                 }
 
                 // Filter out already delete entry, because message ack may be already has changed
-                if (cursor != null) {
+                if (cursor != null && cursor.isDurable()) {
                   if (cursor.isMessageDeleted(entry.getPosition())) {
                       entry.release();
                       continue;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/PulsarCommandSenderImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/PulsarCommandSenderImpl.java
@@ -29,6 +29,7 @@ import org.apache.bookkeeper.mledger.Entry;
 import org.apache.bookkeeper.mledger.impl.ManagedCursorImpl;
 import org.apache.bookkeeper.mledger.impl.PositionImpl;
 import org.apache.pulsar.broker.intercept.BrokerInterceptor;
+import org.apache.pulsar.broker.service.persistent.CompactorSubscription;
 import org.apache.pulsar.broker.service.persistent.PersistentSubscription;
 import org.apache.pulsar.client.api.transaction.TxnID;
 import org.apache.pulsar.common.api.proto.BaseCommand;
@@ -230,7 +231,8 @@ public class PulsarCommandSenderImpl implements PulsarCommandSender {
         final ChannelPromise writePromise = ctx.newPromise();
         ctx.channel().eventLoop().execute(() -> {
             ManagedCursorImpl cursor = null;
-            if (subscription instanceof  PersistentSubscription persistentSubscription) {
+            if (subscription instanceof PersistentSubscription persistentSubscription
+                    && !(subscription instanceof CompactorSubscription)) {
                 cursor = (ManagedCursorImpl) persistentSubscription.getCursor();
             }
 
@@ -244,6 +246,7 @@ public class PulsarCommandSenderImpl implements PulsarCommandSender {
                 // Filter out already delete entry, because message ack may be already has changed
                 if (cursor != null) {
                   if (cursor.isMessageDeleted(entry.getPosition())) {
+                      entry.release();
                       continue;
                   }
                 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/NegativeAcksTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/NegativeAcksTest.java
@@ -20,16 +20,13 @@ package org.apache.pulsar.client.impl;
 
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNull;
-
 import java.lang.reflect.Field;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
-
 import lombok.Cleanup;
 import lombok.extern.slf4j.Slf4j;
-
 import org.apache.pulsar.broker.BrokerTestUtil;
 import org.apache.pulsar.client.api.Consumer;
 import org.apache.pulsar.client.api.Message;
@@ -122,6 +119,7 @@ public class NegativeAcksTest extends ProducerConsumerBase {
                 .subscriptionType(subscriptionType)
                 .negativeAckRedeliveryDelay(negAcksDelayMillis, TimeUnit.MILLISECONDS)
                 .ackTimeout(ackTimeout, TimeUnit.MILLISECONDS)
+                .isAckReceiptEnabled(true)
                 .subscribe();
 
         @Cleanup


### PR DESCRIPTION
Fixes #16949

### Motivation

Now, sending messages to the consumer using io-thread. When the task is scheduled, the message ack may be already changed leading to delivering the message of already been acknowledged.

### Modifications

Filter out already delete entries again before sending message to the consumer.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API: (yes / no)
  - The schema: (yes / no / don't know)
  - The default values of configurations: (yes / no)
  - The wire protocol: (yes / no)
  - The rest endpoints: (yes / no)
  - The admin cli options: (yes / no)
  - Anything that affects deployment: (yes / no / don't know)

### Documentation

Check the box below or label this PR directly.

Need to update docs? 

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)
  
- [x] `doc-not-needed` 
(Please explain why)
  
- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)