### PR TITLE
[fix][client] Fix the message present in incoming queue after go to DLQ

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/TransactionEndToEndTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/TransactionEndToEndTest.java
@@ -1223,7 +1223,7 @@ public class TransactionEndToEndTest extends TransactionTestBase {
         // the message will be sent to DLQ, can't receive
         assertNull(consumer.receive(3, TimeUnit.SECONDS));
 
-        assertEquals(3, ((ConsumerImpl<?>) consumer).getAvailablePermits());
+        assertEquals(((ConsumerImpl<?>) consumer).getAvailablePermits(), 3);
 
         assertEquals(value, new String(deadLetterConsumer.receive(3, TimeUnit.SECONDS).getValue()));
     }
@@ -1289,7 +1289,7 @@ public class TransactionEndToEndTest extends TransactionTestBase {
         // the message will be sent to DLQ, can't receive
         assertNull(consumer.receive(3, TimeUnit.SECONDS));
 
-        assertEquals(6, ((ConsumerImpl<?>) consumer).getAvailablePermits());
+        assertEquals(((ConsumerImpl<?>) consumer).getAvailablePermits(), 6);
 
         assertEquals(value1, new String(deadLetterConsumer.receive(3, TimeUnit.SECONDS).getValue()));
         assertEquals(value2, new String(deadLetterConsumer.receive(3, TimeUnit.SECONDS).getValue()));

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/TransactionEndToEndTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/TransactionEndToEndTest.java
@@ -1223,6 +1223,8 @@ public class TransactionEndToEndTest extends TransactionTestBase {
         // the message will be sent to DLQ, can't receive
         assertNull(consumer.receive(3, TimeUnit.SECONDS));
 
+        assertEquals(3, ((ConsumerImpl<?>) consumer).getAvailablePermits());
+
         assertEquals(value, new String(deadLetterConsumer.receive(3, TimeUnit.SECONDS).getValue()));
     }
 
@@ -1286,6 +1288,8 @@ public class TransactionEndToEndTest extends TransactionTestBase {
         // consumer receive the batch message the third time, redeliverCount = 2,
         // the message will be sent to DLQ, can't receive
         assertNull(consumer.receive(3, TimeUnit.SECONDS));
+
+        assertEquals(6, ((ConsumerImpl<?>) consumer).getAvailablePermits());
 
         assertEquals(value1, new String(deadLetterConsumer.receive(3, TimeUnit.SECONDS).getValue()));
         assertEquals(value2, new String(deadLetterConsumer.receive(3, TimeUnit.SECONDS).getValue()));

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
@@ -1392,6 +1392,8 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
                             Collections.singletonList(message));
                     if (redeliveryCount > deadLetterPolicy.getMaxRedeliverCount()) {
                         redeliverUnacknowledgedMessages(Collections.singleton(message.getMessageId()));
+                        // if send to DeadLetter we need to increase the available permits
+                        increaseAvailablePermits(cnx);
                         return;
                     }
                 }
@@ -1562,6 +1564,8 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
                     // when redeliveryCount > deadLetterPolicy.getMaxRedeliverCount())
                     // the message will not be visible to users
                     if (redeliveryCount > deadLetterPolicy.getMaxRedeliverCount()) {
+                        // if send to DeadLetter we need to increase the available permits
+                        skippedMessages++;
                         continue;
                     }
 
@@ -1582,7 +1586,6 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
                         possibleToDeadLetter);
                 if (redeliveryCount > deadLetterPolicy.getMaxRedeliverCount()) {
                     redeliverUnacknowledgedMessages(Collections.singleton(batchMessage));
-                    return;
                 }
             }
         }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
@@ -1392,7 +1392,8 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
                             Collections.singletonList(message));
                     if (redeliveryCount > deadLetterPolicy.getMaxRedeliverCount()) {
                         redeliverUnacknowledgedMessages(Collections.singleton(message.getMessageId()));
-                        // if send to DeadLetter we need to increase the available permits
+                        // The message is skipped due to reaching the max redelivery count,
+                        // so we need to increase the available permits
                         increaseAvailablePermits(cnx);
                         return;
                     }
@@ -1561,10 +1562,8 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
                 }
                 if (possibleToDeadLetter != null) {
                     possibleToDeadLetter.add(message);
-                    // when redeliveryCount > deadLetterPolicy.getMaxRedeliverCount())
-                    // the message will not be visible to users
+                    // Skip the message which reaches the max redelivery count.
                     if (redeliveryCount > deadLetterPolicy.getMaxRedeliverCount()) {
-                        // if send to DeadLetter we need to increase the available permits
                         skippedMessages++;
                         continue;
                     }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
@@ -1559,6 +1559,12 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
                 }
                 if (possibleToDeadLetter != null) {
                     possibleToDeadLetter.add(message);
+                    // when redeliveryCount > deadLetterPolicy.getMaxRedeliverCount())
+                    // the message will not be visible to users
+                    if (redeliveryCount > deadLetterPolicy.getMaxRedeliverCount()) {
+                        continue;
+                    }
+
                 }
                 executeNotifyCallback(message);
             }


### PR DESCRIPTION
### Motivation
when `redeliveryCount > deadLetterPolicy.getMaxRedeliverCount()`, the batch message can also be received by the client.

This test passed before because `removeExpiredMessagesFromQueue` removed messages from `incomingMessages`

add the available permits when `redeliveryCount > deadLetterPolicy.getMaxRedeliverCount()` send message to deadLetter topic
### Modification
1. 
```
redeliveryCount > deadLetterPolicy.getMaxRedeliverCount()
```
don't invoke `executeNotifyCallback(message);`

2. when `redeliveryCount > deadLetterPolicy.getMaxRedeliverCount()` send message to deadLetter topic, increase the available permits

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation

- [x] `doc-not-needed`
