### PR TITLE
[fix][cpp] Support retry and apply operation timeout for lookup requests

### DIFF
--- a/pulsar-client-cpp/include/pulsar/Result.h
+++ b/pulsar-client-cpp/include/pulsar/Result.h
@@ -29,7 +29,8 @@ namespace pulsar {
  */
 enum Result
 {
-    ResultOk,  /// Operation successful
+    ResultRetryable = -1,  /// An internal error code used for retry
+    ResultOk = 0,          /// Operation successful
 
     ResultUnknownError,  /// Unknown error happened on broker
 

--- a/pulsar-client-cpp/lib/BinaryProtoLookupService.cc
+++ b/pulsar-client-cpp/lib/BinaryProtoLookupService.cc
@@ -111,7 +111,6 @@ void BinaryProtoLookupService::sendPartitionMetadataLookupRequest(const std::str
                                                                   LookupDataResultPromisePtr promise) {
     if (result != ResultOk) {
         promise->setFailed(result);
-        Future<Result, LookupDataResultPtr> future = promise->getFuture();
         return;
     }
     LookupDataResultPromisePtr lookupPromise = std::make_shared<LookupDataResultPromise>();
@@ -160,7 +159,7 @@ void BinaryProtoLookupService::sendGetTopicsOfNamespaceRequest(const std::string
                                                                const ClientConnectionWeakPtr& clientCnx,
                                                                NamespaceTopicsPromisePtr promise) {
     if (result != ResultOk) {
-        promise->setFailed(ResultConnectError);
+        promise->setFailed(result);
         return;
     }
 

--- a/pulsar-client-cpp/lib/ClientConnection.cc
+++ b/pulsar-client-cpp/lib/ClientConnection.cc
@@ -51,7 +51,7 @@ static const uint32_t DefaultBufferSize = 64 * 1024;
 static const int KeepAliveIntervalInSeconds = 30;
 
 // Convert error codes from protobuf to client API Result
-static Result getResult(ServerError serverError) {
+static Result getResult(ServerError serverError, const std::string& message) {
     switch (serverError) {
         case UnknownError:
             return ResultUnknownError;
@@ -75,7 +75,9 @@ static Result getResult(ServerError serverError) {
             return ResultConsumerBusy;
 
         case ServiceNotReady:
-            return ResultServiceUnitNotReady;
+            // If the error is not caused by a PulsarServerException, treat it as retryable.
+            return (message.find("PulsarServerException") == std::string::npos) ? ResultRetryable
+                                                                                : ResultServiceUnitNotReady;
 
         case ProducerBlockedQuotaExceededError:
             return ResultProducerBlockedQuotaExceededError;
@@ -138,7 +140,7 @@ static Result getResult(ServerError serverError) {
 }
 
 inline std::ostream& operator<<(std::ostream& os, ServerError error) {
-    os << getResult(error);
+    os << getResult(error, "");
     return os;
 }
 
@@ -182,7 +184,7 @@ ClientConnection::ClientConnection(const std::string& logicalAddress, const std:
         consumerStatsRequestTimer_ = executor_->createDeadlineTimer();
     } catch (const boost::system::system_error& e) {
         LOG_ERROR("Failed to initialize connection: " << e.what());
-        close();
+        close(ResultRetryable);
         return;
     }
 
@@ -368,7 +370,7 @@ void ClientConnection::handleTcpConnected(const boost::system::error_code& err,
             cnxString_ = cnxStringStream.str();
         } catch (const boost::system::system_error& e) {
             LOG_ERROR("Failed to get endpoint: " << e.what());
-            close();
+            close(ResultRetryable);
             return;
         }
         if (logicalAddress_ == physicalAddress_) {
@@ -450,11 +452,16 @@ void ClientConnection::handleTcpConnected(const boost::system::error_code& err,
                                    std::bind(&ClientConnection::handleTcpConnected, shared_from_this(),
                                              std::placeholders::_1, ++endpointIterator));
         } else {
-            close();
+            if (err == boost::asio::error::operation_aborted) {
+                // TCP connect timeout, which is not retryable
+                close();
+            } else {
+                close(ResultRetryable);
+            }
         }
     } else {
         LOG_ERROR(cnxString_ << "Failed to establish connection: " << err.message());
-        close();
+        close(ResultRetryable);
     }
 }
 
@@ -913,7 +920,8 @@ void ClientConnection::handleIncomingCommand() {
                                                      << " error: " << partitionMetadataResponse.error()
                                                      << " msg: " << partitionMetadataResponse.message());
                                 checkServerError(partitionMetadataResponse.error());
-                                lookupDataPromise->setFailed(getResult(partitionMetadataResponse.error()));
+                                lookupDataPromise->setFailed(getResult(partitionMetadataResponse.error(),
+                                                                       partitionMetadataResponse.message()));
                             } else {
                                 LOG_ERROR(cnxString_ << "Failed partition-metadata lookup req_id: "
                                                      << partitionMetadataResponse.request_id()
@@ -952,7 +960,8 @@ void ClientConnection::handleIncomingCommand() {
                                 LOG_ERROR(cnxString_ << " Failed to get consumer stats - "
                                                      << consumerStatsResponse.error_message());
                             }
-                            consumerStatsPromise.setFailed(getResult(consumerStatsResponse.error_code()));
+                            consumerStatsPromise.setFailed(getResult(consumerStatsResponse.error_code(),
+                                                                     consumerStatsResponse.error_message()));
                         } else {
                             LOG_DEBUG(cnxString_ << "ConsumerStatsResponse command - Received consumer stats "
                                                     "response from server. req_id: "
@@ -1000,7 +1009,8 @@ void ClientConnection::handleIncomingCommand() {
                                           << " error: " << lookupTopicResponse.error()
                                           << " msg: " << lookupTopicResponse.message());
                                 checkServerError(lookupTopicResponse.error());
-                                lookupDataPromise->setFailed(getResult(lookupTopicResponse.error()));
+                                lookupDataPromise->setFailed(
+                                    getResult(lookupTopicResponse.error(), lookupTopicResponse.message()));
                             } else {
                                 LOG_ERROR(cnxString_
                                           << "Failed lookup req_id: " << lookupTopicResponse.request_id()
@@ -1067,7 +1077,7 @@ void ClientConnection::handleIncomingCommand() {
 
                 case BaseCommand::ERROR: {
                     const CommandError& error = incomingCmd_.error();
-                    Result result = getResult(error.error());
+                    Result result = getResult(error.error(), error.message());
                     LOG_WARN(cnxString_ << "Received error response from server: " << result
                                         << (error.has_message() ? (" (" + error.message() + ")") : "")
                                         << " -- req_id: " << error.request_id());
@@ -1080,7 +1090,7 @@ void ClientConnection::handleIncomingCommand() {
                         pendingRequests_.erase(it);
                         lock.unlock();
 
-                        requestData.promise.setFailed(getResult(error.error()));
+                        requestData.promise.setFailed(result);
                         requestData.timer->cancel();
                     } else {
                         PendingGetLastMessageIdRequestsMap::iterator it =
@@ -1090,7 +1100,7 @@ void ClientConnection::handleIncomingCommand() {
                             pendingGetLastMessageIdRequests_.erase(it);
                             lock.unlock();
 
-                            getLastMessageIdPromise.setFailed(getResult(error.error()));
+                            getLastMessageIdPromise.setFailed(result);
                         } else {
                             PendingGetNamespaceTopicsMap::iterator it =
                                 pendingGetNamespaceTopicsRequests_.find(error.request_id());
@@ -1099,7 +1109,7 @@ void ClientConnection::handleIncomingCommand() {
                                 pendingGetNamespaceTopicsRequests_.erase(it);
                                 lock.unlock();
 
-                                getNamespaceTopicsPromise.setFailed(getResult(error.error()));
+                                getNamespaceTopicsPromise.setFailed(result);
                             } else {
                                 lock.unlock();
                             }
@@ -1557,34 +1567,34 @@ void ClientConnection::close(Result result) {
     }
 
     lock.unlock();
-    LOG_INFO(cnxString_ << "Connection closed");
+    LOG_INFO(cnxString_ << "Connection closed with " << result);
 
     for (ProducersMap::iterator it = producers.begin(); it != producers.end(); ++it) {
-        HandlerBase::handleDisconnection(ResultConnectError, shared_from_this(), it->second);
+        HandlerBase::handleDisconnection(result, shared_from_this(), it->second);
     }
 
     for (ConsumersMap::iterator it = consumers.begin(); it != consumers.end(); ++it) {
-        HandlerBase::handleDisconnection(ResultConnectError, shared_from_this(), it->second);
+        HandlerBase::handleDisconnection(result, shared_from_this(), it->second);
     }
 
     connectPromise_.setFailed(result);
 
     // Fail all pending requests, all these type are map whose value type contains the Promise object
     for (auto& kv : pendingRequests) {
-        kv.second.promise.setFailed(ResultConnectError);
+        kv.second.promise.setFailed(result);
     }
     for (auto& kv : pendingLookupRequests) {
-        kv.second.promise->setFailed(ResultConnectError);
+        kv.second.promise->setFailed(result);
     }
     for (auto& kv : pendingConsumerStatsMap) {
         LOG_ERROR(cnxString_ << " Closing Client Connection, please try again later");
-        kv.second.setFailed(ResultConnectError);
+        kv.second.setFailed(result);
     }
     for (auto& kv : pendingGetLastMessageIdRequests) {
-        kv.second.setFailed(ResultConnectError);
+        kv.second.setFailed(result);
     }
     for (auto& kv : pendingGetNamespaceTopicsRequests) {
-        kv.second.setFailed(ResultConnectError);
+        kv.second.setFailed(result);
     }
 }
 

--- a/pulsar-client-cpp/lib/ClientImpl.h
+++ b/pulsar-client-cpp/lib/ClientImpl.h
@@ -21,7 +21,7 @@
 
 #include <pulsar/Client.h>
 #include "ExecutorService.h"
-#include "BinaryProtoLookupService.h"
+#include "LookupService.h"
 #include "MemoryLimitController.h"
 #include "ConnectionPool.h"
 #include "LookupDataResult.h"

--- a/pulsar-client-cpp/lib/HTTPLookupService.cc
+++ b/pulsar-client-cpp/lib/HTTPLookupService.cc
@@ -265,6 +265,9 @@ Result HTTPLookupService::sendHTTPRequest(std::string completeUrl, std::string &
                 }
                 break;
             case CURLE_COULDNT_CONNECT:
+                LOG_ERROR("Response failed for url " << completeUrl << ". Error Code " << res);
+                retResult = ResultRetryable;
+                break;
             case CURLE_COULDNT_RESOLVE_PROXY:
             case CURLE_COULDNT_RESOLVE_HOST:
             case CURLE_HTTP_RETURNED_ERROR:

--- a/pulsar-client-cpp/lib/HandlerBase.cc
+++ b/pulsar-client-cpp/lib/HandlerBase.cc
@@ -121,14 +121,7 @@ void HandlerBase::handleDisconnection(Result result, ClientConnectionWeakPtr con
     }
 }
 
-bool HandlerBase::isRetriableError(Result result) {
-    switch (result) {
-        case ResultServiceUnitNotReady:
-            return true;
-        default:
-            return false;
-    }
-}
+bool HandlerBase::isRetriableError(Result result) { return result == ResultRetryable; }
 
 void HandlerBase::scheduleReconnection(HandlerBasePtr handler) {
     const auto state = handler->state_.load();

--- a/pulsar-client-cpp/lib/HandlerBase.cc
+++ b/pulsar-client-cpp/lib/HandlerBase.cc
@@ -105,6 +105,11 @@ void HandlerBase::handleDisconnection(Result result, ClientConnectionWeakPtr con
 
     handler->connection_.reset();
 
+    if (result == ResultRetryable) {
+        scheduleReconnection(handler);
+        return;
+    }
+
     switch (state) {
         case Pending:
         case Ready:

--- a/pulsar-client-cpp/lib/Result.cc
+++ b/pulsar-client-cpp/lib/Result.cc
@@ -25,6 +25,9 @@ namespace pulsar {
 
 const char* strResult(Result result) {
     switch (result) {
+        case ResultRetryable:
+            return "Retryable";
+
         case ResultOk:
             return "Ok";
 

--- a/pulsar-client-cpp/lib/RetryableLookupService.h
+++ b/pulsar-client-cpp/lib/RetryableLookupService.h
@@ -1,0 +1,151 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+#pragma once
+
+#include <algorithm>
+#include <memory>
+#include "lib/Backoff.h"
+#include "lib/ExecutorService.h"
+#include "lib/LookupService.h"
+#include "lib/SynchronizedHashMap.h"
+#include "lib/LogUtils.h"
+
+namespace pulsar {
+
+class RetryableLookupService : public LookupService,
+                               public std::enable_shared_from_this<RetryableLookupService> {
+   private:
+    friend class PulsarFriend;
+    struct PassKey {
+        explicit PassKey() {}
+    };
+
+   public:
+    template <typename... Args>
+    explicit RetryableLookupService(PassKey, Args&&... args)
+        : RetryableLookupService(std::forward<Args>(args)...) {}
+
+    template <typename... Args>
+    static std::shared_ptr<RetryableLookupService> create(Args&&... args) {
+        return std::make_shared<RetryableLookupService>(PassKey{}, std::forward<Args>(args)...);
+    }
+
+    LookupResultFuture getBroker(const TopicName& topicName) override {
+        return executeAsync<LookupResult>("get-broker-" + topicName.toString(),
+                                          [this, topicName] { return lookupService_->getBroker(topicName); });
+    }
+
+    Future<Result, LookupDataResultPtr> getPartitionMetadataAsync(const TopicNamePtr& topicName) override {
+        return executeAsync<LookupDataResultPtr>(
+            "get-partition-metadata-" + topicName->toString(),
+            [this, topicName] { return lookupService_->getPartitionMetadataAsync(topicName); });
+    }
+
+    Future<Result, NamespaceTopicsPtr> getTopicsOfNamespaceAsync(const NamespaceNamePtr& nsName) override {
+        return executeAsync<NamespaceTopicsPtr>(
+            "get-topics-of-namespace-" + nsName->toString(),
+            [this, nsName] { return lookupService_->getTopicsOfNamespaceAsync(nsName); });
+    }
+
+    template <typename T>
+    Future<Result, T> executeAsync(const std::string& key, std::function<Future<Result, T>()> f) {
+        Promise<Result, T> promise;
+        executeAsyncImpl(key, f, promise, timeout_);
+        return promise.getFuture();
+    }
+
+   private:
+    const std::shared_ptr<LookupService> lookupService_;
+    const TimeDuration timeout_;
+    Backoff backoff_;
+    const ExecutorServiceProviderPtr executorProvider_;
+
+    using Timer = boost::asio::deadline_timer;
+    using TimerPtr = std::unique_ptr<Timer>;
+    SynchronizedHashMap<std::string, TimerPtr> backoffTimers_;
+
+    RetryableLookupService(std::shared_ptr<LookupService> lookupService, int timeoutSeconds,
+                           ExecutorServiceProviderPtr executorProvider)
+        : lookupService_(lookupService),
+          timeout_(boost::posix_time::seconds(timeoutSeconds)),
+          backoff_(boost::posix_time::milliseconds(100), timeout_ + timeout_,
+                   boost::posix_time::milliseconds(0)),
+          executorProvider_(executorProvider) {}
+
+    std::weak_ptr<RetryableLookupService> weak_from_this() noexcept { return shared_from_this(); }
+
+    // NOTE: Set the visibility to fix compilation error in GCC 6
+    template <typename T>
+#ifndef _WIN32
+    __attribute__((visibility("hidden")))
+#endif
+    void
+    executeAsyncImpl(const std::string& key, std::function<Future<Result, T>()> f, Promise<Result, T> promise,
+                     TimeDuration remainingTime) {
+        auto weakSelf = weak_from_this();
+        f().addListener([this, weakSelf, key, f, promise, remainingTime](Result result, const T& value) {
+            auto self = weakSelf.lock();
+            if (!self) {
+                return;
+            }
+
+            if (result == ResultOk) {
+                backoffTimers_.remove(key);
+                promise.setValue(value);
+            } else if (result == ResultRetryable) {
+                if (remainingTime.total_milliseconds() <= 0) {
+                    backoffTimers_.remove(key);
+                    promise.setFailed(ResultTimeout);
+                    return;
+                }
+
+                auto it = backoffTimers_.emplace(
+                    key, TimerPtr{new Timer(executorProvider_->get()->getIOService())});
+                auto& timer = *(it.first->second);
+                auto delay = std::min(backoff_.next(), remainingTime);
+                timer.expires_from_now(delay);
+
+                auto nextRemainingTime = remainingTime - delay;
+                LOG_INFO("Reschedule " << key << " for " << delay.total_milliseconds()
+                                       << " ms, remaining time: " << nextRemainingTime.total_milliseconds()
+                                       << " ms");
+                timer.async_wait([this, weakSelf, key, f, promise,
+                                  nextRemainingTime](const boost::system::error_code& ec) {
+                    auto self = weakSelf.lock();
+                    if (!self || ec) {
+                        if (self && ec != boost::asio::error::operation_aborted) {
+                            LOG_ERROR("The timer for " << key << " failed: " << ec.message());
+                        }
+                        // The lookup service has been destructed or the timer has been cancelled
+                        promise.setFailed(ResultTimeout);
+                        return;
+                    }
+                    executeAsyncImpl(key, f, promise, nextRemainingTime);
+                });
+            } else {
+                backoffTimers_.remove(key);
+                promise.setFailed(result);
+            }
+        });
+    }
+
+    DECLARE_LOG_OBJECT()
+};
+
+}  // namespace pulsar

--- a/pulsar-client-cpp/lib/ServiceNameResolver.h
+++ b/pulsar-client-cpp/lib/ServiceNameResolver.h
@@ -52,6 +52,8 @@ class ServiceNameResolver {
     const ServiceURI serviceUri_;
     const size_t numAddresses_;
     std::atomic_size_t index_{0};
+
+    friend class PulsarFriend;
 };
 
 }  // namespace pulsar

--- a/pulsar-client-cpp/lib/SynchronizedHashMap.h
+++ b/pulsar-client-cpp/lib/SynchronizedHashMap.h
@@ -36,6 +36,8 @@ class SynchronizedHashMap {
    public:
     using OptValue = Optional<V>;
     using PairVector = std::vector<std::pair<K, V>>;
+    using MapType = std::unordered_map<K, V>;
+    using Iterator = typename MapType::iterator;
 
     SynchronizedHashMap() = default;
 
@@ -46,9 +48,9 @@ class SynchronizedHashMap {
     }
 
     template <typename... Args>
-    void emplace(Args&&... args) {
+    std::pair<Iterator, bool> emplace(Args&&... args) {
         Lock lock(mutex_);
-        data_.emplace(std::forward<Args>(args)...);
+        return data_.emplace(std::forward<Args>(args)...);
     }
 
     void forEach(std::function<void(const K&, const V&)> f) const {
@@ -105,7 +107,7 @@ class SynchronizedHashMap {
         Lock lock(mutex_);
         auto it = data_.find(key);
         if (it != data_.end()) {
-            auto result = OptValue::of(it->second);
+            auto result = OptValue::of(std::move(it->second));
             data_.erase(it);
             return result;
         } else {

--- a/pulsar-client-cpp/lib/Utils.h
+++ b/pulsar-client-cpp/lib/Utils.h
@@ -85,6 +85,7 @@ class Optional {
      * Create an Optional with the bound value
      */
     static Optional<T> of(const T& value) { return Optional<T>(value); }
+    static Optional<T> of(T&& value) { return Optional<T>(std::move(value)); }
 
     /**
      * Create an empty optional
@@ -95,6 +96,7 @@ class Optional {
 
    private:
     Optional(const T& value) : value_(value), present_(true) {}
+    Optional(T&& value) : value_(std::move(value)), present_(true) {}
 
     T value_;
     bool present_;

--- a/pulsar-client-cpp/tests/ClientTest.cc
+++ b/pulsar-client-cpp/tests/ClientTest.cc
@@ -85,14 +85,14 @@ TEST(ClientTest, testSwHwChecksum) {
 
 TEST(ClientTest, testServerConnectError) {
     const std::string topic = "test-server-connect-error";
-    Client client("pulsar://localhost:65535");
+    Client client("pulsar://localhost:65535", ClientConfiguration().setOperationTimeoutSeconds(1));
     Producer producer;
-    ASSERT_EQ(ResultConnectError, client.createProducer(topic, producer));
+    ASSERT_EQ(ResultTimeout, client.createProducer(topic, producer));
     Consumer consumer;
-    ASSERT_EQ(ResultConnectError, client.subscribe(topic, "sub", consumer));
+    ASSERT_EQ(ResultTimeout, client.subscribe(topic, "sub", consumer));
     Reader reader;
     ReaderConfiguration readerConf;
-    ASSERT_EQ(ResultConnectError, client.createReader(topic, MessageId::earliest(), readerConf, reader));
+    ASSERT_EQ(ResultTimeout, client.createReader(topic, MessageId::earliest(), readerConf, reader));
     client.close();
 }
 
@@ -121,6 +121,9 @@ TEST(ClientTest, testConnectTimeout) {
 
     clientLow.close();
     clientDefault.close();
+
+    ASSERT_EQ(futureDefault.wait_for(std::chrono::milliseconds(10)), std::future_status::ready);
+    ASSERT_EQ(futureDefault.get(), ResultConnectError);
 }
 
 TEST(ClientTest, testGetNumberOfReferences) {
@@ -268,4 +271,22 @@ TEST(ClientTest, testWrongListener) {
     ASSERT_EQ(ResultConsumerNotInitialized, reader.close());
     ASSERT_EQ(PulsarFriend::getConsumers(client).size(), 0);
     ASSERT_EQ(ResultOk, client.close());
+}
+
+TEST(ClientTest, testMultiBrokerUrl) {
+    const std::string topic = "client-test-multi-broker-url-" + std::to_string(time(nullptr));
+    Client client("pulsar://localhost:6000,localhost");  // the 1st address is not reachable
+
+    Producer producer;
+    PulsarFriend::setServiceUrlIndex(client, 0);
+    ASSERT_EQ(ResultOk, client.createProducer(topic, producer));
+
+    Consumer consumer;
+    PulsarFriend::setServiceUrlIndex(client, 0);
+    ASSERT_EQ(ResultOk, client.subscribe(topic, "sub", consumer));
+
+    Reader reader;
+    PulsarFriend::setServiceUrlIndex(client, 0);
+    ASSERT_EQ(ResultOk, client.createReader(topic, MessageId::earliest(), {}, reader));
+    client.close();
 }

--- a/pulsar-client-cpp/tests/PulsarFriend.h
+++ b/pulsar-client-cpp/tests/PulsarFriend.h
@@ -25,6 +25,7 @@
 #include "lib/ConsumerImpl.h"
 #include "lib/MultiTopicsConsumerImpl.h"
 #include "lib/ReaderImpl.h"
+#include "lib/RetryableLookupService.h"
 
 using std::string;
 
@@ -117,6 +118,16 @@ class PulsarFriend {
 
     static boost::posix_time::ptime& getFirstBackoffTime(Backoff& backoff) {
         return backoff.firstBackoffTime_;
+    }
+
+    static void setServiceUrlIndex(ServiceNameResolver& resolver, size_t index) { resolver.index_ = index; }
+
+    static void setServiceUrlIndex(const Client& client, size_t index) {
+        setServiceUrlIndex(client.impl_->serviceNameResolver_, index);
+    }
+
+    static size_t getNumberOfPendingTasks(const RetryableLookupService& lookupService) {
+        return lookupService.backoffTimers_.size();
     }
 };
 }  // namespace pulsar


### PR DESCRIPTION
### Motivation

Currently the operation timeout only works for requests other than
lookup, like SEND and FLOW. However, the lookup requests, which are sent
by `LookupService`, should also apply the operation timeout, see

https://github.com/apache/pulsar/blob/7075a5ce0d4a70f52625ac8c3d0c48894442b72a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PulsarClientImpl.java#L1019-L1025

In addition, no attempts would be retried if lookup failed even due to a
retryable reason. For example, if some of all configured brokers were
down, the C++ client would fail immediately.

Therefore, this PR intends to retry lookup for some certain cases:
- The connection cannot be established, except connection timeout, which
  is controlled by the connection timeout.
- A `ServiceNotReady` error is received, except it's caused by
  `PulsarServerException`, e.g. the listener name is wrong.

Then, apply the operation timeout to avoid infinite retries.

### Modifications

- Add a `ResultRetryable` error code, which should only be used
  internally. Complete the futures with this error in the cases said
  previously.
- Add a `RetryableLookupService` implementation to support retries based
  on the backoff policy. Replace the directly usages of `LookupService`
  implementations with this class in `ClientImpl`.

The following tests are added:
- `ClientTest.testMultiBrokerUrl`: verify when multiple brokers are
  configured, even if one of them is not available, the creation of
  producer or consumer could still succeed.
- `LookupService.testRetry`: verify all lookup methods could be retried.
- `LookupService.testTimeout`: verify all lookup methods could be
  completed with `ResultTimeout` if no brokers are available.

### TODO

In future, we should add lookup timeout instead of operation timeout for
lookup requests and separate lookup connection pool, see PIP-91.

### Documentation

Check the box below or label this PR directly.

Need to update docs? 

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)
  
- [x] `doc-not-needed` 
(Please explain why)
  
- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)