### PR TITLE
[fix][broker] Duplicate ByteBuffer when Caching Backlogged Consumers

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/cache/RangeEntryCacheImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/cache/RangeEntryCacheImpl.java
@@ -309,7 +309,9 @@ public class RangeEntryCacheImpl implements EntryCache {
                                 entriesToReturn.add(entry);
                                 totalSize += entry.getLength();
                                 if (shouldCacheEntry) {
-                                    insert(entry);
+                                    EntryImpl cacheEntry = EntryImpl.create(entry);
+                                    insert(cacheEntry);
+                                    cacheEntry.release();
                                 }
                             }
 


### PR DESCRIPTION
Fixes #16979 

### Motivation

https://github.com/apache/pulsar/pull/12258 introduced caching for backlogged consumers. When caching the entry, it is important to duplicate the `ByteBuffer` so that the reader index is not shared. The current code has a race condition where the `ByteBuffer` reference in the cache is shared with the dispatcher. When another consumer reads from the cache, the cache calls `duplicate()` on the shared `ByteBuffer`, which copies the current reader index, which might not be 0 if the original dispatcher read data from the `ByteBuffer`.

Note: it seems like the caching `insert` method creates (or recycles) more `EntryImpl` instances than is really necessary. Changing that is outside this PR's scope, so I am going to leave it as is.

### Modifications

* Create a new `Entry` before inserting it into the cache.
* Add a new test to the `EntryCacheTest`. The test fails before this change and passes after it.
* Update the `EntryCacheTest` mocking so that it returns unique entries when mocking reads from the bookkeeper. Before, all returned `LedgerEntry` objects had ledgerId 0 and entryId 0, which messed with the caching for the new test.

### Verifying this change

This change includes a test that failed before the PR and passes after it.

### Documentation

- [x] `doc-not-needed` 