### PR TITLE
[fix][functions] Revert "Enable Log4j2 async loggers (#15188)"

### DIFF
--- a/bin/pulsar
+++ b/bin/pulsar
@@ -316,11 +316,8 @@ OPTS="$OPTS -Dpulsar.log.dir=$PULSAR_LOG_DIR"
 OPTS="$OPTS -Dpulsar.log.level=$PULSAR_LOG_LEVEL"
 OPTS="$OPTS -Dpulsar.log.root.level=$PULSAR_LOG_ROOT_LEVEL"
 OPTS="$OPTS -Dpulsar.routing.appender.default=$PULSAR_ROUTING_APPENDER_DEFAULT"
-
-
 # Configure log4j2 to disable servlet webapp detection so that Garbage free logging can be used
-PULSAR_LOG4J_CONF=${PULSAR_LOG4J_CONF:-"-Dlog4j2.is.webapp=false  -Dlog4j2.contextSelector=org.apache.logging.log4j.core.async.AsyncLoggerContextSelector -Dlog4j2.enableThreadlocals=true -Dlog4j2.enableDirectEncoders=true"}
-OPTS="$OPTS $PULSAR_LOG4J_CONF"
+OPTS="$OPTS -Dlog4j2.is.webapp=false"
 
 # Functions related logging
 OPTS="$OPTS -Dpulsar.functions.process.container.log.dir=$PULSAR_LOG_DIR"

--- a/conf/log4j2.yaml
+++ b/conf/log4j2.yaml
@@ -53,7 +53,6 @@ Configuration:
     Console:
       name: Console
       target: SYSTEM_OUT
-      direct: true
       PatternLayout:
         Pattern: "%d{ISO8601_OFFSET_DATE_TIME_HHMM} [%t] %-5level %logger{36} - %msg%n"
 

--- a/distribution/server/pom.xml
+++ b/distribution/server/pom.xml
@@ -65,11 +65,6 @@
     </dependency>
 
     <dependency>
-      <groupId>com.lmax</groupId>
-      <artifactId>disruptor</artifactId>
-    </dependency>
-
-    <dependency>
       <groupId>org.apache.zookeeper</groupId>
       <artifactId>zookeeper-prometheus-metrics</artifactId>
       <version>${zookeeper.version}</version>

--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -543,8 +543,6 @@ The Apache Software License, Version 2.0
     - io.etcd-jetcd-core-0.5.11.jar
   * IPAddress
     - com.github.seancfoley-ipaddress-5.3.3.jar
-  * LMAX Disruptor
-    - com.lmax-disruptor-3.4.3.jar
   * RxJava
     - io.reactivex.rxjava3-rxjava-3.0.1.jar
   * RabbitMQ Java Client


### PR DESCRIPTION
Fixes #15392

### Motivation

This reverts commit 1e9a1f087e8c6fd9e78f6e3f0635113ba7927bbf.
When using a `log-topic` in Functions, an appender is added to all loggers to send the logs with the Pulsar client.
To prevent sending logs from the framework, the `LogAppender` is added before the function processing (`JavaInstance::handleMessage`) and removed just after.
This is a problem because since #15188, the logs are sent asynchronously and sometimes we remove the appender before the log is processed by the `LogAppender`.
And this is the reason why we see flakyness in `testJavaLoggingFunction` because me miss some logs.

See also #17471 that proposes another way to solve the issue but that maybe deserves more discussions.

### Modifications

This reverts commit 1e9a1f087e8c6fd9e78f6e3f0635113ba7927bbf.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change is already covered by existing tests, such as *testJavaLoggingFunction*.

### Does this pull request potentially affect one of the following parts:

no

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API: (yes / no)
  - The schema: (yes / no / don't know)
  - The default values of configurations: (yes / no)
  - The wire protocol: (yes / no)
  - The rest endpoints: (yes / no)
  - The admin cli options: (yes / no)
  - Anything that affects deployment: (yes / no / don't know)

### Documentation

Check the box below or label this PR directly.

Need to update docs? 

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)
  
- [x] `doc-not-needed` 
fix
  
- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)