### PR TITLE
[improve][admin] PulsarAdminBuilderImpl overrides timeout properties passed through config map

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiTlsAuthTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiTlsAuthTest.java
@@ -480,7 +480,7 @@ public class AdminApiTlsAuthTest extends MockedPulsarServiceBaseTest {
                     .allowTlsInsecureConnection(false)
                     .enableTlsHostnameVerification(false)
                     .serviceHttpUrl(brokerUrlTls.toString())
-                    .autoCertRefreshTime(1, TimeUnit.SECONDS)
+                    .autoCertRefreshTime(autoCertRefreshTimeSec, TimeUnit.SECONDS)
                     .authentication("org.apache.pulsar.client.impl.auth.AuthenticationTls",
                                     String.format("tlsCertFile:%s,tlsKeyFile:%s",
                                                   getTLSFile(adminUser + ".cert"), keyFile))

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/PulsarAdminBuilderImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/PulsarAdminBuilderImpl.java
@@ -33,21 +33,10 @@ import org.apache.pulsar.client.impl.conf.ConfigurationDataUtils;
 public class PulsarAdminBuilderImpl implements PulsarAdminBuilder {
 
     protected ClientConfigurationData conf;
-    private int connectTimeout = PulsarAdminImpl.DEFAULT_CONNECT_TIMEOUT_SECONDS;
-    private int readTimeout = PulsarAdminImpl.DEFAULT_READ_TIMEOUT_SECONDS;
-    private int requestTimeout = PulsarAdminImpl.DEFAULT_REQUEST_TIMEOUT_SECONDS;
-    private int autoCertRefreshTime = PulsarAdminImpl.DEFAULT_CERT_REFRESH_SECONDS;
-    private TimeUnit connectTimeoutUnit = TimeUnit.SECONDS;
-    private TimeUnit readTimeoutUnit = TimeUnit.SECONDS;
-    private TimeUnit requestTimeoutUnit = TimeUnit.SECONDS;
-    private TimeUnit autoCertRefreshTimeUnit = TimeUnit.SECONDS;
-    private ClassLoader clientBuilderClassLoader = null;
 
     @Override
     public PulsarAdmin build() throws PulsarClientException {
-        return new PulsarAdminImpl(conf.getServiceUrl(), conf, connectTimeout, connectTimeoutUnit, readTimeout,
-                readTimeoutUnit, requestTimeout, requestTimeoutUnit, autoCertRefreshTime,
-                autoCertRefreshTimeUnit, clientBuilderClassLoader);
+        return new PulsarAdminImpl(conf.getServiceUrl(), conf);
     }
 
     public PulsarAdminBuilderImpl() {
@@ -187,35 +176,31 @@ public class PulsarAdminBuilderImpl implements PulsarAdminBuilder {
 
     @Override
     public PulsarAdminBuilder connectionTimeout(int connectionTimeout, TimeUnit connectionTimeoutUnit) {
-        this.connectTimeout = connectionTimeout;
-        this.connectTimeoutUnit = connectionTimeoutUnit;
+        this.conf.setConnectionTimeoutMs((int) connectionTimeoutUnit.toMillis(connectionTimeout));
         return this;
     }
 
     @Override
     public PulsarAdminBuilder readTimeout(int readTimeout, TimeUnit readTimeoutUnit) {
-        this.readTimeout = readTimeout;
-        this.readTimeoutUnit = readTimeoutUnit;
+        this.conf.setRequestTimeoutMs((int) readTimeoutUnit.toMillis(readTimeout));
         return this;
     }
 
     @Override
     public PulsarAdminBuilder requestTimeout(int requestTimeout, TimeUnit requestTimeoutUnit) {
-        this.requestTimeout = requestTimeout;
-        this.requestTimeoutUnit = requestTimeoutUnit;
+        this.conf.setRequestTimeoutMs((int) requestTimeoutUnit.toMillis(requestTimeout));
         return this;
     }
 
     @Override
     public PulsarAdminBuilder autoCertRefreshTime(int autoCertRefreshTime, TimeUnit autoCertRefreshTimeUnit) {
-        this.autoCertRefreshTime = autoCertRefreshTime;
-        this.autoCertRefreshTimeUnit = autoCertRefreshTimeUnit;
+        this.conf.setAutoCertRefreshSeconds((int) autoCertRefreshTimeUnit.toSeconds(autoCertRefreshTime));
         return this;
     }
 
     @Override
     public PulsarAdminBuilder setContextClassLoader(ClassLoader clientBuilderClassLoader) {
-        this.clientBuilderClassLoader = clientBuilderClassLoader;
+        this.conf.setContextClassLoader(clientBuilderClassLoader);
         return this;
     }
 }

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/PulsarAdminBuilderImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/PulsarAdminBuilderImpl.java
@@ -34,9 +34,11 @@ public class PulsarAdminBuilderImpl implements PulsarAdminBuilder {
 
     protected ClientConfigurationData conf;
 
+    private ClassLoader clientBuilderClassLoader = null;
+
     @Override
     public PulsarAdmin build() throws PulsarClientException {
-        return new PulsarAdminImpl(conf.getServiceUrl(), conf);
+        return new PulsarAdminImpl(conf.getServiceUrl(), conf, clientBuilderClassLoader);
     }
 
     public PulsarAdminBuilderImpl() {
@@ -182,7 +184,7 @@ public class PulsarAdminBuilderImpl implements PulsarAdminBuilder {
 
     @Override
     public PulsarAdminBuilder readTimeout(int readTimeout, TimeUnit readTimeoutUnit) {
-        this.conf.setRequestTimeoutMs((int) readTimeoutUnit.toMillis(readTimeout));
+        this.conf.setReadTimeoutMs((int) readTimeoutUnit.toMillis(readTimeout));
         return this;
     }
 
@@ -200,7 +202,7 @@ public class PulsarAdminBuilderImpl implements PulsarAdminBuilder {
 
     @Override
     public PulsarAdminBuilder setContextClassLoader(ClassLoader clientBuilderClassLoader) {
-        this.conf.setContextClassLoader(clientBuilderClassLoader);
+        this.clientBuilderClassLoader = clientBuilderClassLoader;
         return this;
     }
 }

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/PulsarAdminImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/PulsarAdminImpl.java
@@ -73,10 +73,7 @@ import org.slf4j.LoggerFactory;
 public class PulsarAdminImpl implements PulsarAdmin {
     private static final Logger LOG = LoggerFactory.getLogger(PulsarAdmin.class);
 
-    public static final int DEFAULT_CONNECT_TIMEOUT_SECONDS = 60;
-    public static final int DEFAULT_READ_TIMEOUT_SECONDS = 60;
     public static final int DEFAULT_REQUEST_TIMEOUT_SECONDS = 300;
-    public static final int DEFAULT_CERT_REFRESH_SECONDS = 300;
 
     private final Clusters clusters;
     private final Brokers brokers;
@@ -106,38 +103,11 @@ public class PulsarAdminImpl implements PulsarAdmin {
     private final Transactions transactions;
     protected final WebTarget root;
     protected final Authentication auth;
-    private final int connectTimeout;
-    private final TimeUnit connectTimeoutUnit;
-    private final int readTimeout;
-    private final TimeUnit readTimeoutUnit;
-    private final int requestTimeout;
-    private final TimeUnit requestTimeoutUnit;
 
-    public PulsarAdminImpl(String serviceUrl, ClientConfigurationData clientConfigData) throws PulsarClientException {
-        this(serviceUrl, clientConfigData, DEFAULT_CONNECT_TIMEOUT_SECONDS, TimeUnit.SECONDS,
-                DEFAULT_READ_TIMEOUT_SECONDS, TimeUnit.SECONDS, DEFAULT_REQUEST_TIMEOUT_SECONDS, TimeUnit.SECONDS,
-                DEFAULT_CERT_REFRESH_SECONDS, TimeUnit.SECONDS, null);
-    }
-
-    public PulsarAdminImpl(String serviceUrl,
-                       ClientConfigurationData clientConfigData,
-                       int connectTimeout,
-                       TimeUnit connectTimeoutUnit,
-                       int readTimeout,
-                       TimeUnit readTimeoutUnit,
-                       int requestTimeout,
-                       TimeUnit requestTimeoutUnit,
-                       int autoCertRefreshTime,
-                       TimeUnit autoCertRefreshTimeUnit,
-                       ClassLoader clientBuilderClassLoader) throws PulsarClientException {
+    public PulsarAdminImpl(String serviceUrl, ClientConfigurationData clientConfigData,
+                           ClassLoader clientBuilderClassLoader) throws PulsarClientException {
         checkArgument(StringUtils.isNotBlank(serviceUrl), "Service URL needs to be specified");
 
-        this.connectTimeout = connectTimeout;
-        this.connectTimeoutUnit = connectTimeoutUnit;
-        this.readTimeout = readTimeout;
-        this.readTimeoutUnit = readTimeoutUnit;
-        this.requestTimeout = requestTimeout;
-        this.requestTimeoutUnit = requestTimeoutUnit;
         this.clientConfigData = clientConfigData;
         this.auth = clientConfigData != null ? clientConfigData.getAuthentication() : new AuthenticationDisabled();
         LOG.debug("created: serviceUrl={}, authMethodName={}", serviceUrl,
@@ -152,7 +122,7 @@ public class PulsarAdminImpl implements PulsarAdmin {
         }
 
         AsyncHttpConnectorProvider asyncConnectorProvider = new AsyncHttpConnectorProvider(clientConfigData,
-                (int) autoCertRefreshTimeUnit.toSeconds(autoCertRefreshTime));
+                clientConfigData.getAutoCertRefreshSeconds());
 
         ClientConfig httpConfig = new ClientConfig();
         httpConfig.property(ClientProperties.FOLLOW_REDIRECTS, true);
@@ -168,8 +138,8 @@ public class PulsarAdminImpl implements PulsarAdmin {
 
         ClientBuilder clientBuilder = ClientBuilder.newBuilder()
                 .withConfig(httpConfig)
-                .connectTimeout(this.connectTimeout, this.connectTimeoutUnit)
-                .readTimeout(this.readTimeout, this.readTimeoutUnit)
+                .connectTimeout(this.clientConfigData.getConnectionTimeoutMs(), TimeUnit.MILLISECONDS)
+                .readTimeout(this.clientConfigData.getReadTimeoutMs(), TimeUnit.MILLISECONDS)
                 .register(JacksonConfigurator.class).register(JacksonFeature.class);
 
         boolean useTls = clientConfigData.getServiceUrl().startsWith("https://");
@@ -181,12 +151,12 @@ public class PulsarAdminImpl implements PulsarAdmin {
         root = client.target(serviceUri.selectOne());
 
         this.asyncHttpConnector = asyncConnectorProvider.getConnector(
-                Math.toIntExact(connectTimeoutUnit.toMillis(this.connectTimeout)),
-                Math.toIntExact(readTimeoutUnit.toMillis(this.readTimeout)),
-                Math.toIntExact(requestTimeoutUnit.toMillis(this.requestTimeout)),
-                (int) autoCertRefreshTimeUnit.toSeconds(autoCertRefreshTime));
+                Math.toIntExact(clientConfigData.getConnectionTimeoutMs()),
+                Math.toIntExact(clientConfigData.getReadTimeoutMs()),
+                Math.toIntExact(clientConfigData.getRequestTimeoutMs()),
+                clientConfigData.getAutoCertRefreshSeconds());
 
-        long readTimeoutMs = readTimeoutUnit.toMillis(this.readTimeout);
+        long readTimeoutMs = clientConfigData.getReadTimeoutMs();
         this.clusters = new ClustersImpl(root, auth, readTimeoutMs);
         this.brokers = new BrokersImpl(root, auth, readTimeoutMs);
         this.brokerStats = new BrokerStatsImpl(root, auth, readTimeoutMs);
@@ -228,7 +198,7 @@ public class PulsarAdminImpl implements PulsarAdmin {
      */
     @Deprecated
     public PulsarAdminImpl(URL serviceUrl, Authentication auth) throws PulsarClientException {
-        this(serviceUrl.toString(), getConfigData(auth));
+        this(serviceUrl.toString(), getConfigData(auth), null);
     }
 
     private static ClientConfigurationData getConfigData(Authentication auth) {

--- a/pulsar-client-admin/src/test/java/org/apache/pulsar/client/admin/internal/PulsarAdminBuilderImplTest.java
+++ b/pulsar-client-admin/src/test/java/org/apache/pulsar/client/admin/internal/PulsarAdminBuilderImplTest.java
@@ -50,14 +50,13 @@ public class PulsarAdminBuilderImplTest {
         config.put("requestTimeoutMs", 10);
         config.put("autoCertRefreshSeconds", 20);
         config.put("connectionTimeoutMs", 30);
+        config.put("readTimeoutMs", 40);
         PulsarAdminBuilder adminBuilder = PulsarAdmin.builder().loadConf(config);
-        ClassLoader classLoader = PulsarAdminBuilderImplTest.class.getClassLoader();
-        adminBuilder.setContextClassLoader(classLoader);
         PulsarAdminImpl admin = (PulsarAdminImpl) adminBuilder.build();
         ClientConfigurationData clientConfigData = admin.getClientConfigData();
         Assert.assertEquals(clientConfigData.getRequestTimeoutMs(), 10);
         Assert.assertEquals(clientConfigData.getAutoCertRefreshSeconds(), 20);
         Assert.assertEquals(clientConfigData.getConnectionTimeoutMs(), 30);
-        Assert.assertEquals(clientConfigData.getContextClassLoader(), classLoader);
+        Assert.assertEquals(clientConfigData.getReadTimeoutMs(), 40);
     }
 }

--- a/pulsar-client-admin/src/test/java/org/apache/pulsar/client/admin/internal/PulsarAdminBuilderImplTest.java
+++ b/pulsar-client-admin/src/test/java/org/apache/pulsar/client/admin/internal/PulsarAdminBuilderImplTest.java
@@ -20,7 +20,6 @@ package org.apache.pulsar.client.admin.internal;
 
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.fail;
-import lombok.SneakyThrows;
 import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.admin.PulsarAdminBuilder;
 import org.apache.pulsar.client.api.PulsarClientException;
@@ -43,8 +42,7 @@ public class PulsarAdminBuilderImplTest {
     }
 
     @Test
-    @SneakyThrows
-    public void testGetPropertiesFromConf() {
+    public void testGetPropertiesFromConf() throws Exception {
         Map<String, Object> config = new HashMap<>();
         config.put("serviceUrl", "pulsar://localhost:6650");
         config.put("requestTimeoutMs", 10);

--- a/pulsar-client-admin/src/test/java/org/apache/pulsar/client/admin/internal/PulsarAdminBuilderImplTest.java
+++ b/pulsar-client-admin/src/test/java/org/apache/pulsar/client/admin/internal/PulsarAdminBuilderImplTest.java
@@ -20,9 +20,15 @@ package org.apache.pulsar.client.admin.internal;
 
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.fail;
+import lombok.SneakyThrows;
 import org.apache.pulsar.client.admin.PulsarAdmin;
+import org.apache.pulsar.client.admin.PulsarAdminBuilder;
 import org.apache.pulsar.client.api.PulsarClientException;
+import org.apache.pulsar.client.impl.conf.ClientConfigurationData;
+import org.testng.Assert;
 import org.testng.annotations.Test;
+import java.util.HashMap;
+import java.util.Map;
 
 public class PulsarAdminBuilderImplTest {
 
@@ -34,5 +40,24 @@ public class PulsarAdminBuilderImplTest {
         } catch (IllegalArgumentException exception) {
             assertEquals("Service URL needs to be specified", exception.getMessage());
         }
+    }
+
+    @Test
+    @SneakyThrows
+    public void testGetPropertiesFromConf() {
+        Map<String, Object> config = new HashMap<>();
+        config.put("serviceUrl", "pulsar://localhost:6650");
+        config.put("requestTimeoutMs", 10);
+        config.put("autoCertRefreshSeconds", 20);
+        config.put("connectionTimeoutMs", 30);
+        PulsarAdminBuilder adminBuilder = PulsarAdmin.builder().loadConf(config);
+        ClassLoader classLoader = PulsarAdminBuilderImplTest.class.getClassLoader();
+        adminBuilder.setContextClassLoader(classLoader);
+        PulsarAdminImpl admin = (PulsarAdminImpl) adminBuilder.build();
+        ClientConfigurationData clientConfigData = admin.getClientConfigData();
+        Assert.assertEquals(clientConfigData.getRequestTimeoutMs(), 10);
+        Assert.assertEquals(clientConfigData.getAutoCertRefreshSeconds(), 20);
+        Assert.assertEquals(clientConfigData.getConnectionTimeoutMs(), 30);
+        Assert.assertEquals(clientConfigData.getContextClassLoader(), classLoader);
     }
 }

--- a/pulsar-client-tools-test/src/test/java/org/apache/pulsar/admin/cli/PulsarAdminToolTest.java
+++ b/pulsar-client-tools-test/src/test/java/org/apache/pulsar/admin/cli/PulsarAdminToolTest.java
@@ -72,6 +72,7 @@ import org.apache.pulsar.client.admin.TopicPolicies;
 import org.apache.pulsar.client.admin.Topics;
 import org.apache.pulsar.client.admin.Transactions;
 import org.apache.pulsar.client.admin.internal.OffloadProcessStatusImpl;
+import org.apache.pulsar.client.admin.internal.PulsarAdminBuilderImpl;
 import org.apache.pulsar.client.admin.internal.PulsarAdminImpl;
 import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.client.api.SubscriptionType;
@@ -2162,19 +2163,15 @@ public class PulsarAdminToolTest {
             //Ok
         }
 
+        Field adminBuilderField = PulsarAdminTool.class.getDeclaredField("adminBuilder");
+        adminBuilderField.setAccessible(true);
+        PulsarAdminBuilderImpl builder = (PulsarAdminBuilderImpl) adminBuilderField.get(tool);
+        Field confField =
+                PulsarAdminBuilderImpl.class.getDeclaredField("conf");
+        confField.setAccessible(true);
+        ClientConfigurationData conf = (ClientConfigurationData) confField.get(builder);
 
-        final PulsarAdmin admin = tool.getPulsarAdminSupplier().get();
-        Field requestTimeoutField =
-                PulsarAdminImpl.class.getDeclaredField("requestTimeout");
-        requestTimeoutField.setAccessible(true);
-        int requestTimeout = (int) requestTimeoutField.get(admin);
-
-        Field requestTimeoutUnitField =
-                PulsarAdminImpl.class.getDeclaredField("requestTimeoutUnit");
-        requestTimeoutUnitField.setAccessible(true);
-        TimeUnit requestTimeoutUnit = (TimeUnit) requestTimeoutUnitField.get(admin);
-        assertEquals(1, requestTimeout);
-        assertEquals(TimeUnit.SECONDS, requestTimeoutUnit);
+        assertEquals(1000, conf.getRequestTimeoutMs());
     }
 
     @Test

--- a/pulsar-client-tools-test/src/test/java/org/apache/pulsar/admin/cli/PulsarAdminToolTest.java
+++ b/pulsar-client-tools-test/src/test/java/org/apache/pulsar/admin/cli/PulsarAdminToolTest.java
@@ -37,7 +37,6 @@ import com.google.common.collect.Sets;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.PrintStream;
-import java.lang.reflect.Field;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.nio.charset.StandardCharsets;
@@ -72,7 +71,6 @@ import org.apache.pulsar.client.admin.TopicPolicies;
 import org.apache.pulsar.client.admin.Topics;
 import org.apache.pulsar.client.admin.Transactions;
 import org.apache.pulsar.client.admin.internal.OffloadProcessStatusImpl;
-import org.apache.pulsar.client.admin.internal.PulsarAdminBuilderImpl;
 import org.apache.pulsar.client.admin.internal.PulsarAdminImpl;
 import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.client.api.SubscriptionType;
@@ -2163,13 +2161,7 @@ public class PulsarAdminToolTest {
             //Ok
         }
 
-        Field adminBuilderField = PulsarAdminTool.class.getDeclaredField("adminBuilder");
-        adminBuilderField.setAccessible(true);
-        PulsarAdminBuilderImpl builder = (PulsarAdminBuilderImpl) adminBuilderField.get(tool);
-        Field confField =
-                PulsarAdminBuilderImpl.class.getDeclaredField("conf");
-        confField.setAccessible(true);
-        ClientConfigurationData conf = (ClientConfigurationData) confField.get(builder);
+        ClientConfigurationData conf =  ((PulsarAdminImpl)tool.getPulsarAdminSupplier().get()).getClientConfigData();
 
         assertEquals(1000, conf.getRequestTimeoutMs());
     }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ClientConfigurationData.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ClientConfigurationData.java
@@ -220,6 +220,12 @@ public class ClientConfigurationData implements Serializable, Cloneable {
     private int requestTimeoutMs = 60000;
 
     @ApiModelProperty(
+            name = "autoCertRefreshSeconds",
+            value = "Seconds of auto refreshing certificate."
+    )
+    private int autoCertRefreshSeconds = 300;
+
+    @ApiModelProperty(
             name = "initialBackoffIntervalNanos",
             value = "Initial backoff interval (in nanosecond)."
     )
@@ -366,6 +372,13 @@ public class ClientConfigurationData implements Serializable, Cloneable {
     )
     @Secret
     private String socks5ProxyPassword;
+
+    @ApiModelProperty(
+            name = "contextClassLoader",
+            value = "Context ClassLoader."
+    )
+    @JsonIgnore
+    private transient ClassLoader contextClassLoader;
 
     public Authentication getAuthentication() {
         if (authentication == null) {

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ClientConfigurationData.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ClientConfigurationData.java
@@ -220,6 +220,12 @@ public class ClientConfigurationData implements Serializable, Cloneable {
     private int requestTimeoutMs = 60000;
 
     @ApiModelProperty(
+            name = "readTimeoutMs",
+            value = "Maximum read time of a request."
+    )
+    private int readTimeoutMs = 60000;
+
+    @ApiModelProperty(
             name = "autoCertRefreshSeconds",
             value = "Seconds of auto refreshing certificate."
     )
@@ -372,13 +378,6 @@ public class ClientConfigurationData implements Serializable, Cloneable {
     )
     @Secret
     private String socks5ProxyPassword;
-
-    @ApiModelProperty(
-            name = "contextClassLoader",
-            value = "Context ClassLoader."
-    )
-    @JsonIgnore
-    private transient ClassLoader contextClassLoader;
 
     public Authentication getAuthentication() {
         if (authentication == null) {


### PR DESCRIPTION
Fixes #17333

Master Issue: #17333

### Motivation

Support PulsarAdminBuilderImpl overrides timeout properties passed through config map.


### Documentation

- [x] `doc-not-needed` 
(Please explain why)
