### PR TITLE
[fix][function] Use the schema set by the Function when it returns a Record

### DIFF
--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/AbstractSinkRecord.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/AbstractSinkRecord.java
@@ -40,6 +40,8 @@ public abstract class AbstractSinkRecord<T> implements Record<T> {
 
     public abstract boolean shouldAlwaysSetMessageProperties();
 
+    public abstract boolean shouldSetSchema();
+
     public Record<?> getSourceRecord() {
         return sourceRecord;
     }

--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/OutputRecordSinkRecord.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/OutputRecordSinkRecord.java
@@ -28,7 +28,7 @@ import org.apache.pulsar.functions.api.Record;
 
 @EqualsAndHashCode(callSuper = true)
 @ToString
-class OutputRecordSinkRecord<T> extends AbstractSinkRecord<T> {
+public class OutputRecordSinkRecord<T> extends AbstractSinkRecord<T> {
 
     private final Record<T> sinkRecord;
 
@@ -89,6 +89,11 @@ class OutputRecordSinkRecord<T> extends AbstractSinkRecord<T> {
 
     @Override
     public boolean shouldAlwaysSetMessageProperties() {
+        return true;
+    }
+
+    @Override
+    public boolean shouldSetSchema() {
         return true;
     }
 }

--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/SinkRecord.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/SinkRecord.java
@@ -25,6 +25,7 @@ import lombok.ToString;
 import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.functions.api.Record;
+import org.apache.pulsar.functions.source.PulsarRecord;
 
 @EqualsAndHashCode(callSuper = true)
 @ToString
@@ -91,5 +92,10 @@ public class SinkRecord<T> extends AbstractSinkRecord<T> {
     @Override
     public boolean shouldAlwaysSetMessageProperties() {
         return false;
+    }
+
+    @Override
+    public boolean shouldSetSchema() {
+        return !(sourceRecord instanceof PulsarRecord);
     }
 }

--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/sink/PulsarSink.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/sink/PulsarSink.java
@@ -236,8 +236,9 @@ public class PulsarSink<T> implements Sink<T> {
         @Override
         public TypedMessageBuilder<T> newMessage(AbstractSinkRecord<T> record) {
             Schema<T> schemaToWrite = record.getSchema();
-            if (record.getSourceRecord() instanceof PulsarRecord) {
+            if (!record.shouldSetSchema()) {
                 // we are receiving data directly from another Pulsar topic
+                // and the Function return type is not a Record
                 // we must use the destination topic schema
                 schemaToWrite = schema;
             }
@@ -304,8 +305,9 @@ public class PulsarSink<T> implements Sink<T> {
                         "PartitionId needs to be specified for every record while in Effectively-once mode");
             }
             Schema<T> schemaToWrite = record.getSchema();
-            if (record.getSourceRecord() instanceof PulsarRecord) {
+            if (!record.shouldSetSchema()) {
                 // we are receiving data directly from another Pulsar topic
+                // and the Function return type is not a Record
                 // we must use the destination topic schema
                 schemaToWrite = schema;
             }

--- a/tests/docker-images/java-test-functions/src/main/java/org/apache/pulsar/tests/integration/functions/RemoveAvroFieldRecordFunction.java
+++ b/tests/docker-images/java-test-functions/src/main/java/org/apache/pulsar/tests/integration/functions/RemoveAvroFieldRecordFunction.java
@@ -1,0 +1,164 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.tests.integration.functions;
+
+import java.io.ByteArrayOutputStream;
+import java.util.stream.Collectors;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericDatumWriter;
+import org.apache.avro.io.BinaryEncoder;
+import org.apache.avro.io.EncoderFactory;
+import org.apache.pulsar.client.api.Schema;
+import org.apache.pulsar.client.api.schema.GenericObject;
+import org.apache.pulsar.client.api.schema.GenericRecord;
+import org.apache.pulsar.client.api.schema.KeyValueSchema;
+import org.apache.pulsar.common.schema.KeyValue;
+import org.apache.pulsar.common.schema.SchemaType;
+import org.apache.pulsar.functions.api.Context;
+import org.apache.pulsar.functions.api.Function;
+import org.apache.pulsar.functions.api.Record;
+
+/**
+ * This function removes a "field" from a AVRO message.
+ */
+@Slf4j
+public class RemoveAvroFieldRecordFunction implements Function<GenericObject, Record<GenericObject>> {
+
+    private static final String FIELD_TO_REMOVE = "age";
+
+    @Override
+    public Record<GenericObject> process(GenericObject genericObject, Context context) throws Exception {
+        Record<?> currentRecord = context.getCurrentRecord();
+        log.info("apply to {} {}", genericObject, genericObject.getNativeObject());
+        log.info("record with schema {} version {} {}", currentRecord.getSchema(),
+            currentRecord.getMessage().get().getSchemaVersion(),
+            currentRecord);
+        Object nativeObject = genericObject.getNativeObject();
+        Schema<?> schema = currentRecord.getSchema();
+
+        Schema outputSchema = schema;
+        Object outputObject = genericObject.getNativeObject();
+        boolean someThingDone = false;
+        if (schema instanceof KeyValueSchema && nativeObject instanceof KeyValue) {
+            KeyValueSchema kvSchema = (KeyValueSchema) schema;
+
+            Schema keySchema = kvSchema.getKeySchema();
+            Schema valueSchema = kvSchema.getValueSchema();
+            // remove a column "age" from the "valueSchema"
+            if (valueSchema.getSchemaInfo().getType() == SchemaType.AVRO) {
+
+                org.apache.avro.Schema avroSchema = (org.apache.avro.Schema) valueSchema.getNativeSchema().get();
+                if (avroSchema.getField(FIELD_TO_REMOVE) != null) {
+                    org.apache.avro.Schema.Parser parser = new org.apache.avro.Schema.Parser();
+                    org.apache.avro.Schema originalAvroSchema = parser.parse(avroSchema.toString(false));
+                    org.apache.avro.Schema modified = org.apache.avro.Schema.createRecord(
+                        originalAvroSchema.getName(), originalAvroSchema.getDoc(), originalAvroSchema.getNamespace(),
+                        originalAvroSchema.isError(),
+                        originalAvroSchema.getFields().
+                            stream()
+                            .filter(f -> !f.name().equals(FIELD_TO_REMOVE))
+                            .map(f -> new org.apache.avro.Schema.Field(f.name(), f.schema(), f.doc(), f.defaultVal(),
+                                f.order()))
+                            .collect(Collectors.toList()));
+
+                    KeyValue originalObject = (KeyValue) nativeObject;
+
+                    GenericRecord value = (GenericRecord) originalObject.getValue();
+                    org.apache.avro.generic.GenericRecord genericRecord =
+                        (org.apache.avro.generic.GenericRecord) value.getNativeObject();
+
+                    org.apache.avro.generic.GenericRecord newRecord = new GenericData.Record(modified);
+                    for (org.apache.avro.Schema.Field field : modified.getFields()) {
+                        newRecord.put(field.name(), genericRecord.get(field.name()));
+                    }
+                    GenericDatumWriter writer = new GenericDatumWriter(modified);
+                    ByteArrayOutputStream oo = new ByteArrayOutputStream();
+                    BinaryEncoder encoder = EncoderFactory.get().directBinaryEncoder(oo, null);
+                    writer.write(newRecord, encoder);
+                    Object newValue = oo.toByteArray();
+
+                    Schema newValueSchema = Schema.NATIVE_AVRO(modified);
+                    outputSchema = Schema.KeyValue(keySchema, newValueSchema, kvSchema.getKeyValueEncodingType());
+                    outputObject = new KeyValue(originalObject.getKey(), newValue);
+                    someThingDone = true;
+                }
+            }
+        } else if (schema.getSchemaInfo().getType() == SchemaType.AVRO) {
+            org.apache.avro.Schema avroSchema = (org.apache.avro.Schema) schema.getNativeSchema().get();
+            if (avroSchema.getField(FIELD_TO_REMOVE) != null) {
+                org.apache.avro.Schema.Parser parser = new org.apache.avro.Schema.Parser();
+                org.apache.avro.Schema originalAvroSchema = parser.parse(avroSchema.toString(false));
+                org.apache.avro.Schema modified = org.apache.avro.Schema.createRecord(
+                    originalAvroSchema.getName(), originalAvroSchema.getDoc(), originalAvroSchema.getNamespace(),
+                    originalAvroSchema.isError(),
+                    originalAvroSchema.getFields().
+                        stream()
+                        .filter(f -> !f.name().equals(FIELD_TO_REMOVE))
+                        .map(f -> new org.apache.avro.Schema.Field(f.name(), f.schema(), f.doc(), f.defaultVal(),
+                            f.order()))
+                        .collect(Collectors.toList()));
+
+                org.apache.avro.generic.GenericRecord genericRecord =
+                    (org.apache.avro.generic.GenericRecord) nativeObject;
+                org.apache.avro.generic.GenericRecord newRecord = new GenericData.Record(modified);
+                for (org.apache.avro.Schema.Field field : modified.getFields()) {
+                    newRecord.put(field.name(), genericRecord.get(field.name()));
+                }
+                GenericDatumWriter writer = new GenericDatumWriter(modified);
+                ByteArrayOutputStream oo = new ByteArrayOutputStream();
+                BinaryEncoder encoder = EncoderFactory.get().directBinaryEncoder(oo, null);
+                writer.write(newRecord, encoder);
+
+                Schema newValueSchema = Schema.NATIVE_AVRO(modified);
+                outputSchema = newValueSchema;
+                outputObject = oo.toByteArray();
+                someThingDone = true;
+            }
+        }
+
+        if (!someThingDone) {
+            // do some processing...
+            final boolean isStruct;
+            switch (currentRecord.getSchema().getSchemaInfo().getType()) {
+                case AVRO:
+                case JSON:
+                case PROTOBUF_NATIVE:
+                    isStruct = true;
+                    break;
+                default:
+                    isStruct = false;
+                    break;
+            }
+            if (isStruct) {
+                // GenericRecord must stay wrapped
+                outputObject = currentRecord.getValue();
+            } else {
+                // primitives and KeyValue must be unwrapped
+                outputObject = nativeObject;
+            }
+        }
+        log.info("output {} schema {}", outputObject, outputSchema);
+
+        return context.newOutputRecordBuilder()
+            .schema(outputSchema)
+            .value(outputObject)
+            .build();
+    }
+}

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/functions/PulsarFunctionsTestBase.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/functions/PulsarFunctionsTestBase.java
@@ -48,6 +48,9 @@ public abstract class PulsarFunctionsTestBase extends PulsarTestSuite {
     public static final String REMOVE_AVRO_FIELD_FUNCTION_JAVA_CLASS =
             "org.apache.pulsar.tests.integration.functions.RemoveAvroFieldFunction";
 
+    public static final String REMOVE_AVRO_FIELD_RECORD_FUNCTION_JAVA_CLASS =
+        "org.apache.pulsar.tests.integration.functions.RemoveAvroFieldRecordFunction";
+
     public static final String SERDE_JAVA_CLASS =
             "org.apache.pulsar.functions.api.examples.CustomBaseToBaseFunction";
 

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/functions/java/PulsarFunctionsJavaTest.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/functions/java/PulsarFunctionsJavaTest.java
@@ -174,8 +174,13 @@ public class PulsarFunctionsJavaTest extends PulsarFunctionsTest {
     }
 
     @Test(groups = {"java_function", "function"})
-    public void testGenericObjectRemoveFiledFunction() throws Exception {
+    public void testGenericObjectRemoveFieldFunction() throws Exception {
         testGenericObjectFunction(REMOVE_AVRO_FIELD_FUNCTION_JAVA_CLASS, true, false);
+    }
+
+    @Test(groups = {"java_function", "function"})
+    public void testGenericObjectRemoveFieldRecordFunction() throws Exception {
+        testGenericObjectFunction(REMOVE_AVRO_FIELD_RECORD_FUNCTION_JAVA_CLASS, true, false);
     }
 
     @Test(groups = {"java_function", "function"})
@@ -184,8 +189,13 @@ public class PulsarFunctionsJavaTest extends PulsarFunctionsTest {
     }
 
     @Test(groups = {"java_function", "function"})
-    public void testGenericObjectRemoveFiledFunctionKeyValue() throws Exception {
+    public void testGenericObjectRemoveFieldFunctionKeyValue() throws Exception {
         testGenericObjectFunction(REMOVE_AVRO_FIELD_FUNCTION_JAVA_CLASS, true, true);
+    }
+
+    @Test(groups = {"java_function", "function"})
+    public void testGenericObjectRemoveFieldRecordFunctionKeyValue() throws Exception {
+        testGenericObjectFunction(REMOVE_AVRO_FIELD_RECORD_FUNCTION_JAVA_CLASS, true, true);
     }
 
     @Test(groups = {"java_function", "function"})


### PR DESCRIPTION
### Motivation

Currently the schema set by a Function returning a Record is not taken into account.

### Modifications

Don't set the schema to the initialized Sink Schema if the record is a OutputRecordSinkRecord

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change added tests and can be verified as follows:

* testGenericObjectRemoveFieldRecordFunction
* testGenericObjectRemoveFieldRecordFunctionKeyValue

### Does this pull request potentially affect one of the following parts:

no

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API: (yes / no)
  - The schema: (yes / no / don't know)
  - The default values of configurations: (yes / no)
  - The wire protocol: (yes / no)
  - The rest endpoints: (yes / no)
  - The admin cli options: (yes / no)
  - Anything that affects deployment: (yes / no / don't know)

### Documentation

Check the box below or label this PR directly.

Need to update docs? 

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)
  
- [x] `doc-not-needed` 
it's a fix
  
- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)