### PR TITLE
[fix][flaky-test]NamespaceServiceTest.flaky/testModularLoadManagerRemoveBundleAndLoad

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/namespace/NamespaceServiceTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/namespace/NamespaceServiceTest.java
@@ -46,7 +46,6 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
-import java.util.function.Predicate;
 import lombok.Cleanup;
 import org.apache.bookkeeper.mledger.ManagedLedger;
 import org.apache.commons.collections4.CollectionUtils;

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/namespace/NamespaceServiceTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/namespace/NamespaceServiceTest.java
@@ -781,8 +781,7 @@ public class NamespaceServiceTest extends BrokerTestBase {
         //create znode for bundle-data
         pulsar.getBrokerService().updateRates();
 
-        waitResourceDataUpdateToZK(loadManager,
-                loadData -> loadData.getBundleData().containsKey(bundleName));
+        waitResourceDataUpdateToZK(loadManager);
         String path = BUNDLE_DATA_PATH + "/" + bundleName;
 
         Optional<GetResult> getResult = pulsar.getLocalMetadataStore().get(path).get();
@@ -794,15 +793,13 @@ public class NamespaceServiceTest extends BrokerTestBase {
         TimeUnit.SECONDS.sleep(5);
 
         // update broker bundle report to zk
-        waitResourceDataUpdateToZK(loadManager,
-                loadData -> !loadData.getBundleData().containsKey(bundleName));
+        waitResourceDataUpdateToZK(loadManager);
 
         getResult = pulsar.getLocalMetadataStore().get(path).get();
         assertFalse(getResult.isPresent());
     }
 
-    private void waitResourceDataUpdateToZK(
-            LoadManager loadManager, Predicate<LoadData> utilChecker) throws Exception {
+    private void waitResourceDataUpdateToZK(LoadManager loadManager) throws Exception {
         CompletableFuture<Void> waitForBrokerChangeNotice = registryBrokerDataChangeNotice();
         // Manually trigger "LoadReportUpdaterTask"
         loadManager.writeLoadReportOnZookeeper();


### PR DESCRIPTION
Fixes #17386

### Motivation

In this test, we expect it works like this: 

1. persistent broker data to ZK
2. receive notice: broker data changes, and refresh bundle data in memory 
3. persistent bundle data which already updated in memory to ZK
4. verify bundle data persist correctly
5. delete namespace
6. verify bundle data deleted

But the flow works like this:
1. persistent broker data to ZK
2. <strong> (High light) race condition </strong>
2-x. receive notice: broker data changes, and refresh bundle data in memory 
2-x. persistent bundle data to ZK ( If the data in memory is not updated, it will not be written to ZK )
3. ......

### Modifications

- guarantee `step-3` is always executed after `step-2`
- In this test, the original codes mock `ModularLoadManagerWrapper` to make `isCentralized` always return `true`. But this mock is completely unnecessary because that's `ModularLoadManagerWrapper.isCentralized` was exactly always returned `true`, so remove the mock. 

### Documentation

- [ ] `doc-required` 
  
- [x] `doc-not-needed` 
  
- [ ] `doc` 

- [ ] `doc-complete`