### PR TITLE
[imp][managed-ledger] Optimize getting ledger and entry id from entry

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
@@ -2288,9 +2288,7 @@ public class ManagedCursorImpl implements ManagedCursor {
             } else {
                 // Remove from the entry list all the entries that were already marked for deletion
                 return Lists.newArrayList(Collections2.filter(entries, entry -> {
-                    boolean includeEntry = !individualDeletedMessages.contains(
-                            ((PositionImpl) entry.getPosition()).getLedgerId(),
-                            ((PositionImpl) entry.getPosition()).getEntryId());
+                    boolean includeEntry = !individualDeletedMessages.contains(entry.getLedgerId(), entry.getEntryId());
                     if (!includeEntry) {
                         if (log.isDebugEnabled()) {
                             log.debug("[{}] [{}] Filtering entry at {} - already deleted", ledger.getName(), name,


### PR DESCRIPTION
### Motivation

Minor optimization. The implementation of `getPosition` involves creating a `PositionImpl` object. We don't need to create that object because we have access to the `ledgerId` and the `entryId`.

https://github.com/apache/pulsar/blob/76f41957d3b388d62067704ceb1b693dbd3e372d/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/EntryImpl.java#L134-L137

### Modifications

* Remove unnecessary `getPosition()` call.

### Verifying this change

This change is a trivial rework / code cleanup without any test coverage.


### Documentation

- [x] `doc-not-needed` 