### PR TITLE
[fix][functions] Make mandatory to provide a schema in Context::newOutputRecordBuilder

### DIFF
--- a/pulsar-functions/api-java/src/main/java/org/apache/pulsar/functions/api/Context.java
+++ b/pulsar-functions/api-java/src/main/java/org/apache/pulsar/functions/api/Context.java
@@ -169,8 +169,10 @@ public interface Context extends BaseContext {
      * Creates a FunctionRecordBuilder initialized with values from this Context.
      * It can be used in Functions to prepare a Record to return with default values taken from the Context and the
      * input Record.
-     *
+
+     * @param schema provide a way to convert between serialized data and domain objects
+     * @param <X> the message type of record builder
      * @return the record builder instance
      */
-    <X> FunctionRecord.FunctionRecordBuilder<X> newOutputRecordBuilder();
+    <X> FunctionRecord.FunctionRecordBuilder<X> newOutputRecordBuilder(Schema<X> schema);
 }

--- a/pulsar-functions/api-java/src/main/java/org/apache/pulsar/functions/api/utils/FunctionRecord.java
+++ b/pulsar-functions/api-java/src/main/java/org/apache/pulsar/functions/api/utils/FunctionRecord.java
@@ -49,11 +49,15 @@ public class FunctionRecord<T> implements Record<T> {
      * @param <T> type of Record to build
      * @return a Record builder initialised with values from the Function Context
      */
-     public static <T> FunctionRecord.FunctionRecordBuilder<T> from(Context context) {
+    public static <T> FunctionRecord.FunctionRecordBuilder<T> from(Context context, Schema<T> schema) {
+        if (schema == null) {
+            throw new IllegalArgumentException("Schema should not be null.");
+        }
         Record<?> currentRecord = context.getCurrentRecord();
         FunctionRecordBuilder<T> builder = new FunctionRecordBuilder<T>()
-                .destinationTopic(context.getOutputTopic())
-                .properties(currentRecord.getProperties());
+            .schema(schema)
+            .destinationTopic(context.getOutputTopic())
+            .properties(currentRecord.getProperties());
         currentRecord.getTopicName().ifPresent(builder::topicName);
         currentRecord.getKey().ifPresent(builder::key);
         currentRecord.getEventTime().ifPresent(builder::eventTime);

--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/ContextImpl.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/ContextImpl.java
@@ -491,8 +491,8 @@ class ContextImpl implements Context, SinkContext, SourceContext, AutoCloseable 
     }
 
     @Override
-    public <X> FunctionRecord.FunctionRecordBuilder<X> newOutputRecordBuilder() {
-        return FunctionRecord.from(this);
+    public <X> FunctionRecord.FunctionRecordBuilder<X> newOutputRecordBuilder(Schema<X> schema) {
+        return FunctionRecord.from(this, schema);
     }
 
     @Override

--- a/pulsar-functions/instance/src/test/java/org/apache/pulsar/functions/instance/ContextImplTest.java
+++ b/pulsar-functions/instance/src/test/java/org/apache/pulsar/functions/instance/ContextImplTest.java
@@ -423,7 +423,8 @@ public class ContextImplTest {
                 return properties;
             }
         });
-        Record<Integer> record = context.<Integer>newOutputRecordBuilder().build();
+        Record<Integer> record = context.newOutputRecordBuilder(Schema.INT32).build();
+        assertEquals(record.getSchema(), Schema.INT32);
         assertEquals(record.getTopicName().get(), "input-topic");
         assertEquals(record.getKey().get(), "input-key");
         assertEquals(record.getEventTime(), Optional.of(now));
@@ -433,6 +434,5 @@ public class ContextImplTest {
         assertTrue(record.getProperties().containsKey("prop-key"));
         assertEquals(record.getProperties().get("prop-key"), "prop-value");
         assertNull(record.getValue());
-        assertNull(record.getSchema());
     }
 }

--- a/pulsar-functions/java-examples/src/main/java/org/apache/pulsar/functions/api/examples/RecordFunction.java
+++ b/pulsar-functions/java-examples/src/main/java/org/apache/pulsar/functions/api/examples/RecordFunction.java
@@ -20,6 +20,7 @@ package org.apache.pulsar.functions.api.examples;
 
 import java.util.HashMap;
 import java.util.Map;
+import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.functions.api.Context;
 import org.apache.pulsar.functions.api.Function;
 import org.apache.pulsar.functions.api.Record;
@@ -34,7 +35,7 @@ public class RecordFunction implements Function<String, Record<String>> {
         Map<String, String> properties = new HashMap<>(context.getCurrentRecord().getProperties());
         context.getCurrentRecord().getTopicName().ifPresent(topic -> properties.put("input_topic", topic));
 
-        return context.<String>newOutputRecordBuilder()
+        return context.newOutputRecordBuilder(Schema.STRING)
                 .destinationTopic(publishTopic)
                 .value(output)
                 .properties(properties)


### PR DESCRIPTION
Fixes #17114

### Modifications

Change `newOutputRecordBuilder` to `newOutputRecordBuilder(Schema<X> schema)`

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change is already covered by existing tests, such as ContextImplTest and PulsarFunctionsJavaTest::testRecordFunctionTest

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - The public API: yes

### Documentation

Check the box below or label this PR directly.

Need to update docs? 

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)
  
- [x] `doc-not-needed` 
fix
  
- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)