### PR TITLE
[improve][metadata-store] Change metadata store operation to async

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/ModularLoadManagerImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/ModularLoadManagerImpl.java
@@ -567,7 +567,7 @@ public class ModularLoadManagerImpl implements ModularLoadManager {
                 if (!activeBundles.contains(bundle)){
                     bundleData.remove(bundle);
                     if (pulsar.getLeaderElectionService().isLeader()){
-                        deleteBundleDataFromMetadataStore(bundle);
+                        deleteBundleDataFromMetadataStoreAsync(bundle);
                     }
                 }
             }
@@ -771,7 +771,7 @@ public class ModularLoadManagerImpl implements ModularLoadManager {
                     // Clear namespace bundle-cache
                     this.pulsar.getNamespaceService().getNamespaceBundleFactory()
                             .invalidateBundleCache(NamespaceName.get(namespaceName));
-                    deleteBundleDataFromMetadataStore(bundleName);
+                    deleteBundleDataFromMetadataStoreAsync(bundleName);
 
                     log.info("Load-manager splitting bundle {} and unloading {}", bundleName, unloadSplitBundles);
                     pulsar.getAdminClient().namespaces().splitNamespaceBundle(namespaceName, bundleRange,
@@ -1136,7 +1136,7 @@ public class ModularLoadManagerImpl implements ModularLoadManager {
         }
     }
 
-    private void deleteBundleDataFromMetadataStore(String bundle) {
+    private void deleteBundleDataFromMetadataStoreAsync(String bundle) {
         bundlesCache.delete(getBundleDataPath(bundle)).whenComplete((__, ex) -> {
             if (ex != null && !(ex.getCause() instanceof MetadataStoreException.NotFoundException)) {
                 log.warn("Failed to delete bundle-data {} from metadata store", bundle, ex);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/ModularLoadManagerImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/ModularLoadManagerImpl.java
@@ -1137,13 +1137,11 @@ public class ModularLoadManagerImpl implements ModularLoadManager {
     }
 
     private void deleteBundleDataFromMetadataStore(String bundle) {
-        try {
-            bundlesCache.delete(getBundleDataPath(bundle)).join();
-        } catch (Exception e) {
-            if (!(e.getCause() instanceof NotFoundException)) {
-                log.warn("Failed to delete bundle-data {} from metadata store", bundle, e);
+        bundlesCache.delete(getBundleDataPath(bundle)).whenComplete((__, ex) -> {
+            if (ex != null && !(ex.getCause() instanceof MetadataStoreException.NotFoundException)) {
+                log.warn("Failed to delete bundle-data {} from metadata store", bundle, ex);
             }
-        }
+        });
     }
 
     private void deleteTimeAverageDataFromMetadataStoreAsync(String broker) {


### PR DESCRIPTION


### Motivation
In  avoiding to not to make metadata-store process waiting. 


### Modifications

Change  `deleteBundleDataFromMetadataStore ` operation  to async


Need to update docs? 

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)
  
- [x] `doc-not-needed` 
(Please explain why)
  
- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)