### PR TITLE
[feature][doc] Sync 2.7.5 specific doc changes

### DIFF
--- a/site2/website/versioned_docs/version-2.7.0/security-basic-auth.md
+++ b/site2/website/versioned_docs/version-2.7.0/security-basic-auth.md
@@ -1,0 +1,162 @@
+---
+id: security-basic-auth
+title: Authentication using HTTP basic
+sidebar_label: "Authentication using HTTP basic"
+original_id: security-basic-auth
+---
+
+````mdx-code-block
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+````
+
+[Basic authentication](https://en.wikipedia.org/wiki/Basic_access_authentication) is a simple authentication scheme built into the HTTP protocol, which uses base64-encoded username and password pairs as credentials.
+
+## Prerequisites
+
+Install [`htpasswd`](https://httpd.apache.org/docs/2.4/programs/htpasswd.html) in your environment to create a password file for storing username-password pairs.
+
+* For Ubuntu/Debian, run the following command to install `htpasswd`.
+
+   ```bash
+   apt install apache2-utils
+   ```
+
+* For CentOS/RHEL, run the following command to install `htpasswd`.
+
+   ```bash
+   yum install httpd-tools
+   ```
+
+## Create your authentication file
+
+:::note
+
+Currently, you can use MD5 (recommended) and CRYPT encryption to authenticate your password.
+
+:::
+
+Create a password file named `.htpasswd` with a user account `superuser/admin`:
+* Use MD5 encryption (recommended):
+
+   ```bash
+   htpasswd -cmb /path/to/.htpasswd superuser admin
+   ```
+
+* Use CRYPT encryption:
+
+   ```bash
+   htpasswd -cdb /path/to/.htpasswd superuser admin
+   ```
+
+You can preview the content of your password file by running the following command:
+
+```bash
+cat path/to/.htpasswd
+superuser:$apr1$GBIYZYFZ$MzLcPrvoUky16mLcK6UtX/
+```
+
+## Enable basic authentication on brokers
+
+To configure brokers to authenticate clients, add the following parameters to the `conf/broker.conf` file. If you use a standalone Pulsar, you need to add these parameters to the `conf/standalone.conf` file:
+
+```conf
+# Configuration to enable Basic authentication
+authenticationEnabled=true
+authenticationProviders=org.apache.pulsar.broker.authentication.AuthenticationProviderBasic
+
+basicAuthConf=file:///path/to/.htpasswd
+# basicAuthConf=/path/to/.htpasswd
+# When use the base64 format, you need to encode the .htpaswd content to bas64
+# basicAuthConf=data:;base64,YOUR-BASE64
+# basicAuthConf=YOUR-BASE64
+
+# Authentication settings of the broker itself. Used when the broker connects to other brokers, either in same or other clusters
+brokerClientAuthenticationPlugin=org.apache.pulsar.client.impl.auth.AuthenticationBasic
+brokerClientAuthenticationParameters={"userId":"superuser","password":"admin"}
+
+# If this flag is set then the broker authenticates the original Auth data
+# else it just accepts the originalPrincipal and authorizes it (if required).
+authenticateOriginalAuthData=true
+```
+
+:::note
+
+You can also set an environment variable named `PULSAR_EXTRA_OPTS` and the value is `-Dpulsar.auth.basic.conf=/path/to/.htpasswd`. Pulsar reads this environment variable to implement HTTP basic authentication.
+
+:::
+
+## Enable basic authentication on proxies
+
+To configure proxies to authenticate clients, add the following parameters to the `conf/proxy.conf` file:
+
+```conf
+# For clients connecting to the proxy
+authenticationEnabled=true
+authenticationProviders=org.apache.pulsar.broker.authentication.AuthenticationProviderBasic
+
+basicAuthConf=file:///path/to/.htpasswd
+# basicAuthConf=/path/to/.htpasswd
+# When use the base64 format, you need to encode the .htpaswd content to bas64
+# basicAuthConf=data:;base64,YOUR-BASE64
+# basicAuthConf=YOUR-BASE64
+
+# For the proxy to connect to brokers
+brokerClientAuthenticationPlugin=org.apache.pulsar.client.impl.auth.AuthenticationBasic
+brokerClientAuthenticationParameters={"userId":"superuser","password":"admin"}
+
+# Whether client authorization credentials are forwarded to the broker for re-authorization.
+# Authentication must be enabled via authenticationEnabled=true for this to take effect.
+forwardAuthorizationCredentials=true
+```
+
+:::note
+
+You can also set an environment variable named `PULSAR_EXTRA_OPTS` and the value is `-Dpulsar.auth.basic.conf=/path/to/.htpasswd`. Pulsar reads this environment variable to implement HTTP basic authentication.
+
+:::
+
+## Configure basic authentication in CLI tools
+
+[Command-line tools](/docs/next/reference-cli-tools), such as [Pulsar-admin](/tools/pulsar-admin/), [Pulsar-perf](/tools/pulsar-perf/) and [Pulsar-client](/tools/pulsar-client/), use the `conf/client.conf` file in your Pulsar installation. To configure basic authentication in Pulsar CLI tools, you need to add the following parameters to the `conf/client.conf` file.
+
+```conf
+authPlugin=org.apache.pulsar.client.impl.auth.AuthenticationBasic
+authParams={"userId":"superuser","password":"admin"}
+```
+
+
+## Configure basic authentication in Pulsar clients
+
+The following example shows how to configure basic authentication when using Pulsar clients.
+
+<Tabs>
+  <TabItem value="Java" label="Java" default>
+
+   ```java
+   AuthenticationBasic auth = new AuthenticationBasic();
+   auth.configure("{\"userId\":\"superuser\",\"password\":\"admin\"}");
+   PulsarClient client = PulsarClient.builder()
+      .serviceUrl("pulsar://broker.example.com:6650")
+      .authentication(auth)
+      .build();
+   ```
+
+  </TabItem>
+  <TabItem value="C++" label="C++" default>
+
+   ```cpp
+   #include <pulsar/Client.h>
+
+   int main() {
+       pulsar::ClientConfiguration config;
+       AuthenticationPtr auth = pulsar::AuthBasic::create("admin", "123456")
+       config.setAuth(auth);
+       pulsar::Client client("pulsar://broker.example.com:6650/", config);
+
+       return 0;
+   }
+   ```
+
+  </TabItem>
+</Tabs>

--- a/site2/website/versioned_docs/version-2.7.1/security-basic-auth.md
+++ b/site2/website/versioned_docs/version-2.7.1/security-basic-auth.md
@@ -1,0 +1,162 @@
+---
+id: security-basic-auth
+title: Authentication using HTTP basic
+sidebar_label: "Authentication using HTTP basic"
+original_id: security-basic-auth
+---
+
+````mdx-code-block
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+````
+
+[Basic authentication](https://en.wikipedia.org/wiki/Basic_access_authentication) is a simple authentication scheme built into the HTTP protocol, which uses base64-encoded username and password pairs as credentials.
+
+## Prerequisites
+
+Install [`htpasswd`](https://httpd.apache.org/docs/2.4/programs/htpasswd.html) in your environment to create a password file for storing username-password pairs.
+
+* For Ubuntu/Debian, run the following command to install `htpasswd`.
+
+   ```bash
+   apt install apache2-utils
+   ```
+
+* For CentOS/RHEL, run the following command to install `htpasswd`.
+
+   ```bash
+   yum install httpd-tools
+   ```
+
+## Create your authentication file
+
+:::note
+
+Currently, you can use MD5 (recommended) and CRYPT encryption to authenticate your password.
+
+:::
+
+Create a password file named `.htpasswd` with a user account `superuser/admin`:
+* Use MD5 encryption (recommended):
+
+   ```bash
+   htpasswd -cmb /path/to/.htpasswd superuser admin
+   ```
+
+* Use CRYPT encryption:
+
+   ```bash
+   htpasswd -cdb /path/to/.htpasswd superuser admin
+   ```
+
+You can preview the content of your password file by running the following command:
+
+```bash
+cat path/to/.htpasswd
+superuser:$apr1$GBIYZYFZ$MzLcPrvoUky16mLcK6UtX/
+```
+
+## Enable basic authentication on brokers
+
+To configure brokers to authenticate clients, add the following parameters to the `conf/broker.conf` file. If you use a standalone Pulsar, you need to add these parameters to the `conf/standalone.conf` file:
+
+```conf
+# Configuration to enable Basic authentication
+authenticationEnabled=true
+authenticationProviders=org.apache.pulsar.broker.authentication.AuthenticationProviderBasic
+
+basicAuthConf=file:///path/to/.htpasswd
+# basicAuthConf=/path/to/.htpasswd
+# When use the base64 format, you need to encode the .htpaswd content to bas64
+# basicAuthConf=data:;base64,YOUR-BASE64
+# basicAuthConf=YOUR-BASE64
+
+# Authentication settings of the broker itself. Used when the broker connects to other brokers, either in same or other clusters
+brokerClientAuthenticationPlugin=org.apache.pulsar.client.impl.auth.AuthenticationBasic
+brokerClientAuthenticationParameters={"userId":"superuser","password":"admin"}
+
+# If this flag is set then the broker authenticates the original Auth data
+# else it just accepts the originalPrincipal and authorizes it (if required).
+authenticateOriginalAuthData=true
+```
+
+:::note
+
+You can also set an environment variable named `PULSAR_EXTRA_OPTS` and the value is `-Dpulsar.auth.basic.conf=/path/to/.htpasswd`. Pulsar reads this environment variable to implement HTTP basic authentication.
+
+:::
+
+## Enable basic authentication on proxies
+
+To configure proxies to authenticate clients, add the following parameters to the `conf/proxy.conf` file:
+
+```conf
+# For clients connecting to the proxy
+authenticationEnabled=true
+authenticationProviders=org.apache.pulsar.broker.authentication.AuthenticationProviderBasic
+
+basicAuthConf=file:///path/to/.htpasswd
+# basicAuthConf=/path/to/.htpasswd
+# When use the base64 format, you need to encode the .htpaswd content to bas64
+# basicAuthConf=data:;base64,YOUR-BASE64
+# basicAuthConf=YOUR-BASE64
+
+# For the proxy to connect to brokers
+brokerClientAuthenticationPlugin=org.apache.pulsar.client.impl.auth.AuthenticationBasic
+brokerClientAuthenticationParameters={"userId":"superuser","password":"admin"}
+
+# Whether client authorization credentials are forwarded to the broker for re-authorization.
+# Authentication must be enabled via authenticationEnabled=true for this to take effect.
+forwardAuthorizationCredentials=true
+```
+
+:::note
+
+You can also set an environment variable named `PULSAR_EXTRA_OPTS` and the value is `-Dpulsar.auth.basic.conf=/path/to/.htpasswd`. Pulsar reads this environment variable to implement HTTP basic authentication.
+
+:::
+
+## Configure basic authentication in CLI tools
+
+[Command-line tools](/docs/next/reference-cli-tools), such as [Pulsar-admin](/tools/pulsar-admin/), [Pulsar-perf](/tools/pulsar-perf/) and [Pulsar-client](/tools/pulsar-client/), use the `conf/client.conf` file in your Pulsar installation. To configure basic authentication in Pulsar CLI tools, you need to add the following parameters to the `conf/client.conf` file.
+
+```conf
+authPlugin=org.apache.pulsar.client.impl.auth.AuthenticationBasic
+authParams={"userId":"superuser","password":"admin"}
+```
+
+
+## Configure basic authentication in Pulsar clients
+
+The following example shows how to configure basic authentication when using Pulsar clients.
+
+<Tabs>
+  <TabItem value="Java" label="Java" default>
+
+   ```java
+   AuthenticationBasic auth = new AuthenticationBasic();
+   auth.configure("{\"userId\":\"superuser\",\"password\":\"admin\"}");
+   PulsarClient client = PulsarClient.builder()
+      .serviceUrl("pulsar://broker.example.com:6650")
+      .authentication(auth)
+      .build();
+   ```
+
+  </TabItem>
+  <TabItem value="C++" label="C++" default>
+
+   ```cpp
+   #include <pulsar/Client.h>
+
+   int main() {
+       pulsar::ClientConfiguration config;
+       AuthenticationPtr auth = pulsar::AuthBasic::create("admin", "123456")
+       config.setAuth(auth);
+       pulsar::Client client("pulsar://broker.example.com:6650/", config);
+
+       return 0;
+   }
+   ```
+
+  </TabItem>
+</Tabs>

--- a/site2/website/versioned_docs/version-2.7.2/security-basic-auth.md
+++ b/site2/website/versioned_docs/version-2.7.2/security-basic-auth.md
@@ -1,0 +1,162 @@
+---
+id: security-basic-auth
+title: Authentication using HTTP basic
+sidebar_label: "Authentication using HTTP basic"
+original_id: security-basic-auth
+---
+
+````mdx-code-block
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+````
+
+[Basic authentication](https://en.wikipedia.org/wiki/Basic_access_authentication) is a simple authentication scheme built into the HTTP protocol, which uses base64-encoded username and password pairs as credentials.
+
+## Prerequisites
+
+Install [`htpasswd`](https://httpd.apache.org/docs/2.4/programs/htpasswd.html) in your environment to create a password file for storing username-password pairs.
+
+* For Ubuntu/Debian, run the following command to install `htpasswd`.
+
+   ```bash
+   apt install apache2-utils
+   ```
+
+* For CentOS/RHEL, run the following command to install `htpasswd`.
+
+   ```bash
+   yum install httpd-tools
+   ```
+
+## Create your authentication file
+
+:::note
+
+Currently, you can use MD5 (recommended) and CRYPT encryption to authenticate your password.
+
+:::
+
+Create a password file named `.htpasswd` with a user account `superuser/admin`:
+* Use MD5 encryption (recommended):
+
+   ```bash
+   htpasswd -cmb /path/to/.htpasswd superuser admin
+   ```
+
+* Use CRYPT encryption:
+
+   ```bash
+   htpasswd -cdb /path/to/.htpasswd superuser admin
+   ```
+
+You can preview the content of your password file by running the following command:
+
+```bash
+cat path/to/.htpasswd
+superuser:$apr1$GBIYZYFZ$MzLcPrvoUky16mLcK6UtX/
+```
+
+## Enable basic authentication on brokers
+
+To configure brokers to authenticate clients, add the following parameters to the `conf/broker.conf` file. If you use a standalone Pulsar, you need to add these parameters to the `conf/standalone.conf` file:
+
+```conf
+# Configuration to enable Basic authentication
+authenticationEnabled=true
+authenticationProviders=org.apache.pulsar.broker.authentication.AuthenticationProviderBasic
+
+basicAuthConf=file:///path/to/.htpasswd
+# basicAuthConf=/path/to/.htpasswd
+# When use the base64 format, you need to encode the .htpaswd content to bas64
+# basicAuthConf=data:;base64,YOUR-BASE64
+# basicAuthConf=YOUR-BASE64
+
+# Authentication settings of the broker itself. Used when the broker connects to other brokers, either in same or other clusters
+brokerClientAuthenticationPlugin=org.apache.pulsar.client.impl.auth.AuthenticationBasic
+brokerClientAuthenticationParameters={"userId":"superuser","password":"admin"}
+
+# If this flag is set then the broker authenticates the original Auth data
+# else it just accepts the originalPrincipal and authorizes it (if required).
+authenticateOriginalAuthData=true
+```
+
+:::note
+
+You can also set an environment variable named `PULSAR_EXTRA_OPTS` and the value is `-Dpulsar.auth.basic.conf=/path/to/.htpasswd`. Pulsar reads this environment variable to implement HTTP basic authentication.
+
+:::
+
+## Enable basic authentication on proxies
+
+To configure proxies to authenticate clients, add the following parameters to the `conf/proxy.conf` file:
+
+```conf
+# For clients connecting to the proxy
+authenticationEnabled=true
+authenticationProviders=org.apache.pulsar.broker.authentication.AuthenticationProviderBasic
+
+basicAuthConf=file:///path/to/.htpasswd
+# basicAuthConf=/path/to/.htpasswd
+# When use the base64 format, you need to encode the .htpaswd content to bas64
+# basicAuthConf=data:;base64,YOUR-BASE64
+# basicAuthConf=YOUR-BASE64
+
+# For the proxy to connect to brokers
+brokerClientAuthenticationPlugin=org.apache.pulsar.client.impl.auth.AuthenticationBasic
+brokerClientAuthenticationParameters={"userId":"superuser","password":"admin"}
+
+# Whether client authorization credentials are forwarded to the broker for re-authorization.
+# Authentication must be enabled via authenticationEnabled=true for this to take effect.
+forwardAuthorizationCredentials=true
+```
+
+:::note
+
+You can also set an environment variable named `PULSAR_EXTRA_OPTS` and the value is `-Dpulsar.auth.basic.conf=/path/to/.htpasswd`. Pulsar reads this environment variable to implement HTTP basic authentication.
+
+:::
+
+## Configure basic authentication in CLI tools
+
+[Command-line tools](/docs/next/reference-cli-tools), such as [Pulsar-admin](/tools/pulsar-admin/), [Pulsar-perf](/tools/pulsar-perf/) and [Pulsar-client](/tools/pulsar-client/), use the `conf/client.conf` file in your Pulsar installation. To configure basic authentication in Pulsar CLI tools, you need to add the following parameters to the `conf/client.conf` file.
+
+```conf
+authPlugin=org.apache.pulsar.client.impl.auth.AuthenticationBasic
+authParams={"userId":"superuser","password":"admin"}
+```
+
+
+## Configure basic authentication in Pulsar clients
+
+The following example shows how to configure basic authentication when using Pulsar clients.
+
+<Tabs>
+  <TabItem value="Java" label="Java" default>
+
+   ```java
+   AuthenticationBasic auth = new AuthenticationBasic();
+   auth.configure("{\"userId\":\"superuser\",\"password\":\"admin\"}");
+   PulsarClient client = PulsarClient.builder()
+      .serviceUrl("pulsar://broker.example.com:6650")
+      .authentication(auth)
+      .build();
+   ```
+
+  </TabItem>
+  <TabItem value="C++" label="C++" default>
+
+   ```cpp
+   #include <pulsar/Client.h>
+
+   int main() {
+       pulsar::ClientConfiguration config;
+       AuthenticationPtr auth = pulsar::AuthBasic::create("admin", "123456")
+       config.setAuth(auth);
+       pulsar::Client client("pulsar://broker.example.com:6650/", config);
+
+       return 0;
+   }
+   ```
+
+  </TabItem>
+</Tabs>

--- a/site2/website/versioned_docs/version-2.7.3/security-basic-auth.md
+++ b/site2/website/versioned_docs/version-2.7.3/security-basic-auth.md
@@ -1,0 +1,162 @@
+---
+id: security-basic-auth
+title: Authentication using HTTP basic
+sidebar_label: "Authentication using HTTP basic"
+original_id: security-basic-auth
+---
+
+````mdx-code-block
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+````
+
+[Basic authentication](https://en.wikipedia.org/wiki/Basic_access_authentication) is a simple authentication scheme built into the HTTP protocol, which uses base64-encoded username and password pairs as credentials.
+
+## Prerequisites
+
+Install [`htpasswd`](https://httpd.apache.org/docs/2.4/programs/htpasswd.html) in your environment to create a password file for storing username-password pairs.
+
+* For Ubuntu/Debian, run the following command to install `htpasswd`.
+
+   ```bash
+   apt install apache2-utils
+   ```
+
+* For CentOS/RHEL, run the following command to install `htpasswd`.
+
+   ```bash
+   yum install httpd-tools
+   ```
+
+## Create your authentication file
+
+:::note
+
+Currently, you can use MD5 (recommended) and CRYPT encryption to authenticate your password.
+
+:::
+
+Create a password file named `.htpasswd` with a user account `superuser/admin`:
+* Use MD5 encryption (recommended):
+
+   ```bash
+   htpasswd -cmb /path/to/.htpasswd superuser admin
+   ```
+
+* Use CRYPT encryption:
+
+   ```bash
+   htpasswd -cdb /path/to/.htpasswd superuser admin
+   ```
+
+You can preview the content of your password file by running the following command:
+
+```bash
+cat path/to/.htpasswd
+superuser:$apr1$GBIYZYFZ$MzLcPrvoUky16mLcK6UtX/
+```
+
+## Enable basic authentication on brokers
+
+To configure brokers to authenticate clients, add the following parameters to the `conf/broker.conf` file. If you use a standalone Pulsar, you need to add these parameters to the `conf/standalone.conf` file:
+
+```conf
+# Configuration to enable Basic authentication
+authenticationEnabled=true
+authenticationProviders=org.apache.pulsar.broker.authentication.AuthenticationProviderBasic
+
+basicAuthConf=file:///path/to/.htpasswd
+# basicAuthConf=/path/to/.htpasswd
+# When use the base64 format, you need to encode the .htpaswd content to bas64
+# basicAuthConf=data:;base64,YOUR-BASE64
+# basicAuthConf=YOUR-BASE64
+
+# Authentication settings of the broker itself. Used when the broker connects to other brokers, either in same or other clusters
+brokerClientAuthenticationPlugin=org.apache.pulsar.client.impl.auth.AuthenticationBasic
+brokerClientAuthenticationParameters={"userId":"superuser","password":"admin"}
+
+# If this flag is set then the broker authenticates the original Auth data
+# else it just accepts the originalPrincipal and authorizes it (if required).
+authenticateOriginalAuthData=true
+```
+
+:::note
+
+You can also set an environment variable named `PULSAR_EXTRA_OPTS` and the value is `-Dpulsar.auth.basic.conf=/path/to/.htpasswd`. Pulsar reads this environment variable to implement HTTP basic authentication.
+
+:::
+
+## Enable basic authentication on proxies
+
+To configure proxies to authenticate clients, add the following parameters to the `conf/proxy.conf` file:
+
+```conf
+# For clients connecting to the proxy
+authenticationEnabled=true
+authenticationProviders=org.apache.pulsar.broker.authentication.AuthenticationProviderBasic
+
+basicAuthConf=file:///path/to/.htpasswd
+# basicAuthConf=/path/to/.htpasswd
+# When use the base64 format, you need to encode the .htpaswd content to bas64
+# basicAuthConf=data:;base64,YOUR-BASE64
+# basicAuthConf=YOUR-BASE64
+
+# For the proxy to connect to brokers
+brokerClientAuthenticationPlugin=org.apache.pulsar.client.impl.auth.AuthenticationBasic
+brokerClientAuthenticationParameters={"userId":"superuser","password":"admin"}
+
+# Whether client authorization credentials are forwarded to the broker for re-authorization.
+# Authentication must be enabled via authenticationEnabled=true for this to take effect.
+forwardAuthorizationCredentials=true
+```
+
+:::note
+
+You can also set an environment variable named `PULSAR_EXTRA_OPTS` and the value is `-Dpulsar.auth.basic.conf=/path/to/.htpasswd`. Pulsar reads this environment variable to implement HTTP basic authentication.
+
+:::
+
+## Configure basic authentication in CLI tools
+
+[Command-line tools](/docs/next/reference-cli-tools), such as [Pulsar-admin](/tools/pulsar-admin/), [Pulsar-perf](/tools/pulsar-perf/) and [Pulsar-client](/tools/pulsar-client/), use the `conf/client.conf` file in your Pulsar installation. To configure basic authentication in Pulsar CLI tools, you need to add the following parameters to the `conf/client.conf` file.
+
+```conf
+authPlugin=org.apache.pulsar.client.impl.auth.AuthenticationBasic
+authParams={"userId":"superuser","password":"admin"}
+```
+
+
+## Configure basic authentication in Pulsar clients
+
+The following example shows how to configure basic authentication when using Pulsar clients.
+
+<Tabs>
+  <TabItem value="Java" label="Java" default>
+
+   ```java
+   AuthenticationBasic auth = new AuthenticationBasic();
+   auth.configure("{\"userId\":\"superuser\",\"password\":\"admin\"}");
+   PulsarClient client = PulsarClient.builder()
+      .serviceUrl("pulsar://broker.example.com:6650")
+      .authentication(auth)
+      .build();
+   ```
+
+  </TabItem>
+  <TabItem value="C++" label="C++" default>
+
+   ```cpp
+   #include <pulsar/Client.h>
+
+   int main() {
+       pulsar::ClientConfiguration config;
+       AuthenticationPtr auth = pulsar::AuthBasic::create("admin", "123456")
+       config.setAuth(auth);
+       pulsar::Client client("pulsar://broker.example.com:6650/", config);
+
+       return 0;
+   }
+   ```
+
+  </TabItem>
+</Tabs>

--- a/site2/website/versioned_docs/version-2.7.4/security-basic-auth.md
+++ b/site2/website/versioned_docs/version-2.7.4/security-basic-auth.md
@@ -1,0 +1,162 @@
+---
+id: security-basic-auth
+title: Authentication using HTTP basic
+sidebar_label: "Authentication using HTTP basic"
+original_id: security-basic-auth
+---
+
+````mdx-code-block
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+````
+
+[Basic authentication](https://en.wikipedia.org/wiki/Basic_access_authentication) is a simple authentication scheme built into the HTTP protocol, which uses base64-encoded username and password pairs as credentials.
+
+## Prerequisites
+
+Install [`htpasswd`](https://httpd.apache.org/docs/2.4/programs/htpasswd.html) in your environment to create a password file for storing username-password pairs.
+
+* For Ubuntu/Debian, run the following command to install `htpasswd`.
+
+   ```bash
+   apt install apache2-utils
+   ```
+
+* For CentOS/RHEL, run the following command to install `htpasswd`.
+
+   ```bash
+   yum install httpd-tools
+   ```
+
+## Create your authentication file
+
+:::note
+
+Currently, you can use MD5 (recommended) and CRYPT encryption to authenticate your password.
+
+:::
+
+Create a password file named `.htpasswd` with a user account `superuser/admin`:
+* Use MD5 encryption (recommended):
+
+   ```bash
+   htpasswd -cmb /path/to/.htpasswd superuser admin
+   ```
+
+* Use CRYPT encryption:
+
+   ```bash
+   htpasswd -cdb /path/to/.htpasswd superuser admin
+   ```
+
+You can preview the content of your password file by running the following command:
+
+```bash
+cat path/to/.htpasswd
+superuser:$apr1$GBIYZYFZ$MzLcPrvoUky16mLcK6UtX/
+```
+
+## Enable basic authentication on brokers
+
+To configure brokers to authenticate clients, add the following parameters to the `conf/broker.conf` file. If you use a standalone Pulsar, you need to add these parameters to the `conf/standalone.conf` file:
+
+```conf
+# Configuration to enable Basic authentication
+authenticationEnabled=true
+authenticationProviders=org.apache.pulsar.broker.authentication.AuthenticationProviderBasic
+
+basicAuthConf=file:///path/to/.htpasswd
+# basicAuthConf=/path/to/.htpasswd
+# When use the base64 format, you need to encode the .htpaswd content to bas64
+# basicAuthConf=data:;base64,YOUR-BASE64
+# basicAuthConf=YOUR-BASE64
+
+# Authentication settings of the broker itself. Used when the broker connects to other brokers, either in same or other clusters
+brokerClientAuthenticationPlugin=org.apache.pulsar.client.impl.auth.AuthenticationBasic
+brokerClientAuthenticationParameters={"userId":"superuser","password":"admin"}
+
+# If this flag is set then the broker authenticates the original Auth data
+# else it just accepts the originalPrincipal and authorizes it (if required).
+authenticateOriginalAuthData=true
+```
+
+:::note
+
+You can also set an environment variable named `PULSAR_EXTRA_OPTS` and the value is `-Dpulsar.auth.basic.conf=/path/to/.htpasswd`. Pulsar reads this environment variable to implement HTTP basic authentication.
+
+:::
+
+## Enable basic authentication on proxies
+
+To configure proxies to authenticate clients, add the following parameters to the `conf/proxy.conf` file:
+
+```conf
+# For clients connecting to the proxy
+authenticationEnabled=true
+authenticationProviders=org.apache.pulsar.broker.authentication.AuthenticationProviderBasic
+
+basicAuthConf=file:///path/to/.htpasswd
+# basicAuthConf=/path/to/.htpasswd
+# When use the base64 format, you need to encode the .htpaswd content to bas64
+# basicAuthConf=data:;base64,YOUR-BASE64
+# basicAuthConf=YOUR-BASE64
+
+# For the proxy to connect to brokers
+brokerClientAuthenticationPlugin=org.apache.pulsar.client.impl.auth.AuthenticationBasic
+brokerClientAuthenticationParameters={"userId":"superuser","password":"admin"}
+
+# Whether client authorization credentials are forwarded to the broker for re-authorization.
+# Authentication must be enabled via authenticationEnabled=true for this to take effect.
+forwardAuthorizationCredentials=true
+```
+
+:::note
+
+You can also set an environment variable named `PULSAR_EXTRA_OPTS` and the value is `-Dpulsar.auth.basic.conf=/path/to/.htpasswd`. Pulsar reads this environment variable to implement HTTP basic authentication.
+
+:::
+
+## Configure basic authentication in CLI tools
+
+[Command-line tools](/docs/next/reference-cli-tools), such as [Pulsar-admin](/tools/pulsar-admin/), [Pulsar-perf](/tools/pulsar-perf/) and [Pulsar-client](/tools/pulsar-client/), use the `conf/client.conf` file in your Pulsar installation. To configure basic authentication in Pulsar CLI tools, you need to add the following parameters to the `conf/client.conf` file.
+
+```conf
+authPlugin=org.apache.pulsar.client.impl.auth.AuthenticationBasic
+authParams={"userId":"superuser","password":"admin"}
+```
+
+
+## Configure basic authentication in Pulsar clients
+
+The following example shows how to configure basic authentication when using Pulsar clients.
+
+<Tabs>
+  <TabItem value="Java" label="Java" default>
+
+   ```java
+   AuthenticationBasic auth = new AuthenticationBasic();
+   auth.configure("{\"userId\":\"superuser\",\"password\":\"admin\"}");
+   PulsarClient client = PulsarClient.builder()
+      .serviceUrl("pulsar://broker.example.com:6650")
+      .authentication(auth)
+      .build();
+   ```
+
+  </TabItem>
+  <TabItem value="C++" label="C++" default>
+
+   ```cpp
+   #include <pulsar/Client.h>
+
+   int main() {
+       pulsar::ClientConfiguration config;
+       AuthenticationPtr auth = pulsar::AuthBasic::create("admin", "123456")
+       config.setAuth(auth);
+       pulsar::Client client("pulsar://broker.example.com:6650/", config);
+
+       return 0;
+   }
+   ```
+
+  </TabItem>
+</Tabs>

--- a/site2/website/versioned_docs/version-2.7.5/reference-configuration.md
+++ b/site2/website/versioned_docs/version-2.7.5/reference-configuration.md
@@ -349,6 +349,21 @@ Pulsar brokers are responsible for handling incoming messages from producers, di
 |haProxyProtocolEnabled | Enable or disable the [HAProxy](http://www.haproxy.org/) protocol. |false|
 |bookieId | If you want to custom a bookie ID or use a dynamic network address for the bookie, you can set this option. <br /><br />Bookie advertises itself using the `bookieId` rather than the `BookieSocketAddress` (`hostname:port` or `IP:port`).<br /><br /> The `bookieId` is a non-empty string that can contain ASCII digits and letters ([a-zA-Z9-0]), colons, dashes, and dots. <br /><br />For more information about `bookieId`, see [here](http://bookkeeper.apache.org/bps/BP-41-bookieid/).|N/A|
 
+#### Configuration override for clients internal to broker
+
+In 2.7.5 and later versions, you can configure some clients by using the appropriate prefix.
+
+|Prefix|Description|
+|---|---|
+|brokerClient_| Configure **all** the broker's Pulsar Clients and Pulsar Admin Clients. These configurations are applied after hard coded configuration and before the above broker client configurations named above.|
+|bookkeeper_| Configure the broker's BookKeeper clients used by managed ledgers and the BookkeeperPackagesStorage bookkeeper client. Takes precedence over most other configuration values.|
+
+:::note
+
+When running the function worker within the broker, these prefixed configurations do not apply to any of those clients. You must configure those clients using the `functions_worker.yml` file.
+
+:::
+
 ## Client
 
 The [`pulsar-client`](reference-cli-tools.md#pulsar-client) CLI tool can be used to publish messages to Pulsar and consume messages from Pulsar topics. This tool can be used in lieu of a client library.
@@ -686,6 +701,14 @@ The [`pulsar-client`](reference-cli-tools.md#pulsar-client) CLI tool can be used
 |tlsKeyFilePath |||
 |tlsTrustCertsFilePath|||
 
+#### Configuration Override For Clients Internal to WebSocket
+
+In 2.7.5 and later versions, you can configure some clients by using the appropriate prefix.
+
+|Prefix|Description|
+|---|---|
+|brokerClient_| Configure **all** the broker's Pulsar Clients. These configurations are applied after hard coded configuration and before the above brokerClient configurations named above.|
+
 
 ## Pulsar proxy
 
@@ -742,6 +765,14 @@ The [Pulsar proxy](concepts-architecture-overview.md#pulsar-proxy) can be config
 |tokenAudienceClaim| The token audience "claim" name, e.g. "aud". It is used to get the audience from token. If it is not set, the audience is not verified. ||
 | tokenAudience | The token audience stands for this broker. The field `tokenAudienceClaim` of a valid token need contains this parameter.| |
 |haProxyProtocolEnabled | Enable or disable the [HAProxy](http://www.haproxy.org/) protocol. |false|
+
+#### Configuration Override For Clients Internal to Proxy
+
+In 2.7.5 and later versions, you can configure some clients by using the appropriate prefix.
+
+|Prefix|Description|
+|---|---|
+|brokerClient_| Configure **all** the proxy's Pulsar Clients. These configurations are applied after hard coded configuration and before the above brokerClient configurations named above.|
 
 ## ZooKeeper
 

--- a/site2/website/versioned_docs/version-2.7.5/security-basic-auth.md
+++ b/site2/website/versioned_docs/version-2.7.5/security-basic-auth.md
@@ -1,0 +1,162 @@
+---
+id: security-basic-auth
+title: Authentication using HTTP basic
+sidebar_label: "Authentication using HTTP basic"
+original_id: security-basic-auth
+---
+
+````mdx-code-block
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+````
+
+[Basic authentication](https://en.wikipedia.org/wiki/Basic_access_authentication) is a simple authentication scheme built into the HTTP protocol, which uses base64-encoded username and password pairs as credentials.
+
+## Prerequisites
+
+Install [`htpasswd`](https://httpd.apache.org/docs/2.4/programs/htpasswd.html) in your environment to create a password file for storing username-password pairs.
+
+* For Ubuntu/Debian, run the following command to install `htpasswd`.
+
+   ```bash
+   apt install apache2-utils
+   ```
+
+* For CentOS/RHEL, run the following command to install `htpasswd`.
+
+   ```bash
+   yum install httpd-tools
+   ```
+
+## Create your authentication file
+
+:::note
+
+Currently, you can use MD5 (recommended) and CRYPT encryption to authenticate your password.
+
+:::
+
+Create a password file named `.htpasswd` with a user account `superuser/admin`:
+* Use MD5 encryption (recommended):
+
+   ```bash
+   htpasswd -cmb /path/to/.htpasswd superuser admin
+   ```
+
+* Use CRYPT encryption:
+
+   ```bash
+   htpasswd -cdb /path/to/.htpasswd superuser admin
+   ```
+
+You can preview the content of your password file by running the following command:
+
+```bash
+cat path/to/.htpasswd
+superuser:$apr1$GBIYZYFZ$MzLcPrvoUky16mLcK6UtX/
+```
+
+## Enable basic authentication on brokers
+
+To configure brokers to authenticate clients, add the following parameters to the `conf/broker.conf` file. If you use a standalone Pulsar, you need to add these parameters to the `conf/standalone.conf` file:
+
+```conf
+# Configuration to enable Basic authentication
+authenticationEnabled=true
+authenticationProviders=org.apache.pulsar.broker.authentication.AuthenticationProviderBasic
+
+basicAuthConf=file:///path/to/.htpasswd
+# basicAuthConf=/path/to/.htpasswd
+# When use the base64 format, you need to encode the .htpaswd content to bas64
+# basicAuthConf=data:;base64,YOUR-BASE64
+# basicAuthConf=YOUR-BASE64
+
+# Authentication settings of the broker itself. Used when the broker connects to other brokers, either in same or other clusters
+brokerClientAuthenticationPlugin=org.apache.pulsar.client.impl.auth.AuthenticationBasic
+brokerClientAuthenticationParameters={"userId":"superuser","password":"admin"}
+
+# If this flag is set then the broker authenticates the original Auth data
+# else it just accepts the originalPrincipal and authorizes it (if required).
+authenticateOriginalAuthData=true
+```
+
+:::note
+
+You can also set an environment variable named `PULSAR_EXTRA_OPTS` and the value is `-Dpulsar.auth.basic.conf=/path/to/.htpasswd`. Pulsar reads this environment variable to implement HTTP basic authentication.
+
+:::
+
+## Enable basic authentication on proxies
+
+To configure proxies to authenticate clients, add the following parameters to the `conf/proxy.conf` file:
+
+```conf
+# For clients connecting to the proxy
+authenticationEnabled=true
+authenticationProviders=org.apache.pulsar.broker.authentication.AuthenticationProviderBasic
+
+basicAuthConf=file:///path/to/.htpasswd
+# basicAuthConf=/path/to/.htpasswd
+# When use the base64 format, you need to encode the .htpaswd content to bas64
+# basicAuthConf=data:;base64,YOUR-BASE64
+# basicAuthConf=YOUR-BASE64
+
+# For the proxy to connect to brokers
+brokerClientAuthenticationPlugin=org.apache.pulsar.client.impl.auth.AuthenticationBasic
+brokerClientAuthenticationParameters={"userId":"superuser","password":"admin"}
+
+# Whether client authorization credentials are forwarded to the broker for re-authorization.
+# Authentication must be enabled via authenticationEnabled=true for this to take effect.
+forwardAuthorizationCredentials=true
+```
+
+:::note
+
+You can also set an environment variable named `PULSAR_EXTRA_OPTS` and the value is `-Dpulsar.auth.basic.conf=/path/to/.htpasswd`. Pulsar reads this environment variable to implement HTTP basic authentication.
+
+:::
+
+## Configure basic authentication in CLI tools
+
+[Command-line tools](/docs/next/reference-cli-tools), such as [Pulsar-admin](/tools/pulsar-admin/), [Pulsar-perf](/tools/pulsar-perf/) and [Pulsar-client](/tools/pulsar-client/), use the `conf/client.conf` file in your Pulsar installation. To configure basic authentication in Pulsar CLI tools, you need to add the following parameters to the `conf/client.conf` file.
+
+```conf
+authPlugin=org.apache.pulsar.client.impl.auth.AuthenticationBasic
+authParams={"userId":"superuser","password":"admin"}
+```
+
+
+## Configure basic authentication in Pulsar clients
+
+The following example shows how to configure basic authentication when using Pulsar clients.
+
+<Tabs>
+  <TabItem value="Java" label="Java" default>
+
+   ```java
+   AuthenticationBasic auth = new AuthenticationBasic();
+   auth.configure("{\"userId\":\"superuser\",\"password\":\"admin\"}");
+   PulsarClient client = PulsarClient.builder()
+      .serviceUrl("pulsar://broker.example.com:6650")
+      .authentication(auth)
+      .build();
+   ```
+
+  </TabItem>
+  <TabItem value="C++" label="C++" default>
+
+   ```cpp
+   #include <pulsar/Client.h>
+
+   int main() {
+       pulsar::ClientConfiguration config;
+       AuthenticationPtr auth = pulsar::AuthBasic::create("admin", "123456")
+       config.setAuth(auth);
+       pulsar::Client client("pulsar://broker.example.com:6650/", config);
+
+       return 0;
+   }
+   ```
+
+  </TabItem>
+</Tabs>

--- a/site2/website/versioned_sidebars/version-2.7.0-sidebars.json
+++ b/site2/website/versioned_sidebars/version-2.7.0-sidebars.json
@@ -368,6 +368,10 @@
         },
         {
           "type": "doc",
+          "id": "version-2.7.0/security-basic-auth"
+        },
+        {
+          "type": "doc",
           "id": "version-2.7.0/security-authorization"
         },
         {

--- a/site2/website/versioned_sidebars/version-2.7.1-sidebars.json
+++ b/site2/website/versioned_sidebars/version-2.7.1-sidebars.json
@@ -372,6 +372,10 @@
         },
         {
           "type": "doc",
+          "id": "version-2.7.1/security-basic-auth"
+        },
+        {
+          "type": "doc",
           "id": "version-2.7.1/security-authorization"
         },
         {

--- a/site2/website/versioned_sidebars/version-2.7.2-sidebars.json
+++ b/site2/website/versioned_sidebars/version-2.7.2-sidebars.json
@@ -372,6 +372,10 @@
         },
         {
           "type": "doc",
+          "id": "version-2.7.2/security-basic-auth"
+        },
+        {
+          "type": "doc",
           "id": "version-2.7.2/security-authorization"
         },
         {

--- a/site2/website/versioned_sidebars/version-2.7.3-sidebars.json
+++ b/site2/website/versioned_sidebars/version-2.7.3-sidebars.json
@@ -372,6 +372,10 @@
         },
         {
           "type": "doc",
+          "id": "version-2.7.3/security-basic-auth"
+        },
+        {
+          "type": "doc",
           "id": "version-2.7.3/security-authorization"
         },
         {

--- a/site2/website/versioned_sidebars/version-2.7.4-sidebars.json
+++ b/site2/website/versioned_sidebars/version-2.7.4-sidebars.json
@@ -372,6 +372,10 @@
         },
         {
           "type": "doc",
+          "id": "version-2.7.4/security-basic-auth"
+        },
+        {
+          "type": "doc",
           "id": "version-2.7.4/security-authorization"
         },
         {

--- a/site2/website/versioned_sidebars/version-2.7.5-sidebars.json
+++ b/site2/website/versioned_sidebars/version-2.7.5-sidebars.json
@@ -372,6 +372,10 @@
         },
         {
           "type": "doc",
+          "id": "version-2.7.5/security-basic-auth"
+        },
+        {
+          "type": "doc",
           "id": "version-2.7.5/security-authorization"
         },
         {

--- a/wiki/release/release-process.md
+++ b/wiki/release/release-process.md
@@ -503,6 +503,7 @@ After you run this command, a new folder `version-<release-version>` is added in
   ```
 
 > **Note**
+>
 > You can move the latest version under the old version in the `versions.json` file. Make sure the Algolia index works before moving 2.X.0 as the current stable.
 
 4. Update the `releases.json` file by adding `<release-version>` to the second of the list (this is to make the search work. After your PR is merged, the Pulsar website is built and tagged for search, you can change it to the first list).
@@ -521,6 +522,7 @@ After you run this command, a new folder `version-<release-version>` is added in
 9. Generate the doc set and sidebar file for the next minor release `2.X.x` based on the `site2/docs` folder. You can follow steps 1, 2, and 3, and submit those files to the `apache/pulsar` repository. This step is a preparation for the `2.X.x` release.
 
 > **Note**
+>
 > Starting from 2.8, you don't need to generate an independent doc set or update the Pulsar site for bug-fix releases, such as 2.8.1, 2.8.2, and so on. Instead, the generic doc set 2.8.x is used.
 
 :::

--- a/wiki/release/release-process.md
+++ b/wiki/release/release-process.md
@@ -525,8 +525,6 @@ After you run this command, a new folder `version-<release-version>` is added in
 >
 > Starting from 2.8, you don't need to generate an independent doc set or update the Pulsar site for bug-fix releases, such as 2.8.1, 2.8.2, and so on. Instead, the generic doc set 2.8.x is used.
 
-:::
-
 ## 18. Announce the release
 
 Once the release artifacts are available in the Apache Mirrors and the website is updated,


### PR DESCRIPTION
### Motivation

Since 2.7.5 is released and the doc set is generated, request to pull 2.7.5-specific doc changes to the 2.7.5 doc set.

### Modifications

1. Sync doc changes implemented in https://github.com/apache/pulsar/pull/15818.
2. Sync the topic for the new feature "basic auth" implemented in https://github.com/apache/pulsar/pull/15734.
3. Fix the note layout in the release process topic.


### Documentation
  
- [x] `doc` 
