### PR TITLE
[fix][standalone] Updated tip section of consume a message

### DIFF
--- a/site2/docs/getting-started-standalone.md
+++ b/site2/docs/getting-started-standalone.md
@@ -277,7 +277,7 @@ If the message has been successfully consumed, you will see a confirmation like 
 
 :::tip
 
-As you have noticed that we do not explicitly create the `my-topic` topic, to which we consume the message. When you consume a message on a topic that does not yet exist, Pulsar creates that topic for you automatically. Producing a message to a topic that does not exist will automatically create that topic for you as well.
+As you have noticed that we do not explicitly create the `my-topic` topic, from which we consume the message. When you consume a message from a topic that does not yet exist, Pulsar creates that topic for you automatically. Producing a message to a topic that does not exist will automatically create that topic for you as well.
 
 :::
 

--- a/site2/docs/standalone.md
+++ b/site2/docs/standalone.md
@@ -232,7 +232,7 @@ If the message has been successfully consumed, you will see a confirmation like 
 
 :::tip
 
-As you have noticed that we do not explicitly create the `my-topic` topic, to which we consume the message. When you consume a message to a topic that does not yet exist, Pulsar creates that topic for you automatically. Producing a message to a topic that does not exist will automatically create that topic for you as well.
+As you have noticed that we do not explicitly create the `my-topic` topic, from which we consume the message. When you consume a message from a topic that does not yet exist, Pulsar creates that topic for you automatically. Producing a message to a topic that does not exist will automatically create that topic for you as well.
 
 :::
 

--- a/site2/website/versioned_docs/version-2.10.0-deprecated/getting-started-standalone.md
+++ b/site2/website/versioned_docs/version-2.10.0-deprecated/getting-started-standalone.md
@@ -291,7 +291,7 @@ If the message has been successfully consumed, you will see a confirmation like 
 
 :::tip
 
-As you have noticed that we do not explicitly create the `my-topic` topic, to which we consume the message. When you consume a message to a topic that does not yet exist, Pulsar creates that topic for you automatically. Producing a message to a topic that does not exist will automatically create that topic for you as well.
+As you have noticed that we do not explicitly create the `my-topic` topic, from which we consume the message. When you consume a message from a topic that does not yet exist, Pulsar creates that topic for you automatically. Producing a message to a topic that does not exist will automatically create that topic for you as well.
 
 :::
 

--- a/site2/website/versioned_docs/version-2.10.0-deprecated/standalone.md
+++ b/site2/website/versioned_docs/version-2.10.0-deprecated/standalone.md
@@ -233,7 +233,7 @@ If the message has been successfully consumed, you will see a confirmation like 
 
 :::tip
 
-As you have noticed that we do not explicitly create the `my-topic` topic, to which we consume the message. When you consume a message to a topic that does not yet exist, Pulsar creates that topic for you automatically. Producing a message to a topic that does not exist will automatically create that topic for you as well.
+As you have noticed that we do not explicitly create the `my-topic` topic, from which we consume the message. When you consume a message from a topic that does not yet exist, Pulsar creates that topic for you automatically. Producing a message to a topic that does not exist will automatically create that topic for you as well.
 
 :::
 

--- a/site2/website/versioned_docs/version-2.10.1-deprecated/getting-started-standalone.md
+++ b/site2/website/versioned_docs/version-2.10.1-deprecated/getting-started-standalone.md
@@ -291,7 +291,7 @@ If the message has been successfully consumed, you will see a confirmation like 
 
 :::tip
 
-As you have noticed that we do not explicitly create the `my-topic` topic, to which we consume the message. When you consume a message to a topic that does not yet exist, Pulsar creates that topic for you automatically. Producing a message to a topic that does not exist will automatically create that topic for you as well.
+As you have noticed that we do not explicitly create the `my-topic` topic, from which we consume the message. When you consume a message from a topic that does not yet exist, Pulsar creates that topic for you automatically. Producing a message to a topic that does not exist will automatically create that topic for you as well.
 
 :::
 

--- a/site2/website/versioned_docs/version-2.10.1-deprecated/standalone.md
+++ b/site2/website/versioned_docs/version-2.10.1-deprecated/standalone.md
@@ -233,7 +233,7 @@ If the message has been successfully consumed, you will see a confirmation like 
 
 :::tip
 
-As you have noticed that we do not explicitly create the `my-topic` topic, to which we consume the message. When you consume a message to a topic that does not yet exist, Pulsar creates that topic for you automatically. Producing a message to a topic that does not exist will automatically create that topic for you as well.
+As you have noticed that we do not explicitly create the `my-topic` topic, from which we consume the message. When you consume a message from a topic that does not yet exist, Pulsar creates that topic for you automatically. Producing a message to a topic that does not exist will automatically create that topic for you as well.
 
 :::
 

--- a/site2/website/versioned_docs/version-2.10.x/getting-started-standalone.md
+++ b/site2/website/versioned_docs/version-2.10.x/getting-started-standalone.md
@@ -291,7 +291,7 @@ If the message has been successfully consumed, you will see a confirmation like 
 
 :::tip
 
-As you have noticed that we do not explicitly create the `my-topic` topic, to which we consume the message. When you consume a message to a topic that does not yet exist, Pulsar creates that topic for you automatically. Producing a message to a topic that does not exist will automatically create that topic for you as well.
+As you have noticed that we do not explicitly create the `my-topic` topic, from which we consume the message. When you consume a message from a topic that does not yet exist, Pulsar creates that topic for you automatically. Producing a message to a topic that does not exist will automatically create that topic for you as well.
 
 :::
 

--- a/site2/website/versioned_docs/version-2.10.x/standalone.md
+++ b/site2/website/versioned_docs/version-2.10.x/standalone.md
@@ -233,7 +233,7 @@ If the message has been successfully consumed, you will see a confirmation like 
 
 :::tip
 
-As you have noticed that we do not explicitly create the `my-topic` topic, to which we consume the message. When you consume a message to a topic that does not yet exist, Pulsar creates that topic for you automatically. Producing a message to a topic that does not exist will automatically create that topic for you as well.
+As you have noticed that we do not explicitly create the `my-topic` topic, from which we consume the message. When you consume a message from a topic that does not yet exist, Pulsar creates that topic for you automatically. Producing a message to a topic that does not exist will automatically create that topic for you as well.
 
 :::
 

