### PR TITLE
[fix][broker] Fix broken build caused by conflict between #17195 and #16605

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/BatchMessageContainerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/BatchMessageContainerImpl.java
@@ -220,7 +220,7 @@ class BatchMessageContainerImpl extends AbstractBatchMessageContainer {
             messageMetadata.copyFrom(messages.get(0).getMessageBuilder());
             ByteBuf encryptedPayload = producer.encryptMessage(messageMetadata, getCompressedBatchMetadataAndPayload());
             ByteBufPair cmd = producer.sendMessage(producer.producerId, messageMetadata.getSequenceId(),
-                1, messageMetadata, encryptedPayload);
+                1, null, messageMetadata, encryptedPayload);
             final OpSendMsg op;
 
             // Shouldn't call create(MessageImpl<?> msg, ByteBufPair cmd, long sequenceId, SendCallback callback),


### PR DESCRIPTION
### Motivation

master branch is broken.
- #17195 changed the method signature that #16605 depended upon

### Modifications

- pass `null` to new argument introduced by #17195
- [x] `doc-not-needed`
