### PR TITLE
[feat][python] Add basic authentication

### DIFF
--- a/pulsar-client-cpp/lib/c/c_Authentication.cc
+++ b/pulsar-client-cpp/lib/c/c_Authentication.cc
@@ -72,3 +72,9 @@ pulsar_authentication_t *pulsar_authentication_oauth2_create(const char *authPar
     authentication->auth = pulsar::AuthOauth2::create(authParamsString);
     return authentication;
 }
+
+pulsar_authentication_t *pulsar_authentication_basic_create(const char *username, const char *password) {
+    pulsar_authentication_t *authentication = new pulsar_authentication_t;
+    authentication->auth = pulsar::AuthBasic::create(username, password);
+    return authentication;
+}

--- a/pulsar-client-cpp/python/pulsar/__init__.py
+++ b/pulsar-client-cpp/python/pulsar/__init__.py
@@ -344,6 +344,23 @@ class AuthenticationOauth2(Authentication):
         _check_type(str, auth_params_string, 'auth_params_string')
         self.auth = _pulsar.AuthenticationOauth2(auth_params_string)
 
+class AuthenticationBasic(Authentication):
+    """
+    Basic Authentication implementation
+    """
+    def __init__(self, username, password):
+        """
+        Create the Basic authentication provider instance.
+
+        **Args**
+
+        * `username`: Used to authentication as username
+        * `password`: Used to authentication as password
+        """
+        _check_type(str, username, 'username')
+        _check_type(str, password, 'password')
+        self.auth = _pulsar.AuthenticationBasic(username, password)
+
 class Client:
     """
     The Pulsar client. A single client instance can be used to create producers

--- a/pulsar-client-cpp/python/pulsar_test.py
+++ b/pulsar-client-cpp/python/pulsar_test.py
@@ -1298,5 +1298,13 @@ class PulsarTest(TestCase):
         self.assertEqual(msg.data(), b"hello")
         client.close()
 
+    def test_invalid_basic_auth(self):
+        username = "invalid"
+        password = "123456"
+        client = Client(self.adminUrl, authentication=AuthenticationBasic(username, password))
+        topic = "persistent://private/auth/my-python-topic-invalid-basic-auth"
+        with self.assertRaises(pulsar.ConnectError):
+            client.subscribe(topic, "my-sub", consumer_type=ConsumerType.Shared)
+
 if __name__ == "__main__":
     main()

--- a/pulsar-client-cpp/python/pulsar_test.py
+++ b/pulsar-client-cpp/python/pulsar_test.py
@@ -31,6 +31,7 @@ from pulsar import (
     CompressionType,
     ConsumerType,
     PartitionsRoutingMode,
+    AuthenticationBasic,
     AuthenticationTLS,
     Authentication,
     AuthenticationToken,
@@ -1282,6 +1283,20 @@ class PulsarTest(TestCase):
         with self.assertRaises(TypeError):
             fun()
 
+    def test_basic_auth(self):
+        username = "admin"
+        password = "123456"
+        client = Client(self.adminUrl, authentication=AuthenticationBasic(username, password))
+
+        topic = "persistent://private/auth/my-python-topic-basic-auth"
+        consumer = client.subscribe(topic, "my-sub", consumer_type=ConsumerType.Shared)
+        producer = client.create_producer(topic)
+        producer.send(b"hello")
+
+        msg = consumer.receive(TM)
+        self.assertTrue(msg)
+        self.assertEqual(msg.data(), b"hello")
+        client.close()
 
 if __name__ == "__main__":
     main()

--- a/pulsar-client-cpp/python/src/authentication.cc
+++ b/pulsar-client-cpp/python/src/authentication.cc
@@ -90,6 +90,13 @@ struct AuthenticationOauth2Wrapper : public AuthenticationWrapper {
     }
 };
 
+struct AuthenticationBasicWrapper : public AuthenticationWrapper {
+    AuthenticationBasicWrapper(const std::string& username, const std::string& password)
+        : AuthenticationWrapper() {
+        this->auth = AuthBasic::create(username, password);
+    }
+};
+
 void export_authentication() {
     using namespace boost::python;
 
@@ -106,4 +113,7 @@ void export_authentication() {
 
     class_<AuthenticationOauth2Wrapper, bases<AuthenticationWrapper> >("AuthenticationOauth2",
                                                                        init<const std::string&>());
+
+    class_<AuthenticationBasicWrapper, bases<AuthenticationWrapper> >(
+        "AuthenticationBasic", init<const std::string&, const std::string&>());
 }


### PR DESCRIPTION
### Motivation

Python misses the basic authentication.

### Verifying this change

Added `test_basic_auth` test to cover this  feature.

### Documentation

Check the box below or label this PR directly.

Need to update docs? 

- [x] `doc-required` 
Add Python basic authentication documentation.
  
- [ ] `doc-not-needed` 
(Please explain why)
  
- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)