--- a/site2/website/versioned_docs/version-2.3.2/getting-started-standalone.md
+++ b/site2/website/versioned_docs/version-2.3.2/getting-started-standalone.md
@@ -222,7 +222,7 @@ If the message has been successfully consumed, you will see a confirmation like 
 
 :::tip
 
-As you have noticed that we do not explicitly create the `my-topic` topic, to which we consume the message. When you consume a message to a topic that does not yet exist, Pulsar creates that topic for you automatically. Producing a message to a topic that does not exist will automatically create that topic for you as well.
+As you have noticed that we do not explicitly create the `my-topic` topic, from which we consume the message. When you consume a message from a topic that does not yet exist, Pulsar creates that topic for you automatically. Producing a message to a topic that does not exist will automatically create that topic for you as well.
 
 :::
 

--- a/site2/website/versioned_docs/version-2.3.2/standalone.md
+++ b/site2/website/versioned_docs/version-2.3.2/standalone.md
@@ -222,7 +222,7 @@ If the message has been successfully consumed, you will see a confirmation like 
 
 :::tip
 
-As you have noticed that we do not explicitly create the `my-topic` topic, to which we consume the message. When you consume a message to a topic that does not yet exist, Pulsar creates that topic for you automatically. Producing a message to a topic that does not exist will automatically create that topic for you as well.
+As you have noticed that we do not explicitly create the `my-topic` topic, from which we consume the message. When you consume a message from a topic that does not yet exist, Pulsar creates that topic for you automatically. Producing a message to a topic that does not exist will automatically create that topic for you as well.
 
 :::
 

--- a/site2/website/versioned_docs/version-2.4.0/getting-started-standalone.md
+++ b/site2/website/versioned_docs/version-2.4.0/getting-started-standalone.md
@@ -222,7 +222,7 @@ If the message has been successfully consumed, you will see a confirmation like 
 
 :::tip
 
-As you have noticed that we do not explicitly create the `my-topic` topic, to which we consume the message. When you consume a message to a topic that does not yet exist, Pulsar creates that topic for you automatically. Producing a message to a topic that does not exist will automatically create that topic for you as well.
+As you have noticed that we do not explicitly create the `my-topic` topic, from which we consume the message. When you consume a message from a topic that does not yet exist, Pulsar creates that topic for you automatically. Producing a message to a topic that does not exist will automatically create that topic for you as well.
 
 :::
 

--- a/site2/website/versioned_docs/version-2.4.0/standalone.md
+++ b/site2/website/versioned_docs/version-2.4.0/standalone.md
@@ -222,7 +222,7 @@ If the message has been successfully consumed, you will see a confirmation like 
 
 :::tip
 
-As you have noticed that we do not explicitly create the `my-topic` topic, to which we consume the message. When you consume a message to a topic that does not yet exist, Pulsar creates that topic for you automatically. Producing a message to a topic that does not exist will automatically create that topic for you as well.
+As you have noticed that we do not explicitly create the `my-topic` topic, from which we consume the message. When you consume a message from a topic that does not yet exist, Pulsar creates that topic for you automatically. Producing a message to a topic that does not exist will automatically create that topic for you as well.
 
 :::
 

--- a/site2/website/versioned_docs/version-2.4.1/getting-started-standalone.md
+++ b/site2/website/versioned_docs/version-2.4.1/getting-started-standalone.md
@@ -230,7 +230,7 @@ If the message has been successfully consumed, you will see a confirmation like 
 
 :::tip
 
-As you have noticed that we do not explicitly create the `my-topic` topic, to which we consume the message. When you consume a message to a topic that does not yet exist, Pulsar creates that topic for you automatically. Producing a message to a topic that does not exist will automatically create that topic for you as well.
+As you have noticed that we do not explicitly create the `my-topic` topic, from which we consume the message. When you consume a message from a topic that does not yet exist, Pulsar creates that topic for you automatically. Producing a message to a topic that does not exist will automatically create that topic for you as well.
 
 :::
 

--- a/site2/website/versioned_docs/version-2.4.1/standalone.md
+++ b/site2/website/versioned_docs/version-2.4.1/standalone.md
@@ -230,7 +230,7 @@ If the message has been successfully consumed, you will see a confirmation like 
 
 :::tip
 
-As you have noticed that we do not explicitly create the `my-topic` topic, to which we consume the message. When you consume a message to a topic that does not yet exist, Pulsar creates that topic for you automatically. Producing a message to a topic that does not exist will automatically create that topic for you as well.
+As you have noticed that we do not explicitly create the `my-topic` topic, from which we consume the message. When you consume a message from a topic that does not yet exist, Pulsar creates that topic for you automatically. Producing a message to a topic that does not exist will automatically create that topic for you as well.
 
 :::
 

--- a/site2/website/versioned_docs/version-2.4.2/getting-started-standalone.md
+++ b/site2/website/versioned_docs/version-2.4.2/getting-started-standalone.md
@@ -231,7 +231,7 @@ If the message has been successfully consumed, you will see a confirmation like 
 
 :::tip
 
-As you have noticed that we do not explicitly create the `my-topic` topic, to which we consume the message. When you consume a message to a topic that does not yet exist, Pulsar creates that topic for you automatically. Producing a message to a topic that does not exist will automatically create that topic for you as well.
+As you have noticed that we do not explicitly create the `my-topic` topic, from which we consume the message. When you consume a message from a topic that does not yet exist, Pulsar creates that topic for you automatically. Producing a message to a topic that does not exist will automatically create that topic for you as well.
 
 :::
 

--- a/site2/website/versioned_docs/version-2.4.2/standalone.md
+++ b/site2/website/versioned_docs/version-2.4.2/standalone.md
@@ -231,7 +231,7 @@ If the message has been successfully consumed, you will see a confirmation like 
 
 :::tip
 
-As you have noticed that we do not explicitly create the `my-topic` topic, to which we consume the message. When you consume a message to a topic that does not yet exist, Pulsar creates that topic for you automatically. Producing a message to a topic that does not exist will automatically create that topic for you as well.
+As you have noticed that we do not explicitly create the `my-topic` topic, from which we consume the message. When you consume a message from a topic that does not yet exist, Pulsar creates that topic for you automatically. Producing a message to a topic that does not exist will automatically create that topic for you as well.
 
 :::
 

