### PR TITLE
[feat][cpp] Add async receive function to C API

### DIFF
--- a/pulsar-client-cpp/.gitignore
+++ b/pulsar-client-cpp/.gitignore
@@ -39,6 +39,7 @@ lib*.so*
 /examples/SampleConsumer
 /examples/SampleConsumerCApi
 /examples/SampleAsyncProducer
+/examples/SampleAsyncConsumerCApi
 /examples/SampleConsumerListener
 /examples/SampleConsumerListenerCApi
 /examples/SampleReaderCApi

--- a/pulsar-client-cpp/examples/CMakeLists.txt
+++ b/pulsar-client-cpp/examples/CMakeLists.txt
@@ -49,6 +49,10 @@ set(SAMPLE_CONSUMER_C_SOURCES
     SampleConsumerCApi.c
 )
 
+set(SAMPLE_ASYNC_CONSUMER_C_SOURCES
+    SampleAsyncConsumerCApi.c
+)
+
 set(SAMPLE_CONSUMER_LISTENER_C_SOURCES
     SampleConsumerListenerCApi.c
 )
@@ -57,22 +61,24 @@ set(SAMPLE_READER_C_SOURCES
         SampleReaderCApi.c
 )
 
-add_executable(SampleAsyncProducer    ${SAMPLE_ASYNC_PRODUCER_SOURCES})
-add_executable(SampleConsumer         ${SAMPLE_CONSUMER_SOURCES})
-add_executable(SampleConsumerListener ${SAMPLE_CONSUMER_LISTENER_SOURCES})
-add_executable(SampleProducer         ${SAMPLE_PRODUCER_SOURCES})
-add_executable(SampleFileLogger       ${SAMPLE_FILE_LOGGER_SOURCES})
+add_executable(SampleAsyncProducer        ${SAMPLE_ASYNC_PRODUCER_SOURCES})
+add_executable(SampleConsumer             ${SAMPLE_CONSUMER_SOURCES})
+add_executable(SampleConsumerListener     ${SAMPLE_CONSUMER_LISTENER_SOURCES})
+add_executable(SampleProducer             ${SAMPLE_PRODUCER_SOURCES})
+add_executable(SampleFileLogger           ${SAMPLE_FILE_LOGGER_SOURCES})
 add_executable(SampleProducerCApi         ${SAMPLE_PRODUCER_C_SOURCES})
 add_executable(SampleConsumerCApi         ${SAMPLE_CONSUMER_C_SOURCES})
-add_executable(SampleConsumerListenerCApi         ${SAMPLE_CONSUMER_LISTENER_C_SOURCES})
-add_executable(SampleReaderCApi         ${SAMPLE_READER_C_SOURCES})
+add_executable(SampleAsyncConsumerCApi    ${SAMPLE_CONSUMER_LISTENER_C_SOURCES})
+add_executable(SampleConsumerListenerCApi ${SAMPLE_CONSUMER_LISTENER_C_SOURCES})
+add_executable(SampleReaderCApi           ${SAMPLE_READER_C_SOURCES})
 
-target_link_libraries(SampleAsyncProducer    ${CLIENT_LIBS} pulsarShared)
-target_link_libraries(SampleConsumer         ${CLIENT_LIBS} pulsarShared)
-target_link_libraries(SampleConsumerListener ${CLIENT_LIBS} pulsarShared)
-target_link_libraries(SampleProducer         ${CLIENT_LIBS} pulsarShared)
-target_link_libraries(SampleFileLogger       ${CLIENT_LIBS} pulsarShared)
-target_link_libraries(SampleProducerCApi     ${CLIENT_LIBS} pulsarShared)
-target_link_libraries(SampleConsumerCApi     ${CLIENT_LIBS} pulsarShared)
-target_link_libraries(SampleConsumerListenerCApi     ${CLIENT_LIBS} pulsarShared)
-target_link_libraries(SampleReaderCApi     ${CLIENT_LIBS} pulsarShared)
+target_link_libraries(SampleAsyncProducer        ${CLIENT_LIBS} pulsarShared)
+target_link_libraries(SampleConsumer             ${CLIENT_LIBS} pulsarShared)
+target_link_libraries(SampleConsumerListener     ${CLIENT_LIBS} pulsarShared)
+target_link_libraries(SampleProducer             ${CLIENT_LIBS} pulsarShared)
+target_link_libraries(SampleFileLogger           ${CLIENT_LIBS} pulsarShared)
+target_link_libraries(SampleProducerCApi         ${CLIENT_LIBS} pulsarShared)
+target_link_libraries(SampleConsumerCApi         ${CLIENT_LIBS} pulsarShared)
+target_link_libraries(SampleAsyncConsumerCApi    ${CLIENT_LIBS} pulsarShared)
+target_link_libraries(SampleConsumerListenerCApi ${CLIENT_LIBS} pulsarShared)
+target_link_libraries(SampleReaderCApi           ${CLIENT_LIBS} pulsarShared)

