### PR TITLE
[security] bump PostgreSQL version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -163,7 +163,7 @@ flexible messaging model and an intuitive client API.</description>
     <guice.version>5.1.0</guice.version>
     <sqlite-jdbc.version>3.36.0.3</sqlite-jdbc.version>
     <mysql-jdbc.version>8.0.11</mysql-jdbc.version>
-    <postgresql-jdbc.version>42.3.3</postgresql-jdbc.version>
+    <postgresql-jdbc.version>42.4.1</postgresql-jdbc.version>
     <clickhouse-jdbc.version>0.3.2</clickhouse-jdbc.version>
     <mariadb-jdbc.version>2.7.5</mariadb-jdbc.version>
     <openmldb-jdbc.version>0.4.4-hotfix1</openmldb-jdbc.version>
@@ -175,7 +175,7 @@ flexible messaging model and an intuitive client API.</description>
     <scala.binary.version>2.13</scala.binary.version>
     <scala-library.version>2.13.6</scala-library.version>
     <debezium.version>1.7.2.Final</debezium.version>
-    <debezium.postgresql.version>42.3.3</debezium.postgresql.version>
+    <debezium.postgresql.version>42.4.1</debezium.postgresql.version>
     <debezium.mysql.version>8.0.28</debezium.mysql.version>
     <jsonwebtoken.version>0.11.1</jsonwebtoken.version>
     <opencensus.version>0.28.0</opencensus.version>


### PR DESCRIPTION
### Motivation

current PostgreSQL client related to CVE-2022031197(https://github.com/pgjdbc/pgjdbc/security/advisories/GHSA-r38f-c4h4-hqq2), update to newest(https://jdbc.postgresql.org/documentation/changelog.html#version_42.4.1).

### Documentation

Check the box below or label this PR directly.

Need to update docs? 

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)
  
- [x] `doc-not-needed` 
(Please explain why)
  
- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)