### PR TITLE
[fix][flaky-test]ConsumedLedgersTrimTest

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ConsumedLedgersTrimTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ConsumedLedgersTrimTest.java
@@ -54,6 +54,13 @@ public class ConsumedLedgersTrimTest extends BrokerTestBase {
         super.internalCleanup();
     }
 
+    @Override
+    protected void doInitConf() throws Exception {
+        super.doInitConf();
+        super.conf.setDefaultRetentionSizeInMB(-1);
+        super.conf.setDefaultRetentionTimeInMinutes(-1);
+    }
+
     @Test
     public void TestConsumedLedgersTrim() throws Exception {
         conf.setRetentionCheckIntervalInSeconds(1);
@@ -96,7 +103,6 @@ public class ConsumedLedgersTrimTest extends BrokerTestBase {
             assertNotNull(msg);
             consumer.acknowledge(msg);
         }
-        Assert.assertEquals(managedLedger.getLedgersInfoAsList().size(), msgNum / 2);
 
         //no traffic, but consumed ledger will be cleaned
         Thread.sleep(1500);
@@ -123,7 +129,7 @@ public class ConsumedLedgersTrimTest extends BrokerTestBase {
         PersistentTopic persistentTopic = (PersistentTopic) pulsar.getBrokerService().getOrCreateTopic(topicName).get();
         ManagedLedgerConfig managedLedgerConfig = persistentTopic.getManagedLedger().getConfig();
         managedLedgerConfig.setRetentionSizeInMB(-1);
-        managedLedgerConfig.setRetentionTime(1, TimeUnit.SECONDS);
+        managedLedgerConfig.setRetentionTime(-1, TimeUnit.SECONDS);
         managedLedgerConfig.setMaxEntriesPerLedger(1000);
         managedLedgerConfig.setMinimumRolloverTime(1, TimeUnit.MILLISECONDS);
         MessageId initialMessageId = persistentTopic.getLastMessageId().get();
@@ -150,15 +156,15 @@ public class ConsumedLedgersTrimTest extends BrokerTestBase {
         assertEquals(messageIdAfterRestart, messageIdBeforeRestart);
 
         persistentTopic = (PersistentTopic) pulsar.getBrokerService().getOrCreateTopic(topicName).get();
+        managedLedger = (ManagedLedgerImpl) persistentTopic.getManagedLedger();
+        // now we have two ledgers, the first is expired but is contains the lastMessageId
+        // the second is empty and should be kept as it is the current tail
+        Assert.assertEquals(managedLedger.getLedgersInfoAsList().size(), 2);
         managedLedgerConfig = persistentTopic.getManagedLedger().getConfig();
         managedLedgerConfig.setRetentionSizeInMB(-1);
         managedLedgerConfig.setRetentionTime(1, TimeUnit.SECONDS);
         managedLedgerConfig.setMaxEntriesPerLedger(1);
         managedLedgerConfig.setMinimumRolloverTime(1, TimeUnit.MILLISECONDS);
-        managedLedger = (ManagedLedgerImpl) persistentTopic.getManagedLedger();
-        // now we have two ledgers, the first is expired but is contains the lastMessageId
-        // the second is empty and should be kept as it is the current tail
-        Assert.assertEquals(managedLedger.getLedgersInfoAsList().size(), 2);
 
         // force trimConsumedLedgers
         Thread.sleep(3000);


### PR DESCRIPTION
Fixes 
- #11145 
- #10380
- #17044

Master Issue: #11145 #10380 #17044

### Motivation

https://github.com/apache/pulsar/blob/4d7b1acff35a1a131ffeff34e8cec6007f6a2ec9/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ConsumedLedgersTrimTest.java#L145-L150

In addition to calling `internalTrimLedgers` directly in this unit test, the Broker also has scheduled tasks `consumedLedgersMonitor` calling `internalTrimLedgers`.

(<strong>High light</strong>)See the code above, If `consumedLedgersMonitor` call `internalTrimLedgers` before `line:148`:
 the command `topics.getLastMessageId` will return `-1:-1:-1`, then the #11145 #10380 occurs.


https://github.com/apache/pulsar/blob/4d7b1acff35a1a131ffeff34e8cec6007f6a2ec9/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ConsumedLedgersTrimTest.java#L152-L161

(<strong>High light</strong>)See the code above, If `consumedLedgersMonitor` call `internalTrimLedgers` before `line:161`:
 the command `managedLedger.getLedgersInfoAsList().size()` will return `1`, then the #17044 occurs.

### Modifications

- Fix flaky test: Make `internalTrimLedgers` never trigger by `consumedLedgersMonitor` before `consumedLedgersMonitor` is triggered manually: disabled policy retention.

https://github.com/apache/pulsar/blob/4d7b1acff35a1a131ffeff34e8cec6007f6a2ec9/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ConsumedLedgersTrimTest.java#L94-L99

- Try to solve another hidden Falky test: See the code above, I think `line:99` may be flaky, because we can't guarantee that `consumedLedgersMonitor --> internalTrimLedgers` will be executed later than `line:99`, so delete `line:99`


### Documentation

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)
  
- [x] `doc-not-needed` 
(Please explain why)
  
- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)