### PR TITLE
[fix][broker] Streaming dispatcher stuck after reading the first entry with SHARED subscriptions

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumers.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumers.java
@@ -114,7 +114,7 @@ public class PersistentDispatcherMultipleConsumers extends AbstractDispatcherMul
                     "blockedDispatcherOnUnackedMsgs");
     protected Optional<DispatchRateLimiter> dispatchRateLimiter = Optional.empty();
     private AtomicBoolean isRescheduleReadInProgress = new AtomicBoolean(false);
-    private final ExecutorService dispatchMessagesThread;
+    protected final ExecutorService dispatchMessagesThread;
     private final SharedConsumerAssignor assignor;
 
     protected enum ReadType {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentStreamingDispatcherMultipleConsumers.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentStreamingDispatcherMultipleConsumers.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pulsar.broker.service.persistent;
 
+import static org.apache.bookkeeper.mledger.util.SafeRun.safeRun;
 import com.google.common.collect.Lists;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
@@ -35,8 +36,6 @@ import org.apache.pulsar.broker.service.Subscription;
 import org.apache.pulsar.broker.service.streamingdispatch.PendingReadEntryRequest;
 import org.apache.pulsar.broker.service.streamingdispatch.StreamingDispatcher;
 import org.apache.pulsar.broker.service.streamingdispatch.StreamingEntryReader;
-
-import static org.apache.bookkeeper.mledger.util.SafeRun.safeRun;
 
 /**
  * A {@link PersistentDispatcherMultipleConsumers} implemented {@link StreamingDispatcher}.


### PR DESCRIPTION
NOTE: THIS BUG IS NOT IN ANY RELEASED VERSION OF PULSAR.

### Motivation
While using a streaming dispatcher (`streamingDispatch=true`), the consumer (with a shared subscription) is stuck and it's not able to fully read a topic. That is because after the an entry is read, the `readMoreEntries` method is not triggered anymore. This is a regression introduced in https://github.com/apache/pulsar/pull/16968

### Modifications
* Aligned the new usage of the method `sendMessagesToConsumers` in the `PersistentStreamingDispatcherMultipleConsumers` in the same way it's used in `PersistentDispatcherMultipleConsumers`
* Implemented the option `DispatcherDispatchMessagesInSubscriptionThread` also in the streaming dispatcher - this might be done in another pull but it's a very tiny change - follow up of https://github.com/apache/pulsar/pull/16603

The evidence of this bug is that the test a several tests with streaming enabled [are failing](https://github.com/apache/pulsar/runs/7864993203#r6) but since they are in the flaky section, they have been ignored. Now these tests are passing 

- [x] `doc-not-needed` 