### PR TITLE
[fix][functions] Fix Java Function instance LogAppender missing logs

### DIFF
--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/JavaInstanceRunnable.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/JavaInstanceRunnable.java
@@ -306,7 +306,6 @@ public class JavaInstanceRunnable implements AutoCloseable, Runnable {
                     }
                 }
 
-                addLogTopicHandler();
                 JavaExecutionResult result;
 
                 // set last invocation time
@@ -326,8 +325,6 @@ public class JavaInstanceRunnable implements AutoCloseable, Runnable {
 
                 // register end time
                 stats.processTimeEnd();
-
-                removeLogTopicHandler();
 
                 if (result != null) {
                     // process the synchronous results
@@ -703,14 +700,8 @@ public class JavaInstanceRunnable implements AutoCloseable, Runnable {
                     instanceConfig.getInstanceName());
             logAppender.start();
             setupLogTopicAppender(LoggerContext.getContext());
+            setupLogTopicAppender(LoggerContext.getContext(false));
         }
-    }
-
-    private void addLogTopicHandler() {
-        if (logAppender == null) {
-            return;
-        }
-        setupLogTopicAppender(LoggerContext.getContext(false));
     }
 
     private void setupLogTopicAppender(LoggerContext context) {
@@ -721,13 +712,6 @@ public class JavaInstanceRunnable implements AutoCloseable, Runnable {
         }
         config.getRootLogger().addAppender(logAppender, null, null);
         context.updateLoggers();
-    }
-
-    private void removeLogTopicHandler() {
-        if (logAppender == null) {
-            return;
-        }
-        removeLogTopicAppender(LoggerContext.getContext(false));
     }
 
     private void removeLogTopicAppender(LoggerContext context) {


### PR DESCRIPTION
Fixes #15392

### Motivation

When using a `log-topic` in Functions, an appender is added to all loggers to send the logs with the Pulsar client.
To prevent sending logs from the framework, the `LogAppender` is added before the function processing (`JavaInstance::handleMessage`) and removed just after.
This is a problem because since #15188, the logs are sent asynchronously and sometimes we remove the appender before the log is processed by the `LogAppender`.
And this is the reason why we see flakyness in `testJavaLoggingFunction` because me miss some logs.
This is also a problem when using an async Function that returns `CompletableFuture` where the execution of the Function will be done async and probably when the appender is removed.
I had a look and the framework only sends error logs. It may even be interesting to get these logs to debug Functions.
So this change is about removing this dynamic add/delete of the appender (which probably also has some effect on perf) and add it once and for all.

### Modifications

Remove calls to `addLogTopicHandler ` and `removeLogTopicHandler` and call `setupLogTopicAppender` during the setup.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change is already covered by existing tests, such as *testJavaLoggingFunction*.

### Does this pull request potentially affect one of the following parts:

no

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API: (yes / no)
  - The schema: (yes / no / don't know)
  - The default values of configurations: (yes / no)
  - The wire protocol: (yes / no)
  - The rest endpoints: (yes / no)
  - The admin cli options: (yes / no)
  - Anything that affects deployment: (yes / no / don't know)

### Documentation

Check the box below or label this PR directly.

Need to update docs? 

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)
  
- [x] `doc-not-needed` 
fix
  
- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)