--- a/pulsar-client-cpp/examples/SampleAsyncConsumerCApi.c
+++ b/pulsar-client-cpp/examples/SampleAsyncConsumerCApi.c
@@ -1,0 +1,68 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <stdio.h>
+#include <pulsar/c/client.h>
+
+static void receive_callback(pulsar_result result, pulsar_message_t *message, void *ctx) {
+    pulsar_consumer_t *consumer = (pulsar_consumer_t *)ctx;
+    if (result == pulsar_result_Ok) {
+        printf("Received message with payload: '%.*s'\n", pulsar_message_get_length(message),
+               (const char *)pulsar_message_get_data(message));
+        pulsar_consumer_acknowledge(consumer, message);
+    } else {
+        printf("Failed to receive message: %s\n", pulsar_result_str(result));
+    }
+    pulsar_message_free(message);
+}
+
+int main() {
+    pulsar_client_configuration_t *conf = pulsar_client_configuration_create();
+    pulsar_client_t *client = pulsar_client_create("pulsar://localhost:6650", conf);
+
+    pulsar_consumer_configuration_t *consumer_conf = pulsar_consumer_configuration_create();
+    pulsar_consumer_configuration_set_consumer_type(consumer_conf, pulsar_ConsumerShared);
+
+    pulsar_consumer_t *consumer;
+    pulsar_result res =
+        pulsar_client_subscribe(client, "my-topic", "my-subscrition", consumer_conf, &consumer);
+    if (res != pulsar_result_Ok) {
+        printf("Failed to create subscribe to topic: %s\n", pulsar_result_str(res));
+        return 1;
+    }
+
+    // receive 10 messages asynchronously
+    for (int i = 0; i < 10; i++) {
+        pulsar_consumer_receive_async(consumer, receive_callback, consumer);
+    }
+
+    // Block main thread
+    fgetc(stdin);
+
+    printf("\nClosing consumer\n");
+
+    // Cleanup
+    pulsar_consumer_close(consumer);
+    pulsar_consumer_free(consumer);
+    pulsar_consumer_configuration_free(consumer_conf);
+
+    pulsar_client_close(client);
+    pulsar_client_free(client);
+    pulsar_client_configuration_free(conf);
+}

