### PR TITLE
[improve][broker]: DelayedDeliveryTracker init and addMessage

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/delayed/DelayedDeliveryTracker.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/delayed/DelayedDeliveryTracker.java
@@ -31,6 +31,8 @@ import org.apache.bookkeeper.mledger.impl.PositionImpl;
 public interface DelayedDeliveryTracker extends AutoCloseable {
 
     /**
+     * may consider mark thread safe
+     *
      * Add a message to the tracker.
      *
      * @param ledgerId   the ledgerId

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/delayed/InMemoryDelayedDeliveryTracker.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/delayed/InMemoryDelayedDeliveryTracker.java
@@ -111,8 +111,10 @@ public class InMemoryDelayedDeliveryTracker implements DelayedDeliveryTracker, T
         }
 
 
-        priorityQueue.add(deliverAt, ledgerId, entryId);
-        updateTimer();
+        synchronized (this) {
+            priorityQueue.add(deliverAt, ledgerId, entryId);
+            updateTimer();
+        }
 
         // Check that new delivery time comes after the current highest, or at
         // least within a single tick time interval of 1 second.


### PR DESCRIPTION
### Motivation

improve DelayedDeliveryTracker perf

### Modifications

1. PersistentDispatcherMultipleConsumers.java use double check lock init DelayedDeliveryTracker
2. PersistentDispatcherMultipleConsumers.java not lock when msgMetadata.hasDeliverAtTime return false
3. InMemoryDelayedDeliveryTracker.java `addMessage` method add lock to ensure thread safe

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change is already covered by existing tests：*org.apache.pulsar.broker.delayed.InMemoryDeliveryTrackerTest*. 

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API: (yes / no)
  - The schema: (yes / no / don't know)
  - The default values of configurations: (yes / no)
  - The wire protocol: (yes / no)
  - The rest endpoints: (yes / no)
  - The admin cli options: (yes / no)
  - Anything that affects deployment: (yes / no / don't know)

### Documentation

Check the box below or label this PR directly.

Need to update docs? 

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)
  
- [x] `doc-not-needed` 
(Please explain why)
  
- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)