### PR TITLE
[improve][broker]fix broker irrational behavior when it is closing

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
@@ -1241,6 +1241,13 @@ public class PulsarService implements AutoCloseable, ShutdownService {
     }
 
     /**
+     * check the current pulsar service is started or not.
+     */
+    public boolean isStarted() {
+        return this.state == State.Started;
+    }
+
+    /**
      * Get a reference of the current <code>LeaderElectionService</code> instance associated with the current
      * <code>PulsarService</code> instance.
      *

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
@@ -1241,10 +1241,10 @@ public class PulsarService implements AutoCloseable, ShutdownService {
     }
 
     /**
-     * check the current pulsar service is started or not.
+     * check the current pulsar service is running, including Started and Init state.
      */
-    public boolean isStarted() {
-        return this.state == State.Started;
+    public boolean isRunning() {
+        return this.state == State.Started || this.state == State.Init;
     }
 
     /**

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
@@ -452,6 +452,16 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
             return;
         }
 
+        if (!this.service.getPulsar().isStarted()) {
+            if (log.isDebugEnabled()) {
+                log.debug("[{}] Failed lookup topic {} due to pulsar service is not ready: {} state", remoteAddress,
+                        topicName, this.service.getPulsar().getState().toString());
+            }
+            ctx.writeAndFlush(newLookupErrorResponse(ServerError.ServiceNotReady,
+                    "Failed due to pulsar service is not ready", requestId));
+            return;
+        }
+
         final Semaphore lookupSemaphore = service.getLookupRequestSemaphore();
         if (lookupSemaphore.tryAcquire()) {
             if (invalidOriginalPrincipal(originalPrincipal)) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
@@ -452,7 +452,7 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
             return;
         }
 
-        if (!this.service.getPulsar().isStarted()) {
+        if (!this.service.getPulsar().isRunning()) {
             if (log.isDebugEnabled()) {
                 log.debug("[{}] Failed lookup topic {} due to pulsar service is not ready: {} state", remoteAddress,
                         topicName, this.service.getPulsar().getState().toString());


### PR DESCRIPTION
### Motivation
When the leader broker is closing, and it will release the ownership of its bundles first. The client will redo topic lookup , and this broker will handle it, resulting in unexpected results. For instance, some unassigned bundles maybe are taken ownership by itself again, but the broker can not server the bundles due to it is closing . see the screenshot log. 
Therefore, it is necessary to check the status of the broker when handling lookup requests.

<img width="1909" alt="image" src="https://user-images.githubusercontent.com/4970972/184530824-b41d7a5b-7309-4251-af2f-58f97f1d58d3.png">


### Modifications
- Check Pulsar Service state when handling lookup request.
- Add 'Init' state as running state in `PulsarService` since `PulsarFunctionWorker` have to lookup topic when broker is starting.

https://github.com/apache/pulsar/blob/4a28c087fe1308ea4eabc104b3d4889b47316afe/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java#L855-L856

https://github.com/apache/pulsar/blob/4a28c087fe1308ea4eabc104b3d4889b47316afe/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/PulsarWorkerService.java#L445-L447

### Verifying this change

- [x]  Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.
### Does this pull request potentially affect one of the following parts:

If `yes` was chosen, please highlight the changes

- Dependencies (does it add or upgrade a dependency): (no)
- The public API: (no)
- The schema: (no)
- The default values of configurations: (no)
- The wire protocol: (no)
- The rest endpoints: (no)
- The admin cli options: (no)
- Anything that affects deployment: (no)

### Documentation
Check the box below and label this PR (if you have committer privilege).

Need to update docs? 
- [x] `doc-not-needed` 
