### PR TITLE
[cleanup][owasp] Supress false positive netty-tcnative

### DIFF
--- a/src/owasp-dependency-check-false-positives.xml
+++ b/src/owasp-dependency-check-false-positives.xml
@@ -55,6 +55,13 @@
     <cpe>cpe:/a:netty:netty</cpe>
   </suppress>
   <suppress>
+    <notes><![CDATA[
+   file name: netty-tcnative-boringssl-static-2.0.52.Final-osx-x86_64.jar
+   ]]></notes>
+    <sha1>87a933c786d4b38355ebbeea684ab48ae88ec265</sha1>
+    <cpe>cpe:/a:chromium_project:chromium</cpe>
+  </suppress>
+  <suppress>
 <!--    Zookkeeper false positive about Jetty and commons-io-->
 <!--    https://github.com/apache/zookeeper/pull/1824-->
     <notes><![CDATA[

--- a/src/owasp-dependency-check-false-positives.xml
+++ b/src/owasp-dependency-check-false-positives.xml
@@ -56,9 +56,9 @@
   </suppress>
   <suppress>
     <notes><![CDATA[
-   file name: netty-tcnative-boringssl-static-2.0.52.Final-osx-x86_64.jar
+   file name: netty-tcnative-boringssl-static-2.0.52.Final-osx-aarch_64.jar
    ]]></notes>
-    <sha1>87a933c786d4b38355ebbeea684ab48ae88ec265</sha1>
+    <packageUrl regex="true">^pkg:maven/io\.netty/netty\-tcnative\-boringssl\-static@.*$</packageUrl>
     <cpe>cpe:/a:chromium_project:chromium</cpe>
   </suppress>
   <suppress>


### PR DESCRIPTION
### Motivation
Owasp check fails with 
```
One or more dependencies were identified with known vulnerabilities in Pulsar :: Distribution :: Server:

netty-tcnative-boringssl-static-2.0.52.Final-osx-x86_64.jar (pkg:maven/io.netty/netty-tcnative-boringssl-static@2.0.52.Final, cpe:2.3:a:chromium_project:chromium:2.0.52:*:*:*:*:*:*:*) : CVE-2011-1797

```

It's clearly a false positive https://github.com/jeremylong/DependencyCheck/issues/4776

### Modifications

* Suppress the violation

- [x] `doc-not-needed` 