### PR TITLE
[improve][broker] Using `handle` instead of `handleAsync` to avoid using common pool thread

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/BookkeeperSchemaStorage.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/BookkeeperSchemaStorage.java
@@ -198,9 +198,7 @@ public class BookkeeperSchemaStorage implements SchemaStorage {
             if (log.isDebugEnabled()) {
                 log.debug("[{}] Fetching schema from store", schemaId);
             }
-            CompletableFuture<StoredSchema> future = new CompletableFuture<>();
-
-            getSchemaLocator(getSchemaPath(schemaId)).thenCompose(locator -> {
+            return getSchemaLocator(getSchemaPath(schemaId)).thenCompose(locator -> {
                 if (log.isDebugEnabled()) {
                     log.debug("[{}] Got schema locator {}", schemaId, locator);
                 }
@@ -213,22 +211,12 @@ public class BookkeeperSchemaStorage implements SchemaStorage {
                 return readSchemaEntry(schemaLocator.getInfo().getPosition())
                         .thenApply(entry -> new StoredSchema(entry.getSchemaData().toByteArray(),
                                 new LongSchemaVersion(schemaLocator.getInfo().getVersion())));
-            }).handle((res, ex) -> {
-                if (log.isDebugEnabled()) {
-                    log.debug("[{}] Get operation completed. res={} -- ex={}", schemaId, res, ex);
-                }
-
-                // Cleanup the pending ops from the map
-                readSchemaOperations.remove(schemaId, future);
-                if (ex != null) {
-                    future.completeExceptionally(ex);
-                } else {
-                    future.complete(res);
-                }
-                return null;
             });
-
-            return future;
+        }).whenComplete((res, ex) -> {
+            if (log.isDebugEnabled()) {
+                log.debug("[{}] Get operation completed. res={} -- ex={}", schemaId, res, ex);
+            }
+            readSchemaOperations.remove(schemaId);
         });
     }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/BookkeeperSchemaStorage.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/BookkeeperSchemaStorage.java
@@ -213,7 +213,7 @@ public class BookkeeperSchemaStorage implements SchemaStorage {
                 return readSchemaEntry(schemaLocator.getInfo().getPosition())
                         .thenApply(entry -> new StoredSchema(entry.getSchemaData().toByteArray(),
                                 new LongSchemaVersion(schemaLocator.getInfo().getVersion())));
-            }).handleAsync((res, ex) -> {
+            }).handle((res, ex) -> {
                 if (log.isDebugEnabled()) {
                     log.debug("[{}] Get operation completed. res={} -- ex={}", schemaId, res, ex);
                 }


### PR DESCRIPTION
### Motivation

When creating consumer, I find that using common pool thread to create the cursor:
```
2022-09-01T21:12:32,515 - INFO  - [bookkeeper-ml-scheduler-OrderedScheduler-0-0:BrokerService$2@1472] - Created topic persistent://prop/ns-test/topic-1 - dedup is disabled
2022-09-01T21:12:32,528 - INFO  - [ForkJoinPool.commonPool-worker-1:ManagedLedgerImpl@961] - [prop/ns-test/persistent/topic-1] Creating new cursor: sub-2
2022-09-01T21:12:32,529 - INFO  - [ForkJoinPool.commonPool-worker-1:ManagedCursorImpl@631] - [prop/ns-test/persistent/topic-1] Cursor sub-2 recovered to position 3:-1
```

And then find that the thread switches in  `BookkeeperSchemaStorage`.   It's introduced by https://github.com/apache/pulsar/pull/2148.   I think it's no need to use `handleAsync` there.


After changing to `handle`, I find some tests failed due to `deadlock`.  Add logs to help troubleshoot the issue:
![image](https://user-images.githubusercontent.com/6297296/188119427-45794d57-2122-44f8-bbe0-3e922d13c330.png)
 you can see thread `bookkeeper-ml-scheduler-OrderedScheduler-9-0` does not print `removing readSchemaOperations`.
```
[bookkeeper-ml-scheduler-OrderedScheduler-8-0:BookkeeperSchemaStorage@196] - entry-into-getSchema : prop-xyz/ns1/test-65ad2f93-6ac1-4efa-aa8d-97d198085f5f, {}
[bookkeeper-ml-scheduler-OrderedScheduler-8-0:BookkeeperSchemaStorage@200] - [prop-xyz/ns1/test-65ad2f93-6ac1-4efa-aa8d-97d198085f5f] Fetching schema from store
[metadata-store-12-1:BookkeeperSchemaStorage@206] - [prop-xyz/ns1/test-65ad2f93-6ac1-4efa-aa8d-97d198085f5f] Got schema locator Optional.empty
[metadata-store-12-1:BookkeeperSchemaStorage@222] - [prop-xyz/ns1/test-65ad2f93-6ac1-4efa-aa8d-97d198085f5f] Get operation completed. res=null -- ex=null
[metadata-store-12-1:BookkeeperSchemaStorage@227] - removing readSchemaOperations{}
[bookkeeper-ml-scheduler-OrderedScheduler-9-0:BookkeeperSchemaStorage@196] - entry-into-getSchema : prop-xyz/ns1/test-b2a4421c-e185-4da8-acf8-e8b56bf3f493, {}
[bookkeeper-ml-scheduler-OrderedScheduler-9-0:BookkeeperSchemaStorage@200] - [prop-xyz/ns1/test-b2a4421c-e185-4da8-acf8-e8b56bf3f493] Fetching schema from store
[bookkeeper-ml-scheduler-OrderedScheduler-9-0:BookkeeperSchemaStorage@206] - [prop-xyz/ns1/test-b2a4421c-e185-4da8-acf8-e8b56bf3f493] Got schema locator Optional.empty
[bookkeeper-ml-scheduler-OrderedScheduler-9-0:BookkeeperSchemaStorage@222] - [prop-xyz/ns1/test-b2a4421c-e185-4da8-acf8-e8b56bf3f493] Get operation completed. res=null -- ex=null
[bookkeeper-ml-scheduler-OrderedScheduler-0-0:ManagedLedgerFactoryImpl$2@380] - [prop-xyz/ns1/persistent/test-b2a4421c-e185-4da8-acf8-e8b56bf3f493-partition-2] Successfully initialize managed ledger
[bookkeeper-ml-scheduler-OrderedScheduler-0-0:BrokerService$2@1472] - Created topic persistent://prop-xyz/ns1/test-b2a4421c-e185-4da8-acf8-e8b56bf3f493-partition-2 - dedup is disabled
[bookkeeper-ml-scheduler-OrderedScheduler-0-0:BookkeeperSchemaStorage@196] - entry-into-getSchema : prop-xyz/ns1/test-b2a4421c-e185-4da8-acf8-e8b56bf3f493, {prop-xyz/ns1/test-b2a4421c-e185-4da8-acf8-e8b56bf3f493=java.util.concurrent.CompletableFuture@78158de6[Not completed, 1 dependents]}

```

To avoid the `deadlock` issue, we can move the `readSchemaOperations.remove(schemaId, future)` outside.

- [x] `doc-not-needed` 
(Please explain why)
