### PR TITLE
[fix][broker]Fix ProducerImpl.sendMessage  is not applicable

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/BatchMessageContainerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/BatchMessageContainerImpl.java
@@ -220,7 +220,7 @@ class BatchMessageContainerImpl extends AbstractBatchMessageContainer {
             messageMetadata.copyFrom(messages.get(0).getMessageBuilder());
             ByteBuf encryptedPayload = producer.encryptMessage(messageMetadata, getCompressedBatchMetadataAndPayload());
             ByteBufPair cmd = producer.sendMessage(producer.producerId, messageMetadata.getSequenceId(),
-                1, messageMetadata, encryptedPayload);
+                1, messages.get(0).getMessageId(), messageMetadata, encryptedPayload);
             final OpSendMsg op;
 
             // Shouldn't call create(MessageImpl<?> msg, ByteBufPair cmd, long sequenceId, SendCallback callback),


### PR DESCRIPTION
### Motivation


* Fix method ProducerImpl.sendMessage(long,long,long,int,MessageMetadata,iByteBuf) is not applicable

### Modifications

*Fix method ProducerImpl.sendMessage(long,long,long,int,MessageMetadata,iByteBuf) is not applicable

### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Documentation

Check the box below or label this PR directly.

Need to update docs? 

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)
  
- [x] `doc-not-needed` 
(Please explain why)
  
- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)