--- a/site2/website/versioned_docs/version-2.5.0/getting-started-standalone.md
+++ b/site2/website/versioned_docs/version-2.5.0/getting-started-standalone.md
@@ -230,7 +230,7 @@ If the message has been successfully consumed, you will see a confirmation like 
 
 :::tip
 
-As you have noticed that we do not explicitly create the `my-topic` topic, to which we consume the message. When you consume a message to a topic that does not yet exist, Pulsar creates that topic for you automatically. Producing a message to a topic that does not exist will automatically create that topic for you as well.
+As you have noticed that we do not explicitly create the `my-topic` topic, from which we consume the message. When you consume a message from a topic that does not yet exist, Pulsar creates that topic for you automatically. Producing a message to a topic that does not exist will automatically create that topic for you as well.
 
 :::
 

--- a/site2/website/versioned_docs/version-2.5.0/standalone.md
+++ b/site2/website/versioned_docs/version-2.5.0/standalone.md
@@ -230,7 +230,7 @@ If the message has been successfully consumed, you will see a confirmation like 
 
 :::tip
 
-As you have noticed that we do not explicitly create the `my-topic` topic, to which we consume the message. When you consume a message to a topic that does not yet exist, Pulsar creates that topic for you automatically. Producing a message to a topic that does not exist will automatically create that topic for you as well.
+As you have noticed that we do not explicitly create the `my-topic` topic, from which we consume the message. When you consume a message from a topic that does not yet exist, Pulsar creates that topic for you automatically. Producing a message to a topic that does not exist will automatically create that topic for you as well.
 
 :::
 

--- a/site2/website/versioned_docs/version-2.5.1/getting-started-standalone.md
+++ b/site2/website/versioned_docs/version-2.5.1/getting-started-standalone.md
@@ -236,7 +236,7 @@ If the message has been successfully consumed, you will see a confirmation like 
 
 :::tip
 
-As you have noticed that we do not explicitly create the `my-topic` topic, to which we consume the message. When you consume a message to a topic that does not yet exist, Pulsar creates that topic for you automatically. Producing a message to a topic that does not exist will automatically create that topic for you as well.
+As you have noticed that we do not explicitly create the `my-topic` topic, from which we consume the message. When you consume a message from a topic that does not yet exist, Pulsar creates that topic for you automatically. Producing a message to a topic that does not exist will automatically create that topic for you as well.
 
 :::
 

--- a/site2/website/versioned_docs/version-2.5.1/standalone.md
+++ b/site2/website/versioned_docs/version-2.5.1/standalone.md
@@ -236,7 +236,7 @@ If the message has been successfully consumed, you will see a confirmation like 
 
 :::tip
 
-As you have noticed that we do not explicitly create the `my-topic` topic, to which we consume the message. When you consume a message to a topic that does not yet exist, Pulsar creates that topic for you automatically. Producing a message to a topic that does not exist will automatically create that topic for you as well.
+As you have noticed that we do not explicitly create the `my-topic` topic, from which we consume the message. When you consume a message from a topic that does not yet exist, Pulsar creates that topic for you automatically. Producing a message to a topic that does not exist will automatically create that topic for you as well.
 
 :::
 

--- a/site2/website/versioned_docs/version-2.5.2/getting-started-standalone.md
+++ b/site2/website/versioned_docs/version-2.5.2/getting-started-standalone.md
@@ -233,7 +233,7 @@ If the message has been successfully consumed, you will see a confirmation like 
 
 :::tip
 
-As you have noticed that we do not explicitly create the `my-topic` topic, to which we consume the message. When you consume a message to a topic that does not yet exist, Pulsar creates that topic for you automatically. Producing a message to a topic that does not exist will automatically create that topic for you as well.
+As you have noticed that we do not explicitly create the `my-topic` topic, from which we consume the message. When you consume a message from a topic that does not yet exist, Pulsar creates that topic for you automatically. Producing a message to a topic that does not exist will automatically create that topic for you as well.
 
 :::
 

--- a/site2/website/versioned_docs/version-2.5.2/standalone.md
+++ b/site2/website/versioned_docs/version-2.5.2/standalone.md
@@ -232,7 +232,7 @@ If the message has been successfully consumed, you will see a confirmation like 
 
 :::tip
 
-As you have noticed that we do not explicitly create the `my-topic` topic, to which we consume the message. When you consume a message to a topic that does not yet exist, Pulsar creates that topic for you automatically. Producing a message to a topic that does not exist will automatically create that topic for you as well.
+As you have noticed that we do not explicitly create the `my-topic` topic, from which we consume the message. When you consume a message from a topic that does not yet exist, Pulsar creates that topic for you automatically. Producing a message to a topic that does not exist will automatically create that topic for you as well.
 
 :::
 

--- a/site2/website/versioned_docs/version-2.6.0/getting-started-standalone.md
+++ b/site2/website/versioned_docs/version-2.6.0/getting-started-standalone.md
@@ -230,7 +230,7 @@ If the message has been successfully consumed, you will see a confirmation like 
 
 :::tip
 
-As you have noticed that we do not explicitly create the `my-topic` topic, to which we consume the message. When you consume a message to a topic that does not yet exist, Pulsar creates that topic for you automatically. Producing a message to a topic that does not exist will automatically create that topic for you as well.
+As you have noticed that we do not explicitly create the `my-topic` topic, from which we consume the message. When you consume a message from a topic that does not yet exist, Pulsar creates that topic for you automatically. Producing a message to a topic that does not exist will automatically create that topic for you as well.
 
 :::
 

--- a/site2/website/versioned_docs/version-2.6.0/standalone.md
+++ b/site2/website/versioned_docs/version-2.6.0/standalone.md
@@ -230,7 +230,7 @@ If the message has been successfully consumed, you will see a confirmation like 
 
 :::tip
 
-As you have noticed that we do not explicitly create the `my-topic` topic, to which we consume the message. When you consume a message to a topic that does not yet exist, Pulsar creates that topic for you automatically. Producing a message to a topic that does not exist will automatically create that topic for you as well.
+As you have noticed that we do not explicitly create the `my-topic` topic, from which we consume the message. When you consume a message from a topic that does not yet exist, Pulsar creates that topic for you automatically. Producing a message to a topic that does not exist will automatically create that topic for you as well.
 
 :::
 

