### PR TITLE
Don't check Topic TimeLimit when quota limitTime less than 0

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BacklogQuotaManager.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BacklogQuotaManager.java
@@ -221,7 +221,7 @@ public class BacklogQuotaManager {
                     // Timestamp only > 0 if ledger has been closed
                     if (ledgerInfo.getTimestamp() > 0
                             // less than 0 means no limitation
-                            && quota.getLimitTime() > 0
+                            && quota.getLimitTime() >= 0
                             && currentMillis - ledgerInfo.getTimestamp() > quota.getLimitTime()) {
                         // skip whole ledger for the slowest cursor
                         PositionImpl nextPosition = mLedger.getNextValidPosition(

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BacklogQuotaManager.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BacklogQuotaManager.java
@@ -207,7 +207,7 @@ public class BacklogQuotaManager {
             );
         } else {
             // If disabled precise time based backlog quota check, will try to remove whole ledger from cursor's backlog
-            Long currentMillis = ((ManagedLedgerImpl) persistentTopic.getManagedLedger()).getClock().millis();
+            long currentMillis = ((ManagedLedgerImpl) persistentTopic.getManagedLedger()).getClock().millis();
             ManagedLedgerImpl mLedger = (ManagedLedgerImpl) persistentTopic.getManagedLedger();
             try {
                 for (;;) {
@@ -220,6 +220,8 @@ public class BacklogQuotaManager {
                     }
                     // Timestamp only > 0 if ledger has been closed
                     if (ledgerInfo.getTimestamp() > 0
+                            // less than 0 means no limitation
+                            && quota.getLimitTime() > 0
                             && currentMillis - ledgerInfo.getTimestamp() > quota.getLimitTime()) {
                         // skip whole ledger for the slowest cursor
                         PositionImpl nextPosition = mLedger.getNextValidPosition(


### PR DESCRIPTION
### Motivation
The limitTime of quota can be less than 0, we should not check timelimit if limittime is less than 0

### Modifications
- add check of limittime
- change `currentMillis` from `Long` to `long`. Primitive type is enough.

### Documentation

Check the box below or label this PR directly.

Need to update docs? 
  
- [x] `doc-not-needed` 
(Please explain why)
