### PR TITLE
[improve][build] Avoid building image multiple times

### DIFF
--- a/docker/pulsar-all/pom.xml
+++ b/docker/pulsar-all/pom.xml
@@ -138,46 +138,7 @@
                 <phase>package</phase>
                 <goals>
                   <goal>build</goal>
-                </goals>
-                <configuration>
-                  <images>
-                    <image>
-                      <name>${docker.organization}/pulsar-all</name>
-                      <build>
-                        <contextDir>${project.basedir}</contextDir>
-                        <tags>
-                          <tag>latest</tag>
-                          <tag>${project.version}</tag>
-                        </tags>
-                      </build>
-                    </image>
-                  </images>
-                </configuration>
-              </execution>
-              <execution>
-                <id>push-latest</id>
-                <goals>
-                  <goal>push</goal>
-                </goals>
-                <configuration>
-                  <images>
-                    <image>
-                      <name>${docker.organization}/pulsar-all</name>
-                      <build>
-                        <contextDir>${project.basedir}</contextDir>
-                        <tags>
-                          <tag>latest</tag>
-                        </tags>
-                      </build>
-                    </image>
-                  </images>
-                </configuration>
-              </execution>
-              <execution>
-                <id>add-no-repo</id>
-                <phase>package</phase>
-                <goals>
-                  <goal>build</goal>
+                  <goal>tag</goal>
                 </goals>
                 <configuration>
                   <images>
@@ -187,11 +148,12 @@
                         <contextDir>${project.basedir}</contextDir>
                         <tags>
                           <tag>latest</tag>
-                          <tag>${project.version}</tag>
                         </tags>
                       </build>
                     </image>
                   </images>
+                  <tagName>latest</tagName>
+                  <repo>${docker.organization}</repo>
                 </configuration>
               </execution>
             </executions>

--- a/docker/pulsar/pom.xml
+++ b/docker/pulsar/pom.xml
@@ -116,46 +116,7 @@
                 <phase>package</phase>
                 <goals>
                   <goal>build</goal>
-                </goals>
-                <configuration>
-                  <images>
-                    <image>
-                      <name>${docker.organization}/pulsar</name>
-                      <build>
-                        <contextDir>${project.basedir}</contextDir>
-                        <tags>
-                          <tag>latest</tag>
-                          <tag>${project.version}</tag>
-                        </tags>
-                      </build>
-                    </image>
-                  </images>
-                </configuration>
-              </execution>
-              <execution>
-                <id>push-latest</id>
-                <goals>
-                  <goal>push</goal>
-                </goals>
-                <configuration>
-                  <images>
-                    <image>
-                      <name>${docker.organization}/pulsar</name>
-                      <build>
-                        <contextDir>${project.basedir}</contextDir>
-                        <tags>
-                          <tag>latest</tag>
-                        </tags>
-                      </build>
-                    </image>
-                  </images>
-                </configuration>
-              </execution>
-              <execution>
-                <id>add-no-repo</id>
-                <phase>package</phase>
-                <goals>
-                  <goal>build</goal>
+                  <goal>tag</goal>
                 </goals>
                 <configuration>
                   <images>
@@ -165,11 +126,12 @@
                         <contextDir>${project.basedir}</contextDir>
                         <tags>
                           <tag>latest</tag>
-                          <tag>${project.version}</tag>
                         </tags>
                       </build>
                     </image>
                   </images>
+                  <tagName>latest</tagName>
+                  <repo>${docker.organization}</repo>
                 </configuration>
               </execution>
             </executions>


### PR DESCRIPTION
### Motivation

The current config will build the pulsar and pulsar-all images multiple times.

https://github.com/apache/pulsar/runs/7945037366?check_suite_focus=true#step:10:5675
https://github.com/apache/pulsar/runs/7945037366?check_suite_focus=true#step:10:6760

One is apache/pulsar, and one is without the apache repository, we should only keep an image without the apache repository, it is enough.

When we do release, only use the image without the apache repository. The following commands are from the `docker/publish.sh`.
```
docker tag pulsar:latest ${docker_registry_org}/pulsar:latest
docker tag pulsar-all:latest ${docker_registry_org}/pulsar-all:latest

docker tag pulsar:latest ${docker_registry_org}/pulsar:$MVN_VERSION
docker tag pulsar-all:latest ${docker_registry_org}/pulsar-all:$MVN_VERSION
```


### Modifications

- Remove `push` step and `${docker.organization}/pulsar/${project.version}` and `${docker.organization}/pulsar-all/${project.version}` images, because we are using the bash script to push image with the latest tag to docker hub, see https://github.com/apache/pulsar/blob/master/wiki/release/release-process.md#publish-docker-images-to-personal-account-in-hubdockercom-if-you-dont-have-access-to-apachepulsar-org
- Use `https://dmp.fabric8.io/#docker:tag` instead of `add-no-repo` step

### Documentation

Check the box below or label this PR directly.

Need to update docs? 

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)
  
- [x] `doc-not-needed` 
(Please explain why)
  
- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)