### PR TITLE
[fix][dependency] Add OWASP suppression for openstack-keystone-2.5.0

### DIFF
--- a/src/owasp-dependency-check-suppressions.xml
+++ b/src/owasp-dependency-check-suppressions.xml
@@ -345,6 +345,13 @@
         <sha1>a7e89bd278fa8be9fa604dda66d1606de5530797</sha1>
         <cve>CVE-2020-12692</cve>
     </suppress>
+    <suppress>
+        <notes><![CDATA[
+       file name: openstack-keystone-2.5.0.jar
+       ]]></notes>
+        <sha1>a7e89bd278fa8be9fa604dda66d1606de5530797</sha1>
+        <cve>CVE-2021-3563</cve>
+    </suppress>
 
     <!-- Solr misdetection.
     Cannot be tied to a sha1,


### PR DESCRIPTION
### Motivation

Currently, there is a failure in the OWASP dependency check in the CI: 
https://github.com/apache/pulsar/runs/8127949104?check_suite_focus=true#step:8:12

We need to add a suppress for openstack-keystone CVE-2021-3563 issue

### Verifying this change

- [x] Make sure that the change passes the CI checks.


### Documentation

Check the box below or label this PR directly.

Need to update docs? 

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)
  
- [x] `doc-not-needed` 
(Please explain why)
  
- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)