### PR TITLE
[improve][cli] CLI extensions: rename default location to 'cliextensions'

### DIFF
--- a/pulsar-client-tools-test/pom.xml
+++ b/pulsar-client-tools-test/pom.xml
@@ -126,8 +126,8 @@
             <configuration>
               <target>
                 <echo>copy filters</echo>
-                <mkdir dir="${project.build.outputDirectory}/cliExtensions" />
-                <copy verbose="true" file="${basedir}/../pulsar-client-tools-customcommand-example/target/customCommands-nar.nar" tofile="${project.build.outputDirectory}/cliExtensions/customCommands-nar.nar" />
+                <mkdir dir="${project.build.outputDirectory}/cliextensions" />
+                <copy verbose="true" file="${basedir}/../pulsar-client-tools-customcommand-example/target/customCommands-nar.nar" tofile="${project.build.outputDirectory}/cliextensions/customCommands-nar.nar" />
               </target>
             </configuration>
           </execution>

--- a/pulsar-client-tools-test/src/test/java/org/apache/pulsar/admin/cli/PulsarAdminToolTest.java
+++ b/pulsar-client-tools-test/src/test/java/org/apache/pulsar/admin/cli/PulsarAdminToolTest.java
@@ -2335,7 +2335,7 @@ public class PulsarAdminToolTest {
 
     private static String runCustomCommand(String[] args) throws Exception {
         File narFile = new File(PulsarAdminTool.class.getClassLoader()
-                .getResource("cliExtensions/customCommands-nar.nar").getFile());
+                .getResource("cliextensions/customCommands-nar.nar").getFile());
         log.info("NAR FILE is {}", narFile);
 
         PulsarAdminBuilder builder = mock(PulsarAdminBuilder.class);

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/utils/CustomCommandFactoryProvider.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/utils/CustomCommandFactoryProvider.java
@@ -55,7 +55,7 @@ public class CustomCommandFactoryProvider {
             return result;
         }
 
-        String directory = conf.getProperty("cliExtensionsDirectory", "cliExtensions");
+        String directory = conf.getProperty("cliExtensionsDirectory", "cliextensions");
         String narExtractionDirectory = NarClassLoader.DEFAULT_NAR_EXTRACTION_DIR;
         CustomCommandFactoryDefinitions definitions = searchForCustomCommandFactories(directory,
                 narExtractionDirectory);


### PR DESCRIPTION
### Motivation
In #17158 the new CLI extensions framework read the nar files from `cliExtensions` by default. This is a bit unusual since the similar nar locations are all lower-case (`filters`, `proxyextensions`, `protocols`...)

Since it hasn't been released yet, we are still in time to change it

### Modifications
* Move from `cliExtensions` to `cliextensions`

- [x] `doc-not-needed` 