### PR TITLE
[refactor][proxy] remove empty else code block when initialize setMetadataStoreUrl 

### DIFF
--- a/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/ProxyServiceStarter.java
+++ b/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/ProxyServiceStarter.java
@@ -136,14 +136,13 @@ public class ProxyServiceStarter {
             // load config file
             config = PulsarConfigurationLoader.create(configFile, ProxyConfiguration.class);
 
+            if (!isBlank(zookeeperServers)) {
+                // Use zookeeperServers from command line
+                config.setMetadataStoreUrl(zookeeperServers);
+            }
             if (!isBlank(metadataStoreUrl)) {
                 // Use metadataStoreUrl from command line
                 config.setMetadataStoreUrl(metadataStoreUrl);
-            } else if (!isBlank(zookeeperServers)){
-                // Use zookeeperServers from command line if metadataStoreUrl is empty;
-                config.setMetadataStoreUrl(zookeeperServers);
-            } else {
-                // use "metadataStoreUrl" property in "proxy.conf".
             }
 
             if (!isBlank(globalZookeeperServers)) {


### PR DESCRIPTION
### Motivation

Minor update for proxy `metadataStoreUrl` configuration
Current code of initializing the MetadataStoreUrl
```java
if (!isBlank(metadataStoreUrl)) {
                // Use metadataStoreUrl from command line
                config.setMetadataStoreUrl(metadataStoreUrl);
            } else if (!isBlank(zookeeperServers)){
                // Use zookeeperServers from command line if metadataStoreUrl is empty;
                config.setMetadataStoreUrl(zookeeperServers);
            } else {
                // use "metadataStoreUrl" property in "proxy.conf".
            }
```
is confusing because the final else is empty.


### Modifications

The priority should be :
1. command line parameters(`zookeeperServers` or `metadataStoreUrl`) have a higher priority than `proxy.conf`
2. if both `zookeeperServers` and `metadataStoreUrl` are provided from the command line, `metadataStoreUrl` has a higher priority
3. if neither `zookeeperServers` nor `metadataStoreUrl` is provided from the command line, use the configuration from `proxy.conf`
So, we can modify the initialization like
```java
          if (!isBlank(zookeeperServers)) {
                // Use zookeeperServers from command line
                config.setMetadataStoreUrl(zookeeperServers);
            }
            if (!isBlank(metadataStoreUrl)) {
                // Use metadataStoreUrl from command line
                config.setMetadataStoreUrl(metadataStoreUrl);
            }
```

### Documentation

- [x] `doc-not-needed` 

 