--- a/pulsar-client-cpp/include/pulsar/c/consumer.h
+++ b/pulsar-client-cpp/include/pulsar/c/consumer.h
@@ -105,8 +105,8 @@ PULSAR_PUBLIC pulsar_result pulsar_consumer_receive_with_timeout(pulsar_consumer
  *
  * @param callback callback that will be triggered when the message is available
  */
-PULSAR_PUBLIC void pulsar_consumer_receive_async(pulsar_consumer_t *consumer, pulsar_receive_callback callback,
-                                                 void *ctx);
+PULSAR_PUBLIC void pulsar_consumer_receive_async(pulsar_consumer_t *consumer,
+                                                 pulsar_receive_callback callback, void *ctx);
 
 /**
  * Acknowledge the reception of a single message.

--- a/pulsar-client-cpp/include/pulsar/c/consumer.h
+++ b/pulsar-client-cpp/include/pulsar/c/consumer.h
@@ -33,6 +33,8 @@ typedef struct _pulsar_consumer pulsar_consumer_t;
 
 typedef void (*pulsar_result_callback)(pulsar_result, void *);
 
+typedef void (*pulsar_receive_callback)(pulsar_result result, pulsar_message_t *msg, void *ctx);
+
 /**
  * @return the topic this consumer is subscribed to
  */
@@ -94,6 +96,17 @@ PULSAR_PUBLIC pulsar_result pulsar_consumer_receive(pulsar_consumer_t *consumer,
  */
 PULSAR_PUBLIC pulsar_result pulsar_consumer_receive_with_timeout(pulsar_consumer_t *consumer,
                                                                  pulsar_message_t **msg, int timeoutMs);
+
+/**
+ * Asynchronously receive a single message.
+ *
+ * This method will initiate the operation and return immediately. The provided callback
+ * will be triggered when the operation is complete.
+ *
+ * @param callback callback that will be triggered when the message is available
+ */
+PULSAR_PUBLIC void pulsar_consumer_receive_async(pulsar_consumer_t *consumer, pulsar_receive_callback callback,
+                                                 void *ctx);
 
 /**
  * Acknowledge the reception of a single message.

--- a/pulsar-client-cpp/lib/c/c_Consumer.cc
+++ b/pulsar-client-cpp/lib/c/c_Consumer.cc
@@ -60,7 +60,8 @@ pulsar_result pulsar_consumer_receive_with_timeout(pulsar_consumer_t *consumer, 
     return (pulsar_result)res;
 }
 
-static void handle_receive_callback(pulsar::Result result, pulsar::Message message, pulsar_receive_callback callback, void *ctx) {
+static void handle_receive_callback(pulsar::Result result, pulsar::Message message,
+                                    pulsar_receive_callback callback, void *ctx) {
     if (callback) {
         pulsar_message_t *msg = new pulsar_message_t;
         msg->message = message;
@@ -69,7 +70,8 @@ static void handle_receive_callback(pulsar::Result result, pulsar::Message messa
 }
 
 void pulsar_consumer_receive_async(pulsar_consumer_t *consumer, pulsar_receive_callback callback, void *ctx) {
-    consumer->consumer.receiveAsync(std::bind(handle_receive_callback, std::placeholders::_1, std::placeholders::_2, callback, ctx));
+    consumer->consumer.receiveAsync(
+        std::bind(handle_receive_callback, std::placeholders::_1, std::placeholders::_2, callback, ctx));
 }
 
 pulsar_result pulsar_consumer_acknowledge(pulsar_consumer_t *consumer, pulsar_message_t *message) {

--- a/pulsar-client-cpp/lib/c/c_Consumer.cc
+++ b/pulsar-client-cpp/lib/c/c_Consumer.cc
@@ -60,6 +60,18 @@ pulsar_result pulsar_consumer_receive_with_timeout(pulsar_consumer_t *consumer, 
     return (pulsar_result)res;
 }
 
+static void handle_receive_callback(pulsar::Result result, pulsar::Message message, pulsar_receive_callback callback, void *ctx) {
+    if (callback) {
+        pulsar_message_t *msg = new pulsar_message_t;
+        msg->message = message;
+        callback((pulsar_result)result, msg, ctx);
+    }
+}
+
+void pulsar_consumer_receive_async(pulsar_consumer_t *consumer, pulsar_receive_callback callback, void *ctx) {
+    consumer->consumer.receiveAsync(std::bind(handle_receive_callback, std::placeholders::_1, std::placeholders::_2, callback, ctx));
+}
+
 pulsar_result pulsar_consumer_acknowledge(pulsar_consumer_t *consumer, pulsar_message_t *message) {
     return (pulsar_result)consumer->consumer.acknowledge(message->message);
 }

--- a/pulsar-client-cpp/tests/CMakeLists.txt
+++ b/pulsar-client-cpp/tests/CMakeLists.txt
@@ -6,9 +6,9 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #   http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -52,7 +52,7 @@ if (NOT GTESTD_LIBRARY_PATH)
     set(GTESTD_LIBRARY_PATH ${GTEST_LIBRARY_PATH})
 endif()
 
-file(GLOB TEST_SOURCES *.cc)
+file(GLOB TEST_SOURCES *.cc c/*.cc)
 
 add_executable(main ${TEST_SOURCES} ${PROTO_SOURCES})
 

--- a/pulsar-client-cpp/tests/c/c_BasicEndToEndTest.cc
+++ b/pulsar-client-cpp/tests/c/c_BasicEndToEndTest.cc
@@ -1,0 +1,102 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <gtest/gtest.h>
+#include <pulsar/c/client.h>
+#include <pulsar/c/producer.h>
+#include <pulsar/c/consumer.h>
+#include <pulsar/c/client_configuration.h>
+#include <pulsar/c/consumer_configuration.h>
+#include <pulsar/c/message.h>
+#include <pulsar/c/message_id.h>
+#include <pulsar/c/result.h>
+
+#include "../lib/Future.h"
+
+TEST(c_BasicEndToEndTest, testAsyncProduceConsume) {
+    const char *lookup_url = "pulsar://localhost:6650";
+    const char *topic_name = "persistent://public/default/test-c-produce-consume";
+    const char *sub_name = "my-sub-name";
+
+    pulsar_client_configuration_t *conf = pulsar_client_configuration_create();
+    pulsar_client_t *client = pulsar_client_create(lookup_url, conf);
+
+    pulsar_producer_configuration_t *producer_conf = pulsar_producer_configuration_create();
+    pulsar_producer_t *producer;
+    pulsar_result result = pulsar_client_create_producer(client, topic_name, producer_conf, &producer);
+    ASSERT_EQ(pulsar_result_Ok, result);
+
+    pulsar_consumer_configuration_t *consumer_conf = pulsar_consumer_configuration_create();
+    pulsar_consumer_t *consumer;
+    result = pulsar_client_subscribe(client, topic_name, sub_name, consumer_conf, &consumer);
+    ASSERT_EQ(pulsar_result_Ok, result);
+
+    ASSERT_STREQ(topic_name, pulsar_producer_get_topic(producer));
+    ASSERT_STREQ(topic_name, pulsar_consumer_get_topic(consumer));
+    ASSERT_STREQ(sub_name, pulsar_consumer_get_subscription_name(consumer));
+
+    // send asynchronously
+    pulsar::Promise<pulsar_result, pulsar_message_id_t *> send_promise;
+    const char *content = "msg-1-content";
+    pulsar_message_t *msg = pulsar_message_create();
+    pulsar_message_set_content(msg, content, strlen(content));
+    ASSERT_STREQ("(-1,-1,-1,-1)", pulsar_message_id_str(pulsar_message_get_message_id(msg)));
+    pulsar_producer_send_async(
+        producer, msg,
+        [](pulsar_result async_result, pulsar_message_id_t *msg_id, void *ctx) {
+            auto ctx_promise = static_cast<pulsar::Promise<pulsar_result, pulsar_message_id_t *> *>(ctx);
+            ASSERT_EQ(pulsar_result_Ok, async_result);
+            ctx_promise->setValue(msg_id);
+        },
+        &send_promise);
+
+    pulsar_message_id_t *msg_id;
+    send_promise.getFuture().get(msg_id);
+    ASSERT_STRNE("(-1,-1,-1,-1)", pulsar_message_id_str(msg_id));
+    pulsar_message_id_free(msg_id);
+    pulsar_message_free(msg);
+
+    pulsar::Promise<pulsar_result, pulsar_message_t *> receive_promise;
+    // receive asynchronously
+    pulsar_consumer_receive_async(
+        consumer,
+        [](pulsar_result async_result, pulsar_message_t *received_msg, void *ctx) {
+            auto ctx_promise = static_cast<pulsar::Promise<pulsar_result, pulsar_message_t *> *>(ctx);
+            ASSERT_EQ(pulsar_result_Ok, async_result);
+            ctx_promise->setValue(received_msg);
+        },
+        &receive_promise);
+
+    pulsar_message_t *received_msg;
+    receive_promise.getFuture().get(received_msg);
+    ASSERT_STREQ(content, static_cast<const char *>(pulsar_message_get_data(received_msg)));
+    pulsar_message_free(received_msg);
+
+    ASSERT_EQ(pulsar_result_Ok, pulsar_consumer_unsubscribe(consumer));
+    ASSERT_EQ(pulsar_result_AlreadyClosed, pulsar_consumer_close(consumer));
+    ASSERT_EQ(pulsar_result_Ok, pulsar_producer_close(producer));
+    ASSERT_EQ(pulsar_result_Ok, pulsar_client_close(client));
+
+    pulsar_consumer_free(consumer);
+    pulsar_consumer_configuration_free(consumer_conf);
+    pulsar_producer_free(producer);
+    pulsar_producer_configuration_free(producer_conf);
+    pulsar_client_free(client);
+    pulsar_client_configuration_free(conf);
+}


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://docs.google.com/document/d/1d8Pw6ZbWk-_pCKdOmdvx9rnhPiyuxwq60_TrD68d7BA/edit#heading=h.trs9rsex3xom)*. 

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.

**(The sections below can be removed for hotfixes of typos)**
-->

Master Issue: [#14452](https://github.com/apache/pulsar/issues/14452)

### Motivation

I want to rewrite the pulsar-client-node `receive` method to rely exclusively on async operations rather than worker threads.
However, an async receive function is not defined currently in C API.

### Modifications

* Define `pulsar_consumer_receive_async` and `pulsar_receive_callback` to use async receive operation in C API

### Verifying this change

- [x] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is already covered by existing tests, such as *C++ tests*.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (yes)
    - https://github.com/apache/pulsar/blob/66765afce540998cbc26cda62eb044c947902b21/pulsar-client-cpp/include/pulsar/c/consumer.h#L36
    - https://github.com/apache/pulsar/blob/66765afce540998cbc26cda62eb044c947902b21/pulsar-client-cpp/include/pulsar/c/consumer.h#L100-L108
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

Check the box below or label this PR directly.

Need to update docs? 

- [x] `doc-not-needed`
