### PR TITLE
[docs] Clarify security vulnerability process and reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -345,7 +345,7 @@ You can self-register at https://apache-pulsar.herokuapp.com/
 
 To report a vulnerability for Pulsar, contact the [Apache Security Team](https://www.apache.org/security/). When reporting a vulnerability to [security@apache.org](mailto:security@apache.org), you can copy your email to [private@pulsar.apache.org](mailto:private@pulsar.apache.org) to send your report to the Apache Pulsar Project Management Committee. This is a private mailing list.
 
-[SECURITY.md](SECURITY.md) contains more details.
+https://github.com/apache/pulsar/security/policy contains more details.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -345,6 +345,8 @@ You can self-register at https://apache-pulsar.herokuapp.com/
 
 To report a vulnerability for Pulsar, contact the [Apache Security Team](https://www.apache.org/security/). When reporting a vulnerability to [security@apache.org](mailto:security@apache.org), you can copy your email to [private@pulsar.apache.org](mailto:private@pulsar.apache.org) to send your report to the Apache Pulsar Project Management Committee. This is a private mailing list.
 
+[SECURITY.md](SECURITY.md) contains more details.
+
 ## License
 
 Licensed under the Apache License, Version 2.0: http://www.apache.org/licenses/LICENSE-2.0

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,3 +1,13 @@
 # Security Policy
 
-The security policy and supported versions are outlined on the Pulsar website here: https://pulsar.apache.org/docs/security-policy-and-supported-versions/.
+## Security Vulnerability Process
+
+The Pulsar community follows the ASF [security vulnerability handling process](https://apache.org/security/#vulnerability-handling).
+
+To report a new vulnerability you have discovered, please follow the [ASF security vulnerability reporting process](https://apache.org/security/#reporting-a-vulnerability). To report a vulnerability for Pulsar, contact the [Apache Security Team](https://www.apache.org/security/). When reporting a vulnerability to [security@apache.org](mailto:security@apache.org), you can copy your email to [private@pulsar.apache.org](mailto:private@pulsar.apache.org) to send your report to the Apache Pulsar Project Management Committee. This is a private mailing list.
+
+It is the responsibility of the security vulnerability handling project team (Apache Pulsar PMC in most cases) to make public security vulnerability announcements. You can follow announcements on the [users@pulsar.apache.org](mailto:users@pulsar.apache.org) mailing list. For instructions on how to subscribe, please see https://pulsar.apache.org/contact/.
+
+## Security Policy details and supported versions of Apache Pulsar
+
+The security policy and supported versions are outlined on the Pulsar website under [Security > Security Policy and Supported Versions](https://pulsar.apache.org/docs/security-policy-and-supported-versions/).

--- a/site2/docs/security-policy-and-supported-versions.md
+++ b/site2/docs/security-policy-and-supported-versions.md
@@ -9,16 +9,13 @@ sidebar_label: "Security Policy and Supported Versions"
 You can find documentation on Pulsar's available security features and how to use them here:
 https://pulsar.apache.org/docs/en/security-overview/.
 
-## Security Vulnerability Announcements
+## Security Vulnerability Process
 
-The Pulsar community will announce security vulnerabilities and how to mitigate them on the [users@pulsar.apache.org](mailto:users@pulsar.apache.org).
-For instructions on how to subscribe, please see https://pulsar.apache.org/contact/.
+The Pulsar community follows the ASF [security vulnerability handling process](https://apache.org/security/#vulnerability-handling).
 
-## Reporting Vulnerabilities
+To report a new vulnerability you have discovered, please follow the [ASF security vulnerability reporting process](https://apache.org/security/#reporting-a-vulnerability). To report a vulnerability for Pulsar, contact the [Apache Security Team](https://www.apache.org/security/). When reporting a vulnerability to [security@apache.org](mailto:security@apache.org), you can copy your email to [private@pulsar.apache.org](mailto:private@pulsar.apache.org) to send your report to the Apache Pulsar Project Management Committee. This is a private mailing list.
 
-The Pulsar community follows the ASF [vulnerability handling process](https://apache.org/security/#vulnerability-handling).
-
-To report a new vulnerability you have discovered please follow the [ASF vulnerability reporting process](https://apache.org/security/#reporting-a-vulnerability).
+It is the responsibility of the security vulnerability handling project team (Apache Pulsar PMC in most cases) to make public security vulnerability announcements. You can follow announcements on the [users@pulsar.apache.org](mailto:users@pulsar.apache.org) mailing list. For instructions on how to subscribe, please see https://pulsar.apache.org/contact/.
 
 ## Versioning Policy
 

--- a/site2/website/versioned_docs/version-2.10.0/security-policy-and-supported-versions.md
+++ b/site2/website/versioned_docs/version-2.10.0/security-policy-and-supported-versions.md
@@ -2,7 +2,6 @@
 id: security-policy-and-supported-versions
 title: Security Policy and Supported Versions
 sidebar_label: "Security Policy and Supported Versions"
-original_id: security-policy-and-supported-versions
 ---
 
 ## Using Pulsar's Security Features
@@ -10,10 +9,13 @@ original_id: security-policy-and-supported-versions
 You can find documentation on Pulsar's available security features and how to use them here:
 https://pulsar.apache.org/docs/en/security-overview/.
 
-## Security Vulnerability Announcements
+## Security Vulnerability Process
 
-The Pulsar community will announce security vulnerabilities and how to mitigate them on the [users@pulsar.apache.org](mailto:users@pulsar.apache.org).
-For instructions on how to subscribe, please see https://pulsar.apache.org/contact/.
+The Pulsar community follows the ASF [security vulnerability handling process](https://apache.org/security/#vulnerability-handling).
+
+To report a new vulnerability you have discovered, please follow the [ASF security vulnerability reporting process](https://apache.org/security/#reporting-a-vulnerability). To report a vulnerability for Pulsar, contact the [Apache Security Team](https://www.apache.org/security/). When reporting a vulnerability to [security@apache.org](mailto:security@apache.org), you can copy your email to [private@pulsar.apache.org](mailto:private@pulsar.apache.org) to send your report to the Apache Pulsar Project Management Committee. This is a private mailing list.
+
+It is the responsibility of the security vulnerability handling project team (Apache Pulsar PMC in most cases) to make public security vulnerability announcements. You can follow announcements on the [users@pulsar.apache.org](mailto:users@pulsar.apache.org) mailing list. For instructions on how to subscribe, please see https://pulsar.apache.org/contact/.
 
 ## Versioning Policy
 

--- a/site2/website/versioned_docs/version-2.10.1/security-policy-and-supported-versions.md
+++ b/site2/website/versioned_docs/version-2.10.1/security-policy-and-supported-versions.md
@@ -2,7 +2,6 @@
 id: security-policy-and-supported-versions
 title: Security Policy and Supported Versions
 sidebar_label: "Security Policy and Supported Versions"
-original_id: security-policy-and-supported-versions
 ---
 
 ## Using Pulsar's Security Features
@@ -10,10 +9,13 @@ original_id: security-policy-and-supported-versions
 You can find documentation on Pulsar's available security features and how to use them here:
 https://pulsar.apache.org/docs/en/security-overview/.
 
-## Security Vulnerability Announcements
+## Security Vulnerability Process
 
-The Pulsar community will announce security vulnerabilities and how to mitigate them on the [users@pulsar.apache.org](mailto:users@pulsar.apache.org).
-For instructions on how to subscribe, please see https://pulsar.apache.org/contact/.
+The Pulsar community follows the ASF [security vulnerability handling process](https://apache.org/security/#vulnerability-handling).
+
+To report a new vulnerability you have discovered, please follow the [ASF security vulnerability reporting process](https://apache.org/security/#reporting-a-vulnerability). To report a vulnerability for Pulsar, contact the [Apache Security Team](https://www.apache.org/security/). When reporting a vulnerability to [security@apache.org](mailto:security@apache.org), you can copy your email to [private@pulsar.apache.org](mailto:private@pulsar.apache.org) to send your report to the Apache Pulsar Project Management Committee. This is a private mailing list.
+
+It is the responsibility of the security vulnerability handling project team (Apache Pulsar PMC in most cases) to make public security vulnerability announcements. You can follow announcements on the [users@pulsar.apache.org](mailto:users@pulsar.apache.org) mailing list. For instructions on how to subscribe, please see https://pulsar.apache.org/contact/.
 
 ## Versioning Policy
 


### PR DESCRIPTION
### Motivation

- the previous description wasn't clear and could cause confusion
- the page https://pulsar.apache.org/docs/security-policy-and-supported-versions/ source is under the last published version and didn't get updated with the last changes made by #16962
 (that was only visible in https://pulsar.apache.org/docs/next/security-policy-and-supported-versions/)

### Modification

- Clarify the security vulnerability process and reporting
- Add information also to SECURITY.md so that the information is available also in cases when pulsar.apache.org isn't reachable or the reader doesn't click on links to read the relevant information. It's better to duplicate information about the vulnerability handling process in SECURITY.md.