### PR TITLE
[improve][cli] Pulsar shell, Pulsar admin, Pulsar client and Pulsar perf: support for Windows

### DIFF
--- a/bin/pulsar-admin-common.cmd
+++ b/bin/pulsar-admin-common.cmd
@@ -1,0 +1,85 @@
+@echo off
+rem Licensed to the Apache Software Foundation (ASF) under one or more
+rem contributor license agreements.  See the NOTICE file distributed with
+rem this work for additional information regarding copyright ownership.
+rem The ASF licenses this file to You under the Apache License, Version 2.0
+rem (the "License"); you may not use this file except in compliance with
+rem the License.  You may obtain a copy of the License at
+rem
+rem     http://www.apache.org/licenses/LICENSE-2.0
+rem
+rem Unless required by applicable law or agreed to in writing, software
+rem distributed under the License is distributed on an "AS IS" BASIS,
+rem WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+rem See the License for the specific language governing permissions and
+rem limitations under the License.
+
+
+if not "%JAVA_HOME%" == "" goto javaHomeSet
+for %%i in (java.exe) do set "JAVACMD=%%~$PATH:i"
+goto checkJavaCmd
+
+:javaHomeSet
+set JAVACMD=%JAVA_HOME%\bin\java.exe
+
+if not exist "%JAVACMD%" (
+  echo The JAVA_HOME environment variable is not defined correctly, so Pulsar Shell cannot be started. >&2
+  echo JAVA_HOME is set to "%JAVA_HOME%", but "%JAVACMD%" does not exist. >&2
+  goto error
+)
+
+:checkJavaCmd
+if not exist "%JAVACMD%" (
+  echo The java.exe command does not exist in PATH nor is JAVA_HOME set, so Pulsar Shell cannot be started. >&2
+  goto error
+)
+
+
+for %%i in ("%~dp0.") do SET "SCRIPT_PATH=%%~fi"
+set "PULSAR_HOME_DIR=%SCRIPT_PATH%\..\"
+for %%i in ("%PULSAR_HOME_DIR%.") do SET "PULSAR_HOME=%%~fi"
+set "PULSAR_CLASSPATH=%PULSAR_CLASSPATH%;%PULSAR_HOME%\lib\*"
+
+
+if "%PULSAR_CLIENT_CONF%" == "" set "PULSAR_CLIENT_CONF=%PULSAR_HOME%\conf\client.conf"
+if "%PULSAR_LOG_CONF%" == "" set "PULSAR_LOG_CONF=%PULSAR_HOME%\conf\log4j2.yaml"
+
+set "PULSAR_LOG_CONF_DIR1=%PULSAR_LOG_CONF%\..\"
+for %%i in ("%PULSAR_LOG_CONF_DIR1%.") do SET "PULSAR_LOG_CONF_DIR=%%~fi"
+for %%a in ("%PULSAR_LOG_CONF%") do SET "PULSAR_LOG_CONF_BASENAME=%%~nxa"
+
+set "PULSAR_CLASSPATH=%PULSAR_CLASSPATH%;%PULSAR_LOG_CONF_DIR%"
+
+set "OPTS=%OPTS% -Dlog4j.configurationFile="%PULSAR_LOG_CONF_BASENAME%""
+set "OPTS=%OPTS% -Djava.net.preferIPv4Stack=true"
+
+set "isjava8=false"
+FOR /F "tokens=*" %%g IN ('"java -version 2>&1"') do (
+  echo %%g|find "version" >nul
+  if errorlevel 0 (
+    echo %%g|find "1.8" >nul
+    if errorlevel 0 (
+     set "isjava8=true"
+    )
+  )
+)
+
+if "%isjava8%" == "false" set "OPTS=%OPTS% --add-opens java.base/sun.net=ALL-UNNAMED"
+
+set "OPTS=-cp "%PULSAR_CLASSPATH%" %OPTS%"
+set "OPTS=%OPTS% %PULSAR_EXTRA_OPTS%"
+
+if "%PULSAR_LOG_DIR%" == "" set "PULSAR_LOG_DIR=%PULSAR_HOME%\logs"
+if "%PULSAR_LOG_APPENDER%" == "" set "PULSAR_LOG_APPENDER=RoutingAppender"
+if "%PULSAR_LOG_LEVEL%" == "" set "PULSAR_LOG_LEVEL=info"
+if "%PULSAR_LOG_ROOT_LEVEL%" == "" set "PULSAR_LOG_ROOT_LEVEL=%PULSAR_LOG_LEVEL%"
+if "%PULSAR_ROUTING_APPENDER_DEFAULT%" == "" set "PULSAR_ROUTING_APPENDER_DEFAULT=Console"
+
+set "OPTS=%OPTS% -Dpulsar.log.appender=%PULSAR_LOG_APPENDER%"
+set "OPTS=%OPTS% -Dpulsar.log.dir=%PULSAR_LOG_DIR%"
+set "OPTS=%OPTS% -Dpulsar.log.level=%PULSAR_LOG_LEVEL%"
+set "OPTS=%OPTS% -Dpulsar.log.root.level=%PULSAR_LOG_ROOT_LEVEL%"
+set "OPTS=%OPTS% -Dpulsar.routing.appender.default=%PULSAR_ROUTING_APPENDER_DEFAULT%"
+
+:error
+set ERROR_CODE=1

