### PR TITLE
[improve][cli] Pulsar shell: fix custom commands execution

### DIFF
--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/PulsarAdminTool.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/PulsarAdminTool.java
@@ -230,7 +230,9 @@ public class PulsarAdminTool {
             jcommander.addCommand(c.getKey(), c.getValue().getConstructor(Supplier.class).newInstance(admin));
         } else {
             // Other mode, all components are initialized.
-            jcommander.addCommand(c.getKey(), c.getValue().getConstructor(Supplier.class).newInstance(admin));
+            if (c.getValue() != null) {
+                jcommander.addCommand(c.getKey(), c.getValue().getConstructor(Supplier.class).newInstance(admin));
+            }
         }
     }
 


### PR DESCRIPTION
### Motivation

In Pulsar shell the custom commands don't work (PIP-201)

```
java.lang.NullPointerException: Cannot invoke "java.lang.Class.getConstructor(java.lang.Class[])" because the return value of "java.util.Map$Entry.getValue()" is null
        at org.apache.pulsar.admin.cli.PulsarAdminTool.addCommand(PulsarAdminTool.java:218)
        at org.apache.pulsar.admin.cli.PulsarAdminTool.setupCommands(PulsarAdminTool.java:164)
        at org.apache.pulsar.admin.cli.PulsarAdminTool.setupAndRun(PulsarAdminTool.java:224)
        at org.apache.pulsar.admin.cli.PulsarAdminTool.run(PulsarAdminTool.java:229)
        at org.apache.pulsar.shell.AdminShell.runCommand(AdminShell.java:72)
        at org.apache.pulsar.shell.PulsarShell.run(PulsarShell.java:436)
        at org.apache.pulsar.shell.PulsarShell.run(PulsarShell.java:220)
        at org.apache.pulsar.shell.PulsarShell.main(PulsarShell.java:209)

```
We just need to avoid the NPE because sometimes the setupCommands is called twice for prepare Pulsar shell commands for the autocompletion

### Modifications

* Avoid NPE


### Verifying this change
Verify both autocompletion and execution work correctly

### Documentation

- [x] `doc-not-needed` 