### PR TITLE
[fix][ci] Fix docbot always cancelled

### DIFF
--- a/.github/workflows/ci-documentbot.yml
+++ b/.github/workflows/ci-documentbot.yml
@@ -28,7 +28,7 @@ on:
       - unlabeled
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event.number }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
Signed-off-by: Zixuan Liu <nodeces@gmail.com>

### Motivation

Randome pick a PR, you will see the docbot CI is always cancelled.

Root cause is using `${{ github.workflow }}-${{ github.ref }}` as id to cancel the docbot task.

The `github.ref` value is always what the PR wants to submit to the base branch like:
```
Canceling since a higher priority waiting request for 'Documentation Bot-refs/heads/master' exists
```

So you saw always cancelled, right now append a PR number to try to fix this issue.

### Modifications

- Append the `github.event.number` to `concurrency.group` value

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API: (yes / no)
  - The schema: (yes / no / don't know)
  - The default values of configurations: (yes / no)
  - The wire protocol: (yes / no)
  - The rest endpoints: (yes / no)
  - The admin cli options: (yes / no)
  - Anything that affects deployment: (yes / no / don't know)

### Documentation

Check the box below or label this PR directly.

Need to update docs? 

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)
  
- [x] `doc-not-needed` 
(Please explain why)
  
- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)