--- a/site2/website/versioned_docs/version-2.6.1/getting-started-standalone.md
+++ b/site2/website/versioned_docs/version-2.6.1/getting-started-standalone.md
@@ -230,7 +230,7 @@ If the message has been successfully consumed, you will see a confirmation like 
 
 :::tip
 
-As you have noticed that we do not explicitly create the `my-topic` topic, to which we consume the message. When you consume a message to a topic that does not yet exist, Pulsar creates that topic for you automatically. Producing a message to a topic that does not exist will automatically create that topic for you as well.
+As you have noticed that we do not explicitly create the `my-topic` topic, from which we consume the message. When you consume a message from a topic that does not yet exist, Pulsar creates that topic for you automatically. Producing a message to a topic that does not exist will automatically create that topic for you as well.
 
 :::
 

--- a/site2/website/versioned_docs/version-2.6.1/standalone.md
+++ b/site2/website/versioned_docs/version-2.6.1/standalone.md
@@ -230,7 +230,7 @@ If the message has been successfully consumed, you will see a confirmation like 
 
 :::tip
 
-As you have noticed that we do not explicitly create the `my-topic` topic, to which we consume the message. When you consume a message to a topic that does not yet exist, Pulsar creates that topic for you automatically. Producing a message to a topic that does not exist will automatically create that topic for you as well.
+As you have noticed that we do not explicitly create the `my-topic` topic, from which we consume the message. When you consume a message from a topic that does not yet exist, Pulsar creates that topic for you automatically. Producing a message to a topic that does not exist will automatically create that topic for you as well.
 
 :::
 

--- a/site2/website/versioned_docs/version-2.6.2/getting-started-standalone.md
+++ b/site2/website/versioned_docs/version-2.6.2/getting-started-standalone.md
@@ -230,7 +230,7 @@ If the message has been successfully consumed, you will see a confirmation like 
 
 :::tip
 
-As you have noticed that we do not explicitly create the `my-topic` topic, to which we consume the message. When you consume a message to a topic that does not yet exist, Pulsar creates that topic for you automatically. Producing a message to a topic that does not exist will automatically create that topic for you as well.
+As you have noticed that we do not explicitly create the `my-topic` topic, from which we consume the message. When you consume a message from a topic that does not yet exist, Pulsar creates that topic for you automatically. Producing a message to a topic that does not exist will automatically create that topic for you as well.
 
 :::
 

--- a/site2/website/versioned_docs/version-2.6.2/standalone.md
+++ b/site2/website/versioned_docs/version-2.6.2/standalone.md
@@ -230,7 +230,7 @@ If the message has been successfully consumed, you will see a confirmation like 
 
 :::tip
 
-As you have noticed that we do not explicitly create the `my-topic` topic, to which we consume the message. When you consume a message to a topic that does not yet exist, Pulsar creates that topic for you automatically. Producing a message to a topic that does not exist will automatically create that topic for you as well.
+As you have noticed that we do not explicitly create the `my-topic` topic, from which we consume the message. When you consume a message from a topic that does not yet exist, Pulsar creates that topic for you automatically. Producing a message to a topic that does not exist will automatically create that topic for you as well.
 
 :::
 

--- a/site2/website/versioned_docs/version-2.6.3/getting-started-standalone.md
+++ b/site2/website/versioned_docs/version-2.6.3/getting-started-standalone.md
@@ -230,7 +230,7 @@ If the message has been successfully consumed, you will see a confirmation like 
 
 :::tip
 
-As you have noticed that we do not explicitly create the `my-topic` topic, to which we consume the message. When you consume a message to a topic that does not yet exist, Pulsar creates that topic for you automatically. Producing a message to a topic that does not exist will automatically create that topic for you as well.
+As you have noticed that we do not explicitly create the `my-topic` topic, from which we consume the message. When you consume a message from a topic that does not yet exist, Pulsar creates that topic for you automatically. Producing a message to a topic that does not exist will automatically create that topic for you as well.
 
 :::
 

--- a/site2/website/versioned_docs/version-2.6.3/standalone.md
+++ b/site2/website/versioned_docs/version-2.6.3/standalone.md
@@ -230,7 +230,7 @@ If the message has been successfully consumed, you will see a confirmation like 
 
 :::tip
 
-As you have noticed that we do not explicitly create the `my-topic` topic, to which we consume the message. When you consume a message to a topic that does not yet exist, Pulsar creates that topic for you automatically. Producing a message to a topic that does not exist will automatically create that topic for you as well.
+As you have noticed that we do not explicitly create the `my-topic` topic, from which we consume the message. When you consume a message from a topic that does not yet exist, Pulsar creates that topic for you automatically. Producing a message to a topic that does not exist will automatically create that topic for you as well.
 
 :::
 

--- a/site2/website/versioned_docs/version-2.6.4/getting-started-standalone.md
+++ b/site2/website/versioned_docs/version-2.6.4/getting-started-standalone.md
@@ -230,7 +230,7 @@ If the message has been successfully consumed, you will see a confirmation like 
 
 :::tip
 
-As you have noticed that we do not explicitly create the `my-topic` topic, to which we consume the message. When you consume a message to a topic that does not yet exist, Pulsar creates that topic for you automatically. Producing a message to a topic that does not exist will automatically create that topic for you as well.
+As you have noticed that we do not explicitly create the `my-topic` topic, from which we consume the message. When you consume a message from a topic that does not yet exist, Pulsar creates that topic for you automatically. Producing a message to a topic that does not exist will automatically create that topic for you as well.
 
 :::
 

--- a/site2/website/versioned_docs/version-2.6.4/standalone.md
+++ b/site2/website/versioned_docs/version-2.6.4/standalone.md
@@ -230,7 +230,7 @@ If the message has been successfully consumed, you will see a confirmation like 
 
 :::tip
 
