### PR TITLE
[fix][schema]ledger handle leak when update schema

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/BookkeeperSchemaStorage.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/BookkeeperSchemaStorage.java
@@ -440,8 +440,10 @@ public class BookkeeperSchemaStorage implements SchemaStorage {
         return createLedger(schemaId).thenCompose(ledgerHandle -> {
             final long ledgerId = ledgerHandle.getId();
             return addEntry(ledgerHandle, schemaEntry)
-                    .thenCompose(entryId -> ledgerHandle.closeAsync().thenApply(__ -> entryId))
-                    .thenApply(entryId -> Functions.newPositionInfo(ledgerId, entryId));
+                    .thenApply(entryId -> {
+                        ledgerHandle.closeAsync();
+                        return Functions.newPositionInfo(ledgerId, entryId);
+                    });
         });
     }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/BookkeeperSchemaStorage.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/BookkeeperSchemaStorage.java
@@ -437,11 +437,12 @@ public class BookkeeperSchemaStorage implements SchemaStorage {
         byte[] data
     ) {
         SchemaStorageFormat.SchemaEntry schemaEntry = newSchemaEntry(index, data);
-        return createLedger(schemaId).thenCompose(ledgerHandle ->
-            addEntry(ledgerHandle, schemaEntry).thenApply(entryId ->
-                Functions.newPositionInfo(ledgerHandle.getId(), entryId)
-            )
-        );
+        return createLedger(schemaId).thenCompose(ledgerHandle -> {
+            final long ledgerId = ledgerHandle.getId();
+            return addEntry(ledgerHandle, schemaEntry)
+                    .thenCompose(entryId -> ledgerHandle.closeAsync().thenApply(__ -> entryId))
+                    .thenApply(entryId -> Functions.newPositionInfo(ledgerId, entryId));
+        });
     }
 
     @NotNull

--- a/pulsar-broker/src/test/java/org/apache/pulsar/schema/compatibility/SchemaCompatibilityCheckTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/schema/compatibility/SchemaCompatibilityCheckTest.java
@@ -24,7 +24,6 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.fail;
 import com.google.common.collect.Sets;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;

--- a/pulsar-broker/src/test/java/org/apache/pulsar/schema/compatibility/SchemaCompatibilityCheckTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/schema/compatibility/SchemaCompatibilityCheckTest.java
@@ -19,18 +19,15 @@
 package org.apache.pulsar.schema.compatibility;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static net.bytebuddy.jar.asm.Opcodes.ACC_PUBLIC;
 import static org.apache.pulsar.common.naming.TopicName.PUBLIC_TENANT;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.fail;
 import com.google.common.collect.Sets;
-import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
-import net.bytebuddy.jar.asm.ClassWriter;
-import net.bytebuddy.jar.asm.Opcodes;
 import org.apache.pulsar.broker.auth.MockedPulsarServiceBaseTest;
 import org.apache.pulsar.client.api.Consumer;
 import org.apache.pulsar.client.api.ConsumerBuilder;
