### PR TITLE
[branch-2.9] Rename test file name from `*Test2.java` to `*Test.java` to run all tests correctly

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -80,7 +80,7 @@ flexible messaging model and an intuitive client API.</description>
     <maven.compiler.source>8</maven.compiler.source>
     <maven.compiler.target>8</maven.compiler.target>
 
-    <!--config keys to congiure test selection -->
+    <!--config keys to configure test selection -->
     <include>**/Test*.java,**/*Test.java,**/*Tests.java,**/*TestCase.java</include>
     <exclude/>
     <groups/>

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApi2Test.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApi2Test.java
@@ -1253,7 +1253,7 @@ public class AdminApi2Test extends MockedPulsarServiceBaseTest {
         assertEquals(topicStats.getSubscriptions().get(subName).getMsgBacklog(), 10);
 
         topicStats = admin.topics().getStats(topic, true, true);
-        assertEquals(topicStats.getSubscriptions().get(subName).getBacklogSize(), 43);
+        assertEquals(topicStats.getSubscriptions().get(subName).getBacklogSize(), 40);
         assertEquals(topicStats.getSubscriptions().get(subName).getMsgBacklog(), 1);
         consumer.acknowledge(message);
 
@@ -1501,7 +1501,7 @@ public class AdminApi2Test extends MockedPulsarServiceBaseTest {
 
         topicStats = admin.topics().getPartitionedStats(topic, false, true, true);
         assertEquals(topicStats.getSubscriptions().get(subName).getMsgBacklog(), 1);
-        assertEquals(topicStats.getSubscriptions().get(subName).getBacklogSize(), 43);
+        assertEquals(topicStats.getSubscriptions().get(subName).getBacklogSize(), 40);
     }
 
     @Test(timeOut = 30000)
@@ -1540,7 +1540,7 @@ public class AdminApi2Test extends MockedPulsarServiceBaseTest {
 
         TopicStats topicStats = admin.topics().getPartitionedStats(topic, false, true, true);
         assertEquals(topicStats.getSubscriptions().get(subName).getMsgBacklog(), 10);
-        assertEquals(topicStats.getSubscriptions().get(subName).getBacklogSize(), 470);
+        assertEquals(topicStats.getSubscriptions().get(subName).getBacklogSize(), 440);
         assertEquals(topicStats.getSubscriptions().get(subName).getMsgBacklogNoDelayed(), 5);
 
         for (int i = 0; i < 5; i++) {
@@ -1550,7 +1550,7 @@ public class AdminApi2Test extends MockedPulsarServiceBaseTest {
         Awaitility.await().untilAsserted(() -> {
             TopicStats topicStats2 = admin.topics().getPartitionedStats(topic, false, true, true);
             assertEquals(topicStats2.getSubscriptions().get(subName).getMsgBacklog(), 5);
-            assertEquals(topicStats2.getSubscriptions().get(subName).getBacklogSize(), 238);
+            assertEquals(topicStats2.getSubscriptions().get(subName).getBacklogSize(), 223);
             assertEquals(topicStats2.getSubscriptions().get(subName).getMsgBacklogNoDelayed(), 0);
         });
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/v1/V1_AdminApi2Test.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/v1/V1_AdminApi2Test.java
@@ -73,7 +73,7 @@ import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 @Test(groups = "broker")
-public class V1_AdminApiTest2 extends MockedPulsarServiceBaseTest {
+public class V1_AdminApi2Test extends MockedPulsarServiceBaseTest {
 
     private MockedPulsarService mockPulsarSetup;
 


### PR DESCRIPTION
Fixes https://github.com/apache/pulsar/issues/16854

cherry-pick: https://github.com/apache/pulsar/pull/13644

### Motivation

It seems some test cases like `**/*Test2.java` aren't run on the default test lifecycle.
This issue is caused by https://github.com/apache/pulsar/pull/10148. I'd like to fix it.

### Modifications

Originally:
* Rename test file name to `**/*Test.java`
* Fix some codes to follow changes
    - https://github.com/apache/pulsar/pull/12687
    - https://github.com/apache/pulsar/pull/11693
    - https://github.com/apache/pulsar/pull/12663
    - https://github.com/apache/pulsar/pull/12749
    - https://github.com/apache/pulsar/pull/11640

Additionally:
* Fix conflict and keep existing changes
    - https://github.com/apache/pulsar/pull/14657/files#diff-8696b1e2ba4ee355256e31b33ccc4f1cab77f1c6c79f7b4ab508b73d43d8ad55L477-R471
* Revert some codes because the change is not cherry-picked to `branch-2.9` yet
    - https://github.com/apache/pulsar/pull/12687
* Cherry-pick additional changes about test code because existing cherry-pick commit is imcomplete
    - existing cherry-pick commit: https://github.com/apache/pulsar/commit/4f65f65c6fe6f7e97e83a13d038c6dbf28c3f8c6
    - original commit: https://github.com/apache/pulsar/commit/ecd275dc21f33483a649e5b872990771257b1d45

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation
- [x] `no-need-doc` 
