### PR TITLE
[fix][broker] Remove timestamp from Promtheus metrics

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/PrometheusMetricStreams.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/PrometheusMetricStreams.java
@@ -46,7 +46,7 @@ public class PrometheusMetricStreams {
                 stream.write(',');
             }
         }
-        stream.write("} ").write(value).write(' ').write(System.currentTimeMillis()).write('\n');
+        stream.write("} ").write(value).write('\n');
     }
 
     /**

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/PrometheusMetricsGenerator.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/PrometheusMetricsGenerator.java
@@ -304,8 +304,7 @@ public class PrometheusMetricsGenerator {
                         appendedQuantile = true;
                     }
                 }
-                stream.write("} ").write(String.valueOf(entry.getValue()))
-                        .write(' ').write(System.currentTimeMillis()).write("\n");
+                stream.write("} ").write(String.valueOf(entry.getValue())).write("\n");
             }
         }
     }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/PrometheusMetricsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/PrometheusMetricsTest.java
@@ -766,10 +766,10 @@ public class PrometheusMetricsTest extends BrokerTestBase {
      This can happen when including topic metrics, since the same metric is reported multiple times with different labels. For example:
 
      # TYPE pulsar_subscriptions_count gauge
-     pulsar_subscriptions_count{cluster="standalone"} 0 1556372982118
-     pulsar_subscriptions_count{cluster="standalone",namespace="public/functions",topic="persistent://public/functions/metadata"} 1.0 1556372982118
-     pulsar_subscriptions_count{cluster="standalone",namespace="public/functions",topic="persistent://public/functions/coordinate"} 1.0 1556372982118
-     pulsar_subscriptions_count{cluster="standalone",namespace="public/functions",topic="persistent://public/functions/assignments"} 1.0 1556372982118
+     pulsar_subscriptions_count{cluster="standalone"} 0
+     pulsar_subscriptions_count{cluster="standalone",namespace="public/functions",topic="persistent://public/functions/metadata"} 1.0
+     pulsar_subscriptions_count{cluster="standalone",namespace="public/functions",topic="persistent://public/functions/coordinate"} 1.0
+     pulsar_subscriptions_count{cluster="standalone",namespace="public/functions",topic="persistent://public/functions/assignments"} 1.0
 
      **/
     // Running the test twice to make sure types are present when generated multiple times
