### PR TITLE
[improve][admin] Unset namespace policy to improve deleting namespace.

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/NamespacesBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/NamespacesBase.java
@@ -498,8 +498,8 @@ public abstract class NamespacesBase extends AdminResource {
                 }
 
                 for (String partitionedTopic : partitionedTopics) {
-                    topicFutures.add(namespaceResources()
-                            .getPartitionedTopicResources().deletePartitionedTopicAsync(TopicName.get(partitionedTopic)));
+                    topicFutures.add(namespaceResources().getPartitionedTopicResources()
+                            .deletePartitionedTopicAsync(TopicName.get(partitionedTopic)));
                 }
 
                 if (log.isDebugEnabled()) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/NamespacesBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/NamespacesBase.java
@@ -478,16 +478,13 @@ public abstract class NamespacesBase extends AdminResource {
                         if (topicName.isPartitioned()) {
                             String partitionedTopic = topicName.getPartitionedTopicName();
                             if (!partitionedTopics.contains(partitionedTopic)) {
-                                // Distinguish partitioned topic to avoid duplicate deletion of the same schema
-                                topicFutures.add(pulsar().getAdminClient().topics().deletePartitionedTopicAsync(
-                                        partitionedTopic, true, true));
                                 partitionedTopics.add(partitionedTopic);
                             }
                         } else {
-                            topicFutures.add(pulsar().getAdminClient().topics().deleteAsync(
-                                    topic, true, true));
                             nonPartitionedTopics.add(topic);
                         }
+                        topicFutures.add(pulsar().getAdminClient().topics().deleteAsync(
+                                topic, true, true));
                     } catch (Exception e) {
                         String errorMessage = String.format("Failed to force delete topic %s, "
                                         + "but the previous deletion command of partitioned-topics:%s "
@@ -498,6 +495,11 @@ public abstract class NamespacesBase extends AdminResource {
                         asyncResponse.resume(new RestException(Status.INTERNAL_SERVER_ERROR, errorMessage));
                         return;
                     }
+                }
+
+                for (String partitionedTopic : partitionedTopics) {
+                    topicFutures.add(namespaceResources()
+                            .getPartitionedTopicResources().deletePartitionedTopicAsync(TopicName.get(partitionedTopic)));
                 }
 
                 if (log.isDebugEnabled()) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/NamespacesBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/NamespacesBase.java
@@ -483,8 +483,7 @@ public abstract class NamespacesBase extends AdminResource {
                         } else {
                             nonPartitionedTopics.add(topic);
                         }
-                        topicFutures.add(pulsar().getAdminClient().topics().deleteAsync(
-                                topic, true, true));
+                        topicFutures.add(pulsar().getAdminClient().topics().deleteAsync(topic, true));
                     } catch (Exception e) {
                         String errorMessage = String.format("Failed to force delete topic %s, "
                                         + "but the previous deletion command of partitioned-topics:%s "

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApi2Test.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApi2Test.java
@@ -122,6 +122,7 @@ public class AdminApi2Test extends MockedPulsarServiceBaseTest {
     @BeforeMethod
     @Override
     public void setup() throws Exception {
+        conf.setForceDeleteNamespaceAllowed(true);
         conf.setLoadBalancerEnabled(true);
         conf.setEnableNamespaceIsolationUpdateOnTime(true);
         super.internalSetup();
@@ -2547,5 +2548,16 @@ public class AdminApi2Test extends MockedPulsarServiceBaseTest {
         PulsarAdminException ex = expectThrows(PulsarAdminException.class,
                 () -> admin.topics().terminateTopic(eventTopic));
         assertTrue(ex instanceof PulsarAdminException.NotAllowedException);
+    }
+
+    @Test
+    private void testDeleteNamespaceForciblyWithManyTopics() throws Exception {
+        final String ns = "prop-xyz/ns-testDeleteNamespaceForciblyWithManyTopics";
+        admin.namespaces().createNamespace(ns, 2);
+        for (int i = 0; i < 100; i++) {
+            admin.topics().createPartitionedTopic(String.format("persistent://%s", ns + "/topic" + i), 3);
+        }
+        admin.namespaces().deleteNamespace(ns, true);
+        Assert.assertFalse(admin.namespaces().getNamespaces("prop-xyz").contains(ns));
     }
 }


### PR DESCRIPTION
### Motivation

When there are many partitioned topics under a namespace, deleting the namespace forcibly will fail, because many requests update ns policies simultaneously and cause the metadata store throws BadVersionException.

See `internalRemovePartitionsAuthenticationPoliciesAsync`
https://github.com/apache/pulsar/blob/374b3a18155cba33c4b4cfdb18c8119487be565e/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java#L612-L629

https://github.com/apache/pulsar/blob/374b3a18155cba33c4b4cfdb18c8119487be565e/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java#L704-L714

When deleting the namespace, there is no need to update namespace policies, we can delete the namespace zk node in the end. 
https://github.com/apache/pulsar/blob/374b3a18155cba33c4b4cfdb18c8119487be565e/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/NamespacesBase.java#L363-L381


### Documentation

- [x] `doc-not-needed` 
(Please explain why)
