### PR TITLE
[fix][doc]Fix fileSystemProfilePath wrong default value

### DIFF
--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -1428,8 +1428,8 @@ gcsManagedLedgerOffloadServiceAccountKeyFile=
 # For Azure BlobStore ledger offload, Blob Container (Bucket) to place offloaded ledger into
 managedLedgerOffloadBucket=
 
-#For File System Storage, file system profile path
-fileSystemProfilePath=../conf/filesystem_offload_core_site.xml
+#For File System Storage, file system profile path (Use a relative path, the current dir is the pulsar dir)
+fileSystemProfilePath=conf/filesystem_offload_core_site.xml
 
 #For File System Storage, file system uri
 fileSystemURI=

--- a/site2/docs/tiered-storage-filesystem.md
+++ b/site2/docs/tiered-storage-filesystem.md
@@ -108,7 +108,7 @@ You can configure the filesystem offloader driver in the `broker.conf` or `stand
   `managedLedgerOffloadDriver` | Offloader driver name, which is case-insensitive. | filesystem
   `fileSystemURI` | Connection address, which is the URI to access the default Hadoop distributed file system. | hdfs://127.0.0.1:9000
   `offloadersDirectory` | Offloader directory | offloaders
-  `fileSystemProfilePath` | Hadoop profile path. The configuration file is stored in the Hadoop profile path. It contains various settings for Hadoop performance tuning. | ../conf/filesystem_offload_core_site.xml
+  `fileSystemProfilePath` | Hadoop profile path. The configuration file is stored in the Hadoop profile path. It contains various settings for Hadoop performance tuning. | conf/filesystem_offload_core_site.xml
 
 
 - **Optional** configurations are as below.
@@ -126,7 +126,7 @@ You can configure the filesystem offloader driver in the `broker.conf` or `stand
   |---|---|---
   `managedLedgerOffloadDriver` | Offloader driver name, which is case-insensitive. | filesystem
   `offloadersDirectory` | Offloader directory | offloaders
-  `fileSystemProfilePath` | NFS profile path. The configuration file is stored in the NFS profile path. It contains various settings for performance tuning. | ../conf/filesystem_offload_core_site.xml
+  `fileSystemProfilePath` | NFS profile path. The configuration file is stored in the NFS profile path. It contains various settings for performance tuning. | conf/filesystem_offload_core_site.xml
 
 - **Optional** configurations are as below.
 
@@ -360,7 +360,7 @@ Set the following configurations in the `conf/standalone.conf` file.
 
 managedLedgerOffloadDriver=filesystem
 fileSystemURI=hdfs://127.0.0.1:9000
-fileSystemProfilePath=../conf/filesystem_offload_core_site.xml
+fileSystemProfilePath=conf/filesystem_offload_core_site.xml
 
 ```
 
@@ -573,7 +573,7 @@ As indicated in the [configuration](#configuration) section, you need to configu
    ```conf
    
    managedLedgerOffloadDriver=filesystem
-   fileSystemProfilePath=../conf/filesystem_offload_core_site.xml
+   fileSystemProfilePath=conf/filesystem_offload_core_site.xml
    
    ```
 

--- a/site2/website/versioned_docs/version-2.10.0/tiered-storage-filesystem.md
+++ b/site2/website/versioned_docs/version-2.10.0/tiered-storage-filesystem.md
@@ -109,7 +109,7 @@ You can configure the filesystem offloader driver in the `broker.conf` or `stand
   `managedLedgerOffloadDriver` | Offloader driver name, which is case-insensitive. | filesystem
   `fileSystemURI` | Connection address, which is the URI to access the default Hadoop distributed file system. | hdfs://127.0.0.1:9000
   `offloadersDirectory` | Offloader directory | offloaders
-  `fileSystemProfilePath` | Hadoop profile path. The configuration file is stored in the Hadoop profile path. It contains various settings for Hadoop performance tuning. | ../conf/filesystem_offload_core_site.xml
+  `fileSystemProfilePath` | Hadoop profile path. The configuration file is stored in the Hadoop profile path. It contains various settings for Hadoop performance tuning. | conf/filesystem_offload_core_site.xml
 
 
 - **Optional** configurations are as below.