-As you have noticed that we do not explicitly create the `my-topic` topic, to which we consume the message. When you consume a message to a topic that does not yet exist, Pulsar creates that topic for you automatically. Producing a message to a topic that does not exist will automatically create that topic for you as well.
+As you have noticed that we do not explicitly create the `my-topic` topic, from which we consume the message. When you consume a message from a topic that does not yet exist, Pulsar creates that topic for you automatically. Producing a message to a topic that does not exist will automatically create that topic for you as well.
 
 :::
 

--- a/site2/website/versioned_docs/version-2.7.0/getting-started-standalone.md
+++ b/site2/website/versioned_docs/version-2.7.0/getting-started-standalone.md
@@ -230,7 +230,7 @@ If the message has been successfully consumed, you will see a confirmation like 
 
 :::tip
 
-As you have noticed that we do not explicitly create the `my-topic` topic, to which we consume the message. When you consume a message to a topic that does not yet exist, Pulsar creates that topic for you automatically. Producing a message to a topic that does not exist will automatically create that topic for you as well.
+As you have noticed that we do not explicitly create the `my-topic` topic, from which we consume the message. When you consume a message from a topic that does not yet exist, Pulsar creates that topic for you automatically. Producing a message to a topic that does not exist will automatically create that topic for you as well.
 
 :::
 

--- a/site2/website/versioned_docs/version-2.7.0/standalone.md
+++ b/site2/website/versioned_docs/version-2.7.0/standalone.md
@@ -230,7 +230,7 @@ If the message has been successfully consumed, you will see a confirmation like 
 
 :::tip
 
-As you have noticed that we do not explicitly create the `my-topic` topic, to which we consume the message. When you consume a message to a topic that does not yet exist, Pulsar creates that topic for you automatically. Producing a message to a topic that does not exist will automatically create that topic for you as well.
+As you have noticed that we do not explicitly create the `my-topic` topic, from which we consume the message. When you consume a message from a topic that does not yet exist, Pulsar creates that topic for you automatically. Producing a message to a topic that does not exist will automatically create that topic for you as well.
 
 :::
 

--- a/site2/website/versioned_docs/version-2.7.1/getting-started-standalone.md
+++ b/site2/website/versioned_docs/version-2.7.1/getting-started-standalone.md
@@ -230,7 +230,7 @@ If the message has been successfully consumed, you will see a confirmation like 
 
 :::tip
 
-As you have noticed that we do not explicitly create the `my-topic` topic, to which we consume the message. When you consume a message to a topic that does not yet exist, Pulsar creates that topic for you automatically. Producing a message to a topic that does not exist will automatically create that topic for you as well.
+As you have noticed that we do not explicitly create the `my-topic` topic, from which we consume the message. When you consume a message from a topic that does not yet exist, Pulsar creates that topic for you automatically. Producing a message to a topic that does not exist will automatically create that topic for you as well.
 
 :::
 

--- a/site2/website/versioned_docs/version-2.7.1/standalone.md
+++ b/site2/website/versioned_docs/version-2.7.1/standalone.md
@@ -230,7 +230,7 @@ If the message has been successfully consumed, you will see a confirmation like 
 
 :::tip
 
-As you have noticed that we do not explicitly create the `my-topic` topic, to which we consume the message. When you consume a message to a topic that does not yet exist, Pulsar creates that topic for you automatically. Producing a message to a topic that does not exist will automatically create that topic for you as well.
+As you have noticed that we do not explicitly create the `my-topic` topic, from which we consume the message. When you consume a message from a topic that does not yet exist, Pulsar creates that topic for you automatically. Producing a message to a topic that does not exist will automatically create that topic for you as well.
 
 :::
 

--- a/site2/website/versioned_docs/version-2.7.2/getting-started-standalone.md
+++ b/site2/website/versioned_docs/version-2.7.2/getting-started-standalone.md
@@ -236,7 +236,7 @@ If the message has been successfully consumed, you will see a confirmation like 
 
 :::tip
 
-As you have noticed that we do not explicitly create the `my-topic` topic, to which we consume the message. When you consume a message to a topic that does not yet exist, Pulsar creates that topic for you automatically. Producing a message to a topic that does not exist will automatically create that topic for you as well.
+As you have noticed that we do not explicitly create the `my-topic` topic, from which we consume the message. When you consume a message from a topic that does not yet exist, Pulsar creates that topic for you automatically. Producing a message to a topic that does not exist will automatically create that topic for you as well.
 
 :::
 

--- a/site2/website/versioned_docs/version-2.7.2/standalone.md
+++ b/site2/website/versioned_docs/version-2.7.2/standalone.md
@@ -236,7 +236,7 @@ If the message has been successfully consumed, you will see a confirmation like 
 
 :::tip
 
-As you have noticed that we do not explicitly create the `my-topic` topic, to which we consume the message. When you consume a message to a topic that does not yet exist, Pulsar creates that topic for you automatically. Producing a message to a topic that does not exist will automatically create that topic for you as well.
+As you have noticed that we do not explicitly create the `my-topic` topic, from which we consume the message. When you consume a message from a topic that does not yet exist, Pulsar creates that topic for you automatically. Producing a message to a topic that does not exist will automatically create that topic for you as well.
 
 :::
 

--- a/site2/website/versioned_docs/version-2.7.3/getting-started-standalone.md
+++ b/site2/website/versioned_docs/version-2.7.3/getting-started-standalone.md
@@ -230,7 +230,7 @@ If the message has been successfully consumed, you will see a confirmation like 
 
 :::tip
 
-As you have noticed that we do not explicitly create the `my-topic` topic, to which we consume the message. When you consume a message to a topic that does not yet exist, Pulsar creates that topic for you automatically. Producing a message to a topic that does not exist will automatically create that topic for you as well.
+As you have noticed that we do not explicitly create the `my-topic` topic, from which we consume the message. When you consume a message from a topic that does not yet exist, Pulsar creates that topic for you automatically. Producing a message to a topic that does not exist will automatically create that topic for you as well.
 
 :::
 

--- a/site2/website/versioned_docs/version-2.7.3/standalone.md
+++ b/site2/website/versioned_docs/version-2.7.3/standalone.md
@@ -230,7 +230,7 @@ If the message has been successfully consumed, you will see a confirmation like 
 
 :::tip
 
