### PR TITLE
[feature][functions] Add HTTP API and CLI to reload built-in functions

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/FunctionsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/FunctionsBase.java
@@ -734,6 +734,20 @@ public class FunctionsBase extends AdminResource {
         return functions().getListOfConnectors();
     }
 
+    @POST
+    @ApiOperation(
+            value = "Reload the built-in Functions"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(code = 401, message = "This operation requires super-user access"),
+            @ApiResponse(code = 503, message = "Function worker service is now initializing. Please try again later."),
+            @ApiResponse(code = 500, message = "Internal server error")
+    })
+    @Path("/builtins/reload")
+    public void reloadBuiltinFunctions() throws IOException {
+        functions().reloadBuiltinFunctions(clientAppId(), clientAuthData());
+    }
+
     @PUT
     @ApiOperation(value = "Updates a Pulsar Function on the worker leader", hidden = true)
     @ApiResponses(value = {

--- a/pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/admin/Functions.java
+++ b/pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/admin/Functions.java
@@ -893,4 +893,17 @@ public interface Functions {
      */
     CompletableFuture<Void> putFunctionStateAsync(
             String tenant, String namespace, String function, FunctionState state);
+
+    /**
+     * Reload the available built-in functions.
+     *
+     * @throws PulsarAdminException
+     *             Unexpected error
+     */
+    void reloadBuiltInFunctions() throws PulsarAdminException;
+
+    /**
+     * Reload the available built-in functions.
+     */
+    CompletableFuture<Void> reloadBuiltInFunctionsAsync();
 }

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/FunctionsImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/FunctionsImpl.java
@@ -841,4 +841,15 @@ public class FunctionsImpl extends ComponentResource implements Functions {
         }
         return future;
     }
+
+    @Override
+    public void reloadBuiltInFunctions() throws PulsarAdminException {
+        sync(this::reloadBuiltInFunctionsAsync);
+    }
+
+    @Override
+    public CompletableFuture<Void> reloadBuiltInFunctionsAsync() {
+        WebTarget path = functions.path("builtins/reload");
+        return asyncPostRequest(path, Entity.entity("", MediaType.APPLICATION_JSON));
+    }
 }

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdFunctions.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdFunctions.java
@@ -1200,6 +1200,15 @@ public class CmdFunctions extends CmdBase {
         }
     }
 
+    @Parameters(commandDescription = "Reload the available built-in functions")
+    public class ReloadBuiltInFunctions extends CmdFunctions.BaseCommand {
+
+        @Override
+        void runCmd() throws Exception {
+            getAdmin().functions().reloadBuiltInFunctions();
+        }
+    }
+
     public CmdFunctions(Supplier<PulsarAdmin> admin) throws PulsarClientException {
         super("functions", admin);
         localRunner = new LocalRunner();
@@ -1235,6 +1244,7 @@ public class CmdFunctions extends CmdBase {
         jcommander.addCommand("trigger", getTriggerer());
         jcommander.addCommand("upload", getUploader());
         jcommander.addCommand("download", getDownloader());
+        jcommander.addCommand("reload", new ReloadBuiltInFunctions());
     }
 
     @VisibleForTesting

--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/api/FunctionsImpl.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/api/FunctionsImpl.java
@@ -774,6 +774,19 @@ public class FunctionsImpl extends ComponentImpl implements Functions<PulsarWork
         }
     }
 
+    @Override
+    public void reloadBuiltinFunctions(String clientRole, AuthenticationDataSource authenticationData)
+        throws IOException {
+        if (!isWorkerServiceAvailable()) {
+            throwUnavailableException();
+        }
+
+        if (worker().getWorkerConfig().isAuthorizationEnabled() && !isSuperUser(clientRole, authenticationData)) {
+            throw new RestException(Response.Status.UNAUTHORIZED, "Client is not authorized to perform operation");
+        }
+        worker().getFunctionsManager().reloadFunctions(worker().getWorkerConfig());
+    }
+
     private Function.FunctionDetails validateUpdateRequestParams(final String tenant,
                                                                  final String namespace,
                                                                  final String componentName,

--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/api/v3/FunctionsApiV3Resource.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/api/v3/FunctionsApiV3Resource.java
@@ -353,6 +353,20 @@ public class FunctionsApiV3Resource extends FunctionApiResource {
         return functions().getListOfConnectors();
     }
 
+    @POST
+    @ApiOperation(
+        value = "Reload the built-in Functions"
+    )
+    @ApiResponses(value = {
+        @ApiResponse(code = 401, message = "This operation requires super-user access"),
+        @ApiResponse(code = 503, message = "Function worker service is now initializing. Please try again later."),
+        @ApiResponse(code = 500, message = "Internal server error")
+    })
+    @Path("/builtins/reload")
+    public void reloadBuiltinFunctions() throws IOException {
+        functions().reloadBuiltinFunctions(clientAppId(), clientAuthData());
+    }
+
     @GET
     @Path("/{tenant}/{namespace}/{functionName}/state/{key}")
     public FunctionState getFunctionState(final @PathParam("tenant") String tenant,

--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/service/api/Functions.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/service/api/Functions.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pulsar.functions.worker.service.api;
 
+import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
 import org.apache.pulsar.broker.authentication.AuthenticationDataHttps;
@@ -160,4 +161,7 @@ public interface Functions<W extends WorkerService> extends Component<W> {
                                                          String clientRole,
                                                          AuthenticationDataSource clientAuthenticationDataHttps);
 
+
+    void reloadBuiltinFunctions(String clientRole, AuthenticationDataSource clientAuthenticationDataHttps)
+        throws IOException;
 }


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://docs.google.com/document/d/1d8Pw6ZbWk-_pCKdOmdvx9rnhPiyuxwq60_TrD68d7BA/edit#heading=h.trs9rsex3xom)*. 

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.

**(The sections below can be removed for hotfixes of typos)**
-->
### Motivation

After adding a nar to the `functions` directory, it is handy to be able to reload the built-in functions in the broker or function worker.
This is the same as `pulsar-admin sinks/sources reload` but for functions.

### Modifications

* Add HTTP endpoint `/admin/v3/functions/builtins/reload` to reload the built-in functions.
* Add Java PulsarAdmin  methods `reloadBuiltInFunctions` and `reloadBuiltInFunctionsAsync` to reload the built-in functions.
* Add CLI command `functions reload` to reload the built-in functions.

### Does this pull request potentially affect one of the following parts:

yes

*If `yes` was chosen, please highlight the changes*

  - The public API: yes
  - The rest endpoints: yes
  - The admin cli options: yes

### Documentation

Check the box below or label this PR directly.

Need to update docs? 

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)
  
- [x] `doc-not-needed` 
the doc is autogenerated
  
- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)