### PR TITLE
[Improvement] Apply maven modernizer to remaining modules.

### DIFF
--- a/pulsar-config-validation/pom.xml
+++ b/pulsar-config-validation/pom.xml
@@ -43,6 +43,24 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.gaul</groupId>
+                <artifactId>modernizer-maven-plugin</artifactId>
+                <configuration>
+                    <failOnViolations>true</failOnViolations>
+                    <javaVersion>17</javaVersion>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>modernizer</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>modernizer</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            
+            <plugin>
                 <groupId>com.github.spotbugs</groupId>
                 <artifactId>spotbugs-maven-plugin</artifactId>
                 <version>${spotbugs-maven-plugin.version}</version>

--- a/pulsar-functions/instance/pom.xml
+++ b/pulsar-functions/instance/pom.xml
@@ -204,6 +204,24 @@
 
   <build>
     <plugins>
+      <plugin>
+        <groupId>org.gaul</groupId>
+        <artifactId>modernizer-maven-plugin</artifactId>
+        <configuration>
+          <failOnViolations>true</failOnViolations>
+          <javaVersion>17</javaVersion>
+        </configuration>
+        <executions>
+          <execution>
+            <id>modernizer</id>
+            <phase>verify</phase>
+            <goals>
+              <goal>modernizer</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      
       <!-- this task is used for copy all python files together to provide a instance directory
            for running python instance -->
       <plugin>

--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/JavaInstanceRunnable.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/JavaInstanceRunnable.java
@@ -18,7 +18,6 @@
  */
 package org.apache.pulsar.functions.instance;
 
-import static com.google.common.base.Preconditions.checkNotNull;
 import static org.apache.pulsar.functions.utils.FunctionCommon.convertFromFunctionDetailsSubscriptionPosition;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.google.common.annotations.VisibleForTesting;
@@ -26,6 +25,7 @@ import com.scurrilous.circe.checksum.Crc32cIntChecksum;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 import java.util.TreeMap;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
@@ -728,7 +728,7 @@ public class JavaInstanceRunnable implements AutoCloseable, Runnable {
                     convertFromFunctionDetailsSubscriptionPosition(sourceSpec.getSubscriptionPosition())
             );
 
-            checkNotNull(contextImpl.getSubscriptionType());
+            Objects.requireNonNull(contextImpl.getSubscriptionType());
             pulsarSourceConfig.setSubscriptionType(contextImpl.getSubscriptionType());
 
             pulsarSourceConfig.setTypeClassName(sourceSpec.getTypeClassName());

--- a/pulsar-functions/runtime/pom.xml
+++ b/pulsar-functions/runtime/pom.xml
@@ -75,6 +75,24 @@
 
   <build>
     <plugins>
+      <plugin>
+        <groupId>org.gaul</groupId>
+        <artifactId>modernizer-maven-plugin</artifactId>
+        <configuration>
+          <failOnViolations>true</failOnViolations>
+          <javaVersion>17</javaVersion>
+        </configuration>
+        <executions>
+          <execution>
+            <id>modernizer</id>
+            <phase>verify</phase>
+            <goals>
+              <goal>modernizer</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      
       <!-- this task will copy config files to resources for the test to work -->
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/worker/WorkerConfig.java
+++ b/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/worker/WorkerConfig.java
@@ -22,7 +22,6 @@ import static org.apache.commons.lang3.StringUtils.isBlank;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
-import com.google.common.collect.Sets;
 import java.io.File;
 import java.io.IOException;
 import java.io.Serializable;
@@ -533,7 +532,7 @@ public class WorkerConfig implements Serializable, PulsarConfiguration {
         category = CATEGORY_WORKER_SECURITY,
         doc = "Authentication provider name list, which is a list of class names"
     )