-As you have noticed that we do not explicitly create the `my-topic` topic, to which we consume the message. When you consume a message to a topic that does not yet exist, Pulsar creates that topic for you automatically. Producing a message to a topic that does not exist will automatically create that topic for you as well.
+As you have noticed that we do not explicitly create the `my-topic` topic, from which we consume the message. When you consume a message from a topic that does not yet exist, Pulsar creates that topic for you automatically. Producing a message to a topic that does not exist will automatically create that topic for you as well.
 
 :::
 

--- a/site2/website/versioned_docs/version-2.7.4/getting-started-standalone.md
+++ b/site2/website/versioned_docs/version-2.7.4/getting-started-standalone.md
@@ -230,7 +230,7 @@ If the message has been successfully consumed, you will see a confirmation like 
 
 :::tip
 
-As you have noticed that we do not explicitly create the `my-topic` topic, to which we consume the message. When you consume a message to a topic that does not yet exist, Pulsar creates that topic for you automatically. Producing a message to a topic that does not exist will automatically create that topic for you as well.
+As you have noticed that we do not explicitly create the `my-topic` topic, from which we consume the message. When you consume a message from a topic that does not yet exist, Pulsar creates that topic for you automatically. Producing a message to a topic that does not exist will automatically create that topic for you as well.
 
 :::
 

--- a/site2/website/versioned_docs/version-2.7.4/standalone.md
+++ b/site2/website/versioned_docs/version-2.7.4/standalone.md
@@ -230,7 +230,7 @@ If the message has been successfully consumed, you will see a confirmation like 
 
 :::tip
 
-As you have noticed that we do not explicitly create the `my-topic` topic, to which we consume the message. When you consume a message to a topic that does not yet exist, Pulsar creates that topic for you automatically. Producing a message to a topic that does not exist will automatically create that topic for you as well.
+As you have noticed that we do not explicitly create the `my-topic` topic, from which we consume the message. When you consume a message from a topic that does not yet exist, Pulsar creates that topic for you automatically. Producing a message to a topic that does not exist will automatically create that topic for you as well.
 
 :::
 

--- a/site2/website/versioned_docs/version-2.8.0-deprecated/getting-started-standalone.md
+++ b/site2/website/versioned_docs/version-2.8.0-deprecated/getting-started-standalone.md
@@ -236,7 +236,7 @@ If the message has been successfully consumed, you will see a confirmation like 
 
 :::tip
 
-As you have noticed that we do not explicitly create the `my-topic` topic, to which we consume the message. When you consume a message to a topic that does not yet exist, Pulsar creates that topic for you automatically. Producing a message to a topic that does not exist will automatically create that topic for you as well.
+As you have noticed that we do not explicitly create the `my-topic` topic, from which we consume the message. When you consume a message from a topic that does not yet exist, Pulsar creates that topic for you automatically. Producing a message to a topic that does not exist will automatically create that topic for you as well.
 
 :::
 

--- a/site2/website/versioned_docs/version-2.8.0-deprecated/standalone.md
+++ b/site2/website/versioned_docs/version-2.8.0-deprecated/standalone.md
@@ -236,7 +236,7 @@ If the message has been successfully consumed, you will see a confirmation like 
 
 :::tip
 
-As you have noticed that we do not explicitly create the `my-topic` topic, to which we consume the message. When you consume a message to a topic that does not yet exist, Pulsar creates that topic for you automatically. Producing a message to a topic that does not exist will automatically create that topic for you as well.
+As you have noticed that we do not explicitly create the `my-topic` topic, from which we consume the message. When you consume a message from a topic that does not yet exist, Pulsar creates that topic for you automatically. Producing a message to a topic that does not exist will automatically create that topic for you as well.
 
 :::
 

--- a/site2/website/versioned_docs/version-2.8.1-deprecated/getting-started-standalone.md
+++ b/site2/website/versioned_docs/version-2.8.1-deprecated/getting-started-standalone.md
@@ -236,7 +236,7 @@ If the message has been successfully consumed, you will see a confirmation like 
 
 :::tip
 
-As you have noticed that we do not explicitly create the `my-topic` topic, to which we consume the message. When you consume a message to a topic that does not yet exist, Pulsar creates that topic for you automatically. Producing a message to a topic that does not exist will automatically create that topic for you as well.
+As you have noticed that we do not explicitly create the `my-topic` topic, from which we consume the message. When you consume a message from a topic that does not yet exist, Pulsar creates that topic for you automatically. Producing a message to a topic that does not exist will automatically create that topic for you as well.
 
 :::
 

--- a/site2/website/versioned_docs/version-2.8.1-deprecated/standalone.md
+++ b/site2/website/versioned_docs/version-2.8.1-deprecated/standalone.md
@@ -236,7 +236,7 @@ If the message has been successfully consumed, you will see a confirmation like 
 
 :::tip
 
-As you have noticed that we do not explicitly create the `my-topic` topic, to which we consume the message. When you consume a message to a topic that does not yet exist, Pulsar creates that topic for you automatically. Producing a message to a topic that does not exist will automatically create that topic for you as well.
+As you have noticed that we do not explicitly create the `my-topic` topic, from which we consume the message. When you consume a message from a topic that does not yet exist, Pulsar creates that topic for you automatically. Producing a message to a topic that does not exist will automatically create that topic for you as well.
 
 :::
 

--- a/site2/website/versioned_docs/version-2.8.2-deprecated/getting-started-standalone.md
+++ b/site2/website/versioned_docs/version-2.8.2-deprecated/getting-started-standalone.md
@@ -236,7 +236,7 @@ If the message has been successfully consumed, you will see a confirmation like 
 
 :::tip
 
-As you have noticed that we do not explicitly create the `my-topic` topic, to which we consume the message. When you consume a message to a topic that does not yet exist, Pulsar creates that topic for you automatically. Producing a message to a topic that does not exist will automatically create that topic for you as well.
+As you have noticed that we do not explicitly create the `my-topic` topic, from which we consume the message. When you consume a message from a topic that does not yet exist, Pulsar creates that topic for you automatically. Producing a message to a topic that does not exist will automatically create that topic for you as well.
 
 :::
 

--- a/site2/website/versioned_docs/version-2.8.2-deprecated/standalone.md
+++ b/site2/website/versioned_docs/version-2.8.2-deprecated/standalone.md
@@ -236,7 +236,7 @@ If the message has been successfully consumed, you will see a confirmation like 
 
 :::tip
 
