### PR TITLE
Support multiple advertisedListener for HTTP protocol

### DIFF
--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/validator/MultipleListenerValidator.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/validator/MultipleListenerValidator.java
@@ -76,7 +76,8 @@ public final class MultipleListenerValidator {
         final Map<String, AdvertisedListener> result = new LinkedHashMap<>();
         final Map<String, Set<String>> reverseMappings = new LinkedHashMap<>();
         for (final Map.Entry<String, List<String>> entry : listeners.entrySet()) {
-            if (entry.getValue().size() > 2) {
+            // one listener could configure at most 4 address: pulsar, pulsar+ssl, http, https
+            if (entry.getValue().size() > 4) {
                 throw new IllegalArgumentException("there are redundant configure for listener `" + entry.getKey()
                         + "`");
             }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/NamespaceService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/NamespaceService.java
@@ -428,9 +428,21 @@ public class NamespaceService implements AutoCloseable {
                         } else {
                             URI url = listener.getBrokerServiceUrl();
                             URI urlTls = listener.getBrokerServiceUrlTls();
-                            future.complete(Optional.of(new LookupResult(nsData.get(),
-                                    url == null ? null : url.toString(),
-                                    urlTls == null ? null : urlTls.toString())));
+                            URI http = listener.getBrokerHttpUrl();
+                            URI https = listener.getBrokerHttpsUrl();
+                            if (http == null && https == null) {
+                                future.complete(Optional.of(
+                                        new LookupResult(nsData.get(),
+                                                url == null ? null : url.toString(),
+                                                urlTls == null ? null : urlTls.toString())));
+                            } else {
+                                future.complete(Optional.of(
+                                        new LookupResult(http == null ? null : http.toString(),
+                                                https == null ? null : https.toString(),
+                                                url == null ? null : url.toString(),
+                                                urlTls == null ? null : urlTls.toString(),
+                                                LookupResult.Type.BrokerUrl, false)));
+                            }
                         }
                         return;
                     } else {
@@ -576,11 +588,21 @@ public class NamespaceService implements AutoCloseable {
                             } else {
                                 URI url = listener.getBrokerServiceUrl();
                                 URI urlTls = listener.getBrokerServiceUrlTls();
-                                lookupFuture.complete(Optional.of(
-                                        new LookupResult(ownerInfo,
-                                                url == null ? null : url.toString(),
-                                                urlTls == null ? null : urlTls.toString())));
-                                return;
+                                URI http = listener.getBrokerHttpUrl();
+                                URI https = listener.getBrokerHttpsUrl();
+                                if (http == null && https == null) {
+                                    lookupFuture.complete(Optional.of(
+                                            new LookupResult(ownerInfo,
+                                                    url == null ? null : url.toString(),
+                                                    urlTls == null ? null : urlTls.toString())));
+                                } else {
+                                    lookupFuture.complete(Optional.of(
+                                            new LookupResult(http == null ? null : http.toString(),
+                                                    https == null ? null : https.toString(),
+                                                    url == null ? null : url.toString(),
+                                                    urlTls == null ? null : urlTls.toString(),
+                                                    LookupResult.Type.BrokerUrl, false)));
+                                }
                             }
                         } else {
                             lookupFuture.complete(Optional.of(new LookupResult(ownerInfo)));

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/PulsarWebResource.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/PulsarWebResource.java
@@ -594,7 +594,7 @@ public abstract class PulsarWebResource {
         NamespaceBundle nsBundle = validateNamespaceBundleRange(fqnn, bundles, bundleRange);
         NamespaceService nsService = pulsar().getNamespaceService();
 
-        String advertisedListener = httpRequest.getHeader(LISTENER_HEADER);
+        String advertisedListener = httpRequest == null ? null : httpRequest.getHeader(LISTENER_HEADER);
         LookupOptions options = LookupOptions.builder()
                 .authoritative(false)
                 .requestHttps(isRequestHttps())
@@ -646,7 +646,7 @@ public abstract class PulsarWebResource {
             // - If authoritative is false and this broker is not leader, forward to leader
             // - If authoritative is false and this broker is leader, determine owner and forward w/ authoritative=true
             // - If authoritative is true, own the namespace and continue
-            String advertisedListener = httpRequest.getHeader(LISTENER_HEADER);
+            String advertisedListener = httpRequest == null ? null : httpRequest.getHeader(LISTENER_HEADER);
 
             LookupOptions options = LookupOptions.builder()
                     .authoritative(authoritative)
@@ -742,7 +742,7 @@ public abstract class PulsarWebResource {
     protected CompletableFuture<Void> validateTopicOwnershipAsync(TopicName topicName, boolean authoritative) {
         NamespaceService nsService = pulsar().getNamespaceService();
 
-        String advertisedListener = httpRequest.getHeader(LISTENER_HEADER);
+        String advertisedListener = httpRequest == null ? null : httpRequest.getHeader(LISTENER_HEADER);
 
         LookupOptions options = LookupOptions.builder()
                 .authoritative(authoritative)

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/MultiBrokerBaseTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/MultiBrokerBaseTest.java
@@ -146,6 +146,23 @@ public abstract class MultiBrokerBaseTest extends MockedPulsarServiceBaseTest {
         return Collections.unmodifiableList(admins);
     }
 
+    public final List<PulsarAdmin> getAllAdmins(String listener) throws Exception {
+        List<PulsarAdmin> admins = new ArrayList<>(numberOfAdditionalBrokers() + 1);
+
+        PulsarAdminBuilder pulsarAdminBuilder = PulsarAdmin.builder().serviceHttpUrl(
+            getPulsar().getWebServiceAddress() != null ? getPulsar().getWebServiceAddress()
+                    : getPulsar().getWebServiceAddressTls()).listenerName(listener);
+        admins.add(pulsarAdminBuilder.build());
+
+        for (PulsarService broker : additionalBrokers) {
+            pulsarAdminBuilder = PulsarAdmin.builder().serviceHttpUrl(broker.getWebServiceAddress() != null
+                    ? broker.getWebServiceAddress() : broker.getWebServiceAddressTls()).listenerName(listener);
+            admins.add(pulsarAdminBuilder.build());
+        }
+
+        return Collections.unmodifiableList(admins);
+    }
+
     public final List<PulsarClient> getAllClients() {
         List<PulsarClient> clients = new ArrayList<>(numberOfAdditionalBrokers() + 1);
         clients.add(pulsarClient);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/MultiHTTPAdvertisedListenersTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/MultiHTTPAdvertisedListenersTest.java
@@ -1,0 +1,166 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.loadbalance;
+
+import java.net.URI;
+import java.util.Optional;
+import lombok.Cleanup;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.bookkeeper.util.PortManager;
+import org.apache.http.HttpEntity;
+import org.apache.http.HttpHeaders;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.util.EntityUtils;
+import org.apache.pulsar.broker.MultiBrokerBaseTest;
+import org.apache.pulsar.broker.ServiceConfiguration;
+import org.apache.pulsar.client.admin.PulsarAdmin;
+import org.apache.pulsar.client.api.Producer;
+import org.apache.pulsar.client.api.Schema;
+import org.apache.pulsar.common.lookup.data.LookupData;
+import org.apache.pulsar.common.policies.data.TopicStats;
+import org.apache.pulsar.common.util.ObjectMapperFactory;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+
+@Slf4j
+@Test(groups = "broker")
+public class MultiHTTPAdvertisedListenersTest extends MultiBrokerBaseTest {
+    @Override
+    protected int numberOfAdditionalBrokers() {
+        return 1;
+    }
+
+    @Override
+    protected void doInitConf() throws Exception {
+        super.doInitConf();
+
+        updateConfig(conf);
+    }
+
+    @Override
+    protected ServiceConfiguration createConfForAdditionalBroker(int additionalBrokerIndex) {
+        ServiceConfiguration conf = super.createConfForAdditionalBroker(additionalBrokerIndex);
+        updateConfig(conf);
+        return conf;
+    }
+
+    private void updateConfig(ServiceConfiguration conf) {
+        int pulsarPort = PortManager.nextFreePort();
+        int httpPort = PortManager.nextFreePort();
+        int httpsPort = PortManager.nextFreePort();
+
+        // Use invalid domain name as identifier and instead make sure the advertised listeners work as intended
+        conf.setAdvertisedListeners(
+                "internal:pulsar://localhost:" + pulsarPort +
+                ",internal:http://localhost:" + httpPort +
+                ",internal:https://localhost:" + httpsPort +
+                ",external:pulsar://externalip:" + pulsarPort +
+                ",external:http://externalip:" + httpPort +
+                ",external:https://externalip:" + httpsPort);
+        conf.setBrokerServicePort(Optional.of(pulsarPort));
+        conf.setWebServicePort(Optional.of(httpPort));
+        conf.setWebServicePortTls(Optional.of(httpsPort));
+    }
+
+    @Test
+    public void testLookupWithoutListener() throws Exception {
+        HttpGet request =
+                new HttpGet(pulsar.getWebServiceAddress() + "/lookup/v2/topic/persistent/public/default/my-topic");
+        request.addHeader(HttpHeaders.CONTENT_TYPE, "application/json");
+        request.addHeader(HttpHeaders.ACCEPT, "application/json");
+        final String topic = "my-topic";
+
+        @Cleanup
+        CloseableHttpClient httpClient = HttpClients.createDefault();
+
+        @Cleanup
+        CloseableHttpResponse response = httpClient.execute(request);
+
+        HttpEntity entity = response.getEntity();
+        LookupData ld = ObjectMapperFactory.getThreadLocal().readValue(EntityUtils.toString(entity), LookupData.class);
+        System.err.println("Lookup data: " + ld);
+
+        assertEquals(new URI(ld.getBrokerUrl()).getHost(), "localhost");
+        assertEquals(new URI(ld.getHttpUrl()).getHost(), "localhost");
+        assertEquals(new URI(ld.getHttpUrlTls()).getHost(), "localhost");
+
+
+        // Produce data
+        @Cleanup
+        Producer<String> p = pulsarClient.newProducer(Schema.STRING)
+                .topic(topic)
+                .create();
+
+        p.send("hello");
+
+        // Verify we can get the correct HTTP redirect to the advertised listener
+        for (PulsarAdmin a : getAllAdmins()) {
+            TopicStats s = a.topics().getStats(topic);
+            assertNotNull(a.lookups().lookupTopic(topic));
+            assertEquals(s.getPublishers().size(), 1);
+        }
+    }
+
+    @Test
+    public void testLookupWithListener() throws Exception {
+        HttpGet request =
+                new HttpGet(pulsar.getWebServiceAddress() + "/lookup/v2/topic/persistent/public/default/my-topic");
+        request.addHeader(HttpHeaders.CONTENT_TYPE, "application/json");
+        request.addHeader(HttpHeaders.ACCEPT, "application/json");
+        request.addHeader("X-Pulsar-ListenerName", "external");
+        final String topic = "my-topic";
+
+        @Cleanup
+        CloseableHttpClient httpClient = HttpClients.createDefault();
+
+        @Cleanup
+        CloseableHttpResponse response = httpClient.execute(request);
+
+        HttpEntity entity = response.getEntity();
+        LookupData ld = ObjectMapperFactory.getThreadLocal().readValue(EntityUtils.toString(entity), LookupData.class);
+        System.err.println("Lookup data: " + ld);
+
+        assertEquals(new URI(ld.getBrokerUrl()).getHost(), "externalip");
+        assertEquals(new URI(ld.getHttpUrl()).getHost(), "externalip");
+        assertEquals(new URI(ld.getHttpUrlTls()).getHost(), "externalip");
+
+
+        // Produce data
+        @Cleanup
+        Producer<String> p = pulsarClient.newProducer(Schema.STRING)
+                .topic(topic)
+                .create();
+
+        p.send("hello");
+
+        // Verify we can get the correct HTTP redirect to the advertised listener
+        for (PulsarAdmin a : getAllAdmins("internal")) {
+            TopicStats s = a.topics().getStats(topic);
+            assertNotNull(a.lookups().lookupTopic(topic));
+            assertEquals(s.getPublishers().size(), 1);
+            a.close();
+        }
+    }
+
+}

--- a/pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/admin/PulsarAdminBuilder.java
+++ b/pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/admin/PulsarAdminBuilder.java
@@ -327,4 +327,11 @@ public interface PulsarAdminBuilder {
      */
     PulsarAdminBuilder setContextClassLoader(ClassLoader clientBuilderClassLoader);
 
+    /**
+     * Listener name for lookup.
+     *
+     * @param listenerName
+     */
+    PulsarAdminBuilder listenerName(String listenerName);
+
 }

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/BaseResource.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/BaseResource.java
@@ -62,9 +62,18 @@ public abstract class BaseResource {
     protected final Authentication auth;
     protected final long readTimeoutMs;
 
+    protected final String advertisedListener;
+
+    static final String LISTENER_HEADER = "X-Pulsar-ListenerName";
+
     protected BaseResource(Authentication auth, long readTimeoutMs) {
+        this(auth, readTimeoutMs, null);
+    }
+
+    protected BaseResource(Authentication auth, long readTimeoutMs, String advertisedListener) {
         this.auth = auth;
         this.readTimeoutMs = readTimeoutMs;
+        this.advertisedListener = advertisedListener;
     }
 
     public Builder request(final WebTarget target) throws PulsarAdminException {
@@ -105,6 +114,10 @@ public abstract class BaseResource {
                         if (headers != null) {
                             headers.forEach(entry -> builder.header(entry.getKey(), entry.getValue()));
                         }
+                    }
+
+                    if (advertisedListener != null) {
+                        builder.header(LISTENER_HEADER, advertisedListener);
                     }
                     builderFuture.complete(builder);
                 } catch (Throwable t) {

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/BookiesImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/BookiesImpl.java
@@ -33,7 +33,11 @@ public class BookiesImpl extends BaseResource implements Bookies {
     private final WebTarget adminBookies;
 
     public BookiesImpl(WebTarget web, Authentication auth, long readTimeoutMs) {
-        super(auth, readTimeoutMs);
+        this(web, auth, readTimeoutMs, null);
+    }
+
+    public BookiesImpl(WebTarget web, Authentication auth, long readTimeoutMs, String advertisedListener) {
+        super(auth, readTimeoutMs, advertisedListener);
         adminBookies = web.path("/admin/v2/bookies");
     }
 

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/BrokerStatsImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/BrokerStatsImpl.java
@@ -39,10 +39,15 @@ public class BrokerStatsImpl extends BaseResource implements BrokerStats {
     private final WebTarget adminV2BrokerStats;
 
     public BrokerStatsImpl(WebTarget target, Authentication auth, long readTimeoutMs) {
-        super(auth, readTimeoutMs);
+        this(target, auth, readTimeoutMs, null);
+    }
+
+    public BrokerStatsImpl(WebTarget target, Authentication auth, long readTimeoutMs, String advertisedListener) {
+        super(auth, readTimeoutMs, advertisedListener);
         adminBrokerStats = target.path("/admin/broker-stats");
         adminV2BrokerStats = target.path("/admin/v2/broker-stats");
     }
+
 
     @Override
     public String getMetrics() throws PulsarAdminException {

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/BrokersImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/BrokersImpl.java
@@ -38,7 +38,11 @@ public class BrokersImpl extends BaseResource implements Brokers {
     private final WebTarget adminBrokers;
 
     public BrokersImpl(WebTarget web, Authentication auth, long readTimeoutMs) {
-        super(auth, readTimeoutMs);
+        this(web, auth, readTimeoutMs, null);
+    }
+
+    public BrokersImpl(WebTarget web, Authentication auth, long readTimeoutMs, String advertisedListener) {
+        super(auth, readTimeoutMs, advertisedListener);
         adminBrokers = web.path("admin/v2/brokers");
     }
 

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/ClustersImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/ClustersImpl.java
@@ -46,7 +46,11 @@ public class ClustersImpl extends BaseResource implements Clusters {
     private final WebTarget adminClusters;
 
     public ClustersImpl(WebTarget web, Authentication auth, long readTimeoutMs) {
-        super(auth, readTimeoutMs);
+        this(web, auth, readTimeoutMs, null);
+    }
+
+    public ClustersImpl(WebTarget web, Authentication auth, long readTimeoutMs, String advertisedListener) {
+        super(auth, readTimeoutMs, advertisedListener);
         adminClusters = web.path("/admin/v2/clusters");
     }
 

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/ComponentResource.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/ComponentResource.java
@@ -35,8 +35,13 @@ import org.asynchttpclient.RequestBuilder;
 public class ComponentResource extends BaseResource {
 
     protected ComponentResource(Authentication auth, long readTimeoutMs) {
-        super(auth, readTimeoutMs);
+        this(auth, readTimeoutMs, null);
     }
+
+    protected ComponentResource(Authentication auth, long readTimeoutMs, String advertisedListener) {
+        super(auth, readTimeoutMs, advertisedListener);
+    }
+
 
     public RequestBuilder addAuthHeaders(WebTarget target, RequestBuilder requestBuilder) throws PulsarAdminException {
 

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/FunctionsImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/FunctionsImpl.java
@@ -76,7 +76,8 @@ public class FunctionsImpl extends ComponentResource implements Functions {
         this(web, auth, asyncHttpClient, readTimeoutMs, null);
     }
 
-    public FunctionsImpl(WebTarget web, Authentication auth, AsyncHttpClient asyncHttpClient, long readTimeoutMs, String advertisedListener) {
+    public FunctionsImpl(WebTarget web, Authentication auth, AsyncHttpClient asyncHttpClient, long readTimeoutMs,
+                         String advertisedListener) {
         super(auth, readTimeoutMs, advertisedListener);
         this.functions = web.path("/admin/v3/functions");
         this.asyncHttpClient = asyncHttpClient;

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/FunctionsImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/FunctionsImpl.java
@@ -73,7 +73,11 @@ public class FunctionsImpl extends ComponentResource implements Functions {
     private final AsyncHttpClient asyncHttpClient;
 
     public FunctionsImpl(WebTarget web, Authentication auth, AsyncHttpClient asyncHttpClient, long readTimeoutMs) {
-        super(auth, readTimeoutMs);
+        this(web, auth, asyncHttpClient, readTimeoutMs, null);
+    }
+
+    public FunctionsImpl(WebTarget web, Authentication auth, AsyncHttpClient asyncHttpClient, long readTimeoutMs, String advertisedListener) {
+        super(auth, readTimeoutMs, advertisedListener);
         this.functions = web.path("/admin/v3/functions");
         this.asyncHttpClient = asyncHttpClient;
     }

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/LookupImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/LookupImpl.java
@@ -40,7 +40,11 @@ public class LookupImpl extends BaseResource implements Lookup {
     private final Topics topics;
 
     public LookupImpl(WebTarget web, Authentication auth, boolean useTls, long readTimeoutMs, Topics topics) {
-        super(auth, readTimeoutMs);
+        this(web, auth, useTls, readTimeoutMs, null, topics);
+    }
+
+    public LookupImpl(WebTarget web, Authentication auth, boolean useTls, long readTimeoutMs, String advertisedListener, Topics topics) {
+        super(auth, readTimeoutMs, advertisedListener);
         this.useTls = useTls;
         v2lookup = web.path("/lookup/v2");
         this.topics = topics;

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/LookupImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/LookupImpl.java
@@ -43,7 +43,8 @@ public class LookupImpl extends BaseResource implements Lookup {
         this(web, auth, useTls, readTimeoutMs, null, topics);
     }
 
-    public LookupImpl(WebTarget web, Authentication auth, boolean useTls, long readTimeoutMs, String advertisedListener, Topics topics) {
+    public LookupImpl(WebTarget web, Authentication auth, boolean useTls, long readTimeoutMs,
+                      String advertisedListener, Topics topics) {
         super(auth, readTimeoutMs, advertisedListener);
         this.useTls = useTls;
         v2lookup = web.path("/lookup/v2");

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/NamespacesImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/NamespacesImpl.java
@@ -65,7 +65,11 @@ public class NamespacesImpl extends BaseResource implements Namespaces {
     private final WebTarget adminV2Namespaces;
 
     public NamespacesImpl(WebTarget web, Authentication auth, long readTimeoutMs) {
-        super(auth, readTimeoutMs);
+        this(web, auth, readTimeoutMs, null);
+    }
+
+    public NamespacesImpl(WebTarget web, Authentication auth, long readTimeoutMs, String advertisedListener) {
+        super(auth, readTimeoutMs, advertisedListener);
         adminNamespaces = web.path("/admin/namespaces");
         adminV2Namespaces = web.path("/admin/v2/namespaces");
     }

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/NonPersistentTopicsImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/NonPersistentTopicsImpl.java
@@ -39,7 +39,11 @@ public class NonPersistentTopicsImpl extends BaseResource implements NonPersiste
     private final WebTarget adminV2NonPersistentTopics;
 
     public NonPersistentTopicsImpl(WebTarget web, Authentication auth, long readTimeoutMs) {
-        super(auth, readTimeoutMs);
+        this(web, auth, readTimeoutMs, null);
+    }
+
+    public NonPersistentTopicsImpl(WebTarget web, Authentication auth, long readTimeoutMs, String advertisedListener) {
+        super(auth, readTimeoutMs, advertisedListener);
         adminNonPersistentTopics = web.path("/admin");
         adminV2NonPersistentTopics = web.path("/admin/v2");
     }

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/PackagesImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/PackagesImpl.java
@@ -57,7 +57,8 @@ public class PackagesImpl extends ComponentResource implements Packages {
         this(webTarget, auth, client, readTimeoutMs, null);
     }
 
-    public PackagesImpl(WebTarget webTarget, Authentication auth, AsyncHttpClient client, long readTimeoutMs, String advertisedListener) {
+    public PackagesImpl(WebTarget webTarget, Authentication auth, AsyncHttpClient client, long readTimeoutMs,
+                        String advertisedListener) {
         super(auth, readTimeoutMs, advertisedListener);
         this.httpClient = client;
         this.packages = webTarget.path("/admin/v3/packages");

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/PackagesImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/PackagesImpl.java
@@ -54,7 +54,11 @@ public class PackagesImpl extends ComponentResource implements Packages {
     private final AsyncHttpClient httpClient;
 
     public PackagesImpl(WebTarget webTarget, Authentication auth, AsyncHttpClient client, long readTimeoutMs) {
-        super(auth, readTimeoutMs);
+        this(webTarget, auth, client, readTimeoutMs, null);
+    }
+
+    public PackagesImpl(WebTarget webTarget, Authentication auth, AsyncHttpClient client, long readTimeoutMs, String advertisedListener) {
+        super(auth, readTimeoutMs, advertisedListener);
         this.httpClient = client;
         this.packages = webTarget.path("/admin/v3/packages");
     }

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/ProxyStatsImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/ProxyStatsImpl.java
@@ -33,7 +33,11 @@ public class ProxyStatsImpl extends BaseResource implements ProxyStats {
     private final WebTarget adminProxyStats;
 
     public ProxyStatsImpl(WebTarget target, Authentication auth, long readTimeoutMs) {
-        super(auth, readTimeoutMs);
+        this(target, auth, readTimeoutMs, null);
+    }
+
+    public ProxyStatsImpl(WebTarget target, Authentication auth, long readTimeoutMs, String advertisedListener) {
+        super(auth, readTimeoutMs, advertisedListener);
         adminProxyStats = target.path("/proxy-stats");
     }
 

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/PulsarAdminBuilderImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/PulsarAdminBuilderImpl.java
@@ -218,4 +218,10 @@ public class PulsarAdminBuilderImpl implements PulsarAdminBuilder {
         this.clientBuilderClassLoader = clientBuilderClassLoader;
         return this;
     }
+
+    @Override
+    public PulsarAdminBuilder listenerName(String listenerName) {
+        conf.setListenerName(listenerName);
+        return this;
+    }
 }

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/PulsarAdminImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/PulsarAdminImpl.java
@@ -112,6 +112,7 @@ public class PulsarAdminImpl implements PulsarAdmin {
     private final TimeUnit readTimeoutUnit;
     private final int requestTimeout;
     private final TimeUnit requestTimeoutUnit;
+    private final String advertisedListener;
 
     public PulsarAdminImpl(String serviceUrl, ClientConfigurationData clientConfigData) throws PulsarClientException {
         this(serviceUrl, clientConfigData, DEFAULT_CONNECT_TIMEOUT_SECONDS, TimeUnit.SECONDS,
@@ -139,6 +140,7 @@ public class PulsarAdminImpl implements PulsarAdmin {
         this.requestTimeout = requestTimeout;
         this.requestTimeoutUnit = requestTimeoutUnit;
         this.clientConfigData = clientConfigData;
+        this.advertisedListener = clientConfigData.getListenerName();
         this.auth = clientConfigData != null ? clientConfigData.getAuthentication() : new AuthenticationDisabled();
         LOG.debug("created: serviceUrl={}, authMethodName={}", serviceUrl,
                 auth != null ? auth.getAuthMethodName() : null);
@@ -187,28 +189,28 @@ public class PulsarAdminImpl implements PulsarAdmin {
                 (int) autoCertRefreshTimeUnit.toSeconds(autoCertRefreshTime));
 
         long readTimeoutMs = readTimeoutUnit.toMillis(this.readTimeout);
-        this.clusters = new ClustersImpl(root, auth, readTimeoutMs);
-        this.brokers = new BrokersImpl(root, auth, readTimeoutMs);
-        this.brokerStats = new BrokerStatsImpl(root, auth, readTimeoutMs);
-        this.proxyStats = new ProxyStatsImpl(root, auth, readTimeoutMs);
-        this.tenants = new TenantsImpl(root, auth, readTimeoutMs);
-        this.resourcegroups = new ResourceGroupsImpl(root, auth, readTimeoutMs);
-        this.properties = new TenantsImpl(root, auth, readTimeoutMs);
-        this.namespaces = new NamespacesImpl(root, auth, readTimeoutMs);
-        this.topics = new TopicsImpl(root, auth, readTimeoutMs);
-        this.localTopicPolicies = new TopicPoliciesImpl(root, auth, readTimeoutMs, false);
-        this.globalTopicPolicies = new TopicPoliciesImpl(root, auth, readTimeoutMs, true);
-        this.nonPersistentTopics = new NonPersistentTopicsImpl(root, auth, readTimeoutMs);
-        this.resourceQuotas = new ResourceQuotasImpl(root, auth, readTimeoutMs);
-        this.lookups = new LookupImpl(root, auth, useTls, readTimeoutMs, topics);
-        this.functions = new FunctionsImpl(root, auth, asyncHttpConnector.getHttpClient(), readTimeoutMs);
-        this.sources = new SourcesImpl(root, auth, asyncHttpConnector.getHttpClient(), readTimeoutMs);
-        this.sinks = new SinksImpl(root, auth, asyncHttpConnector.getHttpClient(), readTimeoutMs);
-        this.worker = new WorkerImpl(root, auth, readTimeoutMs);
-        this.schemas = new SchemasImpl(root, auth, readTimeoutMs);
-        this.bookies = new BookiesImpl(root, auth, readTimeoutMs);
-        this.packages = new PackagesImpl(root, auth, asyncHttpConnector.getHttpClient(), readTimeoutMs);
-        this.transactions = new TransactionsImpl(root, auth, readTimeoutMs);
+        this.clusters = new ClustersImpl(root, auth, readTimeoutMs, advertisedListener);
+        this.brokers = new BrokersImpl(root, auth, readTimeoutMs, advertisedListener);
+        this.brokerStats = new BrokerStatsImpl(root, auth, readTimeoutMs, advertisedListener);
+        this.proxyStats = new ProxyStatsImpl(root, auth, readTimeoutMs, advertisedListener);
+        this.tenants = new TenantsImpl(root, auth, readTimeoutMs, advertisedListener);
+        this.resourcegroups = new ResourceGroupsImpl(root, auth, readTimeoutMs, advertisedListener);
+        this.properties = new TenantsImpl(root, auth, readTimeoutMs, advertisedListener);
+        this.namespaces = new NamespacesImpl(root, auth, readTimeoutMs, advertisedListener);
+        this.topics = new TopicsImpl(root, auth, readTimeoutMs, advertisedListener);
+        this.localTopicPolicies = new TopicPoliciesImpl(root, auth, readTimeoutMs, advertisedListener, false);
+        this.globalTopicPolicies = new TopicPoliciesImpl(root, auth, readTimeoutMs, advertisedListener, true);
+        this.nonPersistentTopics = new NonPersistentTopicsImpl(root, auth, readTimeoutMs, advertisedListener);
+        this.resourceQuotas = new ResourceQuotasImpl(root, auth, readTimeoutMs, advertisedListener);
+        this.lookups = new LookupImpl(root, auth, useTls, readTimeoutMs, advertisedListener, topics);
+        this.functions = new FunctionsImpl(root, auth, asyncHttpConnector.getHttpClient(), readTimeoutMs, advertisedListener);
+        this.sources = new SourcesImpl(root, auth, asyncHttpConnector.getHttpClient(), readTimeoutMs, advertisedListener);
+        this.sinks = new SinksImpl(root, auth, asyncHttpConnector.getHttpClient(), readTimeoutMs, advertisedListener);
+        this.worker = new WorkerImpl(root, auth, readTimeoutMs, advertisedListener);
+        this.schemas = new SchemasImpl(root, auth, readTimeoutMs, advertisedListener);
+        this.bookies = new BookiesImpl(root, auth, readTimeoutMs, advertisedListener);
+        this.packages = new PackagesImpl(root, auth, asyncHttpConnector.getHttpClient(), readTimeoutMs, advertisedListener);
+        this.transactions = new TransactionsImpl(root, auth, readTimeoutMs, advertisedListener);
 
         if (originalCtxLoader != null) {
             Thread.currentThread().setContextClassLoader(originalCtxLoader);

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/PulsarAdminImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/PulsarAdminImpl.java
@@ -203,13 +203,16 @@ public class PulsarAdminImpl implements PulsarAdmin {
         this.nonPersistentTopics = new NonPersistentTopicsImpl(root, auth, readTimeoutMs, advertisedListener);
         this.resourceQuotas = new ResourceQuotasImpl(root, auth, readTimeoutMs, advertisedListener);
         this.lookups = new LookupImpl(root, auth, useTls, readTimeoutMs, advertisedListener, topics);
-        this.functions = new FunctionsImpl(root, auth, asyncHttpConnector.getHttpClient(), readTimeoutMs, advertisedListener);
-        this.sources = new SourcesImpl(root, auth, asyncHttpConnector.getHttpClient(), readTimeoutMs, advertisedListener);
+        this.functions = new FunctionsImpl(root, auth, asyncHttpConnector.getHttpClient(), readTimeoutMs,
+                advertisedListener);
+        this.sources = new SourcesImpl(root, auth, asyncHttpConnector.getHttpClient(), readTimeoutMs,
+                advertisedListener);
         this.sinks = new SinksImpl(root, auth, asyncHttpConnector.getHttpClient(), readTimeoutMs, advertisedListener);
         this.worker = new WorkerImpl(root, auth, readTimeoutMs, advertisedListener);
         this.schemas = new SchemasImpl(root, auth, readTimeoutMs, advertisedListener);
         this.bookies = new BookiesImpl(root, auth, readTimeoutMs, advertisedListener);
-        this.packages = new PackagesImpl(root, auth, asyncHttpConnector.getHttpClient(), readTimeoutMs, advertisedListener);
+        this.packages = new PackagesImpl(root, auth, asyncHttpConnector.getHttpClient(), readTimeoutMs,
+                advertisedListener);
         this.transactions = new TransactionsImpl(root, auth, readTimeoutMs, advertisedListener);
 
         if (originalCtxLoader != null) {

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/ResourceGroupsImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/ResourceGroupsImpl.java
@@ -33,7 +33,11 @@ public class ResourceGroupsImpl extends BaseResource implements ResourceGroups {
     private final WebTarget adminResourceGroups;
 
     public ResourceGroupsImpl(WebTarget web, Authentication auth, long readTimeoutMs) {
-        super(auth, readTimeoutMs);
+        this(web, auth, readTimeoutMs, null);
+    }
+
+    public ResourceGroupsImpl(WebTarget web, Authentication auth, long readTimeoutMs, String advertisedListener) {
+        super(auth, readTimeoutMs, advertisedListener);
         adminResourceGroups = web.path("/admin/v2/resourcegroups");
     }
 

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/ResourceQuotasImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/ResourceQuotasImpl.java
@@ -34,7 +34,11 @@ public class ResourceQuotasImpl extends BaseResource implements ResourceQuotas {
     private final WebTarget adminV2Quotas;
 
     public ResourceQuotasImpl(WebTarget web, Authentication auth, long readTimeoutMs) {
-        super(auth, readTimeoutMs);
+        this(web, auth, readTimeoutMs, null);
+    }
+
+    public ResourceQuotasImpl(WebTarget web, Authentication auth, long readTimeoutMs, String advertisedListener) {
+        super(auth, readTimeoutMs, advertisedListener);
         adminQuotas = web.path("/admin/resource-quotas");
         adminV2Quotas = web.path("/admin/v2/resource-quotas");
     }

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/SchemasImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/SchemasImpl.java
@@ -47,7 +47,11 @@ public class SchemasImpl extends BaseResource implements Schemas {
     private final WebTarget adminV1;
 
     public SchemasImpl(WebTarget web, Authentication auth, long readTimeoutMs) {
-        super(auth, readTimeoutMs);
+        this(web, auth, readTimeoutMs, null);
+    }
+
+    public SchemasImpl(WebTarget web, Authentication auth, long readTimeoutMs, String advertisedListener) {
+        super(auth, readTimeoutMs, advertisedListener);
         this.adminV1 = web.path("/admin/schemas");
         this.adminV2 = web.path("/admin/v2/schemas");
     }

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/SinksImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/SinksImpl.java
@@ -59,7 +59,8 @@ public class SinksImpl extends ComponentResource implements Sinks, Sink {
         this(web, auth, asyncHttpClient, readTimeoutMs, null);
     }
 
-    public SinksImpl(WebTarget web, Authentication auth, AsyncHttpClient asyncHttpClient, long readTimeoutMs, String advertisedListener) {
+    public SinksImpl(WebTarget web, Authentication auth, AsyncHttpClient asyncHttpClient, long readTimeoutMs,
+                     String advertisedListener) {
         super(auth, readTimeoutMs, advertisedListener);
         this.sink = web.path("/admin/v3/sink");
         this.asyncHttpClient = asyncHttpClient;

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/SinksImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/SinksImpl.java
@@ -56,7 +56,11 @@ public class SinksImpl extends ComponentResource implements Sinks, Sink {
     private final AsyncHttpClient asyncHttpClient;
 
     public SinksImpl(WebTarget web, Authentication auth, AsyncHttpClient asyncHttpClient, long readTimeoutMs) {
-        super(auth, readTimeoutMs);
+        this(web, auth, asyncHttpClient, readTimeoutMs, null);
+    }
+
+    public SinksImpl(WebTarget web, Authentication auth, AsyncHttpClient asyncHttpClient, long readTimeoutMs, String advertisedListener) {
+        super(auth, readTimeoutMs, advertisedListener);
         this.sink = web.path("/admin/v3/sink");
         this.asyncHttpClient = asyncHttpClient;
     }

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/SourcesImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/SourcesImpl.java
@@ -58,7 +58,8 @@ public class SourcesImpl extends ComponentResource implements Sources, Source {
         this(web, auth, asyncHttpClient, readTimeoutMs, null);
     }
 
-    public SourcesImpl(WebTarget web, Authentication auth, AsyncHttpClient asyncHttpClient, long readTimeoutMs, String advertisedListener) {
+    public SourcesImpl(WebTarget web, Authentication auth, AsyncHttpClient asyncHttpClient, long readTimeoutMs,
+                       String advertisedListener) {
         super(auth, readTimeoutMs, advertisedListener);
         this.source = web.path("/admin/v3/source");
         this.asyncHttpClient = asyncHttpClient;

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/SourcesImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/SourcesImpl.java
@@ -55,7 +55,11 @@ public class SourcesImpl extends ComponentResource implements Sources, Source {
     private final AsyncHttpClient asyncHttpClient;
 
     public SourcesImpl(WebTarget web, Authentication auth, AsyncHttpClient asyncHttpClient, long readTimeoutMs) {
-        super(auth, readTimeoutMs);
+        this(web, auth, asyncHttpClient, readTimeoutMs, null);
+    }
+
+    public SourcesImpl(WebTarget web, Authentication auth, AsyncHttpClient asyncHttpClient, long readTimeoutMs, String advertisedListener) {
+        super(auth, readTimeoutMs, advertisedListener);
         this.source = web.path("/admin/v3/source");
         this.asyncHttpClient = asyncHttpClient;
     }

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/TenantsImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/TenantsImpl.java
@@ -35,7 +35,11 @@ public class TenantsImpl extends BaseResource implements Tenants, Properties {
     private final WebTarget adminTenants;
 
     public TenantsImpl(WebTarget web, Authentication auth, long readTimeoutMs) {
-        super(auth, readTimeoutMs);
+        this(web, auth, readTimeoutMs, null);
+    }
+
+    public TenantsImpl(WebTarget web, Authentication auth, long readTimeoutMs, String advertisedListener) {
+        super(auth, readTimeoutMs, advertisedListener);
         adminTenants = web.path("/admin/v2/tenants");
     }
 

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/TopicPoliciesImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/TopicPoliciesImpl.java
@@ -53,7 +53,8 @@ public class TopicPoliciesImpl extends BaseResource implements TopicPolicies {
         this(web, auth, readTimeoutMs, null, isGlobal);
     }
 
-    protected TopicPoliciesImpl(WebTarget web, Authentication auth, long readTimeoutMs, String advertisedListener, boolean isGlobal) {
+    protected TopicPoliciesImpl(WebTarget web, Authentication auth, long readTimeoutMs,
+                                String advertisedListener, boolean isGlobal) {
         super(auth, readTimeoutMs, advertisedListener);
         this.adminTopics = web.path("/admin");
         this.adminV2Topics = web.path("/admin/v2");

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/TopicPoliciesImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/TopicPoliciesImpl.java
@@ -50,7 +50,11 @@ public class TopicPoliciesImpl extends BaseResource implements TopicPolicies {
     private final boolean isGlobal;
 
     protected TopicPoliciesImpl(WebTarget web, Authentication auth, long readTimeoutMs, boolean isGlobal) {
-        super(auth, readTimeoutMs);
+        this(web, auth, readTimeoutMs, null, isGlobal);
+    }
+
+    protected TopicPoliciesImpl(WebTarget web, Authentication auth, long readTimeoutMs, String advertisedListener, boolean isGlobal) {
+        super(auth, readTimeoutMs, advertisedListener);
         this.adminTopics = web.path("/admin");
         this.adminV2Topics = web.path("/admin/v2");
         this.isGlobal = isGlobal;

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/TopicsImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/TopicsImpl.java
@@ -132,7 +132,11 @@ public class TopicsImpl extends BaseResource implements Topics {
     // CHECKSTYLE.ON: MemberName
 
     public TopicsImpl(WebTarget web, Authentication auth, long readTimeoutMs) {
-        super(auth, readTimeoutMs);
+        this(web, auth, readTimeoutMs, null);
+    }
+
+    public TopicsImpl(WebTarget web, Authentication auth, long readTimeoutMs, String advertisedListener) {
+        super(auth, readTimeoutMs, advertisedListener);
         adminTopics = web.path("/admin");
         adminV2Topics = web.path("/admin/v2");
     }

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/TransactionsImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/TransactionsImpl.java
@@ -44,7 +44,11 @@ public class TransactionsImpl extends BaseResource implements Transactions {
     private final WebTarget adminV3Transactions;
 
     public TransactionsImpl(WebTarget web, Authentication auth, long readTimeoutMs) {
-        super(auth, readTimeoutMs);
+        this(web, auth, readTimeoutMs, null);
+    }
+
+    public TransactionsImpl(WebTarget web, Authentication auth, long readTimeoutMs, String advertisedListener) {
+        super(auth, readTimeoutMs, advertisedListener);
         adminV3Transactions = web.path("/admin/v3/transactions");
     }
 

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/WorkerImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/WorkerImpl.java
@@ -44,7 +44,11 @@ public class WorkerImpl extends BaseResource implements Worker {
     private final WebTarget worker;
 
     public WorkerImpl(WebTarget web, Authentication auth, long readTimeoutMs) {
-        super(auth, readTimeoutMs);
+        this(web, auth, readTimeoutMs, null);
+    }
+
+    public WorkerImpl(WebTarget web, Authentication auth, long readTimeoutMs, String advertisedListener) {
+        super(auth, readTimeoutMs, advertisedListener);
         this.worker = web.path("/admin/v2/worker");
         this.workerStats = web.path("/admin/v2/worker-stats");
     }

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/PulsarAdminTool.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/PulsarAdminTool.java
@@ -76,6 +76,9 @@ public class PulsarAdminTool {
         @Parameter(names = { "--tls-trust-cert-path" }, description = "Allow TLS trust cert file path")
         String tlsTrustCertsFilePath;
 
+        @Parameter(names = { "--listener" }, description = "Listener name for lookup")
+        String listenerName = null;
+
         @Parameter(names = { "--tls-enable-hostname-verification" },
                 description = "Enable TLS common name verification")
         Boolean tlsEnableHostnameVerification;
@@ -172,6 +175,7 @@ public class PulsarAdminTool {
             adminBuilder.serviceHttpUrl(rootParams.serviceUrl);
             adminBuilder.authentication(rootParams.authPluginClassName, rootParams.authParams);
             adminBuilder.requestTimeout(rootParams.requestTimeout, TimeUnit.SECONDS);
+            adminBuilder.listenerName(rootParams.listenerName);
             if (isBlank(rootParams.tlsProvider)) {
                 rootParams.tlsProvider = properties.getProperty("webserviceTlsProvider");
             }


### PR DESCRIPTION
### Motivation

[PIP 61](https://github.com/apache/pulsar/wiki/PIP-61%3A-Advertised-multiple-addresses) and [PIP 95](https://github.com/apache/pulsar/issues/12040) supports multiple advertised address for binary port. 
For HTTP port, currently we do not have a way to support multiple advertised address.

Consider we are deploying a broker that can be accessed through both private network (for example 192.168.0.1) and public network (for example 10.175.100.1), we could configure multiple advertised listener for binary port, Pulsar client could access broker through both private and public network with correct listener name. For HTTP address, we could only configure one advertised address through internal listener: https://github.com/apache/pulsar/blob/0cf2a7534cbcdffe7574af1ee3717fa3f7ed8ba4/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java#L1613

If we configure private address(192.168.0.1) for HTTP address, we may not execute some PulsarAdmin API from public network, since some http request (for example get topics' stats) may get 307 response code and redirect to another broker's private address.

### Modifications

Configure multiple advertised http address in `advertisedListeners` together with binary address.

> advertisedListeners=internal:pulsar://192.168.0.1:6650,internal:http://192.168.0.1:8080,external:pulsar://10.175.100.1:6650,external:http://10.175.100.1:8080

Broker:
For HTTP request, get listener name from request header `X-Pulsar-ListenerName`, use the listener name for topic lookup and topic owner verification, return advertised http address in case of http redirect.

Pulsar Admin:
Add `listenerName` to `PulsarAdminBuilder`, and set listener name to HTTP request header `X-Pulsar-ListenerName`.

### Verifying this change

This change added tests and can be verified as follows:
MultiHTTPAdvertisedListenersTest

### Documentation

Check the box below or label this PR directly.

Need to update docs? 

- [x] `doc-required` 
Need to update doc for configuration multiple HTTP address after PR accecpt.