--- a/bin/pulsar-admin-common.cmd
+++ b/bin/pulsar-admin-common.cmd
@@ -1,19 +1,23 @@
-@echo off
-rem Licensed to the Apache Software Foundation (ASF) under one or more
-rem contributor license agreements.  See the NOTICE file distributed with
-rem this work for additional information regarding copyright ownership.
-rem The ASF licenses this file to You under the Apache License, Version 2.0
-rem (the "License"); you may not use this file except in compliance with
-rem the License.  You may obtain a copy of the License at
-rem
-rem     http://www.apache.org/licenses/LICENSE-2.0
-rem
-rem Unless required by applicable law or agreed to in writing, software
-rem distributed under the License is distributed on an "AS IS" BASIS,
-rem WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-rem See the License for the specific language governing permissions and
-rem limitations under the License.
+@REM
+@REM Licensed to the Apache Software Foundation (ASF) under one
+@REM or more contributor license agreements.  See the NOTICE file
+@REM distributed with this work for additional information
+@REM regarding copyright ownership.  The ASF licenses this file
+@REM to you under the Apache License, Version 2.0 (the
+@REM "License"); you may not use this file except in compliance
+@REM with the License.  You may obtain a copy of the License at
+@REM
+@REM   http://www.apache.org/licenses/LICENSE-2.0
+@REM
+@REM Unless required by applicable law or agreed to in writing,
+@REM software distributed under the License is distributed on an
+@REM "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+@REM KIND, either express or implied.  See the License for the
+@REM specific language governing permissions and limitations
+@REM under the License.
+@REM
 
+@echo off
 
 if not "%JAVA_HOME%" == "" goto javaHomeSet
 for %%i in (java.exe) do set "JAVACMD=%%~$PATH:i"

--- a/bin/pulsar-admin-common.cmd
+++ b/bin/pulsar-admin-common.cmd
@@ -19,22 +19,15 @@
 
 @echo off
 
