### PR TITLE
[fix][flaky-test]split test group broker_group_2 into 2 parts

### DIFF
--- a/.github/workflows/pulsar-ci.yaml
+++ b/.github/workflows/pulsar-ci.yaml
@@ -153,6 +153,8 @@ jobs:
             group: BROKER_GROUP_2
           - name: Brokers - Broker Group 3
             group: BROKER_GROUP_3
+          - name: Brokers - Broker Group 4
+            group: BROKER_GROUP_4
           - name: Brokers - Client Api
             group: BROKER_CLIENT_API
           - name: Brokers - Client Impl

--- a/build/run_unit_group.sh
+++ b/build/run_unit_group.sh
@@ -62,11 +62,15 @@ function test_group_broker_group_1() {
 }
 
 function test_group_broker_group_2() {
-  mvn_test -pl pulsar-broker -Dgroups='schema,utils,functions-worker,broker-io,broker-discovery,broker-compaction,broker-naming,websocket,other'
+  mvn_test -pl pulsar-broker -Dgroups='schema,utils,functions-worker,broker-io'
 }
 
 function test_group_broker_group_3() {
   mvn_test -pl pulsar-broker -Dgroups='broker-admin'
+}
+
+function test_group_broker_group_4() {
+  mvn_test -pl pulsar-broker -Dgroups='broker-discovery,broker-compaction,broker-naming,websocket,other'
 }
 
 function test_group_broker_client_api() {


### PR DESCRIPTION
Fix: https://github.com/apache/pulsar/issues/17112

### Motivation

Split test group `broker group 2` into 2 parts to prevent run unit tests timeout.


### Documentation

Check the box below or label this PR directly.

Need to update docs? 

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)
  
- [x] `doc-not-needed` 
(Please explain why)
  
- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)