@@ -128,7 +128,7 @@ You can configure the filesystem offloader driver in the `broker.conf` or `stand
   |---|---|---
   `managedLedgerOffloadDriver` | Offloader driver name, which is case-insensitive. | filesystem
   `offloadersDirectory` | Offloader directory | offloaders
-  `fileSystemProfilePath` | NFS profile path. The configuration file is stored in the NFS profile path. It contains various settings for performance tuning. | ../conf/filesystem_offload_core_site.xml
+  `fileSystemProfilePath` | NFS profile path. The configuration file is stored in the NFS profile path. It contains various settings for performance tuning. | conf/filesystem_offload_core_site.xml
 
 - **Optional** configurations are as below.
 
@@ -370,7 +370,7 @@ Set the following configurations in the `conf/standalone.conf` file.
 
 managedLedgerOffloadDriver=filesystem
 fileSystemURI=hdfs://127.0.0.1:9000
-fileSystemProfilePath=../conf/filesystem_offload_core_site.xml
+fileSystemProfilePath=conf/filesystem_offload_core_site.xml
 
 ```
 
@@ -421,7 +421,7 @@ As indicated in the [configuration](#configuration) section, you need to configu
    ```conf
    
    managedLedgerOffloadDriver=filesystem
-   fileSystemProfilePath=../conf/filesystem_offload_core_site.xml
+   fileSystemProfilePath=conf/filesystem_offload_core_site.xml
    
    ```
 

--- a/site2/website/versioned_docs/version-2.10.1/tiered-storage-filesystem.md
+++ b/site2/website/versioned_docs/version-2.10.1/tiered-storage-filesystem.md
@@ -109,7 +109,7 @@ You can configure the filesystem offloader driver in the `broker.conf` or `stand
   `managedLedgerOffloadDriver` | Offloader driver name, which is case-insensitive. | filesystem
   `fileSystemURI` | Connection address, which is the URI to access the default Hadoop distributed file system. | hdfs://127.0.0.1:9000
   `offloadersDirectory` | Offloader directory | offloaders
-  `fileSystemProfilePath` | Hadoop profile path. The configuration file is stored in the Hadoop profile path. It contains various settings for Hadoop performance tuning. | ../conf/filesystem_offload_core_site.xml
+  `fileSystemProfilePath` | Hadoop profile path. The configuration file is stored in the Hadoop profile path. It contains various settings for Hadoop performance tuning. | conf/filesystem_offload_core_site.xml
 
 
 - **Optional** configurations are as below.
@@ -128,7 +128,7 @@ You can configure the filesystem offloader driver in the `broker.conf` or `stand
   |---|---|---
   `managedLedgerOffloadDriver` | Offloader driver name, which is case-insensitive. | filesystem
   `offloadersDirectory` | Offloader directory | offloaders
-  `fileSystemProfilePath` | NFS profile path. The configuration file is stored in the NFS profile path. It contains various settings for performance tuning. | ../conf/filesystem_offload_core_site.xml
+  `fileSystemProfilePath` | NFS profile path. The configuration file is stored in the NFS profile path. It contains various settings for performance tuning. | conf/filesystem_offload_core_site.xml
 
 - **Optional** configurations are as below.
 
@@ -370,7 +370,7 @@ Set the following configurations in the `conf/standalone.conf` file.
 
 managedLedgerOffloadDriver=filesystem
 fileSystemURI=hdfs://127.0.0.1:9000
-fileSystemProfilePath=../conf/filesystem_offload_core_site.xml
+fileSystemProfilePath=conf/filesystem_offload_core_site.xml
 
 ```
 
@@ -421,7 +421,7 @@ As indicated in the [configuration](#configuration) section, you need to configu
    ```conf
    
    managedLedgerOffloadDriver=filesystem
-   fileSystemProfilePath=../conf/filesystem_offload_core_site.xml
+   fileSystemProfilePath=conf/filesystem_offload_core_site.xml
    
    ```
 

--- a/site2/website/versioned_docs/version-2.7.0/tiered-storage-filesystem.md
+++ b/site2/website/versioned_docs/version-2.7.0/tiered-storage-filesystem.md
@@ -109,7 +109,7 @@ You can configure the filesystem offloader driver in the `broker.conf` or `stand
   `managedLedgerOffloadDriver` | Offloader driver name, which is case-insensitive. | filesystem
   `fileSystemURI` | Connection address, which is the URI to access the default Hadoop distributed file system. | hdfs://127.0.0.1:9000
   `offloadersDirectory` | Offloader directory | offloaders
-  `fileSystemProfilePath` | Hadoop profile path. The configuration file is stored in the Hadoop profile path. It contains various settings for Hadoop performance tuning. | ../conf/filesystem_offload_core_site.xml
+  `fileSystemProfilePath` | Hadoop profile path. The configuration file is stored in the Hadoop profile path. It contains various settings for Hadoop performance tuning. | conf/filesystem_offload_core_site.xml
 
 - **Optional** configurations are as below.
 
@@ -127,7 +127,7 @@ You can configure the filesystem offloader driver in the `broker.conf` or `stand
   |---|---|---
   `managedLedgerOffloadDriver` | Offloader driver name, which is case-insensitive. | filesystem
   `offloadersDirectory` | Offloader directory | offloaders
-  `fileSystemProfilePath` | NFS profile path. The configuration file is stored in the NFS profile path. It contains various settings for performance tuning. | ../conf/filesystem_offload_core_site.xml
+  `fileSystemProfilePath` | NFS profile path. The configuration file is stored in the NFS profile path. It contains various settings for performance tuning. | conf/filesystem_offload_core_site.xml
 
 - **Optional** configurations are as below.
 
@@ -369,7 +369,7 @@ Set the following configurations in the `conf/standalone.conf` file.
 
 managedLedgerOffloadDriver=filesystem
 fileSystemURI=hdfs://127.0.0.1:9000
-fileSystemProfilePath=../conf/filesystem_offload_core_site.xml
+fileSystemProfilePath=conf/filesystem_offload_core_site.xml
 
 ```
 
@@ -420,7 +420,7 @@ As indicated in the [configuration](#configuration) section, you need to configu
    ```conf
    
    managedLedgerOffloadDriver=filesystem
-   fileSystemProfilePath=../conf/filesystem_offload_core_site.xml
+   fileSystemProfilePath=conf/filesystem_offload_core_site.xml
    
    ```
 

--- a/site2/website/versioned_docs/version-2.7.1/tiered-storage-filesystem.md
+++ b/site2/website/versioned_docs/version-2.7.1/tiered-storage-filesystem.md
@@ -108,7 +108,7 @@ You can configure the filesystem offloader driver in the `broker.conf` or `stand
   `managedLedgerOffloadDriver` | Offloader driver name, which is case-insensitive. | filesystem
   `fileSystemURI` | Connection address, which is the URI to access the default Hadoop distributed file system. | hdfs://127.0.0.1:9000
   `offloadersDirectory` | Offloader directory | offloaders
-  `fileSystemProfilePath` | Hadoop profile path. The configuration file is stored in the Hadoop profile path. It contains various settings for Hadoop performance tuning. | ../conf/filesystem_offload_core_site.xml
+  `fileSystemProfilePath` | Hadoop profile path. The configuration file is stored in the Hadoop profile path. It contains various settings for Hadoop performance tuning. | conf/filesystem_offload_core_site.xml
 
 - **Optional** configurations are as below.
 
@@ -126,7 +126,7 @@ You can configure the filesystem offloader driver in the `broker.conf` or `stand
   |---|---|---
   `managedLedgerOffloadDriver` | Offloader driver name, which is case-insensitive. | filesystem
   `offloadersDirectory` | Offloader directory | offloaders
-  `fileSystemProfilePath` | NFS profile path. The configuration file is stored in the NFS profile path. It contains various settings for performance tuning. | ../conf/filesystem_offload_core_site.xml
+  `fileSystemProfilePath` | NFS profile path. The configuration file is stored in the NFS profile path. It contains various settings for performance tuning. | conf/filesystem_offload_core_site.xml
 
 - **Optional** configurations are as below.
 
@@ -368,7 +368,7 @@ Set the following configurations in the `conf/standalone.conf` file.
 
 managedLedgerOffloadDriver=filesystem
 fileSystemURI=hdfs://127.0.0.1:9000
-fileSystemProfilePath=../conf/filesystem_offload_core_site.xml
+fileSystemProfilePath=conf/filesystem_offload_core_site.xml
 
 ```
 
@@ -419,7 +419,7 @@ As indicated in the [configuration](#configuration) section, you need to configu
    ```conf
    
    managedLedgerOffloadDriver=filesystem
-   fileSystemProfilePath=../conf/filesystem_offload_core_site.xml
+   fileSystemProfilePath=conf/filesystem_offload_core_site.xml
    
    ```
 

--- a/site2/website/versioned_docs/version-2.7.2/tiered-storage-filesystem.md
+++ b/site2/website/versioned_docs/version-2.7.2/tiered-storage-filesystem.md
@@ -109,7 +109,7 @@ You can configure the filesystem offloader driver in the `broker.conf` or `stand
   `managedLedgerOffloadDriver` | Offloader driver name, which is case-insensitive. | filesystem
   `fileSystemURI` | Connection address, which is the URI to access the default Hadoop distributed file system. | hdfs://127.0.0.1:9000
   `offloadersDirectory` | Offloader directory | offloaders
-  `fileSystemProfilePath` | Hadoop profile path. The configuration file is stored in the Hadoop profile path. It contains various settings for Hadoop performance tuning. | ../conf/filesystem_offload_core_site.xml
+  `fileSystemProfilePath` | Hadoop profile path. The configuration file is stored in the Hadoop profile path. It contains various settings for Hadoop performance tuning. | conf/filesystem_offload_core_site.xml
 
 - **Optional** configurations are as below.
 
@@ -127,7 +127,7 @@ You can configure the filesystem offloader driver in the `broker.conf` or `stand
   |---|---|---
   `managedLedgerOffloadDriver` | Offloader driver name, which is case-insensitive. | filesystem
   `offloadersDirectory` | Offloader directory | offloaders
-  `fileSystemProfilePath` | NFS profile path. The configuration file is stored in the NFS profile path. It contains various settings for performance tuning. | ../conf/filesystem_offload_core_site.xml
+  `fileSystemProfilePath` | NFS profile path. The configuration file is stored in the NFS profile path. It contains various settings for performance tuning. | conf/filesystem_offload_core_site.xml
 
 - **Optional** configurations are as below.
 
@@ -369,7 +369,7 @@ Set the following configurations in the `conf/standalone.conf` file.
 
 managedLedgerOffloadDriver=filesystem
 fileSystemURI=hdfs://127.0.0.1:9000
-fileSystemProfilePath=../conf/filesystem_offload_core_site.xml
+fileSystemProfilePath=conf/filesystem_offload_core_site.xml
 
 ```
 
@@ -420,7 +420,7 @@ As indicated in the [configuration](#configuration) section, you need to configu
    ```conf
    
    managedLedgerOffloadDriver=filesystem
-   fileSystemProfilePath=../conf/filesystem_offload_core_site.xml
+   fileSystemProfilePath=conf/filesystem_offload_core_site.xml
    
    ```
 

--- a/site2/website/versioned_docs/version-2.7.3/tiered-storage-filesystem.md
+++ b/site2/website/versioned_docs/version-2.7.3/tiered-storage-filesystem.md
@@ -109,7 +109,7 @@ You can configure the filesystem offloader driver in the `broker.conf` or `stand
   `managedLedgerOffloadDriver` | Offloader driver name, which is case-insensitive. | filesystem
   `fileSystemURI` | Connection address, which is the URI to access the default Hadoop distributed file system. | hdfs://127.0.0.1:9000
   `offloadersDirectory` | Offloader directory | offloaders
-  `fileSystemProfilePath` | Hadoop profile path. The configuration file is stored in the Hadoop profile path. It contains various settings for Hadoop performance tuning. | ../conf/filesystem_offload_core_site.xml
+  `fileSystemProfilePath` | Hadoop profile path. The configuration file is stored in the Hadoop profile path. It contains various settings for Hadoop performance tuning. | conf/filesystem_offload_core_site.xml
 
 - **Optional** configurations are as below.
 
@@ -127,7 +127,7 @@ You can configure the filesystem offloader driver in the `broker.conf` or `stand
   |---|---|---
   `managedLedgerOffloadDriver` | Offloader driver name, which is case-insensitive. | filesystem
   `offloadersDirectory` | Offloader directory | offloaders
-  `fileSystemProfilePath` | NFS profile path. The configuration file is stored in the NFS profile path. It contains various settings for performance tuning. | ../conf/filesystem_offload_core_site.xml
+  `fileSystemProfilePath` | NFS profile path. The configuration file is stored in the NFS profile path. It contains various settings for performance tuning. | conf/filesystem_offload_core_site.xml
 
 - **Optional** configurations are as below.
 
@@ -369,7 +369,7 @@ Set the following configurations in the `conf/standalone.conf` file.
 
 managedLedgerOffloadDriver=filesystem
 fileSystemURI=hdfs://127.0.0.1:9000
-fileSystemProfilePath=../conf/filesystem_offload_core_site.xml
+fileSystemProfilePath=conf/filesystem_offload_core_site.xml
 
 ```
 
@@ -420,7 +420,7 @@ As indicated in the [configuration](#configuration) section, you need to configu
    ```conf
    
    managedLedgerOffloadDriver=filesystem
-   fileSystemProfilePath=../conf/filesystem_offload_core_site.xml
+   fileSystemProfilePath=conf/filesystem_offload_core_site.xml
    
    ```
 

--- a/site2/website/versioned_docs/version-2.7.4/tiered-storage-filesystem.md
+++ b/site2/website/versioned_docs/version-2.7.4/tiered-storage-filesystem.md
@@ -108,7 +108,7 @@ You can configure the filesystem offloader driver in the `broker.conf` or `stand
   |---|---|---
   `managedLedgerOffloadDriver` | Offloader driver name, which is case-insensitive. | filesystem
   `fileSystemURI` | Connection address, which is the URI to access the default Hadoop distributed file system. | hdfs://127.0.0.1:9000
-  `offloadersDirectory` | Hadoop profile path. The configuration file is stored in the Hadoop profile path. It contains various settings for Hadoop performance tuning. | ../conf/filesystem_offload_core_site.xml
+  `offloadersDirectory` | Hadoop profile path. The configuration file is stored in the Hadoop profile path. It contains various settings for Hadoop performance tuning. | conf/filesystem_offload_core_site.xml
 
 - **Optional** configurations are as below.
 
@@ -125,7 +125,7 @@ You can configure the filesystem offloader driver in the `broker.conf` or `stand
   Parameter | Description | Example value
   |---|---|---
   `managedLedgerOffloadDriver` | Offloader driver name, which is case-insensitive. | filesystem
-  `offloadersDirectory` | Offloader directory. The configuration file is stored in the offloader directory. It contains various settings for performance tuning. | ../conf/filesystem_offload_core_site.xml
+  `offloadersDirectory` | Offloader directory. The configuration file is stored in the offloader directory. It contains various settings for performance tuning. | conf/filesystem_offload_core_site.xml
 
 - **Optional** configurations are as below.
 
@@ -367,7 +367,7 @@ Set the following configurations in the `conf/standalone.conf` file.
 
 managedLedgerOffloadDriver=filesystem
 fileSystemURI=hdfs://127.0.0.1:9000
-fileSystemProfilePath=../conf/filesystem_offload_core_site.xml
+fileSystemProfilePath=conf/filesystem_offload_core_site.xml
 
 ```
 
@@ -418,7 +418,7 @@ As indicated in the [configuration](#configuration) section, you need to configu
    ```conf
    
    managedLedgerOffloadDriver=filesystem
-   fileSystemProfilePath=../conf/filesystem_offload_core_site.xml
+   fileSystemProfilePath=conf/filesystem_offload_core_site.xml
    
    ```
 

--- a/site2/website/versioned_docs/version-2.8.0/tiered-storage-filesystem.md
+++ b/site2/website/versioned_docs/version-2.8.0/tiered-storage-filesystem.md
@@ -109,7 +109,7 @@ You can configure the filesystem offloader driver in the `broker.conf` or `stand
   `managedLedgerOffloadDriver` | Offloader driver name, which is case-insensitive. | filesystem
   `fileSystemURI` | Connection address, which is the URI to access the default Hadoop distributed file system. | hdfs://127.0.0.1:9000
   `offloadersDirectory` | Offloader directory | offloaders
-  `fileSystemProfilePath` | Hadoop profile path. The configuration file is stored in the Hadoop profile path. It contains various settings for Hadoop performance tuning. | ../conf/filesystem_offload_core_site.xml
+  `fileSystemProfilePath` | Hadoop profile path. The configuration file is stored in the Hadoop profile path. It contains various settings for Hadoop performance tuning. | conf/filesystem_offload_core_site.xml
 
 - **Optional** configurations are as below.
 
@@ -127,7 +127,7 @@ You can configure the filesystem offloader driver in the `broker.conf` or `stand
   |---|---|---
   `managedLedgerOffloadDriver` | Offloader driver name, which is case-insensitive. | filesystem
   `offloadersDirectory` | Offloader directory | offloaders
-  `fileSystemProfilePath` | NFS profile path. The configuration file is stored in the NFS profile path. It contains various settings for performance tuning. | ../conf/filesystem_offload_core_site.xml
+  `fileSystemProfilePath` | NFS profile path. The configuration file is stored in the NFS profile path. It contains various settings for performance tuning. | conf/filesystem_offload_core_site.xml
 
 - **Optional** configurations are as below.
 
@@ -369,7 +369,7 @@ Set the following configurations in the `conf/standalone.conf` file.
 
 managedLedgerOffloadDriver=filesystem
 fileSystemURI=hdfs://127.0.0.1:9000
-fileSystemProfilePath=../conf/filesystem_offload_core_site.xml
+fileSystemProfilePath=conf/filesystem_offload_core_site.xml
 
 ```
 
@@ -420,7 +420,7 @@ As indicated in the [configuration](#configuration) section, you need to configu
    ```conf
    
    managedLedgerOffloadDriver=filesystem
-   fileSystemProfilePath=../conf/filesystem_offload_core_site.xml
+   fileSystemProfilePath=conf/filesystem_offload_core_site.xml
    
    ```
 

--- a/site2/website/versioned_docs/version-2.8.1/tiered-storage-filesystem.md
+++ b/site2/website/versioned_docs/version-2.8.1/tiered-storage-filesystem.md
@@ -109,7 +109,7 @@ You can configure the filesystem offloader driver in the `broker.conf` or `stand
   `managedLedgerOffloadDriver` | Offloader driver name, which is case-insensitive. | filesystem
   `fileSystemURI` | Connection address, which is the URI to access the default Hadoop distributed file system. | hdfs://127.0.0.1:9000
   `offloadersDirectory` | Offloader directory | offloaders
-  `fileSystemProfilePath` | Hadoop profile path. The configuration file is stored in the Hadoop profile path. It contains various settings for Hadoop performance tuning. | ../conf/filesystem_offload_core_site.xml
+  `fileSystemProfilePath` | Hadoop profile path. The configuration file is stored in the Hadoop profile path. It contains various settings for Hadoop performance tuning. | conf/filesystem_offload_core_site.xml
 
 - **Optional** configurations are as below.
 
@@ -127,7 +127,7 @@ You can configure the filesystem offloader driver in the `broker.conf` or `stand
   Parameter | Description | Example value
   |---|---|---
   `managedLedgerOffloadDriver` | Offloader driver name, which is case-insensitive. | filesystem
-  `fileSystemProfilePath` | NFS profile path. The configuration file is stored in the NFS profile path. It contains various settings for performance tuning. | ../conf/filesystem_offload_core_site.xml
+  `fileSystemProfilePath` | NFS profile path. The configuration file is stored in the NFS profile path. It contains various settings for performance tuning. | conf/filesystem_offload_core_site.xml
 
 - **Optional** configurations are as below.
 
@@ -369,7 +369,7 @@ Set the following configurations in the `conf/standalone.conf` file.
 
 managedLedgerOffloadDriver=filesystem
 fileSystemURI=hdfs://127.0.0.1:9000
-fileSystemProfilePath=../conf/filesystem_offload_core_site.xml
+fileSystemProfilePath=conf/filesystem_offload_core_site.xml
 
 ```
 
@@ -420,7 +420,7 @@ As indicated in the [configuration](#configuration) section, you need to configu
    ```conf
    
    managedLedgerOffloadDriver=filesystem
-   fileSystemProfilePath=../conf/filesystem_offload_core_site.xml
+   fileSystemProfilePath=conf/filesystem_offload_core_site.xml
    
    ```
 

--- a/site2/website/versioned_docs/version-2.8.2/tiered-storage-filesystem.md
+++ b/site2/website/versioned_docs/version-2.8.2/tiered-storage-filesystem.md
@@ -109,7 +109,7 @@ You can configure the filesystem offloader driver in the `broker.conf` or `stand
   `managedLedgerOffloadDriver` | Offloader driver name, which is case-insensitive. | filesystem
   `fileSystemURI` | Connection address, which is the URI to access the default Hadoop distributed file system. | hdfs://127.0.0.1:9000
   `offloadersDirectory` | Offloader directory | offloaders
-  `fileSystemProfilePath` | Hadoop profile path. The configuration file is stored in the Hadoop profile path. It contains various settings for Hadoop performance tuning. | ../conf/filesystem_offload_core_site.xml
+  `fileSystemProfilePath` | Hadoop profile path. The configuration file is stored in the Hadoop profile path. It contains various settings for Hadoop performance tuning. | conf/filesystem_offload_core_site.xml
 
 - **Optional** configurations are as below.
 
@@ -127,7 +127,7 @@ You can configure the filesystem offloader driver in the `broker.conf` or `stand
   |---|---|---
   `managedLedgerOffloadDriver` | Offloader driver name, which is case-insensitive. | filesystem
   `offloadersDirectory` | Offloader directory | offloaders
-  `fileSystemProfilePath` | NFS profile path. The configuration file is stored in the NFS profile path. It contains various settings for performance tuning. | ../conf/filesystem_offload_core_site.xml
+  `fileSystemProfilePath` | NFS profile path. The configuration file is stored in the NFS profile path. It contains various settings for performance tuning. | conf/filesystem_offload_core_site.xml
 
 - **Optional** configurations are as below.
 
@@ -369,7 +369,7 @@ Set the following configurations in the `conf/standalone.conf` file.
 
 managedLedgerOffloadDriver=filesystem
 fileSystemURI=hdfs://127.0.0.1:9000
-fileSystemProfilePath=../conf/filesystem_offload_core_site.xml
+fileSystemProfilePath=conf/filesystem_offload_core_site.xml
 
 ```
 
@@ -420,7 +420,7 @@ As indicated in the [configuration](#configuration) section, you need to configu
    ```conf
    
    managedLedgerOffloadDriver=filesystem
-   fileSystemProfilePath=../conf/filesystem_offload_core_site.xml
+   fileSystemProfilePath=conf/filesystem_offload_core_site.xml
    
    ```
 

--- a/site2/website/versioned_docs/version-2.8.3/tiered-storage-filesystem.md
+++ b/site2/website/versioned_docs/version-2.8.3/tiered-storage-filesystem.md
@@ -109,7 +109,7 @@ You can configure the filesystem offloader driver in the `broker.conf` or `stand
   `managedLedgerOffloadDriver` | Offloader driver name, which is case-insensitive. | filesystem
   `fileSystemURI` | Connection address, which is the URI to access the default Hadoop distributed file system. | hdfs://127.0.0.1:9000
   `offloadersDirectory` | Offloader directory | offloaders
-  `fileSystemProfilePath` | Hadoop profile path. The configuration file is stored in the Hadoop profile path. It contains various settings for Hadoop performance tuning. | ../conf/filesystem_offload_core_site.xml
+  `fileSystemProfilePath` | Hadoop profile path. The configuration file is stored in the Hadoop profile path. It contains various settings for Hadoop performance tuning. | conf/filesystem_offload_core_site.xml
 
 - **Optional** configurations are as below.
 
@@ -127,7 +127,7 @@ You can configure the filesystem offloader driver in the `broker.conf` or `stand
   |---|---|---
   `managedLedgerOffloadDriver` | Offloader driver name, which is case-insensitive. | filesystem
   `offloadersDirectory` | Offloader directory | offloaders
-  `fileSystemProfilePath` | NFS profile path. The configuration file is stored in the NFS profile path. It contains various settings for performance tuning. | ../conf/filesystem_offload_core_site.xml
+  `fileSystemProfilePath` | NFS profile path. The configuration file is stored in the NFS profile path. It contains various settings for performance tuning. | conf/filesystem_offload_core_site.xml
 
 - **Optional** configurations are as below.
 
@@ -369,7 +369,7 @@ Set the following configurations in the `conf/standalone.conf` file.
 
 managedLedgerOffloadDriver=filesystem
 fileSystemURI=hdfs://127.0.0.1:9000
-fileSystemProfilePath=../conf/filesystem_offload_core_site.xml
+fileSystemProfilePath=conf/filesystem_offload_core_site.xml
 
 ```
 
@@ -420,7 +420,7 @@ As indicated in the [configuration](#configuration) section, you need to configu
    ```conf
    
    managedLedgerOffloadDriver=filesystem
-   fileSystemProfilePath=../conf/filesystem_offload_core_site.xml
+   fileSystemProfilePath=conf/filesystem_offload_core_site.xml
    
    ```
 

--- a/site2/website/versioned_docs/version-2.9.0/tiered-storage-filesystem.md
+++ b/site2/website/versioned_docs/version-2.9.0/tiered-storage-filesystem.md
@@ -98,7 +98,7 @@ You can configure filesystem offloader driver in the configuration file `broker.
   |---|---|---
   `managedLedgerOffloadDriver` | Offloader driver name, which is case-insensitive. | filesystem
   `fileSystemURI` | Connection address | hdfs://127.0.0.1:9000
-  `fileSystemProfilePath` | Hadoop profile path | ../conf/filesystem_offload_core_site.xml
+  `fileSystemProfilePath` | Hadoop profile path | conf/filesystem_offload_core_site.xml
 
 - **Optional** configurations are as below.
 
@@ -139,11 +139,11 @@ The configuration file is stored in the Hadoop profile path. It contains various
 
 ##### Example
 
-This example sets the Hadoop profile path as _../conf/filesystem_offload_core_site.xml_.
+This example sets the Hadoop profile path as _conf/filesystem_offload_core_site.xml_.
 
 ```conf
 
-fileSystemProfilePath=../conf/filesystem_offload_core_site.xml
+fileSystemProfilePath=conf/filesystem_offload_core_site.xml
 
 ```
 

--- a/site2/website/versioned_docs/version-2.9.1/tiered-storage-filesystem.md
+++ b/site2/website/versioned_docs/version-2.9.1/tiered-storage-filesystem.md
@@ -98,7 +98,7 @@ You can configure filesystem offloader driver in the configuration file `broker.
   |---|---|---
   `managedLedgerOffloadDriver` | Offloader driver name, which is case-insensitive. | filesystem
   `fileSystemURI` | Connection address | hdfs://127.0.0.1:9000
-  `fileSystemProfilePath` | Hadoop profile path | ../conf/filesystem_offload_core_site.xml
+  `fileSystemProfilePath` | Hadoop profile path | conf/filesystem_offload_core_site.xml
 
 - **Optional** configurations are as below.
 
@@ -139,11 +139,11 @@ The configuration file is stored in the Hadoop profile path. It contains various
 
 ##### Example
 
-This example sets the Hadoop profile path as _../conf/filesystem_offload_core_site.xml_.
+This example sets the Hadoop profile path as _conf/filesystem_offload_core_site.xml_.
 
 ```conf
 
-fileSystemProfilePath=../conf/filesystem_offload_core_site.xml
+fileSystemProfilePath=conf/filesystem_offload_core_site.xml
 
 ```
 

--- a/site2/website/versioned_docs/version-2.9.2/tiered-storage-filesystem.md
+++ b/site2/website/versioned_docs/version-2.9.2/tiered-storage-filesystem.md
@@ -98,7 +98,7 @@ You can configure filesystem offloader driver in the configuration file `broker.
   |---|---|---
   `managedLedgerOffloadDriver` | Offloader driver name, which is case-insensitive. | filesystem
   `fileSystemURI` | Connection address | hdfs://127.0.0.1:9000
-  `fileSystemProfilePath` | Hadoop profile path | ../conf/filesystem_offload_core_site.xml
+  `fileSystemProfilePath` | Hadoop profile path | conf/filesystem_offload_core_site.xml
 
 - **Optional** configurations are as below.
 
@@ -139,11 +139,11 @@ The configuration file is stored in the Hadoop profile path. It contains various
 
 ##### Example
 
-This example sets the Hadoop profile path as _../conf/filesystem_offload_core_site.xml_.
+This example sets the Hadoop profile path as _conf/filesystem_offload_core_site.xml_.
 
 ```conf
 
-fileSystemProfilePath=../conf/filesystem_offload_core_site.xml
+fileSystemProfilePath=conf/filesystem_offload_core_site.xml
 
 ```
 


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://docs.google.com/document/d/1d8Pw6ZbWk-_pCKdOmdvx9rnhPiyuxwq60_TrD68d7BA/edit#heading=h.trs9rsex3xom)*. 

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.

**(The sections below can be removed for hotfixes of typos)**
-->
### Motivation


The configuration item `fileSystemProfilePath` in` broker.conf `has the wrong default value: For File System Storage, `fileSystemProfilePath` is the file system profile path; when we use a relative path, the current dir is the pulsar root dir, not `conf/ `dir,so the correct relative path is `conf/filesystem_offload_core_site.xml` not `../conf/filesystem_offload_core_site.xml`.
In addition, this configuration item in our docs also uses the wrong default values.
https://pulsar.apache.org/docs/next/tiered-storage-filesystem#configure-filesystem-offloader-driver
https://pulsar.apache.org/docs/next/tiered-storage-filesystem#step-3-configure-the-filesystem-offloader
https://pulsar.apache.org/docs/next/tiered-storage-filesystem#step-3-configure-the-filesystem-offloader-driver


### Modifications

Fix the wrong default va in `broker.conf` & docs link.


### Documentation

Check the box below or label this PR directly.

Need to update docs? 

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)
  
- [ ] `doc-not-needed` 
(Please explain why)
  
- [x] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)