### PR TITLE
[cleanup][broker][Modernizer] fix violations in pulsar-broker

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedLedger.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedLedger.java
@@ -21,6 +21,7 @@ package org.apache.bookkeeper.mledger;
 import io.netty.buffer.ByteBuf;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import java.util.function.Predicate;
 import org.apache.bookkeeper.common.annotation.InterfaceAudience;
 import org.apache.bookkeeper.common.annotation.InterfaceStability;
 import org.apache.bookkeeper.mledger.AsyncCallbacks.AddEntryCallback;
@@ -635,7 +636,7 @@ public interface ManagedLedger {
     /**
      * Find position by sequenceId.
      * */
-    CompletableFuture<Position> asyncFindPosition(com.google.common.base.Predicate<Entry> predicate);
+    CompletableFuture<Position> asyncFindPosition(Predicate<Entry> predicate);
 
     /**
      * Get the ManagedLedgerInterceptor for ManagedLedger.

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
@@ -1711,7 +1711,7 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
     }
 
     @Override
-    public CompletableFuture<Position> asyncFindPosition(com.google.common.base.Predicate<Entry> predicate) {
+    public CompletableFuture<Position> asyncFindPosition(Predicate<Entry> predicate) {
 
         CompletableFuture<Position> future = new CompletableFuture();
         Long firstLedgerId = ledgers.firstKey();
@@ -1736,7 +1736,7 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
                 } else {
                     finalPosition = getNextValidPosition((PositionImpl) position);
                 }
-                future.complete((PositionImpl) finalPosition);
+                future.complete(finalPosition);
             }
 
             @Override

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/OpFindNewest.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/OpFindNewest.java
@@ -18,8 +18,8 @@
  */
 package org.apache.bookkeeper.mledger.impl;
 
-import com.google.common.base.Predicate;
 import java.util.Optional;
+import java.util.function.Predicate;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.bookkeeper.mledger.AsyncCallbacks.FindEntryCallback;
 import org.apache.bookkeeper.mledger.AsyncCallbacks.ReadEntryCallback;
@@ -84,7 +84,7 @@ class OpFindNewest implements ReadEntryCallback {
         final Position position = entry.getPosition();
         switch (state) {
         case checkFirst:
-            if (!condition.apply(entry)) {
+            if (!condition.test(entry)) {
                 // If no entry is found that matches the condition, it is expected to pass null to the callback.
                 // Otherwise, a message before the expiration date will be deleted due to message TTL.
                 // cf. https://github.com/apache/pulsar/issues/5579
@@ -107,7 +107,7 @@ class OpFindNewest implements ReadEntryCallback {
             }
             break;
         case checkLast:
-            if (condition.apply(entry)) {
+            if (condition.test(entry)) {
                 callback.findEntryComplete(position, OpFindNewest.this.ctx);
                 return;
             } else {
@@ -118,7 +118,7 @@ class OpFindNewest implements ReadEntryCallback {
             }
             break;
         case searching:
-            if (condition.apply(entry)) {
+            if (condition.test(entry)) {
                 // mid - last
                 lastMatchedPosition = position;
                 min = mid();

--- a/pulsar-broker/pom.xml
+++ b/pulsar-broker/pom.xml
@@ -432,7 +432,10 @@
           <failOnViolations>true</failOnViolations>
           <javaVersion>17</javaVersion>
           <ignorePackages>
-            <ignorePackage>org.apache.pulsar.broker</ignorePackage>
+            <ignorePackage>org.apache.pulsar.broker.admin</ignorePackage>
+            <ignorePackage>org.apache.pulsar.broker.namespace</ignorePackage>
+            <ignorePackage>org.apache.pulsar.broker.service</ignorePackage>
+            <ignorePackage>org.apache.pulsar.broker.stats</ignorePackage>
             <ignorePackage>org.apache.pulsar.client</ignorePackage>
           </ignorePackages>
         </configuration>

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/ManagedLedgerClientFactory.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/ManagedLedgerClientFactory.java
@@ -19,11 +19,11 @@
 package org.apache.pulsar.broker;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.Maps;
 import io.netty.channel.EventLoopGroup;
 import java.io.IOException;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.RejectedExecutionException;
 import org.apache.bookkeeper.client.BookKeeper;
 import org.apache.bookkeeper.conf.ClientConfiguration;
@@ -49,7 +49,7 @@ public class ManagedLedgerClientFactory implements ManagedLedgerStorage {
     private ManagedLedgerFactory managedLedgerFactory;
     private BookKeeper defaultBkClient;
     private final Map<EnsemblePlacementPolicyConfig, BookKeeper>
-            bkEnsemblePolicyToBkClientMap = Maps.newConcurrentMap();
+            bkEnsemblePolicyToBkClientMap = new ConcurrentHashMap<>();
     private StatsProvider statsProvider = new NullStatsProvider();
 
     public void initialize(ServiceConfiguration conf, MetadataStoreExtended metadataStore,

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
@@ -24,9 +24,6 @@ import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import static org.apache.pulsar.broker.resourcegroup.ResourceUsageTransportManager.DISABLE_RESOURCE_USAGE_TRANSPORT_MANAGER;
 import static org.apache.pulsar.common.naming.SystemTopicNames.isTransactionInternalName;
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
 import io.netty.channel.ChannelInitializer;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.socket.SocketChannel;
@@ -42,6 +39,7 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -914,10 +912,10 @@ public class PulsarService implements AutoCloseable, ShutdownService {
                                       ServiceConfiguration config)
             throws PulsarServerException, PulsarClientException, MalformedURLException, ServletException,
             DeploymentException {
-        Map<String, Object> attributeMap = Maps.newHashMap();
+        Map<String, Object> attributeMap = new HashMap<>();
         attributeMap.put(WebService.ATTRIBUTE_PULSAR_NAME, this);
 
-        Map<String, Object> vipAttributeMap = Maps.newHashMap();
+        Map<String, Object> vipAttributeMap = new HashMap<>();
         vipAttributeMap.put(VipStatus.ATTRIBUTE_STATUS_FILE_PATH, config.getStatusFilePath());
         vipAttributeMap.put(VipStatus.ATTRIBUTE_IS_READY_PROBE, (Supplier<Boolean>) () -> {
             // Ensure the VIP status is only visible when the broker is fully initialized
@@ -1182,7 +1180,7 @@ public class PulsarService implements AutoCloseable, ShutdownService {
             LOG.info("Loading all topics on bundle: {}", bundle);
 
             NamespaceName nsName = bundle.getNamespaceObject();
-            List<CompletableFuture<Optional<Topic>>> persistentTopics = Lists.newArrayList();
+            List<CompletableFuture<Optional<Topic>>> persistentTopics = new ArrayList<>();
             long topicLoadStart = System.nanoTime();
 
             for (String topic : getNamespaceService().getListOfPersistentTopics(nsName)
@@ -1339,7 +1337,7 @@ public class PulsarService implements AutoCloseable, ShutdownService {
                     try {
                         return offloaderFactory.create(
                                 offloadPolicies,
-                                ImmutableMap.of(
+                                Map.of(
                                         LedgerOffloader.METADATA_SOFTWARE_VERSION_KEY.toLowerCase(),
                                         PulsarVersion.getVersion(),
                                         LedgerOffloader.METADATA_SOFTWARE_GITSHA_KEY.toLowerCase(),

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/LinuxInfoUtils.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/LinuxInfoUtils.java
@@ -18,8 +18,8 @@
  */
 package org.apache.pulsar.broker.loadbalance;
 
-import com.google.common.base.Charsets;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -231,7 +231,7 @@ public class LinuxInfoUtils {
     }
 
     private static String readTrimStringFromFile(Path path) throws IOException {
-        return new String(Files.readAllBytes(path), Charsets.UTF_8).trim();
+        return new String(Files.readAllBytes(path), StandardCharsets.UTF_8).trim();
     }
 
     private static long readLongFromFile(Path path) throws IOException {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/LoadManagerShared.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/LoadManagerShared.java
@@ -21,10 +21,10 @@ package org.apache.pulsar.broker.loadbalance.impl;
 import static com.google.common.base.Preconditions.checkArgument;
 import static org.apache.pulsar.common.stats.JvmMetrics.getJvmDirectMemoryUsed;
 import com.beust.jcommander.internal.Lists;
-import com.google.common.collect.Maps;
 import io.netty.util.concurrent.FastThreadLocal;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -392,7 +392,7 @@ public class LoadManagerShared {
             return;
         }
 
-        final Map<String, Integer> domainNamespaceCount = Maps.newHashMap();
+        final Map<String, Integer> domainNamespaceCount = new HashMap<>();
         int leastNamespaceCount = Integer.MAX_VALUE;
         candidates.forEach(broker -> {
             final String domain = brokerToDomainMap.getOrDefault(broker, DEFAULT_DOMAIN);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/ModularLoadManagerImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/ModularLoadManagerImpl.java
@@ -18,8 +18,6 @@
  */
 package org.apache.pulsar.broker.loadbalance.impl;
 
-import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Sets;
 import io.netty.util.concurrent.DefaultThreadFactory;
@@ -214,7 +212,7 @@ public class ModularLoadManagerImpl implements ModularLoadManager {
         loadSheddingPipeline = new ArrayList<>();
         preallocatedBundleToBroker = new ConcurrentHashMap<>();
         scheduler = Executors.newSingleThreadScheduledExecutor(new DefaultThreadFactory("pulsar-modular-load-manager"));
-        this.brokerToFailureDomainMap = Maps.newHashMap();
+        this.brokerToFailureDomainMap = new HashMap<>();
 
         this.brokerTopicLoadingPredicate = new BrokerTopicLoadingPredicate() {
             @Override
@@ -690,7 +688,7 @@ public class ModularLoadManagerImpl implements ModularLoadManager {
         unloadBrokerCount += bundlesToUnload.keySet().size();
         unloadBundleCount += bundlesToUnload.values().size();
 
-        List<Metrics> metrics = Lists.newArrayList();
+        List<Metrics> metrics = new ArrayList<>();
         Map<String, String> dimensions = new HashMap<>();
 
         dimensions.put("metric", "bundleUnloading");
@@ -796,7 +794,7 @@ public class ModularLoadManagerImpl implements ModularLoadManager {
     private void updateBundleSplitMetrics(Set<String> bundlesToBeSplit) {
         bundleSplitCount += bundlesToBeSplit.size();
 
-        List<Metrics> metrics = Lists.newArrayList();
+        List<Metrics> metrics = new ArrayList<>();
         Map<String, String> dimensions = new HashMap<>();
 
         dimensions.put("metric", "bundlesSplit");
@@ -1023,7 +1021,7 @@ public class ModularLoadManagerImpl implements ModularLoadManager {
      * @param bundlesData
      */
     private void updateLoadBalancingBundlesMetrics(Map<String, NamespaceBundleStats> bundlesData) {
-        List<Metrics> metrics = Lists.newArrayList();
+        List<Metrics> metrics = new ArrayList<>();
         for (Map.Entry<String, NamespaceBundleStats> entry: bundlesData.entrySet()) {
             final String bundle = entry.getKey();
             final NamespaceBundleStats stats = entry.getValue();
@@ -1050,7 +1048,7 @@ public class ModularLoadManagerImpl implements ModularLoadManager {
      * @param systemResourceUsage
      */
     private void updateLoadBalancingMetrics(final SystemResourceUsage systemResourceUsage) {
-        List<Metrics> metrics = Lists.newArrayList();
+        List<Metrics> metrics = new ArrayList<>();
         Map<String, String> dimensions = new HashMap<>();
 
         dimensions.put("broker", pulsar.getAdvertisedAddress());
@@ -1165,7 +1163,7 @@ public class ModularLoadManagerImpl implements ModularLoadManager {
         String clusterName = pulsar.getConfiguration().getClusterName();
         try {
             synchronized (brokerToFailureDomainMap) {
-                Map<String, String> tempBrokerToFailureDomainMap = Maps.newHashMap();
+                Map<String, String> tempBrokerToFailureDomainMap = new HashMap<>();
                 for (String domainName : fdr.listFailureDomains(clusterName)) {
                     try {
                         Optional<FailureDomainImpl> domain = fdr.getFailureDomain(clusterName, domainName);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/SimpleLoadManagerImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/SimpleLoadManagerImpl.java
@@ -24,13 +24,12 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
-import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Sets;
 import com.google.common.collect.TreeMultimap;
 import io.netty.util.concurrent.DefaultThreadFactory;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -40,6 +39,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.TreeMap;
+import java.util.TreeSet;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.Executors;
@@ -194,7 +194,7 @@ public class SimpleLoadManagerImpl implements LoadManager, Consumer<Notification
         this.sortedRankings.set(new TreeMap<>());
         this.currentLoadReports = new HashMap<>();
         this.resourceUnitRankings = new HashMap<>();
-        this.loadBalancingMetrics.set(Lists.newArrayList());
+        this.loadBalancingMetrics.set(new ArrayList<>());
         this.realtimeResourceQuotas.set(new HashMap<>());
         this.realtimeAvgResourceQuota = new ResourceQuota();
         placementStrategy = new WRRPlacementStrategy();
@@ -654,7 +654,7 @@ public class SimpleLoadManagerImpl implements LoadManager, Consumer<Notification
         log.info("doLoadRanking - load balancing strategy: {}", strategy);
         if (!currentLoadReports.isEmpty()) {
 
-            Map<Long, Set<ResourceUnit>> newSortedRankings = Maps.newTreeMap();
+            Map<Long, Set<ResourceUnit>> newSortedRankings = new TreeMap<>();
             Map<ResourceUnit, ResourceUnitRanking> newResourceUnitRankings = new HashMap<>();
             ResourceQuota defaultResourceQuota =
                     pulsar.getBrokerService().getBundlesQuotas().getDefaultResourceQuota().join();
@@ -691,10 +691,8 @@ public class SimpleLoadManagerImpl implements LoadManager, Consumer<Notification
                     finalRank = (long) (maxCapacity * idleRatio * idleRatio);
                 }
 
-                if (!newSortedRankings.containsKey(finalRank)) {
-                    newSortedRankings.put(finalRank, new HashSet<ResourceUnit>());
-                }
-                newSortedRankings.get(finalRank).add(entry.getKey());
+                newSortedRankings.computeIfAbsent(finalRank, k -> new HashSet<>())
+                        .add(entry.getKey());
                 if (log.isDebugEnabled()) {
                     log.debug("Added Resource Unit [{}] with Rank [{}]", entry.getKey().getResourceId(), finalRank);
                 }
@@ -719,7 +717,7 @@ public class SimpleLoadManagerImpl implements LoadManager, Consumer<Notification
     }
 
     private void updateLoadBalancingMetrics(String hostname, long finalRank, ResourceUnitRanking ranking) {
-        List<Metrics> metrics = Lists.newArrayList();
+        List<Metrics> metrics = new ArrayList<>();
         Map<String, String> dimensions = new HashMap<>();
 
         dimensions.put("broker", hostname);
@@ -924,11 +922,11 @@ public class SimpleLoadManagerImpl implements LoadManager, Consumer<Notification
             List<String> activeBrokers = loadReports.listLocks(LOADBALANCE_BROKERS_ROOT).join();
             Collections.shuffle(activeBrokers);
 
-            availableBrokers = Maps.newTreeMap();
+            availableBrokers = new HashMap<>();
             for (String broker : activeBrokers) {
                 ResourceUnit resourceUnit = new SimpleResourceUnit(String.format("http://%s", broker),
                         new PulsarResourceDescription());
-                availableBrokers.computeIfAbsent(0L, key -> Sets.newTreeSet()).add(resourceUnit);
+                availableBrokers.computeIfAbsent(0L, key -> new TreeSet<>()).add(resourceUnit);
             }
             log.info("Choosing at random from broker list: [{}]", availableBrokers.values());
         }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/WRRPlacementStrategy.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/WRRPlacementStrategy.java
@@ -18,7 +18,6 @@
  */
 package org.apache.pulsar.broker.loadbalance.impl;
 
-import com.google.common.collect.Iterables;
 import com.google.common.collect.Multimap;
 import java.util.Map;
 import java.util.Random;
@@ -69,7 +68,11 @@ public class WRRPlacementStrategy implements PlacementStrategy {
         if (totalAvailability <= 0) {
             // todo: this means all the brokers are overloaded and we can't assign this namespace to any broker
             // for now, pick anyone and return that one, because when we don't have ranking we put O for each broker
-            return Iterables.get(finalCandidates.get(0L), rand.nextInt(finalCandidates.size()));
+            return finalCandidates.get(0L)
+                    .stream()
+                    .skip(rand.nextInt(finalCandidates.size()))
+                    .findFirst()
+                    .orElse(null);
         }
         int weightedSelector = rand.nextInt(totalAvailability);
         log.debug("Generated Weighted Selector Number - [{}] ", weightedSelector);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/protocol/ProtocolHandlers.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/protocol/ProtocolHandlers.java
@@ -19,13 +19,13 @@
 package org.apache.pulsar.broker.protocol;
 
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Maps;
-import com.google.common.collect.Sets;
 import io.netty.channel.ChannelInitializer;
 import io.netty.channel.socket.SocketChannel;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -122,8 +122,8 @@ public class ProtocolHandlers implements AutoCloseable {
     }
 
     public Map<String, Map<InetSocketAddress, ChannelInitializer<SocketChannel>>> newChannelInitializers() {
-        Map<String, Map<InetSocketAddress, ChannelInitializer<SocketChannel>>> channelInitializers = Maps.newHashMap();
-        Set<InetSocketAddress> addresses = Sets.newHashSet();
+        Map<String, Map<InetSocketAddress, ChannelInitializer<SocketChannel>>> channelInitializers = new HashMap<>();
+        Set<InetSocketAddress> addresses = new HashSet<>();
 
         for (Map.Entry<String, ProtocolHandlerWithClassLoader> handler : handlers.entrySet()) {
             Map<InetSocketAddress, ChannelInitializer<SocketChannel>> initializers =

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/PulsarWebResource.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/PulsarWebResource.java
@@ -23,12 +23,12 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.apache.commons.lang3.StringUtils.isBlank;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.BoundType;
-import com.google.common.collect.Lists;
 import com.google.common.collect.Range;
 import com.google.common.collect.Sets;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URL;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -1145,7 +1145,7 @@ public abstract class PulsarWebResource {
 
     protected CompletableFuture<Void> canUpdateCluster(String tenant, Set<String> oldClusters,
             Set<String> newClusters) {
-        List<CompletableFuture<Void>> activeNamespaceFuture = Lists.newArrayList();
+        List<CompletableFuture<Void>> activeNamespaceFuture = new ArrayList<>();
         for (String cluster : oldClusters) {
             if (Constants.GLOBAL_CLUSTER.equals(cluster) || newClusters.contains(cluster)) {
                 continue;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/WebService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/WebService.java
@@ -18,7 +18,6 @@
  */
 package org.apache.pulsar.broker.web;
 
-import com.google.common.collect.Lists;
 import io.prometheus.client.CollectorRegistry;
 import io.prometheus.client.jetty.JettyStatisticsCollector;
 import java.util.ArrayList;
@@ -86,7 +85,7 @@ public class WebService implements AutoCloseable {
     }
 
     public WebService(PulsarService pulsar) throws PulsarServerException {
-        this.handlers = Lists.newArrayList();
+        this.handlers = new ArrayList<>();
         this.pulsar = pulsar;
         ServiceConfiguration config = pulsar.getConfiguration();
         this.webServiceExecutor = new WebExecutorThreadPool(

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/ConfigHelper.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/ConfigHelper.java
@@ -18,20 +18,18 @@
  */
 package org.apache.pulsar.broker;
 
-import com.google.common.collect.ImmutableMap;
+import java.util.Map;
 import org.apache.pulsar.common.policies.data.BacklogQuota;
 import org.apache.pulsar.common.policies.data.DispatchRate;
 import org.apache.pulsar.common.policies.data.SubscribeRate;
 import org.apache.pulsar.common.policies.data.impl.BacklogQuotaImpl;
-
-import java.util.Map;
 
 public class ConfigHelper {
     private ConfigHelper() {}
 
 
     public static Map<BacklogQuota.BacklogQuotaType, BacklogQuota> backlogQuotaMap(ServiceConfiguration configuration) {
-        return ImmutableMap.of(BacklogQuota.BacklogQuotaType.destination_storage,
+        return Map.of(BacklogQuota.BacklogQuotaType.destination_storage,
                 sizeBacklogQuota(configuration),
                 BacklogQuota.BacklogQuotaType.message_age,
                 timeBacklogQuota(configuration));

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/MockAuthentication.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/MockAuthentication.java
@@ -18,16 +18,12 @@
  */
 package org.apache.pulsar.broker.auth;
 
-import com.google.common.collect.ImmutableMap;
-
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
-
 import org.apache.pulsar.client.api.Authentication;
 import org.apache.pulsar.client.api.AuthenticationDataProvider;
 import org.apache.pulsar.client.api.PulsarClientException;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -56,7 +52,7 @@ public class MockAuthentication implements Authentication {
             public String getHttpAuthType() { return "mock"; }
             @Override
             public Set<Map.Entry<String, String>> getHttpHeaders() {
-                return ImmutableMap.of("mockuser", user).entrySet();
+                return Map.of("mockuser", user).entrySet();
             }
             @Override
             public boolean hasDataFromCommand() {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/MockedPulsarServiceBaseTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/MockedPulsarServiceBaseTest.java
@@ -37,6 +37,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Date;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -419,9 +420,9 @@ public abstract class MockedPulsarServiceBaseTest extends TestRetrySupport {
         if (!admin.clusters().getClusters().contains(configClusterName)) {
             admin.clusters().createCluster(configClusterName, ClusterData.builder().build());
         }
-        Set<String> allowedClusters = Sets.newHashSet();
+        Set<String> allowedClusters = new HashSet<>();
         allowedClusters.add(configClusterName);
-        return new TenantInfoImpl(Sets.newHashSet(), allowedClusters);
+        return new TenantInfoImpl(new HashSet<>(), allowedClusters);
     }
 
     public static MockZooKeeper createMockZooKeeper() throws Exception {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/intercept/BrokerInterceptorWithClassLoaderTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/intercept/BrokerInterceptorWithClassLoaderTest.java
@@ -23,8 +23,12 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.testng.Assert.assertEquals;
-import com.google.common.collect.Maps;
 import io.netty.buffer.ByteBuf;
+import java.util.HashMap;
+import java.util.Map;
+import javax.servlet.FilterChain;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
 import org.apache.bookkeeper.mledger.Entry;
 import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.broker.service.Consumer;
@@ -38,10 +42,6 @@ import org.apache.pulsar.common.api.proto.MessageMetadata;
 import org.apache.pulsar.common.intercept.InterceptException;
 import org.apache.pulsar.common.nar.NarClassLoader;
 import org.testng.annotations.Test;
-import javax.servlet.FilterChain;
-import javax.servlet.ServletRequest;
-import javax.servlet.ServletResponse;
-import java.util.Map;
 
 /**
  * Unit test {@link BrokerInterceptorWithClassLoader}.
@@ -164,11 +164,11 @@ public class BrokerInterceptorWithClassLoaderTest {
         assertEquals(Thread.currentThread().getContextClassLoader(), curClassLoader);
         // test consumerCreated
         brokerInterceptorWithClassLoader
-                .consumerCreated(mock(ServerCnx.class), mock(Consumer.class), Maps.newHashMap());
+                .consumerCreated(mock(ServerCnx.class), mock(Consumer.class), new HashMap<>());
         assertEquals(Thread.currentThread().getContextClassLoader(), curClassLoader);
         // test producerCreated
         brokerInterceptorWithClassLoader
-                .producerCreated(mock(ServerCnx.class), mock(Producer.class), Maps.newHashMap());
+                .producerCreated(mock(ServerCnx.class), mock(Producer.class), new HashMap<>());
         assertEquals(Thread.currentThread().getContextClassLoader(), curClassLoader);
         // test onConnectionCreated
         brokerInterceptorWithClassLoader

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/intercept/InterceptFilterOutTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/intercept/InterceptFilterOutTest.java
@@ -71,7 +71,7 @@ public class InterceptFilterOutTest {
         Mockito.doNothing().when(chain).doFilter(Mockito.any(), Mockito.any());
         HttpServletRequestWrapper mockInputStream = new MockRequestWrapper(request);
         Mockito.doReturn(mockInputStream.getInputStream()).when(request).getInputStream();
-        Mockito.doReturn(new StringBuffer("http://127.0.0.1:8080")).when(request).getRequestURL();
+        Mockito.doReturn(new StringBuilder("http://127.0.0.1:8080")).when(request).getRequestURL();
 
         // "application/json" should be intercepted
         Mockito.doReturn("application/json").when(request).getContentType();
@@ -103,7 +103,7 @@ public class InterceptFilterOutTest {
         Mockito.doNothing().when(chain).doFilter(Mockito.any(), Mockito.any());
         HttpServletRequestWrapper mockInputStream = new MockRequestWrapper(request);
         Mockito.doReturn(mockInputStream.getInputStream()).when(request).getInputStream();
-        Mockito.doReturn(new StringBuffer("http://127.0.0.1:8080")).when(request).getRequestURL();
+        Mockito.doReturn(new StringBuilder("http://127.0.0.1:8080")).when(request).getRequestURL();
         // "application/json" should be intercepted
         Mockito.doReturn("application/json").when(request).getContentType();
 
@@ -129,7 +129,7 @@ public class InterceptFilterOutTest {
         Mockito.doNothing().when(chain).doFilter(Mockito.any(), Mockito.any());
         HttpServletRequestWrapper mockInputStream = new MockRequestWrapper(request);
         Mockito.doReturn(mockInputStream.getInputStream()).when(request).getInputStream();
-        Mockito.doReturn(new StringBuffer("http://127.0.0.1:8080")).when(request).getRequestURL();
+        Mockito.doReturn(new StringBuilder("http://127.0.0.1:8080")).when(request).getRequestURL();
 
         // "application/json" should be intercepted
         Mockito.doReturn("application/json").when(request).getContentType();
@@ -161,7 +161,7 @@ public class InterceptFilterOutTest {
         Mockito.doNothing().when(chain).doFilter(Mockito.any(), Mockito.any());
         HttpServletRequestWrapper mockInputStream = new MockRequestWrapper(request);
         Mockito.doReturn(mockInputStream.getInputStream()).when(request).getInputStream();
-        Mockito.doReturn(new StringBuffer("http://127.0.0.1:8080")).when(request).getRequestURL();
+        Mockito.doReturn(new StringBuilder("http://127.0.0.1:8080")).when(request).getRequestURL();
 
         // Should not be intercepted since the broker interceptor disabled.
         Mockito.doReturn("application/json").when(request).getContentType();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/intercept/MangedLedgerInterceptorImplTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/intercept/MangedLedgerInterceptorImplTest.java
@@ -20,6 +20,7 @@ package org.apache.pulsar.broker.intercept;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
+import java.util.function.Predicate;
 import lombok.Cleanup;
 import org.apache.bookkeeper.mledger.Entry;
 import org.apache.bookkeeper.mledger.ManagedCursor;
@@ -264,7 +265,7 @@ public class MangedLedgerInterceptorImplTest  extends MockedBookKeeperTestCase {
                 Thread.currentThread().getContextClassLoader());
     }
 
-    static class IndexSearchPredicate implements com.google.common.base.Predicate<Entry> {
+    static class IndexSearchPredicate implements Predicate<Entry> {
 
         long indexToSearch = -1;
         public IndexSearchPredicate(long indexToSearch) {
@@ -272,7 +273,7 @@ public class MangedLedgerInterceptorImplTest  extends MockedBookKeeperTestCase {
         }
 
         @Override
-        public boolean apply(@Nullable Entry entry) {
+        public boolean test(@Nullable Entry entry) {
             try {
                 BrokerEntryMetadata brokerEntryMetadata = Commands.parseBrokerEntryMetadataIfExist(entry.getDataBuffer());
                 return brokerEntryMetadata.getIndex() < indexToSearch;

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/AntiAffinityNamespaceGroupTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/AntiAffinityNamespaceGroupTest.java
@@ -22,7 +22,6 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotEquals;
 import static org.testng.Assert.assertTrue;
-import com.beust.jcommander.internal.Maps;
 import com.google.common.collect.BoundType;
 import com.google.common.collect.Range;
 import com.google.common.collect.Sets;
@@ -30,6 +29,8 @@ import com.google.common.hash.Hashing;
 import java.lang.reflect.Field;
 import java.net.URL;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -224,8 +225,8 @@ public class AntiAffinityNamespaceGroupTest {
             admin1.namespaces().setNamespaceAntiAffinityGroup(ns, namespaceAntiAffinityGroup);
         }
 
-        Set<String> brokers = Sets.newHashSet();
-        Map<String, String> brokerToDomainMap = Maps.newHashMap();
+        Set<String> brokers = new HashSet<>();
+        Map<String, String> brokerToDomainMap = new HashMap<>();
         brokers.add("brokerName-0");
         brokerToDomainMap.put("brokerName-0", "domain-0");
         brokers.add("brokerName-1");
@@ -235,7 +236,7 @@ public class AntiAffinityNamespaceGroupTest {
         brokers.add("brokerName-3");
         brokerToDomainMap.put("brokerName-3", "domain-1");
 
-        Set<String> candidate = Sets.newHashSet();
+        Set<String> candidate = new HashSet<>();
         ConcurrentOpenHashMap<String, ConcurrentOpenHashMap<String, ConcurrentOpenHashSet<String>>> brokerToNamespaceToBundleRange =
                 ConcurrentOpenHashMap.<String, ConcurrentOpenHashMap<String, ConcurrentOpenHashSet<String>>>newBuilder().build();
 
@@ -321,8 +322,8 @@ public class AntiAffinityNamespaceGroupTest {
             admin1.namespaces().setNamespaceAntiAffinityGroup(ns, namespaceAntiAffinityGroup);
         }
 
-        Set<String> brokers = Sets.newHashSet();
-        Set<String> candidate = Sets.newHashSet();
+        Set<String> brokers = new HashSet<>();
+        Set<String> candidate = new HashSet<>();
         ConcurrentOpenHashMap<String, ConcurrentOpenHashMap<String, ConcurrentOpenHashSet<String>>> brokerToNamespaceToBundleRange =
                 ConcurrentOpenHashMap.<String, ConcurrentOpenHashMap<String, ConcurrentOpenHashSet<String>>>newBuilder().build();
         brokers.add("broker-0");
@@ -406,7 +407,7 @@ public class AntiAffinityNamespaceGroupTest {
         final String broker1 = primaryHost;
         final String broker2 = secondaryHost;
         final String cluster = pulsar1.getConfiguration().getClusterName();
-        final String tenant = "tenant-" + UUID.randomUUID().toString();
+        final String tenant = "tenant-" + UUID.randomUUID();
         final String namespace1 = tenant + "/" + cluster + "/ns1";
         final String namespace2 = tenant + "/" + cluster + "/ns2";
         final String namespaceAntiAffinityGroup = "group";
@@ -473,8 +474,8 @@ public class AntiAffinityNamespaceGroupTest {
             admin1.namespaces().setNamespaceAntiAffinityGroup(ns, namespaceAntiAffinityGroup);
         }
 
-        Set<String> brokers = Sets.newHashSet();
-        Set<String> candidate = Sets.newHashSet();
+        Set<String> brokers = new HashSet<>();
+        Set<String> candidate = new HashSet<>();
         ConcurrentOpenHashMap<String, ConcurrentOpenHashMap<String, ConcurrentOpenHashSet<String>>> brokerToNamespaceToBundleRange =
                 ConcurrentOpenHashMap.<String, ConcurrentOpenHashMap<String, ConcurrentOpenHashSet<String>>>newBuilder().build();
         brokers.add("broker-0");

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/LoadBalancerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/LoadBalancerTest.java
@@ -25,7 +25,6 @@ import static org.mockito.Mockito.verify;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
-import com.google.common.collect.Lists;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.net.URL;
@@ -555,7 +554,7 @@ public class LoadBalancerTest {
     private BundlesData getBundles(int numBundles) {
         Long maxVal = ((long) 1) << 32;
         Long segSize = maxVal / numBundles;
-        List<String> partitions = Lists.newArrayList();
+        List<String> partitions = new ArrayList<>();
         partitions.add(String.format("0x%08x", 0l));
         Long curPartition = segSize;
         for (int i = 0; i < numBundles; i++) {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/ModularLoadManagerImplTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/ModularLoadManagerImplTest.java
@@ -36,6 +36,7 @@ import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.net.URL;
 import java.util.EnumSet;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -526,7 +527,7 @@ public class ModularLoadManagerImplTest {
         // (1) now we have isolation policy : primary=broker1, secondary=broker2, minLimit=1
 
         // test1: shared=1, primary=1, secondary=1 => It should return 1 primary broker only
-        Set<String> brokerCandidateCache = Sets.newHashSet();
+        Set<String> brokerCandidateCache = new HashSet<>();
         Set<String> availableBrokers = Sets.newHashSet(sharedBroker, broker1Address, broker2Address);
         LoadManagerShared.applyNamespacePolicies(serviceUnit, simpleResourceAllocationPolicies, brokerCandidateCache,
                 availableBrokers, brokerTopicLoadingPredicate);
@@ -534,7 +535,7 @@ public class ModularLoadManagerImplTest {
         assertTrue(brokerCandidateCache.contains(broker1Address));
 
         // test2: shared=1, primary=0, secondary=1 => It should return 1 secondary broker only
-        brokerCandidateCache = Sets.newHashSet();
+        brokerCandidateCache = new HashSet<>();
         availableBrokers = Sets.newHashSet(sharedBroker, broker2Address);
         LoadManagerShared.applyNamespacePolicies(serviceUnit, simpleResourceAllocationPolicies, brokerCandidateCache,
                 availableBrokers, brokerTopicLoadingPredicate);
@@ -542,7 +543,7 @@ public class ModularLoadManagerImplTest {
         assertTrue(brokerCandidateCache.contains(broker2Address));
 
         // test3: shared=1, primary=0, secondary=0 => It should return 0 broker
-        brokerCandidateCache = Sets.newHashSet();
+        brokerCandidateCache = new HashSet<>();
         availableBrokers = Sets.newHashSet(sharedBroker);
         LoadManagerShared.applyNamespacePolicies(serviceUnit, simpleResourceAllocationPolicies, brokerCandidateCache,
                 availableBrokers, brokerTopicLoadingPredicate);
@@ -556,7 +557,7 @@ public class ModularLoadManagerImplTest {
         admin1.clusters().createNamespaceIsolationPolicy("use", newPolicyName, nsPolicyData);
 
         // test1: shared=1, primary=1, secondary=1 => It should return primary + secondary
-        brokerCandidateCache = Sets.newHashSet();
+        brokerCandidateCache = new HashSet<>();
         availableBrokers = Sets.newHashSet(sharedBroker, broker1Address, broker2Address);
         LoadManagerShared.applyNamespacePolicies(serviceUnit, simpleResourceAllocationPolicies, brokerCandidateCache,
                 availableBrokers, brokerTopicLoadingPredicate);
@@ -565,7 +566,7 @@ public class ModularLoadManagerImplTest {
         assertTrue(brokerCandidateCache.contains(broker2Address));
 
         // test2: shared=1, secondary=1 => It should return secondary
-        brokerCandidateCache = Sets.newHashSet();
+        brokerCandidateCache = new HashSet<>();
         availableBrokers = Sets.newHashSet(sharedBroker, broker2Address);
         LoadManagerShared.applyNamespacePolicies(serviceUnit, simpleResourceAllocationPolicies, brokerCandidateCache,
                 availableBrokers, brokerTopicLoadingPredicate);
@@ -573,7 +574,7 @@ public class ModularLoadManagerImplTest {
         assertTrue(brokerCandidateCache.contains(broker2Address));
 
         // test3: shared=1, => It should return 0 broker
-        brokerCandidateCache = Sets.newHashSet();
+        brokerCandidateCache = new HashSet<>();
         availableBrokers = Sets.newHashSet(sharedBroker);
         LoadManagerShared.applyNamespacePolicies(serviceUnit, simpleResourceAllocationPolicies, brokerCandidateCache,
                 availableBrokers, brokerTopicLoadingPredicate);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/SimpleLoadManagerImplTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/SimpleLoadManagerImplTest.java
@@ -29,7 +29,6 @@ import static org.testng.Assert.assertNotEquals;
 import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.collect.Maps;
 import java.lang.reflect.Field;
 import java.net.URL;
 import java.util.Collections;
@@ -202,7 +201,7 @@ public class SimpleLoadManagerImplTest {
         Set<ResourceUnit> rus = new HashSet<>();
         rus.add(ru1);
         LoadRanker lr = new ResourceAvailabilityRanker();
-        AtomicReference<Map<Long, Set<ResourceUnit>>> sortedRankingsInstance = new AtomicReference<>(Maps.newTreeMap());
+        AtomicReference<Map<Long, Set<ResourceUnit>>> sortedRankingsInstance = new AtomicReference<>(new HashMap<>());
         sortedRankingsInstance.get().put(lr.getRank(rd), rus);
 
         Field sortedRankings = SimpleLoadManagerImpl.class.getDeclaredField("sortedRankings");
@@ -252,7 +251,7 @@ public class SimpleLoadManagerImplTest {
         rankings.put(ru1, ranking);
         setObjectField(SimpleLoadManagerImpl.class, loadManager, "resourceUnitRankings", rankings);
 
-        AtomicReference<Map<Long, Set<ResourceUnit>>> sortedRankingsInstance = new AtomicReference<>(Maps.newTreeMap());
+        AtomicReference<Map<Long, Set<ResourceUnit>>> sortedRankingsInstance = new AtomicReference<>(new HashMap<>());
         sortedRankingsInstance.get().put(lr.getRank(rd), rus);
         setObjectField(SimpleLoadManagerImpl.class, loadManager, "sortedRankings", sortedRankingsInstance);
 
@@ -278,7 +277,7 @@ public class SimpleLoadManagerImplTest {
         Set<ResourceUnit> rus = new HashSet<>();
         rus.add(ru1);
         LoadRanker lr = new ResourceAvailabilityRanker();
-        AtomicReference<Map<Long, Set<ResourceUnit>>> sortedRankingsInstance = new AtomicReference<>(Maps.newTreeMap());
+        AtomicReference<Map<Long, Set<ResourceUnit>>> sortedRankingsInstance = new AtomicReference<>(new HashMap<>());
         sortedRankingsInstance.get().put(lr.getRank(rd), rus);
 
         Field sortedRankings = SimpleLoadManagerImpl.class.getDeclaredField("sortedRankings");
@@ -349,7 +348,7 @@ public class SimpleLoadManagerImplTest {
         rus.add(ru1);
         rus.add(ru2);
         LoadRanker lr = new ResourceAvailabilityRanker();
-        AtomicReference<Map<Long, Set<ResourceUnit>>> sortedRankingsInstance = new AtomicReference<>(Maps.newTreeMap());
+        AtomicReference<Map<Long, Set<ResourceUnit>>> sortedRankingsInstance = new AtomicReference<>(new HashMap<>());
         sortedRankingsInstance.get().put(lr.getRank(rd), rus);
 
         Field sortedRankings = SimpleLoadManagerImpl.class.getDeclaredField("sortedRankings");
@@ -359,7 +358,7 @@ public class SimpleLoadManagerImplTest {
         // inject the load report and rankings
         SystemResourceUsage systemResource = new SystemResourceUsage();
         systemResource.setBandwidthIn(new ResourceUsage(90, 100));
-        Map<String, NamespaceBundleStats> stats = Maps.newHashMap();
+        Map<String, NamespaceBundleStats> stats = new HashMap<>();
         NamespaceBundleStats nsb1 = new NamespaceBundleStats();
         nsb1.msgRateOut = 10000;
         NamespaceBundleStats nsb2 = new NamespaceBundleStats();
@@ -462,7 +461,7 @@ public class SimpleLoadManagerImplTest {
 
     @Test
     public void testUsage() {
-        Map<String, Object> metrics = Maps.newHashMap();
+        Map<String, Object> metrics = new HashMap<>();
         metrics.put("brk_conn_cnt", 1L);
         metrics.put("brk_repl_conn_cnt", 1L);
         metrics.put("jvm_thread_cnt", 1L);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/impl/LoadManagerSharedTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/impl/LoadManagerSharedTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pulsar.broker.loadbalance.impl;
 
+import java.util.HashSet;
 import java.util.Set;
 
 import com.google.common.collect.Sets;
@@ -35,7 +36,7 @@ public class LoadManagerSharedTest {
         String namespace = "tenant1/ns1";
         String assignedBundle = namespace + "/0x00000000_0x40000000";
 
-        Set<String> candidates = Sets.newHashSet();
+        Set<String> candidates = new HashSet<>();
         ConcurrentOpenHashMap<String, ConcurrentOpenHashMap<String, ConcurrentOpenHashSet<String>>> map =
                 ConcurrentOpenHashMap.<String,
                         ConcurrentOpenHashMap<String, ConcurrentOpenHashSet<String>>>newBuilder()

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/systopic/NamespaceEventsSystemTopicServiceTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/systopic/NamespaceEventsSystemTopicServiceTest.java
@@ -19,6 +19,7 @@
 package org.apache.pulsar.broker.systopic;
 
 import com.google.common.collect.Sets;
+import java.util.HashSet;
 import lombok.Cleanup;
 import org.apache.pulsar.broker.auth.MockedPulsarServiceBaseTest;
 import org.apache.pulsar.broker.service.BrokerService;
@@ -151,7 +152,7 @@ public class NamespaceEventsSystemTopicServiceTest extends MockedPulsarServiceBa
     private void prepareData() throws PulsarAdminException {
         admin.clusters().createCluster("test", ClusterData.builder().serviceUrl(pulsar.getWebServiceAddress()).build());
         admin.tenants().createTenant("system-topic",
-            new TenantInfoImpl(Sets.newHashSet(), Sets.newHashSet("test")));
+            new TenantInfoImpl(new HashSet<>(), Sets.newHashSet("test")));
         admin.namespaces().createNamespace(NAMESPACE1);
         admin.namespaces().createNamespace(NAMESPACE2);
         admin.namespaces().createNamespace(NAMESPACE3);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/systopic/PartitionedSystemTopicTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/systopic/PartitionedSystemTopicTest.java
@@ -19,6 +19,7 @@
 package org.apache.pulsar.broker.systopic;
 
 import com.google.common.collect.Sets;
+import java.util.HashSet;
 import lombok.Cleanup;
 import org.apache.bookkeeper.mledger.LedgerOffloader;
 import org.apache.bookkeeper.mledger.ManagedLedgerConfig;
@@ -107,7 +108,7 @@ public class PartitionedSystemTopicTest extends BrokerTestBase {
     @Test(timeOut = 1000 * 60)
     public void testConsumerCreationWhenEnablingTopicPolicy() throws Exception {
         String tenant = "tenant-" + RandomStringUtils.randomAlphabetic(4).toLowerCase();
-        admin.tenants().createTenant(tenant, new TenantInfoImpl(Sets.newHashSet(), Sets.newHashSet("test")));
+        admin.tenants().createTenant(tenant, new TenantInfoImpl(new HashSet<>(), Sets.newHashSet("test")));
         int namespaceCount = 30;
         for (int i = 0; i < namespaceCount; i++) {
             String ns = tenant + "/ns-" + i;

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/TransactionConsumeTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/TransactionConsumeTest.java
@@ -23,6 +23,7 @@ import com.google.common.collect.Sets;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
@@ -73,7 +74,7 @@ public class TransactionConsumeTest extends TransactionTestBase {
         String webServicePort = brokerServiceUrlArr[brokerServiceUrlArr.length -1];
         admin.clusters().createCluster(CLUSTER_NAME, ClusterData.builder().serviceUrl("http://localhost:" + webServicePort).build());
         admin.tenants().createTenant("public",
-                new TenantInfoImpl(Sets.newHashSet(), Sets.newHashSet(CLUSTER_NAME)));
+                new TenantInfoImpl(new HashSet<>(), Sets.newHashSet(CLUSTER_NAME)));
         admin.namespaces().createNamespace("public/txn", 10);
         admin.topics().createNonPartitionedTopic(CONSUME_TOPIC);
 

--- a/tiered-storage/jcloud/src/test/java/org/apache/bookkeeper/mledger/offload/jcloud/impl/MockManagedLedger.java
+++ b/tiered-storage/jcloud/src/test/java/org/apache/bookkeeper/mledger/offload/jcloud/impl/MockManagedLedger.java
@@ -18,10 +18,10 @@
  */
 package org.apache.bookkeeper.mledger.offload.jcloud.impl;
 
-import com.google.common.base.Predicate;
 import io.netty.buffer.ByteBuf;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import java.util.function.Predicate;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.bookkeeper.mledger.AsyncCallbacks;
 import org.apache.bookkeeper.mledger.Entry;


### PR DESCRIPTION
Master Issue: #12271 #16991 

### Motivation

Apply Maven Modernizer plugin to enforce we move away from legacy APIs.

### Modifications

fix violations in pulsar-broker

### Verifying this change


This change is already covered by existing tests, such as *(please describe tests)*.




### Does this pull request potentially affect one of the following parts:


  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

- [x] `doc-not-needed` 
 