### PR TITLE
[fix][test] KinesisSink test: use fixed version of localstack docker image

### DIFF
--- a/pulsar-io/kinesis/src/test/java/org/apache/pulsar/io/kinesis/KinesisSinkTest.java
+++ b/pulsar-io/kinesis/src/test/java/org/apache/pulsar/io/kinesis/KinesisSinkTest.java
@@ -58,7 +58,7 @@ import static org.testng.Assert.assertTrue;
 public class KinesisSinkTest {
 
     public static final String STREAM_NAME = "my-stream-1";
-    public static LocalStackContainer LOCALSTACK_CONTAINER = new LocalStackContainer(DockerImageName.parse("localstack/localstack:latest"))
+    public static LocalStackContainer LOCALSTACK_CONTAINER = new LocalStackContainer(DockerImageName.parse("localstack/localstack:1.0.4"))
             .withServices(LocalStackContainer.Service.KINESIS);
 
     @BeforeClass(alwaysRun = true)

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/sinks/KinesisSinkTester.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/sinks/KinesisSinkTester.java
@@ -129,7 +129,7 @@ public class KinesisSinkTester extends SinkTester<LocalStackContainer> {
 
     @Override
     protected LocalStackContainer createSinkService(PulsarCluster cluster) {
-        return new LocalStackContainer(DockerImageName.parse("localstack/localstack:latest"))
+        return new LocalStackContainer(DockerImageName.parse("localstack/localstack:1.0.4"))
                 .withServices(LocalStackContainer.Service.KINESIS);
     }
 


### PR DESCRIPTION
### Motivation
In the kinesis tests we use the latest tag of the localstack docker image. Now kinesis tests are failing in this way
```
java.util.concurrent.ExecutionException: software.amazon.awssdk.core.exception.SdkClientException: Unable to parse date : 1.661885385488E9
```

### Modifications

* Set version to 1.0.4 which works correctly

I suspect that the issue has been caused by a large refactor in the localstack repo around kinesis https://github.com/localstack/localstack/pull/6166

I opened an issue in the localstack repo https://github.com/localstack/localstack/issues/6787

- [x] `doc-not-needed` 