### PR TITLE
[fix][sql] Exclude jsr305 from objectsize.

### DIFF
--- a/pulsar-sql/presto-distribution/pom.xml
+++ b/pulsar-sql/presto-distribution/pom.xml
@@ -132,6 +132,12 @@
       <groupId>com.twitter.common</groupId>
       <artifactId>objectsize</artifactId>
       <version>${objectsize.version}</version>
+      <exclusions>
+        <exclusion>
+          <artifactId>jsr305</artifactId>
+          <groupId>com.google.code.findbugs</groupId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <!-- jackson dependencies -->


### PR DESCRIPTION
### Motivation

When check the license of branch-2.11, I find there are two versions of `jsr305`:
```
- jsr305-2.0.1.jar
- jsr305-3.0.2.jar
```
`2.0.1` depends from `objectsize`, so when build presto-distribution, the version of `jsr305` is `2.0.1`
<img width="1126" alt="image" src="https://user-images.githubusercontent.com/6297296/186629483-a664bd0b-c785-4524-b77f-54047718667d.png">

`3.0.2` depends from `spotbugs`, so when build presto-pulsar, the version of `jsr305` is `3.0.2`
<img width="941" alt="image" src="https://user-images.githubusercontent.com/6297296/186630397-433b96c5-e8b2-41dc-9ffe-6009ce6f1912.png">

So we have to exclude the lower version.

### Documentation

- [x] `doc-not-needed` 
(Please explain why)
