### PR TITLE
[fix][tests] Fix the flaky test MultiTopicsConsumerImplTest.testParallelSubscribeAsync

### DIFF
--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/MultiTopicsConsumerImplTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/MultiTopicsConsumerImplTest.java
@@ -126,7 +126,7 @@ public class MultiTopicsConsumerImplTest {
     //
     // Code under tests is using CompletableFutures. Theses may hang indefinitely if code is broken.
     // That's why a test timeout is defined.
-    @Test(timeOut = 5000)
+    @Test(timeOut = 10000)
     public void testParallelSubscribeAsync() throws Exception {
         String topicName = "parallel-subscribe-async-topic";
         MultiTopicsConsumerImpl<byte[]> impl = createMultiTopicsConsumer();


### PR DESCRIPTION
### Motivation

It fails several times for elapsing over 5s... Maybe we can change the timeout from 5s to 10s.
```
Error:  Tests run: 9, Failures: 2, Errors: 0, Skipped: 3, Time elapsed: 21.724 s <<< FAILURE! - in org.apache.pulsar.client.impl.MultiTopicsConsumerImplTest
Error:  testParallelSubscribeAsync(org.apache.pulsar.client.impl.MultiTopicsConsumerImplTest)  Time elapsed: 5.05 s  <<< FAILURE!
  org.testng.internal.thread.ThreadTimeoutException: Method org.apache.pulsar.client.impl.MultiTopicsConsumerImplTest.testParallelSubscribeAsync() didn't finish within the time-out 5000
  	at org.testng.internal.MethodInvocationHelper.invokeWithTimeoutWithNewExecutor(MethodInvocationHelper.java:371)
  	at org.testng.internal.MethodInvocationHelper.invokeWithTimeout(MethodInvocationHelper.java:282)
  	at org.testng.internal.TestInvoker.invokeMethod(TestInvoker.java:605)
  	at org.testng.internal.TestInvoker.retryFailed(TestInvoker.java:214)
  	at org.testng.internal.MethodRunner.runInSequence(MethodRunner.java:58)
```


https://github.com/apache/pulsar/runs/7875666006?check_suite_focus=true#step:10:3683
https://github.com/apache/pulsar/runs/7875666006?check_suite_focus=true#step:10:3684
https://github.com/apache/pulsar/runs/7875666006?check_suite_focus=true#step:10:3685
https://github.com/apache/pulsar/runs/7875666006?check_suite_focus=true#step:10:3686
https://github.com/apache/pulsar/runs/7875666006?check_suite_focus=true#step:10:3687


### Documentation

- [x] `doc-not-needed` 
