### PR TITLE
[improve][broker] Improve cursor.getNumberOfEntries if isUnackedRangesOpenCacheSetEnabled=true

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
@@ -1460,14 +1460,18 @@ public class ManagedCursorImpl implements ManagedCursor {
                         range.lowerEndpoint().ledgerId, range.lowerEndpoint().entryId,
                         range.upperEndpoint().ledgerId, range.upperEndpoint().entryId);
                 deletedEntries.addAndGet(cardinalityMap.values().stream().mapToInt(v -> v).sum());
-                deletedEntries.addAndGet(
-                    ledger.ledgers.subMap(range.lowerEndpoint().ledgerId, true,
-                                    range.upperEndpoint().ledgerId, true)
-                        .values()
-                        .stream()
-                        .filter(ledgerInfo -> !cardinalityMap.containsKey(ledgerInfo.getLedgerId()))
-                        .mapToLong(LedgerInfo::getEntries).sum()
-                );
+                if (cardinalityMap.isEmpty()) {
+                    deletedEntries.addAndGet(ledger.getNumberOfEntries(range));
+                } else {
+                    deletedEntries.addAndGet(
+                            ledger.ledgers.subMap(range.lowerEndpoint().ledgerId, true,
+                                            range.upperEndpoint().ledgerId, true)
+                                    .values()
+                                    .stream()
+                                    .filter(ledgerInfo -> !cardinalityMap.containsKey(ledgerInfo.getLedgerId()))
+                                    .mapToLong(LedgerInfo::getEntries).sum()
+                    );
+                }
             } else {
                 individualDeletedMessages.forEach((r) -> {
                     try {

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
@@ -1456,20 +1456,10 @@ public class ManagedCursorImpl implements ManagedCursor {
         lock.readLock().lock();
         try {
             if (config.isUnackedRangesOpenCacheSetEnabled()) {
-                Map<Long, Integer> cardinalityMap = individualDeletedMessages.cardinality(
+                int cardinality = individualDeletedMessages.cardinality(
                         range.lowerEndpoint().ledgerId, range.lowerEndpoint().entryId,
                         range.upperEndpoint().ledgerId, range.upperEndpoint().entryId);
-                if (!cardinalityMap.isEmpty()) {
-                    deletedEntries.addAndGet(cardinalityMap.values().stream().mapToInt(v -> v).sum());
-                    deletedEntries.addAndGet(
-                            ledger.ledgers.subMap(range.lowerEndpoint().ledgerId, true,
-                                            range.upperEndpoint().ledgerId, true)
-                                    .values()
-                                    .stream()
-                                    .filter(ledgerInfo -> !cardinalityMap.containsKey(ledgerInfo.getLedgerId()))
-                                    .mapToLong(LedgerInfo::getEntries).sum()
-                    );
-                }
+                deletedEntries.addAndGet(cardinality);
             } else {
                 individualDeletedMessages.forEach((r) -> {
                     try {

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
@@ -1459,10 +1459,8 @@ public class ManagedCursorImpl implements ManagedCursor {
                 Map<Long, Integer> cardinalityMap = individualDeletedMessages.cardinality(
                         range.lowerEndpoint().ledgerId, range.lowerEndpoint().entryId,
                         range.upperEndpoint().ledgerId, range.upperEndpoint().entryId);
-                deletedEntries.addAndGet(cardinalityMap.values().stream().mapToInt(v -> v).sum());
-                if (cardinalityMap.isEmpty()) {
-                    deletedEntries.addAndGet(ledger.getNumberOfEntries(range));
-                } else {
+                if (!cardinalityMap.isEmpty()) {
+                    deletedEntries.addAndGet(cardinalityMap.values().stream().mapToInt(v -> v).sum());
                     deletedEntries.addAndGet(
                             ledger.ledgers.subMap(range.lowerEndpoint().ledgerId, true,
                                             range.upperEndpoint().ledgerId, true)

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/RangeSetWrapper.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/RangeSetWrapper.java
@@ -24,6 +24,7 @@ import com.google.common.collect.Range;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 import org.apache.bookkeeper.mledger.ManagedLedgerConfig;
 import org.apache.pulsar.common.util.collections.ConcurrentOpenLongPairRangeSet;
 import org.apache.pulsar.common.util.collections.LongPairRangeSet;
@@ -131,6 +132,11 @@ public class RangeSetWrapper<T extends Comparable<T>> implements LongPairRangeSe
     @Override
     public Range<T> lastRange() {
         return rangeSet.lastRange();
+    }
+
+    @Override
+    public Map<Long, Integer> cardinality(long lowerKey, long lowerValue, long upperKey, long upperValue) {
+        return rangeSet.cardinality(lowerKey, lowerValue, upperKey, upperValue);
     }
 
     @VisibleForTesting

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/RangeSetWrapper.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/RangeSetWrapper.java
@@ -24,7 +24,6 @@ import com.google.common.collect.Range;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-import java.util.Map;
 import org.apache.bookkeeper.mledger.ManagedLedgerConfig;
 import org.apache.pulsar.common.util.collections.ConcurrentOpenLongPairRangeSet;
 import org.apache.pulsar.common.util.collections.LongPairRangeSet;
@@ -135,7 +134,7 @@ public class RangeSetWrapper<T extends Comparable<T>> implements LongPairRangeSe
     }
 
     @Override
-    public Map<Long, Integer> cardinality(long lowerKey, long lowerValue, long upperKey, long upperValue) {
+    public int cardinality(long lowerKey, long lowerValue, long upperKey, long upperValue) {
         return rangeSet.cardinality(lowerKey, lowerValue, upperKey, upperValue);
     }
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/systopic/PartitionedSystemTopicTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/systopic/PartitionedSystemTopicTest.java
@@ -235,26 +235,4 @@ public class PartitionedSystemTopicTest extends BrokerTestBase {
             Assert.fail("failed to create producer");
         }
     }
-
-    @Test
-    public void testGetTopic() throws Exception {
-        final String ns = "prop/ns-test";
-        admin.namespaces().createNamespace(ns, 2);
-        final String topicName = ns + "/topic-1";
-        admin.topics().createNonPartitionedTopic(String.format("persistent://%s", topicName));
-        Producer<String> producer1 = pulsarClient.newProducer(Schema.STRING).topic(topicName).create();
-        producer1.close();
-        PersistentTopic persistentTopic = (PersistentTopic) pulsar.getBrokerService().getTopic(topicName.toString(), false).get().get();
-        persistentTopic.close().join();
-        List<String> topics = new ArrayList<>(pulsar.getBrokerService().getTopics().keys());
-        topics.removeIf(item -> item.contains(SystemTopicNames.NAMESPACE_EVENTS_LOCAL_NAME));
-        Assert.assertEquals(topics.size(), 0);
-        @Cleanup
-        Consumer<String> consumer = pulsarClient.newConsumer(Schema.STRING)
-                .topic(topicName)
-                .subscriptionName("sub-1")
-                .subscriptionInitialPosition(SubscriptionInitialPosition.Earliest)
-                .subscriptionType(SubscriptionType.Shared)
-                .subscribe();
-    }
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/systopic/PartitionedSystemTopicTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/systopic/PartitionedSystemTopicTest.java
@@ -235,4 +235,26 @@ public class PartitionedSystemTopicTest extends BrokerTestBase {
             Assert.fail("failed to create producer");
         }
     }
+
+    @Test
+    public void testGetTopic() throws Exception {
+        final String ns = "prop/ns-test";
+        admin.namespaces().createNamespace(ns, 2);
+        final String topicName = ns + "/topic-1";
+        admin.topics().createNonPartitionedTopic(String.format("persistent://%s", topicName));
+        Producer<String> producer1 = pulsarClient.newProducer(Schema.STRING).topic(topicName).create();
+        producer1.close();
+        PersistentTopic persistentTopic = (PersistentTopic) pulsar.getBrokerService().getTopic(topicName.toString(), false).get().get();
+        persistentTopic.close().join();
+        List<String> topics = new ArrayList<>(pulsar.getBrokerService().getTopics().keys());
+        topics.removeIf(item -> item.contains(SystemTopicNames.NAMESPACE_EVENTS_LOCAL_NAME));
+        Assert.assertEquals(topics.size(), 0);
+        @Cleanup
+        Consumer<String> consumer = pulsarClient.newConsumer(Schema.STRING)
+                .topic(topicName)
+                .subscriptionName("sub-1")
+                .subscriptionInitialPosition(SubscriptionInitialPosition.Earliest)
+                .subscriptionType(SubscriptionType.Shared)
+                .subscribe();
+    }
 }

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/util/collections/ConcurrentOpenLongPairRangeSet.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/util/collections/ConcurrentOpenLongPairRangeSet.java
@@ -23,6 +23,7 @@ import com.google.common.collect.BoundType;
 import com.google.common.collect.Range;
 import java.util.ArrayList;
 import java.util.BitSet;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -247,6 +248,9 @@ public class ConcurrentOpenLongPairRangeSet<T extends Comparable<T>> implements 
     @Override
     public Map<Long, Integer> cardinality(long lowerKey, long lowerValue, long upperKey, long upperValue) {
         NavigableMap<Long, BitSet> subMap = rangeBitSetMap.subMap(lowerKey, true, upperKey, true);
+        if (subMap.isEmpty()) {
+            return Collections.emptyMap();
+        }
         Map<Long, Integer> v = new HashMap<>();
         subMap.forEach((ledgerId, bitset) -> {
             boolean isLowerOrUpper = false;

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/util/collections/LongPairRangeSet.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/util/collections/LongPairRangeSet.java
@@ -25,6 +25,7 @@ import com.google.common.collect.TreeRangeSet;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Set;
 import lombok.EqualsAndHashCode;
@@ -124,6 +125,11 @@ public interface LongPairRangeSet<T extends Comparable<T>> {
      * @return last biggest range into the set
      */
     Range<T> lastRange();
+
+    /**
+     * Return the number bit sets to true for each key from lower to upper.
+     */
+    Map<Long, Integer> cardinality(long lowerKey, long lowerValue, long upperKey, long upperValue);
 
     /**
      * Represents a function that accepts two long arguments and produces a result.
@@ -294,6 +300,11 @@ public interface LongPairRangeSet<T extends Comparable<T>> {
             }
             List<Range<T>> list = Lists.newArrayList(set.asRanges().iterator());
             return list.get(list.size() - 1);
+        }
+
+        @Override
+        public Map<Long, Integer> cardinality(long lowerKey, long lowerValue, long upperKey, long upperValue) {
+            throw new UnsupportedOperationException();
         }
 
         @Override

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/util/collections/LongPairRangeSet.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/util/collections/LongPairRangeSet.java
@@ -25,7 +25,6 @@ import com.google.common.collect.TreeRangeSet;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Set;
 import lombok.EqualsAndHashCode;
@@ -127,9 +126,9 @@ public interface LongPairRangeSet<T extends Comparable<T>> {
     Range<T> lastRange();
 
     /**
-     * Return the number bit sets to true for each key from lower to upper.
+     * Return the number bit sets to true from lower to upper.
      */
-    Map<Long, Integer> cardinality(long lowerKey, long lowerValue, long upperKey, long upperValue);
+    int cardinality(long lowerKey, long lowerValue, long upperKey, long upperValue);
 
     /**
      * Represents a function that accepts two long arguments and produces a result.
@@ -303,7 +302,7 @@ public interface LongPairRangeSet<T extends Comparable<T>> {
         }
 
         @Override
-        public Map<Long, Integer> cardinality(long lowerKey, long lowerValue, long upperKey, long upperValue) {
+        public int cardinality(long lowerKey, long lowerValue, long upperKey, long upperValue) {
             throw new UnsupportedOperationException();
         }
 

--- a/pulsar-common/src/test/java/org/apache/pulsar/common/util/collections/ConcurrentOpenLongPairRangeSetTest.java
+++ b/pulsar-common/src/test/java/org/apache/pulsar/common/util/collections/ConcurrentOpenLongPairRangeSetTest.java
@@ -25,7 +25,6 @@ import static org.testng.Assert.assertTrue;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 
 import org.apache.pulsar.common.util.collections.LongPairRangeSet.LongPair;
@@ -465,26 +464,20 @@ public class ConcurrentOpenLongPairRangeSetTest {
     @Test
     public void testCardinality() {
         ConcurrentOpenLongPairRangeSet<LongPair> set = new ConcurrentOpenLongPairRangeSet<>(consumer);
-        Map<Long, Integer> v = set.cardinality(0, 0, Integer.MAX_VALUE, Integer.MAX_VALUE);
-        assertEquals(v.size(), 0 );
+        int v = set.cardinality(0, 0, Integer.MAX_VALUE, Integer.MAX_VALUE);
+        assertEquals(v, 0 );
         set.addOpenClosed(1, 0, 1, 20);
         set.addOpenClosed(1, 30, 1, 90);
         set.addOpenClosed(2, 0, 3, 30);
         v = set.cardinality(1, 0, 1, 100);
-        assertEquals(v.size(), 1);
-        assertEquals((int) v.get(1L), 80);
+        assertEquals(v, 80);
         v = set.cardinality(1, 11, 1, 100);
-        assertEquals(v.size(), 1);
-        assertEquals((int) v.get(1L), 70);
+        assertEquals(v, 70);
         v = set.cardinality(1, 0, 1, 90);
-        assertEquals(v.size(), 1);
-        assertEquals((int) v.get(1L), 80);
+        assertEquals(v, 80);
         v = set.cardinality(1, 0, 1, 80);
-        assertEquals(v.size(), 1);
-        assertEquals((int) v.get(1L), 70);
+        assertEquals(v, 70);
         v = set.cardinality(1, 0, 3, 30);
-        assertEquals(v.size(), 2);
-        assertEquals((int) v.get(1L), 80);
-        assertEquals((int) v.get(3L), 31);
+        assertEquals(v, 80 + 31);
     }
 }

--- a/pulsar-common/src/test/java/org/apache/pulsar/common/util/collections/ConcurrentOpenLongPairRangeSetTest.java
+++ b/pulsar-common/src/test/java/org/apache/pulsar/common/util/collections/ConcurrentOpenLongPairRangeSetTest.java
@@ -25,6 +25,7 @@ import static org.testng.Assert.assertTrue;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import org.apache.pulsar.common.util.collections.LongPairRangeSet.LongPair;
@@ -459,5 +460,31 @@ public class ConcurrentOpenLongPairRangeSetTest {
                 lastRange.upperEndpoint());
         gRangeConnected.add(lastRange);
         return gRangeConnected;
+    }
+
+    @Test
+    public void testCardinality() {
+        ConcurrentOpenLongPairRangeSet<LongPair> set = new ConcurrentOpenLongPairRangeSet<>(consumer);
+        Map<Long, Integer> v = set.cardinality(0, 0, Integer.MAX_VALUE, Integer.MAX_VALUE);
+        assertEquals(v.size(), 0 );
+        set.addOpenClosed(1, 0, 1, 20);
+        set.addOpenClosed(1, 30, 1, 90);
+        set.addOpenClosed(2, 0, 3, 30);
+        v = set.cardinality(1, 0, 1, 100);
+        assertEquals(v.size(), 1);
+        assertEquals((int) v.get(1L), 80);
+        v = set.cardinality(1, 11, 1, 100);
+        assertEquals(v.size(), 1);
+        assertEquals((int) v.get(1L), 70);
+        v = set.cardinality(1, 0, 1, 90);
+        assertEquals(v.size(), 1);
+        assertEquals((int) v.get(1L), 80);
+        v = set.cardinality(1, 0, 1, 80);
+        assertEquals(v.size(), 1);
+        assertEquals((int) v.get(1L), 70);
+        v = set.cardinality(1, 0, 3, 30);
+        assertEquals(v.size(), 2);
+        assertEquals((int) v.get(1L), 80);
+        assertEquals((int) v.get(3L), 31);
     }
 }


### PR DESCRIPTION
Fixes #17451 

### Motivation

Improve the `ManagedCursorImpl.getNumberOfEntries()` if `isUnackedRangesOpenCacheSetEnabled=true`.
Since the `ConcurrentOpenLongPairRangeSet` has the ability to get the acked count for each Ledger,
the `ManagedCursorImpl` can avoid iterating each range to calculate the acked count. 

### Modifications

Make the `ConcurrentOpenLongPairRangeSet` able to get acked count.

### Verifying this change

Unit test for the new method introduced in `ConcurrentOpenLongPairRangeSet`
The `getNumberOfEntries()` change is already covered by the existing test

### Documentation

Check the box below or label this PR directly.

Need to update docs? 
  
- [x] `doc-not-needed` 
(Just an improvement for the presented implementation)