-if not "%JAVA_HOME%" == "" goto javaHomeSet
-for %%i in (java.exe) do set "JAVACMD=%%~$PATH:i"
-goto checkJavaCmd
-
-:javaHomeSet
-set JAVACMD=%JAVA_HOME%\bin\java.exe
-
-if not exist "%JAVACMD%" (
-  echo The JAVA_HOME environment variable is not defined correctly, so Pulsar Shell cannot be started. >&2
-  echo JAVA_HOME is set to "%JAVA_HOME%", but "%JAVACMD%" does not exist. >&2
-  goto error
+if "%JAVA_HOME%" == "" (
+  for %%i in (java.exe) do set "JAVACMD=%%~$PATH:i"
+) else (
+  set "JAVACMD=%JAVA_HOME%\bin\java.exe"
 )
 
-:checkJavaCmd
 if not exist "%JAVACMD%" (
-  echo The java.exe command does not exist in PATH nor is JAVA_HOME set, so Pulsar Shell cannot be started. >&2
+  echo The JAVA_HOME environment variable is not defined correctly, so Pulsar CLI cannot be started. >&2
+  echo JAVA_HOME is set to "%JAVA_HOME%", but "%JAVACMD%" does not exist. >&2
   goto error
 )
 
@@ -86,4 +79,4 @@ set "OPTS=%OPTS% -Dpulsar.log.root.level=%PULSAR_LOG_ROOT_LEVEL%"
 set "OPTS=%OPTS% -Dpulsar.routing.appender.default=%PULSAR_ROUTING_APPENDER_DEFAULT%"
 
 :error
-set ERROR_CODE=1
+exit /b 1

--- a/bin/pulsar-admin.cmd
+++ b/bin/pulsar-admin.cmd
@@ -23,15 +23,8 @@ for %%i in ("%~dp0.") do SET "SCRIPT_PATH=%%~fi"
 set "PULSAR_HOME_DIR=%SCRIPT_PATH%\..\"
 for %%i in ("%PULSAR_HOME_DIR%.") do SET "PULSAR_HOME=%%~fi"
 call "%PULSAR_HOME%\bin\pulsar-admin-common.cmd"
-
+if ERRORLEVEL 1 (
+  exit /b 1
+)
 cd "%PULSAR_HOME%"
 "%JAVACMD%" %OPTS% org.apache.pulsar.admin.cli.PulsarAdminTool %PULSAR_CLIENT_CONF% %*
-
-if ERRORLEVEL 1 goto error
-goto end
-
-:error
-set ERROR_CODE=1
-
-:end
-set ERROR_CODE=%ERROR_CODE%

--- a/bin/pulsar-admin.cmd
+++ b/bin/pulsar-admin.cmd
@@ -19,10 +19,9 @@ set "PULSAR_HOME_DIR=%SCRIPT_PATH%\..\"
 for %%i in ("%PULSAR_HOME_DIR%.") do SET "PULSAR_HOME=%%~fi"
 call "%PULSAR_HOME%\bin\pulsar-admin-common.cmd"
 
-set "OPTS=%OPTS% -Dorg.jline.terminal.jansi=false"
-set "DEFAULT_CONFIG=-Dpulsar.shell.config.default="%PULSAR_CLIENT_CONF%""
+cd "%PULSAR_HOME%"
+"%JAVACMD%" %OPTS% org.apache.pulsar.admin.cli.PulsarAdminTool %PULSAR_CLIENT_CONF% %*
 
-"%JAVACMD%" %OPTS%  %DEFAULT_CONFIG%  org.apache.pulsar.shell.PulsarShell %*
 if ERRORLEVEL 1 goto error
 goto end
 

--- a/bin/pulsar-admin.cmd
+++ b/bin/pulsar-admin.cmd
@@ -1,18 +1,23 @@
+@REM
+@REM Licensed to the Apache Software Foundation (ASF) under one
+@REM or more contributor license agreements.  See the NOTICE file
+@REM distributed with this work for additional information
+@REM regarding copyright ownership.  The ASF licenses this file
+@REM to you under the Apache License, Version 2.0 (the
+@REM "License"); you may not use this file except in compliance
+@REM with the License.  You may obtain a copy of the License at
+@REM
+@REM   http://www.apache.org/licenses/LICENSE-2.0
+@REM
+@REM Unless required by applicable law or agreed to in writing,
+@REM software distributed under the License is distributed on an
+@REM "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+@REM KIND, either express or implied.  See the License for the
+@REM specific language governing permissions and limitations
+@REM under the License.
+@REM
+
 @echo off
-rem Licensed to the Apache Software Foundation (ASF) under one or more
-rem contributor license agreements.  See the NOTICE file distributed with
-rem this work for additional information regarding copyright ownership.
-rem The ASF licenses this file to You under the Apache License, Version 2.0
-rem (the "License"); you may not use this file except in compliance with
-rem the License.  You may obtain a copy of the License at
-rem
-rem     http://www.apache.org/licenses/LICENSE-2.0
-rem
-rem Unless required by applicable law or agreed to in writing, software
-rem distributed under the License is distributed on an "AS IS" BASIS,
-rem WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-rem See the License for the specific language governing permissions and
-rem limitations under the License.
 
 for %%i in ("%~dp0.") do SET "SCRIPT_PATH=%%~fi"
 set "PULSAR_HOME_DIR=%SCRIPT_PATH%\..\"

--- a/bin/pulsar-client.cmd
+++ b/bin/pulsar-client.cmd
@@ -14,15 +14,15 @@ rem WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 rem See the License for the specific language governing permissions and
 rem limitations under the License.
 
+
 for %%i in ("%~dp0.") do SET "SCRIPT_PATH=%%~fi"
 set "PULSAR_HOME_DIR=%SCRIPT_PATH%\..\"
 for %%i in ("%PULSAR_HOME_DIR%.") do SET "PULSAR_HOME=%%~fi"
 call "%PULSAR_HOME%\bin\pulsar-admin-common.cmd"
 
-set "OPTS=%OPTS% -Dorg.jline.terminal.jansi=false"
-set "DEFAULT_CONFIG=-Dpulsar.shell.config.default="%PULSAR_CLIENT_CONF%""
+cd "%PULSAR_HOME%"
+"%JAVACMD%" %OPTS% org.apache.pulsar.client.cli.PulsarClientTool %PULSAR_CLIENT_CONF% %*
 
-"%JAVACMD%" %OPTS%  %DEFAULT_CONFIG%  org.apache.pulsar.shell.PulsarShell %*
 if ERRORLEVEL 1 goto error
 goto end
 
@@ -31,3 +31,4 @@ set ERROR_CODE=1
 
 :end
 set ERROR_CODE=%ERROR_CODE%
+

--- a/bin/pulsar-client.cmd
+++ b/bin/pulsar-client.cmd
@@ -23,16 +23,8 @@ for %%i in ("%~dp0.") do SET "SCRIPT_PATH=%%~fi"
 set "PULSAR_HOME_DIR=%SCRIPT_PATH%\..\"
 for %%i in ("%PULSAR_HOME_DIR%.") do SET "PULSAR_HOME=%%~fi"
 call "%PULSAR_HOME%\bin\pulsar-admin-common.cmd"
-
+if ERRORLEVEL 1 (
+  exit /b 1
+)
 cd "%PULSAR_HOME%"
 "%JAVACMD%" %OPTS% org.apache.pulsar.client.cli.PulsarClientTool %PULSAR_CLIENT_CONF% %*
-
-if ERRORLEVEL 1 goto error
-goto end
-
-:error
-set ERROR_CODE=1
-
-:end
-set ERROR_CODE=%ERROR_CODE%
-

--- a/bin/pulsar-client.cmd
+++ b/bin/pulsar-client.cmd
@@ -1,19 +1,23 @@
-@echo off
-rem Licensed to the Apache Software Foundation (ASF) under one or more
-rem contributor license agreements.  See the NOTICE file distributed with
-rem this work for additional information regarding copyright ownership.
-rem The ASF licenses this file to You under the Apache License, Version 2.0
-rem (the "License"); you may not use this file except in compliance with
-rem the License.  You may obtain a copy of the License at
-rem
-rem     http://www.apache.org/licenses/LICENSE-2.0
-rem
-rem Unless required by applicable law or agreed to in writing, software
-rem distributed under the License is distributed on an "AS IS" BASIS,
-rem WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-rem See the License for the specific language governing permissions and
-rem limitations under the License.
+@REM
+@REM Licensed to the Apache Software Foundation (ASF) under one
+@REM or more contributor license agreements.  See the NOTICE file
+@REM distributed with this work for additional information
+@REM regarding copyright ownership.  The ASF licenses this file
+@REM to you under the Apache License, Version 2.0 (the
+@REM "License"); you may not use this file except in compliance
+@REM with the License.  You may obtain a copy of the License at
+@REM
+@REM   http://www.apache.org/licenses/LICENSE-2.0
+@REM
+@REM Unless required by applicable law or agreed to in writing,
+@REM software distributed under the License is distributed on an
+@REM "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+@REM KIND, either express or implied.  See the License for the
+@REM specific language governing permissions and limitations
+@REM under the License.
+@REM
 
+@echo off
 
 for %%i in ("%~dp0.") do SET "SCRIPT_PATH=%%~fi"
 set "PULSAR_HOME_DIR=%SCRIPT_PATH%\..\"

--- a/bin/pulsar-perf.cmd
+++ b/bin/pulsar-perf.cmd
@@ -1,0 +1,164 @@
+@REM
+@REM Licensed to the Apache Software Foundation (ASF) under one
+@REM or more contributor license agreements.  See the NOTICE file
+@REM distributed with this work for additional information
+@REM regarding copyright ownership.  The ASF licenses this file
+@REM to you under the Apache License, Version 2.0 (the
+@REM "License"); you may not use this file except in compliance
+@REM with the License.  You may obtain a copy of the License at
+@REM
+@REM   http://www.apache.org/licenses/LICENSE-2.0
+@REM
+@REM Unless required by applicable law or agreed to in writing,
+@REM software distributed under the License is distributed on an
+@REM "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+@REM KIND, either express or implied.  See the License for the
+@REM specific language governing permissions and limitations
+@REM under the License.
+@REM
+
+@echo off
+
+if "%JAVA_HOME%" == "" (
+  for %%i in (java.exe) do set "JAVACMD=%%~$PATH:i"
+) else (
+  set "JAVACMD=%JAVA_HOME%\bin\java.exe"
+)
+
+if not exist "%JAVACMD%" (
+  echo The JAVA_HOME environment variable is not defined correctly, so Pulsar CLI cannot be started. >&2
+  echo JAVA_HOME is set to "%JAVA_HOME%", but "%JAVACMD%" does not exist. >&2
+  exit /B 1
+)
+
+for %%i in ("%~dp0.") do SET "SCRIPT_PATH=%%~fi"
+set "PULSAR_HOME_DIR=%SCRIPT_PATH%\..\"
+for %%i in ("%PULSAR_HOME_DIR%.") do SET "PULSAR_HOME=%%~fi"
+set "PULSAR_CLASSPATH=%PULSAR_CLASSPATH%;%PULSAR_HOME%\lib\*"
+
+
+if "%PULSAR_CLIENT_CONF%" == "" set "PULSAR_CLIENT_CONF=%PULSAR_HOME%\conf\client.conf"
+if "%PULSAR_LOG_CONF%" == "" set "PULSAR_LOG_CONF=%PULSAR_HOME%\conf\log4j2.yaml"
+
+set "PULSAR_LOG_CONF_DIR1=%PULSAR_LOG_CONF%\..\"
+for %%i in ("%PULSAR_LOG_CONF_DIR1%.") do SET "PULSAR_LOG_CONF_DIR=%%~fi"
+for %%a in ("%PULSAR_LOG_CONF%") do SET "PULSAR_LOG_CONF_BASENAME=%%~nxa"
+
+set "PULSAR_CLASSPATH=%PULSAR_CLASSPATH%;%PULSAR_LOG_CONF_DIR%"
+if not "%PULSAR_EXTRA_CLASSPATH%" == "" set "PULSAR_CLASSPATH=%PULSAR_CLASSPATH%;%PULSAR_EXTRA_CLASSPATH%"
+
+
+if "%PULSAR_PERFTEST_CONF%" == "" set "PULSAR_PERFTEST_CONF=%PULSAR_CLIENT_CONF%"
+
+
+set "OPTS=%OPTS% -Dlog4j.configurationFile="%PULSAR_LOG_CONF_BASENAME%""
+set "OPTS=%OPTS% -Djava.net.preferIPv4Stack=true"
+
+
+set "OPTS=-cp "%PULSAR_CLASSPATH%" %OPTS%"
+set "OPTS=%OPTS% %PULSAR_EXTRA_OPTS%"
+
+if "%PULSAR_LOG_DIR%" == "" set "PULSAR_LOG_DIR=%PULSAR_HOME%\logs"
+if "%PULSAR_LOG_FILE%" == "" set "PULSAR_LOG_FILE=pulsar-perftest.log"
+if "%PULSAR_LOG_APPENDER%" == "" set "PULSAR_LOG_APPENDER=Console"
+if "%PULSAR_LOG_LEVEL%" == "" set "PULSAR_LOG_LEVEL=info"
+if "%PULSAR_LOG_ROOT_LEVEL%" == "" set "PULSAR_LOG_ROOT_LEVEL=%PULSAR_LOG_LEVEL%"
+
+
+set "OPTS=%OPTS% -Dpulsar.log.appender=%PULSAR_LOG_APPENDER%"
+set "OPTS=%OPTS% -Dpulsar.log.dir=%PULSAR_LOG_DIR%"
+set "OPTS=%OPTS% -Dpulsar.log.level=%PULSAR_LOG_LEVEL%"
+set "OPTS=%OPTS% -Dpulsar.log.root.level=%PULSAR_LOG_ROOT_LEVEL%"
+
+set "COMMAND=%1"
+
+for /f "tokens=1,* delims= " %%a in ("%*") do set "_args=%%b"
+
+if "%COMMAND%" == "produce" (
+  call :execCmdWithConfigFile org.apache.pulsar.testclient.PerformanceProducer
+  exit /B %ERROR_CODE%
+)
+if "%COMMAND%" == "consume" (
+  call :execCmdWithConfigFile org.apache.pulsar.testclient.PerformanceConsumer
+  exit /B %ERROR_CODE%
+)
+if "%COMMAND%" == "transaction" (
+  call :execCmdWithConfigFile org.apache.pulsar.testclient.PerformanceTransaction
+  exit /B %ERROR_CODE%
+)
+if "%COMMAND%" == "read" (
+  call :execCmdWithConfigFile org.apache.pulsar.testclient.PerformanceReader
+  exit /B %ERROR_CODE%
+)
+if "%COMMAND%" == "monitor-brokers" (
+  call :execCmd org.apache.pulsar.testclient.BrokerMonitor
+  exit /B %ERROR_CODE%
+)
+if "%COMMAND%" == "simulation-client" (
+  call :execCmd org.apache.pulsar.testclient.LoadSimulationClient
+  exit /B %ERROR_CODE%
+)
+if "%COMMAND%" == "simulation-controller" (
+  call :execCmd org.apache.pulsar.testclient.LoadSimulationController
+  exit /B %ERROR_CODE%
+)
+if "%COMMAND%" == "websocket-producer" (
+  call :execCmd org.apache.pulsar.proxy.socket.client.PerformanceClient
+  exit /B %ERROR_CODE%
+)
+if "%COMMAND%" == "managed-ledger" (
+  call :execCmd org.apache.pulsar.testclient.ManagedLedgerWriter
+  exit /B %ERROR_CODE%
+)
+if "%COMMAND%" == "gen-doc" (
+  call :execCmd  org.apache.pulsar.testclient.CmdGenerateDocumentation
+  exit /B %ERROR_CODE%
+)
+
+call :usage
+exit /B %ERROR_CODE%
+
+:execCmdWithConfigFile
+"%JAVACMD%" %OPTS% %1 --conf-file "%PULSAR_PERFTEST_CONF%" %_args%
+if ERRORLEVEL 1 (
+  call :error
+)
+goto :eof
+
+:execCmd
+"%JAVACMD%" %OPTS% %1 %_args%
+if ERRORLEVEL 1 (
+  call :error
+)
+goto :eof
+
+
+
+:error
+set ERROR_CODE=1
+goto :eof
+
+
+
+
+:usage
+echo Usage: pulsar-perf COMMAND
+echo where command is one of:
+echo     produce                 Run a producer
+echo     consume                 Run a consumer
+echo     transaction             Run a transaction repeatedly
+echo     read                    Run a topic reader
+echo     websocket-producer      Run a websocket producer
+echo     managed-ledger          Write directly on managed-ledgers
+echo     monitor-brokers         Continuously receive broker data and/or load reports
+echo     simulation-client       Run a simulation server acting as a Pulsar client
+echo     simulation-controller   Run a simulation controller to give commands to servers
+echo     gen-doc                 Generate documentation automatically.
+echo     help                    This help message
+echo or command is the full name of a class with a defined main() method.
+echo Environment variables:
+echo     PULSAR_LOG_CONF               Log4j configuration file (default %PULSAR_HOME%\logs)
+echo     PULSAR_CLIENT_CONF            Configuration file for client (default: %PULSAR_HOME%\conf\client.conf)
+echo     PULSAR_EXTRA_OPTS             Extra options to be passed to the jvm
+echo     PULSAR_EXTRA_CLASSPATH        Add extra paths to the pulsar classpath
+goto error

--- a/bin/pulsar-shell.cmd
+++ b/bin/pulsar-shell.cmd
@@ -23,16 +23,11 @@ for %%i in ("%~dp0.") do SET "SCRIPT_PATH=%%~fi"
 set "PULSAR_HOME_DIR=%SCRIPT_PATH%\..\"
 for %%i in ("%PULSAR_HOME_DIR%.") do SET "PULSAR_HOME=%%~fi"
 call "%PULSAR_HOME%\bin\pulsar-admin-common.cmd"
+if ERRORLEVEL 1 (
+  exit /b 1
+)
 
 set "OPTS=%OPTS% -Dorg.jline.terminal.jansi=false"
 set "DEFAULT_CONFIG=-Dpulsar.shell.config.default="%PULSAR_CLIENT_CONF%""
 
 "%JAVACMD%" %OPTS%  %DEFAULT_CONFIG%  org.apache.pulsar.shell.PulsarShell %*
-if ERRORLEVEL 1 goto error
-goto end
-
-:error
-set ERROR_CODE=1
-
-:end
-set ERROR_CODE=%ERROR_CODE%

--- a/bin/pulsar-shell.cmd
+++ b/bin/pulsar-shell.cmd
@@ -1,18 +1,23 @@
+@REM
+@REM Licensed to the Apache Software Foundation (ASF) under one
+@REM or more contributor license agreements.  See the NOTICE file
+@REM distributed with this work for additional information
+@REM regarding copyright ownership.  The ASF licenses this file
+@REM to you under the Apache License, Version 2.0 (the
+@REM "License"); you may not use this file except in compliance
+@REM with the License.  You may obtain a copy of the License at
+@REM
+@REM   http://www.apache.org/licenses/LICENSE-2.0
+@REM
+@REM Unless required by applicable law or agreed to in writing,
+@REM software distributed under the License is distributed on an
+@REM "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+@REM KIND, either express or implied.  See the License for the
+@REM specific language governing permissions and limitations
+@REM under the License.
+@REM
+
 @echo off
-rem Licensed to the Apache Software Foundation (ASF) under one or more
-rem contributor license agreements.  See the NOTICE file distributed with
-rem this work for additional information regarding copyright ownership.
-rem The ASF licenses this file to You under the Apache License, Version 2.0
-rem (the "License"); you may not use this file except in compliance with
-rem the License.  You may obtain a copy of the License at
-rem
-rem     http://www.apache.org/licenses/LICENSE-2.0
-rem
-rem Unless required by applicable law or agreed to in writing, software
-rem distributed under the License is distributed on an "AS IS" BASIS,
-rem WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-rem See the License for the specific language governing permissions and
-rem limitations under the License.
 
 for %%i in ("%~dp0.") do SET "SCRIPT_PATH=%%~fi"
 set "PULSAR_HOME_DIR=%SCRIPT_PATH%\..\"

--- a/bin/pulsar-shell.cmd
+++ b/bin/pulsar-shell.cmd
@@ -1,0 +1,96 @@
+@echo off
+rem Licensed to the Apache Software Foundation (ASF) under one or more
+rem contributor license agreements.  See the NOTICE file distributed with
+rem this work for additional information regarding copyright ownership.
+rem The ASF licenses this file to You under the Apache License, Version 2.0
+rem (the "License"); you may not use this file except in compliance with
+rem the License.  You may obtain a copy of the License at
+rem
+rem     http://www.apache.org/licenses/LICENSE-2.0
+rem
+rem Unless required by applicable law or agreed to in writing, software
+rem distributed under the License is distributed on an "AS IS" BASIS,
+rem WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+rem See the License for the specific language governing permissions and
+rem limitations under the License.
+
+
+if not "%JAVA_HOME%" == "" goto javaHomeSet
+for %%i in (java.exe) do set "JAVACMD=%%~$PATH:i"
+goto checkJavaCmd
+
+:javaHomeSet
+set JAVACMD=%JAVA_HOME%\bin\java.exe
+
+if not exist "%JAVACMD%" (
+  echo The JAVA_HOME environment variable is not defined correctly, so Pulsar Shell cannot be started. >&2
+  echo JAVA_HOME is set to "%JAVA_HOME%", but "%JAVACMD%" does not exist. >&2
+  goto error
+)
+
+:checkJavaCmd
+if not exist "%JAVACMD%" (
+  echo The java.exe command does not exist in PATH nor is JAVA_HOME set, so Pulsar Shell cannot be started. >&2
+  goto error
+)
+
+
+for %%i in ("%~dp0.") do SET "SCRIPT_PATH=%%~fi"
+set "PULSAR_HOME_DIR=%SCRIPT_PATH%\..\"
+for %%i in ("%PULSAR_HOME_DIR%.") do SET "PULSAR_HOME=%%~fi"
+set "PULSAR_CLASSPATH=%PULSAR_CLASSPATH%;%PULSAR_HOME%\lib\*"
+
+
+if "%PULSAR_CLIENT_CONF%" == "" set "PULSAR_CLIENT_CONF=%PULSAR_HOME%/conf/client.conf"
+if "%PULSAR_LOG_CONF%" == "" set "PULSAR_LOG_CONF=%PULSAR_HOME%/conf/log4j2.yaml"
+
+set "PULSAR_LOG_CONF_DIR_TMP=%PULSAR_LOG_CONF%\..\"
+for %%i in ("%PULSAR_LOG_CONF_DIR_TMP%.") do SET "PULSAR_LOG_CONF_DIR=%%~fi"
+for %%a in ("%PULSAR_LOG_CONF%") do SET "PULSAR_LOG_CONF_BASENAME=%%~nxa"
+
+set "PULSAR_CLASSPATH=%PULSAR_CLASSPATH%;%PULSAR_LOG_CONF_DIR%"
+
+set "OPTS=%OPTS% "-Dlog4j.configurationFile=%PULSAR_LOG_CONF_BASENAME%""
+set "OPTS=%OPTS% "-Djava.net.preferIPv4Stack=true""
+
+set "isjava8=false"
+FOR /F "tokens=*" %%g IN ('"java -version 2>&1"') do (
+  echo %%g|find "version" >nul
+  if errorlevel 0 (
+    echo %%g|find "1.8" >nul
+    if errorlevel 0 (
+     set "isjava8=true"
+    )
+  )
+)
+
+if "%isjava8%" == "false" set "OPTS=%OPTS% "--add-opens java.base/sun.net=ALL-UNNAMED""
+
+set "OPTS=-cp "%PULSAR_CLASSPATH% %OPTS%""
+set "OPTS=%OPTS% %PULSAR_EXTRA_OPTS%"
+
+if "%PULSAR_LOG_DIR%" == "" set "PULSAR_LOG_DIR=%PULSAR_HOME%/logs"
+if "%PULSAR_LOG_APPENDER%" == "" set "PULSAR_LOG_APPENDER=RoutingAppender"
+if "%PULSAR_LOG_LEVEL%" == "" set "PULSAR_LOG_LEVEL=info"
+if "%PULSAR_LOG_ROOT_LEVEL%" == "" set "PULSAR_LOG_ROOT_LEVEL=%PULSAR_LOG_LEVEL%"
+if "%PULSAR_ROUTING_APPENDER_DEFAULT%" == "" set "PULSAR_ROUTING_APPENDER_DEFAULT=Console"
+
+set "OPTS=%OPTS% "-Dpulsar.log.appender=%PULSAR_LOG_APPENDER%""
+set "OPTS=%OPTS% "-Dpulsar.log.dir=%PULSAR_LOG_DIR%""
+set "OPTS=%OPTS% "-Dpulsar.log.level=%PULSAR_LOG_LEVEL%""
+set "OPTS=%OPTS% "-Dpulsar.log.root.level=%PULSAR_LOG_ROOT_LEVEL%""
+set "OPTS=%OPTS% "-Dpulsar.routing.appender.default=%PULSAR_ROUTING_APPENDER_DEFAULT%""
+
+set "OPTS=%OPTS% "-Dorg.jline.terminal.jansi=false""
+set "DEFAULT_CONFIG="-Dpulsar.shell.config.default=%PULSAR_CLIENT_CONF%""
+
+
+"%JAVACMD%" %OPTS%  %DEFAULT_CONFIG%  org.apache.pulsar.shell.PulsarShell %*
+if ERRORLEVEL 1 goto error
+goto end
+
+:error
+set ERROR_CODE=1
+
+:end
+set ERROR_CODE=%ERROR_CODE%

--- a/distribution/shell/src/assemble/shell.xml
+++ b/distribution/shell/src/assemble/shell.xml
@@ -24,6 +24,7 @@
   <id>shell</id>
   <formats>
     <format>tar.gz</format>
+    <format>zip</format>
   </formats>
   <includeBaseDirectory>true</includeBaseDirectory>
   <files>

--- a/pom.xml
+++ b/pom.xml
@@ -211,7 +211,7 @@ flexible messaging model and an intuitive client API.</description>
     <jakarta.activation.version>1.2.2</jakarta.activation.version>
     <jakarta.xml.bind.version>2.3.3</jakarta.xml.bind.version>
     <jakarta.validation.version>2.0.2</jakarta.validation.version>
-    <jna.version>4.2.0</jna.version>
+    <jna.version>5.12.1</jna.version>
     <kubernetesclient.version>12.0.1</kubernetesclient.version>
     <okhttp3.version>4.9.3</okhttp3.version>
     <!-- use okio version that matches the okhttp3 version -->

--- a/pom.xml
+++ b/pom.xml
@@ -211,7 +211,7 @@ flexible messaging model and an intuitive client API.</description>
     <jakarta.activation.version>1.2.2</jakarta.activation.version>
     <jakarta.xml.bind.version>2.3.3</jakarta.xml.bind.version>
     <jakarta.validation.version>2.0.2</jakarta.validation.version>
-    <jna.version>5.12.1</jna.version>
+    <jna.version>4.2.0</jna.version>
     <kubernetesclient.version>12.0.1</kubernetesclient.version>
     <okhttp3.version>4.9.3</okhttp3.version>
     <!-- use okio version that matches the okhttp3 version -->

--- a/pulsar-client-tools/pom.xml
+++ b/pulsar-client-tools/pom.xml
@@ -119,6 +119,11 @@
       <version>${jline3.version}</version>
     </dependency>
     <dependency>
+      <groupId>net.java.dev.jna</groupId>
+      <artifactId>jna</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-text</artifactId>
       <version>${commons-text.version}</version>

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/shell/PulsarShell.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/shell/PulsarShell.java
@@ -216,7 +216,6 @@ public class PulsarShell {
     }
 
     public void run() throws Exception {
-        System.setProperty("org.jline.terminal.dumb", "true");
         final Terminal terminal = TerminalBuilder.builder().build();
         run((providersMap) -> {
             List<Completer> completers = new ArrayList<>();


### PR DESCRIPTION
Fixes #16688

TL; DR - now Pulsar shell works on Windows
![Screen Shot 2022-08-23 at 6 02 50 PM](https://user-images.githubusercontent.com/23314389/186206825-b644054a-8729-4a79-902f-a6ac598d6929.png)


### Motivation
Currently pulsar shell is only runnable on Unix system because the entry point script is written in bash.

### Modifications

1. Provided a new `pulsar-shell.cmd`, `pulsar-admin.cmd`, `pulsar-client.cmd` and `pulsar-perf.cmd` files (written in Windows Command Prompt language) that starts their processes

It implements the exact same configurations from the current pulsar-shell, even the java8 detection. The only thing not implemented is the on-the-fly compile. Actually, the batch script only work if you unzip the distro tarball. Running it from the codebase (so without the `lib` dir) is not supported (and it's okay since currently it's not even possible develop Pulsar on a Win machine)

2. Added the jna lib to make the jline command prompt display colors correctly - will need to upgrade to the latest JNA version to fix some current issues

3. Added zip distribution to pulsar-shell (distribution/shell). The idea is to distribute both and suggest to download the .zip for Windows user

- [x] `doc-not-needed` 
