### PR TITLE
[improve][broker] Avoid using `common-pool` when run async method.

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
@@ -3019,7 +3019,7 @@ public class BrokerService implements Closeable {
         }
         return pulsarService.getPulsarResources().getNamespaceResources()
                 .getPoliciesAsync(topicName.getNamespaceObject())
-                .thenComposeAsync(optPolicies -> {
+                .thenCompose(optPolicies -> {
                     if (optPolicies.isPresent() && optPolicies.get().deleted) {
                         // We can return the completed future directly if the namespace is already deleted.
                         return CompletableFuture.completedFuture(null);


### PR DESCRIPTION
### Motivation

Because `common-pool` is an uncontrolled thread pool, we need to avoid using it directly.
For the case where the metadata thread will be used here we need to optimize in a later discussion.

### Modifications

- Use the original thread to process the following operation.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API: (yes / no)
  - The schema: (yes / no / don't know)
  - The default values of configurations: (yes / no)
  - The wire protocol: (yes / no)
  - The rest endpoints: (yes / no)
  - The admin cli options: (yes / no)
  - Anything that affects deployment: (yes / no / don't know)

### Documentation

Check the box below or label this PR directly.

Need to update docs? 

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)
  
- [x] `doc-not-needed` 
(Please explain why)
  
- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)