### PR TITLE
[fix][connectors] Fix OutputRecordSinkRecord getValue and getSchema

### DIFF
--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/OutputRecordSinkRecord.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/OutputRecordSinkRecord.java
@@ -35,10 +35,7 @@ public class OutputRecordSinkRecord<T> extends AbstractSinkRecord<T> {
     private final Schema<T> schema;
 
     OutputRecordSinkRecord(Record<T> sourceRecord, Record<T> sinkRecord) {
-        super(sourceRecord);
-        this.sinkRecord = sinkRecord;
-        this.value = sinkRecord.getValue();
-        this.schema = getRecordSchema(sinkRecord);
+        this(sourceRecord, sinkRecord, sinkRecord.getValue(), getRecordSchema(sinkRecord));
     }
 
     OutputRecordSinkRecord(Record<T> sourceRecord, Record<T> sinkRecord, T value, Schema<T> schema) {
@@ -55,7 +52,7 @@ public class OutputRecordSinkRecord<T> extends AbstractSinkRecord<T> {
 
     @Override
     public T getValue() {
-        return sinkRecord.getValue();
+        return value;
     }
 
     @Override
@@ -85,7 +82,7 @@ public class OutputRecordSinkRecord<T> extends AbstractSinkRecord<T> {
 
     @Override
     public Schema<T> getSchema() {
-        return getRecordSchema(sinkRecord);
+        return schema;
     }
 
     @Override


### PR DESCRIPTION
### Motivation

OutputRecordSinkRecord returns the record schema and value instead of the one passed to the constructor.
It's a problem when a Sink has a transform Function where the record value is re-encoded.

### Modifications

Use the value and schema set by constructor.

### Documentation

Check the box below or label this PR directly.

Need to update docs? 

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)
  
- [x] `doc-not-needed` 
fix
  
- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)