-As you have noticed that we do not explicitly create the `my-topic` topic, to which we consume the message. When you consume a message to a topic that does not yet exist, Pulsar creates that topic for you automatically. Producing a message to a topic that does not exist will automatically create that topic for you as well.
+As you have noticed that we do not explicitly create the `my-topic` topic, from which we consume the message. When you consume a message from a topic that does not yet exist, Pulsar creates that topic for you automatically. Producing a message to a topic that does not exist will automatically create that topic for you as well.
 
 :::
 

--- a/site2/website/versioned_docs/version-2.8.3-deprecated/getting-started-standalone.md
+++ b/site2/website/versioned_docs/version-2.8.3-deprecated/getting-started-standalone.md
@@ -236,7 +236,7 @@ If the message has been successfully consumed, you will see a confirmation like 
 
 :::tip
 
-As you have noticed that we do not explicitly create the `my-topic` topic, to which we consume the message. When you consume a message to a topic that does not yet exist, Pulsar creates that topic for you automatically. Producing a message to a topic that does not exist will automatically create that topic for you as well.
+As you have noticed that we do not explicitly create the `my-topic` topic, from which we consume the message. When you consume a message from a topic that does not yet exist, Pulsar creates that topic for you automatically. Producing a message to a topic that does not exist will automatically create that topic for you as well.
 
 :::
 

--- a/site2/website/versioned_docs/version-2.8.3-deprecated/standalone.md
+++ b/site2/website/versioned_docs/version-2.8.3-deprecated/standalone.md
@@ -236,7 +236,7 @@ If the message has been successfully consumed, you will see a confirmation like 
 
 :::tip
 
-As you have noticed that we do not explicitly create the `my-topic` topic, to which we consume the message. When you consume a message to a topic that does not yet exist, Pulsar creates that topic for you automatically. Producing a message to a topic that does not exist will automatically create that topic for you as well.
+As you have noticed that we do not explicitly create the `my-topic` topic, from which we consume the message. When you consume a message from a topic that does not yet exist, Pulsar creates that topic for you automatically. Producing a message to a topic that does not exist will automatically create that topic for you as well.
 
 :::
 

--- a/site2/website/versioned_docs/version-2.8.x/getting-started-standalone.md
+++ b/site2/website/versioned_docs/version-2.8.x/getting-started-standalone.md
@@ -236,7 +236,7 @@ If the message has been successfully consumed, you will see a confirmation like 
 
 :::tip
 
-As you have noticed that we do not explicitly create the `my-topic` topic, to which we consume the message. When you consume a message to a topic that does not yet exist, Pulsar creates that topic for you automatically. Producing a message to a topic that does not exist will automatically create that topic for you as well.
+As you have noticed that we do not explicitly create the `my-topic` topic, from which we consume the message. When you consume a message from a topic that does not yet exist, Pulsar creates that topic for you automatically. Producing a message to a topic that does not exist will automatically create that topic for you as well.
 
 :::
 

--- a/site2/website/versioned_docs/version-2.8.x/standalone.md
+++ b/site2/website/versioned_docs/version-2.8.x/standalone.md
@@ -236,7 +236,7 @@ If the message has been successfully consumed, you will see a confirmation like 
 
 :::tip
 
-As you have noticed that we do not explicitly create the `my-topic` topic, to which we consume the message. When you consume a message to a topic that does not yet exist, Pulsar creates that topic for you automatically. Producing a message to a topic that does not exist will automatically create that topic for you as well.
+As you have noticed that we do not explicitly create the `my-topic` topic, from which we consume the message. When you consume a message from a topic that does not yet exist, Pulsar creates that topic for you automatically. Producing a message to a topic that does not exist will automatically create that topic for you as well.
 
 :::
 

--- a/site2/website/versioned_docs/version-2.9.0-deprecated/getting-started-standalone.md
+++ b/site2/website/versioned_docs/version-2.9.0-deprecated/getting-started-standalone.md
@@ -233,7 +233,7 @@ If the message has been successfully consumed, you will see a confirmation like 
 
 :::tip
 
-As you have noticed that we do not explicitly create the `my-topic` topic, to which we consume the message. When you consume a message to a topic that does not yet exist, Pulsar creates that topic for you automatically. Producing a message to a topic that does not exist will automatically create that topic for you as well.
+As you have noticed that we do not explicitly create the `my-topic` topic, from which we consume the message. When you consume a message from a topic that does not yet exist, Pulsar creates that topic for you automatically. Producing a message to a topic that does not exist will automatically create that topic for you as well.
 
 :::
 

--- a/site2/website/versioned_docs/version-2.9.0-deprecated/standalone.md
+++ b/site2/website/versioned_docs/version-2.9.0-deprecated/standalone.md
@@ -233,7 +233,7 @@ If the message has been successfully consumed, you will see a confirmation like 
 
 :::tip
 
-As you have noticed that we do not explicitly create the `my-topic` topic, to which we consume the message. When you consume a message to a topic that does not yet exist, Pulsar creates that topic for you automatically. Producing a message to a topic that does not exist will automatically create that topic for you as well.
+As you have noticed that we do not explicitly create the `my-topic` topic, from which we consume the message. When you consume a message from a topic that does not yet exist, Pulsar creates that topic for you automatically. Producing a message to a topic that does not exist will automatically create that topic for you as well.
 
 :::
 

--- a/site2/website/versioned_docs/version-2.9.1-deprecated/getting-started-standalone.md
+++ b/site2/website/versioned_docs/version-2.9.1-deprecated/getting-started-standalone.md
@@ -233,7 +233,7 @@ If the message has been successfully consumed, you will see a confirmation like 
 
 :::tip
 
-As you have noticed that we do not explicitly create the `my-topic` topic, to which we consume the message. When you consume a message to a topic that does not yet exist, Pulsar creates that topic for you automatically. Producing a message to a topic that does not exist will automatically create that topic for you as well.
+As you have noticed that we do not explicitly create the `my-topic` topic, from which we consume the message. When you consume a message from a topic that does not yet exist, Pulsar creates that topic for you automatically. Producing a message to a topic that does not exist will automatically create that topic for you as well.
 
 :::
 

