### PR TITLE
[fix][flaky-test]AdminApi2Test.testDeleteNamespace

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApi2Test.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApi2Test.java
@@ -105,6 +105,7 @@ import org.apache.pulsar.common.policies.data.PartitionedTopicStats;
 import org.apache.pulsar.common.policies.data.PersistencePolicies;
 import org.apache.pulsar.common.policies.data.PersistentTopicInternalStats;
 import org.apache.pulsar.common.policies.data.RetentionPolicies;
+import org.apache.pulsar.common.policies.data.SubscribeRate;
 import org.apache.pulsar.common.policies.data.SubscriptionStats;
 import org.apache.pulsar.common.policies.data.TenantInfoImpl;
 import org.apache.pulsar.common.policies.data.TopicStats;
@@ -1458,8 +1459,8 @@ public class AdminApi2Test extends MockedPulsarServiceBaseTest {
             return;
         }
         // Trigger change event topic create.
-        Consumer consumer = pulsarClient.newConsumer().subscriptionName("del-ns-sub").topic(topic).subscribe();
-        consumer.close();
+        SubscribeRate subscribeRate = new SubscribeRate(-1, 60);
+        admin.topicPolicies().setSubscribeRate(topic, subscribeRate);
         // Wait for change event topic and compaction create finish.
         String allowAutoTopicCreationType = pulsar.getConfiguration().getAllowAutoTopicCreationType();
         int defaultNumPartitions = pulsar.getConfiguration().getDefaultNumPartitions();


### PR DESCRIPTION
Fixes: #17111

### Motivation

same as #17070, there have two race conditions:

1. delete namespace and asynchronously create topic `__change_event`
2. delete namespace and asynchronously create subscription `__change_event/__compaction`

### Modifications

Make delete namespace after `__change_event` and `__change_event/__compaction` create finish.


### Documentation

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)
  
- [x] `doc-not-needed` 
(Please explain why)
  
- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)