### PR TITLE
[fix][broker] Fix intermittent issue where leader broker information is lost and causes lookup issues

### DIFF
--- a/pulsar-common/src/main/java/org/apache/pulsar/common/util/FutureUtil.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/util/FutureUtil.java
@@ -203,6 +203,28 @@ public class FutureUtil {
     }
 
     /**
+     * Completes a future after a given delay.
+     *
+     * @param delay the duration of the delay
+     * @param executor the executor to use for scheduling the delayed execution
+     * @param supplier the supplier for creating the return value
+     * @return a future that completes after a given delay by using the supplier
+     * @param <T> type parameter for the future
+     */
+    public static <T> CompletableFuture<T> delayedFuture(Duration delay, ScheduledExecutorService executor,
+                                                         Supplier<T> supplier) {
+        CompletableFuture<T> future = new CompletableFuture<>();
+        executor.schedule(() -> {
+            try {
+                future.complete(supplier.get());
+            } catch (Exception e) {
+                future.completeExceptionally(e);
+            }
+        }, delay.toMillis(), TimeUnit.MILLISECONDS);
+        return future;
+    }
+
+    /**
      * Creates a low-overhead timeout exception which is performance optimized to minimize allocations
      * and cpu consumption. It sets the stacktrace of the exception to the given source class and
      * source method name. The instances of this class can be cached or stored as constants and reused

--- a/pulsar-common/src/test/java/org/apache/pulsar/common/util/FutureUtilTest.java
+++ b/pulsar-common/src/test/java/org/apache/pulsar/common/util/FutureUtilTest.java
@@ -19,6 +19,11 @@
 
 package org.apache.pulsar.common.util;
 
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.time.Duration;
@@ -30,16 +35,10 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeoutException;
-import java.util.concurrent.atomic.AtomicLong;
 import lombok.Cleanup;
 import org.assertj.core.util.Lists;
 import org.awaitility.Awaitility;
 import org.testng.annotations.Test;
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertFalse;
-import static org.testng.Assert.assertNotNull;
-import static org.testng.Assert.assertTrue;
-import static org.testng.Assert.fail;
 
 public class FutureUtilTest {
 

--- a/pulsar-common/src/test/java/org/apache/pulsar/common/util/FutureUtilTest.java
+++ b/pulsar-common/src/test/java/org/apache/pulsar/common/util/FutureUtilTest.java
@@ -30,6 +30,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicLong;
 import lombok.Cleanup;
 import org.assertj.core.util.Lists;
 import org.awaitility.Awaitility;
@@ -178,5 +179,16 @@ public class FutureUtilTest {
         } catch (CompletionException ex) {
             assertTrue(ex.getCause() instanceof RuntimeException);
         }
+    }
+
+    @Test
+    public void testDelayedFuture() throws ExecutionException, InterruptedException {
+        @Cleanup("shutdownNow")
+        ScheduledExecutorService executor = Executors.newScheduledThreadPool(1);
+        long startTime = System.currentTimeMillis();
+        Duration delay = Duration.ofMillis(250);
+        FutureUtil.delayedFuture(delay, executor, () -> null).get();
+        long elapsedTime = System.currentTimeMillis() - startTime;
+        assertTrue(elapsedTime > delay.toMillis());
     }
 }


### PR DESCRIPTION
### Motivation

- Fixes issue where leader broker information isn't available and this warning gets logged:
  `WARN  org.apache.pulsar.broker.namespace.NamespaceService - The information about the current leader broker wasn't available. Handling load manager decisions in a decentralized way.`

### Modifications

- use `LeaderElectionService`'s `readCurrentLeader` method instead of `getCurrentLeader` method. This ensures that the leader broker information is refreshed if it happens to be missing. 
- refactor existing code so that the asynchronous `readCurrentLeader` method can be used.