### PR TITLE
[fix][broker]fix arithmetic exception for LeastResourceUsageWithWeight strategy

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/LeastResourceUsageWithWeight.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/LeastResourceUsageWithWeight.java
@@ -39,6 +39,7 @@ import org.apache.pulsar.policies.data.loadbalancer.LocalBrokerData;
  */
 @Slf4j
 public class LeastResourceUsageWithWeight implements ModularLoadManagerStrategy {
+    private final static double MAX_RESOURCE_USAGE = 1.0d;
     // Maintain this list to reduce object creation.
     private final ArrayList<String> bestBrokers;
     private final Map<String, Double> brokerAvgResourceUsageWithWeight;
@@ -144,7 +145,7 @@ public class LeastResourceUsageWithWeight implements ModularLoadManagerStrategy 
         final double diffThreshold =
                 conf.getLoadBalancerAverageResourceUsageDifferenceThresholdPercentage() / 100.0;
         candidates.forEach(broker -> {
-            Double avgResUsage = brokerAvgResourceUsageWithWeight.getOrDefault(broker, Double.MAX_VALUE);
+            Double avgResUsage = brokerAvgResourceUsageWithWeight.getOrDefault(broker, MAX_RESOURCE_USAGE);
             if ((avgResUsage + diffThreshold <= avgUsage)) {
                 bestBrokers.add(broker);
             }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/LeastResourceUsageWithWeight.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/LeastResourceUsageWithWeight.java
@@ -39,7 +39,7 @@ import org.apache.pulsar.policies.data.loadbalancer.LocalBrokerData;
  */
 @Slf4j
 public class LeastResourceUsageWithWeight implements ModularLoadManagerStrategy {
-    private final static double MAX_RESOURCE_USAGE = 1.0d;
+    private static final double MAX_RESOURCE_USAGE = 1.0d;
     // Maintain this list to reduce object creation.
     private final ArrayList<String> bestBrokers;
     private final Map<String, Double> brokerAvgResourceUsageWithWeight;

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/ModularLoadManagerStrategyTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/ModularLoadManagerStrategyTest.java
@@ -20,6 +20,8 @@ package org.apache.pulsar.broker.loadbalance;
 
 import static org.testng.Assert.assertEquals;
 
+import java.lang.reflect.Field;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Optional;
@@ -129,6 +131,46 @@ public class ModularLoadManagerStrategyTest {
         brokerDataMap.put("2", brokerData2);
         brokerDataMap.put("3", brokerData3);
         assertEquals(strategy.selectBroker(candidates, bundleData, loadData, conf), Optional.of("2"));
+    }
+
+    public void testLeastResourceUsageWithWeightWithArithmeticException()
+            throws NoSuchFieldException, IllegalAccessException {
+        BundleData bundleData = new BundleData();
+        BrokerData brokerData1 = initBrokerData(10, 100);
+        BrokerData brokerData2 = initBrokerData(30, 100);
+        BrokerData brokerData3 = initBrokerData(60, 100);
+        BrokerData brokerData4 = initBrokerData(5, 100);
+        LoadData loadData = new LoadData();
+        Map<String, BrokerData> brokerDataMap = loadData.getBrokerData();
+        brokerDataMap.put("1", brokerData1);
+        brokerDataMap.put("2", brokerData2);
+        brokerDataMap.put("3", brokerData3);
+        brokerDataMap.put("4", brokerData4);
+
+        ServiceConfiguration conf = new ServiceConfiguration();
+        conf.setLoadBalancerCPUResourceWeight(1.0);
+        conf.setLoadBalancerMemoryResourceWeight(0.1);
+        conf.setLoadBalancerDirectMemoryResourceWeight(0.1);
+        conf.setLoadBalancerBandwithInResourceWeight(1.0);
+        conf.setLoadBalancerBandwithOutResourceWeight(1.0);
+        conf.setLoadBalancerHistoryResourcePercentage(0.5);
+        conf.setLoadBalancerAverageResourceUsageDifferenceThresholdPercentage(5);
+
+        LeastResourceUsageWithWeight strategy = new LeastResourceUsageWithWeight();
+
+        // Should choice broker from broker1 2 3.
+        Set<String> candidates = new HashSet<>();
+        candidates.add("1");
+        candidates.add("2");
+        candidates.add("3");
+        Field strategyUpdater = LeastResourceUsageWithWeight.class.getDeclaredField("brokerAvgResourceUsageWithWeight");
+        strategyUpdater.setAccessible(true);
+        Map<String, Double> brokerAvgResourceUsageWithWeight = new HashMap<>();
+        brokerAvgResourceUsageWithWeight.put("1", 0.1d);
+        brokerAvgResourceUsageWithWeight.put("2", 0.3d);
+        brokerAvgResourceUsageWithWeight.put("4", 0.05d);
+        strategyUpdater.set(strategy, brokerAvgResourceUsageWithWeight);
+        assertEquals(strategy.selectBroker(candidates, bundleData, loadData, conf), Optional.of("1"));
     }
 
     private BrokerData initBrokerData(double usage, double limit) {


### PR DESCRIPTION
### Motivation
For a candidate broker, the addition expression maybe results in out of bounds and causes unexpected result when executing the following code.
https://github.com/apache/pulsar/blob/3ecf34abf99afd7c53a681ab82d5bcec2bc499a1/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/LeastResourceUsageWithWeight.java#L146-L151

### Modifications
Make the max resource usage as 100% instead of `Double.MAX_VALUE`.

### Verifying this change

- [x]  Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.
### Does this pull request potentially affect one of the following parts:

If `yes` was chosen, please highlight the changes

- Dependencies (does it add or upgrade a dependency): (no)
- The public API: (no)
- The schema: (no)
- The default values of configurations: (no)
- The wire protocol: (no)
- The rest endpoints: (no)
- The admin cli options: (no)
- Anything that affects deployment: (no)

### Documentation
Check the box below and label this PR (if you have committer privilege).

Need to update docs? 
- [x] `doc-not-needed` 
