### PR TITLE
[fix][flaky-test]BatchMessageWithBatchIndexLevelTest.testBatchMessageAck

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BatchMessageWithBatchIndexLevelTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BatchMessageWithBatchIndexLevelTest.java
@@ -101,11 +101,13 @@ public class BatchMessageWithBatchIndexLevelTest extends BatchMessageTest {
         Awaitility.await().untilAsserted(() -> {
             assertEquals(dispatcher.getConsumers().get(0).getUnackedMessages(), 16);
         });
+        consumer.pause();
         Message<byte[]> receive5 = consumer.receive();
         consumer.negativeAcknowledge(receive5);
         Awaitility.await().pollInterval(1, TimeUnit.MILLISECONDS).untilAsserted(() -> {
             assertEquals(dispatcher.getConsumers().get(0).getUnackedMessages(), 0);
         });
+        consumer.resume();
         consumer.receive();
         Awaitility.await().untilAsserted(() -> {
             assertEquals(dispatcher.getConsumers().get(0).getUnackedMessages(), 16);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BatchMessageWithBatchIndexLevelTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BatchMessageWithBatchIndexLevelTest.java
@@ -101,12 +101,14 @@ public class BatchMessageWithBatchIndexLevelTest extends BatchMessageTest {
         Awaitility.await().untilAsserted(() -> {
             assertEquals(dispatcher.getConsumers().get(0).getUnackedMessages(), 16);
         });
+        // Block cmd-flow send until verify finish. see: https://github.com/apache/pulsar/pull/17436.
         consumer.pause();
         Message<byte[]> receive5 = consumer.receive();
         consumer.negativeAcknowledge(receive5);
         Awaitility.await().pollInterval(1, TimeUnit.MILLISECONDS).untilAsserted(() -> {
             assertEquals(dispatcher.getConsumers().get(0).getUnackedMessages(), 0);
         });
+        // Unblock cmd-flow.
         consumer.resume();
         consumer.receive();
         Awaitility.await().untilAsserted(() -> {


### PR DESCRIPTION
Fixes 
- #17363

### Motivation

In this test:

1. `receive` and `ack` to make the num of un-ack messages to 16, and verify
2. `receive` and `negative` to make the num of un-ack messages to 0, and verify
3. `receive` to make the num of un-ack messages back to 16, and verify

<strong>(High light)</strong> But in step 2, there has race condition:

- `negative` will make the num of un-ack messages to 0
- `cmd-negative` will trigger another `cmd-receive which will make the num of un-ack messages back to 16, see [Code-1] below
- `cmd-receive` also will trigger another `cmd-receive which will make the num of un-ack messages back to 16, see [Code-2] below
  - `receive` pops messages from the queue, when the queue is half empty, the next `receive` will be fired

#### Code-1 (High light line: 84)

https://github.com/apache/pulsar/blob/1bf9a262d972f4ce9301298214f26cf5857fc60f/pulsar-client/src/main/java/org/apache/pulsar/client/impl/NegativeAcksTracker.java#L64-L85

#### Code-2 (High light line: 1683)

https://github.com/apache/pulsar/blob/1bf9a262d972f4ce9301298214f26cf5857fc60f/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java#L1679-L1689

### Modifications

Block `cmd-flow` send until step-2 finish.

### Documentation

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)
  
- [x] `doc-not-needed` 
(Please explain why)
  
- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)