### PR TITLE
[improve][broker]prevent partitioned metadata lookup request when broker is closing

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
@@ -530,6 +530,18 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
             return;
         }
 
+        if (!this.service.getPulsar().isRunning()) {
+            if (log.isDebugEnabled()) {
+                log.debug("[{}] Failed PartitionMetadataLookup from {} for {} "
+                                + "due to pulsar service is not ready: {} state",
+                        partitionMetadata.getTopic(), remoteAddress, requestId,
+                        this.service.getPulsar().getState().toString());
+            }
+            ctx.writeAndFlush(Commands.newPartitionMetadataResponse(ServerError.ServiceNotReady,
+                    "Failed due to pulsar service is not ready", requestId));
+            return;
+        }
+
         final Semaphore lookupSemaphore = service.getLookupRequestSemaphore();
         if (lookupSemaphore.tryAcquire()) {
             if (invalidOriginalPrincipal(originalPrincipal)) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
@@ -2970,11 +2970,6 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
         return state;
     }
 
-    public void setState(State state) {
-        this.state = state;
-    }
-
-
     public SocketAddress getRemoteAddress() {
         return remoteAddress;
     }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
@@ -2970,6 +2970,11 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
         return state;
     }
 
+    public void setState(State state) {
+        this.state = state;
+    }
+
+
     public SocketAddress getRemoteAddress() {
         return remoteAddress;
     }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ServerCnxTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ServerCnxTest.java
@@ -22,7 +22,6 @@ import static org.apache.pulsar.broker.BrokerTestUtil.spyWithClassAndConstructor
 import static org.apache.pulsar.broker.auth.MockedPulsarServiceBaseTest.createMockBookKeeper;
 import static org.apache.pulsar.broker.auth.MockedPulsarServiceBaseTest.createMockZooKeeper;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.CALLS_REAL_METHODS;
 import static org.mockito.Mockito.doAnswer;

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ServerCnxTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ServerCnxTest.java
@@ -2313,8 +2313,6 @@ public class ServerCnxTest {
     public void handlePartitionMetadataRequestWithServiceNotReady() throws Exception {
         resetChannel();
         setChannelConnected();
-        CompletableFuture<Boolean> successFuture = CompletableFuture.completedFuture(true);
-        doReturn(successFuture).when(namespaceService).checkTopicExists(any(TopicName.class));
         doReturn(false).when(pulsar).isRunning();
         assertTrue(channel.isActive());
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/utils/ClientChannelHelper.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/utils/ClientChannelHelper.java
@@ -21,6 +21,7 @@ package org.apache.pulsar.broker.service.utils;
 import java.util.Queue;
 
 import org.apache.pulsar.common.api.proto.CommandGetTopicsOfNamespaceResponse;
+import org.apache.pulsar.common.api.proto.CommandPartitionedTopicMetadataResponse;
 import org.apache.pulsar.common.api.proto.CommandWatchTopicListSuccess;
 import org.apache.pulsar.common.protocol.PulsarDecoder;
 import org.apache.pulsar.common.api.proto.CommandAck;
@@ -161,6 +162,11 @@ public class ClientChannelHelper {
         @Override
         protected void handleCommandWatchTopicListSuccess(CommandWatchTopicListSuccess commandWatchTopicListSuccess) {
             queue.offer(new CommandWatchTopicListSuccess().copyFrom(commandWatchTopicListSuccess));
+        }
+
+        @Override
+        protected void handlePartitionResponse(CommandPartitionedTopicMetadataResponse response) {
+            queue.offer(new CommandPartitionedTopicMetadataResponse().copyFrom(response));
         }
     };
 


### PR DESCRIPTION
### Motivation
Inspired by #17085 
When the leader broker is closing, and the client will reconnect and redo lookup, resulting in unexpected results. 

> @codelipenghui 
> Looks like we also need to check other cases (e.g. handleConnect)
> If the broker is shutting down, we should also prevent new connections.

Therefore, it is necessary to check the status of the broker when handling requests, including connect\lookup\partitioned metadata.

The following is the interaction workflow between consumer and broker.
```
Consumer -> Broker: CONNECT
Broker -> Consumer: CONNECTED
Consumer -> Broker: PARTITIONED_METADATA
Broker -> Consumer: PARTITIONED_METADATA_RESPONSE
Consumer -> Broker: LOOKUP
Broker -> Consumer: LOOKUP_RESPONSE
Consumer -> Broker: SUBSCIBE
Broker -> Consumer: SUCCESS
Consumer -> Broker: FLOW
Broker -> Consumer: MESSAGE
Consumer - Broker: ACK
```

The following screenshot is the interaction workflow between producer and broker.
<img width="510" alt="image" src="https://user-images.githubusercontent.com/4970972/187061264-36cd2a06-0414-4e5e-a097-05af07eb6c39.png">

### Modifications
- Check Pulsar Service state when handle connection and partitioned metadata request.

### Verifying this change

- [x]  Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.
### Does this pull request potentially affect one of the following parts:

If `yes` was chosen, please highlight the changes

- Dependencies (does it add or upgrade a dependency): (no)
- The public API: (no)
- The schema: (no)
- The default values of configurations: (no)
- The wire protocol: (no)
- The rest endpoints: (no)
- The admin cli options: (no)
- Anything that affects deployment: (no)

### Documentation
Check the box below and label this PR (if you have committer privilege).

Need to update docs? 
- [x] `doc-not-needed` 
