### PR TITLE
[fix][tool] Using int instead of long in python scripts

### DIFF
--- a/bin/pulsar-managed-ledger-admin
+++ b/bin/pulsar-managed-ledger-admin
@@ -244,7 +244,7 @@ def deleteMLLedgerIdsCommand(zk, mlPath, deleteLedgerIds):
             deletLedgerIds = set(deleteLedgerIds.split(","))
             deletLedgerIdSet = set()
             for id in deletLedgerIds:
-                deletLedgerIdSet.add(long(id))
+                deletLedgerIdSet.add(int(id))
             deleteLedgerIdsFromManagedLedgerInfo(zk, mlPath, deletLedgerIdSet)
         else:
             print('Usage: --command {} [--ledgerIds]'.format(deleteMlLedgerIds))
@@ -274,7 +274,7 @@ def updateMarkDeleteOfCursorCommand(zk, mlPath, cursorName, markDeletePosition):
             if markDeletePosition:
                 positionPair = markDeletePosition.split(":")
                 if len(positionPair) == 2:
-                    updateCursorMarkDelete(zk, mlPath + "/" + cursorName, (long(positionPair[0])), long(positionPair[1]))
+                    updateCursorMarkDelete(zk, mlPath + "/" + cursorName, (int(positionPair[0])), int(positionPair[1]))
                 else:
                     print("markDeletePosition must be in format <ledger_id>:<entry_id>")
             else:


### PR DESCRIPTION

### Motivation

In python3.x, long renamed to int, so we should use int instead
of long in scripts.

Traceback (most recent call last):
  File "bin/pulsar-managed-ledger-admin", line 247, in deleteMLLedgerIdsCommand
    deletLedgerIdSet.add(long(id))
NameError: name 'long' is not defined


### Modifications

- rename long to int
- 
### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API: (yes / no)
  - The schema: (yes / no / don't know)
  - The default values of configurations: (yes / no)
  - The wire protocol: (yes / no)
  - The rest endpoints: (yes / no)
  - The admin cli options: (yes / no)
  - Anything that affects deployment: (yes / no / don't know)

### Documentation

Check the box below or label this PR directly.

Need to update docs? 

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)
  
- [x] `doc-not-needed` 
(Please explain why)
  
- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)