### PR TITLE
Fix the add to project CI can't work with classic project

### DIFF
--- a/.github/workflows/project-flaky-test.yml
+++ b/.github/workflows/project-flaky-test.yml
@@ -36,7 +36,7 @@ jobs:
     steps:
       - uses: actions/add-to-project@v0.3.0
         with:
-          project-url: https://github.com/apache/pulsar/projects/11
+          project-url: https://github.com/orgs/apache/projects/66
           github-token: ${{ secrets.GITHUB_TOKEN }}
           labeled: flaky-tests
           label-operator: OR


### PR DESCRIPTION
From the source code of actions/add-to-project

https://github.com/actions/add-to-project/blob/33e78e774384e272ef5071febf7585f394542eca/src/add-to-project.ts#L6-L8

Looks like it can't support to add the issue/pr to the link of https://github.com/apache/pulsar/projects/11
Change to the project under apache org.