### PR TITLE
[fix][cpp] Fix potential segfault when resending messages

### DIFF
--- a/pulsar-client-cpp/lib/PeriodicTask.cc
+++ b/pulsar-client-cpp/lib/PeriodicTask.cc
@@ -27,9 +27,14 @@ void PeriodicTask::start() {
     }
     state_ = Ready;
     if (periodMs_ >= 0) {
-        auto self = shared_from_this();
+        std::weak_ptr<PeriodicTask> weakSelf{shared_from_this()};
         timer_.expires_from_now(boost::posix_time::millisec(periodMs_));
-        timer_.async_wait([this, self](const ErrorCode& ec) { handleTimeout(ec); });
+        timer_.async_wait([weakSelf](const ErrorCode& ec) {
+            auto self = weakSelf.lock();
+            if (self) {
+                self->handleTimeout(ec);
+            }
+        });
     }
 }
 

--- a/pulsar-client-cpp/lib/ProducerImpl.cc
+++ b/pulsar-client-cpp/lib/ProducerImpl.cc
@@ -56,7 +56,9 @@ ProducerImpl::ProducerImpl(ClientImplPtr client, const TopicName& topicName,
       producerStr_("[" + topic_ + ", " + producerName_ + "] "),
       producerId_(client->newProducerId()),
       msgSequenceGenerator_(0),
-      dataKeyGenIntervalSec_(4 * 60 * 60),
+      batchTimer_(executor_->getIOService()),
+      sendTimer_(executor_->getIOService()),
+      dataKeyRefreshTask_(executor_->getIOService(), 4 * 60 * 60 * 1000),
       memoryLimitController_(client->getMemoryLimitController()),
       chunkingEnabled_(conf_.isChunkingEnabled() && topicName.isPersistent() && !conf_.getBatchingEnabled()) {
     LOG_DEBUG("ProducerName - " << producerName_ << " Created producer on topic " << topic_
@@ -102,7 +104,6 @@ ProducerImpl::ProducerImpl(ClientImplPtr client, const TopicName& topicName,
                 LOG_ERROR("Unknown batching type: " << conf_.getBatchingType());
                 return;
         }
-        batchTimer_ = executor_->createDeadlineTimer();
     }
 }
 
@@ -122,19 +123,6 @@ const std::string& ProducerImpl::getProducerName() const { return producerName_;
 int64_t ProducerImpl::getLastSequenceId() const { return lastSequenceIdPublished_; }
 
 const std::string& ProducerImpl::getSchemaVersion() const { return schemaVersion_; }
-
-void ProducerImpl::refreshEncryptionKey(const boost::system::error_code& ec) {
-    if (ec) {
-        LOG_DEBUG("Ignoring timer cancelled event, code[" << ec << "]");
-        return;
-    }
-
-    msgCrypto_->addPublicKeyCipher(conf_.getEncryptionKeys(), conf_.getCryptoKeyReader());
-
-    dataKeyGenTImer_->expires_from_now(boost::posix_time::seconds(dataKeyGenIntervalSec_));
-    dataKeyGenTImer_->async_wait(
-        std::bind(&pulsar::ProducerImpl::refreshEncryptionKey, shared_from_this(), std::placeholders::_1));
-}
 
 void ProducerImpl::connectionOpened(const ClientConnectionPtr& cnx) {
     if (state_ == Closed) {
@@ -200,11 +188,19 @@ void ProducerImpl::handleCreateProducer(const ClientConnectionPtr& cnx, Result r
         backoff_.reset();
         lock.unlock();
 
-        if (!dataKeyGenTImer_ && conf_.isEncryptionEnabled()) {
-            dataKeyGenTImer_ = executor_->createDeadlineTimer();
-            dataKeyGenTImer_->expires_from_now(boost::posix_time::seconds(dataKeyGenIntervalSec_));
-            dataKeyGenTImer_->async_wait(std::bind(&pulsar::ProducerImpl::refreshEncryptionKey,
-                                                   shared_from_this(), std::placeholders::_1));
+        if (conf_.isEncryptionEnabled()) {
+            auto weakSelf{weak_from_this()};
+            dataKeyRefreshTask_.setCallback([this, weakSelf](const PeriodicTask::ErrorCode& ec) {
+                auto self = weakSelf.lock();
+                if (!self) {
+                    return;
+                }
+                if (ec) {
+                    LOG_ERROR("DataKeyRefresh timer failed: " << ec.message());
+                    return;
+                }
+                msgCrypto_->addPublicKeyCipher(conf_.getEncryptionKeys(), conf_.getCryptoKeyReader());
+            });
         }
 
         // if the producer is lazy the send timeout timer is already running
@@ -466,10 +462,29 @@ void ProducerImpl::sendAsyncWithStatsUpdate(const Message& msg, const SendCallba
         bool isFirstMessage = batchMessageContainer_->isFirstMessageToAdd(msg);
         bool isFull = batchMessageContainer_->add(msg, callback);
         if (isFirstMessage) {
-            batchTimer_->expires_from_now(
+            batchTimer_.expires_from_now(
                 boost::posix_time::milliseconds(conf_.getBatchingMaxPublishDelayMs()));
-            batchTimer_->async_wait(std::bind(&ProducerImpl::batchMessageTimeoutHandler, shared_from_this(),
-                                              std::placeholders::_1));
+            auto weakSelf{weak_from_this()};
+            batchTimer_.async_wait([this, weakSelf](const boost::system::error_code& ec) {
+                auto self = weakSelf.lock();
+                if (!self) {
+                    return;
+                }
+                if (ec) {
+                    LOG_DEBUG(getName() << " Ignoring timer cancelled event, code[" << ec << "]");
+                    return;
+                }
+                LOG_DEBUG(getName() << " - Batch Message Timer expired");
+
+                // ignore if the producer is already closing/closed
+                const auto state = state_.load();
+                if (state == Pending || state == Ready) {
+                    Lock lock(mutex_);
+                    auto failures = batchMessageAndSend();
+                    lock.unlock();
+                    failures.complete();
+                }
+            });
         }
 
         if (isFull) {
@@ -560,7 +575,7 @@ void ProducerImpl::releaseSemaphoreForSendOp(const OpSendMsg& op) {
 PendingFailures ProducerImpl::batchMessageAndSend(const FlushCallback& flushCallback) {
     PendingFailures failures;
     LOG_DEBUG("batchMessageAndSend " << *batchMessageContainer_);
-    batchTimer_->cancel();
+    batchTimer_.cancel();
 
     batchMessageContainer_->processAndClear(
         [this, &failures](Result result, const OpSendMsg& opSendMsg) {
@@ -594,23 +609,6 @@ void ProducerImpl::sendMessage(const OpSendMsg& op) {
         cnx->sendMessage(op);
     } else {
         LOG_DEBUG(getName() << "Connection is not ready - seq: " << sequenceId);
-    }
-}
-
-void ProducerImpl::batchMessageTimeoutHandler(const boost::system::error_code& ec) {
-    if (ec) {
-        LOG_DEBUG(getName() << " Ignoring timer cancelled event, code[" << ec << "]");
-        return;
-    }
-    LOG_DEBUG(getName() << " - Batch Message Timer expired");
-
-    // ignore if the producer is already closing/closed
-    const auto state = state_.load();
-    if (state == Pending || state == Ready) {
-        Lock lock(mutex_);
-        auto failures = batchMessageAndSend();
-        lock.unlock();
-        failures.complete();
     }
 }
 
@@ -870,20 +868,9 @@ void ProducerImpl::shutdown() {
 }
 
 void ProducerImpl::cancelTimers() {
-    if (dataKeyGenTImer_) {
-        dataKeyGenTImer_->cancel();
-        dataKeyGenTImer_.reset();
-    }
-
-    if (batchTimer_) {
-        batchTimer_->cancel();
-        batchTimer_.reset();
-    }
-
-    if (sendTimer_) {
-        sendTimer_->cancel();
-        sendTimer_.reset();
-    }
+    dataKeyRefreshTask_.stop();
+    batchTimer_.cancel();
+    sendTimer_.cancel();
 }
 
 bool ProducerImplCmp::operator()(const ProducerImplPtr& a, const ProducerImplPtr& b) const {
@@ -898,26 +885,24 @@ uint64_t ProducerImpl::getNumberOfConnectedProducer() { return isConnected() ? 1
 
 bool ProducerImpl::isStarted() const { return state_ != NotStarted; }
 void ProducerImpl::startSendTimeoutTimer() {
-    // Initialize the sendTimer only once per producer and only when producer timeout is
-    // configured. Set the timeout as configured value and asynchronously wait for the
-    // timeout to happen.
-    if (!sendTimer_ && conf_.getSendTimeout() > 0) {
-        sendTimer_ = executor_->createDeadlineTimer();
+    if (conf_.getSendTimeout() > 0) {
         asyncWaitSendTimeout(milliseconds(conf_.getSendTimeout()));
     }
 }
 
 void ProducerImpl::asyncWaitSendTimeout(DurationType expiryTime) {
-    sendTimer_->expires_from_now(expiryTime);
+    sendTimer_.expires_from_now(expiryTime);
 
-    ProducerImplBaseWeakPtr weakSelf = shared_from_this();
-    sendTimer_->async_wait([weakSelf](const boost::system::error_code& err) {
+    auto weakSelf{weak_from_this()};
+    sendTimer_.async_wait([weakSelf](const boost::system::error_code& err) {
         auto self = weakSelf.lock();
         if (self) {
             std::static_pointer_cast<ProducerImpl>(self)->handleSendTimeout(err);
         }
     });
 }
+
+ProducerImplWeakPtr ProducerImpl::weak_from_this() noexcept { return shared_from_this(); }
 
 }  // namespace pulsar
 /* namespace pulsar */

--- a/pulsar-client-cpp/lib/ProducerImpl.cc
+++ b/pulsar-client-cpp/lib/ProducerImpl.cc
@@ -189,7 +189,7 @@ void ProducerImpl::handleCreateProducer(const ClientConnectionPtr& cnx, Result r
         lock.unlock();
 
         if (conf_.isEncryptionEnabled()) {
-            auto weakSelf{weak_from_this()};
+            auto weakSelf = weak_from_this();
             dataKeyRefreshTask_.setCallback([this, weakSelf](const PeriodicTask::ErrorCode& ec) {
                 auto self = weakSelf.lock();
                 if (!self) {
@@ -464,7 +464,7 @@ void ProducerImpl::sendAsyncWithStatsUpdate(const Message& msg, const SendCallba
         if (isFirstMessage) {
             batchTimer_.expires_from_now(
                 boost::posix_time::milliseconds(conf_.getBatchingMaxPublishDelayMs()));
-            auto weakSelf{weak_from_this()};
+            auto weakSelf = weak_from_this();
             batchTimer_.async_wait([this, weakSelf](const boost::system::error_code& ec) {
                 auto self = weakSelf.lock();
                 if (!self) {
@@ -893,7 +893,7 @@ void ProducerImpl::startSendTimeoutTimer() {
 void ProducerImpl::asyncWaitSendTimeout(DurationType expiryTime) {
     sendTimer_.expires_from_now(expiryTime);
 
-    auto weakSelf{weak_from_this()};
+    auto weakSelf = weak_from_this();
     sendTimer_.async_wait([weakSelf](const boost::system::error_code& err) {
         auto self = weakSelf.lock();
         if (self) {

--- a/pulsar-client-cpp/lib/ProducerImpl.h
+++ b/pulsar-client-cpp/lib/ProducerImpl.h
@@ -35,6 +35,7 @@
 #include "BatchMessageContainerBase.h"
 #include "PendingFailures.h"
 #include "Semaphore.h"
+#include "PeriodicTask.h"
 
 using namespace pulsar;
 
@@ -86,6 +87,9 @@ class ProducerImpl : public HandlerBase,
 
     static int getNumOfChunks(uint32_t size, uint32_t maxMessageSize);
 
+    // NOTE: this method is introduced into `enable_shared_from_this` since C++17
+    ProducerImplWeakPtr weak_from_this() noexcept;
+
    protected:
     ProducerStatsBasePtr producerStatsBasePtr_;
 
@@ -94,8 +98,6 @@ class ProducerImpl : public HandlerBase,
     void setMessageMetadata(const Message& msg, const uint64_t& sequenceId, const uint32_t& uncompressedSize);
 
     void sendMessage(const OpSendMsg& opSendMsg);
-
-    void batchMessageTimeoutHandler(const boost::system::error_code& ec);
 
     void startSendTimeoutTimer();
 
@@ -162,13 +164,13 @@ class ProducerImpl : public HandlerBase,
     proto::BaseCommand cmd_;
 
     std::unique_ptr<BatchMessageContainerBase> batchMessageContainer_;
-    DeadlineTimerPtr batchTimer_;
+    boost::asio::deadline_timer batchTimer_;
     PendingFailures batchMessageAndSend(const FlushCallback& flushCallback = nullptr);
 
     volatile int64_t lastSequenceIdPublished_;
     std::string schemaVersion_;
 
-    DeadlineTimerPtr sendTimer_;
+    boost::asio::deadline_timer sendTimer_;
     void handleSendTimeout(const boost::system::error_code& err);
     using DurationType = typename boost::asio::deadline_timer::duration_type;
     void asyncWaitSendTimeout(DurationType expiryTime);
@@ -182,8 +184,7 @@ class ProducerImpl : public HandlerBase,
     void failPendingMessages(Result result, bool withLock);
 
     MessageCryptoPtr msgCrypto_;
-    DeadlineTimerPtr dataKeyGenTImer_;
-    uint32_t dataKeyGenIntervalSec_;
+    PeriodicTask dataKeyRefreshTask_;
 
     MemoryLimitController& memoryLimitController_;
     const bool chunkingEnabled_;


### PR DESCRIPTION
Fixes #17392

### Motivation

All timers in `ProducerImpl` are `std::shared_ptr` objects that can be
reset with `nullptr` in `ProducerImpl::cancelTimers`. It could lead to
null pointer access in some cases.

See
https://github.com/apache/pulsar/issues/17392#issuecomment-1233929427
for the analysis.

Generally it's not necessary to hold a nullable pointer to the timer.
However, to resolve the cyclic reference issue, #5246 reset the shared
pointer to reduce the reference count manually. It's not a good solution
because we have to perform null check for timers everywhere. The null
check still has some race condition issue like:

Thread 1:

```c++
if (timer) {  // [1] timer is not nullptr
    timer->async_wait(/* ... */);  // [3] timer is null now, see [2] below
}
```

Thread 2:

```c++
timer.reset();  // [2]
```

The best solution is to capture `weak_ptr` in timer's callback and call
`lock()` to check if the referenced object is still valid.

### Modifications
- Change the type of `sendTimer_` and `batchTimer_` to `deadline_timer`,
  not a `shared_ptr`.
- Use `PeriodicTask` instead of the `deadline_timer` for token refresh.
- Migrate `weak_from_this()` method from C++17 and capture
  `weak_from_this()` instead of `shared_from_this()` in callbacks.

### Verifying this change

Run the `testResendViaSendCallback` for many times and we can see it
won't fail after this patch.

```bash
./tests/main --gtest_filter='BasicEndToEndTest.testResendViaSendCallback' --gtest_repeat=30
```

### Documentation

Check the box below or label this PR directly.

Need to update docs? 

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)
  
- [x] `doc-not-needed` 
(Please explain why)
  
- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)