### PR TITLE
[improve][admin] Remove duplicate  subName encoding

### DIFF
--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/TopicsImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/TopicsImpl.java
@@ -766,8 +766,7 @@ public class TopicsImpl extends BaseResource implements Topics {
     @Override
     public CompletableFuture<Void> deleteSubscriptionAsync(String topic, String subName, boolean force) {
         TopicName tn = validateTopic(topic);
-        String encodedSubName = Codec.encode(subName);
-        WebTarget path = topicPath(tn, "subscription", encodedSubName);
+        WebTarget path = topicPath(tn, "subscription", subName);
         path = path.queryParam("force", force);
         return asyncDeleteRequest(path);
     }
@@ -780,8 +779,7 @@ public class TopicsImpl extends BaseResource implements Topics {
     @Override
     public CompletableFuture<Void> skipAllMessagesAsync(String topic, String subName) {
         TopicName tn = validateTopic(topic);
-        String encodedSubName = Codec.encode(subName);
-        WebTarget path = topicPath(tn, "subscription", encodedSubName, "skip_all");
+        WebTarget path = topicPath(tn, "subscription", subName, "skip_all");
         return asyncPostRequest(path, Entity.entity("", MediaType.APPLICATION_JSON));
     }
 
@@ -793,8 +791,7 @@ public class TopicsImpl extends BaseResource implements Topics {
     @Override
     public CompletableFuture<Void> skipMessagesAsync(String topic, String subName, long numMessages) {
         TopicName tn = validateTopic(topic);
-        String encodedSubName = Codec.encode(subName);
-        WebTarget path = topicPath(tn, "subscription", encodedSubName, "skip", String.valueOf(numMessages));
+        WebTarget path = topicPath(tn, "subscription", subName, "skip", String.valueOf(numMessages));
         return asyncPostRequest(path, Entity.entity("", MediaType.APPLICATION_JSON));
     }
 
@@ -806,8 +803,7 @@ public class TopicsImpl extends BaseResource implements Topics {
     @Override
     public CompletableFuture<Void> expireMessagesAsync(String topic, String subName, long expireTimeInSeconds) {
         TopicName tn = validateTopic(topic);
-        String encodedSubName = Codec.encode(subName);
-        WebTarget path = topicPath(tn, "subscription", encodedSubName,
+        WebTarget path = topicPath(tn, "subscription", subName,
                 "expireMessages", String.valueOf(expireTimeInSeconds));
         return asyncPostRequest(path, Entity.entity("", MediaType.APPLICATION_JSON));
     }
@@ -822,10 +818,9 @@ public class TopicsImpl extends BaseResource implements Topics {
     public CompletableFuture<Void> expireMessagesAsync(String topic, String subscriptionName,
                                                        MessageId messageId, boolean isExcluded) {
         TopicName tn = validateTopic(topic);
-        String encodedSubName = Codec.encode(subscriptionName);
         ResetCursorData resetCursorData = new ResetCursorData(messageId);
         resetCursorData.setExcluded(isExcluded);
-        WebTarget path = topicPath(tn, "subscription", encodedSubName, "expireMessages");
+        WebTarget path = topicPath(tn, "subscription", subscriptionName, "expireMessages");
         return asyncPostRequest(path, Entity.entity(resetCursorData, MediaType.APPLICATION_JSON));
     }
 
@@ -844,8 +839,7 @@ public class TopicsImpl extends BaseResource implements Topics {
 
     private CompletableFuture<List<Message<byte[]>>> peekNthMessage(String topic, String subName, int messagePosition) {
         TopicName tn = validateTopic(topic);
-        String encodedSubName = Codec.encode(subName);
-        WebTarget path = topicPath(tn, "subscription", encodedSubName,
+        WebTarget path = topicPath(tn, "subscription", subName,
                 "position", String.valueOf(messagePosition));
         final CompletableFuture<List<Message<byte[]>>> future = new CompletableFuture<>();
         asyncGetRequest(path,
@@ -1035,8 +1029,7 @@ public class TopicsImpl extends BaseResource implements Topics {
     public CompletableFuture<Void> createSubscriptionAsync(String topic, String subscriptionName,
             MessageId messageId, boolean replicated, Map<String, String> properties) {
         TopicName tn = validateTopic(topic);
-        String encodedSubName = Codec.encode(subscriptionName);
-        WebTarget path = topicPath(tn, "subscription", encodedSubName);
+        WebTarget path = topicPath(tn, "subscription", subscriptionName);
         path = path.queryParam("replicated", replicated);
         Object payload = messageId;
         if (properties != null && !properties.isEmpty()) {
@@ -1052,8 +1045,7 @@ public class TopicsImpl extends BaseResource implements Topics {
     public void resetCursor(String topic, String subName, long timestamp) throws PulsarAdminException {
         try {
             TopicName tn = validateTopic(topic);
-            String encodedSubName = Codec.encode(subName);
-            WebTarget path = topicPath(tn, "subscription", encodedSubName,
+            WebTarget path = topicPath(tn, "subscription", subName,
                     "resetcursor", String.valueOf(timestamp));
             request(path).post(Entity.entity("", MediaType.APPLICATION_JSON), ErrorData.class);
         } catch (Exception e) {
@@ -1064,8 +1056,7 @@ public class TopicsImpl extends BaseResource implements Topics {
     @Override
     public CompletableFuture<Void> resetCursorAsync(String topic, String subName, long timestamp) {
         TopicName tn = validateTopic(topic);
-        String encodedSubName = Codec.encode(subName);
-        WebTarget path = topicPath(tn, "subscription", encodedSubName,
+        WebTarget path = topicPath(tn, "subscription", subName,
                 "resetcursor", String.valueOf(timestamp));
         return asyncPostRequest(path, Entity.entity("", MediaType.APPLICATION_JSON));
     }
@@ -1091,8 +1082,7 @@ public class TopicsImpl extends BaseResource implements Topics {
     public CompletableFuture<Void> updateSubscriptionPropertiesAsync(String topic, String subName,
                                                                      Map<String, String> subscriptionProperties) {
         TopicName tn = validateTopic(topic);
-        String encodedSubName = Codec.encode(subName);
-        WebTarget path = topicPath(tn, "subscription", encodedSubName,
+        WebTarget path = topicPath(tn, "subscription", subName,
                 "properties");
         if (subscriptionProperties == null) {
             subscriptionProperties = new HashMap<>();
@@ -1103,8 +1093,7 @@ public class TopicsImpl extends BaseResource implements Topics {
     @Override
     public CompletableFuture<Map<String, String>> getSubscriptionPropertiesAsync(String topic, String subName) {
         TopicName tn = validateTopic(topic);
-        String encodedSubName = Codec.encode(subName);
-        WebTarget path = topicPath(tn, "subscription", encodedSubName,
+        WebTarget path = topicPath(tn, "subscription", subName,
                 "properties");
         return asyncGetRequest(path, new FutureCallback<Map<String, String>>(){});
     }
@@ -1124,8 +1113,7 @@ public class TopicsImpl extends BaseResource implements Topics {
     public CompletableFuture<Void> resetCursorAsync(String topic, String subName
             , MessageId messageId, boolean isExcluded) {
         TopicName tn = validateTopic(topic);
-        String encodedSubName = Codec.encode(subName);
-        final WebTarget path = topicPath(tn, "subscription", encodedSubName, "resetcursor");
+        final WebTarget path = topicPath(tn, "subscription", subName, "resetcursor");
         ResetCursorData resetCursorData = new ResetCursorData(messageId);
         resetCursorData.setExcluded(isExcluded);
         return asyncPostRequest(path, Entity.entity(resetCursorData, MediaType.APPLICATION_JSON));
@@ -1490,8 +1478,7 @@ public class TopicsImpl extends BaseResource implements Topics {
                                                                                 String subscriptionName,
                                                                                 Optional<MessageId> startPosition) {
         TopicName topicName = validateTopic(topic);
-        String encodedSubName = Codec.encode(subscriptionName);
-        WebTarget path = topicPath(topicName, "subscription", encodedSubName, "analyzeBacklog");
+        WebTarget path = topicPath(topicName, "subscription", subscriptionName, "analyzeBacklog");
 
         final CompletableFuture<AnalyzeSubscriptionBacklogResult> future = new CompletableFuture<>();
         Entity entity = null;
@@ -2593,8 +2580,7 @@ public class TopicsImpl extends BaseResource implements Topics {
     @Override
     public CompletableFuture<Void> setReplicatedSubscriptionStatusAsync(String topic, String subName, boolean enabled) {
         TopicName topicName = validateTopic(topic);
-        String encodedSubName = Codec.encode(subName);
-        WebTarget path = topicPath(topicName, "subscription", encodedSubName, "replicatedSubscriptionStatus");
+        WebTarget path = topicPath(topicName, "subscription", subName, "replicatedSubscriptionStatus");
         return asyncPostRequest(path, Entity.entity(enabled, MediaType.APPLICATION_JSON));
     }
 
@@ -2605,8 +2591,7 @@ public class TopicsImpl extends BaseResource implements Topics {
 
     public CompletableFuture<Map<String, Boolean>> getReplicatedSubscriptionStatusAsync(String topic, String subName) {
         TopicName topicName = validateTopic(topic);
-        String encodedSubName = Codec.encode(subName);
-        WebTarget path = topicPath(topicName, "subscription", encodedSubName, "replicatedSubscriptionStatus");
+        WebTarget path = topicPath(topicName, "subscription", subName, "replicatedSubscriptionStatus");
         return asyncGetRequest(path, new FutureCallback<Map<String, Boolean>>(){});
     }
 

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/TopicsImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/TopicsImpl.java
@@ -90,7 +90,6 @@ import org.apache.pulsar.common.policies.data.SubscribeRate;
 import org.apache.pulsar.common.policies.data.TopicStats;
 import org.apache.pulsar.common.protocol.Commands;
 import org.apache.pulsar.common.stats.AnalyzeSubscriptionBacklogResult;
-import org.apache.pulsar.common.util.Codec;
 import org.apache.pulsar.common.util.DateFormatter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;


### PR DESCRIPTION


### Motivation
In `TopicsImpl`, we encoded subscription name twice.


### Modifications
Remove `Codec.encode(subName);`, do encoding in `topicPath` method



### Documentation

Check the box below or label this PR directly.

Need to update docs? 

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)
  
- [x] `doc-not-needed` 
(Please explain why)
  
- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)