### PR TITLE
[test][proxy]auto relealse connection when use proxy

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/AutoCloseUselessClientConMultiPartTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/AutoCloseUselessClientConMultiPartTest.java
@@ -22,7 +22,6 @@ import java.time.Duration;
 import java.util.List;
 import java.util.UUID;
 import org.apache.pulsar.client.admin.PulsarAdmin;
-import org.apache.pulsar.client.admin.PulsarAdminException;
 import org.apache.pulsar.client.api.Consumer;
 import org.apache.pulsar.client.api.Producer;
 import org.apache.pulsar.client.api.Schema;
@@ -38,7 +37,7 @@ public class AutoCloseUselessClientConMultiPartTest extends AutoCloseUselessClie
     private static String topicFullName = "persistent://public/default/" + topicName;
 
     @BeforeMethod
-    public void before() throws PulsarAdminException {
+    public void before() throws Exception {
         // Create Topics
         PulsarAdmin pulsarAdmin_0 = super.getAllAdmins().get(0);
         List<String> topicList = pulsarAdmin_0.topics().getList("public/default");
@@ -51,7 +50,7 @@ public class AutoCloseUselessClientConMultiPartTest extends AutoCloseUselessClie
     @Test
     public void testConnectionAutoReleasePartitionedTopic() throws Exception {
         // Init clients
-        PulsarClientImpl pulsarClient = (PulsarClientImpl) super.getAllClients().get(0);
+        PulsarClientImpl pulsarClient = choosePulsarClient();
         Consumer consumer = pulsarClient.newConsumer()
                 .topic(topicName)
                 .subscriptionName("my-subscription-x")

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/AutoCloseUselessClientConMultiTopicTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/AutoCloseUselessClientConMultiTopicTest.java
@@ -22,7 +22,6 @@ import java.time.Duration;
 import java.util.List;
 import java.util.UUID;
 import org.apache.pulsar.client.admin.PulsarAdmin;
-import org.apache.pulsar.client.admin.PulsarAdminException;
 import org.apache.pulsar.client.api.Consumer;
 import org.apache.pulsar.client.api.Producer;
 import org.awaitility.Awaitility;
@@ -38,7 +37,7 @@ public class AutoCloseUselessClientConMultiTopicTest extends AutoCloseUselessCli
     private static String topicFullName_2 = "persistent://public/default/" + topicName_2;
 
     @BeforeMethod
-    public void before() throws PulsarAdminException {
+    public void before() throws Exception {
         // Create Topics
         PulsarAdmin pulsarAdmin_0 = super.getAllAdmins().get(0);
         List<String> topicList = pulsarAdmin_0.topics().getList("public/default");
@@ -55,7 +54,7 @@ public class AutoCloseUselessClientConMultiTopicTest extends AutoCloseUselessCli
     @Test
     public void testConnectionAutoReleaseMultiTopic() throws Exception {
         // Init clients
-        PulsarClientImpl pulsarClient = (PulsarClientImpl) super.getAllClients().get(0);
+        PulsarClientImpl pulsarClient = choosePulsarClient();
         Consumer consumer = pulsarClient.newConsumer()
                 .topic(topicName_1, topicName_2)
                 .subscriptionName("my-subscription-x")

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/AutoCloseUselessClientConNoPartTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/AutoCloseUselessClientConNoPartTest.java
@@ -22,7 +22,6 @@ import java.time.Duration;
 import java.util.List;
 import java.util.UUID;
 import org.apache.pulsar.client.admin.PulsarAdmin;
-import org.apache.pulsar.client.admin.PulsarAdminException;
 import org.apache.pulsar.client.api.Consumer;
 import org.apache.pulsar.client.api.Producer;
 import org.apache.pulsar.client.api.Schema;
@@ -38,7 +37,7 @@ public class AutoCloseUselessClientConNoPartTest extends AutoCloseUselessClientC
     private static String topicFullName = "persistent://public/default/" + topicName;
 
     @BeforeMethod
-    public void before() throws PulsarAdminException {
+    public void before() throws Exception {
         // Create Topics
         PulsarAdmin pulsarAdmin_0 = super.getAllAdmins().get(0);
         List<String> topicList = pulsarAdmin_0.topics().getList("public/default");
@@ -51,7 +50,7 @@ public class AutoCloseUselessClientConNoPartTest extends AutoCloseUselessClientC
     @Test
     public void testConnectionAutoReleaseUnPartitionedTopic() throws Exception {
         // Init clients
-        PulsarClientImpl pulsarClient = (PulsarClientImpl) super.getAllClients().get(0);
+        PulsarClientImpl pulsarClient = choosePulsarClient();
         Consumer consumer = pulsarClient.newConsumer(Schema.BYTES)
                 .topic(topicName)
                 .isAckReceiptEnabled(true)

--- a/pulsar-proxy/pom.xml
+++ b/pulsar-proxy/pom.xml
@@ -160,6 +160,12 @@
     </dependency>
 
     <dependency>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>com.beust</groupId>
       <artifactId>jcommander</artifactId>
     </dependency>

--- a/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/AutoCloseUselessClientConMultiPartProxyTest.java
+++ b/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/AutoCloseUselessClientConMultiPartProxyTest.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.pulsar.proxy.server;
 
 import java.util.concurrent.TimeUnit;

--- a/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/AutoCloseUselessClientConMultiPartProxyTest.java
+++ b/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/AutoCloseUselessClientConMultiPartProxyTest.java
@@ -1,0 +1,42 @@
+package org.apache.pulsar.proxy.server;
+
+import java.util.concurrent.TimeUnit;
+import org.apache.pulsar.client.api.PulsarClient;
+import org.apache.pulsar.client.impl.AutoCloseUselessClientConMultiPartTest;
+import org.apache.pulsar.client.impl.PulsarClientImpl;
+import org.apache.pulsar.proxy.util.ProxyServiceFactory;
+import org.apache.pulsar.proxy.util.ProxyServiceInfo;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+
+public class AutoCloseUselessClientConMultiPartProxyTest extends AutoCloseUselessClientConMultiPartTest {
+
+    private ProxyServiceInfo proxyServiceInfo;
+
+    @Override
+    @BeforeMethod
+    public void before() throws Exception {
+        super.before();
+        proxyServiceInfo = ProxyServiceFactory.startProxyService(mockZooKeeper, mockZooKeeperGlobal, alreadyUsedPort());
+    }
+
+    @Override
+    protected PulsarClientImpl choosePulsarClient() throws Exception {
+        PulsarClientImpl pulsarClient = (PulsarClientImpl) PulsarClient.builder()
+                .operationTimeout(30000, TimeUnit.SECONDS)
+                .serviceUrl("pulsar://" + proxyServiceInfo.getProxyAddress().getHostString() + ":"
+                        + proxyServiceInfo.getProxyAddress().getPort())
+                .build();
+        return pulsarClient;
+    }
+
+    @AfterMethod
+    public void afterMethod() throws Exception{
+        proxyServiceInfo.getProxyService().close();
+    }
+
+    @Override
+    protected void connectionToEveryBrokerWithUnloadBundle(PulsarClientImpl pulsarClient){
+        connectionToEveryBroker(pulsarClient, proxyServiceInfo.getProxyAddress());
+    }
+}

--- a/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/AutoCloseUselessClientConMultiTopicProxyTest.java
+++ b/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/AutoCloseUselessClientConMultiTopicProxyTest.java
@@ -1,0 +1,42 @@
+package org.apache.pulsar.proxy.server;
+
+import java.util.concurrent.TimeUnit;
+import org.apache.pulsar.client.api.PulsarClient;
+import org.apache.pulsar.client.impl.AutoCloseUselessClientConMultiTopicTest;
+import org.apache.pulsar.client.impl.PulsarClientImpl;
+import org.apache.pulsar.proxy.util.ProxyServiceFactory;
+import org.apache.pulsar.proxy.util.ProxyServiceInfo;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+
+public class AutoCloseUselessClientConMultiTopicProxyTest extends AutoCloseUselessClientConMultiTopicTest {
+
+    private ProxyServiceInfo proxyServiceInfo;
+
+    @Override
+    @BeforeMethod
+    public void before() throws Exception {
+        super.before();
+        proxyServiceInfo = ProxyServiceFactory.startProxyService(mockZooKeeper, mockZooKeeperGlobal, alreadyUsedPort());
+    }
+
+    @Override
+    protected PulsarClientImpl choosePulsarClient() throws Exception {
+        PulsarClientImpl pulsarClient = (PulsarClientImpl) PulsarClient.builder()
+                .operationTimeout(30000, TimeUnit.SECONDS)
+                .serviceUrl("pulsar://" + proxyServiceInfo.getProxyAddress().getHostString() + ":"
+                        + proxyServiceInfo.getProxyAddress().getPort())
+                .build();
+        return pulsarClient;
+    }
+
+    @AfterMethod
+    public void afterMethod() throws Exception{
+        proxyServiceInfo.getProxyService().close();
+    }
+
+    @Override
+    protected void connectionToEveryBrokerWithUnloadBundle(PulsarClientImpl pulsarClient){
+        connectionToEveryBroker(pulsarClient, proxyServiceInfo.getProxyAddress());
+    }
+}

--- a/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/AutoCloseUselessClientConMultiTopicProxyTest.java
+++ b/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/AutoCloseUselessClientConMultiTopicProxyTest.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.pulsar.proxy.server;
 
 import java.util.concurrent.TimeUnit;

--- a/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/AutoCloseUselessClientConNoPartProxyTest.java
+++ b/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/AutoCloseUselessClientConNoPartProxyTest.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.pulsar.proxy.server;
 
 import java.util.concurrent.TimeUnit;

--- a/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/AutoCloseUselessClientConNoPartProxyTest.java
+++ b/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/AutoCloseUselessClientConNoPartProxyTest.java
@@ -1,0 +1,42 @@
+package org.apache.pulsar.proxy.server;
+
+import java.util.concurrent.TimeUnit;
+import org.apache.pulsar.client.api.PulsarClient;
+import org.apache.pulsar.client.impl.AutoCloseUselessClientConNoPartTest;
+import org.apache.pulsar.client.impl.PulsarClientImpl;
+import org.apache.pulsar.proxy.util.ProxyServiceFactory;
+import org.apache.pulsar.proxy.util.ProxyServiceInfo;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+
+public class AutoCloseUselessClientConNoPartProxyTest extends AutoCloseUselessClientConNoPartTest {
+
+    private ProxyServiceInfo proxyServiceInfo;
+
+    @Override
+    @BeforeMethod
+    public void before() throws Exception {
+        super.before();
+        proxyServiceInfo = ProxyServiceFactory.startProxyService(mockZooKeeper, mockZooKeeperGlobal, alreadyUsedPort());
+    }
+
+    @Override
+    protected PulsarClientImpl choosePulsarClient() throws Exception {
+        PulsarClientImpl pulsarClient = (PulsarClientImpl) PulsarClient.builder()
+                .operationTimeout(30000, TimeUnit.SECONDS)
+                .serviceUrl("pulsar://" + proxyServiceInfo.getProxyAddress().getHostString() + ":"
+                        + proxyServiceInfo.getProxyAddress().getPort())
+                .build();
+        return pulsarClient;
+    }
+
+    @AfterMethod
+    public void afterMethod() throws Exception{
+        proxyServiceInfo.getProxyService().close();
+    }
+
+    @Override
+    protected void connectionToEveryBrokerWithUnloadBundle(PulsarClientImpl pulsarClient){
+        connectionToEveryBroker(pulsarClient, proxyServiceInfo.getProxyAddress());
+    }
+}

--- a/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/AutoCloseUselessClientConTXProxyTest.java
+++ b/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/AutoCloseUselessClientConTXProxyTest.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.pulsar.proxy.server;
 
 import java.net.InetSocketAddress;

--- a/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/AutoCloseUselessClientConTXProxyTest.java
+++ b/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/AutoCloseUselessClientConTXProxyTest.java
@@ -1,0 +1,49 @@
+package org.apache.pulsar.proxy.server;
+
+import java.net.InetSocketAddress;
+import java.util.concurrent.TimeUnit;
+import org.apache.pulsar.client.api.PulsarClient;
+import org.apache.pulsar.client.impl.AutoCloseUselessClientConTXTest;
+import org.apache.pulsar.client.impl.PulsarClientImpl;
+import org.apache.pulsar.proxy.util.ProxyServiceFactory;
+import org.apache.pulsar.proxy.util.ProxyServiceInfo;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+
+public class AutoCloseUselessClientConTXProxyTest extends AutoCloseUselessClientConTXTest {
+
+    private ProxyServiceInfo proxyServiceInfo;
+
+    @Override
+    @BeforeMethod
+    public void before() throws Exception {
+        super.before();
+        proxyServiceInfo = ProxyServiceFactory.startProxyService(mockZooKeeper, mockZooKeeperGlobal, alreadyUsedPort());
+    }
+
+    @Override
+    protected PulsarClientImpl choosePulsarClient() throws Exception {
+        PulsarClientImpl pulsarClient = (PulsarClientImpl) PulsarClient.builder()
+                .operationTimeout(30000, TimeUnit.SECONDS)
+                .serviceUrl("pulsar://" + proxyServiceInfo.getProxyAddress().getHostString() + ":"
+                        + proxyServiceInfo.getProxyAddress().getPort())
+                .enableTransaction(true)
+                .build();
+        return pulsarClient;
+    }
+
+    @AfterMethod
+    public void afterMethod() throws Exception{
+        proxyServiceInfo.getProxyService().close();
+    }
+
+    @Override
+    protected void connectionToEveryBrokerWithUnloadBundle(PulsarClientImpl pulsarClient){
+        connectionToEveryBroker(pulsarClient, proxyServiceInfo.getProxyAddress());
+    }
+
+    @Override
+    protected void connectionToEveryBroker(PulsarClientImpl pulsarClient, InetSocketAddress proxyAddress){
+        super.connectionToEveryBroker(pulsarClient, proxyServiceInfo.getProxyAddress());
+    }
+}

--- a/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/util/ProxyServiceFactory.java
+++ b/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/util/ProxyServiceFactory.java
@@ -1,0 +1,55 @@
+package org.apache.pulsar.proxy.util;
+
+import static org.mockito.Mockito.doReturn;
+import java.net.InetSocketAddress;
+import java.util.Optional;
+import java.util.Random;
+import java.util.Set;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.pulsar.broker.authentication.AuthenticationService;
+import org.apache.pulsar.client.impl.AutoCloseUselessClientConSupports;
+import org.apache.pulsar.common.configuration.PulsarConfigurationLoader;
+import org.apache.pulsar.metadata.impl.ZKMetadataStore;
+import org.apache.pulsar.proxy.server.ProxyConfiguration;
+import org.apache.pulsar.proxy.server.ProxyService;
+import org.apache.zookeeper.ZooKeeper;
+import org.mockito.Mockito;
+
+@Slf4j
+public class ProxyServiceFactory extends AutoCloseUselessClientConSupports {
+
+    public static ProxyServiceInfo startProxyService(ZooKeeper localMetadataStore, ZooKeeper configurationMetadataStore,
+                                                     Set<Integer> deniedPort) throws Exception{
+        ProxyConfiguration proxyConfig = new ProxyConfiguration();
+        proxyConfig.setServicePort(Optional.of(0));
+        proxyConfig.setBrokerProxyAllowedTargetPorts("*");
+        proxyConfig.setMetadataStoreUrl("DUMMY_VALUE");
+        proxyConfig.setConfigurationMetadataStoreUrl("GLOBAL_DUMMY_VALUE");
+        proxyConfig.setMaxConcurrentLookupRequests(100);
+        proxyConfig.setMaxConcurrentInboundConnections(100);
+        proxyConfig.setAuthenticationEnabled(false);
+        proxyConfig.setBindAddress("127.0.0.1");
+        int port = choosePort(deniedPort);
+        log.info("Proxy service use port : {}", port);
+        proxyConfig.setServicePort(Optional.of(port));
+        ProxyService proxyService = Mockito.spy(new ProxyService(proxyConfig, new AuthenticationService(
+                PulsarConfigurationLoader.convertFrom(proxyConfig))));
+        doReturn(new ZKMetadataStore(localMetadataStore)).when(proxyService).createLocalMetadataStore();
+        doReturn(new ZKMetadataStore(configurationMetadataStore)).when(proxyService)
+                .createConfigurationMetadataStore();
+        proxyService.start();
+        InetSocketAddress proxyAddress =
+                InetSocketAddress.createUnresolved(proxyConfig.getBindAddress(), proxyConfig.getServicePort().get());
+        return new ProxyServiceInfo(proxyService, proxyConfig, proxyAddress);
+    }
+
+    public static int choosePort(Set<Integer> deniedPort){
+        while (true){
+            int randomPort = 10000 + new Random().nextInt(10000);
+            if (deniedPort.contains(randomPort)){
+                continue;
+            }
+            return randomPort;
+        }
+    }
+}

--- a/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/util/ProxyServiceFactory.java
+++ b/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/util/ProxyServiceFactory.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.pulsar.proxy.util;
 
 import static org.mockito.Mockito.doReturn;

--- a/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/util/ProxyServiceInfo.java
+++ b/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/util/ProxyServiceInfo.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.pulsar.proxy.util;
 
 import java.net.InetSocketAddress;

--- a/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/util/ProxyServiceInfo.java
+++ b/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/util/ProxyServiceInfo.java
@@ -1,0 +1,18 @@
+package org.apache.pulsar.proxy.util;
+
+import java.net.InetSocketAddress;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import org.apache.pulsar.proxy.server.ProxyConfiguration;
+import org.apache.pulsar.proxy.server.ProxyService;
+
+@Data
+@AllArgsConstructor
+public class ProxyServiceInfo {
+
+    private ProxyService proxyService;
+
+    private ProxyConfiguration proxyConfiguration;
+
+    private InetSocketAddress proxyAddress;
+}


### PR DESCRIPTION
### Motavitions

There are some test cases that are not covered in PIP-165: When the Pulsar Proxy is deployed, the client automatically releases free connections
- #16165

### Modifications

Append test case.

### Documentation

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)
  
- [x] `doc-not-needed` 
(Please explain why)
  
- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)