### PR TITLE
[fix][doc] correct configuration name to exposingBrokerEntryMetadataToClientEnabled

### DIFF
--- a/site2/docs/developing-binary-protocol.md
+++ b/site2/docs/developing-binary-protocol.md
@@ -68,7 +68,7 @@ If you want to use broker entry metadata for **consumers**:
 
 1. Use the client protocol version [18 or later](https://github.com/apache/pulsar/blob/ca37e67211feda4f7e0984e6414e707f1c1dfd07/pulsar-common/src/main/proto/PulsarApi.proto#L259).
    
-2. Configure the [`brokerEntryMetadataInterceptors`](reference-configuration.md#broker) parameter and set the [`enableExposingBrokerEntryMetadataToClient`](reference-configuration.md#broker) parameter to `true` in the `broker.conf` file.
+2. Configure the [`brokerEntryMetadataInterceptors`](reference-configuration.md#broker) parameter and set the [`exposingBrokerEntryMetadataToClientEnabled`](reference-configuration-broker.md#exposingbrokerentrymetadatatoclientenabled) parameter to `true` in the `broker.conf` file.
 
 ## Message metadata
 

--- a/site2/website/versioned_docs/version-2.1.1-incubating/developing-binary-protocol.md
+++ b/site2/website/versioned_docs/version-2.1.1-incubating/developing-binary-protocol.md
@@ -68,7 +68,7 @@ If you want to use broker entry metadata for **consumers**:
 
 1. Use the client protocol version [18 or later](https://github.com/apache/pulsar/blob/ca37e67211feda4f7e0984e6414e707f1c1dfd07/pulsar-common/src/main/proto/PulsarApi.proto#L259).
    
-2. Configure the [`brokerEntryMetadataInterceptors`](reference-configuration.md#broker) parameter and set the [`enableExposingBrokerEntryMetadataToClient`](reference-configuration.md#broker) parameter to `true` in the `broker.conf` file.
+2. Configure the [`brokerEntryMetadataInterceptors`](reference-configuration.md#broker) parameter and set the [`exposingBrokerEntryMetadataToClientEnabled`](reference-configuration-broker.md#exposingbrokerentrymetadatatoclientenabled) parameter to `true` in the `broker.conf` file.
 
 ## Message metadata
 

--- a/site2/website/versioned_docs/version-2.1.1-incubating/developing-binary-protocol.md
+++ b/site2/website/versioned_docs/version-2.1.1-incubating/developing-binary-protocol.md
@@ -52,24 +52,6 @@ Payload commands have this basic structure:
 | `metadata`                         | Required  | The message [metadata](#message-metadata) stored as a binary protobuf message               |                 |
 | `payload`                          | Required  | Anything left in the frame is considered the payload and can include any sequence of bytes  |                 |
 
-## Broker entry metadata
-
-Broker entry metadata is stored alongside the message metadata as a serialized protobuf message.
-It is created by the broker when the message arrived at the broker and passed without changes to the consumer if configured.
-
-| Field              | Required or optional       | Description                                                                                                                   |
-|:-------------------|:----------------|:------------------------------------------------------------------------------------------------------------------------------|
-| `broker_timestamp` | Optional        | The timestamp when a message arrived at the broker (`id est` as the number of milliseconds since January 1st, 1970 in UTC)      |
-| `index`            | Optional        | The index of the message. It is assigned by the broker.
-
-If you want to use broker entry metadata for **brokers**, configure the [`brokerEntryMetadataInterceptors`](reference-configuration.md#broker) parameter in the `broker.conf` file.
-
-If you want to use broker entry metadata for **consumers**:
-
-1. Use the client protocol version [18 or later](https://github.com/apache/pulsar/blob/ca37e67211feda4f7e0984e6414e707f1c1dfd07/pulsar-common/src/main/proto/PulsarApi.proto#L259).
-   
-2. Configure the [`brokerEntryMetadataInterceptors`](reference-configuration.md#broker) parameter and set the [`exposingBrokerEntryMetadataToClientEnabled`](reference-configuration-broker.md#exposingbrokerentrymetadatatoclientenabled) parameter to `true` in the `broker.conf` file.
-
 ## Message metadata
 
 Message metadata is stored alongside the application-specified payload as a serialized protobuf message. Metadata is created by the producer and passed without changes to the consumer.

--- a/site2/website/versioned_docs/version-2.10.0/developing-binary-protocol.md
+++ b/site2/website/versioned_docs/version-2.10.0/developing-binary-protocol.md
@@ -69,7 +69,7 @@ If you want to use broker entry metadata for **consumers**:
 
 1. Use the client protocol version [18 or later](https://github.com/apache/pulsar/blob/ca37e67211feda4f7e0984e6414e707f1c1dfd07/pulsar-common/src/main/proto/PulsarApi.proto#L259).
    
-2. Configure the [`brokerEntryMetadataInterceptors`](reference-configuration.md#broker) parameter and set the [`enableExposingBrokerEntryMetadataToClient`](reference-configuration.md#broker) parameter to `true` in the `broker.conf` file.
+2. Configure the [`brokerEntryMetadataInterceptors`](reference-configuration.md#broker) parameter and set the [`exposingBrokerEntryMetadataToClientEnabled`](reference-configuration-broker.md#exposingbrokerentrymetadatatoclientenabled) parameter to `true` in the `broker.conf` file.
 
 ## Message metadata
 

--- a/site2/website/versioned_docs/version-2.10.1/developing-binary-protocol.md
+++ b/site2/website/versioned_docs/version-2.10.1/developing-binary-protocol.md
@@ -69,7 +69,7 @@ If you want to use broker entry metadata for **consumers**:
 
 1. Use the client protocol version [18 or later](https://github.com/apache/pulsar/blob/ca37e67211feda4f7e0984e6414e707f1c1dfd07/pulsar-common/src/main/proto/PulsarApi.proto#L259).
    
-2. Configure the [`brokerEntryMetadataInterceptors`](reference-configuration.md#broker) parameter and set the [`enableExposingBrokerEntryMetadataToClient`](reference-configuration.md#broker) parameter to `true` in the `broker.conf` file.
+2. Configure the [`brokerEntryMetadataInterceptors`](reference-configuration.md#broker) parameter and set the [`exposingBrokerEntryMetadataToClientEnabled`](reference-configuration-broker.md#exposingbrokerentrymetadatatoclientenabled) parameter to `true` in the `broker.conf` file.
 
 ## Message metadata
 

--- a/site2/website/versioned_docs/version-2.10.x/developing-binary-protocol.md
+++ b/site2/website/versioned_docs/version-2.10.x/developing-binary-protocol.md
@@ -69,7 +69,7 @@ If you want to use broker entry metadata for **consumers**:
 
 1. Use the client protocol version [18 or later](https://github.com/apache/pulsar/blob/ca37e67211feda4f7e0984e6414e707f1c1dfd07/pulsar-common/src/main/proto/PulsarApi.proto#L259).
    
-2. Configure the [`brokerEntryMetadataInterceptors`](reference-configuration.md#broker) parameter and set the [`enableExposingBrokerEntryMetadataToClient`](reference-configuration.md#broker) parameter to `true` in the `broker.conf` file.
+2. Configure the [`brokerEntryMetadataInterceptors`](reference-configuration.md#broker) parameter and set the [`exposingBrokerEntryMetadataToClientEnabled`](reference-configuration-broker.md#exposingbrokerentrymetadatatoclientenabled) parameter to `true` in the `broker.conf` file.
 
 ## Message metadata
 

--- a/site2/website/versioned_docs/version-2.2.1/developing-binary-protocol.md
+++ b/site2/website/versioned_docs/version-2.2.1/developing-binary-protocol.md
@@ -68,7 +68,7 @@ If you want to use broker entry metadata for **consumers**:
 
 1. Use the client protocol version [18 or later](https://github.com/apache/pulsar/blob/ca37e67211feda4f7e0984e6414e707f1c1dfd07/pulsar-common/src/main/proto/PulsarApi.proto#L259).
    
-2. Configure the [`brokerEntryMetadataInterceptors`](reference-configuration.md#broker) parameter and set the [`enableExposingBrokerEntryMetadataToClient`](reference-configuration.md#broker) parameter to `true` in the `broker.conf` file.
+2. Configure the [`brokerEntryMetadataInterceptors`](reference-configuration.md#broker) parameter and set the [`exposingBrokerEntryMetadataToClientEnabled`](reference-configuration-broker.md#exposingbrokerentrymetadatatoclientenabled) parameter to `true` in the `broker.conf` file.
 
 ## Message metadata
 

--- a/site2/website/versioned_docs/version-2.2.1/developing-binary-protocol.md
+++ b/site2/website/versioned_docs/version-2.2.1/developing-binary-protocol.md
@@ -52,24 +52,6 @@ Payload commands have this basic structure:
 | `metadata`                         | Required  | The message [metadata](#message-metadata) stored as a binary protobuf message               |                 |
 | `payload`                          | Required  | Anything left in the frame is considered the payload and can include any sequence of bytes  |                 |
 
-## Broker entry metadata
-
-Broker entry metadata is stored alongside the message metadata as a serialized protobuf message.
-It is created by the broker when the message arrived at the broker and passed without changes to the consumer if configured.
-
-| Field              | Required or optional       | Description                                                                                                                   |
-|:-------------------|:----------------|:------------------------------------------------------------------------------------------------------------------------------|
-| `broker_timestamp` | Optional        | The timestamp when a message arrived at the broker (`id est` as the number of milliseconds since January 1st, 1970 in UTC)      |
-| `index`            | Optional        | The index of the message. It is assigned by the broker.
-
-If you want to use broker entry metadata for **brokers**, configure the [`brokerEntryMetadataInterceptors`](reference-configuration.md#broker) parameter in the `broker.conf` file.
-
-If you want to use broker entry metadata for **consumers**:
-
-1. Use the client protocol version [18 or later](https://github.com/apache/pulsar/blob/ca37e67211feda4f7e0984e6414e707f1c1dfd07/pulsar-common/src/main/proto/PulsarApi.proto#L259).
-   
-2. Configure the [`brokerEntryMetadataInterceptors`](reference-configuration.md#broker) parameter and set the [`exposingBrokerEntryMetadataToClientEnabled`](reference-configuration-broker.md#exposingbrokerentrymetadatatoclientenabled) parameter to `true` in the `broker.conf` file.
-
 ## Message metadata
 
 Message metadata is stored alongside the application-specified payload as a serialized protobuf message. Metadata is created by the producer and passed without changes to the consumer.

--- a/site2/website/versioned_docs/version-2.3.0/developing-binary-protocol.md
+++ b/site2/website/versioned_docs/version-2.3.0/developing-binary-protocol.md
@@ -68,7 +68,7 @@ If you want to use broker entry metadata for **consumers**:
 
 1. Use the client protocol version [18 or later](https://github.com/apache/pulsar/blob/ca37e67211feda4f7e0984e6414e707f1c1dfd07/pulsar-common/src/main/proto/PulsarApi.proto#L259).
    
-2. Configure the [`brokerEntryMetadataInterceptors`](reference-configuration.md#broker) parameter and set the [`enableExposingBrokerEntryMetadataToClient`](reference-configuration.md#broker) parameter to `true` in the `broker.conf` file.
+2. Configure the [`brokerEntryMetadataInterceptors`](reference-configuration.md#broker) parameter and set the [`exposingBrokerEntryMetadataToClientEnabled`](reference-configuration-broker.md#exposingbrokerentrymetadatatoclientenabled) parameter to `true` in the `broker.conf` file.
 
 ## Message metadata
 

--- a/site2/website/versioned_docs/version-2.3.0/developing-binary-protocol.md
+++ b/site2/website/versioned_docs/version-2.3.0/developing-binary-protocol.md
@@ -52,24 +52,6 @@ Payload commands have this basic structure:
 | `metadata`                         | Required  | The message [metadata](#message-metadata) stored as a binary protobuf message               |                 |
 | `payload`                          | Required  | Anything left in the frame is considered the payload and can include any sequence of bytes  |                 |
 
-## Broker entry metadata
-
-Broker entry metadata is stored alongside the message metadata as a serialized protobuf message.
-It is created by the broker when the message arrived at the broker and passed without changes to the consumer if configured.
-
-| Field              | Required or optional       | Description                                                                                                                   |
-|:-------------------|:----------------|:------------------------------------------------------------------------------------------------------------------------------|
-| `broker_timestamp` | Optional        | The timestamp when a message arrived at the broker (`id est` as the number of milliseconds since January 1st, 1970 in UTC)      |
-| `index`            | Optional        | The index of the message. It is assigned by the broker.
-
-If you want to use broker entry metadata for **brokers**, configure the [`brokerEntryMetadataInterceptors`](reference-configuration.md#broker) parameter in the `broker.conf` file.
-
-If you want to use broker entry metadata for **consumers**:
-
-1. Use the client protocol version [18 or later](https://github.com/apache/pulsar/blob/ca37e67211feda4f7e0984e6414e707f1c1dfd07/pulsar-common/src/main/proto/PulsarApi.proto#L259).
-   
-2. Configure the [`brokerEntryMetadataInterceptors`](reference-configuration.md#broker) parameter and set the [`exposingBrokerEntryMetadataToClientEnabled`](reference-configuration-broker.md#exposingbrokerentrymetadatatoclientenabled) parameter to `true` in the `broker.conf` file.
-
 ## Message metadata
 
 Message metadata is stored alongside the application-specified payload as a serialized protobuf message. Metadata is created by the producer and passed without changes to the consumer.

--- a/site2/website/versioned_docs/version-2.3.1/developing-binary-protocol.md
+++ b/site2/website/versioned_docs/version-2.3.1/developing-binary-protocol.md
@@ -68,7 +68,7 @@ If you want to use broker entry metadata for **consumers**:
 
 1. Use the client protocol version [18 or later](https://github.com/apache/pulsar/blob/ca37e67211feda4f7e0984e6414e707f1c1dfd07/pulsar-common/src/main/proto/PulsarApi.proto#L259).
    
-2. Configure the [`brokerEntryMetadataInterceptors`](reference-configuration.md#broker) parameter and set the [`enableExposingBrokerEntryMetadataToClient`](reference-configuration.md#broker) parameter to `true` in the `broker.conf` file.
+2. Configure the [`brokerEntryMetadataInterceptors`](reference-configuration.md#broker) parameter and set the [`exposingBrokerEntryMetadataToClientEnabled`](reference-configuration-broker.md#exposingbrokerentrymetadatatoclientenabled) parameter to `true` in the `broker.conf` file.
 
 ## Message metadata
 

--- a/site2/website/versioned_docs/version-2.3.1/developing-binary-protocol.md
+++ b/site2/website/versioned_docs/version-2.3.1/developing-binary-protocol.md
@@ -52,24 +52,6 @@ Payload commands have this basic structure:
 | `metadata`                         | Required  | The message [metadata](#message-metadata) stored as a binary protobuf message               |                 |
 | `payload`                          | Required  | Anything left in the frame is considered the payload and can include any sequence of bytes  |                 |
 
-## Broker entry metadata
-
-Broker entry metadata is stored alongside the message metadata as a serialized protobuf message.
-It is created by the broker when the message arrived at the broker and passed without changes to the consumer if configured.
-
-| Field              | Required or optional       | Description                                                                                                                   |
-|:-------------------|:----------------|:------------------------------------------------------------------------------------------------------------------------------|
-| `broker_timestamp` | Optional        | The timestamp when a message arrived at the broker (`id est` as the number of milliseconds since January 1st, 1970 in UTC)      |
-| `index`            | Optional        | The index of the message. It is assigned by the broker.
-
-If you want to use broker entry metadata for **brokers**, configure the [`brokerEntryMetadataInterceptors`](reference-configuration.md#broker) parameter in the `broker.conf` file.
-
-If you want to use broker entry metadata for **consumers**:
-
-1. Use the client protocol version [18 or later](https://github.com/apache/pulsar/blob/ca37e67211feda4f7e0984e6414e707f1c1dfd07/pulsar-common/src/main/proto/PulsarApi.proto#L259).
-   
-2. Configure the [`brokerEntryMetadataInterceptors`](reference-configuration.md#broker) parameter and set the [`exposingBrokerEntryMetadataToClientEnabled`](reference-configuration-broker.md#exposingbrokerentrymetadatatoclientenabled) parameter to `true` in the `broker.conf` file.
-
 ## Message metadata
 
 Message metadata is stored alongside the application-specified payload as a serialized protobuf message. Metadata is created by the producer and passed without changes to the consumer.

--- a/site2/website/versioned_docs/version-2.3.2/developing-binary-protocol.md
+++ b/site2/website/versioned_docs/version-2.3.2/developing-binary-protocol.md
@@ -68,7 +68,7 @@ If you want to use broker entry metadata for **consumers**:
 
 1. Use the client protocol version [18 or later](https://github.com/apache/pulsar/blob/ca37e67211feda4f7e0984e6414e707f1c1dfd07/pulsar-common/src/main/proto/PulsarApi.proto#L259).
    
-2. Configure the [`brokerEntryMetadataInterceptors`](reference-configuration.md#broker) parameter and set the [`enableExposingBrokerEntryMetadataToClient`](reference-configuration.md#broker) parameter to `true` in the `broker.conf` file.
+2. Configure the [`brokerEntryMetadataInterceptors`](reference-configuration.md#broker) parameter and set the [`exposingBrokerEntryMetadataToClientEnabled`](reference-configuration-broker.md#exposingbrokerentrymetadatatoclientenabled) parameter to `true` in the `broker.conf` file.
 
 ## Message metadata
 

--- a/site2/website/versioned_docs/version-2.3.2/developing-binary-protocol.md
+++ b/site2/website/versioned_docs/version-2.3.2/developing-binary-protocol.md
@@ -52,24 +52,6 @@ Payload commands have this basic structure:
 | `metadata`                         | Required  | The message [metadata](#message-metadata) stored as a binary protobuf message               |                 |
 | `payload`                          | Required  | Anything left in the frame is considered the payload and can include any sequence of bytes  |                 |
 
-## Broker entry metadata
-
-Broker entry metadata is stored alongside the message metadata as a serialized protobuf message.
-It is created by the broker when the message arrived at the broker and passed without changes to the consumer if configured.
-
-| Field              | Required or optional       | Description                                                                                                                   |
-|:-------------------|:----------------|:------------------------------------------------------------------------------------------------------------------------------|
-| `broker_timestamp` | Optional        | The timestamp when a message arrived at the broker (`id est` as the number of milliseconds since January 1st, 1970 in UTC)      |
-| `index`            | Optional        | The index of the message. It is assigned by the broker.
-
-If you want to use broker entry metadata for **brokers**, configure the [`brokerEntryMetadataInterceptors`](reference-configuration.md#broker) parameter in the `broker.conf` file.
-
-If you want to use broker entry metadata for **consumers**:
-
-1. Use the client protocol version [18 or later](https://github.com/apache/pulsar/blob/ca37e67211feda4f7e0984e6414e707f1c1dfd07/pulsar-common/src/main/proto/PulsarApi.proto#L259).
-   
-2. Configure the [`brokerEntryMetadataInterceptors`](reference-configuration.md#broker) parameter and set the [`exposingBrokerEntryMetadataToClientEnabled`](reference-configuration-broker.md#exposingbrokerentrymetadatatoclientenabled) parameter to `true` in the `broker.conf` file.
-
 ## Message metadata
 
 Message metadata is stored alongside the application-specified payload as a serialized protobuf message. Metadata is created by the producer and passed without changes to the consumer.

--- a/site2/website/versioned_docs/version-2.4.1/developing-binary-protocol.md
+++ b/site2/website/versioned_docs/version-2.4.1/developing-binary-protocol.md
@@ -68,7 +68,7 @@ If you want to use broker entry metadata for **consumers**:
 
 1. Use the client protocol version [18 or later](https://github.com/apache/pulsar/blob/ca37e67211feda4f7e0984e6414e707f1c1dfd07/pulsar-common/src/main/proto/PulsarApi.proto#L259).
    
-2. Configure the [`brokerEntryMetadataInterceptors`](reference-configuration.md#broker) parameter and set the [`enableExposingBrokerEntryMetadataToClient`](reference-configuration.md#broker) parameter to `true` in the `broker.conf` file.
+2. Configure the [`brokerEntryMetadataInterceptors`](reference-configuration.md#broker) parameter and set the [`exposingBrokerEntryMetadataToClientEnabled`](reference-configuration-broker.md#exposingbrokerentrymetadatatoclientenabled) parameter to `true` in the `broker.conf` file.
 
 ## Message metadata
 

--- a/site2/website/versioned_docs/version-2.4.1/developing-binary-protocol.md
+++ b/site2/website/versioned_docs/version-2.4.1/developing-binary-protocol.md
@@ -52,24 +52,6 @@ Payload commands have this basic structure:
 | `metadata`                         | Required  | The message [metadata](#message-metadata) stored as a binary protobuf message               |                 |
 | `payload`                          | Required  | Anything left in the frame is considered the payload and can include any sequence of bytes  |                 |
 
-## Broker entry metadata
-
-Broker entry metadata is stored alongside the message metadata as a serialized protobuf message.
-It is created by the broker when the message arrived at the broker and passed without changes to the consumer if configured.
-
-| Field              | Required or optional       | Description                                                                                                                   |
-|:-------------------|:----------------|:------------------------------------------------------------------------------------------------------------------------------|
-| `broker_timestamp` | Optional        | The timestamp when a message arrived at the broker (`id est` as the number of milliseconds since January 1st, 1970 in UTC)      |
-| `index`            | Optional        | The index of the message. It is assigned by the broker.
-
-If you want to use broker entry metadata for **brokers**, configure the [`brokerEntryMetadataInterceptors`](reference-configuration.md#broker) parameter in the `broker.conf` file.
-
-If you want to use broker entry metadata for **consumers**:
-
-1. Use the client protocol version [18 or later](https://github.com/apache/pulsar/blob/ca37e67211feda4f7e0984e6414e707f1c1dfd07/pulsar-common/src/main/proto/PulsarApi.proto#L259).
-   
-2. Configure the [`brokerEntryMetadataInterceptors`](reference-configuration.md#broker) parameter and set the [`exposingBrokerEntryMetadataToClientEnabled`](reference-configuration-broker.md#exposingbrokerentrymetadatatoclientenabled) parameter to `true` in the `broker.conf` file.
-
 ## Message metadata
 
 Message metadata is stored alongside the application-specified payload as a serialized protobuf message. Metadata is created by the producer and passed without changes to the consumer.

--- a/site2/website/versioned_docs/version-2.4.2/developing-binary-protocol.md
+++ b/site2/website/versioned_docs/version-2.4.2/developing-binary-protocol.md
@@ -68,7 +68,7 @@ If you want to use broker entry metadata for **consumers**:
 
 1. Use the client protocol version [18 or later](https://github.com/apache/pulsar/blob/ca37e67211feda4f7e0984e6414e707f1c1dfd07/pulsar-common/src/main/proto/PulsarApi.proto#L259).
    
-2. Configure the [`brokerEntryMetadataInterceptors`](reference-configuration.md#broker) parameter and set the [`enableExposingBrokerEntryMetadataToClient`](reference-configuration.md#broker) parameter to `true` in the `broker.conf` file.
+2. Configure the [`brokerEntryMetadataInterceptors`](reference-configuration.md#broker) parameter and set the [`exposingBrokerEntryMetadataToClientEnabled`](reference-configuration-broker.md#exposingbrokerentrymetadatatoclientenabled) parameter to `true` in the `broker.conf` file.
 
 ## Message metadata
 

--- a/site2/website/versioned_docs/version-2.4.2/developing-binary-protocol.md
+++ b/site2/website/versioned_docs/version-2.4.2/developing-binary-protocol.md
@@ -52,24 +52,6 @@ Payload commands have this basic structure:
 | `metadata`                         | Required  | The message [metadata](#message-metadata) stored as a binary protobuf message               |                 |
 | `payload`                          | Required  | Anything left in the frame is considered the payload and can include any sequence of bytes  |                 |
 
-## Broker entry metadata
-
-Broker entry metadata is stored alongside the message metadata as a serialized protobuf message.
-It is created by the broker when the message arrived at the broker and passed without changes to the consumer if configured.
-
-| Field              | Required or optional       | Description                                                                                                                   |
-|:-------------------|:----------------|:------------------------------------------------------------------------------------------------------------------------------|
-| `broker_timestamp` | Optional        | The timestamp when a message arrived at the broker (`id est` as the number of milliseconds since January 1st, 1970 in UTC)      |
-| `index`            | Optional        | The index of the message. It is assigned by the broker.
-
-If you want to use broker entry metadata for **brokers**, configure the [`brokerEntryMetadataInterceptors`](reference-configuration.md#broker) parameter in the `broker.conf` file.
-
-If you want to use broker entry metadata for **consumers**:
-
-1. Use the client protocol version [18 or later](https://github.com/apache/pulsar/blob/ca37e67211feda4f7e0984e6414e707f1c1dfd07/pulsar-common/src/main/proto/PulsarApi.proto#L259).
-   
-2. Configure the [`brokerEntryMetadataInterceptors`](reference-configuration.md#broker) parameter and set the [`exposingBrokerEntryMetadataToClientEnabled`](reference-configuration-broker.md#exposingbrokerentrymetadatatoclientenabled) parameter to `true` in the `broker.conf` file.
-
 ## Message metadata
 
 Message metadata is stored alongside the application-specified payload as a serialized protobuf message. Metadata is created by the producer and passed without changes to the consumer.

--- a/site2/website/versioned_docs/version-2.5.0/developing-binary-protocol.md
+++ b/site2/website/versioned_docs/version-2.5.0/developing-binary-protocol.md
@@ -68,7 +68,7 @@ If you want to use broker entry metadata for **consumers**:
 
 1. Use the client protocol version [18 or later](https://github.com/apache/pulsar/blob/ca37e67211feda4f7e0984e6414e707f1c1dfd07/pulsar-common/src/main/proto/PulsarApi.proto#L259).
    
-2. Configure the [`brokerEntryMetadataInterceptors`](reference-configuration.md#broker) parameter and set the [`enableExposingBrokerEntryMetadataToClient`](reference-configuration.md#broker) parameter to `true` in the `broker.conf` file.
+2. Configure the [`brokerEntryMetadataInterceptors`](reference-configuration.md#broker) parameter and set the [`exposingBrokerEntryMetadataToClientEnabled`](reference-configuration-broker.md#exposingbrokerentrymetadatatoclientenabled) parameter to `true` in the `broker.conf` file.
 
 ## Message metadata
 

--- a/site2/website/versioned_docs/version-2.5.0/developing-binary-protocol.md
+++ b/site2/website/versioned_docs/version-2.5.0/developing-binary-protocol.md
@@ -52,24 +52,6 @@ Payload commands have this basic structure:
 | `metadata`                         | Required  | The message [metadata](#message-metadata) stored as a binary protobuf message               |                 |
 | `payload`                          | Required  | Anything left in the frame is considered the payload and can include any sequence of bytes  |                 |
 
-## Broker entry metadata
-
-Broker entry metadata is stored alongside the message metadata as a serialized protobuf message.
-It is created by the broker when the message arrived at the broker and passed without changes to the consumer if configured.
-
-| Field              | Required or optional       | Description                                                                                                                   |
-|:-------------------|:----------------|:------------------------------------------------------------------------------------------------------------------------------|
-| `broker_timestamp` | Optional        | The timestamp when a message arrived at the broker (`id est` as the number of milliseconds since January 1st, 1970 in UTC)      |
-| `index`            | Optional        | The index of the message. It is assigned by the broker.
-
-If you want to use broker entry metadata for **brokers**, configure the [`brokerEntryMetadataInterceptors`](reference-configuration.md#broker) parameter in the `broker.conf` file.
-
-If you want to use broker entry metadata for **consumers**:
-
-1. Use the client protocol version [18 or later](https://github.com/apache/pulsar/blob/ca37e67211feda4f7e0984e6414e707f1c1dfd07/pulsar-common/src/main/proto/PulsarApi.proto#L259).
-   
-2. Configure the [`brokerEntryMetadataInterceptors`](reference-configuration.md#broker) parameter and set the [`exposingBrokerEntryMetadataToClientEnabled`](reference-configuration-broker.md#exposingbrokerentrymetadatatoclientenabled) parameter to `true` in the `broker.conf` file.
-
 ## Message metadata
 
 Message metadata is stored alongside the application-specified payload as a serialized protobuf message. Metadata is created by the producer and passed without changes to the consumer.

--- a/site2/website/versioned_docs/version-2.8.x/developing-binary-protocol.md
+++ b/site2/website/versioned_docs/version-2.8.x/developing-binary-protocol.md
@@ -50,6 +50,17 @@ Payload commands have this basic structure:
 | metadata     | The message [metadata](#message-metadata) stored as a binary protobuf message               |                 |
 | payload      | Anything left in the frame is considered the payload and can include any sequence of bytes  |                 |
 
+## Broker entry metadata
+
+Broker entry metadata is stored alongside the message metadata as a serialized protobuf message.
+
+It is created by the broker when the message arrived at the broker and passed without changes to the consumer if configured.
+
+| Field              | Required or optional       | Description                                                                                                                   |
+|:-------------------|:----------------|:------------------------------------------------------------------------------------------------------------------------------|
+| `broker_timestamp` | Optional        | The timestamp when a message arrived at the broker (`id est` as the number of milliseconds since January 1st, 1970 in UTC)      |
+| `index`            | Optional        | The index of the message. It is assigned by the broker.
+
 ## Message metadata
 
 Message metadata is stored alongside the application-specified payload as a serialized protobuf message. Metadata is created by the producer and passed on unchanged to the consumer.

--- a/site2/website/versioned_docs/version-2.9.x/developing-binary-protocol.md
+++ b/site2/website/versioned_docs/version-2.9.x/developing-binary-protocol.md
@@ -50,6 +50,17 @@ Payload commands have this basic structure:
 | metadata     | The message [metadata](#message-metadata) stored as a binary protobuf message               |                 |
 | payload      | Anything left in the frame is considered the payload and can include any sequence of bytes  |                 |
 
+## Broker entry metadata
+
+Broker entry metadata is stored alongside the message metadata as a serialized protobuf message.
+
+It is created by the broker when the message arrived at the broker and passed without changes to the consumer if configured.
+
+| Field              | Required or optional       | Description                                                                                                                   |
+|:-------------------|:----------------|:------------------------------------------------------------------------------------------------------------------------------|
+| `broker_timestamp` | Optional        | The timestamp when a message arrived at the broker (`id est` as the number of milliseconds since January 1st, 1970 in UTC)      |
+| `index`            | Optional        | The index of the message. It is assigned by the broker.
+
 ## Message metadata
 
 Message metadata is stored alongside the application-specified payload as a serialized protobuf message. Metadata is created by the producer and passed on unchanged to the consumer.


### PR DESCRIPTION
Fix https://github.com/apache/pulsar/pull/13336#pullrequestreview-1068084883

I do not fix occurrences in `reference-configuration.md` because we're optimizing the workflow (trying to generate docs from code automatically for https://pulsar.apache.org/docs/next/reference-configuration)
- [x] `doc`
