### PR TITLE
[improve][dependency] Upgrade JNA to 5.12.1

### DIFF
--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -399,7 +399,7 @@ The Apache Software License, Version 2.0
     - org.apache.logging.log4j-log4j-core-2.18.0.jar
     - org.apache.logging.log4j-log4j-slf4j-impl-2.18.0.jar
     - org.apache.logging.log4j-log4j-web-2.18.0.jar
- * Java Native Access JNA -- net.java.dev.jna-jna-4.2.0.jar
+ * Java Native Access JNA -- net.java.dev.jna-jna-5.12.1.jar
  * BookKeeper
     - org.apache.bookkeeper-bookkeeper-common-4.15.0.jar
     - org.apache.bookkeeper-bookkeeper-common-allocator-4.15.0.jar

--- a/pom.xml
+++ b/pom.xml
@@ -211,7 +211,7 @@ flexible messaging model and an intuitive client API.</description>
     <jakarta.activation.version>1.2.2</jakarta.activation.version>
     <jakarta.xml.bind.version>2.3.3</jakarta.xml.bind.version>
     <jakarta.validation.version>2.0.2</jakarta.validation.version>
-    <jna.version>4.2.0</jna.version>
+    <jna.version>5.12.1</jna.version>
     <kubernetesclient.version>12.0.1</kubernetesclient.version>
     <okhttp3.version>4.9.3</okhttp3.version>
     <!-- use okio version that matches the okhttp3 version -->


### PR DESCRIPTION
### Motivation

JLine3 doesn't work well with current JNA version on Windows. It's a requirement for https://github.com/apache/pulsar/pull/17243


### Modifications

* Upgrade JNA from 4.2.0 to 5.12.1

Note that this lib is also used by the ZK cli. I tested it and it still works correctly after the upgrade.

- [x] `doc-not-needed` 