@@ -1598,8 +1598,8 @@ public class PrometheusMetricsTest extends BrokerTestBase {
         // jvm_threads_current{cluster="standalone",} 203.0
         // or
         // pulsar_subscriptions_count{cluster="standalone", namespace="public/default",
-        // topic="persistent://public/default/test-2"} 0.0 1517945780897
-        Pattern pattern = Pattern.compile("^(\\w+)\\{([^\\}]+)\\}\\s([+-]?[\\d\\w\\.-]+)(\\s(\\d+))?$");
+        // topic="persistent://public/default/test-2"} 0.0
+        Pattern pattern = Pattern.compile("^(\\w+)\\{([^\\}]+)\\}\\s([+-]?[\\d\\w\\.-]+)$");
         Pattern tagsPattern = Pattern.compile("(\\w+)=\"([^\"]+)\"(,\\s?)?");
 
         Splitter.on("\n").split(metrics).forEach(line -> {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/functions/worker/PulsarFunctionTestUtils.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/functions/worker/PulsarFunctionTestUtils.java
@@ -74,8 +74,8 @@ public class PulsarFunctionTestUtils {
         // jvm_threads_current{cluster="standalone",} 203.0
         // or
         // pulsar_subscriptions_count{cluster="standalone", namespace="public/default",
-        // topic="persistent://public/default/test-2"} 0.0 1517945780897
-        Pattern pattern = Pattern.compile("^(\\w+)(\\{[^\\}]+\\})?\\s([+-]?[\\d\\w\\.-]+)(\\s(\\d+))?$");
+        // topic="persistent://public/default/test-2"} 0.0
+        Pattern pattern = Pattern.compile("^(\\w+)(\\{[^\\}]+\\})?\\s([+-]?[\\d\\w\\.-]+)$");
         Pattern tagsPattern = Pattern.compile("(\\w+)=\"([^\"]+)\"(,\\s?)?");
         Arrays.asList(metrics.split("\n")).forEach(line -> {
             if (line.isEmpty() || line.startsWith("#")) {

--- a/pulsar-broker/src/test/resources/prometheus_metrics_sample.txt
+++ b/pulsar-broker/src/test/resources/prometheus_metrics_sample.txt
@@ -316,318 +316,318 @@ pulsar_authentication_failures_total{cluster="use",provider_name="Authentication
 # TYPE pulsar_broker_lookup_answers counter
 pulsar_broker_lookup_answers{cluster="use"} 134.0
 # TYPE pulsar_topics_count gauge
-pulsar_topics_count{cluster="use"} 0 1617950344967
+pulsar_topics_count{cluster="use"} 0
 # TYPE pulsar_subscriptions_count gauge
-pulsar_subscriptions_count{cluster="use"} 0 1617950344967
+pulsar_subscriptions_count{cluster="use"} 0
 # TYPE pulsar_producers_count gauge
-pulsar_producers_count{cluster="use"} 0 1617950344967
+pulsar_producers_count{cluster="use"} 0
 # TYPE pulsar_consumers_count gauge
-pulsar_consumers_count{cluster="use"} 0 1617950344967
+pulsar_consumers_count{cluster="use"} 0
 # TYPE pulsar_rate_in gauge
-pulsar_rate_in{cluster="use"} 0 1617950344967
+pulsar_rate_in{cluster="use"} 0
 # TYPE pulsar_rate_out gauge
-pulsar_rate_out{cluster="use"} 0 1617950344967
+pulsar_rate_out{cluster="use"} 0
 # TYPE pulsar_throughput_in gauge
-pulsar_throughput_in{cluster="use"} 0 1617950344967
+pulsar_throughput_in{cluster="use"} 0
 # TYPE pulsar_throughput_out gauge
-pulsar_throughput_out{cluster="use"} 0 1617950344967
+pulsar_throughput_out{cluster="use"} 0
 # TYPE pulsar_storage_size gauge
-pulsar_storage_size{cluster="use"} 0 1617950344967
+pulsar_storage_size{cluster="use"} 0
 # TYPE pulsar_storage_write_rate gauge
-pulsar_storage_write_rate{cluster="use"} 0 1617950344967
+pulsar_storage_write_rate{cluster="use"} 0
 # TYPE pulsar_storage_read_rate gauge
-pulsar_storage_read_rate{cluster="use"} 0 1617950344967
+pulsar_storage_read_rate{cluster="use"} 0
 # TYPE pulsar_msg_backlog gauge
-pulsar_msg_backlog{cluster="use"} 0 1617950344967
-pulsar_subscriptions_count{cluster="use",namespace="external-repl-prop/io",topic="persistent://external-repl-prop/io/my-topic1"} 1.0 1617950344967
-pulsar_producers_count{cluster="use",namespace="external-repl-prop/io",topic="persistent://external-repl-prop/io/my-topic1"} 1.0 1617950344967
-pulsar_consumers_count{cluster="use",namespace="external-repl-prop/io",topic="persistent://external-repl-prop/io/my-topic1"} 1.0 1617950344967
-pulsar_rate_in{cluster="use",namespace="external-repl-prop/io",topic="persistent://external-repl-prop/io/my-topic1"} 0.0 1617950344967
-pulsar_rate_out{cluster="use",namespace="external-repl-prop/io",topic="persistent://external-repl-prop/io/my-topic1"} 0.0 1617950344967
-pulsar_throughput_in{cluster="use",namespace="external-repl-prop/io",topic="persistent://external-repl-prop/io/my-topic1"} 0.0 1617950344967
-pulsar_throughput_out{cluster="use",namespace="external-repl-prop/io",topic="persistent://external-repl-prop/io/my-topic1"} 0.0 1617950344967
-pulsar_storage_size{cluster="use",namespace="external-repl-prop/io",topic="persistent://external-repl-prop/io/my-topic1"} 0.0 1617950344967
-pulsar_msg_backlog{cluster="use",namespace="external-repl-prop/io",topic="persistent://external-repl-prop/io/my-topic1"} 0.0 1617950344967
+pulsar_msg_backlog{cluster="use"} 0
+pulsar_subscriptions_count{cluster="use",namespace="external-repl-prop/io",topic="persistent://external-repl-prop/io/my-topic1"} 1.0
+pulsar_producers_count{cluster="use",namespace="external-repl-prop/io",topic="persistent://external-repl-prop/io/my-topic1"} 1.0
+pulsar_consumers_count{cluster="use",namespace="external-repl-prop/io",topic="persistent://external-repl-prop/io/my-topic1"} 1.0
+pulsar_rate_in{cluster="use",namespace="external-repl-prop/io",topic="persistent://external-repl-prop/io/my-topic1"} 0.0
+pulsar_rate_out{cluster="use",namespace="external-repl-prop/io",topic="persistent://external-repl-prop/io/my-topic1"} 0.0
+pulsar_throughput_in{cluster="use",namespace="external-repl-prop/io",topic="persistent://external-repl-prop/io/my-topic1"} 0.0
+pulsar_throughput_out{cluster="use",namespace="external-repl-prop/io",topic="persistent://external-repl-prop/io/my-topic1"} 0.0
+pulsar_storage_size{cluster="use",namespace="external-repl-prop/io",topic="persistent://external-repl-prop/io/my-topic1"} 0.0
+pulsar_msg_backlog{cluster="use",namespace="external-repl-prop/io",topic="persistent://external-repl-prop/io/my-topic1"} 0.0
 # TYPE pulsar_storage_backlog_size gauge
-pulsar_storage_backlog_size{cluster="use",namespace="external-repl-prop/io",topic="persistent://external-repl-prop/io/my-topic1"} 0.0 1617950344967
+pulsar_storage_backlog_size{cluster="use",namespace="external-repl-prop/io",topic="persistent://external-repl-prop/io/my-topic1"} 0.0
 # TYPE pulsar_storage_offloaded_size gauge
-pulsar_storage_offloaded_size{cluster="use",namespace="external-repl-prop/io",topic="persistent://external-repl-prop/io/my-topic1"} 0.0 1617950344967
+pulsar_storage_offloaded_size{cluster="use",namespace="external-repl-prop/io",topic="persistent://external-repl-prop/io/my-topic1"} 0.0
 # TYPE pulsar_storage_backlog_quota_limit gauge
-pulsar_storage_backlog_quota_limit{cluster="use",namespace="external-repl-prop/io",topic="persistent://external-repl-prop/io/my-topic1"} -1073741824.0 1617950344967
+pulsar_storage_backlog_quota_limit{cluster="use",namespace="external-repl-prop/io",topic="persistent://external-repl-prop/io/my-topic1"} -1073741824.0
 # TYPE pulsar_storage_write_latency_le_0_5 gauge
-pulsar_storage_write_latency_le_0_5{cluster="use",namespace="external-repl-prop/io",topic="persistent://external-repl-prop/io/my-topic1"} 0.0 1617950344967
+pulsar_storage_write_latency_le_0_5{cluster="use",namespace="external-repl-prop/io",topic="persistent://external-repl-prop/io/my-topic1"} 0.0
 # TYPE pulsar_storage_write_latency_le_1 gauge
-pulsar_storage_write_latency_le_1{cluster="use",namespace="external-repl-prop/io",topic="persistent://external-repl-prop/io/my-topic1"} 0.0 1617950344967
+pulsar_storage_write_latency_le_1{cluster="use",namespace="external-repl-prop/io",topic="persistent://external-repl-prop/io/my-topic1"} 0.0
 # TYPE pulsar_storage_write_latency_le_5 gauge
-pulsar_storage_write_latency_le_5{cluster="use",namespace="external-repl-prop/io",topic="persistent://external-repl-prop/io/my-topic1"} 0.0 1617950344967
+pulsar_storage_write_latency_le_5{cluster="use",namespace="external-repl-prop/io",topic="persistent://external-repl-prop/io/my-topic1"} 0.0
 # TYPE pulsar_storage_write_latency_le_10 gauge
-pulsar_storage_write_latency_le_10{cluster="use",namespace="external-repl-prop/io",topic="persistent://external-repl-prop/io/my-topic1"} 0.0 1617950344967
+pulsar_storage_write_latency_le_10{cluster="use",namespace="external-repl-prop/io",topic="persistent://external-repl-prop/io/my-topic1"} 0.0
 # TYPE pulsar_storage_write_latency_le_20 gauge
-pulsar_storage_write_latency_le_20{cluster="use",namespace="external-repl-prop/io",topic="persistent://external-repl-prop/io/my-topic1"} 0.0 1617950344967
+pulsar_storage_write_latency_le_20{cluster="use",namespace="external-repl-prop/io",topic="persistent://external-repl-prop/io/my-topic1"} 0.0
 # TYPE pulsar_storage_write_latency_le_50 gauge
-pulsar_storage_write_latency_le_50{cluster="use",namespace="external-repl-prop/io",topic="persistent://external-repl-prop/io/my-topic1"} 0.0 1617950344967
+pulsar_storage_write_latency_le_50{cluster="use",namespace="external-repl-prop/io",topic="persistent://external-repl-prop/io/my-topic1"} 0.0
 # TYPE pulsar_storage_write_latency_le_100 gauge
-pulsar_storage_write_latency_le_100{cluster="use",namespace="external-repl-prop/io",topic="persistent://external-repl-prop/io/my-topic1"} 0.0 1617950344967
+pulsar_storage_write_latency_le_100{cluster="use",namespace="external-repl-prop/io",topic="persistent://external-repl-prop/io/my-topic1"} 0.0
 # TYPE pulsar_storage_write_latency_le_200 gauge
-pulsar_storage_write_latency_le_200{cluster="use",namespace="external-repl-prop/io",topic="persistent://external-repl-prop/io/my-topic1"} 0.0 1617950344967
+pulsar_storage_write_latency_le_200{cluster="use",namespace="external-repl-prop/io",topic="persistent://external-repl-prop/io/my-topic1"} 0.0
 # TYPE pulsar_storage_write_latency_le_1000 gauge
-pulsar_storage_write_latency_le_1000{cluster="use",namespace="external-repl-prop/io",topic="persistent://external-repl-prop/io/my-topic1"} 0.0 1617950344967
+pulsar_storage_write_latency_le_1000{cluster="use",namespace="external-repl-prop/io",topic="persistent://external-repl-prop/io/my-topic1"} 0.0
 # TYPE pulsar_storage_write_latency_overflow gauge
-pulsar_storage_write_latency_overflow{cluster="use",namespace="external-repl-prop/io",topic="persistent://external-repl-prop/io/my-topic1"} 0.0 1617950344967
+pulsar_storage_write_latency_overflow{cluster="use",namespace="external-repl-prop/io",topic="persistent://external-repl-prop/io/my-topic1"} 0.0
 # TYPE pulsar_storage_write_latency_count gauge
-pulsar_storage_write_latency_count{cluster="use",namespace="external-repl-prop/io",topic="persistent://external-repl-prop/io/my-topic1"} 0.0 1617950344967
+pulsar_storage_write_latency_count{cluster="use",namespace="external-repl-prop/io",topic="persistent://external-repl-prop/io/my-topic1"} 0.0
 # TYPE pulsar_storage_write_latency_sum gauge
-pulsar_storage_write_latency_sum{cluster="use",namespace="external-repl-prop/io",topic="persistent://external-repl-prop/io/my-topic1"} 0.0 1617950344967
+pulsar_storage_write_latency_sum{cluster="use",namespace="external-repl-prop/io",topic="persistent://external-repl-prop/io/my-topic1"} 0.0
 # TYPE pulsar_storage_ledger_write_latency_le_0_5 gauge
-pulsar_storage_ledger_write_latency_le_0_5{cluster="use",namespace="external-repl-prop/io",topic="persistent://external-repl-prop/io/my-topic1"} 0.0 1617950344967
+pulsar_storage_ledger_write_latency_le_0_5{cluster="use",namespace="external-repl-prop/io",topic="persistent://external-repl-prop/io/my-topic1"} 0.0
 # TYPE pulsar_storage_ledger_write_latency_le_1 gauge
-pulsar_storage_ledger_write_latency_le_1{cluster="use",namespace="external-repl-prop/io",topic="persistent://external-repl-prop/io/my-topic1"} 0.0 1617950344967
+pulsar_storage_ledger_write_latency_le_1{cluster="use",namespace="external-repl-prop/io",topic="persistent://external-repl-prop/io/my-topic1"} 0.0
 # TYPE pulsar_storage_ledger_write_latency_le_5 gauge
-pulsar_storage_ledger_write_latency_le_5{cluster="use",namespace="external-repl-prop/io",topic="persistent://external-repl-prop/io/my-topic1"} 0.0 1617950344967
+pulsar_storage_ledger_write_latency_le_5{cluster="use",namespace="external-repl-prop/io",topic="persistent://external-repl-prop/io/my-topic1"} 0.0
 # TYPE pulsar_storage_ledger_write_latency_le_10 gauge
-pulsar_storage_ledger_write_latency_le_10{cluster="use",namespace="external-repl-prop/io",topic="persistent://external-repl-prop/io/my-topic1"} 0.0 1617950344967
+pulsar_storage_ledger_write_latency_le_10{cluster="use",namespace="external-repl-prop/io",topic="persistent://external-repl-prop/io/my-topic1"} 0.0
 # TYPE pulsar_storage_ledger_write_latency_le_20 gauge
-pulsar_storage_ledger_write_latency_le_20{cluster="use",namespace="external-repl-prop/io",topic="persistent://external-repl-prop/io/my-topic1"} 0.0 1617950344967
+pulsar_storage_ledger_write_latency_le_20{cluster="use",namespace="external-repl-prop/io",topic="persistent://external-repl-prop/io/my-topic1"} 0.0
 # TYPE pulsar_storage_ledger_write_latency_le_50 gauge
-pulsar_storage_ledger_write_latency_le_50{cluster="use",namespace="external-repl-prop/io",topic="persistent://external-repl-prop/io/my-topic1"} 0.0 1617950344967
+pulsar_storage_ledger_write_latency_le_50{cluster="use",namespace="external-repl-prop/io",topic="persistent://external-repl-prop/io/my-topic1"} 0.0
 # TYPE pulsar_storage_ledger_write_latency_le_100 gauge
-pulsar_storage_ledger_write_latency_le_100{cluster="use",namespace="external-repl-prop/io",topic="persistent://external-repl-prop/io/my-topic1"} 0.0 1617950344967
+pulsar_storage_ledger_write_latency_le_100{cluster="use",namespace="external-repl-prop/io",topic="persistent://external-repl-prop/io/my-topic1"} 0.0
 # TYPE pulsar_storage_ledger_write_latency_le_200 gauge
-pulsar_storage_ledger_write_latency_le_200{cluster="use",namespace="external-repl-prop/io",topic="persistent://external-repl-prop/io/my-topic1"} 0.0 1617950344967
+pulsar_storage_ledger_write_latency_le_200{cluster="use",namespace="external-repl-prop/io",topic="persistent://external-repl-prop/io/my-topic1"} 0.0
 # TYPE pulsar_storage_ledger_write_latency_le_1000 gauge
-pulsar_storage_ledger_write_latency_le_1000{cluster="use",namespace="external-repl-prop/io",topic="persistent://external-repl-prop/io/my-topic1"} 0.0 1617950344967
+pulsar_storage_ledger_write_latency_le_1000{cluster="use",namespace="external-repl-prop/io",topic="persistent://external-repl-prop/io/my-topic1"} 0.0
 # TYPE pulsar_storage_ledger_write_latency_overflow gauge
-pulsar_storage_ledger_write_latency_overflow{cluster="use",namespace="external-repl-prop/io",topic="persistent://external-repl-prop/io/my-topic1"} 0.0 1617950344967
+pulsar_storage_ledger_write_latency_overflow{cluster="use",namespace="external-repl-prop/io",topic="persistent://external-repl-prop/io/my-topic1"} 0.0
 # TYPE pulsar_storage_ledger_write_latency_count gauge
-pulsar_storage_ledger_write_latency_count{cluster="use",namespace="external-repl-prop/io",topic="persistent://external-repl-prop/io/my-topic1"} 0.0 1617950344967
+pulsar_storage_ledger_write_latency_count{cluster="use",namespace="external-repl-prop/io",topic="persistent://external-repl-prop/io/my-topic1"} 0.0
 # TYPE pulsar_storage_ledger_write_latency_sum gauge
-pulsar_storage_ledger_write_latency_sum{cluster="use",namespace="external-repl-prop/io",topic="persistent://external-repl-prop/io/my-topic1"} 0.0 1617950344967
+pulsar_storage_ledger_write_latency_sum{cluster="use",namespace="external-repl-prop/io",topic="persistent://external-repl-prop/io/my-topic1"} 0.0
 # TYPE pulsar_entry_size_le_128 gauge
-pulsar_entry_size_le_128{cluster="use",namespace="external-repl-prop/io",topic="persistent://external-repl-prop/io/my-topic1"} 0.0 1617950344967
+pulsar_entry_size_le_128{cluster="use",namespace="external-repl-prop/io",topic="persistent://external-repl-prop/io/my-topic1"} 0.0
 # TYPE pulsar_entry_size_le_512 gauge
-pulsar_entry_size_le_512{cluster="use",namespace="external-repl-prop/io",topic="persistent://external-repl-prop/io/my-topic1"} 0.0 1617950344967
+pulsar_entry_size_le_512{cluster="use",namespace="external-repl-prop/io",topic="persistent://external-repl-prop/io/my-topic1"} 0.0
 # TYPE pulsar_entry_size_le_1_kb gauge
-pulsar_entry_size_le_1_kb{cluster="use",namespace="external-repl-prop/io",topic="persistent://external-repl-prop/io/my-topic1"} 0.0 1617950344967
+pulsar_entry_size_le_1_kb{cluster="use",namespace="external-repl-prop/io",topic="persistent://external-repl-prop/io/my-topic1"} 0.0
 # TYPE pulsar_entry_size_le_2_kb gauge
-pulsar_entry_size_le_2_kb{cluster="use",namespace="external-repl-prop/io",topic="persistent://external-repl-prop/io/my-topic1"} 0.0 1617950344967
+pulsar_entry_size_le_2_kb{cluster="use",namespace="external-repl-prop/io",topic="persistent://external-repl-prop/io/my-topic1"} 0.0
 # TYPE pulsar_entry_size_le_4_kb gauge
-pulsar_entry_size_le_4_kb{cluster="use",namespace="external-repl-prop/io",topic="persistent://external-repl-prop/io/my-topic1"} 0.0 1617950344967
+pulsar_entry_size_le_4_kb{cluster="use",namespace="external-repl-prop/io",topic="persistent://external-repl-prop/io/my-topic1"} 0.0
 # TYPE pulsar_entry_size_le_16_kb gauge
-pulsar_entry_size_le_16_kb{cluster="use",namespace="external-repl-prop/io",topic="persistent://external-repl-prop/io/my-topic1"} 0.0 1617950344967
+pulsar_entry_size_le_16_kb{cluster="use",namespace="external-repl-prop/io",topic="persistent://external-repl-prop/io/my-topic1"} 0.0
 # TYPE pulsar_entry_size_le_100_kb gauge
-pulsar_entry_size_le_100_kb{cluster="use",namespace="external-repl-prop/io",topic="persistent://external-repl-prop/io/my-topic1"} 0.0 1617950344967
+pulsar_entry_size_le_100_kb{cluster="use",namespace="external-repl-prop/io",topic="persistent://external-repl-prop/io/my-topic1"} 0.0
 # TYPE pulsar_entry_size_le_1_mb gauge
-pulsar_entry_size_le_1_mb{cluster="use",namespace="external-repl-prop/io",topic="persistent://external-repl-prop/io/my-topic1"} 0.0 1617950344967
+pulsar_entry_size_le_1_mb{cluster="use",namespace="external-repl-prop/io",topic="persistent://external-repl-prop/io/my-topic1"} 0.0
 # TYPE pulsar_entry_size_le_overflow gauge
-pulsar_entry_size_le_overflow{cluster="use",namespace="external-repl-prop/io",topic="persistent://external-repl-prop/io/my-topic1"} 0.0 1617950344967
+pulsar_entry_size_le_overflow{cluster="use",namespace="external-repl-prop/io",topic="persistent://external-repl-prop/io/my-topic1"} 0.0
 # TYPE pulsar_entry_size_count gauge
-pulsar_entry_size_count{cluster="use",namespace="external-repl-prop/io",topic="persistent://external-repl-prop/io/my-topic1"} 0.0 1617950344967
+pulsar_entry_size_count{cluster="use",namespace="external-repl-prop/io",topic="persistent://external-repl-prop/io/my-topic1"} 0.0
 # TYPE pulsar_entry_size_sum gauge
-pulsar_entry_size_sum{cluster="use",namespace="external-repl-prop/io",topic="persistent://external-repl-prop/io/my-topic1"} 0.0 1617950344967
+pulsar_entry_size_sum{cluster="use",namespace="external-repl-prop/io",topic="persistent://external-repl-prop/io/my-topic1"} 0.0
 # TYPE pulsar_subscription_back_log gauge
-pulsar_subscription_back_log{cluster="use",namespace="external-repl-prop/io",topic="persistent://external-repl-prop/io/my-topic1",subscription="test-sub"} 0 1617950344967
+pulsar_subscription_back_log{cluster="use",namespace="external-repl-prop/io",topic="persistent://external-repl-prop/io/my-topic1",subscription="test-sub"} 0
 # TYPE pulsar_subscription_back_log_no_delayed gauge
-pulsar_subscription_back_log_no_delayed{cluster="use",namespace="external-repl-prop/io",topic="persistent://external-repl-prop/io/my-topic1",subscription="test-sub"} 0 1617950344967
+pulsar_subscription_back_log_no_delayed{cluster="use",namespace="external-repl-prop/io",topic="persistent://external-repl-prop/io/my-topic1",subscription="test-sub"} 0
 # TYPE pulsar_subscription_delayed gauge
-pulsar_subscription_delayed{cluster="use",namespace="external-repl-prop/io",topic="persistent://external-repl-prop/io/my-topic1",subscription="test-sub"} 0 1617950344967
+pulsar_subscription_delayed{cluster="use",namespace="external-repl-prop/io",topic="persistent://external-repl-prop/io/my-topic1",subscription="test-sub"} 0
 # TYPE pulsar_subscription_msg_rate_redeliver gauge
-pulsar_subscription_msg_rate_redeliver{cluster="use",namespace="external-repl-prop/io",topic="persistent://external-repl-prop/io/my-topic1",subscription="test-sub"} 0.0 1617950344967
+pulsar_subscription_msg_rate_redeliver{cluster="use",namespace="external-repl-prop/io",topic="persistent://external-repl-prop/io/my-topic1",subscription="test-sub"} 0.0
 # TYPE pulsar_subscription_unacked_messages gauge
-pulsar_subscription_unacked_messages{cluster="use",namespace="external-repl-prop/io",topic="persistent://external-repl-prop/io/my-topic1",subscription="test-sub"} 0 1617950344967
+pulsar_subscription_unacked_messages{cluster="use",namespace="external-repl-prop/io",topic="persistent://external-repl-prop/io/my-topic1",subscription="test-sub"} 0
 # TYPE pulsar_subscription_blocked_on_unacked_messages gauge
-pulsar_subscription_blocked_on_unacked_messages{cluster="use",namespace="external-repl-prop/io",topic="persistent://external-repl-prop/io/my-topic1",subscription="test-sub"} 0 1617950344967
+pulsar_subscription_blocked_on_unacked_messages{cluster="use",namespace="external-repl-prop/io",topic="persistent://external-repl-prop/io/my-topic1",subscription="test-sub"} 0
 # TYPE pulsar_subscription_msg_rate_out gauge
-pulsar_subscription_msg_rate_out{cluster="use",namespace="external-repl-prop/io",topic="persistent://external-repl-prop/io/my-topic1",subscription="test-sub"} 0.0 1617950344967
+pulsar_subscription_msg_rate_out{cluster="use",namespace="external-repl-prop/io",topic="persistent://external-repl-prop/io/my-topic1",subscription="test-sub"} 0.0
 # TYPE pulsar_subscription_msg_throughput_out gauge
-pulsar_subscription_msg_throughput_out{cluster="use",namespace="external-repl-prop/io",topic="persistent://external-repl-prop/io/my-topic1",subscription="test-sub"} 0.0 1617950344967
+pulsar_subscription_msg_throughput_out{cluster="use",namespace="external-repl-prop/io",topic="persistent://external-repl-prop/io/my-topic1",subscription="test-sub"} 0.0
 # TYPE pulsar_out_bytes_total gauge
-pulsar_out_bytes_total{cluster="use",namespace="external-repl-prop/io",topic="persistent://external-repl-prop/io/my-topic1",subscription="test-sub"} 0 1617950344967
+pulsar_out_bytes_total{cluster="use",namespace="external-repl-prop/io",topic="persistent://external-repl-prop/io/my-topic1",subscription="test-sub"} 0
 # TYPE pulsar_out_messages_total gauge
-pulsar_out_messages_total{cluster="use",namespace="external-repl-prop/io",topic="persistent://external-repl-prop/io/my-topic1",subscription="test-sub"} 0 1617950344967
+pulsar_out_messages_total{cluster="use",namespace="external-repl-prop/io",topic="persistent://external-repl-prop/io/my-topic1",subscription="test-sub"} 0
 # TYPE pulsar_subscription_last_expire_timestamp gauge
-pulsar_subscription_last_expire_timestamp{cluster="use",namespace="external-repl-prop/io",topic="persistent://external-repl-prop/io/my-topic1",subscription="test-sub"} 0 1617950344967
+pulsar_subscription_last_expire_timestamp{cluster="use",namespace="external-repl-prop/io",topic="persistent://external-repl-prop/io/my-topic1",subscription="test-sub"} 0
 # TYPE pulsar_subscription_last_acked_timestamp gauge
-pulsar_subscription_last_acked_timestamp{cluster="use",namespace="external-repl-prop/io",topic="persistent://external-repl-prop/io/my-topic1",subscription="test-sub"} 0 1617950344967
+pulsar_subscription_last_acked_timestamp{cluster="use",namespace="external-repl-prop/io",topic="persistent://external-repl-prop/io/my-topic1",subscription="test-sub"} 0
 # TYPE pulsar_subscription_last_consumed_flow_timestamp gauge
-pulsar_subscription_last_consumed_flow_timestamp{cluster="use",namespace="external-repl-prop/io",topic="persistent://external-repl-prop/io/my-topic1",subscription="test-sub"} 1617950344921 1617950344967
+pulsar_subscription_last_consumed_flow_timestamp{cluster="use",namespace="external-repl-prop/io",topic="persistent://external-repl-prop/io/my-topic1",subscription="test-sub"} 1617950344921
 # TYPE pulsar_subscription_last_consumed_timestamp gauge
-pulsar_subscription_last_consumed_timestamp{cluster="use",namespace="external-repl-prop/io",topic="persistent://external-repl-prop/io/my-topic1",subscription="test-sub"} 0 1617950344967
+pulsar_subscription_last_consumed_timestamp{cluster="use",namespace="external-repl-prop/io",topic="persistent://external-repl-prop/io/my-topic1",subscription="test-sub"} 0
 # TYPE pulsar_subscription_last_mark_delete_advanced_timestamp gauge
-pulsar_subscription_last_mark_delete_advanced_timestamp{cluster="use",namespace="external-repl-prop/io",topic="persistent://external-repl-prop/io/my-topic1",subscription="test-sub"} 0 1617950344967
+pulsar_subscription_last_mark_delete_advanced_timestamp{cluster="use",namespace="external-repl-prop/io",topic="persistent://external-repl-prop/io/my-topic1",subscription="test-sub"} 0
 # TYPE pulsar_subscription_msg_rate_expired gauge
-pulsar_subscription_msg_rate_expired{cluster="use",namespace="external-repl-prop/io",topic="persistent://external-repl-prop/io/my-topic1",subscription="test-sub"} 0.0 1617950344967
+pulsar_subscription_msg_rate_expired{cluster="use",namespace="external-repl-prop/io",topic="persistent://external-repl-prop/io/my-topic1",subscription="test-sub"} 0.0
 # TYPE pulsar_subscription_total_msg_expired gauge
-pulsar_subscription_total_msg_expired{cluster="use",namespace="external-repl-prop/io",topic="persistent://external-repl-prop/io/my-topic1",subscription="test-sub"} 0 1617950344967
+pulsar_subscription_total_msg_expired{cluster="use",namespace="external-repl-prop/io",topic="persistent://external-repl-prop/io/my-topic1",subscription="test-sub"} 0
 # TYPE pulsar_in_bytes_total gauge
-pulsar_in_bytes_total{cluster="use",namespace="external-repl-prop/io",topic="persistent://external-repl-prop/io/my-topic1"} 0.0 1617950344967
+pulsar_in_bytes_total{cluster="use",namespace="external-repl-prop/io",topic="persistent://external-repl-prop/io/my-topic1"} 0.0
 # TYPE pulsar_in_messages_total gauge
-pulsar_in_messages_total{cluster="use",namespace="external-repl-prop/io",topic="persistent://external-repl-prop/io/my-topic1"} 0.0 1617950344967
-pulsar_topics_count{cluster="use",namespace="external-repl-prop/io"} 1 1617950344967
-pulsar_subscriptions_count{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/metadata"} 0.0 1617950344967
-pulsar_producers_count{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/metadata"} 1.0 1617950344967
-pulsar_consumers_count{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/metadata"} 0.0 1617950344967
-pulsar_rate_in{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/metadata"} 0.0 1617950344967
-pulsar_rate_out{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/metadata"} 0.0 1617950344967
-pulsar_throughput_in{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/metadata"} 0.0 1617950344967
-pulsar_throughput_out{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/metadata"} 0.0 1617950344967
-pulsar_storage_size{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/metadata"} 1728.0 1617950344967
-pulsar_msg_backlog{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/metadata"} 0.0 1617950344967
-pulsar_storage_backlog_size{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/metadata"} 0.0 1617950344967
-pulsar_storage_offloaded_size{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/metadata"} 0.0 1617950344967
-pulsar_storage_backlog_quota_limit{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/metadata"} -1073741824.0 1617950344967
-pulsar_storage_write_latency_le_0_5{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/metadata"} 0.0 1617950344967
-pulsar_storage_write_latency_le_1{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/metadata"} 0.0 1617950344967
-pulsar_storage_write_latency_le_5{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/metadata"} 0.0 1617950344967
-pulsar_storage_write_latency_le_10{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/metadata"} 0.0 1617950344967
-pulsar_storage_write_latency_le_20{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/metadata"} 0.0 1617950344967
-pulsar_storage_write_latency_le_50{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/metadata"} 0.0 1617950344967
-pulsar_storage_write_latency_le_100{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/metadata"} 0.0 1617950344967
-pulsar_storage_write_latency_le_200{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/metadata"} 0.0 1617950344967
-pulsar_storage_write_latency_le_1000{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/metadata"} 0.0 1617950344967
-pulsar_storage_write_latency_overflow{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/metadata"} 0.0 1617950344968
-pulsar_storage_write_latency_count{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/metadata"} 0.0 1617950344968
-pulsar_storage_write_latency_sum{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/metadata"} 0.0 1617950344968
-pulsar_storage_ledger_write_latency_le_0_5{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/metadata"} 0.0 1617950344968
-pulsar_storage_ledger_write_latency_le_1{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/metadata"} 0.0 1617950344968
-pulsar_storage_ledger_write_latency_le_5{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/metadata"} 0.0 1617950344968
-pulsar_storage_ledger_write_latency_le_10{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/metadata"} 0.0 1617950344968
-pulsar_storage_ledger_write_latency_le_20{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/metadata"} 0.0 1617950344968
-pulsar_storage_ledger_write_latency_le_50{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/metadata"} 0.0 1617950344968
-pulsar_storage_ledger_write_latency_le_100{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/metadata"} 0.0 1617950344968
-pulsar_storage_ledger_write_latency_le_200{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/metadata"} 0.0 1617950344968
-pulsar_storage_ledger_write_latency_le_1000{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/metadata"} 0.0 1617950344968
-pulsar_storage_ledger_write_latency_overflow{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/metadata"} 0.0 1617950344968
-pulsar_storage_ledger_write_latency_count{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/metadata"} 0.0 1617950344968
-pulsar_storage_ledger_write_latency_sum{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/metadata"} 0.0 1617950344968
-pulsar_entry_size_le_128{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/metadata"} 0.0 1617950344968
-pulsar_entry_size_le_512{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/metadata"} 0.0 1617950344968
-pulsar_entry_size_le_1_kb{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/metadata"} 0.0 1617950344968
-pulsar_entry_size_le_2_kb{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/metadata"} 0.0 1617950344968
-pulsar_entry_size_le_4_kb{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/metadata"} 0.0 1617950344968
-pulsar_entry_size_le_16_kb{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/metadata"} 0.0 1617950344968
-pulsar_entry_size_le_100_kb{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/metadata"} 0.0 1617950344968
-pulsar_entry_size_le_1_mb{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/metadata"} 0.0 1617950344968
-pulsar_entry_size_le_overflow{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/metadata"} 0.0 1617950344968
-pulsar_entry_size_count{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/metadata"} 0.0 1617950344968
-pulsar_entry_size_sum{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/metadata"} 0.0 1617950344968
-pulsar_in_bytes_total{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/metadata"} 864.0 1617950344968
-pulsar_in_messages_total{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/metadata"} 2.0 1617950344968
-pulsar_subscriptions_count{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/assignment"} 0.0 1617950344968
-pulsar_producers_count{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/assignment"} 1.0 1617950344968
-pulsar_consumers_count{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/assignment"} 0.0 1617950344968
-pulsar_rate_in{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/assignment"} 0.0 1617950344968
-pulsar_rate_out{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/assignment"} 0.0 1617950344968
-pulsar_throughput_in{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/assignment"} 0.0 1617950344968
-pulsar_throughput_out{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/assignment"} 0.0 1617950344968
-pulsar_storage_size{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/assignment"} 1748.0 1617950344968
-pulsar_msg_backlog{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/assignment"} 0.0 1617950344968
-pulsar_storage_backlog_size{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/assignment"} 0.0 1617950344968
-pulsar_storage_offloaded_size{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/assignment"} 0.0 1617950344968
-pulsar_storage_backlog_quota_limit{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/assignment"} -1073741824.0 1617950344968
-pulsar_storage_write_latency_le_0_5{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/assignment"} 0.0 1617950344968
-pulsar_storage_write_latency_le_1{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/assignment"} 0.0 1617950344968
-pulsar_storage_write_latency_le_5{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/assignment"} 0.0 1617950344968
-pulsar_storage_write_latency_le_10{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/assignment"} 0.0 1617950344968
-pulsar_storage_write_latency_le_20{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/assignment"} 0.0 1617950344968
-pulsar_storage_write_latency_le_50{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/assignment"} 0.0 1617950344968
-pulsar_storage_write_latency_le_100{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/assignment"} 0.0 1617950344968
-pulsar_storage_write_latency_le_200{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/assignment"} 0.0 1617950344968
-pulsar_storage_write_latency_le_1000{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/assignment"} 0.0 1617950344968
-pulsar_storage_write_latency_overflow{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/assignment"} 0.0 1617950344968
-pulsar_storage_write_latency_count{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/assignment"} 0.0 1617950344968
-pulsar_storage_write_latency_sum{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/assignment"} 0.0 1617950344968
-pulsar_storage_ledger_write_latency_le_0_5{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/assignment"} 0.0 1617950344968
-pulsar_storage_ledger_write_latency_le_1{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/assignment"} 0.0 1617950344968
-pulsar_storage_ledger_write_latency_le_5{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/assignment"} 0.0 1617950344968
-pulsar_storage_ledger_write_latency_le_10{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/assignment"} 0.0 1617950344968
-pulsar_storage_ledger_write_latency_le_20{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/assignment"} 0.0 1617950344968
-pulsar_storage_ledger_write_latency_le_50{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/assignment"} 0.0 1617950344968
-pulsar_storage_ledger_write_latency_le_100{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/assignment"} 0.0 1617950344968
-pulsar_storage_ledger_write_latency_le_200{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/assignment"} 0.0 1617950344968
-pulsar_storage_ledger_write_latency_le_1000{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/assignment"} 0.0 1617950344968
-pulsar_storage_ledger_write_latency_overflow{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/assignment"} 0.0 1617950344968
-pulsar_storage_ledger_write_latency_count{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/assignment"} 0.0 1617950344968
-pulsar_storage_ledger_write_latency_sum{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/assignment"} 0.0 1617950344968
-pulsar_entry_size_le_128{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/assignment"} 0.0 1617950344968
-pulsar_entry_size_le_512{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/assignment"} 0.0 1617950344968
-pulsar_entry_size_le_1_kb{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/assignment"} 0.0 1617950344968
-pulsar_entry_size_le_2_kb{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/assignment"} 0.0 1617950344968
-pulsar_entry_size_le_4_kb{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/assignment"} 0.0 1617950344968
-pulsar_entry_size_le_16_kb{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/assignment"} 0.0 1617950344968
-pulsar_entry_size_le_100_kb{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/assignment"} 0.0 1617950344968
-pulsar_entry_size_le_1_mb{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/assignment"} 0.0 1617950344968
-pulsar_entry_size_le_overflow{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/assignment"} 0.0 1617950344968
-pulsar_entry_size_count{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/assignment"} 0.0 1617950344968
-pulsar_entry_size_sum{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/assignment"} 0.0 1617950344968
-pulsar_in_bytes_total{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/assignment"} 874.0 1617950344968
-pulsar_in_messages_total{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/assignment"} 2.0 1617950344968
-pulsar_subscriptions_count{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/coordinate"} 1.0 1617950344968
-pulsar_producers_count{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/coordinate"} 0.0 1617950344968
-pulsar_consumers_count{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/coordinate"} 1.0 1617950344968
-pulsar_rate_in{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/coordinate"} 0.0 1617950344968
-pulsar_rate_out{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/coordinate"} 0.0 1617950344968
-pulsar_throughput_in{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/coordinate"} 0.0 1617950344968
-pulsar_throughput_out{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/coordinate"} 0.0 1617950344968
-pulsar_storage_size{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/coordinate"} 0.0 1617950344968
-pulsar_msg_backlog{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/coordinate"} 0.0 1617950344968
-pulsar_storage_backlog_size{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/coordinate"} 0.0 1617950344968
-pulsar_storage_offloaded_size{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/coordinate"} 0.0 1617950344968
-pulsar_storage_backlog_quota_limit{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/coordinate"} -1073741824.0 1617950344968
-pulsar_storage_write_latency_le_0_5{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/coordinate"} 0.0 1617950344968
-pulsar_storage_write_latency_le_1{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/coordinate"} 0.0 1617950344968
-pulsar_storage_write_latency_le_5{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/coordinate"} 0.0 1617950344968
-pulsar_storage_write_latency_le_10{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/coordinate"} 0.0 1617950344968
-pulsar_storage_write_latency_le_20{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/coordinate"} 0.0 1617950344968
-pulsar_storage_write_latency_le_50{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/coordinate"} 0.0 1617950344968
-pulsar_storage_write_latency_le_100{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/coordinate"} 0.0 1617950344968
-pulsar_storage_write_latency_le_200{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/coordinate"} 0.0 1617950344968
-pulsar_storage_write_latency_le_1000{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/coordinate"} 0.0 1617950344968
-pulsar_storage_write_latency_overflow{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/coordinate"} 0.0 1617950344968
-pulsar_storage_write_latency_count{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/coordinate"} 0.0 1617950344968
-pulsar_storage_write_latency_sum{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/coordinate"} 0.0 1617950344968
-pulsar_storage_ledger_write_latency_le_0_5{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/coordinate"} 0.0 1617950344968
-pulsar_storage_ledger_write_latency_le_1{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/coordinate"} 0.0 1617950344968
-pulsar_storage_ledger_write_latency_le_5{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/coordinate"} 0.0 1617950344968
-pulsar_storage_ledger_write_latency_le_10{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/coordinate"} 0.0 1617950344968
-pulsar_storage_ledger_write_latency_le_20{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/coordinate"} 0.0 1617950344968
-pulsar_storage_ledger_write_latency_le_50{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/coordinate"} 0.0 1617950344968
-pulsar_storage_ledger_write_latency_le_100{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/coordinate"} 0.0 1617950344968
-pulsar_storage_ledger_write_latency_le_200{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/coordinate"} 0.0 1617950344968
-pulsar_storage_ledger_write_latency_le_1000{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/coordinate"} 0.0 1617950344968
-pulsar_storage_ledger_write_latency_overflow{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/coordinate"} 0.0 1617950344968
-pulsar_storage_ledger_write_latency_count{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/coordinate"} 0.0 1617950344968
-pulsar_storage_ledger_write_latency_sum{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/coordinate"} 0.0 1617950344968
-pulsar_entry_size_le_128{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/coordinate"} 0.0 1617950344968
-pulsar_entry_size_le_512{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/coordinate"} 0.0 1617950344968
-pulsar_entry_size_le_1_kb{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/coordinate"} 0.0 1617950344968
-pulsar_entry_size_le_2_kb{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/coordinate"} 0.0 1617950344968
-pulsar_entry_size_le_4_kb{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/coordinate"} 0.0 1617950344968
-pulsar_entry_size_le_16_kb{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/coordinate"} 0.0 1617950344968
-pulsar_entry_size_le_100_kb{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/coordinate"} 0.0 1617950344968
-pulsar_entry_size_le_1_mb{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/coordinate"} 0.0 1617950344968
-pulsar_entry_size_le_overflow{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/coordinate"} 0.0 1617950344968
-pulsar_entry_size_count{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/coordinate"} 0.0 1617950344968
-pulsar_entry_size_sum{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/coordinate"} 0.0 1617950344968
-pulsar_subscription_back_log{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/coordinate",subscription="participants"} 0 1617950344968
-pulsar_subscription_back_log_no_delayed{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/coordinate",subscription="participants"} 0 1617950344968
-pulsar_subscription_delayed{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/coordinate",subscription="participants"} 0 1617950344968
-pulsar_subscription_msg_rate_redeliver{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/coordinate",subscription="participants"} 0.0 1617950344968
-pulsar_subscription_unacked_messages{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/coordinate",subscription="participants"} 0 1617950344968
-pulsar_subscription_blocked_on_unacked_messages{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/coordinate",subscription="participants"} 0 1617950344968
-pulsar_subscription_msg_rate_out{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/coordinate",subscription="participants"} 0.0 1617950344968
-pulsar_subscription_msg_throughput_out{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/coordinate",subscription="participants"} 0.0 1617950344968
-pulsar_out_bytes_total{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/coordinate",subscription="participants"} 0 1617950344968
-pulsar_out_messages_total{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/coordinate",subscription="participants"} 0 1617950344968
-pulsar_subscription_last_expire_timestamp{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/coordinate",subscription="participants"} 0 1617950344968
-pulsar_subscription_last_acked_timestamp{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/coordinate",subscription="participants"} 0 1617950344968
-pulsar_subscription_last_consumed_flow_timestamp{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/coordinate",subscription="participants"} 1617950342238 1617950344968
-pulsar_subscription_last_consumed_timestamp{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/coordinate",subscription="participants"} 0 1617950344968
-pulsar_subscription_last_mark_delete_advanced_timestamp{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/coordinate",subscription="participants"} 0 1617950344968
-pulsar_subscription_msg_rate_expired{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/coordinate",subscription="participants"} 0.0 1617950344968
-pulsar_subscription_total_msg_expired{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/coordinate",subscription="participants"} 0 1617950344968
-pulsar_in_bytes_total{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/coordinate"} 0.0 1617950344968
-pulsar_in_messages_total{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/coordinate"} 0.0 1617950344968
-pulsar_topics_count{cluster="use",namespace="external-repl-prop/pulsar-function-admin"} 3 1617950344968
+pulsar_in_messages_total{cluster="use",namespace="external-repl-prop/io",topic="persistent://external-repl-prop/io/my-topic1"} 0.0
+pulsar_topics_count{cluster="use",namespace="external-repl-prop/io"} 1
+pulsar_subscriptions_count{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/metadata"} 0.0
+pulsar_producers_count{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/metadata"} 1.0
+pulsar_consumers_count{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/metadata"} 0.0
+pulsar_rate_in{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/metadata"} 0.0
+pulsar_rate_out{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/metadata"} 0.0
+pulsar_throughput_in{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/metadata"} 0.0
+pulsar_throughput_out{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/metadata"} 0.0
+pulsar_storage_size{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/metadata"} 1728.0
+pulsar_msg_backlog{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/metadata"} 0.0
+pulsar_storage_backlog_size{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/metadata"} 0.0
+pulsar_storage_offloaded_size{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/metadata"} 0.0
+pulsar_storage_backlog_quota_limit{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/metadata"} -1073741824.0
+pulsar_storage_write_latency_le_0_5{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/metadata"} 0.0
+pulsar_storage_write_latency_le_1{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/metadata"} 0.0
+pulsar_storage_write_latency_le_5{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/metadata"} 0.0
+pulsar_storage_write_latency_le_10{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/metadata"} 0.0
+pulsar_storage_write_latency_le_20{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/metadata"} 0.0
+pulsar_storage_write_latency_le_50{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/metadata"} 0.0
+pulsar_storage_write_latency_le_100{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/metadata"} 0.0
+pulsar_storage_write_latency_le_200{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/metadata"} 0.0
+pulsar_storage_write_latency_le_1000{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/metadata"} 0.0
+pulsar_storage_write_latency_overflow{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/metadata"} 0.0
+pulsar_storage_write_latency_count{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/metadata"} 0.0
+pulsar_storage_write_latency_sum{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/metadata"} 0.0
+pulsar_storage_ledger_write_latency_le_0_5{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/metadata"} 0.0
+pulsar_storage_ledger_write_latency_le_1{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/metadata"} 0.0
+pulsar_storage_ledger_write_latency_le_5{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/metadata"} 0.0
+pulsar_storage_ledger_write_latency_le_10{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/metadata"} 0.0
+pulsar_storage_ledger_write_latency_le_20{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/metadata"} 0.0
+pulsar_storage_ledger_write_latency_le_50{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/metadata"} 0.0
+pulsar_storage_ledger_write_latency_le_100{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/metadata"} 0.0
+pulsar_storage_ledger_write_latency_le_200{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/metadata"} 0.0
+pulsar_storage_ledger_write_latency_le_1000{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/metadata"} 0.0
+pulsar_storage_ledger_write_latency_overflow{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/metadata"} 0.0
+pulsar_storage_ledger_write_latency_count{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/metadata"} 0.0
+pulsar_storage_ledger_write_latency_sum{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/metadata"} 0.0
+pulsar_entry_size_le_128{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/metadata"} 0.0
+pulsar_entry_size_le_512{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/metadata"} 0.0
+pulsar_entry_size_le_1_kb{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/metadata"} 0.0
+pulsar_entry_size_le_2_kb{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/metadata"} 0.0
+pulsar_entry_size_le_4_kb{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/metadata"} 0.0
+pulsar_entry_size_le_16_kb{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/metadata"} 0.0
+pulsar_entry_size_le_100_kb{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/metadata"} 0.0
+pulsar_entry_size_le_1_mb{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/metadata"} 0.0
+pulsar_entry_size_le_overflow{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/metadata"} 0.0
+pulsar_entry_size_count{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/metadata"} 0.0
+pulsar_entry_size_sum{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/metadata"} 0.0
+pulsar_in_bytes_total{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/metadata"} 864.0
+pulsar_in_messages_total{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/metadata"} 2.0
+pulsar_subscriptions_count{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/assignment"} 0.0
+pulsar_producers_count{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/assignment"} 1.0
+pulsar_consumers_count{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/assignment"} 0.0
+pulsar_rate_in{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/assignment"} 0.0
+pulsar_rate_out{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/assignment"} 0.0
+pulsar_throughput_in{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/assignment"} 0.0
+pulsar_throughput_out{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/assignment"} 0.0
+pulsar_storage_size{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/assignment"} 1748.0
+pulsar_msg_backlog{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/assignment"} 0.0
+pulsar_storage_backlog_size{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/assignment"} 0.0
+pulsar_storage_offloaded_size{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/assignment"} 0.0
+pulsar_storage_backlog_quota_limit{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/assignment"} -1073741824.0
+pulsar_storage_write_latency_le_0_5{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/assignment"} 0.0
+pulsar_storage_write_latency_le_1{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/assignment"} 0.0
+pulsar_storage_write_latency_le_5{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/assignment"} 0.0
+pulsar_storage_write_latency_le_10{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/assignment"} 0.0
+pulsar_storage_write_latency_le_20{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/assignment"} 0.0
+pulsar_storage_write_latency_le_50{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/assignment"} 0.0
+pulsar_storage_write_latency_le_100{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/assignment"} 0.0
+pulsar_storage_write_latency_le_200{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/assignment"} 0.0
+pulsar_storage_write_latency_le_1000{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/assignment"} 0.0
+pulsar_storage_write_latency_overflow{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/assignment"} 0.0
+pulsar_storage_write_latency_count{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/assignment"} 0.0
+pulsar_storage_write_latency_sum{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/assignment"} 0.0
+pulsar_storage_ledger_write_latency_le_0_5{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/assignment"} 0.0
+pulsar_storage_ledger_write_latency_le_1{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/assignment"} 0.0
+pulsar_storage_ledger_write_latency_le_5{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/assignment"} 0.0
+pulsar_storage_ledger_write_latency_le_10{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/assignment"} 0.0
+pulsar_storage_ledger_write_latency_le_20{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/assignment"} 0.0
+pulsar_storage_ledger_write_latency_le_50{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/assignment"} 0.0
+pulsar_storage_ledger_write_latency_le_100{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/assignment"} 0.0
+pulsar_storage_ledger_write_latency_le_200{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/assignment"} 0.0
+pulsar_storage_ledger_write_latency_le_1000{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/assignment"} 0.0
+pulsar_storage_ledger_write_latency_overflow{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/assignment"} 0.0
+pulsar_storage_ledger_write_latency_count{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/assignment"} 0.0
+pulsar_storage_ledger_write_latency_sum{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/assignment"} 0.0
+pulsar_entry_size_le_128{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/assignment"} 0.0
+pulsar_entry_size_le_512{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/assignment"} 0.0
+pulsar_entry_size_le_1_kb{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/assignment"} 0.0
+pulsar_entry_size_le_2_kb{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/assignment"} 0.0
+pulsar_entry_size_le_4_kb{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/assignment"} 0.0
+pulsar_entry_size_le_16_kb{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/assignment"} 0.0
+pulsar_entry_size_le_100_kb{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/assignment"} 0.0
+pulsar_entry_size_le_1_mb{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/assignment"} 0.0
+pulsar_entry_size_le_overflow{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/assignment"} 0.0
+pulsar_entry_size_count{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/assignment"} 0.0
+pulsar_entry_size_sum{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/assignment"} 0.0
+pulsar_in_bytes_total{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/assignment"} 874.0
+pulsar_in_messages_total{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/assignment"} 2.0
+pulsar_subscriptions_count{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/coordinate"} 1.0
+pulsar_producers_count{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/coordinate"} 0.0
+pulsar_consumers_count{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/coordinate"} 1.0
+pulsar_rate_in{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/coordinate"} 0.0
+pulsar_rate_out{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/coordinate"} 0.0
+pulsar_throughput_in{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/coordinate"} 0.0
+pulsar_throughput_out{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/coordinate"} 0.0
+pulsar_storage_size{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/coordinate"} 0.0
+pulsar_msg_backlog{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/coordinate"} 0.0
+pulsar_storage_backlog_size{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/coordinate"} 0.0
+pulsar_storage_offloaded_size{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/coordinate"} 0.0
+pulsar_storage_backlog_quota_limit{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/coordinate"} -1073741824.0
+pulsar_storage_write_latency_le_0_5{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/coordinate"} 0.0
+pulsar_storage_write_latency_le_1{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/coordinate"} 0.0
+pulsar_storage_write_latency_le_5{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/coordinate"} 0.0
+pulsar_storage_write_latency_le_10{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/coordinate"} 0.0
+pulsar_storage_write_latency_le_20{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/coordinate"} 0.0
+pulsar_storage_write_latency_le_50{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/coordinate"} 0.0
+pulsar_storage_write_latency_le_100{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/coordinate"} 0.0
+pulsar_storage_write_latency_le_200{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/coordinate"} 0.0
+pulsar_storage_write_latency_le_1000{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/coordinate"} 0.0
+pulsar_storage_write_latency_overflow{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/coordinate"} 0.0
+pulsar_storage_write_latency_count{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/coordinate"} 0.0
+pulsar_storage_write_latency_sum{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/coordinate"} 0.0
+pulsar_storage_ledger_write_latency_le_0_5{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/coordinate"} 0.0
+pulsar_storage_ledger_write_latency_le_1{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/coordinate"} 0.0
+pulsar_storage_ledger_write_latency_le_5{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/coordinate"} 0.0
+pulsar_storage_ledger_write_latency_le_10{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/coordinate"} 0.0
+pulsar_storage_ledger_write_latency_le_20{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/coordinate"} 0.0
+pulsar_storage_ledger_write_latency_le_50{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/coordinate"} 0.0
+pulsar_storage_ledger_write_latency_le_100{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/coordinate"} 0.0
+pulsar_storage_ledger_write_latency_le_200{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/coordinate"} 0.0
+pulsar_storage_ledger_write_latency_le_1000{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/coordinate"} 0.0
+pulsar_storage_ledger_write_latency_overflow{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/coordinate"} 0.0
+pulsar_storage_ledger_write_latency_count{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/coordinate"} 0.0
+pulsar_storage_ledger_write_latency_sum{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/coordinate"} 0.0
+pulsar_entry_size_le_128{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/coordinate"} 0.0
+pulsar_entry_size_le_512{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/coordinate"} 0.0
+pulsar_entry_size_le_1_kb{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/coordinate"} 0.0
+pulsar_entry_size_le_2_kb{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/coordinate"} 0.0
+pulsar_entry_size_le_4_kb{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/coordinate"} 0.0
+pulsar_entry_size_le_16_kb{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/coordinate"} 0.0
+pulsar_entry_size_le_100_kb{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/coordinate"} 0.0
+pulsar_entry_size_le_1_mb{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/coordinate"} 0.0
+pulsar_entry_size_le_overflow{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/coordinate"} 0.0
+pulsar_entry_size_count{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/coordinate"} 0.0
+pulsar_entry_size_sum{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/coordinate"} 0.0
+pulsar_subscription_back_log{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/coordinate",subscription="participants"} 0
+pulsar_subscription_back_log_no_delayed{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/coordinate",subscription="participants"} 0
+pulsar_subscription_delayed{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/coordinate",subscription="participants"} 0
+pulsar_subscription_msg_rate_redeliver{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/coordinate",subscription="participants"} 0.0
+pulsar_subscription_unacked_messages{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/coordinate",subscription="participants"} 0
+pulsar_subscription_blocked_on_unacked_messages{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/coordinate",subscription="participants"} 0
+pulsar_subscription_msg_rate_out{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/coordinate",subscription="participants"} 0.0
+pulsar_subscription_msg_throughput_out{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/coordinate",subscription="participants"} 0.0
+pulsar_out_bytes_total{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/coordinate",subscription="participants"} 0
+pulsar_out_messages_total{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/coordinate",subscription="participants"} 0
+pulsar_subscription_last_expire_timestamp{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/coordinate",subscription="participants"} 0
+pulsar_subscription_last_acked_timestamp{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/coordinate",subscription="participants"} 0
+pulsar_subscription_last_consumed_flow_timestamp{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/coordinate",subscription="participants"} 1617950342238
+pulsar_subscription_last_consumed_timestamp{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/coordinate",subscription="participants"} 0
+pulsar_subscription_last_mark_delete_advanced_timestamp{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/coordinate",subscription="participants"} 0
+pulsar_subscription_msg_rate_expired{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/coordinate",subscription="participants"} 0.0
+pulsar_subscription_total_msg_expired{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/coordinate",subscription="participants"} 0
+pulsar_in_bytes_total{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/coordinate"} 0.0
+pulsar_in_messages_total{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/coordinate"} 0.0
+pulsar_topics_count{cluster="use",namespace="external-repl-prop/pulsar-function-admin"} 3
 pulsar_function_worker_schedule_execution_time_total_ms{cluster="use",quantile="0.5",} 39.596969
 pulsar_function_worker_schedule_execution_time_total_ms{cluster="use",quantile="0.9",} 84.478748
 pulsar_function_worker_schedule_execution_time_total_ms{cluster="use",quantile="1.0",} 125.453621
@@ -686,169 +686,169 @@ pulsar_function_process_latency_ms_sum{tenant="external-repl-prop",namespace="ex
 pulsar_function_system_exceptions_1min_total{tenant="external-repl-prop",namespace="external-repl-prop/io",name="PulsarSink-test",instance_id="0",cluster="use",fqfn="external-repl-prop/io/PulsarSink-test",} 0.0
 pulsar_function_user_exceptions_1min_total{tenant="external-repl-prop",namespace="external-repl-prop/io",name="PulsarSink-test",instance_id="0",cluster="use",fqfn="external-repl-prop/io/PulsarSink-test",} 0.0
 # TYPE pulsar_ml_cache_evictions gauge
-pulsar_ml_cache_evictions{cluster="use"} 0 1617950344971
+pulsar_ml_cache_evictions{cluster="use"} 0
 # TYPE pulsar_ml_cache_hits_rate gauge
-pulsar_ml_cache_hits_rate{cluster="use"} 0.0 1617950344971
+pulsar_ml_cache_hits_rate{cluster="use"} 0.0
 # TYPE pulsar_ml_cache_hits_throughput gauge
-pulsar_ml_cache_hits_throughput{cluster="use"} 0.0 1617950344971
+pulsar_ml_cache_hits_throughput{cluster="use"} 0.0
 # TYPE pulsar_ml_cache_misses_rate gauge
-pulsar_ml_cache_misses_rate{cluster="use"} 0.0 1617950344971
+pulsar_ml_cache_misses_rate{cluster="use"} 0.0
 # TYPE pulsar_ml_cache_misses_throughput gauge
-pulsar_ml_cache_misses_throughput{cluster="use"} 0.0 1617950344971
+pulsar_ml_cache_misses_throughput{cluster="use"} 0.0
 # TYPE pulsar_ml_cache_pool_active_allocations gauge
-pulsar_ml_cache_pool_active_allocations{cluster="use"} 0 1617950344971
+pulsar_ml_cache_pool_active_allocations{cluster="use"} 0
 # TYPE pulsar_ml_cache_pool_active_allocations_huge gauge
-pulsar_ml_cache_pool_active_allocations_huge{cluster="use"} 0 1617950344971
+pulsar_ml_cache_pool_active_allocations_huge{cluster="use"} 0
 # TYPE pulsar_ml_cache_pool_active_allocations_normal gauge
-pulsar_ml_cache_pool_active_allocations_normal{cluster="use"} 0 1617950344971
+pulsar_ml_cache_pool_active_allocations_normal{cluster="use"} 0
 # TYPE pulsar_ml_cache_pool_active_allocations_small gauge
-pulsar_ml_cache_pool_active_allocations_small{cluster="use"} 0 1617950344971
+pulsar_ml_cache_pool_active_allocations_small{cluster="use"} 0
 # TYPE pulsar_ml_cache_pool_active_allocations_tiny gauge
-pulsar_ml_cache_pool_active_allocations_tiny{cluster="use"} 0 1617950344971
+pulsar_ml_cache_pool_active_allocations_tiny{cluster="use"} 0
 # TYPE pulsar_ml_cache_pool_allocated gauge
-pulsar_ml_cache_pool_allocated{cluster="use"} 0 1617950344971
+pulsar_ml_cache_pool_allocated{cluster="use"} 0
 # TYPE pulsar_ml_cache_pool_used gauge
-pulsar_ml_cache_pool_used{cluster="use"} 0 1617950344971
+pulsar_ml_cache_pool_used{cluster="use"} 0
 # TYPE pulsar_ml_cache_used_size gauge
-pulsar_ml_cache_used_size{cluster="use"} 0 1617950344971
+pulsar_ml_cache_used_size{cluster="use"} 0
 # TYPE pulsar_ml_count gauge
-pulsar_ml_count{cluster="use"} 4 1617950344971
+pulsar_ml_count{cluster="use"} 4
 # TYPE pulsar_ml_AddEntryBytesRate gauge
-pulsar_ml_AddEntryBytesRate{cluster="use", namespace="external-repl-prop/io/persistent"} 0.0 1617950344972
+pulsar_ml_AddEntryBytesRate{cluster="use", namespace="external-repl-prop/io/persistent"} 0.0
 # TYPE pulsar_ml_AddEntryErrors gauge
-pulsar_ml_AddEntryErrors{cluster="use", namespace="external-repl-prop/io/persistent"} 0.0 1617950344972
+pulsar_ml_AddEntryErrors{cluster="use", namespace="external-repl-prop/io/persistent"} 0.0
 # TYPE pulsar_ml_AddEntryLatencyBuckets gauge
-pulsar_ml_AddEntryLatencyBuckets{cluster="use", namespace="external-repl-prop/io/persistent", quantile="0.0_0.5"} 0.0 1617950344972
-pulsar_ml_AddEntryLatencyBuckets{cluster="use", namespace="external-repl-prop/io/persistent", quantile="0.5_1.0"} 0.0 1617950344972
-pulsar_ml_AddEntryLatencyBuckets{cluster="use", namespace="external-repl-prop/io/persistent", quantile="1.0_5.0"} 0.0 1617950344972
-pulsar_ml_AddEntryLatencyBuckets{cluster="use", namespace="external-repl-prop/io/persistent", quantile="10.0_20.0"} 0.0 1617950344972
-pulsar_ml_AddEntryLatencyBuckets{cluster="use", namespace="external-repl-prop/io/persistent", quantile="100.0_200.0"} 0.0 1617950344972
-pulsar_ml_AddEntryLatencyBuckets{cluster="use", namespace="external-repl-prop/io/persistent", quantile="20.0_50.0"} 0.0 1617950344972
-pulsar_ml_AddEntryLatencyBuckets{cluster="use", namespace="external-repl-prop/io/persistent", quantile="200.0_1000.0"} 0.0 1617950344972
-pulsar_ml_AddEntryLatencyBuckets{cluster="use", namespace="external-repl-prop/io/persistent", quantile="5.0_10.0"} 0.0 1617950344972
-pulsar_ml_AddEntryLatencyBuckets{cluster="use", namespace="external-repl-prop/io/persistent", quantile="50.0_100.0"} 0.0 1617950344972
+pulsar_ml_AddEntryLatencyBuckets{cluster="use", namespace="external-repl-prop/io/persistent", quantile="0.0_0.5"} 0.0
+pulsar_ml_AddEntryLatencyBuckets{cluster="use", namespace="external-repl-prop/io/persistent", quantile="0.5_1.0"} 0.0
+pulsar_ml_AddEntryLatencyBuckets{cluster="use", namespace="external-repl-prop/io/persistent", quantile="1.0_5.0"} 0.0
+pulsar_ml_AddEntryLatencyBuckets{cluster="use", namespace="external-repl-prop/io/persistent", quantile="10.0_20.0"} 0.0
+pulsar_ml_AddEntryLatencyBuckets{cluster="use", namespace="external-repl-prop/io/persistent", quantile="100.0_200.0"} 0.0
+pulsar_ml_AddEntryLatencyBuckets{cluster="use", namespace="external-repl-prop/io/persistent", quantile="20.0_50.0"} 0.0
+pulsar_ml_AddEntryLatencyBuckets{cluster="use", namespace="external-repl-prop/io/persistent", quantile="200.0_1000.0"} 0.0
+pulsar_ml_AddEntryLatencyBuckets{cluster="use", namespace="external-repl-prop/io/persistent", quantile="5.0_10.0"} 0.0
+pulsar_ml_AddEntryLatencyBuckets{cluster="use", namespace="external-repl-prop/io/persistent", quantile="50.0_100.0"} 0.0
 # TYPE pulsar_ml_AddEntryLatencyBuckets_OVERFLOW gauge
-pulsar_ml_AddEntryLatencyBuckets_OVERFLOW{cluster="use", namespace="external-repl-prop/io/persistent"} 0.0 1617950344972
+pulsar_ml_AddEntryLatencyBuckets_OVERFLOW{cluster="use", namespace="external-repl-prop/io/persistent"} 0.0
 # TYPE pulsar_ml_AddEntryMessagesRate gauge
-pulsar_ml_AddEntryMessagesRate{cluster="use", namespace="external-repl-prop/io/persistent"} 0.0 1617950344972
+pulsar_ml_AddEntryMessagesRate{cluster="use", namespace="external-repl-prop/io/persistent"} 0.0
 # TYPE pulsar_ml_AddEntrySucceed gauge
-pulsar_ml_AddEntrySucceed{cluster="use", namespace="external-repl-prop/io/persistent"} 0.0 1617950344972
+pulsar_ml_AddEntrySucceed{cluster="use", namespace="external-repl-prop/io/persistent"} 0.0
 # TYPE pulsar_ml_EntrySizeBuckets gauge
-pulsar_ml_EntrySizeBuckets{cluster="use", namespace="external-repl-prop/io/persistent", quantile="0.0_128.0"} 0.0 1617950344972
-pulsar_ml_EntrySizeBuckets{cluster="use", namespace="external-repl-prop/io/persistent", quantile="1024.0_2048.0"} 0.0 1617950344972
-pulsar_ml_EntrySizeBuckets{cluster="use", namespace="external-repl-prop/io/persistent", quantile="102400.0_1232896.0"} 0.0 1617950344972
-pulsar_ml_EntrySizeBuckets{cluster="use", namespace="external-repl-prop/io/persistent", quantile="128.0_512.0"} 0.0 1617950344972
-pulsar_ml_EntrySizeBuckets{cluster="use", namespace="external-repl-prop/io/persistent", quantile="16384.0_102400.0"} 0.0 1617950344972
-pulsar_ml_EntrySizeBuckets{cluster="use", namespace="external-repl-prop/io/persistent", quantile="2048.0_4096.0"} 0.0 1617950344972
-pulsar_ml_EntrySizeBuckets{cluster="use", namespace="external-repl-prop/io/persistent", quantile="4096.0_16384.0"} 0.0 1617950344972
-pulsar_ml_EntrySizeBuckets{cluster="use", namespace="external-repl-prop/io/persistent", quantile="512.0_1024.0"} 0.0 1617950344972
+pulsar_ml_EntrySizeBuckets{cluster="use", namespace="external-repl-prop/io/persistent", quantile="0.0_128.0"} 0.0
+pulsar_ml_EntrySizeBuckets{cluster="use", namespace="external-repl-prop/io/persistent", quantile="1024.0_2048.0"} 0.0
+pulsar_ml_EntrySizeBuckets{cluster="use", namespace="external-repl-prop/io/persistent", quantile="102400.0_1232896.0"} 0.0
+pulsar_ml_EntrySizeBuckets{cluster="use", namespace="external-repl-prop/io/persistent", quantile="128.0_512.0"} 0.0
+pulsar_ml_EntrySizeBuckets{cluster="use", namespace="external-repl-prop/io/persistent", quantile="16384.0_102400.0"} 0.0
+pulsar_ml_EntrySizeBuckets{cluster="use", namespace="external-repl-prop/io/persistent", quantile="2048.0_4096.0"} 0.0
+pulsar_ml_EntrySizeBuckets{cluster="use", namespace="external-repl-prop/io/persistent", quantile="4096.0_16384.0"} 0.0
+pulsar_ml_EntrySizeBuckets{cluster="use", namespace="external-repl-prop/io/persistent", quantile="512.0_1024.0"} 0.0
 # TYPE pulsar_ml_EntrySizeBuckets_OVERFLOW gauge
-pulsar_ml_EntrySizeBuckets_OVERFLOW{cluster="use", namespace="external-repl-prop/io/persistent"} 0.0 1617950344972
+pulsar_ml_EntrySizeBuckets_OVERFLOW{cluster="use", namespace="external-repl-prop/io/persistent"} 0.0
 # TYPE pulsar_ml_LedgerAddEntryLatencyBuckets gauge
-pulsar_ml_LedgerAddEntryLatencyBuckets{cluster="use", namespace="external-repl-prop/io/persistent", quantile="0.0_0.5"} 0.0 1617950344972
-pulsar_ml_LedgerAddEntryLatencyBuckets{cluster="use", namespace="external-repl-prop/io/persistent", quantile="0.5_1.0"} 0.0 1617950344972
-pulsar_ml_LedgerAddEntryLatencyBuckets{cluster="use", namespace="external-repl-prop/io/persistent", quantile="1.0_5.0"} 0.0 1617950344972
-pulsar_ml_LedgerAddEntryLatencyBuckets{cluster="use", namespace="external-repl-prop/io/persistent", quantile="10.0_20.0"} 0.0 1617950344972
-pulsar_ml_LedgerAddEntryLatencyBuckets{cluster="use", namespace="external-repl-prop/io/persistent", quantile="100.0_200.0"} 0.0 1617950344972
-pulsar_ml_LedgerAddEntryLatencyBuckets{cluster="use", namespace="external-repl-prop/io/persistent", quantile="20.0_50.0"} 0.0 1617950344972
-pulsar_ml_LedgerAddEntryLatencyBuckets{cluster="use", namespace="external-repl-prop/io/persistent", quantile="200.0_1000.0"} 0.0 1617950344972
-pulsar_ml_LedgerAddEntryLatencyBuckets{cluster="use", namespace="external-repl-prop/io/persistent", quantile="5.0_10.0"} 0.0 1617950344972
-pulsar_ml_LedgerAddEntryLatencyBuckets{cluster="use", namespace="external-repl-prop/io/persistent", quantile="50.0_100.0"} 0.0 1617950344972
+pulsar_ml_LedgerAddEntryLatencyBuckets{cluster="use", namespace="external-repl-prop/io/persistent", quantile="0.0_0.5"} 0.0
+pulsar_ml_LedgerAddEntryLatencyBuckets{cluster="use", namespace="external-repl-prop/io/persistent", quantile="0.5_1.0"} 0.0
+pulsar_ml_LedgerAddEntryLatencyBuckets{cluster="use", namespace="external-repl-prop/io/persistent", quantile="1.0_5.0"} 0.0
+pulsar_ml_LedgerAddEntryLatencyBuckets{cluster="use", namespace="external-repl-prop/io/persistent", quantile="10.0_20.0"} 0.0
+pulsar_ml_LedgerAddEntryLatencyBuckets{cluster="use", namespace="external-repl-prop/io/persistent", quantile="100.0_200.0"} 0.0
+pulsar_ml_LedgerAddEntryLatencyBuckets{cluster="use", namespace="external-repl-prop/io/persistent", quantile="20.0_50.0"} 0.0
+pulsar_ml_LedgerAddEntryLatencyBuckets{cluster="use", namespace="external-repl-prop/io/persistent", quantile="200.0_1000.0"} 0.0
+pulsar_ml_LedgerAddEntryLatencyBuckets{cluster="use", namespace="external-repl-prop/io/persistent", quantile="5.0_10.0"} 0.0
+pulsar_ml_LedgerAddEntryLatencyBuckets{cluster="use", namespace="external-repl-prop/io/persistent", quantile="50.0_100.0"} 0.0
 # TYPE pulsar_ml_LedgerAddEntryLatencyBuckets_OVERFLOW gauge
-pulsar_ml_LedgerAddEntryLatencyBuckets_OVERFLOW{cluster="use", namespace="external-repl-prop/io/persistent"} 0.0 1617950344972
+pulsar_ml_LedgerAddEntryLatencyBuckets_OVERFLOW{cluster="use", namespace="external-repl-prop/io/persistent"} 0.0
 # TYPE pulsar_ml_LedgerSwitchLatencyBuckets gauge
-pulsar_ml_LedgerSwitchLatencyBuckets{cluster="use", namespace="external-repl-prop/io/persistent", quantile="0.0_0.5"} 0.0 1617950344972
-pulsar_ml_LedgerSwitchLatencyBuckets{cluster="use", namespace="external-repl-prop/io/persistent", quantile="0.5_1.0"} 0.0 1617950344972
-pulsar_ml_LedgerSwitchLatencyBuckets{cluster="use", namespace="external-repl-prop/io/persistent", quantile="1.0_5.0"} 0.0 1617950344972
-pulsar_ml_LedgerSwitchLatencyBuckets{cluster="use", namespace="external-repl-prop/io/persistent", quantile="10.0_20.0"} 0.0 1617950344972
-pulsar_ml_LedgerSwitchLatencyBuckets{cluster="use", namespace="external-repl-prop/io/persistent", quantile="100.0_200.0"} 0.0 1617950344972
-pulsar_ml_LedgerSwitchLatencyBuckets{cluster="use", namespace="external-repl-prop/io/persistent", quantile="20.0_50.0"} 0.0 1617950344972
-pulsar_ml_LedgerSwitchLatencyBuckets{cluster="use", namespace="external-repl-prop/io/persistent", quantile="200.0_1000.0"} 0.0 1617950344972
-pulsar_ml_LedgerSwitchLatencyBuckets{cluster="use", namespace="external-repl-prop/io/persistent", quantile="5.0_10.0"} 0.0 1617950344972
-pulsar_ml_LedgerSwitchLatencyBuckets{cluster="use", namespace="external-repl-prop/io/persistent", quantile="50.0_100.0"} 0.0 1617950344972
+pulsar_ml_LedgerSwitchLatencyBuckets{cluster="use", namespace="external-repl-prop/io/persistent", quantile="0.0_0.5"} 0.0
+pulsar_ml_LedgerSwitchLatencyBuckets{cluster="use", namespace="external-repl-prop/io/persistent", quantile="0.5_1.0"} 0.0
+pulsar_ml_LedgerSwitchLatencyBuckets{cluster="use", namespace="external-repl-prop/io/persistent", quantile="1.0_5.0"} 0.0
+pulsar_ml_LedgerSwitchLatencyBuckets{cluster="use", namespace="external-repl-prop/io/persistent", quantile="10.0_20.0"} 0.0
+pulsar_ml_LedgerSwitchLatencyBuckets{cluster="use", namespace="external-repl-prop/io/persistent", quantile="100.0_200.0"} 0.0
+pulsar_ml_LedgerSwitchLatencyBuckets{cluster="use", namespace="external-repl-prop/io/persistent", quantile="20.0_50.0"} 0.0
+pulsar_ml_LedgerSwitchLatencyBuckets{cluster="use", namespace="external-repl-prop/io/persistent", quantile="200.0_1000.0"} 0.0
+pulsar_ml_LedgerSwitchLatencyBuckets{cluster="use", namespace="external-repl-prop/io/persistent", quantile="5.0_10.0"} 0.0
+pulsar_ml_LedgerSwitchLatencyBuckets{cluster="use", namespace="external-repl-prop/io/persistent", quantile="50.0_100.0"} 0.0
 # TYPE pulsar_ml_LedgerSwitchLatencyBuckets_OVERFLOW gauge
-pulsar_ml_LedgerSwitchLatencyBuckets_OVERFLOW{cluster="use", namespace="external-repl-prop/io/persistent"} 0.0 1617950344972
+pulsar_ml_LedgerSwitchLatencyBuckets_OVERFLOW{cluster="use", namespace="external-repl-prop/io/persistent"} 0.0
 # TYPE pulsar_ml_MarkDeleteRate gauge
-pulsar_ml_MarkDeleteRate{cluster="use", namespace="external-repl-prop/io/persistent"} 0.0 1617950344972
+pulsar_ml_MarkDeleteRate{cluster="use", namespace="external-repl-prop/io/persistent"} 0.0
 # TYPE pulsar_ml_NumberOfMessagesInBacklog gauge
-pulsar_ml_NumberOfMessagesInBacklog{cluster="use", namespace="external-repl-prop/io/persistent"} 0.0 1617950344972
+pulsar_ml_NumberOfMessagesInBacklog{cluster="use", namespace="external-repl-prop/io/persistent"} 0.0
 # TYPE pulsar_ml_ReadEntriesBytesRate gauge
-pulsar_ml_ReadEntriesBytesRate{cluster="use", namespace="external-repl-prop/io/persistent"} 0.0 1617950344972
+pulsar_ml_ReadEntriesBytesRate{cluster="use", namespace="external-repl-prop/io/persistent"} 0.0
 # TYPE pulsar_ml_ReadEntriesErrors gauge
-pulsar_ml_ReadEntriesErrors{cluster="use", namespace="external-repl-prop/io/persistent"} 0.0 1617950344972
+pulsar_ml_ReadEntriesErrors{cluster="use", namespace="external-repl-prop/io/persistent"} 0.0
 # TYPE pulsar_ml_ReadEntriesRate gauge
-pulsar_ml_ReadEntriesRate{cluster="use", namespace="external-repl-prop/io/persistent"} 0.0 1617950344972
+pulsar_ml_ReadEntriesRate{cluster="use", namespace="external-repl-prop/io/persistent"} 0.0
 # TYPE pulsar_ml_ReadEntriesSucceeded gauge
-pulsar_ml_ReadEntriesSucceeded{cluster="use", namespace="external-repl-prop/io/persistent"} 0.0 1617950344972
+pulsar_ml_ReadEntriesSucceeded{cluster="use", namespace="external-repl-prop/io/persistent"} 0.0
 # TYPE pulsar_ml_StoredMessagesSize gauge
-pulsar_ml_StoredMessagesSize{cluster="use", namespace="external-repl-prop/io/persistent"} 0.0 1617950344972
-pulsar_ml_AddEntryBytesRate{cluster="use", namespace="external-repl-prop/pulsar-function-admin/persistent"} 0.0 1617950344972
-pulsar_ml_AddEntryErrors{cluster="use", namespace="external-repl-prop/pulsar-function-admin/persistent"} 0.0 1617950344972
-pulsar_ml_AddEntryLatencyBuckets{cluster="use", namespace="external-repl-prop/pulsar-function-admin/persistent", quantile="0.0_0.5"} 0.0 1617950344972
-pulsar_ml_AddEntryLatencyBuckets{cluster="use", namespace="external-repl-prop/pulsar-function-admin/persistent", quantile="0.5_1.0"} 0.0 1617950344972
-pulsar_ml_AddEntryLatencyBuckets{cluster="use", namespace="external-repl-prop/pulsar-function-admin/persistent", quantile="1.0_5.0"} 0.0 1617950344972
-pulsar_ml_AddEntryLatencyBuckets{cluster="use", namespace="external-repl-prop/pulsar-function-admin/persistent", quantile="10.0_20.0"} 0.0 1617950344972
-pulsar_ml_AddEntryLatencyBuckets{cluster="use", namespace="external-repl-prop/pulsar-function-admin/persistent", quantile="100.0_200.0"} 0.0 1617950344972
-pulsar_ml_AddEntryLatencyBuckets{cluster="use", namespace="external-repl-prop/pulsar-function-admin/persistent", quantile="20.0_50.0"} 0.0 1617950344972
-pulsar_ml_AddEntryLatencyBuckets{cluster="use", namespace="external-repl-prop/pulsar-function-admin/persistent", quantile="200.0_1000.0"} 0.0 1617950344972
-pulsar_ml_AddEntryLatencyBuckets{cluster="use", namespace="external-repl-prop/pulsar-function-admin/persistent", quantile="5.0_10.0"} 0.0 1617950344972
-pulsar_ml_AddEntryLatencyBuckets{cluster="use", namespace="external-repl-prop/pulsar-function-admin/persistent", quantile="50.0_100.0"} 0.0 1617950344972
-pulsar_ml_AddEntryLatencyBuckets_OVERFLOW{cluster="use", namespace="external-repl-prop/pulsar-function-admin/persistent"} 0.0 1617950344972
-pulsar_ml_AddEntryMessagesRate{cluster="use", namespace="external-repl-prop/pulsar-function-admin/persistent"} 0.0 1617950344972
-pulsar_ml_AddEntrySucceed{cluster="use", namespace="external-repl-prop/pulsar-function-admin/persistent"} 0.0 1617950344972
-pulsar_ml_EntrySizeBuckets{cluster="use", namespace="external-repl-prop/pulsar-function-admin/persistent", quantile="0.0_128.0"} 0.0 1617950344972
-pulsar_ml_EntrySizeBuckets{cluster="use", namespace="external-repl-prop/pulsar-function-admin/persistent", quantile="1024.0_2048.0"} 0.0 1617950344972
-pulsar_ml_EntrySizeBuckets{cluster="use", namespace="external-repl-prop/pulsar-function-admin/persistent", quantile="102400.0_1232896.0"} 0.0 1617950344972
-pulsar_ml_EntrySizeBuckets{cluster="use", namespace="external-repl-prop/pulsar-function-admin/persistent", quantile="128.0_512.0"} 0.0 1617950344972
-pulsar_ml_EntrySizeBuckets{cluster="use", namespace="external-repl-prop/pulsar-function-admin/persistent", quantile="16384.0_102400.0"} 0.0 1617950344972
-pulsar_ml_EntrySizeBuckets{cluster="use", namespace="external-repl-prop/pulsar-function-admin/persistent", quantile="2048.0_4096.0"} 0.0 1617950344972
-pulsar_ml_EntrySizeBuckets{cluster="use", namespace="external-repl-prop/pulsar-function-admin/persistent", quantile="4096.0_16384.0"} 0.0 1617950344972
-pulsar_ml_EntrySizeBuckets{cluster="use", namespace="external-repl-prop/pulsar-function-admin/persistent", quantile="512.0_1024.0"} 0.0 1617950344972
-pulsar_ml_EntrySizeBuckets_OVERFLOW{cluster="use", namespace="external-repl-prop/pulsar-function-admin/persistent"} 0.0 1617950344972
-pulsar_ml_LedgerAddEntryLatencyBuckets{cluster="use", namespace="external-repl-prop/pulsar-function-admin/persistent", quantile="0.0_0.5"} 0.0 1617950344972
-pulsar_ml_LedgerAddEntryLatencyBuckets{cluster="use", namespace="external-repl-prop/pulsar-function-admin/persistent", quantile="0.5_1.0"} 0.0 1617950344972
-pulsar_ml_LedgerAddEntryLatencyBuckets{cluster="use", namespace="external-repl-prop/pulsar-function-admin/persistent", quantile="1.0_5.0"} 0.0 1617950344972
-pulsar_ml_LedgerAddEntryLatencyBuckets{cluster="use", namespace="external-repl-prop/pulsar-function-admin/persistent", quantile="10.0_20.0"} 0.0 1617950344972
-pulsar_ml_LedgerAddEntryLatencyBuckets{cluster="use", namespace="external-repl-prop/pulsar-function-admin/persistent", quantile="100.0_200.0"} 0.0 1617950344972
-pulsar_ml_LedgerAddEntryLatencyBuckets{cluster="use", namespace="external-repl-prop/pulsar-function-admin/persistent", quantile="20.0_50.0"} 0.0 1617950344972
-pulsar_ml_LedgerAddEntryLatencyBuckets{cluster="use", namespace="external-repl-prop/pulsar-function-admin/persistent", quantile="200.0_1000.0"} 0.0 1617950344972
-pulsar_ml_LedgerAddEntryLatencyBuckets{cluster="use", namespace="external-repl-prop/pulsar-function-admin/persistent", quantile="5.0_10.0"} 0.0 1617950344972
-pulsar_ml_LedgerAddEntryLatencyBuckets{cluster="use", namespace="external-repl-prop/pulsar-function-admin/persistent", quantile="50.0_100.0"} 0.0 1617950344972
-pulsar_ml_LedgerAddEntryLatencyBuckets_OVERFLOW{cluster="use", namespace="external-repl-prop/pulsar-function-admin/persistent"} 0.0 1617950344972
-pulsar_ml_LedgerSwitchLatencyBuckets{cluster="use", namespace="external-repl-prop/pulsar-function-admin/persistent", quantile="0.0_0.5"} 0.0 1617950344972
-pulsar_ml_LedgerSwitchLatencyBuckets{cluster="use", namespace="external-repl-prop/pulsar-function-admin/persistent", quantile="0.5_1.0"} 0.0 1617950344972
-pulsar_ml_LedgerSwitchLatencyBuckets{cluster="use", namespace="external-repl-prop/pulsar-function-admin/persistent", quantile="1.0_5.0"} 0.0 1617950344972
-pulsar_ml_LedgerSwitchLatencyBuckets{cluster="use", namespace="external-repl-prop/pulsar-function-admin/persistent", quantile="10.0_20.0"} 0.0 1617950344972
-pulsar_ml_LedgerSwitchLatencyBuckets{cluster="use", namespace="external-repl-prop/pulsar-function-admin/persistent", quantile="100.0_200.0"} 0.0 1617950344972
-pulsar_ml_LedgerSwitchLatencyBuckets{cluster="use", namespace="external-repl-prop/pulsar-function-admin/persistent", quantile="20.0_50.0"} 0.0 1617950344972
-pulsar_ml_LedgerSwitchLatencyBuckets{cluster="use", namespace="external-repl-prop/pulsar-function-admin/persistent", quantile="200.0_1000.0"} 0.0 1617950344972
-pulsar_ml_LedgerSwitchLatencyBuckets{cluster="use", namespace="external-repl-prop/pulsar-function-admin/persistent", quantile="5.0_10.0"} 0.0 1617950344972
-pulsar_ml_LedgerSwitchLatencyBuckets{cluster="use", namespace="external-repl-prop/pulsar-function-admin/persistent", quantile="50.0_100.0"} 0.0 1617950344972
-pulsar_ml_LedgerSwitchLatencyBuckets_OVERFLOW{cluster="use", namespace="external-repl-prop/pulsar-function-admin/persistent"} 0.0 1617950344972
-pulsar_ml_MarkDeleteRate{cluster="use", namespace="external-repl-prop/pulsar-function-admin/persistent"} 0.0 1617950344972
-pulsar_ml_NumberOfMessagesInBacklog{cluster="use", namespace="external-repl-prop/pulsar-function-admin/persistent"} 0.0 1617950344972
-pulsar_ml_ReadEntriesBytesRate{cluster="use", namespace="external-repl-prop/pulsar-function-admin/persistent"} 0.0 1617950344972
-pulsar_ml_ReadEntriesErrors{cluster="use", namespace="external-repl-prop/pulsar-function-admin/persistent"} 0.0 1617950344972
-pulsar_ml_ReadEntriesRate{cluster="use", namespace="external-repl-prop/pulsar-function-admin/persistent"} 0.0 1617950344972
-pulsar_ml_ReadEntriesSucceeded{cluster="use", namespace="external-repl-prop/pulsar-function-admin/persistent"} 0.0 1617950344972
-pulsar_ml_StoredMessagesSize{cluster="use", namespace="external-repl-prop/pulsar-function-admin/persistent"} 3476.0 1617950344972
+pulsar_ml_StoredMessagesSize{cluster="use", namespace="external-repl-prop/io/persistent"} 0.0
+pulsar_ml_AddEntryBytesRate{cluster="use", namespace="external-repl-prop/pulsar-function-admin/persistent"} 0.0
+pulsar_ml_AddEntryErrors{cluster="use", namespace="external-repl-prop/pulsar-function-admin/persistent"} 0.0
+pulsar_ml_AddEntryLatencyBuckets{cluster="use", namespace="external-repl-prop/pulsar-function-admin/persistent", quantile="0.0_0.5"} 0.0
+pulsar_ml_AddEntryLatencyBuckets{cluster="use", namespace="external-repl-prop/pulsar-function-admin/persistent", quantile="0.5_1.0"} 0.0
+pulsar_ml_AddEntryLatencyBuckets{cluster="use", namespace="external-repl-prop/pulsar-function-admin/persistent", quantile="1.0_5.0"} 0.0
+pulsar_ml_AddEntryLatencyBuckets{cluster="use", namespace="external-repl-prop/pulsar-function-admin/persistent", quantile="10.0_20.0"} 0.0
+pulsar_ml_AddEntryLatencyBuckets{cluster="use", namespace="external-repl-prop/pulsar-function-admin/persistent", quantile="100.0_200.0"} 0.0
+pulsar_ml_AddEntryLatencyBuckets{cluster="use", namespace="external-repl-prop/pulsar-function-admin/persistent", quantile="20.0_50.0"} 0.0
+pulsar_ml_AddEntryLatencyBuckets{cluster="use", namespace="external-repl-prop/pulsar-function-admin/persistent", quantile="200.0_1000.0"} 0.0
+pulsar_ml_AddEntryLatencyBuckets{cluster="use", namespace="external-repl-prop/pulsar-function-admin/persistent", quantile="5.0_10.0"} 0.0
+pulsar_ml_AddEntryLatencyBuckets{cluster="use", namespace="external-repl-prop/pulsar-function-admin/persistent", quantile="50.0_100.0"} 0.0
+pulsar_ml_AddEntryLatencyBuckets_OVERFLOW{cluster="use", namespace="external-repl-prop/pulsar-function-admin/persistent"} 0.0
+pulsar_ml_AddEntryMessagesRate{cluster="use", namespace="external-repl-prop/pulsar-function-admin/persistent"} 0.0
+pulsar_ml_AddEntrySucceed{cluster="use", namespace="external-repl-prop/pulsar-function-admin/persistent"} 0.0
+pulsar_ml_EntrySizeBuckets{cluster="use", namespace="external-repl-prop/pulsar-function-admin/persistent", quantile="0.0_128.0"} 0.0
+pulsar_ml_EntrySizeBuckets{cluster="use", namespace="external-repl-prop/pulsar-function-admin/persistent", quantile="1024.0_2048.0"} 0.0
+pulsar_ml_EntrySizeBuckets{cluster="use", namespace="external-repl-prop/pulsar-function-admin/persistent", quantile="102400.0_1232896.0"} 0.0
+pulsar_ml_EntrySizeBuckets{cluster="use", namespace="external-repl-prop/pulsar-function-admin/persistent", quantile="128.0_512.0"} 0.0
+pulsar_ml_EntrySizeBuckets{cluster="use", namespace="external-repl-prop/pulsar-function-admin/persistent", quantile="16384.0_102400.0"} 0.0
+pulsar_ml_EntrySizeBuckets{cluster="use", namespace="external-repl-prop/pulsar-function-admin/persistent", quantile="2048.0_4096.0"} 0.0
+pulsar_ml_EntrySizeBuckets{cluster="use", namespace="external-repl-prop/pulsar-function-admin/persistent", quantile="4096.0_16384.0"} 0.0
+pulsar_ml_EntrySizeBuckets{cluster="use", namespace="external-repl-prop/pulsar-function-admin/persistent", quantile="512.0_1024.0"} 0.0
+pulsar_ml_EntrySizeBuckets_OVERFLOW{cluster="use", namespace="external-repl-prop/pulsar-function-admin/persistent"} 0.0
+pulsar_ml_LedgerAddEntryLatencyBuckets{cluster="use", namespace="external-repl-prop/pulsar-function-admin/persistent", quantile="0.0_0.5"} 0.0
+pulsar_ml_LedgerAddEntryLatencyBuckets{cluster="use", namespace="external-repl-prop/pulsar-function-admin/persistent", quantile="0.5_1.0"} 0.0
+pulsar_ml_LedgerAddEntryLatencyBuckets{cluster="use", namespace="external-repl-prop/pulsar-function-admin/persistent", quantile="1.0_5.0"} 0.0
+pulsar_ml_LedgerAddEntryLatencyBuckets{cluster="use", namespace="external-repl-prop/pulsar-function-admin/persistent", quantile="10.0_20.0"} 0.0
+pulsar_ml_LedgerAddEntryLatencyBuckets{cluster="use", namespace="external-repl-prop/pulsar-function-admin/persistent", quantile="100.0_200.0"} 0.0
+pulsar_ml_LedgerAddEntryLatencyBuckets{cluster="use", namespace="external-repl-prop/pulsar-function-admin/persistent", quantile="20.0_50.0"} 0.0
+pulsar_ml_LedgerAddEntryLatencyBuckets{cluster="use", namespace="external-repl-prop/pulsar-function-admin/persistent", quantile="200.0_1000.0"} 0.0
+pulsar_ml_LedgerAddEntryLatencyBuckets{cluster="use", namespace="external-repl-prop/pulsar-function-admin/persistent", quantile="5.0_10.0"} 0.0
+pulsar_ml_LedgerAddEntryLatencyBuckets{cluster="use", namespace="external-repl-prop/pulsar-function-admin/persistent", quantile="50.0_100.0"} 0.0
+pulsar_ml_LedgerAddEntryLatencyBuckets_OVERFLOW{cluster="use", namespace="external-repl-prop/pulsar-function-admin/persistent"} 0.0
+pulsar_ml_LedgerSwitchLatencyBuckets{cluster="use", namespace="external-repl-prop/pulsar-function-admin/persistent", quantile="0.0_0.5"} 0.0
+pulsar_ml_LedgerSwitchLatencyBuckets{cluster="use", namespace="external-repl-prop/pulsar-function-admin/persistent", quantile="0.5_1.0"} 0.0
+pulsar_ml_LedgerSwitchLatencyBuckets{cluster="use", namespace="external-repl-prop/pulsar-function-admin/persistent", quantile="1.0_5.0"} 0.0
+pulsar_ml_LedgerSwitchLatencyBuckets{cluster="use", namespace="external-repl-prop/pulsar-function-admin/persistent", quantile="10.0_20.0"} 0.0
+pulsar_ml_LedgerSwitchLatencyBuckets{cluster="use", namespace="external-repl-prop/pulsar-function-admin/persistent", quantile="100.0_200.0"} 0.0
+pulsar_ml_LedgerSwitchLatencyBuckets{cluster="use", namespace="external-repl-prop/pulsar-function-admin/persistent", quantile="20.0_50.0"} 0.0
+pulsar_ml_LedgerSwitchLatencyBuckets{cluster="use", namespace="external-repl-prop/pulsar-function-admin/persistent", quantile="200.0_1000.0"} 0.0
+pulsar_ml_LedgerSwitchLatencyBuckets{cluster="use", namespace="external-repl-prop/pulsar-function-admin/persistent", quantile="5.0_10.0"} 0.0
+pulsar_ml_LedgerSwitchLatencyBuckets{cluster="use", namespace="external-repl-prop/pulsar-function-admin/persistent", quantile="50.0_100.0"} 0.0
+pulsar_ml_LedgerSwitchLatencyBuckets_OVERFLOW{cluster="use", namespace="external-repl-prop/pulsar-function-admin/persistent"} 0.0
+pulsar_ml_MarkDeleteRate{cluster="use", namespace="external-repl-prop/pulsar-function-admin/persistent"} 0.0
+pulsar_ml_NumberOfMessagesInBacklog{cluster="use", namespace="external-repl-prop/pulsar-function-admin/persistent"} 0.0
+pulsar_ml_ReadEntriesBytesRate{cluster="use", namespace="external-repl-prop/pulsar-function-admin/persistent"} 0.0
+pulsar_ml_ReadEntriesErrors{cluster="use", namespace="external-repl-prop/pulsar-function-admin/persistent"} 0.0
+pulsar_ml_ReadEntriesRate{cluster="use", namespace="external-repl-prop/pulsar-function-admin/persistent"} 0.0
+pulsar_ml_ReadEntriesSucceeded{cluster="use", namespace="external-repl-prop/pulsar-function-admin/persistent"} 0.0
+pulsar_ml_StoredMessagesSize{cluster="use", namespace="external-repl-prop/pulsar-function-admin/persistent"} 3476.0
 # TYPE pulsar_active_connections gauge
-pulsar_active_connections{cluster="use", broker="localhost", metric="broker_connection"} 3 1617950344972
+pulsar_active_connections{cluster="use", broker="localhost", metric="broker_connection"} 3
 # TYPE pulsar_connection_closed_total_count gauge
-pulsar_connection_closed_total_count{cluster="use", broker="localhost", metric="broker_connection"} 0 1617950344972
+pulsar_connection_closed_total_count{cluster="use", broker="localhost", metric="broker_connection"} 0
 # TYPE pulsar_connection_create_fail_count gauge
-pulsar_connection_create_fail_count{cluster="use", broker="localhost", metric="broker_connection"} 0 1617950344972
+pulsar_connection_create_fail_count{cluster="use", broker="localhost", metric="broker_connection"} 0
 # TYPE pulsar_connection_create_success_count gauge
-pulsar_connection_create_success_count{cluster="use", broker="localhost", metric="broker_connection"} 3 1617950344972
+pulsar_connection_create_success_count{cluster="use", broker="localhost", metric="broker_connection"} 3
 # TYPE pulsar_connection_created_total_count gauge
-pulsar_connection_created_total_count{cluster="use", broker="localhost", metric="broker_connection"} 3 1617950344972
+pulsar_connection_created_total_count{cluster="use", broker="localhost", metric="broker_connection"} 3
 # TYPE pulsar_lb_load_rank gauge
-pulsar_lb_load_rank{cluster="use", broker="localhost"} 19 1617950344972
+pulsar_lb_load_rank{cluster="use", broker="localhost"} 19
 # TYPE pulsar_lb_quota_pct_bandwidth_in gauge
-pulsar_lb_quota_pct_bandwidth_in{cluster="use", broker="localhost"} 0.0 1617950344972
+pulsar_lb_quota_pct_bandwidth_in{cluster="use", broker="localhost"} 0.0
 # TYPE pulsar_lb_quota_pct_bandwidth_out gauge
-pulsar_lb_quota_pct_bandwidth_out{cluster="use", broker="localhost"} 0.0 1617950344972
+pulsar_lb_quota_pct_bandwidth_out{cluster="use", broker="localhost"} 0.0
 # TYPE pulsar_lb_quota_pct_cpu gauge
-pulsar_lb_quota_pct_cpu{cluster="use", broker="localhost"} 0.0 1617950344972
+pulsar_lb_quota_pct_cpu{cluster="use", broker="localhost"} 0.0
 # TYPE pulsar_lb_quota_pct_memory gauge
-pulsar_lb_quota_pct_memory{cluster="use", broker="localhost"} 0.0 1617950344972
+pulsar_lb_quota_pct_memory{cluster="use", broker="localhost"} 0.0

--- a/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyPrometheusMetricsTest.java
+++ b/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyPrometheusMetricsTest.java
@@ -132,8 +132,8 @@ public class ProxyPrometheusMetricsTest extends MockedPulsarServiceBaseTest {
         // jvm_threads_current{cluster="standalone",} 203.0
         // or
         // pulsar_subscriptions_count{cluster="standalone", namespace="public/default",
-        // topic="persistent://public/default/test-2"} 0.0 1517945780897
-        Pattern pattern = Pattern.compile("^(\\w+)\\{([^\\}]+)\\}\\s([+-]?[\\d\\w\\.-]+)(\\s(\\d+))?$");
+        // topic="persistent://public/default/test-2"} 0.0
+        Pattern pattern = Pattern.compile("^(\\w+)\\{([^\\}]+)\\}\\s([+-]?[\\d\\w\\.-]+)$");
         Pattern tagsPattern = Pattern.compile("(\\w+)=\"([^\"]+)\"(,\\s?)?");
 
         Splitter.on("\n").split(metrics).forEach(line -> {


### PR DESCRIPTION
### Motivation

When a Pulsar topic is unloaded from a broker, certain metrics related to that topic will appear to remain active for the broker for 5 minutes. This is confusing for troubleshooting because it makes the topic appear to be owned by multiple brokers for a short period of time. See below for a way to reproduce this behavior.

In order to solve this "zombie" metric problem, I propose we remove the timestamps that get exported with each Prometheus metric served by the broker.

### Analysis

Since we introduced Prometheus metrics in #294, we have exported a timestamp along with most metrics. This is an optional, valid part of the spec defined [here](https://prometheus.io/docs/instrumenting/exposition_formats/#comments-help-text-and-type-information). However, after our adoption of Prometheus metrics, the Prometheus project released version 2.0 with a significant improvement to its concept of staleness. In short, before 2.0, a metric that was in the last scrape but not the next one (this often happens for topics that are unloaded) will essentially inherit the most recent value for the last 5 minute window. If there isn't one in the past 5 minutes, the metric becomes "stale" and isn't reported. Starting in 2.0, there was new logic to consider a value stale the very first time that it is not reported in a scrape. Importantly, this new behavior is only available if you do not export timestamps with metrics, as documented here: https://prometheus.io/docs/prometheus/latest/querying/basics/#staleness. We want to use the new behavior because it gives better insight into all topic metrics, which are subject to move between brokers at any time.

This presentation https://www.youtube.com/watch?v=GcTzd2CLH7I and slide deck https://promcon.io/2017-munich/slides/staleness-in-prometheus-2-0.pdf document the feature in detail. This blog post was also helpful: https://www.robustperception.io/staleness-and-promql/.

Additional motivation comes from mailing list threads like this one https://groups.google.com/g/prometheus-users/c/8OFAwp1OEcY. It says:

> Note, however, that adding timestamps is an extremely niche use
case. Most of the users who think the need it should actually not do
it.
>
> The main usecases within that tiny niche are federation and mirroring
the data from another monitoring system.

The Prometheus Go client also indicates a similar motivation: https://pkg.go.dev/github.com/prometheus/client_golang/prometheus#NewMetricWithTimestamp.

The OpenMetrics project also recommends against exporting timestamps: https://github.com/OpenObservability/OpenMetrics/blob/main/specification/OpenMetrics.md#exposing-timestamps.

As such, I think we are not a niche use case, and we should not add timestamps to our metrics.

### Reproducing the problem

1. Run any 2.x version of Prometheus (I used 2.31.0) along with the following scrape config:
```yaml
  - job_name: broker
    honor_timestamps: true
    scrape_interval: 30s
    scrape_timeout: 10s
    metrics_path: /metrics
    scheme: http
    follow_redirects: true
    static_configs:
      - targets: ["localhost:8080"]
```
2. Start pulsar standalone on the same machine. I used a recently compiled version of master.
3. Publish messages to a topic.
4. Observe `pulsar_in_messages_total` metric for the topic in the prometheus UI (localhost:9090)
5. Stop the producer.
6. Unload the topic from the broker.
7. Optionally, `curl` the metrics endpoint to verify that the topic’s `pulsar_in_messages_total` metric is no longer reported.
8. Watch the metrics get reported in prometheus for 5 additional minutes.

When you set `honor_timestamps: false`, the metric stops getting reported right after the topic is unloaded, which is the desired behavior.

### Modifications

* Remove all timestamps from metrics
* Fix affected tests and test files (some of those tests were in the proxy and the function worker, but no code was changed for those modules)

### Verifying this change

This change is accompanied by updated tests.

### Does this pull request potentially affect one of the following parts:

This is technically a breaking change to the metrics, though I would consider it a bug fix at this point. I will discuss it on the mailing list to ensure it gets proper visibility.

Given how frequently Pulsar changes which metrics are exposed between each scrape, I think this is an important fix that should be cherry picked to older release branches. Technically, we can avoid cherry picking this change if we advise users to set `honor_timestamps: false`. However, I think it is better to just remove them.

### Documentation
- [x] `doc-not-needed` 