### PR TITLE
[fix][broker] Fix dispatch duplicated messages with `Exclusive` mode.

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherSingleActiveConsumer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherSingleActiveConsumer.java
@@ -28,6 +28,7 @@ import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import org.apache.bookkeeper.mledger.AsyncCallbacks.ReadEntriesCallback;
 import org.apache.bookkeeper.mledger.Entry;
 import org.apache.bookkeeper.mledger.ManagedCursor;
@@ -58,6 +59,7 @@ import org.slf4j.LoggerFactory;
 public class PersistentDispatcherSingleActiveConsumer extends AbstractDispatcherSingleActiveConsumer
         implements Dispatcher, ReadEntriesCallback {
 
+    private final AtomicBoolean isRescheduleReadInProgress = new AtomicBoolean(false);
     protected final PersistentTopic topic;
     protected final String name;
     private Optional<DispatchRateLimiter> dispatchRateLimiter = Optional.empty();
@@ -242,14 +244,7 @@ public class PersistentDispatcherSingleActiveConsumer extends AbstractDispatcher
                         SafeRun.safeRun(() -> {
                             synchronized (PersistentDispatcherSingleActiveConsumer.this) {
                                 Consumer newConsumer = getActiveConsumer();
-                                if (newConsumer != null && !havePendingRead) {
-                                    readMoreEntries(newConsumer);
-                                } else {
-                                    log.debug(
-                                            "[{}-{}] Ignoring write future complete."
-                                                    + " consumerAvailable={} havePendingRead={}",
-                                            name, newConsumer, newConsumer != null, havePendingRead);
-                                }
+                                readMoreEntries(newConsumer);
                             }
                         }));
                 }
@@ -332,42 +327,54 @@ public class PersistentDispatcherSingleActiveConsumer extends AbstractDispatcher
     }
 
     @Override