--- a/site2/website/versioned_docs/version-2.9.1-deprecated/standalone.md
+++ b/site2/website/versioned_docs/version-2.9.1-deprecated/standalone.md
@@ -233,7 +233,7 @@ If the message has been successfully consumed, you will see a confirmation like 
 
 :::tip
 
-As you have noticed that we do not explicitly create the `my-topic` topic, to which we consume the message. When you consume a message to a topic that does not yet exist, Pulsar creates that topic for you automatically. Producing a message to a topic that does not exist will automatically create that topic for you as well.
+As you have noticed that we do not explicitly create the `my-topic` topic, from which we consume the message. When you consume a message from a topic that does not yet exist, Pulsar creates that topic for you automatically. Producing a message to a topic that does not exist will automatically create that topic for you as well.
 
 :::
 

--- a/site2/website/versioned_docs/version-2.9.2-deprecated/getting-started-standalone.md
+++ b/site2/website/versioned_docs/version-2.9.2-deprecated/getting-started-standalone.md
@@ -233,7 +233,7 @@ If the message has been successfully consumed, you will see a confirmation like 
 
 :::tip
 
-As you have noticed that we do not explicitly create the `my-topic` topic, to which we consume the message. When you consume a message to a topic that does not yet exist, Pulsar creates that topic for you automatically. Producing a message to a topic that does not exist will automatically create that topic for you as well.
+As you have noticed that we do not explicitly create the `my-topic` topic, from which we consume the message. When you consume a message from a topic that does not yet exist, Pulsar creates that topic for you automatically. Producing a message to a topic that does not exist will automatically create that topic for you as well.
 
 :::
 

--- a/site2/website/versioned_docs/version-2.9.2-deprecated/standalone.md
+++ b/site2/website/versioned_docs/version-2.9.2-deprecated/standalone.md
@@ -233,7 +233,7 @@ If the message has been successfully consumed, you will see a confirmation like 
 
 :::tip
 
-As you have noticed that we do not explicitly create the `my-topic` topic, to which we consume the message. When you consume a message to a topic that does not yet exist, Pulsar creates that topic for you automatically. Producing a message to a topic that does not exist will automatically create that topic for you as well.
+As you have noticed that we do not explicitly create the `my-topic` topic, from which we consume the message. When you consume a message from a topic that does not yet exist, Pulsar creates that topic for you automatically. Producing a message to a topic that does not exist will automatically create that topic for you as well.
 
 :::
 

--- a/site2/website/versioned_docs/version-2.9.3-deprecated/getting-started-standalone.md
+++ b/site2/website/versioned_docs/version-2.9.3-deprecated/getting-started-standalone.md
@@ -233,7 +233,7 @@ If the message has been successfully consumed, you will see a confirmation like 
 
 :::tip
 
-As you have noticed that we do not explicitly create the `my-topic` topic, to which we consume the message. When you consume a message to a topic that does not yet exist, Pulsar creates that topic for you automatically. Producing a message to a topic that does not exist will automatically create that topic for you as well.
+As you have noticed that we do not explicitly create the `my-topic` topic, from which we consume the message. When you consume a message from a topic that does not yet exist, Pulsar creates that topic for you automatically. Producing a message to a topic that does not exist will automatically create that topic for you as well.
 
 :::
 

--- a/site2/website/versioned_docs/version-2.9.3-deprecated/standalone.md
+++ b/site2/website/versioned_docs/version-2.9.3-deprecated/standalone.md
@@ -233,7 +233,7 @@ If the message has been successfully consumed, you will see a confirmation like 
 
 :::tip
 
-As you have noticed that we do not explicitly create the `my-topic` topic, to which we consume the message. When you consume a message to a topic that does not yet exist, Pulsar creates that topic for you automatically. Producing a message to a topic that does not exist will automatically create that topic for you as well.
+As you have noticed that we do not explicitly create the `my-topic` topic, from which we consume the message. When you consume a message from a topic that does not yet exist, Pulsar creates that topic for you automatically. Producing a message to a topic that does not exist will automatically create that topic for you as well.
 
 :::
 

--- a/site2/website/versioned_docs/version-2.9.x/getting-started-standalone.md
+++ b/site2/website/versioned_docs/version-2.9.x/getting-started-standalone.md
@@ -233,7 +233,7 @@ If the message has been successfully consumed, you will see a confirmation like 
 
 :::tip
 
-As you have noticed that we do not explicitly create the `my-topic` topic, to which we consume the message. When you consume a message to a topic that does not yet exist, Pulsar creates that topic for you automatically. Producing a message to a topic that does not exist will automatically create that topic for you as well.
+As you have noticed that we do not explicitly create the `my-topic` topic, from which we consume the message. When you consume a message from a topic that does not yet exist, Pulsar creates that topic for you automatically. Producing a message to a topic that does not exist will automatically create that topic for you as well.
 
 :::
 

--- a/site2/website/versioned_docs/version-2.9.x/standalone.md
+++ b/site2/website/versioned_docs/version-2.9.x/standalone.md
@@ -233,7 +233,7 @@ If the message has been successfully consumed, you will see a confirmation like 
 
 :::tip
 
-As you have noticed that we do not explicitly create the `my-topic` topic, to which we consume the message. When you consume a message to a topic that does not yet exist, Pulsar creates that topic for you automatically. Producing a message to a topic that does not exist will automatically create that topic for you as well.
+As you have noticed that we do not explicitly create the `my-topic` topic, from which we consume the message. When you consume a message from a topic that does not yet exist, Pulsar creates that topic for you automatically. Producing a message to a topic that does not exist will automatically create that topic for you as well.
 
 :::
 


### PR DESCRIPTION

### Motivation

* The tip section states <code>...**to** which we consume the message. When you consume a message **on** a topic... </code>
 
### Modifications

* Updated tip to <code>... **from** which we consume the message. When you consume a message **from** a topic...</code>

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): no
  - The public API: no
  - The schema: no
  - The default values of configurations: no
  - The wire protocol: no
  - The rest endpoints: no
  - The admin cli options: no
  - Anything that affects deployment: no

### Documentation

Check the box below or label this PR directly.

Need to update docs? 

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)
  
- [ ] `doc-not-needed` 
(Please explain why)
  
- [x] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)