### PR TITLE
[fix][flaky-test]DispatcherBlockConsumerTest.testBrokerSubscriptionRecovery

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/DispatcherBlockConsumerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/DispatcherBlockConsumerTest.java
@@ -616,12 +616,13 @@ public class DispatcherBlockConsumerTest extends ProducerConsumerBase {
         }
         latch.await();
         // (2) consume all messages except: unackMessages-set
-        Set<Integer> unackMessages = Sets.newHashSet(5, 10, 20, 21, 22, 23, 25, 26, 30, 32, 40, 80, 160, 320);
+        Set<Integer> unackMsgIndex = Sets.newHashSet(5, 10, 20, 21, 22, 23, 25, 26, 30, 32, 40, 80, 160, 320);
+        Set<String> unackMsgs = unackMsgIndex.stream().map(i -> "my-message-" + i).collect(Collectors.toSet());
         int receivedMsgCount = 0;
         for (int i = 0; i < totalProducedMsgs; i++) {
             Message<?> msg = consumer.receive(500, TimeUnit.MILLISECONDS);
             assertNotNull(msg);
-            if (!unackMessages.contains(i)) {
+            if (!unackMsgs.contains(new String(msg.getData()))) {
                 consumer.acknowledge(msg);
             }
             receivedMsgCount++;
@@ -643,7 +644,6 @@ public class DispatcherBlockConsumerTest extends ProducerConsumerBase {
                 .subscriptionType(SubscriptionType.Shared).subscribe();
 
         // consumer should only receive unakced messages
-        Set<String> unackMsgs = unackMessages.stream().map(i -> "my-message-" + i).collect(Collectors.toSet());
         Set<String> receivedMsgs = Sets.newHashSet();
         for (int i = 0; i < totalProducedMsgs; i++) {
             Message<?> msg = consumer.receive(500, TimeUnit.MILLISECONDS);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/DispatcherBlockConsumerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/DispatcherBlockConsumerTest.java
@@ -646,7 +646,7 @@ public class DispatcherBlockConsumerTest extends ProducerConsumerBase {
         // consumer should only receive unakced messages
         Set<String> receivedMsgs = Sets.newHashSet();
         for (int i = 0; i < totalProducedMsgs; i++) {
-            Message<?> msg = consumer.receive(500, TimeUnit.MILLISECONDS);
+            Message<?> msg = consumer.receive(5, TimeUnit.SECONDS);
             if (msg == null) {
                 break;
             }


### PR DESCRIPTION
### Motivation

test example: https://github.com/apache/pulsar/runs/8128077384?check_suite_focus=true

#### Why flaky

This test, uses the index to compare the messages, but the order of received messages is not guaranteed: 

- Subscription type is `Shared`
- Enabled streaming dispatch (There may be bugs in this scenario. I am confirming it)

![截屏2022-09-02 12 15 36](https://user-images.githubusercontent.com/25195800/188057817-b165969e-1b4a-435e-b548-dd2b8a20a3ad.png)

### Modifications

- This PR is only concerned with fixing flaky Test 
  - Compare using the content of the unack messages
- There may be bugs when enabled streaming dispatch. 
  - There should be another PR solution

### Documentation


- [ ] `doc-required` 

  
- [x] `doc-not-needed` 

  
- [ ] `doc` 


- [ ] `doc-complete`
