### PR TITLE
[fix][doc] Add verifying the client cert

### DIFF
--- a/site2/docs/security-tls-authentication.md
+++ b/site2/docs/security-tls-authentication.md
@@ -71,6 +71,7 @@ To configure brokers to authenticate clients, add the following parameters to `b
 # Configuration to enable authentication
 authenticationEnabled=true
 authenticationProviders=org.apache.pulsar.broker.authentication.AuthenticationProviderTls
+tlsRequireTrustedClientCertOnConnect=true
 
 brokerClientAuthenticationPlugin=org.apache.pulsar.client.impl.auth.AuthenticationTls
 brokerClientAuthenticationParameters={"tlsCertFile":"/path/my-ca/admin.cert.pem","tlsKeyFile":"/path/my-ca/admin.key-pk8.pem"}
@@ -87,6 +88,7 @@ The proxy should have its own client key pair for connecting to brokers. You nee
 # For clients connecting to the proxy
 authenticationEnabled=true
 authenticationProviders=org.apache.pulsar.broker.authentication.AuthenticationProviderTls
+tlsRequireTrustedClientCertOnConnect=true
 
 # For the proxy to connect to brokers
 brokerClientAuthenticationPlugin=org.apache.pulsar.client.impl.auth.AuthenticationTls


### PR DESCRIPTION
Fix #11381

### Motivation

When using the TLS authentication, we need to enable the `tlsRequireTrustedClientCertOnConnect` in the config file, this config means the client must provide the TLS certificates.

### Documentation

Check the box below or label this PR directly.

Need to update docs? 

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)
  
- [ ] `doc-not-needed` 
(Please explain why)
  
- [x] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)