### PR TITLE
[ci] Add branch-2.11 to periodic owasp check

### DIFF
--- a/.github/workflows/ci-owasp-dependency-check.yaml
+++ b/.github/workflows/ci-owasp-dependency-check.yaml
@@ -37,6 +37,8 @@ jobs:
         include:
           - name: master
             checkout_branch: 'master'
+          - name: branch-2.11
+            checkout_branch: 'branch-2.11'
           - name: branch-2.10
             checkout_branch: 'branch-2.10'
           - name: branch-2.9


### PR DESCRIPTION
### Motivation
Branch 2.11 is not included in the owasp check 


### Modifications

Added it to the matrix 

- [x] `doc-not-needed` 