-    private Set<String> authenticationProviders = Sets.newTreeSet();
+    private Set<String> authenticationProviders = new TreeSet<>();
     @FieldContext(
         category = CATEGORY_WORKER_SECURITY,
         doc = "Enforce authorization on accessing functions admin-api"
@@ -548,7 +547,7 @@ public class WorkerConfig implements Serializable, PulsarConfiguration {
         category = CATEGORY_WORKER_SECURITY,
         doc = "Role names that are treated as `super-user`, meaning they will be able to access any admin-api"
     )
-    private Set<String> superUserRoles = Sets.newTreeSet();
+    private Set<String> superUserRoles = new TreeSet<>();
 
     @FieldContext(
             category = CATEGORY_WORKER_SECURITY,

--- a/pulsar-functions/secrets/pom.xml
+++ b/pulsar-functions/secrets/pom.xml
@@ -46,6 +46,24 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>org.gaul</groupId>
+        <artifactId>modernizer-maven-plugin</artifactId>
+        <configuration>
+          <failOnViolations>true</failOnViolations>
+          <javaVersion>17</javaVersion>
+        </configuration>
+        <executions>
+          <execution>
+            <id>modernizer</id>
+            <phase>verify</phase>
+            <goals>
+              <goal>modernizer</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      
+      <plugin>
         <groupId>com.github.spotbugs</groupId>
         <artifactId>spotbugs-maven-plugin</artifactId>
         <version>${spotbugs-maven-plugin.version}</version>

--- a/pulsar-functions/utils/pom.xml
+++ b/pulsar-functions/utils/pom.xml
@@ -103,6 +103,24 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>org.gaul</groupId>
+        <artifactId>modernizer-maven-plugin</artifactId>
+        <configuration>
+          <failOnViolations>true</failOnViolations>
+          <javaVersion>17</javaVersion>
+        </configuration>
+        <executions>
+          <execution>
+            <id>modernizer</id>
+            <phase>verify</phase>
+            <goals>
+              <goal>modernizer</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      
+      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-checkstyle-plugin</artifactId>
         <executions>

--- a/pulsar-functions/worker/pom.xml
+++ b/pulsar-functions/worker/pom.xml
@@ -188,6 +188,24 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>org.gaul</groupId>
+        <artifactId>modernizer-maven-plugin</artifactId>
+        <configuration>
+          <failOnViolations>true</failOnViolations>
+          <javaVersion>17</javaVersion>
+        </configuration>
+        <executions>
+          <execution>
+            <id>modernizer</id>
+            <phase>verify</phase>
+            <goals>
+              <goal>modernizer</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      
+      <plugin>
         <artifactId>maven-dependency-plugin</artifactId>
         <executions>
           <execution>

--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/SchedulerManager.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/SchedulerManager.java
@@ -18,12 +18,10 @@
  */
 package org.apache.pulsar.functions.worker;
 
-import static com.google.common.base.Preconditions.checkNotNull;
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
 import static org.apache.pulsar.common.util.Runnables.catchingAndLoggingThrowables;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.Lists;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import io.netty.util.concurrent.DefaultThreadFactory;
 import java.util.ArrayList;
@@ -32,6 +30,7 @@ import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
@@ -272,7 +271,7 @@ public class SchedulerManager implements AutoCloseable {
                 }
 
                 // A worker must be specified at this point. This would be set up by the caller.
-                checkNotNull(workerId);
+                Objects.requireNonNull(workerId);
 
                 // [We can get stricter, and require that every drain op be followed up with a cleanup of the
                 // corresponding worker before any other drain op, so that the drainOpStatusMap should be empty
@@ -714,7 +713,7 @@ public class SchedulerManager implements AutoCloseable {
             Map<String, Map<String, Assignment>> currentAssignments, Map<String, Function.Instance> functionInstances) {
 
         List<Function.Instance> unassignedFunctionInstances = new LinkedList<>();
-        List<Assignment> heartBeatAssignments = Lists.newArrayList();
+        List<Assignment> heartBeatAssignments = new ArrayList<>();
         Map<String, Assignment> assignmentMap = new HashMap<>();
         if (currentAssignments != null) {
             for (Map<String, Assignment> entry : currentAssignments.values()) {
@@ -845,7 +844,7 @@ public class SchedulerManager implements AutoCloseable {
         public void removedAssignment(Assignment assignment) {
             String workerId = assignment.getWorkerId();
             WorkerStats stats = workerStatsMap.get(workerId);
-            checkNotNull(stats);
+            Objects.requireNonNull(stats);
 
             stats.instancesRemoved++;
             stats.finalNumAssignments--;
@@ -857,14 +856,14 @@ public class SchedulerManager implements AutoCloseable {
             String oldWorkerId = instanceToWorkerId.get(fullyQualifiedInstanceId);
             if (oldWorkerId != null) {
                 WorkerStats oldWorkerStats = workerStatsMap.get(oldWorkerId);
-                checkNotNull(oldWorkerStats);
+                Objects.requireNonNull(oldWorkerStats);
 
                 oldWorkerStats.instancesRemoved++;
                 oldWorkerStats.finalNumAssignments--;
             }
 
             WorkerStats newWorkerStats = workerStatsMap.get(newWorkerId);
-            checkNotNull(newWorkerStats);
+            Objects.requireNonNull(newWorkerStats);
 
             newWorkerStats.instancesAdded++;
             newWorkerStats.finalNumAssignments++;
@@ -873,7 +872,7 @@ public class SchedulerManager implements AutoCloseable {
         public void updatedAssignment(Assignment assignment) {
             String workerId = assignment.getWorkerId();
             WorkerStats stats = workerStatsMap.get(workerId);
-            checkNotNull(stats);
+            Objects.requireNonNull(stats);
 
             stats.instancesUpdated++;
         }

--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/api/ComponentImpl.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/api/ComponentImpl.java
@@ -18,7 +18,6 @@
  */
 package org.apache.pulsar.functions.worker.rest.api;
 
-import static com.google.common.base.Preconditions.checkNotNull;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.apache.bookkeeper.common.concurrent.FutureUtils.result;
@@ -47,6 +46,7 @@ import java.util.Base64;
 import java.util.Collection;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Objects;
 import java.util.TreeMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -274,7 +274,7 @@ public abstract class ComponentImpl implements Component<PulsarWorkerService> {
     @Override
     public PulsarWorkerService worker() {
         try {
-            return checkNotNull(workerServiceSupplier.get());
+            return Objects.requireNonNull(workerServiceSupplier.get());
         } catch (Throwable t) {
             log.info("Failed to get worker service", t);
             throw t;

--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/api/WorkerImpl.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/api/WorkerImpl.java
@@ -18,7 +18,6 @@
  */
 package org.apache.pulsar.functions.worker.rest.api;
 
-import static com.google.common.base.Preconditions.checkNotNull;
 import static org.apache.pulsar.functions.worker.rest.RestUtils.throwUnavailableException;
 import java.io.IOException;
 import java.net.URI;
@@ -27,6 +26,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.function.Supplier;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Response;
@@ -61,7 +61,7 @@ public class WorkerImpl implements Workers<PulsarWorkerService> {
 
     private PulsarWorkerService worker() {
         try {
-            return checkNotNull(workerServiceSupplier.get());
+            return Objects.requireNonNull(workerServiceSupplier.get());
         } catch (Throwable t) {
             log.info("Failed to get worker service", t);
             throw t;

--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/scheduler/RoundRobinScheduler.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/scheduler/RoundRobinScheduler.java
@@ -18,7 +18,7 @@
  */
 package org.apache.pulsar.functions.worker.scheduler;
 
-import com.google.common.collect.Lists;
+import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.LinkedList;
@@ -38,7 +38,7 @@ public class RoundRobinScheduler implements IScheduler {
                                      List<Assignment> currentAssignments, Set<String> workers) {
 
         Map<String, List<Instance>> workerIdToAssignment = new HashMap<>();
-        List<Assignment> newAssignments = Lists.newArrayList();
+        List<Assignment> newAssignments = new ArrayList<>();
 
         for (String workerId : workers) {
             workerIdToAssignment.put(workerId, new LinkedList<>());

--- a/pulsar-functions/worker/src/test/java/org/apache/pulsar/functions/worker/FunctionRuntimeManagerTest.java
+++ b/pulsar-functions/worker/src/test/java/org/apache/pulsar/functions/worker/FunctionRuntimeManagerTest.java
@@ -38,7 +38,6 @@ import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
-import com.google.common.collect.ImmutableList;
 import io.netty.buffer.Unpooled;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -1225,7 +1224,7 @@ public class FunctionRuntimeManagerTest {
                 .setInstance(Function.Instance.newBuilder()
                         .setFunctionMetaData(function).setInstanceId(0).build())
                 .build();
-        doReturn(ImmutableList.of(assignment)).when(functionRuntimeManager)
+        doReturn(List.of(assignment)).when(functionRuntimeManager)
                 .findFunctionAssignments("test-tenant", "test-namespace", "function");
         functionRuntimeManager.restartFunctionInstances("test-tenant", "test-namespace", "function");
         if (expectRestartByPulsarAdmin) {

--- a/pulsar-functions/worker/src/test/java/org/apache/pulsar/functions/worker/SchedulerManagerTest.java
+++ b/pulsar-functions/worker/src/test/java/org/apache/pulsar/functions/worker/SchedulerManagerTest.java
@@ -31,11 +31,11 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
-import com.google.common.collect.Sets;
 import com.google.protobuf.InvalidProtocolBufferException;
 import io.netty.util.concurrent.DefaultThreadFactory;
 import java.lang.reflect.Method;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -468,7 +468,7 @@ public class SchedulerManagerTest {
         invocations = getMethodInvocationDetails(message, TypedMessageBuilder.class.getMethod("value",
                 Object.class));
 
-        Set<Assignment> allAssignments = Sets.newHashSet();
+        Set<Assignment> allAssignments = new HashSet<>();
         invocations.forEach(invocation -> {
             try {
                 allAssignments.add(Assignment.parseFrom((byte[]) invocation.getRawArguments()[0]));
@@ -543,7 +543,7 @@ public class SchedulerManagerTest {
             Assert.assertEquals(assignment, expectedAssignment);
         }
 
-        Set<Assignment> allAssignments = Sets.newHashSet();
+        Set<Assignment> allAssignments = new HashSet<>();
         invocations.forEach(invocation -> {
             try {
                 allAssignments.add(Assignment.parseFrom((byte[]) invocation.getRawArguments()[0]));
@@ -610,7 +610,7 @@ public class SchedulerManagerTest {
         invocations = getMethodInvocationDetails(message, TypedMessageBuilder.class.getMethod("value",
                 Object.class));
 
-        Set<Assignment> allAssignments2 = Sets.newHashSet();
+        Set<Assignment> allAssignments2 = new HashSet<>();
         invocations.forEach(invocation -> {
             try {
                 allAssignments2.add(Assignment.parseFrom((byte[]) invocation.getRawArguments()[0]));
@@ -755,7 +755,7 @@ public class SchedulerManagerTest {
         invocations = getMethodInvocationDetails(message, TypedMessageBuilder.class.getMethod("value",
                 Object.class));
 
-        Set<Assignment> allAssignments = Sets.newHashSet();
+        Set<Assignment> allAssignments = new HashSet<>();
         invocations.forEach(invocation -> {
             try {
                 allAssignments.add(Assignment.parseFrom((byte[]) invocation.getRawArguments()[0]));
@@ -818,7 +818,7 @@ public class SchedulerManagerTest {
         invocations = getMethodInvocationDetails(message, TypedMessageBuilder.class.getMethod("value",
                 Object.class));
 
-        Set<Assignment> allAssignments2 = Sets.newHashSet();
+        Set<Assignment> allAssignments2 = new HashSet<>();
         invocations.forEach(invocation -> {
             try {
                 allAssignments2.add(Assignment.parseFrom((byte[]) invocation.getRawArguments()[0]));

--- a/pulsar-functions/worker/src/test/java/org/apache/pulsar/functions/worker/dlog/DLInputStreamTest.java
+++ b/pulsar-functions/worker/src/test/java/org/apache/pulsar/functions/worker/dlog/DLInputStreamTest.java
@@ -18,7 +18,6 @@
  */
 package org.apache.pulsar.functions.worker.dlog;
 
-import static com.google.common.base.Charsets.UTF_8;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyBoolean;
 import static org.mockito.Mockito.eq;
@@ -28,6 +27,8 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.testng.AssertJUnit.assertEquals;
 import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+
 import org.apache.distributedlog.DLSN;
 import org.apache.distributedlog.LogRecordWithDLSN;
 import org.apache.distributedlog.api.DistributedLogManager;
@@ -83,7 +84,7 @@ public class DLInputStreamTest {
         LogReader reader = mock(LogReader.class);
         when(dlm.getInputStream(any(DLSN.class))).thenReturn(reader);
 
-        byte[] data = "test-read".getBytes(UTF_8);
+        byte[] data = "test-read".getBytes(StandardCharsets.UTF_8);
         LogRecordWithDLSN record = mock(LogRecordWithDLSN.class);
         when(record.getPayLoadInputStream())
             .thenReturn(new ByteArrayInputStream(data));

--- a/pulsar-functions/worker/src/test/java/org/apache/pulsar/functions/worker/executor/MockExecutorController.java
+++ b/pulsar-functions/worker/src/test/java/org/apache/pulsar/functions/worker/executor/MockExecutorController.java
@@ -22,9 +22,9 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyLong;
 import static org.mockito.Mockito.doAnswer;
-import com.google.common.collect.Lists;
 import com.google.common.util.concurrent.SettableFuture;
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
@@ -113,7 +113,7 @@ public class MockExecutorController {
 
     @Getter
     private final MockClock clock = new MockClock();
-    private final List<DeferredTask> deferredTasks = Lists.newArrayList();
+    private final List<DeferredTask> deferredTasks = new ArrayList<>();
 
     public MockExecutorController controlSubmit(ScheduledExecutorService service) {
         doAnswer(answerNow()).when(service).submit(any(Runnable.class));
@@ -197,7 +197,7 @@ public class MockExecutorController {
     public void advance(Duration duration) {
         clock.advance(duration);
         Iterator<DeferredTask> entries = deferredTasks.iterator();
-        List<DeferredTask> toExecute = Lists.newArrayList();
+        List<DeferredTask> toExecute = new ArrayList<>();
         while (entries.hasNext()) {
             DeferredTask next = entries.next();
             if (next.getDelay(TimeUnit.MILLISECONDS) <= 0) {

--- a/pulsar-metadata/pom.xml
+++ b/pulsar-metadata/pom.xml
@@ -104,6 +104,24 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>org.gaul</groupId>
+        <artifactId>modernizer-maven-plugin</artifactId>
+        <configuration>
+          <failOnViolations>true</failOnViolations>
+          <javaVersion>17</javaVersion>
+        </configuration>
+        <executions>
+          <execution>
+            <id>modernizer</id>
+            <phase>verify</phase>
+            <goals>
+              <goal>modernizer</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      
+      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
         <executions>

--- a/pulsar-package-management/core/pom.xml
+++ b/pulsar-package-management/core/pom.xml
@@ -53,6 +53,24 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.gaul</groupId>
+                <artifactId>modernizer-maven-plugin</artifactId>
+                <configuration>
+                    <failOnViolations>true</failOnViolations>
+                    <javaVersion>17</javaVersion>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>modernizer</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>modernizer</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            
+            <plugin>
                 <groupId>com.github.spotbugs</groupId>
                 <artifactId>spotbugs-maven-plugin</artifactId>
                 <configuration>


### PR DESCRIPTION

Master Issue: https://github.com/apache/pulsar/issues/12271

### Motivation
### Modifications
Applied to following modeules:
pulsar-config-validation
pulsar-functions
pulsar-metadata
pulsar-package-management

### Verifying this change

- [x] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

Check the box below or label this PR directly.

Need to update docs? 

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)
  
- [x] `doc-not-needed` 
(Please explain why)
  
- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)