### PR TITLE
[branch-2.11][license] Fix license issue.

### DIFF
--- a/pulsar-sql/presto-distribution/LICENSE
+++ b/pulsar-sql/presto-distribution/LICENSE
@@ -222,7 +222,6 @@ The Apache Software License, Version 2.0
     - jackson-module-jsonSchema-2.13.2.jar
  * Guava
     - guava-31.0.1-jre.jar
-    - listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.jar
     - failureaccess-1.0.1.jar
  * Google Guice
     - guice-5.1.0.jar
@@ -272,7 +271,6 @@ The Apache Software License, Version 2.0
 
  * Joda Time
     - joda-time-2.10.5.jar
-    - failsafe-2.4.4.jar
   * Jetty
     - http2-client-9.4.48.v20220622.jar
     - http2-common-9.4.48.v20220622.jar
@@ -344,6 +342,10 @@ The Apache Software License, Version 2.0
     - leveldb-api-0.10.jar
   * Log4j implemented over SLF4J
     - log4j-over-slf4j-1.7.32.jar
+  * Log4j
+    - log4j-api-2.18.0.jar
+    - log4j-core-2.18.0.jar
+    - log4j-slf4j-impl-2.18.0.jar
   * Lucene Common Analyzers
     - lucene-analyzers-common-8.4.1.jar
     - lucene-core-8.4.1.jar
@@ -388,7 +390,7 @@ The Apache Software License, Version 2.0
   * JCommander
     - jcommander-1.82.jar
   * FindBugs JSR305
-    - jsr305-3.0.2.jar
+    - jsr305-2.0.1.jar
   * Objenesis
     - objenesis-2.6.jar
   * Okio
@@ -407,7 +409,7 @@ The Apache Software License, Version 2.0
     - presto-spi-334.jar
     - presto-record-decoder-334.jar
   * RocksDB JNI
-    - rocksdbjni-6.10.2.jar
+    - rocksdbjni-6.29.4.1.jar
   * SnakeYAML
     - snakeyaml-1.30.jar
   * Bean Validation API
@@ -449,7 +451,7 @@ The Apache Software License, Version 2.0
   * Apache Commons
     - commons-cli-1.5.0.jar
     - commons-codec-1.15.jar
-    - commons-collections4-4.1.jar
+    - commons-collections4-4.4.jar
     - commons-configuration-1.10.jar
     - commons-io-2.8.0.jar
     - commons-lang-2.6.jar
@@ -480,6 +482,8 @@ The Apache Software License, Version 2.0
     - perfmark-api-0.19.0.jar
   * Annotations
     - auto-service-annotations-1.0.jar
+  * AMQP
+    - amqp-client-5.5.3.jar
 
 Protocol Buffers License
  * Protocol Buffers

--- a/pulsar-sql/presto-distribution/LICENSE
+++ b/pulsar-sql/presto-distribution/LICENSE
@@ -391,7 +391,6 @@ The Apache Software License, Version 2.0
   * JCommander
     - jcommander-1.82.jar
   * FindBugs JSR305
-    - jsr305-2.0.1.jar
     - jsr305-3.0.2.jar
   * Objenesis
     - objenesis-2.6.jar

--- a/pulsar-sql/presto-distribution/LICENSE
+++ b/pulsar-sql/presto-distribution/LICENSE
@@ -255,6 +255,7 @@ The Apache Software License, Version 2.0
     - netty-transport-native-epoll-4.1.77.Final-linux-x86_64.jar
     - netty-transport-native-unix-common-4.1.77.Final.jar
     - netty-transport-native-unix-common-4.1.77.Final-linux-x86_64.jar
+    - netty-transport-native-epoll-4.1.77.Final.jar
     - netty-codec-http2-4.1.77.Final.jar
  * GRPC
     - grpc-api-1.45.1.jar
@@ -391,6 +392,10 @@ The Apache Software License, Version 2.0
     - jcommander-1.82.jar
   * FindBugs JSR305
     - jsr305-2.0.1.jar
+<<<<<<< Updated upstream
+=======
+    - jsr305-3.0.2.jar
+>>>>>>> Stashed changes
   * Objenesis
     - objenesis-2.6.jar
   * Okio
@@ -420,6 +425,7 @@ The Apache Software License, Version 2.0
     - metrics-core-4.1.12.1.jar
     - metrics-graphite-4.1.12.1.jar
     - metrics-jvm-4.1.12.1.jar
+    - metrics-jmx-4.1.12.1.jar
   * Prometheus
     - simpleclient-0.16.0.jar
     - simpleclient_common-0.16.0.jar
@@ -540,14 +546,13 @@ CDDL-1.1 -- licenses/LICENSE-CDDL-1.1.txt
     - jersey-client-2.34.jar
     - jersey-container-servlet-2.34.jar
     - jersey-container-servlet-core-2.34.jar
-    - jersey-entity-filtering-2.34.jar
     - jersey-hk2-2.34.jar
-    - jersey-media-json-jackson-2.34.jar
-    - jersey-media-multipart-2.34.jar
     - jersey-server-2.34.jar
     - jersey-common-2.34.jar
  * JAXB
     - jaxb-api-2.3.1.jar
+ * RXJava
+    - rxjava-3.0.1.jar
 
  Eclipse Public License 1.0 -- licenses/LICENSE-AspectJ.txt
   * Aether

--- a/pulsar-sql/presto-distribution/LICENSE
+++ b/pulsar-sql/presto-distribution/LICENSE
@@ -392,10 +392,7 @@ The Apache Software License, Version 2.0
     - jcommander-1.82.jar
   * FindBugs JSR305
     - jsr305-2.0.1.jar
-<<<<<<< Updated upstream
-=======
     - jsr305-3.0.2.jar
->>>>>>> Stashed changes
   * Objenesis
     - objenesis-2.6.jar
   * Okio


### PR DESCRIPTION
### Motivation

When run license check, it throw the following exception :
```
amqp-client-5.5.3.jar unaccounted for in lib/presto/LICENSE
commons-collections4-4.4.jar unaccounted for in lib/presto/LICENSE
jsr305-2.0.1.jar unaccounted for in lib/presto/LICENSE
log4j-api-2.18.0.jar unaccounted for in lib/presto/LICENSE
log4j-core-2.18.0.jar unaccounted for in lib/presto/LICENSE
log4j-slf4j-impl-2.18.0.jar unaccounted for in lib/presto/LICENSE
metrics-jmx-4.1.12.1.jar unaccounted for in lib/presto/LICENSE
netty-transport-native-epoll-4.1.77.Final.jar unaccounted for in lib/presto/LICENSE
rocksdbjni-6.29.4.1.jar unaccounted for in lib/presto/LICENSE
rxjava-3.0.1.jar unaccounted for in lib/presto/LICENSE
listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.jar mentioned in lib/presto/LICENSE, but not bundled
failsafe-2.4.4.jar mentioned in lib/presto/LICENSE, but not bundled
jersey-entity-filtering-2.34.jar mentioned in lib/presto/LICENSE, but not bundled
jersey-media-json-jackson-2.34.jar mentioned in lib/presto/LICENSE, but not bundled
jersey-media-multipart-2.34.jar mentioned in lib/presto/LICENSE, but not bundled
```


### Documentation


- [x] `doc-not-needed` 
(Please explain why)
