### PR TITLE
[fix][broker] Added check for invisible characters for subscription name

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/AdminResource.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/AdminResource.java
@@ -273,6 +273,9 @@ public abstract class AdminResource extends PulsarWebResource {
     @Deprecated
     protected void validateTopicName(String property, String cluster, String namespace, String encodedTopic) {
         String topic = Codec.decode(encodedTopic);
+        if (StringUtil.invisibleCharacters(topic)) {
+            throw new RestException(Response.Status.PRECONDITION_FAILED, "Topic name is not valid");
+        }
         try {
             this.namespaceName = NamespaceName.get(property, cluster, namespace);
             this.topicName = TopicName.get(domain(), namespaceName, topic);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/AdminResource.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/AdminResource.java
@@ -68,6 +68,7 @@ import org.apache.pulsar.common.util.ObjectMapperFactory;
 import org.apache.pulsar.metadata.api.MetadataStoreException;
 import org.apache.pulsar.metadata.api.MetadataStoreException.AlreadyExistsException;
 import org.apache.pulsar.metadata.api.MetadataStoreException.BadVersionException;
+import org.apache.pulsar.utils.StringUtil;
 
 @Slf4j
 public abstract class AdminResource extends PulsarWebResource {
@@ -222,8 +223,18 @@ public abstract class AdminResource extends PulsarWebResource {
         }
     }
 
+    protected void validateSubscriptionName(String subscriptionName) {
+        if (StringUtil.invisibleCharacters(subscriptionName)) {
+            throw new RestException(Response.Status.PRECONDITION_FAILED, "Subscription name is not valid");
+        }
+    }
+
     protected void validateTopicName(String property, String namespace, String encodedTopic) {
         String topic = Codec.decode(encodedTopic);
+        if (StringUtil.invisibleCharacters(topic)) {
+            throw new RestException(Response.Status.PRECONDITION_FAILED, "Topic name is not valid");
+        }
+
         try {
             this.namespaceName = NamespaceName.get(property, namespace);
             this.topicName = TopicName.get(domain(), namespaceName, topic);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/AdminResource.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/AdminResource.java
@@ -225,14 +225,15 @@ public abstract class AdminResource extends PulsarWebResource {
 
     protected void validateSubscriptionName(String subscriptionName) {
         if (StringUtil.invisibleCharacters(subscriptionName)) {
-            throw new RestException(Response.Status.PRECONDITION_FAILED, "Subscription name is not valid");
+            throw new RestException(Response.Status.PRECONDITION_FAILED, "Subscription name contains "
+                    + "invisible characters");
         }
     }
 
     protected void validateTopicName(String property, String namespace, String encodedTopic) {
         String topic = Codec.decode(encodedTopic);
         if (StringUtil.invisibleCharacters(topic)) {
-            throw new RestException(Response.Status.PRECONDITION_FAILED, "Topic name is not valid");
+            throw new RestException(Response.Status.PRECONDITION_FAILED, "Topic name contains invisible characters");
         }
 
         try {
@@ -274,7 +275,7 @@ public abstract class AdminResource extends PulsarWebResource {
     protected void validateTopicName(String property, String cluster, String namespace, String encodedTopic) {
         String topic = Codec.decode(encodedTopic);
         if (StringUtil.invisibleCharacters(topic)) {
-            throw new RestException(Response.Status.PRECONDITION_FAILED, "Topic name is not valid");
+            throw new RestException(Response.Status.PRECONDITION_FAILED, "Topic name contains invisible characters");
         }
         try {
             this.namespaceName = NamespaceName.get(property, cluster, namespace);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/AdminResource.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/AdminResource.java
@@ -224,7 +224,7 @@ public abstract class AdminResource extends PulsarWebResource {
     }
 
     protected void validateSubscriptionName(String subscriptionName) {
-        if (StringUtil.invisibleCharacters(subscriptionName)) {
+        if (StringUtil.containsInvisibleCharacters(subscriptionName)) {
             throw new RestException(Response.Status.PRECONDITION_FAILED, "Subscription name contains "
                     + "invisible characters");
         }
@@ -232,10 +232,6 @@ public abstract class AdminResource extends PulsarWebResource {
 
     protected void validateTopicName(String property, String namespace, String encodedTopic) {
         String topic = Codec.decode(encodedTopic);
-        if (StringUtil.invisibleCharacters(topic)) {
-            throw new RestException(Response.Status.PRECONDITION_FAILED, "Topic name contains invisible characters");
-        }
-
         try {
             this.namespaceName = NamespaceName.get(property, namespace);
             this.topicName = TopicName.get(domain(), namespaceName, topic);
@@ -274,9 +270,6 @@ public abstract class AdminResource extends PulsarWebResource {
     @Deprecated
     protected void validateTopicName(String property, String cluster, String namespace, String encodedTopic) {
         String topic = Codec.decode(encodedTopic);
-        if (StringUtil.invisibleCharacters(topic)) {
-            throw new RestException(Response.Status.PRECONDITION_FAILED, "Topic name contains invisible characters");
-        }
         try {
             this.namespaceName = NamespaceName.get(property, cluster, namespace);
             this.topicName = TopicName.get(domain(), namespaceName, topic);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v1/PersistentTopics.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v1/PersistentTopics.java
@@ -760,12 +760,14 @@ public class PersistentTopics extends PersistentTopicsBase {
             @QueryParam("authoritative") @DefaultValue("false") boolean authoritative, MessageIdImpl messageId,
             @QueryParam("replicated") boolean replicated) {
         try {
+            String subscriptionName = decode(encodedSubName);
+            validateSubscriptionName(subscriptionName);
             validateTopicName(property, cluster, namespace, topic);
             if (!topicName.isPersistent()) {
                 throw new RestException(Response.Status.BAD_REQUEST, "Create subscription on non-persistent topic "
                         + "can only be done through client");
             }
-            internalCreateSubscription(asyncResponse, decode(encodedSubName), messageId, authoritative, replicated,
+            internalCreateSubscription(asyncResponse, subscriptionName, messageId, authoritative, replicated,
                     null);
         } catch (WebApplicationException wae) {
             asyncResponse.resume(wae);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/PersistentTopics.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/PersistentTopics.java
@@ -1616,8 +1616,8 @@ public class PersistentTopics extends PersistentTopicsBase {
     ) {
         try {
             String subscriptionName = decode(encodedSubName);
-            if (StringUtil.isSpecialChar(subscriptionName)) {
-                throw new RestException(Response.Status.BAD_REQUEST, "subscriptionName contains special characters");
+            if (StringUtil.invisibleCharacters(subscriptionName)) {
+                throw new RestException(Response.Status.BAD_REQUEST, "subscriptionName contains invisible characters!");
             }
             validateTopicName(tenant, namespace, topic);
             if (!topicName.isPersistent()) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/PersistentTopics.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/PersistentTopics.java
@@ -74,6 +74,7 @@ import org.apache.pulsar.common.policies.data.impl.DispatchRateImpl;
 import org.apache.pulsar.common.util.Codec;
 import org.apache.pulsar.common.util.FutureUtil;
 import org.apache.pulsar.metadata.api.MetadataStoreException;
+import org.apache.pulsar.utils.StringUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -1614,6 +1615,10 @@ public class PersistentTopics extends PersistentTopicsBase {
             @QueryParam("replicated") boolean replicated
     ) {
         try {
+            String subscriptionName = decode(encodedSubName);
+            if (StringUtil.isSpecialChar(subscriptionName)) {
+                throw new RestException(Response.Status.BAD_REQUEST, "subscriptionName contains special characters");
+            }
             validateTopicName(tenant, namespace, topic);
             if (!topicName.isPersistent()) {
                 throw new RestException(Response.Status.BAD_REQUEST, "Create subscription on non-persistent topic "
@@ -1624,7 +1629,7 @@ public class PersistentTopics extends PersistentTopicsBase {
             MessageIdImpl messageId = resetCursorData == null ? null :
                     new MessageIdImpl(resetCursorData.getLedgerId(), resetCursorData.getEntryId(),
                             resetCursorData.getPartitionIndex());
-            internalCreateSubscription(asyncResponse, decode(encodedSubName), messageId, authoritative,
+            internalCreateSubscription(asyncResponse, subscriptionName, messageId, authoritative,
                     replicated, subscriptionProperties);
         } catch (WebApplicationException wae) {
             asyncResponse.resume(wae);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/PersistentTopics.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/PersistentTopics.java
@@ -1616,9 +1616,7 @@ public class PersistentTopics extends PersistentTopicsBase {
     ) {
         try {
             String subscriptionName = decode(encodedSubName);
-            if (StringUtil.invisibleCharacters(subscriptionName)) {
-                throw new RestException(Response.Status.BAD_REQUEST, "subscriptionName contains invisible characters!");
-            }
+            validateSubscriptionName(subscriptionName);
             validateTopicName(tenant, namespace, topic);
             if (!topicName.isPersistent()) {
                 throw new RestException(Response.Status.BAD_REQUEST, "Create subscription on non-persistent topic "

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/PersistentTopics.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/PersistentTopics.java
@@ -74,7 +74,6 @@ import org.apache.pulsar.common.policies.data.impl.DispatchRateImpl;
 import org.apache.pulsar.common.util.Codec;
 import org.apache.pulsar.common.util.FutureUtil;
 import org.apache.pulsar.metadata.api.MetadataStoreException;
-import org.apache.pulsar.utils.StringUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/utils/StringUtil.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/utils/StringUtil.java
@@ -18,15 +18,15 @@
  */
 package org.apache.pulsar.utils;
 
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
 public class StringUtil {
-    private static String regEx = "[ _`~!@#$%^&*()+=|{}':;',\\[\\].<>/?~！@#￥%……&*（）——+|{}【】‘；：”“’。，、？]|\n|\r|\t";
-    private static Pattern p = Pattern.compile(regEx);
 
-    public static boolean isSpecialChar(String str) {
-        Matcher m = p.matcher(str);
-        return m.find();
+    public static boolean invisibleCharacters(String str) {
+        for (char i = 0; i < 32; i++) {
+            Character ch = Character.valueOf(i);
+            if (str.contains(ch.toString())) {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/utils/StringUtil.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/utils/StringUtil.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.pulsar.utils;
 
 import java.util.regex.Matcher;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/utils/StringUtil.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/utils/StringUtil.java
@@ -20,13 +20,16 @@ package org.apache.pulsar.utils;
 
 public class StringUtil {
 
+    /**
+     * The ASCII values of invisible characters are 0~32 and 127.
+     * */
     public static boolean invisibleCharacters(String str) {
-        for (char i = 0; i < 32; i++) {
+        for (char i = 0; i < 33; i++) {
             Character ch = Character.valueOf(i);
             if (str.contains(ch.toString())) {
                 return true;
             }
         }
-        return false;
+        return str.contains(Character.valueOf((char) 127).toString());
     }
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/utils/StringUtil.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/utils/StringUtil.java
@@ -1,0 +1,14 @@
+package org.apache.pulsar.utils;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class StringUtil {
+    private static String regEx = "[ _`~!@#$%^&*()+=|{}':;',\\[\\].<>/?~！@#￥%……&*（）——+|{}【】‘；：”“’。，、？]|\n|\r|\t";
+    private static Pattern p = Pattern.compile(regEx);
+
+    public static boolean isSpecialChar(String str) {
+        Matcher m = p.matcher(str);
+        return m.find();
+    }
+}

--- a/pulsar-broker/src/main/java/org/apache/pulsar/utils/StringUtil.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/utils/StringUtil.java
@@ -45,4 +45,32 @@ public class StringUtil {
         }
         return false;
     }
+
+    public static String removeInvisible(String str, String replaceChar) {
+        if (str == null) {
+            return "";
+        }
+
+        str = str.trim();
+        StringBuilder newString = new StringBuilder(str.length());
+        for (int offset = 0; offset < str.length(); ) {
+            int codePoint = str.codePointAt(offset);
+            offset += Character.charCount(codePoint);
+            switch (Character.getType(codePoint)) {
+                case Character.CONTROL:
+                case Character.FORMAT:
+                case Character.PRIVATE_USE:
+                case Character.SURROGATE:
+                case Character.UNASSIGNED:
+                case Character.OTHER_SYMBOL:
+                case Character.SPACE_SEPARATOR:
+                    newString.append(replaceChar);
+                    break;
+                default:
+                    newString.append(Character.toChars(codePoint));
+                    break;
+            }
+        }
+        return newString.toString();
+    }
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/utils/StringUtil.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/utils/StringUtil.java
@@ -18,14 +18,12 @@
  */
 package org.apache.pulsar.utils;
 
-import org.apache.pulsar.common.naming.TopicName;
-
 public class StringUtil {
 
     /**
      * Check for invisible characters.
      * */
-    public static boolean invisibleCharacters(String str) {
+    public static boolean containsInvisibleCharacters(String str) {
         if (str == null) {
             return false;
         }
@@ -39,6 +37,7 @@ public class StringUtil {
                 case Character.SURROGATE:
                 case Character.UNASSIGNED:
                 case Character.OTHER_SYMBOL:
+                case Character.SPACE_SEPARATOR:
                     return true;
                 default:
                     break;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/utils/StringUtil.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/utils/StringUtil.java
@@ -21,15 +21,28 @@ package org.apache.pulsar.utils;
 public class StringUtil {
 
     /**
-     * The ASCII values of invisible characters are 0~32 and 127.
+     * Check for invisible characters.
      * */
     public static boolean invisibleCharacters(String str) {
-        for (char i = 0; i < 33; i++) {
-            Character ch = Character.valueOf(i);
-            if (str.contains(ch.toString())) {
-                return true;
+        if (str == null) {
+            return false;
+        }
+        for (int offset = 0; offset < str.length(); ) {
+            int codePoint = str.codePointAt(offset);
+            offset += Character.charCount(codePoint);
+            switch (Character.getType(codePoint)) {
+                case Character.CONTROL:
+                case Character.FORMAT:
+                case Character.PRIVATE_USE:
+                case Character.SURROGATE:
+                case Character.UNASSIGNED:
+                case Character.OTHER_SYMBOL:
+                case Character.SPACE_SEPARATOR:
+                    return true;
+                default:
+                    break;
             }
         }
-        return str.contains(Character.valueOf((char) 127).toString());
+        return false;
     }
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/utils/StringUtil.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/utils/StringUtil.java
@@ -18,6 +18,8 @@
  */
 package org.apache.pulsar.utils;
 
+import org.apache.pulsar.common.naming.TopicName;
+
 public class StringUtil {
 
     /**
@@ -37,7 +39,6 @@ public class StringUtil {
                 case Character.SURROGATE:
                 case Character.UNASSIGNED:
                 case Character.OTHER_SYMBOL:
-                case Character.SPACE_SEPARATOR:
                     return true;
                 default:
                     break;

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiTest.java
@@ -135,6 +135,7 @@ import org.apache.pulsar.common.policies.data.TopicStats;
 import org.apache.pulsar.common.util.Codec;
 import org.apache.pulsar.common.util.ObjectMapperFactory;
 import org.apache.pulsar.compaction.Compactor;
+import org.apache.pulsar.utils.StringUtil;
 import org.awaitility.Awaitility;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -855,7 +856,7 @@ public class AdminApiTest extends MockedPulsarServiceBaseTest {
 
     @Test(dataProvider = "topicName")
     public void persistentTopics(String topicName) throws Exception {
-        final String subName = topicName;
+        final String subName = StringUtil.removeInvisible(topicName, "");
         assertEquals(admin.topics().getList("prop-xyz/ns1"), new ArrayList<>());
 
         final String persistentTopicName = "persistent://prop-xyz/ns1/" + topicName;

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/CreateSubscriptionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/CreateSubscriptionTest.java
@@ -31,6 +31,7 @@ import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.io.IOException;
 import javax.ws.rs.ClientErrorException;
+import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 
 import lombok.extern.slf4j.Slf4j;
@@ -137,6 +138,7 @@ public class CreateSubscriptionTest extends ProducerConsumerBase {
 
     public void testContainsInvisibleCharactersForSubscriptionName() throws PulsarAdminException {
         String topic = "persistent://my-property/my-ns/my-partitioned-topic";
+        String errorMsg = "Subscription name contains invisible characters";
         admin.topics().createPartitionedTopic(topic, 10);
         admin.topics().createSubscription(topic, "sub-1", MessageId.latest);
         admin.topics().createSubscription(topic, "sub~`!@#$￥%^……&*(){「【[]}】』\\|、:;\"'<《,>。》.?/-1",
@@ -146,32 +148,37 @@ public class CreateSubscriptionTest extends ProducerConsumerBase {
         try {
             admin.topics().createSubscription(topic, "sub\u0000-2", MessageId.latest);
             fail("Should have failed");
-        } catch (Exception e) {
-            // Expected
+        } catch (PulsarAdminException.PreconditionFailedException e) {
+            assertEquals(Response.Status.PRECONDITION_FAILED.getStatusCode(), e.getStatusCode());
+            assertEquals(e.getMessage(), errorMsg);
         }
         try {
             admin.topics().createSubscription(topic, "sub\r-3", MessageId.latest);
             fail("Should have failed");
-        } catch (Exception e) {
-            // Expected
+        } catch (PulsarAdminException.PreconditionFailedException e) {
+            assertEquals(Response.Status.PRECONDITION_FAILED.getStatusCode(), e.getStatusCode());
+            assertEquals(e.getMessage(), errorMsg);
         }
         try {
             admin.topics().createSubscription(topic, "sub\n-4", MessageId.latest);
             fail("Should have failed");
-        } catch (Exception e) {
-            // Expected
+        } catch (PulsarAdminException.PreconditionFailedException e) {
+            assertEquals(Response.Status.PRECONDITION_FAILED.getStatusCode(), e.getStatusCode());
+            assertEquals(e.getMessage(), errorMsg);
         }
         try {
             admin.topics().createSubscription(topic, "sub\t-5", MessageId.latest);
             fail("Should have failed");
-        } catch (Exception e) {
-            // Expected
+        } catch (PulsarAdminException.PreconditionFailedException e) {
+            assertEquals(Response.Status.PRECONDITION_FAILED.getStatusCode(), e.getStatusCode());
+            assertEquals(e.getMessage(), errorMsg);
         }
         try {
             admin.topics().createSubscription(topic, "sub -6", MessageId.latest);
             fail("Should have failed");
-        } catch (Exception e) {
-            // Expected
+        } catch (PulsarAdminException.PreconditionFailedException e) {
+            assertEquals(Response.Status.PRECONDITION_FAILED.getStatusCode(), e.getStatusCode());
+            assertEquals(e.getMessage(), errorMsg);
         }
     }
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/CreateSubscriptionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/CreateSubscriptionTest.java
@@ -135,6 +135,44 @@ public class CreateSubscriptionTest extends ProducerConsumerBase {
         }
     }
 
+    public void testContainsInvisibleCharactersForSubscriptionName() throws PulsarAdminException {
+        String topic = "persistent://my-property/my-ns/my-partitioned-topic";
+        admin.topics().createPartitionedTopic(topic, 10);
+        admin.topics().createSubscription(topic, "sub-1", MessageId.latest);
+
+        // Create should fail if the subscription name contain invisible characters
+        try {
+            admin.topics().createSubscription(topic, "sub\u0000-2", MessageId.latest);
+            fail("Should have failed");
+        } catch (Exception e) {
+            // Expected
+        }
+        try {
+            admin.topics().createSubscription(topic, "sub\r-3", MessageId.latest);
+            fail("Should have failed");
+        } catch (Exception e) {
+            // Expected
+        }
+        try {
+            admin.topics().createSubscription(topic, "sub\n-4", MessageId.latest);
+            fail("Should have failed");
+        } catch (Exception e) {
+            // Expected
+        }
+        try {
+            admin.topics().createSubscription(topic, "sub\t-5", MessageId.latest);
+            fail("Should have failed");
+        } catch (Exception e) {
+            // Expected
+        }
+        try {
+            admin.topics().createSubscription(topic, "sub -6", MessageId.latest);
+            fail("Should have failed");
+        } catch (Exception e) {
+            // Expected
+        }
+    }
+
     @Test
     public void createSubscriptionOnPartitionedTopicWithPartialFailure() throws Exception {
         String topic = "persistent://my-property/my-ns/my-partitioned-topic";

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/CreateSubscriptionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/CreateSubscriptionTest.java
@@ -139,6 +139,8 @@ public class CreateSubscriptionTest extends ProducerConsumerBase {
         String topic = "persistent://my-property/my-ns/my-partitioned-topic";
         admin.topics().createPartitionedTopic(topic, 10);
         admin.topics().createSubscription(topic, "sub-1", MessageId.latest);
+        admin.topics().createSubscription(topic, "sub~`!@#$￥%^……&*(){「【[]}】』\\|、:;\"'<《,>。》.?/-1",
+                MessageId.latest);
 
         // Create should fail if the subscription name contain invisible characters
         try {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/utils/StringUtilTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/utils/StringUtilTest.java
@@ -27,13 +27,18 @@ import org.testng.annotations.Test;
 public class StringUtilTest {
 
     @Test
-    public void testInvisibleCharacters() {
-        String str1 = "hello\u0000world";
-        assertTrue(StringUtil.invisibleCharacters(str1));
-        String str2 = "hello\u0003world";
-        assertTrue(StringUtil.invisibleCharacters(str2));
-        String str3 = "helloworld";
-        assertFalse(StringUtil.invisibleCharacters(str3));
+    public void testContainsInvisibleCharacters() {
+        assertTrue(StringUtil.containsInvisibleCharacters("hello\u0000world"));
+        assertTrue(StringUtil.containsInvisibleCharacters("hello\u0002world"));
+        assertTrue(StringUtil.containsInvisibleCharacters("hello\u0003world"));
+        assertTrue(StringUtil.containsInvisibleCharacters("hello\u3000world"));
+        assertTrue(StringUtil.containsInvisibleCharacters("hello\u001Aworld"));
+        assertTrue(StringUtil.containsInvisibleCharacters("hello world"));
+        assertTrue(StringUtil.containsInvisibleCharacters("hello\nworld"));
+        assertTrue(StringUtil.containsInvisibleCharacters("hello\tworld"));
+        assertTrue(StringUtil.containsInvisibleCharacters("hello\rworld"));
+        assertFalse(StringUtil.containsInvisibleCharacters(
+                "hello~`!@#$￥%^……&*(){「【[]}】』\\|、:;\"'<《,>。》.?/world"));
     }
 
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/utils/StringUtilTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/utils/StringUtilTest.java
@@ -1,0 +1,39 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.utils;
+
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.assertFalse;
+import org.testng.annotations.Test;
+
+
+@Test(groups = "utils")
+public class StringUtilTest {
+
+    @Test
+    public void testInvisibleCharacters() {
+        String str1 = "hello\u0000world";
+        assertTrue(StringUtil.invisibleCharacters(str1));
+        String str2 = "hello\u0003world";
+        assertTrue(StringUtil.invisibleCharacters(str2));
+        String str3 = "helloworld";
+        assertFalse(StringUtil.invisibleCharacters(str3));
+    }
+
+}


### PR DESCRIPTION
### Motivation
When the subscription name contains some invisible characters, such as \u0000, the subscription cannot be deleted：
<img width="1652" alt="image" src="https://user-images.githubusercontent.com/19296967/185276426-216dce7d-e340-4a1b-bb25-a7f869998397.png">

<img width="1654" alt="image" src="https://user-images.githubusercontent.com/19296967/185276545-96f11ff9-f6b5-4296-9149-5b70d58c37b3.png">


So when creating a subscription name, we should check the subscription name: create subscription group fails when subscription name contains invisible characters

### Documentation

Check the box below or label this PR directly.

Need to update docs? 

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)
  
- [ ] `doc-not-needed` 
(Please explain why)
  
- [x] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)


### Matching PR in forked repository

PR in forked repository: https://github.com/lordcheng10/pulsar/pull/3