### PR TITLE
[Branch-2.9]Upgrade rocksdb version to 6.16.4 to keep sync with bookkeeper

### DIFF
--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -450,7 +450,7 @@ The Apache Software License, Version 2.0
     - org.eclipse.jetty-jetty-alpn-conscrypt-server-9.4.48.v20220622.jar
     - org.eclipse.jetty-jetty-alpn-server-9.4.48.v20220622.jar
  * SnakeYaml -- org.yaml-snakeyaml-1.30.jar
- * RocksDB - org.rocksdb-rocksdbjni-6.10.2.jar
+ * RocksDB - org.rocksdb-rocksdbjni-6.16.4.jar
  * Google Error Prone Annotations - com.google.errorprone-error_prone_annotations-2.5.1.jar
  * Apache Thrift - org.apache.thrift-libthrift-0.14.2.jar
  * OkHttp3

--- a/pom.xml
+++ b/pom.xml
@@ -117,7 +117,7 @@ flexible messaging model and an intuitive client API.</description>
     <athenz.version>1.10.9</athenz.version>
     <prometheus.version>0.5.0</prometheus.version>
     <vertx.version>3.9.8</vertx.version>
-    <rocksdb.version>6.10.2</rocksdb.version>
+    <rocksdb.version>6.16.4</rocksdb.version>
     <slf4j.version>1.7.32</slf4j.version>
     <commons.collections.version>3.2.2</commons.collections.version>
     <log4j2.version>2.18.0</log4j2.version>

--- a/pulsar-sql/presto-distribution/LICENSE
+++ b/pulsar-sql/presto-distribution/LICENSE
@@ -396,7 +396,7 @@ The Apache Software License, Version 2.0
     - presto-spi-332.jar
     - presto-record-decoder-332.jar
   * RocksDB JNI
-    - rocksdbjni-6.10.2.jar
+    - rocksdbjni-6.16.4.jar
   * SnakeYAML
     - snakeyaml-1.30.jar
   * Bean Validation API


### PR DESCRIPTION
### Motivation
- Pulsar 2.9.x use BookKeeper 4.14.5
- BookKeeper 4.14.5 use RocksDB 6.16.4
- Pulsar 2.9.x uses RocksDB 6.10.2

In Pulsar packaging, it uses RocksDB 6.10.2 override 6.16.4, So in our image, BookKeeper uses RocksDB 6.10.2 instead of 6.16.4

### Modification
Upgrade Pulsar broker-side RocksDB dependency to 6.16.4 to keep sync with BookKeeper.