### PR TITLE
[ci] move back PersistentStreamingDispatcherBlockConsumerTest to the flaky suite

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/PersistentStreamingDispatcherBlockConsumerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/PersistentStreamingDispatcherBlockConsumerTest.java
@@ -26,7 +26,7 @@ import org.testng.annotations.Test;
 /**
  * DispatcherBlockConsumerTest with {@link StreamingDispatcher}
  */
-@Test(groups = "broker")
+@Test(groups = "flaky")
 public class PersistentStreamingDispatcherBlockConsumerTest extends DispatcherBlockConsumerTest {
 
     @BeforeMethod


### PR DESCRIPTION
### Motivation
In https://github.com/apache/pulsar/pull/17161 we moved that class out of the flaky suite because we fixed that single test. But the class is still flaky for this test `testBrokerSubscriptionRecovery ` https://github.com/apache/pulsar/issues/17011

### Modifications

* Move the class to the flaky suite to unblock CI for other pulls  

- [x] `doc-not-needed` 