@@ -491,11 +488,22 @@ public class SchemaCompatibilityCheckTest extends MockedPulsarServiceBaseTest {
         String topicName = "persistent://" + namespaceName + "/tp";
         admin.namespaces().createNamespace(namespaceName, Sets.newHashSet(CLUSTER_NAME));
         admin.namespaces().setSchemaCompatibilityStrategy(namespaceName, SchemaCompatibilityStrategy.ALWAYS_COMPATIBLE);
-        ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
         // Update schema 100 times.
-        ArrayList<Class> classes = createManyClass(classLoader, 100);
-        for (int i = 0; i < classes.size(); i++){
-            Schema schema = Schema.KeyValue(Integer.class, classes.get(i));
+        for (int i = 0; i < 100; i++){
+            Schema schema = Schema.JSON(SchemaDefinition.builder()
+                    .withJsonDef(String.format("""
+                            {
+                            	"type": "record",
+                            	"name": "Test_Pojo",
+                            	"namespace": "org.apache.pulsar.schema.compatibility",
+                            	"fields": [{
+                            		"name": "prop_%s",
+                            		"type": ["null", "string"],
+                            		"default": null
+                            	}]
+                            }
+                            """, i))
+                    .build());
             Producer producer = pulsarClient
                     .newProducer(schema)
                     .topic(topicName)
@@ -507,21 +515,6 @@ public class SchemaCompatibilityCheckTest extends MockedPulsarServiceBaseTest {
                 .filter(ledger -> !ledger.isFenced())
                 .collect(Collectors.toList()).size() < 20);
         admin.topics().delete(topicName, true);
-    }
-
-    private ArrayList<Class> createManyClass(ClassLoader classLoader, int count){
-        DynamicClassLoader dynamicClassLoader = new DynamicClassLoader(classLoader);
-        ArrayList<Class> list = new ArrayList<>(count);
-        for (int i = 0; i < count; i++){
-            ClassWriter cw = new ClassWriter(ClassWriter.COMPUTE_FRAMES);
-            String className = "Dynamic_GEN_Class_" + i;
-            cw.visit(Opcodes.V17, ACC_PUBLIC, className, null, "java/lang/Object", null);
-            cw.visitEnd();
-            byte[] bytes = cw.toByteArray();
-            Class c = dynamicClassLoader.defineClass(className, bytes);
-            list.add(c);
-        }
-        return list;
     }
 
     private static class DynamicClassLoader extends ClassLoader{

--- a/pulsar-broker/src/test/java/org/apache/pulsar/schema/compatibility/SchemaCompatibilityCheckTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/schema/compatibility/SchemaCompatibilityCheckTest.java
@@ -516,17 +516,6 @@ public class SchemaCompatibilityCheckTest extends MockedPulsarServiceBaseTest {
         admin.topics().delete(topicName, true);
     }
 
-    private static class DynamicClassLoader extends ClassLoader{
-
-        private DynamicClassLoader(ClassLoader parent) {
-            super(parent);
-        }
-
-        private Class<?> defineClass(String name, byte[] bytes) throws ClassFormatError {
-            return defineClass(name, bytes, 0, bytes.length);
-        }
-    }
-
     @Test
     public void testAutoProduceSchemaAlwaysCompatible() throws Exception {
         final String tenant = PUBLIC_TENANT;

--- a/testmocks/src/main/java/org/apache/bookkeeper/client/PulsarMockLedgerHandle.java
+++ b/testmocks/src/main/java/org/apache/bookkeeper/client/PulsarMockLedgerHandle.java
@@ -18,6 +18,7 @@
  */
 package org.apache.bookkeeper.client;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Lists;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
@@ -29,6 +30,7 @@ import java.util.Enumeration;
 import java.util.List;
 import java.util.Queue;
 import java.util.concurrent.CompletableFuture;
+import lombok.Getter;
 import org.apache.bookkeeper.client.AsyncCallback.AddCallback;
 import org.apache.bookkeeper.client.AsyncCallback.CloseCallback;
 import org.apache.bookkeeper.client.AsyncCallback.ReadCallback;
@@ -58,6 +60,8 @@ public class PulsarMockLedgerHandle extends LedgerHandle {
     final byte[] passwd;
     final ReadHandle readHandle;
     long lastEntry = -1;
+    @VisibleForTesting
+    @Getter
     boolean fenced = false;
 
     public PulsarMockLedgerHandle(PulsarMockBookKeeper bk, long id,


### PR DESCRIPTION
### Motivation

in the schema update, will create a `ledgerHandle` and write data to BK, after that `ledgerHandle` is no longer useful and no other object holds references to it. `ledgerHandle` will be recycled with GC, but `ledgerHandle` also hold external connections, which will cause leakage.

https://github.com/apache/pulsar/blob/40b9d7ea50cef54becb09f2543193e08375abe0b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/BookkeeperSchemaStorage.java#L452-L456

### Modifications

after the schema is updated, close the `ledgerHandle`, just like schema-read:

https://github.com/apache/pulsar/blob/40b9d7ea50cef54becb09f2543193e08375abe0b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/BookkeeperSchemaStorage.java#L519-L525

### Documentation


- [ ] `doc-required` 

  
- [x] `doc-not-needed` 

  
- [ ] `doc` 


- [ ] `doc-complete`

### Matching PR in forked repository

PR in forked repository: 

- https://github.com/poorbarcode/pulsar/pull/6
