### PR TITLE
[improve][transactions] Add command to list transaction coordinators

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/TransactionsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/TransactionsBase.java
@@ -39,6 +39,7 @@ import org.apache.pulsar.broker.admin.AdminResource;
 import org.apache.pulsar.broker.service.Topic;
 import org.apache.pulsar.broker.service.persistent.PersistentTopic;
 import org.apache.pulsar.broker.web.RestException;
+import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.admin.Transactions;
 import org.apache.pulsar.client.api.transaction.TxnID;
 import org.apache.pulsar.common.naming.NamespaceName;
@@ -47,6 +48,7 @@ import org.apache.pulsar.common.naming.TopicDomain;
 import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.partition.PartitionedTopicMetadata;
 import org.apache.pulsar.common.policies.data.TransactionBufferStats;
+import org.apache.pulsar.common.policies.data.TransactionCoordinatorInfo;
 import org.apache.pulsar.common.policies.data.TransactionCoordinatorInternalStats;
 import org.apache.pulsar.common.policies.data.TransactionCoordinatorStats;
 import org.apache.pulsar.common.policies.data.TransactionInBufferStats;
@@ -67,6 +69,37 @@ import org.apache.pulsar.transaction.coordinator.impl.MLTransactionMetadataStore
 
 @Slf4j
 public abstract class TransactionsBase extends AdminResource {
+
+    protected void internalListCoordinators(AsyncResponse asyncResponse) {
+        final PulsarAdmin admin;
+        try {
+            admin = pulsar().getAdminClient();
+        } catch (PulsarServerException ex) {
+            asyncResponse.resume(new RestException(ex));
+            return;
+        }
+        admin.lookups()
+                .lookupPartitionedTopicAsync(SystemTopicNames.TRANSACTION_COORDINATOR_ASSIGN.getPartitionedTopicName())
+                .thenAccept(map -> {
+                    if (map.isEmpty()) {
+                        asyncResponse.resume(new RestException(Response.Status.NOT_FOUND,
+                                "Transaction coordinator not found"));
+                        return;
+                    }
+                    Map<Integer, TransactionCoordinatorInfo> result = new HashMap<>();
+                    map.forEach((topicPartition, brokerServiceUrl) -> {
+                        final int coordinatorId = TopicName.getPartitionIndex(topicPartition);
+                        result.put(coordinatorId, new TransactionCoordinatorInfo(brokerServiceUrl));
+                    });
+                    asyncResponse.resume(result);
+
+                })
+                .exceptionally(ex -> {
+                    log.error("[{}] Failed to list transaction coordinators.", clientAppId(), ex);
+                    resumeAsyncResponseExceptionally(asyncResponse, ex);
+                    return null;
+                });
+    }
 
     protected void internalGetCoordinatorStats(AsyncResponse asyncResponse, boolean authoritative,
                                                Integer coordinatorId) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v3/Transactions.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v3/Transactions.java
@@ -53,6 +53,17 @@ import org.apache.pulsar.common.util.FutureUtil;
 public class Transactions extends TransactionsBase {
 
     @GET
+    @Path("/coordinators")
+    @ApiOperation(value = "List transaction coordinators.")
+    @ApiResponses(value = {@ApiResponse(code = 403, message = "Don't have admin permission"),
+            @ApiResponse(code = 503, message = "This Broker is not "
+                    + "configured with transactionCoordinatorEnabled=true.")})
+    public void listCoordinators(@Suspended final AsyncResponse asyncResponse) {
+        checkTransactionCoordinatorEnabled();
+        internalListCoordinators(asyncResponse);
+    }
+
+    @GET
     @Path("/coordinatorStats")
     @ApiOperation(value = "Get transaction coordinator stats.")
     @ApiResponses(value = {@ApiResponse(code = 403, message = "Don't have admin permission"),

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/v3/AdminApiTransactionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/v3/AdminApiTransactionTest.java
@@ -113,8 +113,9 @@ public class AdminApiTransactionTest extends MockedPulsarServiceBaseTest {
     @Test(timeOut = 20000)
     public void testListTransactionCoordinators() throws Exception {
         initTransaction(4);
-        final Map<Integer, TransactionCoordinatorInfo> result = admin
+        final List<TransactionCoordinatorInfo> result = admin
                 .transactions().listTransactionCoordinatorsAsync().get();
+        System.out.println("result" + result);
         assertEquals(result.size(), 4);
         final String expectedUrl = pulsar.getBrokerServiceUrl();
         for (int i = 0; i < 4; i++) {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/v3/AdminApiTransactionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/v3/AdminApiTransactionTest.java
@@ -62,6 +62,7 @@ import org.apache.pulsar.common.policies.data.ClusterData;
 import org.apache.pulsar.common.policies.data.ManagedLedgerInternalStats;
 import org.apache.pulsar.common.policies.data.TenantInfoImpl;
 import org.apache.pulsar.common.policies.data.TransactionBufferStats;
+import org.apache.pulsar.common.policies.data.TransactionCoordinatorInfo;
 import org.apache.pulsar.common.policies.data.TransactionCoordinatorInternalStats;
 import org.apache.pulsar.common.policies.data.TransactionCoordinatorStats;
 import org.apache.pulsar.common.policies.data.TransactionInBufferStats;
@@ -107,6 +108,18 @@ public class AdminApiTransactionTest extends MockedPulsarServiceBaseTest {
     @Override
     protected void cleanup() throws Exception {
         super.internalCleanup();
+    }
+
+    @Test(timeOut = 20000)
+    public void testListTransactionCoordinators() throws Exception {
+        initTransaction(4);
+        final Map<Integer, TransactionCoordinatorInfo> result = admin
+                .transactions().listTransactionCoordinatorsAsync().get();
+        assertEquals(result.size(), 4);
+        final String expectedUrl = pulsar.getBrokerServiceUrl();
+        for (int i = 0; i < 4; i++) {
+            assertEquals(result.get(i).getBrokerServiceUrl(), expectedUrl);
+        }
     }
 
     @Test(timeOut = 20000)

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/v3/AdminApiTransactionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/v3/AdminApiTransactionTest.java
@@ -115,7 +115,6 @@ public class AdminApiTransactionTest extends MockedPulsarServiceBaseTest {
         initTransaction(4);
         final List<TransactionCoordinatorInfo> result = admin
                 .transactions().listTransactionCoordinatorsAsync().get();
-        System.out.println("result" + result);
         assertEquals(result.size(), 4);
         final String expectedUrl = pulsar.getBrokerServiceUrl();
         for (int i = 0; i < 4; i++) {

--- a/pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/admin/Transactions.java
+++ b/pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/admin/Transactions.java
@@ -23,6 +23,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import org.apache.pulsar.client.api.transaction.TxnID;
 import org.apache.pulsar.common.policies.data.TransactionBufferStats;
+import org.apache.pulsar.common.policies.data.TransactionCoordinatorInfo;
 import org.apache.pulsar.common.policies.data.TransactionCoordinatorInternalStats;
 import org.apache.pulsar.common.policies.data.TransactionCoordinatorStats;
 import org.apache.pulsar.common.policies.data.TransactionInBufferStats;
@@ -33,6 +34,21 @@ import org.apache.pulsar.common.policies.data.TransactionPendingAckStats;
 import org.apache.pulsar.common.stats.PositionInPendingAckStats;
 
 public interface Transactions {
+
+    /**
+     * List transaction coordinators.
+     *
+     * @return the transaction coordinators list.
+     */
+    Map<Integer, TransactionCoordinatorInfo> listTransactionCoordinators() throws PulsarAdminException;
+
+    /**
+     * List transaction coordinators.
+     *
+     * @return the future of the transaction coordinators list.
+     */
+    CompletableFuture<Map<Integer, TransactionCoordinatorInfo>> listTransactionCoordinatorsAsync();
+
 
     /**
      * Get transaction metadataStore stats.

--- a/pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/admin/Transactions.java
+++ b/pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/admin/Transactions.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pulsar.client.admin;
 
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
@@ -40,14 +41,14 @@ public interface Transactions {
      *
      * @return the transaction coordinators list.
      */
-    Map<Integer, TransactionCoordinatorInfo> listTransactionCoordinators() throws PulsarAdminException;
+    List<TransactionCoordinatorInfo> listTransactionCoordinators() throws PulsarAdminException;
 
     /**
      * List transaction coordinators.
      *
      * @return the future of the transaction coordinators list.
      */
-    CompletableFuture<Map<Integer, TransactionCoordinatorInfo>> listTransactionCoordinatorsAsync();
+    CompletableFuture<List<TransactionCoordinatorInfo>> listTransactionCoordinatorsAsync();
 
 
     /**

--- a/pulsar-client-admin-api/src/main/java/org/apache/pulsar/common/policies/data/TransactionCoordinatorInfo.java
+++ b/pulsar-client-admin-api/src/main/java/org/apache/pulsar/common/policies/data/TransactionCoordinatorInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/pulsar-client-admin-api/src/main/java/org/apache/pulsar/common/policies/data/TransactionCoordinatorInfo.java
+++ b/pulsar-client-admin-api/src/main/java/org/apache/pulsar/common/policies/data/TransactionCoordinatorInfo.java
@@ -19,7 +19,6 @@
 package org.apache.pulsar.common.policies.data;
 
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;

--- a/pulsar-client-admin-api/src/main/java/org/apache/pulsar/common/policies/data/TransactionCoordinatorInfo.java
+++ b/pulsar-client-admin-api/src/main/java/org/apache/pulsar/common/policies/data/TransactionCoordinatorInfo.java
@@ -1,0 +1,34 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.common.policies.data;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * Transaction coordinator information.
+ */
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class TransactionCoordinatorInfo {
+    private String brokerServiceUrl;
+}

--- a/pulsar-client-admin-api/src/main/java/org/apache/pulsar/common/policies/data/TransactionCoordinatorInfo.java
+++ b/pulsar-client-admin-api/src/main/java/org/apache/pulsar/common/policies/data/TransactionCoordinatorInfo.java
@@ -22,6 +22,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
 
 /**
  * Transaction coordinator information.
@@ -29,6 +30,8 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
+@ToString
 public class TransactionCoordinatorInfo {
+    private long id;
     private String brokerServiceUrl;
 }

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/TransactionsImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/TransactionsImpl.java
@@ -19,7 +19,6 @@
 package org.apache.pulsar.client.admin.internal;
 
 import static com.google.common.base.Preconditions.checkArgument;
-
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/TransactionsImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/TransactionsImpl.java
@@ -31,6 +31,7 @@ import org.apache.pulsar.client.api.Authentication;
 import org.apache.pulsar.client.api.transaction.TxnID;
 import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.policies.data.TransactionBufferStats;
+import org.apache.pulsar.common.policies.data.TransactionCoordinatorInfo;
 import org.apache.pulsar.common.policies.data.TransactionCoordinatorInternalStats;
 import org.apache.pulsar.common.policies.data.TransactionCoordinatorStats;
 import org.apache.pulsar.common.policies.data.TransactionInBufferStats;
@@ -46,6 +47,17 @@ public class TransactionsImpl extends BaseResource implements Transactions {
     public TransactionsImpl(WebTarget web, Authentication auth, long readTimeoutMs) {
         super(auth, readTimeoutMs);
         adminV3Transactions = web.path("/admin/v3/transactions");
+    }
+
+    @Override
+    public Map<Integer, TransactionCoordinatorInfo> listTransactionCoordinators() throws PulsarAdminException {
+        return sync(() -> listTransactionCoordinatorsAsync());
+    }
+
+    @Override
+    public CompletableFuture<Map<Integer, TransactionCoordinatorInfo>> listTransactionCoordinatorsAsync() {
+        WebTarget path = adminV3Transactions.path("coordinators");
+        return asyncGetRequest(path, new FutureCallback<Map<Integer, TransactionCoordinatorInfo>>(){});
     }
 
     @Override

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/TransactionsImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/TransactionsImpl.java
@@ -19,6 +19,8 @@
 package org.apache.pulsar.client.admin.internal;
 
 import static com.google.common.base.Preconditions.checkArgument;
+
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
@@ -50,14 +52,14 @@ public class TransactionsImpl extends BaseResource implements Transactions {
     }
 
     @Override
-    public Map<Integer, TransactionCoordinatorInfo> listTransactionCoordinators() throws PulsarAdminException {
+    public List<TransactionCoordinatorInfo> listTransactionCoordinators() throws PulsarAdminException {
         return sync(() -> listTransactionCoordinatorsAsync());
     }
 
     @Override
-    public CompletableFuture<Map<Integer, TransactionCoordinatorInfo>> listTransactionCoordinatorsAsync() {
+    public CompletableFuture<List<TransactionCoordinatorInfo>> listTransactionCoordinatorsAsync() {
         WebTarget path = adminV3Transactions.path("coordinators");
-        return asyncGetRequest(path, new FutureCallback<Map<Integer, TransactionCoordinatorInfo>>(){});
+        return asyncGetRequest(path, new FutureCallback<List<TransactionCoordinatorInfo>>(){});
     }
 
     @Override

--- a/pulsar-client-tools-test/src/test/java/org/apache/pulsar/admin/cli/PulsarAdminToolTest.java
+++ b/pulsar-client-tools-test/src/test/java/org/apache/pulsar/admin/cli/PulsarAdminToolTest.java
@@ -2314,6 +2314,10 @@ public class PulsarAdminToolTest {
         cmdTransactions = new CmdTransactions(() -> admin);
         cmdTransactions.run(split("position-stats-in-pending-ack -t test -s test -l 1 -e 1 -b 1"));
         verify(transactions).getPositionStatsInPendingAck("test", "test", 1L, 1L, 1);
+
+        cmdTransactions = new CmdTransactions(() -> admin);
+        cmdTransactions.run(split("coordinators-list"));
+        verify(transactions).listTransactionCoordinators();
     }
 
     @Test

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdTransactions.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdTransactions.java
@@ -23,8 +23,11 @@ import com.beust.jcommander.ParameterException;
 import com.beust.jcommander.Parameters;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
 import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.api.transaction.TxnID;
+import org.apache.pulsar.common.policies.data.TransactionCoordinatorInfo;
 import org.apache.pulsar.common.util.RelativeTimeUtil;
 
 @Parameters(commandDescription = "Operations on transactions")
@@ -223,7 +226,15 @@ public class CmdTransactions extends CmdBase {
     private class ListTransactionCoordinators extends CliCommand {
         @Override
         void run() throws Exception {
-            print(getAdmin().transactions().listTransactionCoordinators());
+            print(getAdmin()
+                    .transactions()
+                    .listTransactionCoordinators()
+                    .stream()
+                    .collect(Collectors.toMap(
+                            TransactionCoordinatorInfo::getId,
+                            TransactionCoordinatorInfo::getBrokerServiceUrl
+                    ))
+            );
         }
     }
 

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdTransactions.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdTransactions.java
@@ -219,6 +219,14 @@ public class CmdTransactions extends CmdBase {
         }
     }
 
+    @Parameters(commandDescription = "List transaction coordinators")
+    private class ListTransactionCoordinators extends CliCommand {
+        @Override
+        void run() throws Exception {
+            print(getAdmin().transactions().listTransactionCoordinators());
+        }
+    }
+
 
     public CmdTransactions(Supplier<PulsarAdmin> admin) {
         super("transactions", admin);
@@ -233,6 +241,7 @@ public class CmdTransactions extends CmdBase {
         jcommander.addCommand("slow-transactions", new GetSlowTransactions());
         jcommander.addCommand("scale-transactionCoordinators", new ScaleTransactionCoordinators());
         jcommander.addCommand("position-stats-in-pending-ack", new GetPositionStatsInPendingAck());
+        jcommander.addCommand("coordinators-list", new ListTransactionCoordinators());
 
     }
 }

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdTransactions.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdTransactions.java
@@ -24,7 +24,6 @@ import com.beust.jcommander.Parameters;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
-
 import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.api.transaction.TxnID;
 import org.apache.pulsar.common.policies.data.TransactionCoordinatorInfo;


### PR DESCRIPTION

Fixes #17513 

### Motivation
At the moment there's no way to list all the transaction coordinators and to understand to which broker own.

### Modifications

* New endpoint `transactions/coordinators´ to get all the coordinators
   * Under the hood it does a `lookup` to the TC partitioned topic
* New data object ´TransactionCoordinatorInfo´ -> only contains the `brokerServiceUrl` field
* Added the equivalent client call in the pulsar-client admin
* Added the equivalent client call in the pulsar-admin CLI `coordinators-list` 

- [x] `doc-not-needed` 
