### PR TITLE
[fix][tests] Close producer to avoid create schema again.

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/schema/SchemaTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/schema/SchemaTest.java
@@ -839,10 +839,6 @@ public class SchemaTest extends MockedPulsarServiceBaseTest {
             assertNotNull(schema);
         }
 
-        // Close producer to avoid reconnect.
-        p1_1.close();
-        p1_2.close();
-        p2_1.close();
         // not-force delete topic
         try {
             admin.topics().delete(topic1, false);
@@ -865,6 +861,10 @@ public class SchemaTest extends MockedPulsarServiceBaseTest {
         assertEquals(this.getPulsar().getSchemaRegistryService()
                 .trimDeletedSchemaAndGetList(TopicName.get(topic2).getSchemaName()).get().size(), 1);
 
+        // Close producer to avoid reconnect.
+        p1_1.close();
+        p1_2.close();
+        p2_1.close();
         // force and delete-schema when delete topic
         admin.topics().delete(topic1, true);
         assertEquals(this.getPulsar().getSchemaRegistryService()
@@ -932,10 +932,6 @@ public class SchemaTest extends MockedPulsarServiceBaseTest {
             assertNotNull(schema);
         }
 
-        // Close producer to avoid reconnect.
-        p1_1.close();
-        p1_2.close();
-        p2_1.close();
         // not force delete topic and will fail because it has active producers or subscriptions
         try {
             admin.topics().delete(topicOne, false);
@@ -954,6 +950,10 @@ public class SchemaTest extends MockedPulsarServiceBaseTest {
         assertEquals(this.getPulsar().getSchemaRegistryService()
                 .trimDeletedSchemaAndGetList(TopicName.get(topicTwo).getSchemaName()).get().size(), 1);
 
+        // Close producer to avoid reconnect.
+        p1_1.close();
+        p1_2.close();
+        p2_1.close();
         // force delete topic and will delete schema by default
         admin.topics().delete(topicOne, true);
         assertEquals(this.getPulsar().getSchemaRegistryService()

--- a/pulsar-broker/src/test/java/org/apache/pulsar/schema/SchemaTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/schema/SchemaTest.java
@@ -734,12 +734,10 @@ public class SchemaTest extends MockedPulsarServiceBaseTest {
                 tenant + "/" + namespace,
                 Sets.newHashSet(CLUSTER_NAME));
 
-        @Cleanup
         Producer<Schemas.PersonOne> p1 = pulsarClient.newProducer(Schema.JSON(Schemas.PersonOne.class))
                 .topic(topic)
                 .create();
 
-        @Cleanup
         Producer<Schemas.PersonThree> p2 = pulsarClient.newProducer(Schema.JSON(Schemas.PersonThree.class))
                 .topic(topic)
                 .create();
@@ -763,6 +761,10 @@ public class SchemaTest extends MockedPulsarServiceBaseTest {
         List<Long> ledgers = ((BookkeeperSchemaStorage)this.getPulsar().getSchemaStorage())
                 .getSchemaLedgerList(TopicName.get(topic).getSchemaName());
         assertEquals(ledgers.size(), 2);
+
+        // Close producer to avoid reconnect.
+        p1.close();
+        p2.close();
         admin.topics().delete(topic, true, true);
         assertEquals(this.getPulsar().getSchemaRegistryService()
                 .trimDeletedSchemaAndGetList(TopicName.get(topic).getSchemaName()).get().size(), 0);
@@ -795,16 +797,14 @@ public class SchemaTest extends MockedPulsarServiceBaseTest {
         // persistent, partitioned v1/topic
         admin.topics().createPartitionedTopic(topic2, 1);
 
-        @Cleanup
         Producer<Schemas.PersonOne> p1_1 = pulsarClient.newProducer(Schema.JSON(Schemas.PersonOne.class))
                 .topic(topic1)
                 .create();
 
-        @Cleanup
         Producer<Schemas.PersonThree> p1_2 = pulsarClient.newProducer(Schema.JSON(Schemas.PersonThree.class))
                 .topic(topic1)
                 .create();
-        @Cleanup
+
         Producer<Schemas.PersonThree> p2_1 = pulsarClient.newProducer(Schema.JSON(Schemas.PersonThree.class))
                 .topic(topic2)
                 .create();
@@ -839,6 +839,10 @@ public class SchemaTest extends MockedPulsarServiceBaseTest {
             assertNotNull(schema);
         }
 
+        // Close producer to avoid reconnect.
+        p1_1.close();
+        p1_2.close();
+        p2_1.close();
         // not-force delete topic
         try {
             admin.topics().delete(topic1, false);
@@ -885,16 +889,13 @@ public class SchemaTest extends MockedPulsarServiceBaseTest {
         // persistent, partitioned v2/topic
         admin.topics().createPartitionedTopic(topicTwo, 1);
 
-        @Cleanup
         Producer<Schemas.PersonOne> p1_1 = pulsarClient.newProducer(Schema.JSON(Schemas.PersonOne.class))
                 .topic(topicOne)
                 .create();
 
-        @Cleanup
         Producer<Schemas.PersonThree> p1_2 = pulsarClient.newProducer(Schema.JSON(Schemas.PersonThree.class))
                 .topic(topicOne)
                 .create();
-        @Cleanup
         Producer<Schemas.PersonThree> p2_1 = pulsarClient.newProducer(Schema.JSON(Schemas.PersonThree.class))
                 .topic(topicTwo)
                 .create();
@@ -931,6 +932,10 @@ public class SchemaTest extends MockedPulsarServiceBaseTest {
             assertNotNull(schema);
         }
 
+        // Close producer to avoid reconnect.
+        p1_1.close();
+        p1_2.close();
+        p2_1.close();
         // not force delete topic and will fail because it has active producers or subscriptions
         try {
             admin.topics().delete(topicOne, false);


### PR DESCRIPTION
Fixes #17224

Master Issue:  #17224

### Motivation

From the log, we can see that when we deleted the schema, the schema was re-registered due to the reconnecting of the producer.

>2022-08-23T12:12:32,213 - INFO  - [pulsar-web-32-16:Producer@642] - Disconnecting producer: Producer{topic=PersistentTopic{topic=persistent://public/test-namespace-sfyppbtzkaqjgdgw/test-delete-topic-and-schema}, client=/127.0.0.1:59612, producerName=test-0-0, producerId=0}
2022-08-23T12:12:32,213 - INFO  - [pulsar-web-32-16:Producer@642] - Disconnecting producer: Producer{topic=PersistentTopic{topic=persistent://public/test-namespace-sfyppbtzkaqjgdgw/test-delete-topic-and-schema}, client=/127.0.0.1:59612, producerName=test-0-1, producerId=1}
2022-08-23T12:12:32,217 - INFO  - [pulsar-client-io-37-1:ClientCnx@748] - [localhost/127.0.0.1:59605] Broker notification of Closed producer: 0
2022-08-23T12:12:32,217 - INFO  - [pulsar-client-io-37-1:ConnectionHandler@139] - [persistent://public/test-namespace-sfyppbtzkaqjgdgw/test-delete-topic-and-schema] [test-0-0] Closed connection [id: 0x9682e2cf, L:/127.0.0.1:59612 - R:localhost/127.0.0.1:59605] -- Will try again in 0.1 s
2022-08-23T12:12:32,218 - INFO  - [pulsar-client-io-37-1:ClientCnx@748] - [localhost/127.0.0.1:59605] Broker notification of Closed producer: 1
2022-08-23T12:12:32,218 - INFO  - [pulsar-client-io-37-1:ConnectionHandler@139] - [persistent://public/test-namespace-sfyppbtzkaqjgdgw/test-delete-topic-and-schema] [test-0-1] Closed connection [id: 0x9682e2cf, L:/127.0.0.1:59612 - R:localhost/127.0.0.1:59605] -- Will try again in 0.1 s
**2022-08-23T12:12:32,218 - INFO  - [ForkJoinPool.commonPool-worker-1:AbstractTopic@646] - Delete schema storage of id: public/test-namespace-sfyppbtzkaqjgdgw/test-delete-topic-and-schema**
**2022-08-23T12:12:32,221 - INFO  - [ForkJoinPool.commonPool-worker-2:BookkeeperSchemaStorage@388] - deleteSchema : public/test-namespace-sfyppbtzkaqjgdgw/test-delete-topic-and-schema, forcefully : false**
**2022-08-23T12:12:32,240 - INFO  - [metadata-store-12-1:BookkeeperSchemaStorage@417] - deleted schema path : /schemas/public/test-namespace-sfyppbtzkaqjgdgw/test-delete-topic-and-schema**
**2022-08-23T12:12:32,240 - INFO  - [metadata-store-12-1:SchemaRegistryServiceImpl@276] - [public/test-namespace-sfyppbtzkaqjgdgw/test-delete-topic-and-schema] Delete schema storage finished**
2022-08-23T12:12:32,241 - INFO  - [metadata-store-12-1:NamespaceEventsSystemTopicFactory@42] - Create topic policies system topic client persistent://public/test-namespace-sfyppbtzkaqjgdgw/__change_events
2022-08-23T12:12:32,272 - INFO  - [pulsar-io-6-3:ProducerImpl@1617] - [persistent://public/test-namespace-sfyppbtzkaqjgdgw/__change_events] [null] Creating producer on cnx [id: 0x9ed5f11f, L:/127.0.0.1:59613 - R:localhost/127.0.0.1:59605]
2022-08-23T12:12:32,278 - INFO  - [pulsar-io-6-4:SchemaRegistryServiceImpl@167] - [public/test-namespace-sfyppbtzkaqjgdgw/__change_events] 1 schemas is found
2022-08-23T12:12:32,286 - INFO  - [mock-pulsar-bk-OrderedExecutor-0-0:ServerCnx@1443] - [/127.0.0.1:59613] Created new producer: Producer{topic=SystemTopic{topic=persistent://public/test-namespace-sfyppbtzkaqjgdgw/__change_events}, client=/127.0.0.1:59613, producerName=test-0-2, producerId=0}
2022-08-23T12:12:32,288 - INFO  - [pulsar-io-6-3:ProducerImpl@1672] - [persistent://public/test-namespace-sfyppbtzkaqjgdgw/__change_events] [test-0-2] Created producer on cnx [id: 0x9ed5f11f, L:/127.0.0.1:59613 - R:localhost/127.0.0.1:59605]
2022-08-23T12:12:32,319 - INFO  - [pulsar-timer-43-1:ConnectionHandler@143] - [persistent://public/test-namespace-sfyppbtzkaqjgdgw/test-delete-topic-and-schema] [test-0-0] Reconnecting after timeout
2022-08-23T12:12:32,323 - WARN  - [pulsar-io-6-3:Crc32cIntChecksum@44] - Failed to load Circe JNI library. Falling back to Java based CRC32c provider
2022-08-23T12:12:32,324 - INFO  - [pulsar-timer-43-1:ConnectionHandler@143] - [persistent://public/test-namespace-sfyppbtzkaqjgdgw/test-delete-topic-and-schema] [test-0-1] Reconnecting after timeout
2022-08-23T12:12:32,351 - INFO  - [pulsar-web-32-16:Slf4jRequestLogWriter@62] - 127.0.0.1 - - [23/Aug/2022:12:12:32 +0800] “GET /lookup/v2/topic/persistent/public/test-namespace-sfyppbtzkaqjgdgw/test-delete-topic-and-schema HTTP/1.1” 200 217 “-” “Pulsar-Java-v2.11.0-SNAPSHOT” 13
2022-08-23T12:12:32,351 - INFO  - [pulsar-web-32-14:Slf4jRequestLogWriter@62] - 127.0.0.1 - - [23/Aug/2022:12:12:32 +0800] “GET /lookup/v2/topic/persistent/public/test-namespace-sfyppbtzkaqjgdgw/test-delete-topic-and-schema HTTP/1.1" 200 217 “-” “Pulsar-Java-v2.11.0-SNAPSHOT” 23
2022-08-23T12:12:32,351 - INFO  - [pulsar-client-io-37-1:ProducerImpl@1617] - [persistent://public/test-namespace-sfyppbtzkaqjgdgw/test-delete-topic-and-schema] [test-0-0] Creating producer on cnx [id: 0x9682e2cf, L:/127.0.0.1:59612 - R:localhost/127.0.0.1:59605]
2022-08-23T12:12:32,353 - INFO  - [pulsar-client-io-37-1:ProducerImpl@1617] - [persistent://public/test-namespace-sfyppbtzkaqjgdgw/test-delete-topic-and-schema] [test-0-1] Creating producer on cnx [id: 0x9682e2cf, L:/127.0.0.1:59612 - R:localhost/127.0.0.1:59605]
**2022-08-23T12:12:32,362 - INFO  - [metadata-store-12-1:SchemaRegistryServiceImpl@167] - [public/test-namespace-sfyppbtzkaqjgdgw/test-delete-topic-and-schema] 0 schemas is found
2022-08-23T12:12:32,363 - INFO  - [metadata-store-12-1:SchemaRegistryServiceImpl@167] - [public/test-namespace-sfyppbtzkaqjgdgw/test-delete-topic-and-schema] 0 schemas is found**
2022-08-23T12:12:32,365 - INFO  - [mock-pulsar-bk-OrderedExecutor-0-0:PulsarMockBookKeeper@122] - Creating ledger 8
2022-08-23T12:12:32,366 - INFO  - [mock-pulsar-bk-OrderedExecutor-0-0:PulsarMockBookKeeper@122] - Creating ledger 9


We can look at the code as follow to know why we can add the schema even topic is fenced.

https://github.com/apache/pulsar/blob/423ab75425211c52f43384a915fb775b8ecb5070/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java#L1279-L1302

### Modifications

- Close producer before deleting topic.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Documentation

Check the box below or label this PR directly.

Need to update docs? 

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)
  
- [x] `doc-not-needed` 
(Please explain why)
  
- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)