### PR TITLE
[fix][cli] Exclude windows script from the docker image

### DIFF
--- a/distribution/shell/src/assemble/shell.xml
+++ b/distribution/shell/src/assemble/shell.xml
@@ -51,6 +51,16 @@
       <fileMode>755</fileMode>
     </file>
     <file>
+      <outputDirectory>bin</outputDirectory>
+      <source>${basedir}/../../bin/pulsar-admin-common.cmd</source>
+      <fileMode>755</fileMode>
+    </file>
+    <file>
+      <outputDirectory>bin</outputDirectory>
+      <source>${basedir}/../../bin/pulsar-shell.cmd</source>
+      <fileMode>755</fileMode>
+    </file>
+    <file>
       <outputDirectory>conf</outputDirectory>
       <source>${basedir}/../../conf/client.conf</source>
     </file>

--- a/docker/pulsar/Dockerfile
+++ b/docker/pulsar/Dockerfile
@@ -24,6 +24,7 @@ ARG PULSAR_TARBALL
 
 ADD ${PULSAR_TARBALL} /
 RUN mv /apache-pulsar-* /pulsar
+RUN rm -rf /pulsar/bin/*.cmd
 
 COPY scripts/apply-config-from-env.py /pulsar/bin
 COPY scripts/apply-config-from-env-with-prefix.py /pulsar/bin


### PR DESCRIPTION
### Motivation
After #16688 (only for the master branch) all the new Windows scripts are included in the docker image unnecessarly.
Users that want to use the CLI commands can still download the tarballs (server or pulsar-shell)

### Modifications

* Remove *cmd files in the Dockerfile
* Add .cmd files to the pulsar-shell tarball

- [x] `doc-not-needed` 