### PR TITLE
[broker] Do not log stacktrace for 'Failed to flush mark-delete position' case

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
@@ -1729,7 +1729,7 @@ public class ManagedCursorImpl implements ManagedCursor {
      */
     PositionImpl setAcknowledgedPosition(PositionImpl newMarkDeletePosition) {
         if (newMarkDeletePosition.compareTo(markDeletePosition) < 0) {
-            throw new IllegalArgumentException(
+            throw new MarkDeletingMarkedPosition(
                     "Mark deleting an already mark-deleted position. Current mark-delete: " + markDeletePosition
                             + " -- attempted mark delete: " + newMarkDeletePosition);
         }
@@ -1798,6 +1798,12 @@ public class ManagedCursorImpl implements ManagedCursor {
     @Override
     public void asyncMarkDelete(final Position position, final MarkDeleteCallback callback, final Object ctx) {
         asyncMarkDelete(position, Collections.emptyMap(), callback, ctx);
+    }
+
+    private final class MarkDeletingMarkedPosition extends IllegalArgumentException {
+        public MarkDeletingMarkedPosition(String s) {
+            super(s);
+        }
     }
 
     @Override
@@ -3289,7 +3295,13 @@ public class ManagedCursorImpl implements ManagedCursor {
 
             @Override
             public void markDeleteFailed(ManagedLedgerException exception, Object ctx) {
-                log.warn("[{}][{}] Failed to flush mark-delete position", ledger.getName(), name, exception);
+                if (exception.getCause() instanceof MarkDeletingMarkedPosition) {
+                    // this is not actually a problem, we should not log a stacktrace
+                    log.info("[{}][{}] Cannot flush mark-delete position: {}", ledger.getName(),
+                            name, exception.getCause().getMessage());
+                } else {
+                    log.warn("[{}][{}] Failed to flush mark-delete position", ledger.getName(), name, exception);
+                }
             }
         }, null);
     }


### PR DESCRIPTION
### Motivation

It is very common, under load, to see this stack trace, this is very annoying and it is scary for system administrator.

```
org.apache.bookkeeper.mledger.ManagedLedgerException: java.lang.IllegalArgumentException: Mark deleting an already mark-deleted position. Current mark-delete: 1160:823636 -- attempted mark delete: 1160:823579
Caused by: java.lang.IllegalArgumentException: Mark deleting an already mark-deleted position. Current mark-delete: 1160:823636 -- attempted mark delete: 1160:823579
        at org.apache.bookkeeper.mledger.impl.ManagedCursorImpl.setAcknowledgedPosition(ManagedCursorImpl.java:1715) ~[com.datastax.oss-managed-ledger-2.10.1.5-SNAPSHOT.jar:2.10.1.5-SNAPSHOT]
        at org.apache.bookkeeper.mledger.impl.ManagedCursorImpl.asyncMarkDelete(ManagedCursorImpl.java:1855) ~[com.datastax.oss-managed-ledger-2.10.1.5-SNAPSHOT.jar:2.10.1.5-SNAPSHOT]
        at org.apache.bookkeeper.mledger.impl.ManagedCursorImpl.flush(ManagedCursorImpl.java:3245) ~[com.datastax.oss-managed-ledger-2.10.1.5-SNAPSHOT.jar:2.10.1.5-SNAPSHOT]
        at org.apache.bookkeeper.mledger.impl.ManagedLedgerFactoryImpl.lambda$flushCursors$1(ManagedLedgerFactoryImpl.java:238) ~[com.datastax.oss-managed-ledger-2.10.1.5-SNAPSHOT.jar:2.10.1.5-SNAPSHOT]
        at java.lang.Iterable.forEach(Iterable.java:75) ~[?:?]
        at org.apache.bookkeeper.mledger.impl.ManagedLedgerFactoryImpl.lambda$flushCursors$2(ManagedLedgerFactoryImpl.java:238) ~[com.datastax.oss-managed-ledger-2.10.1.5-SNAPSHOT.jar:2.10.1.5-SNAPSHOT]
        at java.util.concurrent.ConcurrentHashMap$ValuesView.forEach(ConcurrentHashMap.java:4772) ~[?:?]
        at org.apache.bookkeeper.mledger.impl.ManagedLedgerFactoryImpl.flushCursors(ManagedLedgerFactoryImpl.java:234) ~[com.datastax.oss-managed-ledger-2.10.1.5-SNAPSHOT.jar:2.10.1.5-SNAPSHOT]
        at org.apache.pulsar.common.util.Runnables$CatchingAndLoggingRunnable.run(Runnables.java:54) ~[com.datastax.oss-pulsar-common-2.10.1.5-SNAPSHOT.jar:2.10.1.5-SNAPSHOT]
        at org.apache.bookkeeper.common.util.OrderedExecutor$TimedRunnable.run(OrderedExecutor.java:203) ~[com.datastax.oss-bookkeeper-common-4.14.5.1.0.2.jar:4.14.5.1.0.2]
        at org.apache.bookkeeper.common.util.OrderedExecutor$TimedRunnable.run(OrderedExecutor.java:203) ~[com.datastax.oss-bookkeeper-common-4.14.5.1.0.2.jar:4.14.5.1.0.2]
        at com.google.common.util.concurrent.MoreExecutors$ScheduledListeningDecorator$NeverSuccessfulListenableFutureTask.run(MoreExecutors.java:718) ~[com.google.guava-guava-31.0.1-jre.jar:?]
        at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515) ~[?:?]
        at java.util.concurrent.FutureTask.runAndReset(FutureTask.java:305) ~[?:?]
        at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:305) ~[?:?]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128) ~[?:?]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628) ~[?:?]
```

### Modifications

This is a simple fix that detects that case and does not print the full stacktrace.
1) Don't print the stacktrace
2) Do not log at WARN level but INFO

### Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

- [x] `doc-not-needed`
