### PR TITLE
[improve][admin]namespace CLI set-offload-policy's thresholdBytes support negative and 0

### DIFF
--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdNamespaces.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdNamespaces.java
@@ -2357,8 +2357,7 @@ public class CmdNamespaces extends CmdBase {
             Long offloadAfterThresholdInBytes = OffloadPoliciesImpl.DEFAULT_OFFLOAD_THRESHOLD_IN_BYTES;
             if (StringUtils.isNotEmpty(offloadAfterThresholdStr)) {
                 long offloadAfterThreshold = validateSizeString(offloadAfterThresholdStr);
-                if (positiveCheck("OffloadAfterThreshold", offloadAfterThreshold)
-                        && maxValueCheck("OffloadAfterThreshold", offloadAfterThreshold, Long.MAX_VALUE)) {
+                if (maxValueCheck("OffloadAfterThreshold", offloadAfterThreshold, Long.MAX_VALUE)) {
                     offloadAfterThresholdInBytes = offloadAfterThreshold;
                 }
             }


### PR DESCRIPTION

### Motivation
we could set namespace level offload-policy's offload-threshold In the following two `pulsar-admin CLI` ways:
1. `pulsar-admin namespaces set-offload-threshold -s $OFFLOAD_THRESHOLD demo/demo`
2. `pulsar-admin namespaces set-offload-policies --offloadAfterThreshold $OFFLOAD_THRESHOLD demo/demo`

while set offload-threshold value , Negative values disable automatic offload. 0 triggers offloading as soon as possible.
but we can't use `pulsar-admin namespaces set-offload-policies` to set offload-threshold'value to negative or 0 , show as follow：
<img width="1073" alt="image" src="https://user-images.githubusercontent.com/16517186/188781816-1f9ecb6b-69e6-4436-af9a-a56aaf9a3dfe.png">
`pulsar-admin namespaces set-offload-threshold` as expected.

![image](https://user-images.githubusercontent.com/16517186/188781588-aed309bf-2fcb-4939-9e98-8cb98ab6a1df.png)

we should keep `set-offload-threshold` and `set-offload-policies` CLI behavior consistent.

### Modifications
remove `positiveCheck` process while check offloadAfterThreshold value validity at `CmdNamespaces#SetOffloadPolicies`.

### Does this pull request potentially affect one of the following parts:

_If `yes` was chosen, please highlight the changes_

-   Dependencies (does it add or upgrade a dependency): (no)
-   The public API: (no)
-   The schema: (no)
-   The default values of configurations: (no)
-   The wire protocol: (no)
-   The rest endpoints: (no)
-   The admin cli options: (no)
-   Anything that affects deployment: (no)
### Documentation

Check the box below or label this PR directly.

Need to update docs? 

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)
  
- [x] `doc-not-needed` 
(Please explain why)
  
- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)