### PR TITLE
[fix][cpp] Use weak ptr avoid circular references.

### DIFF
--- a/pulsar-client-cpp/lib/MultiTopicsConsumerImpl.cc
+++ b/pulsar-client-cpp/lib/MultiTopicsConsumerImpl.cc
@@ -577,7 +577,9 @@ void MultiTopicsConsumerImpl::negativeAcknowledge(const MessageId& msgId) {
     }
 }
 
-MultiTopicsConsumerImpl::~MultiTopicsConsumerImpl() {}
+MultiTopicsConsumerImpl::~MultiTopicsConsumerImpl() {
+    LOG_DEBUG(getName() << "~MultiTopicsConsumerImpl");
+}
 
 Future<Result, ConsumerImplBaseWeakPtr> MultiTopicsConsumerImpl::getConsumerCreatedFuture() {
     return multiTopicsConsumerCreatedPromise_.getFuture();
@@ -740,11 +742,12 @@ uint64_t MultiTopicsConsumerImpl::getNumberOfConnectedConsumer() {
 }
 void MultiTopicsConsumerImpl::runPartitionUpdateTask() {
     partitionsUpdateTimer_->expires_from_now(partitionsUpdateInterval_);
-    auto self = shared_from_this();
-    partitionsUpdateTimer_->async_wait([self](const boost::system::error_code& ec) {
+    std::weak_ptr<MultiTopicsConsumerImpl> weakSelf{shared_from_this()};
+    partitionsUpdateTimer_->async_wait([weakSelf](const boost::system::error_code& ec) {
         // If two requests call runPartitionUpdateTask at the same time, the timer will fail, and it
         // cannot continue at this time, and the request needs to be ignored.
-        if (!ec) {
+        auto self = weakSelf.lock();
+        if (self && !ec) {
             self->topicPartitionUpdate();
         }
     });

--- a/pulsar-client-cpp/lib/MultiTopicsConsumerImpl.cc
+++ b/pulsar-client-cpp/lib/MultiTopicsConsumerImpl.cc
@@ -577,7 +577,7 @@ void MultiTopicsConsumerImpl::negativeAcknowledge(const MessageId& msgId) {
     }
 }
 
-MultiTopicsConsumerImpl::~MultiTopicsConsumerImpl() { LOG_DEBUG(getName() << "~MultiTopicsConsumerImpl"); }
+MultiTopicsConsumerImpl::~MultiTopicsConsumerImpl() {}
 
 Future<Result, ConsumerImplBaseWeakPtr> MultiTopicsConsumerImpl::getConsumerCreatedFuture() {
     return multiTopicsConsumerCreatedPromise_.getFuture();

--- a/pulsar-client-cpp/lib/MultiTopicsConsumerImpl.cc
+++ b/pulsar-client-cpp/lib/MultiTopicsConsumerImpl.cc
@@ -577,9 +577,7 @@ void MultiTopicsConsumerImpl::negativeAcknowledge(const MessageId& msgId) {
     }
 }
 
-MultiTopicsConsumerImpl::~MultiTopicsConsumerImpl() {
-    LOG_DEBUG(getName() << "~MultiTopicsConsumerImpl");
-}
+MultiTopicsConsumerImpl::~MultiTopicsConsumerImpl() { LOG_DEBUG(getName() << "~MultiTopicsConsumerImpl"); }
 
 Future<Result, ConsumerImplBaseWeakPtr> MultiTopicsConsumerImpl::getConsumerCreatedFuture() {
     return multiTopicsConsumerCreatedPromise_.getFuture();


### PR DESCRIPTION
### Motivation

Capturing shared ptr in the timer function will cause a circular reference.

### Modifications

- Use weak ptr instead shared ptr.


### Documentation

- [x] `doc-not-needed` 
