### PR TITLE
[feat] Add option to clean up all metadata.

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/PulsarClusterMetadataTeardown.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/PulsarClusterMetadataTeardown.java
@@ -43,7 +43,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Teardown the metadata for a existed Pulsar cluster.
+ * Teardown the metadata after deleting a Pulsar cluster.
  */
 public class PulsarClusterMetadataTeardown {
 
@@ -68,6 +68,13 @@ public class PulsarClusterMetadataTeardown {
 
         @Parameter(names = { "-h", "--help" }, description = "Show this help message")
         private boolean help = false;
+
+        @Parameter(names = { "-cp", "--clean-up-policies" }, description = "Whether to clean up topics policies")
+        private boolean cleanUpPolicies = false;
+
+        @Parameter(names = { "-cf", "--clean-up--function-meta" },
+                description = "Whether to clean up function related metadata")
+        private boolean cleanUpFunctionMeta = false;
 
         @Parameter(names = {"-g", "--generate-docs"}, description = "Generate docs")
         private boolean generateDocs = false;
@@ -123,9 +130,23 @@ public class PulsarClusterMetadataTeardown {
             MetadataStore configMetadataStore = MetadataStoreFactory.create(arguments.configurationStore,
                     MetadataStoreConfig.builder().sessionTimeoutMillis(arguments.zkSessionTimeoutMillis).build());
             deleteRecursively(configMetadataStore, "/admin/clusters/" + arguments.cluster).join();
+            cleanUpTopicPoliciesAndFunctionMeta(configMetadataStore, arguments);
+        } else {
+            cleanUpTopicPoliciesAndFunctionMeta(metadataStore, arguments);
         }
 
         log.info("Cluster metadata for '{}' teardown.", arguments.cluster);
+    }
+
+    // clean up all topic policies and function related meta if necessary
+    private static void cleanUpTopicPoliciesAndFunctionMeta(MetadataStore metadataStore, Arguments arguments) {
+        if (arguments.cleanUpPolicies) {
+            deleteRecursively(metadataStore, "/admin").join();
+        }
+
+        if (arguments.cleanUpFunctionMeta) {
+            deleteRecursively(metadataStore, "/pulsar").join();
+        }
     }
 
     private static CompletableFuture<Void> deleteRecursively(MetadataStore metadataStore, String path) {


### PR DESCRIPTION

Fixes https://github.com/apache/pulsar/issues/15450

### Motivation
Currently after calling `delete-cluster-metadata` there're still metadata remain under `/admin` and `/pulsar` path which could cause trouble if zookeeper is shared between different Pulsar cluster.

### Modifications
Add option to clean up topics policies and other policies and function related metadata under `/admin` and` /pulsar` when tearing down cluster.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

Check the box below or label this PR directly.

Need to update docs? 

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)
  
- [x] `doc-not-needed` 
doc auto generated
  
- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)