### PR TITLE
[improve][CI] Optimize "Pulsar Bot" workflow

### DIFF
--- a/.github/workflows/ci-pulsarbot.yaml
+++ b/.github/workflows/ci-pulsarbot.yaml
@@ -21,29 +21,15 @@ name: Pulsar Bot
 on:
   issue_comment:
     types: [created]
-  pull_request:
-    types: [closed]
-
-env:
-  MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.class=standard -Dmaven.wagon.http.retryHandler.count=3
 
 jobs:
-
-  action-runner:
-    name:
+  pulsarbot:
     runs-on: ubuntu-latest
-    timeout-minutes: 120
-
+    timeout-minutes: 10
+    if: github.event_name == 'issue_comment' && contains(github.event.comment.body, '/pulsarbot')
     steps:
-      - name: checkout
-        uses: actions/checkout@v2
-
-      - name: Tune Runner VM
-        uses: ./.github/actions/tune-runner-vm
-
       - name: Execute pulsarbot command
-        id:   pulsarbot
-        if: github.event_name == 'issue_comment' && contains(github.event.comment.body, '/pulsarbot')
+        id: pulsarbot
         env:
           GITHUB_TOKEN: ${{ secrets.PULSARBOT_TOKEN }}
         uses: apache/pulsar-test-infra/pulsarbot@master


### PR DESCRIPTION
### Motivation

Currently build jobs in the "Pulsar Bot" workflow will get triggered for all issue/PR comments. This wastes resources since the build jobs will get added to the build queue and this consumes quota.
The "Pulsar Bot" workflow can be optimized to save CI resources.

### Modifications

- move the filter from the build step to the build job
   - only start the build job if the comment includes "/pulsarbot"
- no need to checkout code
- no need to run the tune VM action



- [x] `doc-not-needed` 
