### PR TITLE
[improve][broker] Avoid infinite cursor growth `readPosition`.

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
@@ -1834,7 +1834,8 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
             final Long ceilingLedgerId = ceilingLedgerInfo.getKey();
             final boolean ledgerIdChanged = ceilingLedgerId != readLedgerId;
             LedgerInfo ledgerInfo = ledgers.get(ledgerIdChanged ? ceilingLedgerId : readLedgerId);
-            if (ledgerInfo.getLedgerId() != currentLedger.getId() // avoid race condition, check again
+            if (currentLedger != null
+                    && ledgerInfo.getLedgerId() != currentLedger.getId() // avoid race condition, check again
                     && ledgerInfo.getEntries() == 0) {
                 // skip 0 entries ledger if it's not current ledger.
                 return new PositionImpl(ceilingLedgerInfo.getKey() + 1, 0);

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/OpReadEntry.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/OpReadEntry.java
@@ -48,7 +48,7 @@ class OpReadEntry implements ReadEntriesCallback {
     public static OpReadEntry create(ManagedCursorImpl cursor, PositionImpl readPositionRef, int count,
             ReadEntriesCallback callback, Object ctx, PositionImpl maxPosition) {
         OpReadEntry op = RECYCLER.get();
-        op.readPosition = cursor.ledger.startReadOperationOnLedger(readPositionRef);
+        op.readPosition = readPositionRef;
         op.cursor = cursor;
         op.count = count;
         op.callback = callback;
@@ -140,7 +140,7 @@ class OpReadEntry implements ReadEntriesCallback {
 
             // We still have more entries to read from the next ledger, schedule a new async operation
             cursor.ledger.getExecutor().execute(safeRun(() -> {
-                readPosition = cursor.ledger.startReadOperationOnLedger(nextReadPosition);
+                readPosition = nextReadPosition;
                 cursor.ledger.asyncReadEntries(OpReadEntry.this);
             }));
         } else {

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedCursorTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedCursorTest.java
@@ -4079,11 +4079,12 @@ public class ManagedCursorTest extends MockedBookKeeperTestCase {
         ManagedCursorImpl managedCursorImpl = (ManagedCursorImpl) managedCursor;
         PositionImpl invalidPosition = PositionImpl.get(writePosition.getLedgerId() + 5, 0);
         managedCursorImpl.setReadPosition(invalidPosition);
-        try {
-            managedCursor.readEntries(10);
-            fail();
-        } catch (Exception ex) {
-            Assert.assertTrue(ex instanceof ManagedLedgerException.NoMoreEntriesToReadException);
+        for (int i = 0; i < 50; i++) {
+            try {
+                managedCursor.readEntries(10);
+            } catch (Exception ex) {
+                Assert.assertTrue(ex instanceof ManagedLedgerException.NoMoreEntriesToReadException);
+            }
         }
         // Read position does not change
         Assert.assertEquals(managedCursor.getReadPosition(), invalidPosition);

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedCursorTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedCursorTest.java
@@ -4042,7 +4042,7 @@ public class ManagedCursorTest extends MockedBookKeeperTestCase {
     }
 
     @Test
-    public void testReadPositionUpdateOverflow() throws ManagedLedgerException, InterruptedException,
+    public void testReadPositionInfinityGrowth() throws ManagedLedgerException, InterruptedException,
             NoSuchFieldException, IllegalAccessException {
         // Init managed ledger
         ManagedLedgerConfig managedLedgerConfig = new ManagedLedgerConfig();

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedCursorTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedCursorTest.java
@@ -4042,10 +4042,12 @@ public class ManagedCursorTest extends MockedBookKeeperTestCase {
     }
 
     @Test
-    public void testReadPositionUpdateOverflow() throws ManagedLedgerException, InterruptedException, NoSuchFieldException, IllegalAccessException {
+    public void testReadPositionUpdateOverflow() throws ManagedLedgerException, InterruptedException,
+            NoSuchFieldException, IllegalAccessException {
         // Init managed ledger
         ManagedLedgerConfig managedLedgerConfig = new ManagedLedgerConfig();
-        ManagedLedgerImpl ledger = (ManagedLedgerImpl) factory.open("testReadPositionUpdateOverflow", managedLedgerConfig);
+        ManagedLedgerImpl ledger = (ManagedLedgerImpl) factory.open("testReadPositionUpdateOverflow",
+                managedLedgerConfig);
         ledger.config.setMaximumRolloverTime(0, TimeUnit.MILLISECONDS);
         Position writePosition = ledger.addEntry("test".getBytes());
         NavigableMap<Long, MLDataFormats.ManagedLedgerInfo.LedgerInfo> ledgers = ledger.ledgers;


### PR DESCRIPTION
### Motivation

In the current implementation, if the managed cursor `readPosition` is greater than the maximum ledger position, the `readPosition` will increment to infinity when you continue reading entries. 
You can use the new test `testReadPositionUpdateOverflow` to verify this condition.

e.g.
```java
java.lang.AssertionError: 
Expected :8:0
Actual   :58:0
<Click to see difference>
```
I'm unsure what condition would reset the read position greater than the max ledger. But I think it's worth supporting this mechanism to prevent this from happening.

> We can keep looking for another logic that might set `readPosition` to be larger than the largest ledger.

### Modifications

- Move the old logic in `startReadOperationOnLedger` to `asyncReadEntries` to make the `OpReadEntry` more clear.
- If `readPosition` grater than the maximum ledger id throw `ManagedLedgerException.NoMoreEntriesToReadException`.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

Add new test `testReadPositionUpdateOverflow` to verify this change.

### Documentation

- [x] `doc-not-needed` 
(Please explain why)
  
