### PR TITLE
[fix][test][sql]Fix presto sql avro decode error when publish non-batched msgs

### DIFF
--- a/pulsar-common/src/main/java/org/apache/pulsar/common/api/raw/RawMessageImpl.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/api/raw/RawMessageImpl.java
@@ -37,6 +37,7 @@ public class RawMessageImpl implements RawMessage {
 
     private ReferenceCountedMessageMetadata msgMetadata;
     private final SingleMessageMetadata singleMessageMetadata = new SingleMessageMetadata();
+    private volatile boolean setSingleMessageMetadata;
     private ByteBuf payload;
 
     private static final Recycler<RawMessageImpl> RECYCLER = new Recycler<RawMessageImpl>() {
@@ -57,6 +58,7 @@ public class RawMessageImpl implements RawMessage {
         msgMetadata.release();
         msgMetadata = null;
         singleMessageMetadata.clear();
+        setSingleMessageMetadata = false;
 
         payload.release();
         handle.recycle(this);
@@ -72,6 +74,7 @@ public class RawMessageImpl implements RawMessage {
 
         if (singleMessageMetadata != null) {
             msg.singleMessageMetadata.copyFrom(singleMessageMetadata);
+            msg.setSingleMessageMetadata = true;
         }
         msg.messageId.ledgerId = ledgerId;
         msg.messageId.entryId = entryId;
@@ -90,7 +93,7 @@ public class RawMessageImpl implements RawMessage {
 
     @Override
     public Map<String, String> getProperties() {
-        if (singleMessageMetadata != null && singleMessageMetadata.getPropertiesCount() > 0) {
+        if (setSingleMessageMetadata && singleMessageMetadata.getPropertiesCount() > 0) {
             return singleMessageMetadata.getPropertiesList().stream()
                       .collect(Collectors.toMap(KeyValue::getKey, KeyValue::getValue,
                               (oldValue, newValue) -> newValue));
@@ -119,7 +122,7 @@ public class RawMessageImpl implements RawMessage {
 
     @Override
     public long getEventTime() {
-        if (singleMessageMetadata != null && singleMessageMetadata.hasEventTime()) {
+        if (setSingleMessageMetadata && singleMessageMetadata.hasEventTime()) {
             return singleMessageMetadata.getEventTime();
         } else if (msgMetadata.getMetadata().hasEventTime()) {
             return msgMetadata.getMetadata().getEventTime();
@@ -140,7 +143,7 @@ public class RawMessageImpl implements RawMessage {
 
     @Override
     public Optional<String> getKey() {
-        if (singleMessageMetadata != null && singleMessageMetadata.hasPartitionKey()) {
+        if (setSingleMessageMetadata && singleMessageMetadata.hasPartitionKey()) {
             return Optional.of(singleMessageMetadata.getPartitionKey());
         } else if (msgMetadata.getMetadata().hasPartitionKey()){
             return Optional.of(msgMetadata.getMetadata().getPartitionKey());
@@ -171,7 +174,7 @@ public class RawMessageImpl implements RawMessage {
 
     @Override
     public boolean hasBase64EncodedKey() {
-        if (singleMessageMetadata != null) {
+        if (setSingleMessageMetadata) {
             return singleMessageMetadata.isPartitionKeyB64Encoded();
         }
         return msgMetadata.getMetadata().isPartitionKeyB64Encoded();

--- a/pulsar-common/src/test/java/org/apache/pulsar/common/api/raw/RawMessageImplTest.java
+++ b/pulsar-common/src/test/java/org/apache/pulsar/common/api/raw/RawMessageImplTest.java
@@ -18,14 +18,19 @@
  */
 package org.apache.pulsar.common.api.raw;
 
-import io.netty.buffer.ByteBuf;
-import org.apache.pulsar.common.api.proto.SingleMessageMetadata;
-import org.mockito.Mockito;
-import org.testng.annotations.Test;
-
-import java.util.Map;
-
+import static java.util.Collections.singletonList;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+import com.google.common.collect.ImmutableMap;
+import io.netty.buffer.ByteBuf;
+import java.util.Map;
+import org.apache.pulsar.common.api.proto.KeyValue;
+import org.apache.pulsar.common.api.proto.MessageMetadata;
+import org.apache.pulsar.common.api.proto.SingleMessageMetadata;
+import org.testng.annotations.Test;
 
 public class RawMessageImplTest {
 
@@ -38,7 +43,7 @@ public class RawMessageImplTest {
     @Test
     public void testGetProperties() {
         ReferenceCountedMessageMetadata refCntMsgMetadata =
-                ReferenceCountedMessageMetadata.get(Mockito.mock(ByteBuf.class));
+                ReferenceCountedMessageMetadata.get(mock(ByteBuf.class));
         SingleMessageMetadata singleMessageMetadata = new SingleMessageMetadata();
         singleMessageMetadata.addProperty().setKey(HARD_CODE_KEY).setValue(KEY_VALUE_FIRST);
         singleMessageMetadata.addProperty().setKey(HARD_CODE_KEY).setValue(KEY_VALUE_SECOND);
@@ -49,5 +54,43 @@ public class RawMessageImplTest {
         assertEquals(properties.get(HARD_CODE_KEY_ID), HARD_CODE_KEY_ID_VALUE);
         assertEquals(KEY_VALUE_SECOND, properties.get(HARD_CODE_KEY));
         assertEquals(HARD_CODE_KEY_ID_VALUE, properties.get(HARD_CODE_KEY_ID));
+    }
+
+    @Test
+    public void testNonBatchedMessage() {
+        MessageMetadata messageMetadata = new MessageMetadata();
+        messageMetadata.setPartitionKeyB64Encoded(true);
+        messageMetadata.addAllProperties(singletonList(new KeyValue().setKey("key1").setValue("value1")));
+        messageMetadata.setEventTime(100L);
+
+        ReferenceCountedMessageMetadata refCntMsgMetadata = mock(ReferenceCountedMessageMetadata.class);
+        when(refCntMsgMetadata.getMetadata()).thenReturn(messageMetadata);
+
+        // Non-batched message's singleMessageMetadata is null
+        RawMessage msg = RawMessageImpl.get(refCntMsgMetadata, null, null, 0, 0, 0);
+        assertTrue(msg.hasBase64EncodedKey());
+        assertEquals(msg.getProperties(), ImmutableMap.of("key1", "value1"));
+        assertEquals(msg.getEventTime(), 100L);
+    }
+
+    @Test
+    public void testBatchedMessage() {
+        MessageMetadata messageMetadata = new MessageMetadata();
+        messageMetadata.setPartitionKeyB64Encoded(true);
+        messageMetadata.addAllProperties(singletonList(new KeyValue().setKey("key1").setValue("value1")));
+        messageMetadata.setEventTime(100L);
+
+        ReferenceCountedMessageMetadata refCntMsgMetadata = mock(ReferenceCountedMessageMetadata.class);
+        when(refCntMsgMetadata.getMetadata()).thenReturn(messageMetadata);
+
+        SingleMessageMetadata singleMessageMetadata = new SingleMessageMetadata();
+        singleMessageMetadata.setPartitionKeyB64Encoded(false);
+        singleMessageMetadata.addAllProperties(singletonList(new KeyValue().setKey("key2").setValue("value2")));
+        singleMessageMetadata.setEventTime(200L);
+
+        RawMessage msg = RawMessageImpl.get(refCntMsgMetadata, singleMessageMetadata, null, 0, 0, 0);
+        assertFalse(msg.hasBase64EncodedKey());
+        assertEquals(msg.getProperties(), ImmutableMap.of("key2", "value2"));
+        assertEquals(msg.getEventTime(), 200L);
     }
 }


### PR DESCRIPTION
### Motivation

Finally I find the bug, which makes `org.apache.pulsar.tests.integration.presto.TestBasicPresto#testForSchema` fail, But I still don't know why other PRs can run it success

* This PR will fix https://github.com/apache/pulsar/issues/16975 OR https://github.com/apache/pulsar/issues/9704
* The root cause is that:
    * The `keyByteBuf ` we get from `currentMessage ` is not correct (line545 in code block 1), because we didn't decode the key with Base64 when the message is non-batched published.  Explain in details:
       *   As we know `SingleMessageMetadata`  is only set when publish batched messages.  So we will use `RawMessageImpl#singleMessageMetadata` to decode the key when messages is batched, or use `RawMessageImpl#msgMetadata` if messages in non-batched, As line174 in code block 2.
       * The problem is that `RawMessageImpl#singleMessageMetadata` will never be null (line38 code block 3)
       * If we try to decode non-batched message, the line175 in code block 2 will execute and return false.
       * Then line166 in code block 2 will execute and decode the key without Base64
       
       code block 1: [PulsarRecordCursor.java]:
       https://github.com/apache/pulsar/blob/70020f14c3959f232ae53816022268fc61e0f955/pulsar-sql/presto-pulsar/src/main/java/org/apache/pulsar/sql/presto/PulsarRecordCursor.java#L542-L547
   
       code block 2 [step into `currentMessage.getKeyBytes()` in `RawMessageImpl.java`]：
       https://github.com/apache/pulsar/blob/70020f14c3959f232ae53816022268fc61e0f955/pulsar-common/src/main/java/org/apache/pulsar/common/api/raw/RawMessageImpl.java#L161-L178

      code block 3 [RawMessageImpl.java]
      https://github.com/apache/pulsar/blob/70020f14c3959f232ae53816022268fc61e0f955/pulsar-common/src/main/java/org/apache/pulsar/common/api/raw/RawMessageImpl.java#L34-L41

### Modifications

* Add `boolean setSingleMessageMetadata` in `org.apache.pulsar.common.api.raw.RawMessageImpl` in order to check if
`singleMessageMetadata` is set or not

### Verifying this change

- [x] Make sure that the change passes the CI checks.
- `org.apache.pulsar.tests.integration.presto.TestBasicPresto#testForSchema` has covered this change
- Add UT `org.apache.pulsar.common.api.raw.RawMessageImplTest#testNonBatchedMessage`
- Add UT `org.apache.pulsar.common.api.raw.RawMessageImplTest#testBatchedMessage`


### Documentation

Check the box below or label this PR directly.

Need to update docs? 

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)
  
- [x] `doc-not-needed` 
(Please explain why)
  
- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)