### PR TITLE
[improve][broker] Optimize the logic of terminating system topic

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
@@ -3675,6 +3675,11 @@ public class PersistentTopicsBase extends AdminResource {
     }
 
     protected CompletableFuture<MessageId> internalTerminateAsync(boolean authoritative) {
+        if (SystemTopicNames.isSystemTopic(topicName)) {
+            return FutureUtil.failedFuture(new RestException(Status.METHOD_NOT_ALLOWED,
+                    "Termination of a system topic is not allowed"));
+        }
+
         CompletableFuture<Void> ret;
         if (topicName.isGlobal()) {
             ret = validateGlobalNamespaceOwnershipAsync(namespaceName);
@@ -3688,10 +3693,6 @@ public class PersistentTopicsBase extends AdminResource {
                     if (partitionMetadata.partitions > 0) {
                         throw new RestException(Status.METHOD_NOT_ALLOWED,
                                 "Termination of a partitioned topic is not allowed");
-                    }
-                    if (SystemTopicNames.isSystemTopic(topicName)) {
-                        throw new RestException(Status.METHOD_NOT_ALLOWED,
-                                "Termination of a system topic is not allowed");
                     }
                 })
                 .thenCompose(__ -> getTopicReferenceAsync(topicName))


### PR DESCRIPTION
### Motivation
It's not allow to terminate the system topic in pr #17006, but the best position for this logic is at the head of `internalTerminateAsync` to avoid redundant or unnecessary judgments.

### Modifications
- Put the logic of judging whether it is a system theme to the beginning of the `internalTerminateAsync`

### Documentation  
- [x] `doc-not-needed` 
 