### PR TITLE
[fix][client-c++] Fix wrong consumers size

### DIFF
--- a/pulsar-client-cpp/lib/ReaderImpl.cc
+++ b/pulsar-client-cpp/lib/ReaderImpl.cc
@@ -84,8 +84,8 @@ void ReaderImpl::start(const MessageId& startMessageId,
     consumer_->getConsumerCreatedFuture().addListener(
         [this, self, callback](Result result, const ConsumerImplBaseWeakPtr& weakConsumerPtr) {
             if (result == ResultOk) {
-                readerCreatedCallback_(result, Reader(self));
                 callback(weakConsumerPtr);
+                readerCreatedCallback_(result, Reader(self));
             } else {
                 readerCreatedCallback_(result, {});
             }


### PR DESCRIPTION
Fixes #14848

### Motivation

We should execute `callback` before executing `readerCreatedCallback_`, otherwise, we may get the wrong consumers size. More see:

https://github.com/apache/pulsar/blob/e23d312c04da1d82d35f9e2faf8a446f8e8a4eeb/pulsar-client-cpp/lib/ReaderImpl.cc#L84-L92

https://github.com/apache/pulsar/blob/c48a3243287c7d775459b6437d9f4b24ed44cf4c/pulsar-client-cpp/lib/ClientImpl.cc#L250-L254

### Modifications

execute `callback` before executing `readerCreatedCallback_`

### Documentation

Check the box below or label this PR directly.

Need to update docs? 

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)
  
- [x] `doc-not-needed` 
(Please explain why)
  
- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)