### PR TITLE
[improve][broker]add ServerCnx state check before server handle request

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
@@ -434,6 +434,7 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
 
     @Override
     protected void handleLookup(CommandLookupTopic lookup) {
+        checkArgument(state == State.Connected);
         final long requestId = lookup.getRequestId();
         final boolean authoritative = lookup.isAuthoritative();
 
@@ -504,6 +505,7 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
 
     @Override
     protected void handlePartitionMetadataRequest(CommandPartitionedTopicMetadata partitionMetadata) {
+        checkArgument(state == State.Connected);
         final long requestId = partitionMetadata.getRequestId();
         if (log.isDebugEnabled()) {
             log.debug("[{}] Received PartitionMetadataLookup from {} for {}", partitionMetadata.getTopic(),
@@ -580,6 +582,7 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
 
     @Override
     protected void handleConsumerStats(CommandConsumerStats commandConsumerStats) {
+        checkArgument(state == State.Connected);
         if (log.isDebugEnabled()) {
             log.debug("Received CommandConsumerStats call from {}", remoteAddress);
         }
@@ -1988,6 +1991,7 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
 
     @Override
     protected void handleGetTopicsOfNamespace(CommandGetTopicsOfNamespace commandGetTopicsOfNamespace) {
+        checkArgument(state == State.Connected);
         final long requestId = commandGetTopicsOfNamespace.getRequestId();
         final String namespace = commandGetTopicsOfNamespace.getNamespace();
         final CommandGetTopicsOfNamespace.Mode mode = commandGetTopicsOfNamespace.getMode();
@@ -2076,6 +2080,7 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
 
     @Override
     protected void handleGetSchema(CommandGetSchema commandGetSchema) {
+        checkArgument(state == State.Connected);
         if (log.isDebugEnabled()) {
             if (commandGetSchema.hasSchemaVersion()) {
                 log.debug("Received CommandGetSchema call from {}, schemaVersion: {}, topic: {}, requestId: {}",
@@ -2123,6 +2128,7 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
 
     @Override
     protected void handleGetOrCreateSchema(CommandGetOrCreateSchema commandGetOrCreateSchema) {
+        checkArgument(state == State.Connected);
         if (log.isDebugEnabled()) {
             log.debug("Received CommandGetOrCreateSchema call from {}", remoteAddress);
         }
@@ -2158,6 +2164,7 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
 
     @Override
     protected void handleTcClientConnectRequest(CommandTcClientConnectRequest command) {
+        checkArgument(state == State.Connected);
         final long requestId = command.getRequestId();
         final TransactionCoordinatorID tcId = TransactionCoordinatorID.get(command.getTcId());
         if (log.isDebugEnabled()) {
@@ -2219,6 +2226,7 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
     }
     @Override
     protected void handleNewTxn(CommandNewTxn command) {
+        checkArgument(state == State.Connected);
         final long requestId = command.getRequestId();
         final TransactionCoordinatorID tcId = TransactionCoordinatorID.get(command.getTcId());
         if (log.isDebugEnabled()) {
@@ -2260,6 +2268,7 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
 
     @Override
     protected void handleAddPartitionToTxn(CommandAddPartitionToTxn command) {
+        checkArgument(state == State.Connected);
         final TxnID txnID = new TxnID(command.getTxnidMostBits(), command.getTxnidLeastBits());
         final TransactionCoordinatorID tcId = TransactionCoordinatorID.get(command.getTxnidMostBits());
         final long requestId = command.getRequestId();
@@ -2297,6 +2306,7 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
 
     @Override
     protected void handleEndTxn(CommandEndTxn command) {
+        checkArgument(state == State.Connected);
         final long requestId = command.getRequestId();
         final int txnAction = command.getTxnAction().getValue();
         TxnID txnID = new TxnID(command.getTxnidMostBits(), command.getTxnidLeastBits());
@@ -2327,6 +2337,7 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
 
     @Override
     protected void handleEndTxnOnPartition(CommandEndTxnOnPartition command) {
+        checkArgument(state == State.Connected);
         final long requestId = command.getRequestId();
         final String topic = command.getTopic();
         final int txnAction = command.getTxnAction().getValue();
@@ -2397,6 +2408,7 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
 
     @Override
     protected void handleEndTxnOnSubscription(CommandEndTxnOnSubscription command) {
+        checkArgument(state == State.Connected);
         final long requestId = command.getRequestId();
         final long txnidMostBits = command.getTxnidMostBits();
         final long txnidLeastBits = command.getTxnidLeastBits();
@@ -2503,6 +2515,7 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
 
     @Override
     protected void handleAddSubscriptionToTxn(CommandAddSubscriptionToTxn command) {
+        checkArgument(state == State.Connected);
         final TxnID txnID = new TxnID(command.getTxnidMostBits(), command.getTxnidLeastBits());
         final long requestId = command.getRequestId();
         if (log.isDebugEnabled()) {
@@ -2541,6 +2554,7 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
     }
 
     protected void handleCommandWatchTopicList(CommandWatchTopicList commandWatchTopicList) {
+        checkArgument(state == State.Connected);
         final long requestId = commandWatchTopicList.getRequestId();
         final long watcherId = commandWatchTopicList.getWatcherId();
         final NamespaceName namespaceName = NamespaceName.get(commandWatchTopicList.getNamespace());
@@ -2590,6 +2604,7 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
     }
 
     protected void handleCommandWatchTopicListClose(CommandWatchTopicListClose commandWatchTopicListClose) {
+        checkArgument(state == State.Connected);
         topicListService.handleWatchTopicListClose(commandWatchTopicListClose);
     }
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ServerCnxTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ServerCnxTest.java
@@ -2174,8 +2174,7 @@ public class ServerCnxTest {
         Field stateUpdater = ServerCnx.class.getDeclaredField("state");
         stateUpdater.setAccessible(true);
         stateUpdater.set(serverCnx, ServerCnx.State.Failed);
-        CommandLookupTopic commandLookupTopic = any(CommandLookupTopic.class);
-        serverCnx.handleLookup(commandLookupTopic);
+        serverCnx.handleLookup(any(CommandLookupTopic.class));
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
@@ -2184,8 +2183,7 @@ public class ServerCnxTest {
         Field stateUpdater = ServerCnx.class.getDeclaredField("state");
         stateUpdater.setAccessible(true);
         stateUpdater.set(serverCnx, ServerCnx.State.Failed);
-        CommandPartitionedTopicMetadata partitionMetadata = any(CommandPartitionedTopicMetadata.class);
-        serverCnx.handlePartitionMetadataRequest(partitionMetadata);
+        serverCnx.handlePartitionMetadataRequest(any(CommandPartitionedTopicMetadata.class));
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
@@ -2194,8 +2192,7 @@ public class ServerCnxTest {
         Field stateUpdater = ServerCnx.class.getDeclaredField("state");
         stateUpdater.setAccessible(true);
         stateUpdater.set(serverCnx, ServerCnx.State.Failed);
-        CommandConsumerStats commandConsumerStats = any(CommandConsumerStats.class);
-        serverCnx.handleConsumerStats(commandConsumerStats);
+        serverCnx.handleConsumerStats(any(CommandConsumerStats.class));
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
@@ -2204,8 +2201,7 @@ public class ServerCnxTest {
         Field stateUpdater = ServerCnx.class.getDeclaredField("state");
         stateUpdater.setAccessible(true);
         stateUpdater.set(serverCnx, ServerCnx.State.Failed);
-        CommandGetTopicsOfNamespace commandGetTopicsOfNamespace = any(CommandGetTopicsOfNamespace.class);
-        serverCnx.handleGetTopicsOfNamespace(commandGetTopicsOfNamespace);
+        serverCnx.handleGetTopicsOfNamespace(any(CommandGetTopicsOfNamespace.class));
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
@@ -2214,8 +2210,7 @@ public class ServerCnxTest {
         Field stateUpdater = ServerCnx.class.getDeclaredField("state");
         stateUpdater.setAccessible(true);
         stateUpdater.set(serverCnx, ServerCnx.State.Failed);
-        CommandGetSchema commandGetSchema = any(CommandGetSchema.class);
-        serverCnx.handleGetSchema(commandGetSchema);
+        serverCnx.handleGetSchema(any(CommandGetSchema.class));
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
@@ -2224,8 +2219,7 @@ public class ServerCnxTest {
         Field stateUpdater = ServerCnx.class.getDeclaredField("state");
         stateUpdater.setAccessible(true);
         stateUpdater.set(serverCnx, ServerCnx.State.Failed);
-        CommandGetOrCreateSchema commandGetOrCreateSchema = any(CommandGetOrCreateSchema.class);
-        serverCnx.handleGetOrCreateSchema(commandGetOrCreateSchema);
+        serverCnx.handleGetOrCreateSchema(any(CommandGetOrCreateSchema.class));
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
@@ -2234,8 +2228,7 @@ public class ServerCnxTest {
         Field stateUpdater = ServerCnx.class.getDeclaredField("state");
         stateUpdater.setAccessible(true);
         stateUpdater.set(serverCnx, ServerCnx.State.Failed);
-        CommandTcClientConnectRequest command = any(CommandTcClientConnectRequest.class);
-        serverCnx.handleTcClientConnectRequest(command);
+        serverCnx.handleTcClientConnectRequest(any(CommandTcClientConnectRequest.class));
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
@@ -2244,8 +2237,7 @@ public class ServerCnxTest {
         Field stateUpdater = ServerCnx.class.getDeclaredField("state");
         stateUpdater.setAccessible(true);
         stateUpdater.set(serverCnx, ServerCnx.State.Failed);
-        CommandNewTxn command = any(CommandNewTxn.class);
-        serverCnx.handleNewTxn(command);
+        serverCnx.handleNewTxn(any(CommandNewTxn.class));
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
@@ -2254,8 +2246,7 @@ public class ServerCnxTest {
         Field stateUpdater = ServerCnx.class.getDeclaredField("state");
         stateUpdater.setAccessible(true);
         stateUpdater.set(serverCnx, ServerCnx.State.Failed);
-        CommandAddPartitionToTxn command = any(CommandAddPartitionToTxn.class);
-        serverCnx.handleAddPartitionToTxn(command);
+        serverCnx.handleAddPartitionToTxn(any(CommandAddPartitionToTxn.class));
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
@@ -2264,8 +2255,7 @@ public class ServerCnxTest {
         Field stateUpdater = ServerCnx.class.getDeclaredField("state");
         stateUpdater.setAccessible(true);
         stateUpdater.set(serverCnx, ServerCnx.State.Failed);
-        CommandEndTxn command = any(CommandEndTxn.class);
-        serverCnx.handleEndTxn(command);
+        serverCnx.handleEndTxn(any(CommandEndTxn.class));
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
@@ -2274,8 +2264,7 @@ public class ServerCnxTest {
         Field stateUpdater = ServerCnx.class.getDeclaredField("state");
         stateUpdater.setAccessible(true);
         stateUpdater.set(serverCnx, ServerCnx.State.Failed);
-        CommandEndTxnOnPartition command = any(CommandEndTxnOnPartition.class);
-        serverCnx.handleEndTxnOnPartition(command);
+        serverCnx.handleEndTxnOnPartition(any(CommandEndTxnOnPartition.class));
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
@@ -2284,8 +2273,7 @@ public class ServerCnxTest {
         Field stateUpdater = ServerCnx.class.getDeclaredField("state");
         stateUpdater.setAccessible(true);
         stateUpdater.set(serverCnx, ServerCnx.State.Failed);
-        CommandEndTxnOnSubscription command = any(CommandEndTxnOnSubscription.class);
-        serverCnx.handleEndTxnOnSubscription(command);
+        serverCnx.handleEndTxnOnSubscription(any(CommandEndTxnOnSubscription.class));
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
@@ -2294,8 +2282,7 @@ public class ServerCnxTest {
         Field stateUpdater = ServerCnx.class.getDeclaredField("state");
         stateUpdater.setAccessible(true);
         stateUpdater.set(serverCnx, ServerCnx.State.Failed);
-        CommandAddSubscriptionToTxn command = any(CommandAddSubscriptionToTxn.class);
-        serverCnx.handleAddSubscriptionToTxn(command);
+        serverCnx.handleAddSubscriptionToTxn(any(CommandAddSubscriptionToTxn.class));
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
@@ -2304,9 +2291,7 @@ public class ServerCnxTest {
         Field stateUpdater = ServerCnx.class.getDeclaredField("state");
         stateUpdater.setAccessible(true);
         stateUpdater.set(serverCnx, ServerCnx.State.Failed);
-        CommandWatchTopicList commandWatchTopicList = any(CommandWatchTopicList.class);
-        serverCnx.handleCommandWatchTopicList(commandWatchTopicList);
-
+        serverCnx.handleCommandWatchTopicList(any(CommandWatchTopicList.class));
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
@@ -2315,7 +2300,6 @@ public class ServerCnxTest {
         Field stateUpdater = ServerCnx.class.getDeclaredField("state");
         stateUpdater.setAccessible(true);
         stateUpdater.set(serverCnx, ServerCnx.State.Failed);
-        CommandWatchTopicListClose commandWatchTopicListClose = any(CommandWatchTopicListClose.class);
-        serverCnx.handleCommandWatchTopicListClose(commandWatchTopicListClose);
+        serverCnx.handleCommandWatchTopicListClose(any(CommandWatchTopicListClose.class));
     }
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ServerCnxTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ServerCnxTest.java
@@ -2169,155 +2169,153 @@ public class ServerCnxTest {
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
-    void shouldFailHandleLookup() throws Exception {
-        resetChannel();
+    public void shouldFailHandleLookup() throws Exception {
+        ServerCnx serverCnx = mock(ServerCnx.class, CALLS_REAL_METHODS);
         Field stateUpdater = ServerCnx.class.getDeclaredField("state");
         stateUpdater.setAccessible(true);
         stateUpdater.set(serverCnx, ServerCnx.State.Failed);
-
-        CommandLookupTopic commandLookupTopic = spy(CommandLookupTopic.class);
+        CommandLookupTopic commandLookupTopic = any(CommandLookupTopic.class);
         serverCnx.handleLookup(commandLookupTopic);
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
-    void shouldFailHandlePartitionMetadataRequest() throws Exception {
-        resetChannel();
+    public void shouldFailHandlePartitionMetadataRequest() throws Exception {
+        ServerCnx serverCnx = mock(ServerCnx.class, CALLS_REAL_METHODS);
         Field stateUpdater = ServerCnx.class.getDeclaredField("state");
         stateUpdater.setAccessible(true);
         stateUpdater.set(serverCnx, ServerCnx.State.Failed);
-
-        CommandPartitionedTopicMetadata partitionMetadata = spy(CommandPartitionedTopicMetadata.class);
+        CommandPartitionedTopicMetadata partitionMetadata = any(CommandPartitionedTopicMetadata.class);
         serverCnx.handlePartitionMetadataRequest(partitionMetadata);
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
-    void shouldFailHandleConsumerStats() throws Exception {
-        resetChannel();
+    public void shouldFailHandleConsumerStats() throws Exception {
+        ServerCnx serverCnx = mock(ServerCnx.class, CALLS_REAL_METHODS);
         Field stateUpdater = ServerCnx.class.getDeclaredField("state");
         stateUpdater.setAccessible(true);
         stateUpdater.set(serverCnx, ServerCnx.State.Failed);
-        CommandConsumerStats commandConsumerStats = spy(CommandConsumerStats.class);
+        CommandConsumerStats commandConsumerStats = any(CommandConsumerStats.class);
         serverCnx.handleConsumerStats(commandConsumerStats);
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
-    void shouldFailHandleGetTopicsOfNamespace() throws Exception {
-        resetChannel();
+    public void shouldFailHandleGetTopicsOfNamespace() throws Exception {
+        ServerCnx serverCnx = mock(ServerCnx.class, CALLS_REAL_METHODS);
         Field stateUpdater = ServerCnx.class.getDeclaredField("state");
         stateUpdater.setAccessible(true);
         stateUpdater.set(serverCnx, ServerCnx.State.Failed);
-        CommandGetTopicsOfNamespace commandGetTopicsOfNamespace = spy(CommandGetTopicsOfNamespace.class);
+        CommandGetTopicsOfNamespace commandGetTopicsOfNamespace = any(CommandGetTopicsOfNamespace.class);
         serverCnx.handleGetTopicsOfNamespace(commandGetTopicsOfNamespace);
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
-    void shouldFailHandleGetSchema() throws Exception {
-        resetChannel();
+    public void shouldFailHandleGetSchema() throws Exception {
+        ServerCnx serverCnx = mock(ServerCnx.class, CALLS_REAL_METHODS);
         Field stateUpdater = ServerCnx.class.getDeclaredField("state");
         stateUpdater.setAccessible(true);
         stateUpdater.set(serverCnx, ServerCnx.State.Failed);
-        CommandGetSchema commandGetSchem = spy(CommandGetSchema.class);
-        serverCnx.handleGetSchema(commandGetSchem);
+        CommandGetSchema commandGetSchema = any(CommandGetSchema.class);
+        serverCnx.handleGetSchema(commandGetSchema);
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
-    void shouldFailHandleGetOrCreateSchema() throws Exception {
-        resetChannel();
+    public void shouldFailHandleGetOrCreateSchema() throws Exception {
+        ServerCnx serverCnx = mock(ServerCnx.class, CALLS_REAL_METHODS);
         Field stateUpdater = ServerCnx.class.getDeclaredField("state");
         stateUpdater.setAccessible(true);
         stateUpdater.set(serverCnx, ServerCnx.State.Failed);
-        CommandGetOrCreateSchema commandGetOrCreateSchema = spy(CommandGetOrCreateSchema.class);
+        CommandGetOrCreateSchema commandGetOrCreateSchema = any(CommandGetOrCreateSchema.class);
         serverCnx.handleGetOrCreateSchema(commandGetOrCreateSchema);
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
-    void shouldFailHandleTcClientConnectRequest() throws Exception {
-        resetChannel();
+    public void shouldFailHandleTcClientConnectRequest() throws Exception {
+        ServerCnx serverCnx = mock(ServerCnx.class, CALLS_REAL_METHODS);
         Field stateUpdater = ServerCnx.class.getDeclaredField("state");
         stateUpdater.setAccessible(true);
         stateUpdater.set(serverCnx, ServerCnx.State.Failed);
-        CommandTcClientConnectRequest command = spy(CommandTcClientConnectRequest.class);
+        CommandTcClientConnectRequest command = any(CommandTcClientConnectRequest.class);
         serverCnx.handleTcClientConnectRequest(command);
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
-    void shouldFailHandleNewTxn() throws Exception {
-        resetChannel();
+    public void shouldFailHandleNewTxn() throws Exception {
+        ServerCnx serverCnx = mock(ServerCnx.class, CALLS_REAL_METHODS);
         Field stateUpdater = ServerCnx.class.getDeclaredField("state");
         stateUpdater.setAccessible(true);
         stateUpdater.set(serverCnx, ServerCnx.State.Failed);
-        CommandNewTxn command = spy(CommandNewTxn.class);
+        CommandNewTxn command = any(CommandNewTxn.class);
         serverCnx.handleNewTxn(command);
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
-    void shouldFailHandleAddPartitionToTxn() throws Exception {
-        resetChannel();
+    public void shouldFailHandleAddPartitionToTxn() throws Exception {
+        ServerCnx serverCnx = mock(ServerCnx.class, CALLS_REAL_METHODS);
         Field stateUpdater = ServerCnx.class.getDeclaredField("state");
         stateUpdater.setAccessible(true);
         stateUpdater.set(serverCnx, ServerCnx.State.Failed);
-        CommandAddPartitionToTxn command = spy(CommandAddPartitionToTxn.class);
+        CommandAddPartitionToTxn command = any(CommandAddPartitionToTxn.class);
         serverCnx.handleAddPartitionToTxn(command);
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
-    void shouldFailHandleEndTxn() throws Exception {
-        resetChannel();
+    public void shouldFailHandleEndTxn() throws Exception {
+        ServerCnx serverCnx = mock(ServerCnx.class, CALLS_REAL_METHODS);
         Field stateUpdater = ServerCnx.class.getDeclaredField("state");
         stateUpdater.setAccessible(true);
         stateUpdater.set(serverCnx, ServerCnx.State.Failed);
-        CommandEndTxn command = spy(CommandEndTxn.class);
+        CommandEndTxn command = any(CommandEndTxn.class);
         serverCnx.handleEndTxn(command);
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
-    void shouldFailHandleEndTxnOnPartition() throws Exception {
-        resetChannel();
+    public void shouldFailHandleEndTxnOnPartition() throws Exception {
+        ServerCnx serverCnx = mock(ServerCnx.class, CALLS_REAL_METHODS);
         Field stateUpdater = ServerCnx.class.getDeclaredField("state");
         stateUpdater.setAccessible(true);
         stateUpdater.set(serverCnx, ServerCnx.State.Failed);
-        CommandEndTxnOnPartition command = spy(CommandEndTxnOnPartition.class);
+        CommandEndTxnOnPartition command = any(CommandEndTxnOnPartition.class);
         serverCnx.handleEndTxnOnPartition(command);
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
-    void shouldFailHandleEndTxnOnSubscription() throws Exception {
-        resetChannel();
+    public void shouldFailHandleEndTxnOnSubscription() throws Exception {
+        ServerCnx serverCnx = mock(ServerCnx.class, CALLS_REAL_METHODS);
         Field stateUpdater = ServerCnx.class.getDeclaredField("state");
         stateUpdater.setAccessible(true);
         stateUpdater.set(serverCnx, ServerCnx.State.Failed);
-        CommandEndTxnOnSubscription command = spy(CommandEndTxnOnSubscription.class);
+        CommandEndTxnOnSubscription command = any(CommandEndTxnOnSubscription.class);
         serverCnx.handleEndTxnOnSubscription(command);
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
-    void shouldFailHandleAddSubscriptionToTxn() throws Exception {
-        resetChannel();
+    public void shouldFailHandleAddSubscriptionToTxn() throws Exception {
+        ServerCnx serverCnx = mock(ServerCnx.class, CALLS_REAL_METHODS);
         Field stateUpdater = ServerCnx.class.getDeclaredField("state");
         stateUpdater.setAccessible(true);
         stateUpdater.set(serverCnx, ServerCnx.State.Failed);
-        CommandAddSubscriptionToTxn command = spy(CommandAddSubscriptionToTxn.class);
+        CommandAddSubscriptionToTxn command = any(CommandAddSubscriptionToTxn.class);
         serverCnx.handleAddSubscriptionToTxn(command);
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
-    void shouldFailHandleCommandWatchTopicList() throws Exception {
-        resetChannel();
+    public void shouldFailHandleCommandWatchTopicList() throws Exception {
+        ServerCnx serverCnx = mock(ServerCnx.class, CALLS_REAL_METHODS);
         Field stateUpdater = ServerCnx.class.getDeclaredField("state");
         stateUpdater.setAccessible(true);
         stateUpdater.set(serverCnx, ServerCnx.State.Failed);
-        CommandWatchTopicList commandWatchTopicList = spy(CommandWatchTopicList.class);
+        CommandWatchTopicList commandWatchTopicList = any(CommandWatchTopicList.class);
         serverCnx.handleCommandWatchTopicList(commandWatchTopicList);
 
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
-    void shouldFailHandleCommandWatchTopicListClose() throws Exception {
-        resetChannel();
+    public void shouldFailHandleCommandWatchTopicListClose() throws Exception {
+        ServerCnx serverCnx = mock(ServerCnx.class, CALLS_REAL_METHODS);
         Field stateUpdater = ServerCnx.class.getDeclaredField("state");
         stateUpdater.setAccessible(true);
         stateUpdater.set(serverCnx, ServerCnx.State.Failed);
-        CommandWatchTopicListClose commandWatchTopicListClose = spy(CommandWatchTopicListClose.class);
+        CommandWatchTopicListClose commandWatchTopicListClose = any(CommandWatchTopicListClose.class);
         serverCnx.handleCommandWatchTopicListClose(commandWatchTopicListClose);
     }
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ServerCnxTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ServerCnxTest.java
@@ -96,18 +96,32 @@ import org.apache.pulsar.common.api.proto.AuthMethod;
 import org.apache.pulsar.common.api.proto.BaseCommand;
 import org.apache.pulsar.common.api.proto.BaseCommand.Type;
 import org.apache.pulsar.common.api.proto.CommandAck.AckType;
+import org.apache.pulsar.common.api.proto.CommandAddPartitionToTxn;
+import org.apache.pulsar.common.api.proto.CommandAddSubscriptionToTxn;
 import org.apache.pulsar.common.api.proto.CommandAuthResponse;
 import org.apache.pulsar.common.api.proto.CommandConnected;
+import org.apache.pulsar.common.api.proto.CommandConsumerStats;
+import org.apache.pulsar.common.api.proto.CommandEndTxn;
+import org.apache.pulsar.common.api.proto.CommandEndTxnOnPartition;
+import org.apache.pulsar.common.api.proto.CommandEndTxnOnSubscription;
 import org.apache.pulsar.common.api.proto.CommandError;
+import org.apache.pulsar.common.api.proto.CommandGetOrCreateSchema;
+import org.apache.pulsar.common.api.proto.CommandGetSchema;
 import org.apache.pulsar.common.api.proto.CommandGetTopicsOfNamespace;
 import org.apache.pulsar.common.api.proto.CommandGetTopicsOfNamespaceResponse;
+import org.apache.pulsar.common.api.proto.CommandLookupTopic;
 import org.apache.pulsar.common.api.proto.CommandLookupTopicResponse;
+import org.apache.pulsar.common.api.proto.CommandNewTxn;
+import org.apache.pulsar.common.api.proto.CommandPartitionedTopicMetadata;
 import org.apache.pulsar.common.api.proto.CommandProducerSuccess;
 import org.apache.pulsar.common.api.proto.CommandSendError;
 import org.apache.pulsar.common.api.proto.CommandSendReceipt;
 import org.apache.pulsar.common.api.proto.CommandSubscribe.InitialPosition;
 import org.apache.pulsar.common.api.proto.CommandSubscribe.SubType;
 import org.apache.pulsar.common.api.proto.CommandSuccess;
+import org.apache.pulsar.common.api.proto.CommandTcClientConnectRequest;
+import org.apache.pulsar.common.api.proto.CommandWatchTopicList;
+import org.apache.pulsar.common.api.proto.CommandWatchTopicListClose;
 import org.apache.pulsar.common.api.proto.CommandWatchTopicListSuccess;
 import org.apache.pulsar.common.api.proto.MessageMetadata;
 import org.apache.pulsar.common.api.proto.ProtocolVersion;
@@ -2152,5 +2166,158 @@ public class ServerCnxTest {
         }
         verify(authResponse, times(1)).hasClientVersion();
         verify(authResponse, times(0)).getClientVersion();
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    void shouldFailHandleLookup() throws Exception {
+        resetChannel();
+        Field stateUpdater = ServerCnx.class.getDeclaredField("state");
+        stateUpdater.setAccessible(true);
+        stateUpdater.set(serverCnx, ServerCnx.State.Failed);
+
+        CommandLookupTopic commandLookupTopic = spy(CommandLookupTopic.class);
+        serverCnx.handleLookup(commandLookupTopic);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    void shouldFailHandlePartitionMetadataRequest() throws Exception {
+        resetChannel();
+        Field stateUpdater = ServerCnx.class.getDeclaredField("state");
+        stateUpdater.setAccessible(true);
+        stateUpdater.set(serverCnx, ServerCnx.State.Failed);
+
+        CommandPartitionedTopicMetadata partitionMetadata = spy(CommandPartitionedTopicMetadata.class);
+        serverCnx.handlePartitionMetadataRequest(partitionMetadata);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    void shouldFailHandleConsumerStats() throws Exception {
+        resetChannel();
+        Field stateUpdater = ServerCnx.class.getDeclaredField("state");
+        stateUpdater.setAccessible(true);
+        stateUpdater.set(serverCnx, ServerCnx.State.Failed);
+        CommandConsumerStats commandConsumerStats = spy(CommandConsumerStats.class);
+        serverCnx.handleConsumerStats(commandConsumerStats);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    void shouldFailHandleGetTopicsOfNamespace() throws Exception {
+        resetChannel();
+        Field stateUpdater = ServerCnx.class.getDeclaredField("state");
+        stateUpdater.setAccessible(true);
+        stateUpdater.set(serverCnx, ServerCnx.State.Failed);
+        CommandGetTopicsOfNamespace commandGetTopicsOfNamespace = spy(CommandGetTopicsOfNamespace.class);
+        serverCnx.handleGetTopicsOfNamespace(commandGetTopicsOfNamespace);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    void shouldFailHandleGetSchema() throws Exception {
+        resetChannel();
+        Field stateUpdater = ServerCnx.class.getDeclaredField("state");
+        stateUpdater.setAccessible(true);
+        stateUpdater.set(serverCnx, ServerCnx.State.Failed);
+        CommandGetSchema commandGetSchem = spy(CommandGetSchema.class);
+        serverCnx.handleGetSchema(commandGetSchem);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    void shouldFailHandleGetOrCreateSchema() throws Exception {
+        resetChannel();
+        Field stateUpdater = ServerCnx.class.getDeclaredField("state");
+        stateUpdater.setAccessible(true);
+        stateUpdater.set(serverCnx, ServerCnx.State.Failed);
+        CommandGetOrCreateSchema commandGetOrCreateSchema = spy(CommandGetOrCreateSchema.class);
+        serverCnx.handleGetOrCreateSchema(commandGetOrCreateSchema);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    void shouldFailHandleTcClientConnectRequest() throws Exception {
+        resetChannel();
+        Field stateUpdater = ServerCnx.class.getDeclaredField("state");
+        stateUpdater.setAccessible(true);
+        stateUpdater.set(serverCnx, ServerCnx.State.Failed);
+        CommandTcClientConnectRequest command = spy(CommandTcClientConnectRequest.class);
+        serverCnx.handleTcClientConnectRequest(command);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    void shouldFailHandleNewTxn() throws Exception {
+        resetChannel();
+        Field stateUpdater = ServerCnx.class.getDeclaredField("state");
+        stateUpdater.setAccessible(true);
+        stateUpdater.set(serverCnx, ServerCnx.State.Failed);
+        CommandNewTxn command = spy(CommandNewTxn.class);
+        serverCnx.handleNewTxn(command);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    void shouldFailHandleAddPartitionToTxn() throws Exception {
+        resetChannel();
+        Field stateUpdater = ServerCnx.class.getDeclaredField("state");
+        stateUpdater.setAccessible(true);
+        stateUpdater.set(serverCnx, ServerCnx.State.Failed);
+        CommandAddPartitionToTxn command = spy(CommandAddPartitionToTxn.class);
+        serverCnx.handleAddPartitionToTxn(command);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    void shouldFailHandleEndTxn() throws Exception {
+        resetChannel();
+        Field stateUpdater = ServerCnx.class.getDeclaredField("state");
+        stateUpdater.setAccessible(true);
+        stateUpdater.set(serverCnx, ServerCnx.State.Failed);
+        CommandEndTxn command = spy(CommandEndTxn.class);
+        serverCnx.handleEndTxn(command);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    void shouldFailHandleEndTxnOnPartition() throws Exception {
+        resetChannel();
+        Field stateUpdater = ServerCnx.class.getDeclaredField("state");
+        stateUpdater.setAccessible(true);
+        stateUpdater.set(serverCnx, ServerCnx.State.Failed);
+        CommandEndTxnOnPartition command = spy(CommandEndTxnOnPartition.class);
+        serverCnx.handleEndTxnOnPartition(command);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    void shouldFailHandleEndTxnOnSubscription() throws Exception {
+        resetChannel();
+        Field stateUpdater = ServerCnx.class.getDeclaredField("state");
+        stateUpdater.setAccessible(true);
+        stateUpdater.set(serverCnx, ServerCnx.State.Failed);
+        CommandEndTxnOnSubscription command = spy(CommandEndTxnOnSubscription.class);
+        serverCnx.handleEndTxnOnSubscription(command);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    void shouldFailHandleAddSubscriptionToTxn() throws Exception {
+        resetChannel();
+        Field stateUpdater = ServerCnx.class.getDeclaredField("state");
+        stateUpdater.setAccessible(true);
+        stateUpdater.set(serverCnx, ServerCnx.State.Failed);
+        CommandAddSubscriptionToTxn command = spy(CommandAddSubscriptionToTxn.class);
+        serverCnx.handleAddSubscriptionToTxn(command);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    void shouldFailHandleCommandWatchTopicList() throws Exception {
+        resetChannel();
+        Field stateUpdater = ServerCnx.class.getDeclaredField("state");
+        stateUpdater.setAccessible(true);
+        stateUpdater.set(serverCnx, ServerCnx.State.Failed);
+        CommandWatchTopicList commandWatchTopicList = spy(CommandWatchTopicList.class);
+        serverCnx.handleCommandWatchTopicList(commandWatchTopicList);
+
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    void shouldFailHandleCommandWatchTopicListClose() throws Exception {
+        resetChannel();
+        Field stateUpdater = ServerCnx.class.getDeclaredField("state");
+        stateUpdater.setAccessible(true);
+        stateUpdater.set(serverCnx, ServerCnx.State.Failed);
+        CommandWatchTopicListClose commandWatchTopicListClose = spy(CommandWatchTopicListClose.class);
+        serverCnx.handleCommandWatchTopicListClose(commandWatchTopicListClose);
     }
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ServerCnxTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ServerCnxTest.java
@@ -96,32 +96,18 @@ import org.apache.pulsar.common.api.proto.AuthMethod;
 import org.apache.pulsar.common.api.proto.BaseCommand;
 import org.apache.pulsar.common.api.proto.BaseCommand.Type;
 import org.apache.pulsar.common.api.proto.CommandAck.AckType;
-import org.apache.pulsar.common.api.proto.CommandAddPartitionToTxn;
-import org.apache.pulsar.common.api.proto.CommandAddSubscriptionToTxn;
 import org.apache.pulsar.common.api.proto.CommandAuthResponse;
 import org.apache.pulsar.common.api.proto.CommandConnected;
-import org.apache.pulsar.common.api.proto.CommandConsumerStats;
-import org.apache.pulsar.common.api.proto.CommandEndTxn;
-import org.apache.pulsar.common.api.proto.CommandEndTxnOnPartition;
-import org.apache.pulsar.common.api.proto.CommandEndTxnOnSubscription;
 import org.apache.pulsar.common.api.proto.CommandError;
-import org.apache.pulsar.common.api.proto.CommandGetOrCreateSchema;
-import org.apache.pulsar.common.api.proto.CommandGetSchema;
 import org.apache.pulsar.common.api.proto.CommandGetTopicsOfNamespace;
 import org.apache.pulsar.common.api.proto.CommandGetTopicsOfNamespaceResponse;
-import org.apache.pulsar.common.api.proto.CommandLookupTopic;
 import org.apache.pulsar.common.api.proto.CommandLookupTopicResponse;
-import org.apache.pulsar.common.api.proto.CommandNewTxn;
-import org.apache.pulsar.common.api.proto.CommandPartitionedTopicMetadata;
 import org.apache.pulsar.common.api.proto.CommandProducerSuccess;
 import org.apache.pulsar.common.api.proto.CommandSendError;
 import org.apache.pulsar.common.api.proto.CommandSendReceipt;
 import org.apache.pulsar.common.api.proto.CommandSubscribe.InitialPosition;
 import org.apache.pulsar.common.api.proto.CommandSubscribe.SubType;
 import org.apache.pulsar.common.api.proto.CommandSuccess;
-import org.apache.pulsar.common.api.proto.CommandTcClientConnectRequest;
-import org.apache.pulsar.common.api.proto.CommandWatchTopicList;
-import org.apache.pulsar.common.api.proto.CommandWatchTopicListClose;
 import org.apache.pulsar.common.api.proto.CommandWatchTopicListSuccess;
 import org.apache.pulsar.common.api.proto.MessageMetadata;
 import org.apache.pulsar.common.api.proto.ProtocolVersion;
@@ -2174,7 +2160,7 @@ public class ServerCnxTest {
         Field stateUpdater = ServerCnx.class.getDeclaredField("state");
         stateUpdater.setAccessible(true);
         stateUpdater.set(serverCnx, ServerCnx.State.Failed);
-        serverCnx.handleLookup(any(CommandLookupTopic.class));
+        serverCnx.handleLookup(any());
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
@@ -2183,7 +2169,7 @@ public class ServerCnxTest {
         Field stateUpdater = ServerCnx.class.getDeclaredField("state");
         stateUpdater.setAccessible(true);
         stateUpdater.set(serverCnx, ServerCnx.State.Failed);
-        serverCnx.handlePartitionMetadataRequest(any(CommandPartitionedTopicMetadata.class));
+        serverCnx.handlePartitionMetadataRequest(any());
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
@@ -2192,7 +2178,7 @@ public class ServerCnxTest {
         Field stateUpdater = ServerCnx.class.getDeclaredField("state");
         stateUpdater.setAccessible(true);
         stateUpdater.set(serverCnx, ServerCnx.State.Failed);
-        serverCnx.handleConsumerStats(any(CommandConsumerStats.class));
+        serverCnx.handleConsumerStats(any());
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
@@ -2201,7 +2187,7 @@ public class ServerCnxTest {
         Field stateUpdater = ServerCnx.class.getDeclaredField("state");
         stateUpdater.setAccessible(true);
         stateUpdater.set(serverCnx, ServerCnx.State.Failed);
-        serverCnx.handleGetTopicsOfNamespace(any(CommandGetTopicsOfNamespace.class));
+        serverCnx.handleGetTopicsOfNamespace(any());
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
@@ -2210,7 +2196,7 @@ public class ServerCnxTest {
         Field stateUpdater = ServerCnx.class.getDeclaredField("state");
         stateUpdater.setAccessible(true);
         stateUpdater.set(serverCnx, ServerCnx.State.Failed);
-        serverCnx.handleGetSchema(any(CommandGetSchema.class));
+        serverCnx.handleGetSchema(any());
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
@@ -2219,7 +2205,7 @@ public class ServerCnxTest {
         Field stateUpdater = ServerCnx.class.getDeclaredField("state");
         stateUpdater.setAccessible(true);
         stateUpdater.set(serverCnx, ServerCnx.State.Failed);
-        serverCnx.handleGetOrCreateSchema(any(CommandGetOrCreateSchema.class));
+        serverCnx.handleGetOrCreateSchema(any());
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
@@ -2228,7 +2214,7 @@ public class ServerCnxTest {
         Field stateUpdater = ServerCnx.class.getDeclaredField("state");
         stateUpdater.setAccessible(true);
         stateUpdater.set(serverCnx, ServerCnx.State.Failed);
-        serverCnx.handleTcClientConnectRequest(any(CommandTcClientConnectRequest.class));
+        serverCnx.handleTcClientConnectRequest(any());
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
@@ -2237,7 +2223,7 @@ public class ServerCnxTest {
         Field stateUpdater = ServerCnx.class.getDeclaredField("state");
         stateUpdater.setAccessible(true);
         stateUpdater.set(serverCnx, ServerCnx.State.Failed);
-        serverCnx.handleNewTxn(any(CommandNewTxn.class));
+        serverCnx.handleNewTxn(any());
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
@@ -2246,7 +2232,7 @@ public class ServerCnxTest {
         Field stateUpdater = ServerCnx.class.getDeclaredField("state");
         stateUpdater.setAccessible(true);
         stateUpdater.set(serverCnx, ServerCnx.State.Failed);
-        serverCnx.handleAddPartitionToTxn(any(CommandAddPartitionToTxn.class));
+        serverCnx.handleAddPartitionToTxn(any());
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
@@ -2255,7 +2241,7 @@ public class ServerCnxTest {
         Field stateUpdater = ServerCnx.class.getDeclaredField("state");
         stateUpdater.setAccessible(true);
         stateUpdater.set(serverCnx, ServerCnx.State.Failed);
-        serverCnx.handleEndTxn(any(CommandEndTxn.class));
+        serverCnx.handleEndTxn(any());
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
@@ -2264,7 +2250,7 @@ public class ServerCnxTest {
         Field stateUpdater = ServerCnx.class.getDeclaredField("state");
         stateUpdater.setAccessible(true);
         stateUpdater.set(serverCnx, ServerCnx.State.Failed);
-        serverCnx.handleEndTxnOnPartition(any(CommandEndTxnOnPartition.class));
+        serverCnx.handleEndTxnOnPartition(any());
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
@@ -2273,7 +2259,7 @@ public class ServerCnxTest {
         Field stateUpdater = ServerCnx.class.getDeclaredField("state");
         stateUpdater.setAccessible(true);
         stateUpdater.set(serverCnx, ServerCnx.State.Failed);
-        serverCnx.handleEndTxnOnSubscription(any(CommandEndTxnOnSubscription.class));
+        serverCnx.handleEndTxnOnSubscription(any());
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
@@ -2282,7 +2268,7 @@ public class ServerCnxTest {
         Field stateUpdater = ServerCnx.class.getDeclaredField("state");
         stateUpdater.setAccessible(true);
         stateUpdater.set(serverCnx, ServerCnx.State.Failed);
-        serverCnx.handleAddSubscriptionToTxn(any(CommandAddSubscriptionToTxn.class));
+        serverCnx.handleAddSubscriptionToTxn(any());
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
@@ -2291,7 +2277,7 @@ public class ServerCnxTest {
         Field stateUpdater = ServerCnx.class.getDeclaredField("state");
         stateUpdater.setAccessible(true);
         stateUpdater.set(serverCnx, ServerCnx.State.Failed);
-        serverCnx.handleCommandWatchTopicList(any(CommandWatchTopicList.class));
+        serverCnx.handleCommandWatchTopicList(any());
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
@@ -2300,6 +2286,6 @@ public class ServerCnxTest {
         Field stateUpdater = ServerCnx.class.getDeclaredField("state");
         stateUpdater.setAccessible(true);
         stateUpdater.set(serverCnx, ServerCnx.State.Failed);
-        serverCnx.handleCommandWatchTopicListClose(any(CommandWatchTopicListClose.class));
+        serverCnx.handleCommandWatchTopicListClose(any());
     }
 }


### PR DESCRIPTION
### Motivation
When the server receives a request, it is supposed to check its own state. like `handleAck\handleCloseProducer\handleConnect\handleFlow\handleProducer`

### Modifications
Add ServerCnx state check when server handle request

### Verifying this change

- [x]  Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.
### Does this pull request potentially affect one of the following parts:

If `yes` was chosen, please highlight the changes

- Dependencies (does it add or upgrade a dependency): (no)
- The public API: (no)
- The schema: (no)
- The default values of configurations: (no)
- The wire protocol: (no)
- The rest endpoints: (no)
- The admin cli options: (no)
- Anything that affects deployment: (no)

### Documentation
Check the box below and label this PR (if you have committer privilege).

Need to update docs? 
- [x] `doc-not-needed` 
