### PR TITLE
[improve][broker] Improve tls config on replication client and cluster cli

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
@@ -1265,9 +1265,18 @@ public class BrokerService implements Closeable {
                         : data.getServiceUrlTls();
                 if (data.isBrokerClientTlsEnabled()) {
                     configTlsSettings(clientBuilder, serviceUrlTls,
-                            data.isBrokerClientTlsEnabledWithKeyStore(), data.isTlsAllowInsecureConnection(),
-                            data.getBrokerClientTlsTrustStoreType(), data.getBrokerClientTlsTrustStore(),
-                            data.getBrokerClientTlsTrustStorePassword(), data.getBrokerClientTrustCertsFilePath());
+                            data.isBrokerClientTlsEnabledWithKeyStore(),
+                            data.isTlsAllowInsecureConnection(),
+                            data.getBrokerClientTlsTrustStoreType(),
+                            data.getBrokerClientTlsTrustStore(),
+                            data.getBrokerClientTlsTrustStorePassword(),
+                            data.getBrokerClientTlsKeyStoreType(),
+                            data.getBrokerClientTlsKeyStore(),
+                            data.getBrokerClientTlsKeyStorePassword(),
+                            data.getBrokerClientTrustCertsFilePath(),
+                            data.getBrokerClientKeyFilePath(),
+                            data.getBrokerClientCertificateFilePath()
+                    );
                 } else if (pulsar.getConfiguration().isBrokerClientTlsEnabled()) {
                     configTlsSettings(clientBuilder, serviceUrlTls,
                             pulsar.getConfiguration().isBrokerClientTlsEnabledWithKeyStore(),
@@ -1275,7 +1284,13 @@ public class BrokerService implements Closeable {
                             pulsar.getConfiguration().getBrokerClientTlsTrustStoreType(),
                             pulsar.getConfiguration().getBrokerClientTlsTrustStore(),
                             pulsar.getConfiguration().getBrokerClientTlsTrustStorePassword(),
-                            pulsar.getConfiguration().getBrokerClientTrustCertsFilePath());
+                            pulsar.getConfiguration().getBrokerClientTlsKeyStoreType(),
+                            pulsar.getConfiguration().getBrokerClientTlsKeyStore(),
+                            pulsar.getConfiguration().getBrokerClientTlsKeyStorePassword(),
+                            pulsar.getConfiguration().getBrokerClientTrustCertsFilePath(),
+                            pulsar.getConfiguration().getBrokerClientKeyFilePath(),
+                            pulsar.getConfiguration().getBrokerClientCertificateFilePath()
+                    );
                 } else {
                     clientBuilder.serviceUrl(
                             isNotBlank(data.getBrokerServiceUrl()) ? data.getBrokerServiceUrl() : data.getServiceUrl());
@@ -1301,18 +1316,25 @@ public class BrokerService implements Closeable {
     private void configTlsSettings(ClientBuilder clientBuilder, String serviceUrl,
                                    boolean brokerClientTlsEnabledWithKeyStore, boolean isTlsAllowInsecureConnection,
                                    String brokerClientTlsTrustStoreType, String brokerClientTlsTrustStore,
-                                   String brokerClientTlsTrustStorePassword, String brokerClientTrustCertsFilePath) {
+                                   String brokerClientTlsTrustStorePassword, String brokerClientTlsKeyStoreType,
+                                   String brokerClientTlsKeyStore, String brokerClientTlsKeyStorePassword,
+                                   String brokerClientTrustCertsFilePath,
+                                   String brokerClientKeyFilePath, String brokerClientCertificateFilePath) {
         clientBuilder
                 .serviceUrl(serviceUrl)
-                .enableTls(true)
                 .allowTlsInsecureConnection(isTlsAllowInsecureConnection);
         if (brokerClientTlsEnabledWithKeyStore) {
             clientBuilder.useKeyStoreTls(true)
                     .tlsTrustStoreType(brokerClientTlsTrustStoreType)
                     .tlsTrustStorePath(brokerClientTlsTrustStore)
-                    .tlsTrustStorePassword(brokerClientTlsTrustStorePassword);
+                    .tlsTrustStorePassword(brokerClientTlsTrustStorePassword)
+                    .tlsKeyStoreType(brokerClientTlsKeyStoreType)
+                    .tlsKeyStorePath(brokerClientTlsKeyStore)
+                    .tlsKeyStorePassword(brokerClientTlsKeyStorePassword);
         } else {
-            clientBuilder.tlsTrustCertsFilePath(brokerClientTrustCertsFilePath);
+            clientBuilder.tlsTrustCertsFilePath(brokerClientTrustCertsFilePath)
+                    .tlsKeyFilePath(brokerClientKeyFilePath)
+                    .tlsCertificateFilePath(brokerClientCertificateFilePath);
         }
     }
 

--- a/pulsar-client-admin-api/src/main/java/org/apache/pulsar/common/policies/data/ClusterData.java
+++ b/pulsar-client-admin-api/src/main/java/org/apache/pulsar/common/policies/data/ClusterData.java
@@ -58,6 +58,16 @@ public interface ClusterData {
 
     String getBrokerClientTrustCertsFilePath();
 
+    String getBrokerClientCertificateFilePath();
+
+    String getBrokerClientKeyFilePath();
+
+    String getBrokerClientTlsKeyStoreType();
+
+    String getBrokerClientTlsKeyStorePassword();
+
+    String getBrokerClientTlsKeyStore();
+
     String getListenerName();
 
     boolean isMigrated();
@@ -96,6 +106,16 @@ public interface ClusterData {
         Builder brokerClientTlsTrustStorePassword(String trustStorePassword);
 
         Builder brokerClientTrustCertsFilePath(String trustCertsFilePath);
+
+        Builder brokerClientCertificateFilePath(String certificateFilePath);
+
+        Builder brokerClientKeyFilePath(String keyFilePath);
+
+        Builder brokerClientTlsKeyStoreType(String keyStoreType);
+
+        Builder brokerClientTlsKeyStorePassword(String keyStorePassword);
+
+        Builder brokerClientTlsKeyStore(String keyStore);
 
         Builder listenerName(String listenerName);
 

--- a/pulsar-client-tools-test/src/test/java/org/apache/pulsar/admin/cli/PulsarAdminToolTest.java
+++ b/pulsar-client-tools-test/src/test/java/org/apache/pulsar/admin/cli/PulsarAdminToolTest.java
@@ -292,22 +292,32 @@ public class PulsarAdminToolTest {
         clusters = new CmdClusters(() -> admin);
         clusters.run(split("create my-tls-cluster --url-secure https://my-service.url:4443 --tls-enable "
                 + "--tls-enable-keystore --tls-trust-store-type JKS --tls-trust-store /var/private/tls/client.truststore.jks "
-                + "--tls-trust-store-pwd clientpw"));
+                + "--tls-trust-store-pwd clientpw --tls-key-store-type KEYSTORE_TYPE --tls-key-store /var/private/tls/client.keystore.jks "
+                + "--tls-key-store-pwd KEYSTORE_STORE_PWD"));
         ClusterData.Builder data = ClusterData.builder()
                 .serviceUrlTls("https://my-service.url:4443")
                 .brokerClientTlsEnabled(true)
                 .brokerClientTlsEnabledWithKeyStore(true)
                 .brokerClientTlsTrustStoreType("JKS")
                 .brokerClientTlsTrustStore("/var/private/tls/client.truststore.jks")
-                .brokerClientTlsTrustStorePassword("clientpw");
+                .brokerClientTlsTrustStorePassword("clientpw")
+                .brokerClientTlsKeyStoreType("KEYSTORE_TYPE")
+                .brokerClientTlsKeyStore("/var/private/tls/client.keystore.jks")
+                .brokerClientTlsKeyStorePassword("KEYSTORE_STORE_PWD");
+
         verify(mockClusters).createCluster("my-tls-cluster", data.build());
 
         clusters.run(split("update my-tls-cluster --url-secure https://my-service.url:4443 --tls-enable "
-                + "--tls-trust-certs-filepath /path/to/ca.cert.pem"));
+                + "--tls-trust-certs-filepath /path/to/ca.cert.pem --tls-key-filepath KEY_FILEPATH --tls-certs-filepath CERTS_FILEPATH"));
         data.brokerClientTlsEnabledWithKeyStore(false)
                 .brokerClientTlsTrustStore(null)
                 .brokerClientTlsTrustStorePassword(null)
-                .brokerClientTrustCertsFilePath("/path/to/ca.cert.pem");
+                .brokerClientTlsKeyStoreType("JKS")
+                .brokerClientTlsKeyStore(null)
+                .brokerClientTlsKeyStorePassword(null)
+                .brokerClientTrustCertsFilePath("/path/to/ca.cert.pem")
+                .brokerClientKeyFilePath("KEY_FILEPATH")
+                .brokerClientCertificateFilePath("CERTS_FILEPATH");
         verify(mockClusters).updateCluster("my-tls-cluster", data.build());
     }
 

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdClusters.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdClusters.java
@@ -336,9 +336,29 @@ public class CmdClusters extends CmdBase {
                 description = "TLS TrustStore password for internal client", required = false)
         protected String brokerClientTlsTrustStorePassword;
 