-    protected synchronized void readMoreEntries(Consumer consumer) {
+    protected void readMoreEntries(Consumer consumer) {
         // consumer can be null when all consumers are disconnected from broker.
         // so skip reading more entries if currently there is no active consumer.
         if (null == consumer) {
+            if (log.isDebugEnabled()) {
+                log.debug("[{}] Skipping read for the topic, Due to the current consumer is null", topic.getName());
+            }
             return;
         }
         if (havePendingRead) {
-            // we cannot read more entries while sending the previous batch
-            // otherwise we could re-read the same entries and send duplicates
+            if (log.isDebugEnabled()) {
+                log.debug("[{}] Skipping read for the topic, Due to we have pending read.", topic.getName());
+            }
             return;
         }
 
         if (consumer.getAvailablePermits() > 0) {
-            Pair<Integer, Long> calculateResult = calculateToRead(consumer);
-            int messagesToRead = calculateResult.getLeft();
-            long bytesToRead = calculateResult.getRight();
+            synchronized (this) {
+                if (havePendingRead) {
+                    if (log.isDebugEnabled()) {
+                        log.debug("[{}] Skipping read for the topic, Due to we have pending read.", topic.getName());
+                    }
+                    return;
+                }
 
-            if (-1 == messagesToRead || bytesToRead == -1) {
-                // Skip read as topic/dispatcher has exceed the dispatch rate.
-                return;
-            }
+                Pair<Integer, Long> calculateResult = calculateToRead(consumer);
+                int messagesToRead = calculateResult.getLeft();
+                long bytesToRead = calculateResult.getRight();
 
-            // Schedule read
-            if (log.isDebugEnabled()) {
-                log.debug("[{}-{}] Schedule read of {} messages", name, consumer, messagesToRead);
-            }
+                if (-1 == messagesToRead || bytesToRead == -1) {
+                    // Skip read as topic/dispatcher has exceed the dispatch rate.
+                    return;
+                }
 
-            havePendingRead = true;
-            if (consumer.readCompacted()) {
-                topic.getCompactedTopic().asyncReadEntriesOrWait(cursor, messagesToRead, isFirstRead,
-                        this, consumer);
-            } else {
-                ReadEntriesCtx readEntriesCtx =
-                        ReadEntriesCtx.create(consumer, consumer.getConsumerEpoch());
-                cursor.asyncReadEntriesOrWait(messagesToRead,
-                        bytesToRead, this, readEntriesCtx, topic.getMaxReadPosition());
+                // Schedule read
+                if (log.isDebugEnabled()) {
+                    log.debug("[{}-{}] Schedule read of {} messages", name, consumer, messagesToRead);
+                }
+                havePendingRead = true;
+                if (consumer.readCompacted()) {
+                    topic.getCompactedTopic().asyncReadEntriesOrWait(cursor, messagesToRead, isFirstRead,
+                            this, consumer);
+                } else {
+                    ReadEntriesCtx readEntriesCtx =
+                            ReadEntriesCtx.create(consumer, consumer.getConsumerEpoch());
+                    cursor.asyncReadEntriesOrWait(messagesToRead,
+                            bytesToRead, this, readEntriesCtx, topic.getMaxReadPosition());
+                }
             }
         } else {
             if (log.isDebugEnabled()) {
@@ -378,19 +385,16 @@ public class PersistentDispatcherSingleActiveConsumer extends AbstractDispatcher
 
     @Override
     protected void reScheduleRead() {
-        topic.getBrokerService().executor().schedule(() -> {
-            Consumer currentConsumer = ACTIVE_CONSUMER_UPDATER.get(this);
-            if (currentConsumer != null && !havePendingRead) {
-                readMoreEntries(currentConsumer);
-            } else {
-                if (log.isDebugEnabled()) {
-                    log.debug("[{}] Skipping read retry for topic: Current Consumer {},"
-                                    + " havePendingRead {}",
-                            topic.getName(), currentConsumer, havePendingRead);
-                }
+        if (isRescheduleReadInProgress.compareAndSet(false, true)) {
+            if (log.isDebugEnabled()) {
+                log.debug("[{}] [{}] Reschedule message read in {} ms", topic.getName(), name, MESSAGE_RATE_BACKOFF_MS);
             }
-        }, MESSAGE_RATE_BACKOFF_MS, TimeUnit.MILLISECONDS);
-
+            topic.getBrokerService().executor().schedule(() -> {
+                isRescheduleReadInProgress.set(false);
+                Consumer currentConsumer = ACTIVE_CONSUMER_UPDATER.get(this);
+                readMoreEntries(currentConsumer);
+            }, MESSAGE_RATE_BACKOFF_MS, TimeUnit.MILLISECONDS);
+        }
     }
 
     protected Pair<Integer, Long> calculateToRead(Consumer consumer) {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SubscriptionMessageDispatchThrottlingTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SubscriptionMessageDispatchThrottlingTest.java
@@ -220,7 +220,7 @@ public class SubscriptionMessageDispatchThrottlingTest extends MessageDispatchTh
         log.info("-- Exiting {} test --", methodName);
     }
 
-    @Test(dataProvider = "subscriptions", timeOut = 30000)
+    @Test(dataProvider = "subscriptions", timeOut = 30000, invocationCount = 15)
     private void testMessageNotDuplicated(SubscriptionType subscription) throws Exception {
         int brokerRate = 1000;
         int topicRate = 5000;

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SubscriptionMessageDispatchThrottlingTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SubscriptionMessageDispatchThrottlingTest.java
@@ -220,6 +220,93 @@ public class SubscriptionMessageDispatchThrottlingTest extends MessageDispatchTh
         log.info("-- Exiting {} test --", methodName);
     }
 
+    @Test(dataProvider = "subscriptions", timeOut = 30000)
+    private void testMessageNotDuplicated(SubscriptionType subscription) throws Exception {
+        int brokerRate = 1000;
+        int topicRate = 5000;
+        int subRate = 10000;
+        int expectRate = 1000;
+        final String namespace = "my-property/throttling_ns_non_dup";
+        final String topicName = BrokerTestUtil.newUniqueName("persistent://" + namespace + "/throttlingAll");
+        final String subName = "my-subscriber-name-" + subscription;
+
+        DispatchRate subscriptionDispatchRate = DispatchRate.builder()
+                .dispatchThrottlingRateInMsg(-1)
+                .dispatchThrottlingRateInByte(subRate)
+                .ratePeriodInSecond(1)
+                .build();
+        DispatchRate topicDispatchRate = DispatchRate.builder()
+                .dispatchThrottlingRateInMsg(-1)
+                .dispatchThrottlingRateInByte(topicRate)
+                .ratePeriodInSecond(1)
+                .build();
+        admin.namespaces().createNamespace(namespace, Sets.newHashSet("test"));
+        admin.namespaces().setSubscriptionDispatchRate(namespace, subscriptionDispatchRate);
+        admin.namespaces().setDispatchRate(namespace, topicDispatchRate);
+        admin.brokers().updateDynamicConfiguration("dispatchThrottlingRateInByte", "" + brokerRate);
+
+        final int numProducedMessages = 30;
+        final CountDownLatch latch = new CountDownLatch(numProducedMessages);
+        final AtomicInteger totalReceived = new AtomicInteger(0);
+        // enable throttling for nonBacklog consumers
+        conf.setDispatchThrottlingOnNonBacklogConsumerEnabled(true);
+
+        Consumer<byte[]> consumer = pulsarClient.newConsumer().topic(topicName).subscriptionName(subName)
+                .receiverQueueSize(10)
+                .subscriptionType(subscription).messageListener((c1, msg) -> {
+                    Assert.assertNotNull(msg, "Message cannot be null");
+                    String receivedMessage = new String(msg.getData());
+                    log.debug("Received message [{}] in the listener", receivedMessage);
+                    totalReceived.incrementAndGet();
+                    latch.countDown();
+                }).subscribe();
+
+        Producer<byte[]> producer = pulsarClient.newProducer().topic(topicName).create();
+        PersistentTopic topic = (PersistentTopic) pulsar.getBrokerService().getOrCreateTopic(topicName).get();
+
+        DispatchRateLimiter subRateLimiter = null;
+        Dispatcher subDispatcher = topic.getSubscription(subName).getDispatcher();
+        if (subDispatcher instanceof PersistentDispatcherMultipleConsumers) {
+            subRateLimiter = subDispatcher.getRateLimiter().get();
+        } else if (subDispatcher instanceof PersistentDispatcherSingleActiveConsumer) {
+            subRateLimiter = subDispatcher.getRateLimiter().get();
+        } else {
+            Assert.fail("Should only have PersistentDispatcher in this test");
+        }
+        final DispatchRateLimiter subDispatchRateLimiter = subRateLimiter;
+        Awaitility.await().atMost(Duration.ofMillis(500)).untilAsserted(() -> {
+            DispatchRateLimiter brokerDispatchRateLimiter = pulsar.getBrokerService().getBrokerDispatchRateLimiter();
+            Assert.assertTrue(brokerDispatchRateLimiter != null
+                    && brokerDispatchRateLimiter.getDispatchRateOnByte() > 0);
+            DispatchRateLimiter topicDispatchRateLimiter = topic.getDispatchRateLimiter().orElse(null);
+            Assert.assertTrue(topicDispatchRateLimiter != null
+                    && topicDispatchRateLimiter.getDispatchRateOnByte() > 0);
+            Assert.assertTrue(subDispatchRateLimiter != null
+                    && subDispatchRateLimiter.getDispatchRateOnByte() > 0);
+        });
+
+        Assert.assertEquals(admin.namespaces().getSubscriptionDispatchRate(namespace)
+                .getDispatchThrottlingRateInByte(), subRate);
+        Assert.assertEquals(admin.namespaces().getDispatchRate(namespace)
+                .getDispatchThrottlingRateInByte(), topicRate);
+
+        // Asynchronously produce messages
+        for (int i = 0; i < numProducedMessages; i++) {
+            producer.send(new byte[expectRate / 10]);
+        }
+
+        latch.await();
+        // Wait 2000 milli sec to check if we can get more than 30 messages.
+        Thread.sleep(2000);
+        // If this assertion failed, please alert we may have some regression cause message dispatch was duplicated.
+        Assert.assertEquals(totalReceived.get(), numProducedMessages, 10);
+
+        consumer.close();
+        producer.close();
+        admin.topics().delete(topicName, true);
+        admin.namespaces().deleteNamespace(namespace);
+    }
+
     /**
      * verify rate-limiting should throttle message-dispatching based on byte-rate
      *

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SubscriptionMessageDispatchThrottlingTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SubscriptionMessageDispatchThrottlingTest.java
@@ -290,7 +290,6 @@ public class SubscriptionMessageDispatchThrottlingTest extends MessageDispatchTh
         Assert.assertEquals(admin.namespaces().getDispatchRate(namespace)
                 .getDispatchThrottlingRateInByte(), topicRate);
 
-        // Asynchronously produce messages
         for (int i = 0; i < numProducedMessages; i++) {
             producer.send(new byte[expectRate / 10]);
         }


### PR DESCRIPTION
### Motivation

When invoking `readMoreEntries` we have to check if the `havePendingRead` state is `true` to avoid reading the same position many times in the race condition. 

You can add `invocationCount` on the `Test` annotation to call the new test multiple times to understand the problem.

The relative logs:

```
2022-08-23T19:10:01,016 - INFO  - [pulsar-web-191-16:Slf4jRequestLogWriter@62] - 127.0.0.1 - - [23/Aug/2022:19:10:01 +0800] "GET /admin/v2/namespaces/my-property/throttling_ns/subscriptionDispatchRate HTTP/1.1" 200 124 "-" "Pulsar-Java-v2.11.0-SNAPSHOT" 2
2022-08-23T19:10:01,019 - INFO  - [pulsar-web-191-14:Slf4jRequestLogWriter@62] - 127.0.0.1 - - [23/Aug/2022:19:10:01 +0800] "GET /admin/v2/namespaces/my-property/throttling_ns/dispatchRate HTTP/1.1" 200 123 "-" "Pulsar-Java-v2.11.0-SNAPSHOT" 2
2022-08-23T19:10:01,021 - INFO  - [broker-topic-workers-OrderedExecutor-7-0:PersistentDispatcherSingleActiveConsumer@162] - ============ before dispatch
2022-08-23T19:10:01,021 - INFO  - [broker-topic-workers-OrderedExecutor-7-0:PersistentDispatcherSingleActiveConsumer@164] - dispatch message to consumer ledger:3, entry:0
2022-08-23T19:10:01,021 - INFO  - [broker-topic-workers-OrderedExecutor-7-0:PersistentDispatcherSingleActiveConsumer@166] - ============ after dispatch
2022-08-23T19:10:01,023 - INFO  - [pulsar-external-listener-197-1:SubscriptionMessageDispatchThrottlingTest@346] - Received message [0] in the listener
2022-08-23T19:10:01,036 - INFO  - [broker-topic-workers-OrderedExecutor-7-0:PersistentDispatcherSingleActiveConsumer@162] - ============ before dispatch
2022-08-23T19:10:01,036 - INFO  - [broker-topic-workers-OrderedExecutor-7-0:PersistentDispatcherSingleActiveConsumer@164] - dispatch message to consumer ledger:3, entry:1
2022-08-23T19:10:01,036 - INFO  - [broker-topic-workers-OrderedExecutor-7-0:PersistentDispatcherSingleActiveConsumer@164] - dispatch message to consumer ledger:3, entry:2
2022-08-23T19:10:01,036 - INFO  - [broker-topic-workers-OrderedExecutor-7-0:PersistentDispatcherSingleActiveConsumer@164] - dispatch message to consumer ledger:3, entry:3
2022-08-23T19:10:01,036 - INFO  - [broker-topic-workers-OrderedExecutor-7-0:PersistentDispatcherSingleActiveConsumer@164] - dispatch message to consumer ledger:3, entry:4
2022-08-23T19:10:01,036 - INFO  - [broker-topic-workers-OrderedExecutor-7-0:PersistentDispatcherSingleActiveConsumer@164] - dispatch message to consumer ledger:3, entry:5
2022-08-23T19:10:01,036 - INFO  - [broker-topic-workers-OrderedExecutor-7-0:PersistentDispatcherSingleActiveConsumer@166] - ============ after dispatch
2022-08-23T19:10:01,037 - INFO  - [pulsar-external-listener-197-1:SubscriptionMessageDispatchThrottlingTest@346] - Received message [1] in the listener
2022-08-23T19:10:01,037 - INFO  - [pulsar-external-listener-197-1:SubscriptionMessageDispatchThrottlingTest@346] - Received message [2] in the listener
2022-08-23T19:10:01,037 - INFO  - [pulsar-external-listener-197-1:SubscriptionMessageDispatchThrottlingTest@346] - Received message [3] in the listener
2022-08-23T19:10:01,037 - INFO  - [pulsar-external-listener-197-1:SubscriptionMessageDispatchThrottlingTest@346] - Received message [4] in the listener
2022-08-23T19:10:01,037 - INFO  - [pulsar-external-listener-197-1:SubscriptionMessageDispatchThrottlingTest@346] - Received message [5] in the listener
2022-08-23T19:10:01,037 - INFO  - [broker-topic-workers-OrderedExecutor-7-0:PersistentDispatcherSingleActiveConsumer@162] - ============ before dispatch
2022-08-23T19:10:01,037 - INFO  - [broker-topic-workers-OrderedExecutor-7-0:PersistentDispatcherSingleActiveConsumer@164] - dispatch message to consumer ledger:3, entry:6
2022-08-23T19:10:01,037 - INFO  - [broker-topic-workers-OrderedExecutor-7-0:PersistentDispatcherSingleActiveConsumer@166] - ============ after dispatch
2022-08-23T19:10:01,038 - INFO  - [broker-topic-workers-OrderedExecutor-7-0:PersistentDispatcherSingleActiveConsumer@162] - ============ before dispatch
2022-08-23T19:10:01,038 - INFO  - [broker-topic-workers-OrderedExecutor-7-0:PersistentDispatcherSingleActiveConsumer@164] - dispatch message to consumer ledger:3, entry:7
2022-08-23T19:10:01,038 - INFO  - [broker-topic-workers-OrderedExecutor-7-0:PersistentDispatcherSingleActiveConsumer@166] - ============ after dispatch
2022-08-23T19:10:01,038 - INFO  - [pulsar-external-listener-197-1:SubscriptionMessageDispatchThrottlingTest@346] - Received message [6] in the listener
2022-08-23T19:10:01,038 - INFO  - [pulsar-external-listener-197-1:SubscriptionMessageDispatchThrottlingTest@346] - Received message [7] in the listener
2022-08-23T19:10:02,039 - INFO  - [broker-topic-workers-OrderedExecutor-7-0:PersistentDispatcherSingleActiveConsumer@162] - ============ before dispatch
2022-08-23T19:10:02,039 - INFO  - [broker-topic-workers-OrderedExecutor-7-0:PersistentDispatcherSingleActiveConsumer@164] - dispatch message to consumer ledger:3, entry:8
2022-08-23T19:10:02,039 - INFO  - [broker-topic-workers-OrderedExecutor-7-0:PersistentDispatcherSingleActiveConsumer@164] - dispatch message to consumer ledger:3, entry:9
2022-08-23T19:10:02,039 - INFO  - [broker-topic-workers-OrderedExecutor-7-0:PersistentDispatcherSingleActiveConsumer@164] - dispatch message to consumer ledger:3, entry:10
2022-08-23T19:10:02,039 - INFO  - [broker-topic-workers-OrderedExecutor-7-0:PersistentDispatcherSingleActiveConsumer@164] - dispatch message to consumer ledger:3, entry:11
2022-08-23T19:10:02,039 - INFO  - [broker-topic-workers-OrderedExecutor-7-0:PersistentDispatcherSingleActiveConsumer@164] - dispatch message to consumer ledger:3, entry:12
2022-08-23T19:10:02,039 - INFO  - [broker-topic-workers-OrderedExecutor-7-0:PersistentDispatcherSingleActiveConsumer@166] - ============ after dispatch
2022-08-23T19:10:02,039 - INFO  - [broker-topic-workers-OrderedExecutor-7-0:PersistentDispatcherSingleActiveConsumer@162] - ============ before dispatch
2022-08-23T19:10:02,039 - INFO  - [broker-topic-workers-OrderedExecutor-7-0:PersistentDispatcherSingleActiveConsumer@164] - dispatch message to consumer ledger:3, entry:13
2022-08-23T19:10:02,039 - INFO  - [broker-topic-workers-OrderedExecutor-7-0:PersistentDispatcherSingleActiveConsumer@164] - dispatch message to consumer ledger:3, entry:14
2022-08-23T19:10:02,040 - INFO  - [broker-topic-workers-OrderedExecutor-7-0:PersistentDispatcherSingleActiveConsumer@164] - dispatch message to consumer ledger:3, entry:15
2022-08-23T19:10:02,040 - INFO  - [broker-topic-workers-OrderedExecutor-7-0:PersistentDispatcherSingleActiveConsumer@164] - dispatch message to consumer ledger:3, entry:16
2022-08-23T19:10:02,040 - INFO  - [broker-topic-workers-OrderedExecutor-7-0:PersistentDispatcherSingleActiveConsumer@164] - dispatch message to consumer ledger:3, entry:17
2022-08-23T19:10:02,040 - INFO  - [broker-topic-workers-OrderedExecutor-7-0:PersistentDispatcherSingleActiveConsumer@166] - ============ after dispatch
2022-08-23T19:10:02,041 - INFO  - [pulsar-external-listener-197-1:SubscriptionMessageDispatchThrottlingTest@346] - Received message [8] in the listener
2022-08-23T19:10:02,041 - INFO  - [pulsar-external-listener-197-1:SubscriptionMessageDispatchThrottlingTest@346] - Received message [9] in the listener
2022-08-23T19:10:02,041 - INFO  - [pulsar-external-listener-197-1:SubscriptionMessageDispatchThrottlingTest@346] - Received message [10] in the listener
2022-08-23T19:10:02,041 - INFO  - [pulsar-external-listener-197-1:SubscriptionMessageDispatchThrottlingTest@346] - Received message [11] in the listener
2022-08-23T19:10:02,041 - INFO  - [pulsar-external-listener-197-1:SubscriptionMessageDispatchThrottlingTest@346] - Received message [12] in the listener
2022-08-23T19:10:02,041 - INFO  - [pulsar-external-listener-197-1:SubscriptionMessageDispatchThrottlingTest@346] - Received message [13] in the listener
2022-08-23T19:10:02,041 - INFO  - [pulsar-external-listener-197-1:SubscriptionMessageDispatchThrottlingTest@346] - Received message [14] in the listener
2022-08-23T19:10:02,041 - INFO  - [pulsar-external-listener-197-1:SubscriptionMessageDispatchThrottlingTest@346] - Received message [15] in the listener
2022-08-23T19:10:02,041 - INFO  - [pulsar-external-listener-197-1:SubscriptionMessageDispatchThrottlingTest@346] - Received message [16] in the listener
2022-08-23T19:10:02,041 - INFO  - [pulsar-external-listener-197-1:SubscriptionMessageDispatchThrottlingTest@346] - Received message [17] in the listener
2022-08-23T19:10:03,042 - INFO  - [broker-topic-workers-OrderedExecutor-7-0:PersistentDispatcherSingleActiveConsumer@162] - ============ before dispatch
2022-08-23T19:10:03,042 - INFO  - [broker-topic-workers-OrderedExecutor-7-0:PersistentDispatcherSingleActiveConsumer@164] - dispatch message to consumer ledger:3, entry:18
2022-08-23T19:10:03,042 - INFO  - [broker-topic-workers-OrderedExecutor-7-0:PersistentDispatcherSingleActiveConsumer@166] - ============ after dispatch
2022-08-23T19:10:03,043 - INFO  - [broker-topic-workers-OrderedExecutor-7-0:PersistentDispatcherSingleActiveConsumer@162] - ============ before dispatch
2022-08-23T19:10:03,043 - INFO  - [broker-topic-workers-OrderedExecutor-7-0:PersistentDispatcherSingleActiveConsumer@164] - dispatch message to consumer ledger:3, entry:18
2022-08-23T19:10:03,043 - INFO  - [broker-topic-workers-OrderedExecutor-7-0:PersistentDispatcherSingleActiveConsumer@166] - ============ after dispatch
2022-08-23T19:10:03,043 - INFO  - [broker-topic-workers-OrderedExecutor-7-0:PersistentDispatcherSingleActiveConsumer@162] - ============ before dispatch
2022-08-23T19:10:03,043 - INFO  - [broker-topic-workers-OrderedExecutor-7-0:PersistentDispatcherSingleActiveConsumer@164] - dispatch message to consumer ledger:3, entry:19
2022-08-23T19:10:03,043 - INFO  - [pulsar-external-listener-197-1:SubscriptionMessageDispatchThrottlingTest@346] - Received message [18] in the listener
2022-08-23T19:10:03,044 - INFO  - [broker-topic-workers-OrderedExecutor-7-0:PersistentDispatcherSingleActiveConsumer@166] - ============ after dispatch
2022-08-23T19:10:03,044 - INFO  - [pulsar-external-listener-197-1:SubscriptionMessageDispatchThrottlingTest@346] - Received message [18] in the listener
2022-08-23T19:10:03,044 - INFO  - [pulsar-external-listener-197-1:SubscriptionMessageDispatchThrottlingTest@346] - Received message [19] in the listener
2022-08-23T19:10:04,045 - INFO  - [broker-topic-workers-OrderedExecutor-7-0:PersistentDispatcherSingleActiveConsumer@162] - ============ before dispatch
2022-08-23T19:10:04,045 - INFO  - [broker-topic-workers-OrderedExecutor-7-0:PersistentDispatcherSingleActiveConsumer@164] - dispatch message to consumer ledger:3, entry:20
2022-08-23T19:10:04,045 - INFO  - [broker-topic-workers-OrderedExecutor-7-0:PersistentDispatcherSingleActiveConsumer@164] - dispatch message to consumer ledger:3, entry:21
2022-08-23T19:10:04,045 - INFO  - [broker-topic-workers-OrderedExecutor-7-0:PersistentDispatcherSingleActiveConsumer@164] - dispatch message to consumer ledger:3, entry:22
2022-08-23T19:10:04,045 - INFO  - [broker-topic-workers-OrderedExecutor-7-0:PersistentDispatcherSingleActiveConsumer@164] - dispatch message to consumer ledger:3, entry:23
2022-08-23T19:10:04,045 - INFO  - [broker-topic-workers-OrderedExecutor-7-0:PersistentDispatcherSingleActiveConsumer@166] - ============ after dispatch
2022-08-23T19:10:04,045 - INFO  - [broker-topic-workers-OrderedExecutor-7-0:PersistentDispatcherSingleActiveConsumer@162] - ============ before dispatch
2022-08-23T19:10:04,045 - INFO  - [broker-topic-workers-OrderedExecutor-7-0:PersistentDispatcherSingleActiveConsumer@164] - dispatch message to consumer ledger:3, entry:20
2022-08-23T19:10:04,045 - INFO  - [broker-topic-workers-OrderedExecutor-7-0:PersistentDispatcherSingleActiveConsumer@164] - dispatch message to consumer ledger:3, entry:21
2022-08-23T19:10:04,045 - INFO  - [broker-topic-workers-OrderedExecutor-7-0:PersistentDispatcherSingleActiveConsumer@164] - dispatch message to consumer ledger:3, entry:22
2022-08-23T19:10:04,046 - INFO  - [broker-topic-workers-OrderedExecutor-7-0:PersistentDispatcherSingleActiveConsumer@164] - dispatch message to consumer ledger:3, entry:23
2022-08-23T19:10:04,046 - INFO  - [broker-topic-workers-OrderedExecutor-7-0:PersistentDispatcherSingleActiveConsumer@166] - ============ after dispatch
2022-08-23T19:10:04,046 - INFO  - [pulsar-external-listener-197-1:SubscriptionMessageDispatchThrottlingTest@346] - Received message [20] in the listener
2022-08-23T19:10:04,047 - INFO  - [pulsar-external-listener-197-1:SubscriptionMessageDispatchThrottlingTest@346] - Received message [21] in the listener
2022-08-23T19:10:04,047 - INFO  - [pulsar-external-listener-197-1:SubscriptionMessageDispatchThrottlingTest@346] - Received message [22] in the listener
2022-08-23T19:10:04,047 - INFO  - [pulsar-external-listener-197-1:SubscriptionMessageDispatchThrottlingTest@346] - Received message [23] in the listener
2022-08-23T19:10:04,047 - INFO  - [pulsar-external-listener-197-1:SubscriptionMessageDispatchThrottlingTest@346] - Received message [20] in the listener
2022-08-23T19:10:04,047 - INFO  - [pulsar-external-listener-197-1:SubscriptionMessageDispatchThrottlingTest@346] - Received message [21] in the listener
2022-08-23T19:10:04,047 - INFO  - [pulsar-external-listener-197-1:SubscriptionMessageDispatchThrottlingTest@346] - Received message [22] in the listener
2022-08-23T19:10:04,047 - INFO  - [pulsar-external-listener-197-1:SubscriptionMessageDispatchThrottlingTest@346] - Received message [23] in the listener
2022-08-23T19:10:05,048 - INFO  - [broker-topic-workers-OrderedExecutor-7-0:PersistentDispatcherSingleActiveConsumer@162] - ============ before dispatch
2022-08-23T19:10:05,048 - INFO  - [broker-topic-workers-OrderedExecutor-7-0:PersistentDispatcherSingleActiveConsumer@164] - dispatch message to consumer ledger:3, entry:24
2022-08-23T19:10:05,048 - INFO  - [broker-topic-workers-OrderedExecutor-7-0:PersistentDispatcherSingleActiveConsumer@164] - dispatch message to consumer ledger:3, entry:25
2022-08-23T19:10:05,048 - INFO  - [broker-topic-workers-OrderedExecutor-7-0:PersistentDispatcherSingleActiveConsumer@164] - dispatch message to consumer ledger:3, entry:26
2022-08-23T19:10:05,048 - INFO  - [broker-topic-workers-OrderedExecutor-7-0:PersistentDispatcherSingleActiveConsumer@166] - ============ after dispatch
2022-08-23T19:10:05,048 - INFO  - [broker-topic-workers-OrderedExecutor-7-0:PersistentDispatcherSingleActiveConsumer@162] - ============ before dispatch
2022-08-23T19:10:05,048 - INFO  - [broker-topic-workers-OrderedExecutor-7-0:PersistentDispatcherSingleActiveConsumer@164] - dispatch message to consumer ledger:3, entry:24
2022-08-23T19:10:05,048 - INFO  - [broker-topic-workers-OrderedExecutor-7-0:PersistentDispatcherSingleActiveConsumer@164] - dispatch message to consumer ledger:3, entry:25
2022-08-23T19:10:05,048 - INFO  - [broker-topic-workers-OrderedExecutor-7-0:PersistentDispatcherSingleActiveConsumer@164] - dispatch message to consumer ledger:3, entry:26
2022-08-23T19:10:05,048 - INFO  - [broker-topic-workers-OrderedExecutor-7-0:PersistentDispatcherSingleActiveConsumer@166] - ============ after dispatch
2022-08-23T19:10:05,049 - INFO  - [pulsar-external-listener-197-1:SubscriptionMessageDispatchThrottlingTest@346] - Received message [24] in the listener
2022-08-23T19:10:05,049 - INFO  - [pulsar-external-listener-197-1:SubscriptionMessageDispatchThrottlingTest@346] - Received message [25] in the listener
2022-08-23T19:10:05,049 - INFO  - [pulsar-external-listener-197-1:SubscriptionMessageDispatchThrottlingTest@346] - Received message [26] in the listener
2022-08-23T19:10:05,049 - INFO  - [pulsar-external-listener-197-1:SubscriptionMessageDispatchThrottlingTest@346] - Received message [24] in the listener
2022-08-23T19:10:05,049 - INFO  - [pulsar-external-listener-197-1:SubscriptionMessageDispatchThrottlingTest@346] - Received message [25] in the listener
2022-08-23T19:10:05,050 - INFO  - [pulsar-external-listener-197-1:SubscriptionMessageDispatchThrottlingTest@346] - Received message [26] in the listener
2022-08-23T19:10:05,659 - INFO  - [pulsar-load-manager-163-1:ModularLoadManagerImpl@466] - Writing local data to metadata store because maximum change 55.46875% exceeded threshold 10%; time since last report written is 5.02 seconds. ResourceUsage:[cpu: 11.06%, memory: 55.47%, directMemory: 9.38%, bandwidthIn: 0.00%, bandwidthOut: 0.00%]
2022-08-23T19:10:05,661 - INFO  - [metadata-store-171-1:ResourceLockImpl@165] - Acquired resource lock on /loadbalance/brokers/localhost:52221
2022-08-23T19:10:06,053 - INFO  - [broker-topic-workers-OrderedExecutor-7-0:PersistentDispatcherSingleActiveConsumer@162] - ============ before dispatch
2022-08-23T19:10:06,053 - INFO  - [broker-topic-workers-OrderedExecutor-7-0:PersistentDispatcherSingleActiveConsumer@164] - dispatch message to consumer ledger:3, entry:27
2022-08-23T19:10:06,053 - INFO  - [broker-topic-workers-OrderedExecutor-7-0:PersistentDispatcherSingleActiveConsumer@164] - dispatch message to consumer ledger:3, entry:28
2022-08-23T19:10:06,053 - INFO  - [broker-topic-workers-OrderedExecutor-7-0:PersistentDispatcherSingleActiveConsumer@164] - dispatch message to consumer ledger:3, entry:29
2022-08-23T19:10:06,053 - INFO  - [broker-topic-workers-OrderedExecutor-7-0:PersistentDispatcherSingleActiveConsumer@166] - ============ after dispatch
2022-08-23T19:10:06,053 - INFO  - [broker-topic-workers-OrderedExecutor-7-0:PersistentDispatcherSingleActiveConsumer@162] - ============ before dispatch
2022-08-23T19:10:06,053 - INFO  - [broker-topic-workers-OrderedExecutor-7-0:PersistentDispatcherSingleActiveConsumer@164] - dispatch message to consumer ledger:3, entry:27
2022-08-23T19:10:06,053 - INFO  - [broker-topic-workers-OrderedExecutor-7-0:PersistentDispatcherSingleActiveConsumer@164] - dispatch message to consumer ledger:3, entry:28
2022-08-23T19:10:06,053 - INFO  - [broker-topic-workers-OrderedExecutor-7-0:PersistentDispatcherSingleActiveConsumer@164] - dispatch message to consumer ledger:3, entry:29
2022-08-23T19:10:06,053 - INFO  - [broker-topic-workers-OrderedExecutor-7-0:PersistentDispatcherSingleActiveConsumer@166] - ============ after dispatch
2022-08-23T19:10:06,056 - INFO  - [pulsar-external-listener-197-1:SubscriptionMessageDispatchThrottlingTest@346] - Received message [27] in the listener
2022-08-23T19:10:06,056 - INFO  - [pulsar-external-listener-197-1:SubscriptionMessageDispatchThrottlingTest@346] - Received message [28] in the listener
2022-08-23T19:10:06,056 - INFO  - [pulsar-external-listener-197-1:SubscriptionMessageDispatchThrottlingTest@346] - Received message [29] in the listener
2022-08-23T19:10:06,056 - INFO  - [pulsar-external-listener-197-1:SubscriptionMessageDispatchThrottlingTest@346] - Received message [27] in the listener
2022-08-23T19:10:06,056 - INFO  - [pulsar-external-listener-197-1:SubscriptionMessageDispatchThrottlingTest@346] - Received message [28] in the listener
2022-08-23T19:10:06,056 - INFO  - [pulsar-external-listener-197-1:SubscriptionMessageDispatchThrottlingTest@346] - Received message [29] in the listener

java.lang.AssertionError: 
Expected :30.0
Actual   :41.0
<Click to see difference>


	at org.testng.Assert.fail(Assert.java:99)
	at org.testng.Assert.failNotEquals(Assert.java:1037)
	at org.testng.Assert.assertEquals(Assert.java:744)
	at org.testng.Assert.assertEquals(Assert.java:757)
	at org.apache.pulsar.client.api.SubscriptionMessageDispatchThrottlingTest.testDispatchRate(SubscriptionMessageDispatchThrottlingTest.java:390)
	at org.apache.pulsar.client.api.SubscriptionMessageDispatchThrottlingTest.testMultiLevelDispatch(SubscriptionMessageDispatchThrottlingTest.java:420)
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:104)
	at java.base/java.lang.reflect.Method.invoke(Method.java:577)
	at org.testng.internal.MethodInvocationHelper.invokeMethod(MethodInvocationHelper.java:132)
	at org.testng.internal.TestInvoker.invokeMethod(TestInvoker.java:599)
	at org.testng.internal.TestInvoker.invokeTestMethod(TestInvoker.java:174)
	at org.testng.internal.MethodRunner.runInSequence(MethodRunner.java:46)
	at org.testng.internal.TestInvoker$MethodInvocationAgent.invoke(TestInvoker.java:822)
	at org.testng.internal.TestInvoker.invokeTestMethods(TestInvoker.java:147)
	at org.testng.internal.TestMethodWorker.invokeTestMethods(TestMethodWorker.java:146)
	at org.testng.internal.TestMethodWorker.run(TestMethodWorker.java:128)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)
	at org.testng.TestRunner.privateRun(TestRunner.java:764)
	at org.testng.TestRunner.run(TestRunner.java:585)
	at org.testng.SuiteRunner.runTest(SuiteRunner.java:384)
	at org.testng.SuiteRunner.runSequentially(SuiteRunner.java:378)
	at org.testng.SuiteRunner.privateRun(SuiteRunner.java:337)
	at org.testng.SuiteRunner.run(SuiteRunner.java:286)
	at org.testng.SuiteRunnerWorker.runSuite(SuiteRunnerWorker.java:53)
	at org.testng.SuiteRunnerWorker.run(SuiteRunnerWorker.java:96)
	at org.testng.TestNG.runSuitesSequentially(TestNG.java:1218)
	at org.testng.TestNG.runSuitesLocally(TestNG.java:1140)
	at org.testng.TestNG.runSuites(TestNG.java:1069)
	at org.testng.TestNG.run(TestNG.java:1037)
	at com.intellij.rt.testng.IDEARemoteTestNG.run(IDEARemoteTestNG.java:66)
	at com.intellij.rt.testng.RemoteTestNGStarter.main(RemoteTestNGStarter.java:109)
```

### Modifications

- Add `synchronized` keyword and `havePendingRead` state to avoid read same position many times.
- Clean up the unnecessary `havePendingRead` check.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Documentation

Check the box below or label this PR directly.

Need to update docs? 

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)
  
- [x] `doc-not-needed` 
(Please explain why)
  
- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)