### PR TITLE
[fix][broker]ManagedLedger metrics fail cause of zero period

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerMBeanImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerMBeanImpl.java
@@ -63,6 +63,10 @@ public class ManagedLedgerMBeanImpl implements ManagedLedgerMXBean {
 
     public void refreshStats(long period, TimeUnit unit) {
         double seconds = unit.toMillis(period) / 1000.0;
+        if (seconds <= 0.0) {
+            // skip refreshing stats
+            return;
+        }
         addEntryOps.calculateRate(seconds);
         addEntryWithReplicasOps.calculateRate(seconds);
         addEntryOpsFailed.calculateRate(seconds);


### PR DESCRIPTION
### Motivation

`ManagedLedgerMBeanImpl` will execute method `refreshStats` immediately after it is created, but if `refreshStats` is executed too fast, will throws `IllegalArgumentException`.

- `refreshStats` execute immediately
https://github.com/apache/pulsar/blob/fd9489771959f3e722656e4b70d4bd891a13f690/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerFactoryImpl.java#L198-L199

- throw `IllegalArgumentException` if executed too fast
https://github.com/apache/pulsar/blob/1de80e0684ec5c13b6edcd217af62d74d8677f04/pulsar-common/src/main/java/org/apache/pulsar/common/stats/Rate.java#L62-L64

`ManagedLedgerMBeanImpl.refreshStats` will immediatelly execute after create

### Modifications

Skip refreshing stats, just like `ManagedLedgerFactoryMBeanImpl.refreshStats`

https://github.com/apache/pulsar/blob/1de80e0684ec5c13b6edcd217af62d74d8677f04/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerFactoryMBeanImpl.java#L38-L44

### Documentation


- [ ] `doc-required` 

  
- [x] `doc-not-needed` 

  
- [ ] `doc` 


- [ ] `doc-complete`