### PR TITLE
[improve][c++] Add producerId to the log of closed producer

### DIFF
--- a/pulsar-client-cpp/lib/ProducerImpl.cc
+++ b/pulsar-client-cpp/lib/ProducerImpl.cc
@@ -705,7 +705,7 @@ void ProducerImpl::handleClose(Result result, ResultCallback callback, ProducerI
     if (result == ResultOk) {
         Lock lock(mutex_);
         state_ = Closed;
-        LOG_INFO(getName() << "Closed producer");
+        LOG_INFO(getName() << "Closed producer " << producerId_);
         ClientConnectionPtr cnx = getCnx().lock();
         if (cnx) {
             cnx->removeProducer(producerId_);


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://docs.google.com/document/d/1d8Pw6ZbWk-_pCKdOmdvx9rnhPiyuxwq60_TrD68d7BA/edit#heading=h.trs9rsex3xom)*. 

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.

**(The sections below can be removed for hotfixes of typos)**
-->

### Motivation

When I investigate the c++ flaky tests, there is no producer id in the log of `closed producer`.
Need to add the producer id like that in the consumer:
https://github.com/apache/pulsar/blob/bc68f02a4060ef0042a50c2b1d834c6ab84cfd13/pulsar-client-cpp/lib/ConsumerImpl.cc#L1064
This will help debug.

### Modifications

* Add producerId to the log of closed producer.


### Documentation

Check the box below or label this PR directly.

Need to update docs? 

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)
  
- [x] `doc-not-needed` 
(Please explain why)
  
- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)