+        @Parameter(names = "--tls-key-store-type",
+                description = "TLS TrustStore type configuration for internal client eg: JKS", required = false)
+        protected String brokerClientTlsKeyStoreType;
+
+        @Parameter(names = "--tls-key-store",
+                description = "TLS KeyStore path for internal client", required = false)
+        protected String brokerClientTlsKeyStore;
+
+        @Parameter(names = "--tls-key-store-pwd",
+                description = "TLS KeyStore password for internal client", required = false)
+        protected String brokerClientTlsKeyStorePassword;
+
         @Parameter(names = "--tls-trust-certs-filepath",
                 description = "path for the trusted TLS certificate file", required = false)
         protected String brokerClientTrustCertsFilePath;
+
+        @Parameter(names = "--tls-key-filepath",
+                description = "path for the TLS private key file", required = false)
+        protected String brokerClientKeyFilePath;
+
+        @Parameter(names = "--tls-certs-filepath",
+                description = "path for the TLS certificate file", required = false)
+        protected String brokerClientCertificateFilePath;
 
         @Parameter(names = "--listener-name",
                 description = "listenerName when client would like to connect to cluster", required = false)
@@ -403,8 +423,23 @@ public class CmdClusters extends CmdBase {
             if (brokerClientTlsTrustStorePassword != null) {
                 builder.brokerClientTlsTrustStorePassword(brokerClientTlsTrustStorePassword);
             }
+            if (brokerClientTlsKeyStoreType != null) {
+                builder.brokerClientTlsKeyStoreType(brokerClientTlsKeyStoreType);
+            }
+            if (brokerClientTlsKeyStore != null) {
+                builder.brokerClientTlsKeyStore(brokerClientTlsKeyStore);
+            }
+            if (brokerClientTlsKeyStorePassword != null) {
+                builder.brokerClientTlsKeyStorePassword(brokerClientTlsKeyStorePassword);
+            }
             if (brokerClientTrustCertsFilePath != null) {
                 builder.brokerClientTrustCertsFilePath(brokerClientTrustCertsFilePath);
+            }
+            if (brokerClientKeyFilePath != null) {
+                builder.brokerClientKeyFilePath(brokerClientKeyFilePath);
+            }
+            if (brokerClientCertificateFilePath != null) {
+                builder.brokerClientCertificateFilePath(brokerClientCertificateFilePath);
             }
 
             if (listenerName != null) {

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/ClusterDataImpl.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/ClusterDataImpl.java
@@ -132,10 +132,39 @@ public final class ClusterDataImpl implements  ClusterData, Cloneable {
     )
     private String brokerClientTlsTrustStorePassword;
     @ApiModelProperty(
-        name = "brokerClientTrustCertsFilePath",
-        value = "Path for the trusted TLS certificate file for outgoing connection to a server (broker)"
+            name = "brokerClientTlsKeyStoreType",
+            value = "TLS KeyStore type configuration for internal client: JKS, PKCS12,"
+                    + " used by the internal client to authenticate with Pulsar brokers"
+    )
+    private String brokerClientTlsKeyStoreType;
+    @ApiModelProperty(
+            name = "brokerClientTlsKeyStore",
+            value = "TLS KeyStore path for internal client, "
+                    + " used by the internal client to authenticate with Pulsar brokers"
+    )
+    private String brokerClientTlsKeyStore;
+    @ApiModelProperty(
+            name = "brokerClientTlsKeyStorePassword",
+            value = "TLS KeyStore password for internal client, "
+                    + " used by the internal client to authenticate with Pulsar brokers"
+    )
+    private String brokerClientTlsKeyStorePassword;
+    @ApiModelProperty(
+            name = "brokerClientTrustCertsFilePath",
+            value = "Path for the trusted TLS certificate file for outgoing connection to a server (broker)"
     )
     private String brokerClientTrustCertsFilePath;
+    @ApiModelProperty(
+            name = "brokerClientKeyFilePath",
+            value = "TLS private key file for internal client, "
+                    + "used by the internal client to authenticate with Pulsar brokers")
+    private String brokerClientKeyFilePath;
+    @ApiModelProperty(
+            name = "brokerClientCertificateFilePath",
+            value = "TLS certificate file for internal client, "
+                    + "used by the internal client to authenticate with Pulsar brokers"
+    )
+    private String brokerClientCertificateFilePath;
     @ApiModelProperty(
             name = "listenerName",
             value = "listenerName when client would like to connect to cluster",
@@ -176,7 +205,12 @@ public final class ClusterDataImpl implements  ClusterData, Cloneable {
                 .brokerClientTlsTrustStoreType(brokerClientTlsTrustStoreType)
                 .brokerClientTlsTrustStore(brokerClientTlsTrustStore)
                 .brokerClientTlsTrustStorePassword(brokerClientTlsTrustStorePassword)
+                .brokerClientTlsKeyStoreType(brokerClientTlsTrustStoreType)
+                .brokerClientTlsKeyStore(brokerClientTlsTrustStore)
+                .brokerClientTlsKeyStorePassword(brokerClientTlsTrustStorePassword)
                 .brokerClientTrustCertsFilePath(brokerClientTrustCertsFilePath)
+                .brokerClientCertificateFilePath(brokerClientCertificateFilePath)
+                .brokerClientKeyFilePath(brokerClientKeyFilePath)
                 .listenerName(listenerName);
     }
 
@@ -197,6 +231,11 @@ public final class ClusterDataImpl implements  ClusterData, Cloneable {
         private String brokerClientTlsTrustStoreType = "JKS";
         private String brokerClientTlsTrustStore;
         private String brokerClientTlsTrustStorePassword;
+        private String brokerClientTlsKeyStoreType = "JKS";
+        private String brokerClientTlsKeyStore;
+        private String brokerClientTlsKeyStorePassword;
+        private String brokerClientCertificateFilePath;
+        private String brokerClientKeyFilePath;
         private String brokerClientTrustCertsFilePath;
         private String listenerName;
         private boolean migrated;
@@ -280,10 +319,41 @@ public final class ClusterDataImpl implements  ClusterData, Cloneable {
             return this;
         }
 
+        @Override
+        public ClusterDataImplBuilder brokerClientTlsKeyStoreType(String keyStoreType) {
+            this.brokerClientTlsKeyStoreType = keyStoreType;
+            return this;
+        }
+
+        @Override
+        public ClusterDataImplBuilder brokerClientTlsKeyStorePassword(String keyStorePassword) {
+            this.brokerClientTlsKeyStorePassword = keyStorePassword;
+            return this;
+        }
+
+        @Override
+        public ClusterDataImplBuilder brokerClientTlsKeyStore(String keyStore) {
+            this.brokerClientTlsKeyStore = keyStore;
+            return this;
+        }
+
         public ClusterDataImplBuilder brokerClientTrustCertsFilePath(String brokerClientTrustCertsFilePath) {
             this.brokerClientTrustCertsFilePath = brokerClientTrustCertsFilePath;
             return this;
         }
+
+        @Override
+        public ClusterDataImplBuilder brokerClientCertificateFilePath(String certificateFilePath) {
+            this.brokerClientCertificateFilePath = certificateFilePath;
+            return this;
+        }
+
+        @Override
+        public ClusterDataImplBuilder brokerClientKeyFilePath(String keyFilePath) {
+            this.brokerClientKeyFilePath = keyFilePath;
+            return this;
+        }
+
 
         public ClusterDataImplBuilder listenerName(String listenerName) {
             this.listenerName = listenerName;
@@ -317,7 +387,12 @@ public final class ClusterDataImpl implements  ClusterData, Cloneable {
                     brokerClientTlsTrustStoreType,
                     brokerClientTlsTrustStore,
                     brokerClientTlsTrustStorePassword,
+                    brokerClientTlsKeyStoreType,
+                    brokerClientTlsKeyStore,
+                    brokerClientTlsKeyStorePassword,
                     brokerClientTrustCertsFilePath,
+                    brokerClientKeyFilePath,
+                    brokerClientCertificateFilePath,
                     listenerName,
                     migrated,
                     migratedClusterUrl);


### PR DESCRIPTION
### Motivation

Add a separate TLS transport configuration to replication client and cluster cli.

:( Need to add the integration tests to verify.

### Modifications

- Add KeyStore and private file and certificate file config to cluster data
- Add manage these configs in cluster cmd
- Using these configs when creating replication client

### Documentation

Check the box below or label this PR directly.

Need to update docs? 

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)
  
- [x] `doc-not-needed` 
(Please explain why)
  
- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)