### PR TITLE
[fix][broker] One topic can be closed multiple times concurrently

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -53,7 +53,6 @@ import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 import java.util.function.BiFunction;
 import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.Value;
 import org.apache.bookkeeper.client.api.LedgerMetadata;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -330,11 +330,17 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
      * Event: Topic delete.
      *  the three futures will be initialized as "waiting for clients disconnect".
      */
-    @AllArgsConstructor
     private class CloseFutures {
-        private final CompletableFuture<Void> waitDisconnectClients;
-        private final CompletableFuture<Void> notWaitDisconnectClients;
         private final CompletableFuture<Void> transferring;
+        private final CompletableFuture<Void> notWaitDisconnectClients;
+        private final CompletableFuture<Void> waitDisconnectClients;
+
+        public CloseFutures(CompletableFuture<Void> transferring, CompletableFuture<Void> waitDisconnectClients,
+                            CompletableFuture<Void> notWaitDisconnectClients) {
+            this.transferring = transferring;
+            this.waitDisconnectClients = waitDisconnectClients;
+            this.notWaitDisconnectClients = notWaitDisconnectClients;
+        }
     }
 
     private static class TopicStatsHelper {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/OneWayReplicatorTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/OneWayReplicatorTest.java
@@ -25,6 +25,7 @@ import static org.mockito.Mockito.spy;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotEquals;
+import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 import com.google.common.collect.Sets;
@@ -226,7 +227,7 @@ public class OneWayReplicatorTest extends OneWayReplicatorTestBase {
         });
     }
 
-    private void injectMockReplicatorProducerBuilder(
+    private Runnable injectMockReplicatorProducerBuilder(
                                 BiFunction<ProducerConfigurationData, ProducerImpl, ProducerImpl> producerDecorator)
             throws Exception {
         String cluster2 = pulsar2.getConfig().getClusterName();
@@ -246,7 +247,8 @@ public class OneWayReplicatorTest extends OneWayReplicatorTestBase {
                 replicationClients = WhiteboxImpl.getInternalState(brokerService, "replicationClients");
         PulsarClientImpl internalClient = (PulsarClientImpl) replicationClients.get(cluster2);
         PulsarClient spyClient = spy(internalClient);
-        replicationClients.put(cluster2, spyClient);
+        assertTrue(replicationClients.remove(cluster2, internalClient));
+        assertNull(replicationClients.putIfAbsent(cluster2, spyClient));
 
         // Inject producer decorator.
         doAnswer(invocation -> {
@@ -275,6 +277,12 @@ public class OneWayReplicatorTest extends OneWayReplicatorTestBase {
             }).when(spyProducerBuilder).createAsync();
             return spyProducerBuilder;
         }).when(spyClient).newProducer(any(Schema.class));
+
+        // Return a cleanup injection task;
+        return () -> {
+            assertTrue(replicationClients.remove(cluster2, spyClient));
+            assertNull(replicationClients.putIfAbsent(cluster2, internalClient));
+        };
     }
 
     private SpyCursor spyCursor(PersistentTopic persistentTopic, String cursorName) throws Exception {
@@ -368,7 +376,7 @@ public class OneWayReplicatorTest extends OneWayReplicatorTestBase {
         //   If the retry counter is larger than 6, the next creation will be slow enough to close Replicator.
         final AtomicInteger createProducerCounter = new AtomicInteger();
         final int failTimes = 6;
-        injectMockReplicatorProducerBuilder((producerCnf, originalProducer) -> {
+        Runnable taskToClearInjection = injectMockReplicatorProducerBuilder((producerCnf, originalProducer) -> {
             if (topicName.equals(producerCnf.getTopicName())) {
                 // There is a switch to determine create producer successfully or not.
                 if (createProducerCounter.incrementAndGet() > failTimes) {
@@ -427,6 +435,7 @@ public class OneWayReplicatorTest extends OneWayReplicatorTestBase {
         });
 
         // cleanup.
+        taskToClearInjection.run();
         cleanupTopics(() -> {
             admin1.topics().delete(topicName);
             admin2.topics().delete(topicName);
@@ -531,7 +540,7 @@ public class OneWayReplicatorTest extends OneWayReplicatorTestBase {
         //   If the retry counter is larger than 6, the next creation will be slow enough to close Replicator.
         final AtomicInteger createProducerCounter = new AtomicInteger();
         final int failTimes = 6;
-        injectMockReplicatorProducerBuilder((producerCnf, originalProducer) -> {
+        Runnable taskToClearInjection = injectMockReplicatorProducerBuilder((producerCnf, originalProducer) -> {
             if (topicName.equals(producerCnf.getTopicName())) {
                 // There is a switch to determine create producer successfully or not.
                 if (createProducerCounter.incrementAndGet() > failTimes) {
@@ -593,6 +602,7 @@ public class OneWayReplicatorTest extends OneWayReplicatorTestBase {
         });
 
         // cleanup.
+        taskToClearInjection.run();
         cleanupTopics(namespaceName, () -> {
             admin1.topics().delete(topicName);
             admin2.topics().delete(topicName);
@@ -644,8 +654,9 @@ public class OneWayReplicatorTest extends OneWayReplicatorTestBase {
             assertTrue(replicator2.producer != null && replicator2.producer.isConnected());
         });
 
-        // cleanup.
+        // cleanup the injection.
         persistentTopic.getProducers().remove(mockProducerName, mockProducer);
+        // cleanup.
         producer1.close();
         cleanupTopics(() -> {
             admin1.topics().delete(topicName);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/PersistentTopicTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/PersistentTopicTest.java
@@ -49,6 +49,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.Map;
+import java.util.Objects;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
@@ -56,6 +58,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
 import lombok.Cleanup;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.bookkeeper.client.LedgerHandle;
@@ -70,6 +73,8 @@ import org.apache.pulsar.broker.service.BrokerService;
 import org.apache.pulsar.broker.service.BrokerTestBase;
 import org.apache.pulsar.broker.service.Topic;
 import org.apache.pulsar.broker.service.TopicPoliciesService;
+import org.apache.pulsar.broker.service.Topic;
+import org.apache.pulsar.broker.stats.prometheus.PrometheusMetricsGenerator;
 import org.apache.pulsar.client.admin.PulsarAdminException;
 import org.apache.pulsar.client.api.Consumer;
 import org.apache.pulsar.client.api.Message;
@@ -322,6 +327,83 @@ public class PersistentTopicTest extends BrokerTestBase {
         }
     }
 
+    @DataProvider(name = "closeWithoutWaitingClientDisconnectInFirstBatch")
+    public Object[][] closeWithoutWaitingClientDisconnectInFirstBatch() {
+        return new Object[][]{
+                new Object[] {true},
+                new Object[] {false},
+        };
+    }
+
+    @Test(dataProvider = "closeWithoutWaitingClientDisconnectInFirstBatch")
+    public void testConcurrentClose(boolean closeWithoutWaitingClientDisconnectInFirstBatch) throws Exception {
+        final String topicName = "persistent://prop/ns/concurrentClose";
+        final String ns = "prop/ns";
+        admin.namespaces().createNamespace(ns, 1);
+        admin.topics().createNonPartitionedTopic(topicName);
+        final Topic topic = pulsar.getBrokerService().getTopicIfExists(topicName).get().get();
+        List<CompletableFuture<Void>> futureList =
+                make2ConcurrentBatchesOfClose(topic, 10, closeWithoutWaitingClientDisconnectInFirstBatch);
+        Map<Integer, List<CompletableFuture<Void>>> futureMap =
+                futureList.stream().collect(Collectors.groupingBy(Objects::hashCode));
+        /**
+         * The first call: get the return value of "topic.close".
+         * The other 19 calls: get the cached value which related {@link PersistentTopic#closeFutures}.
+         */
+        assertEquals(futureMap.size(), 3);
+        for (List list : futureMap.values()){
+            if (list.size() == 1){
+                // This is the first call, the future is the return value of `topic.close`.
+            } else {
+                // Two types future list: wait client close or not.
+                assertTrue(list.size() >= 9 && list.size() <= 10);
+            }
+        }
+    }
+
+    private List<CompletableFuture<Void>> make2ConcurrentBatchesOfClose(Topic topic, int tryTimes,
+                                                              boolean closeWithoutWaitingClientDisconnectInFirstBatch){
+        final List<CompletableFuture<Void>> futureList = Collections.synchronizedList(new ArrayList<>());
+        final List<Thread> taskList = new ArrayList<>();
+        CountDownLatch allTaskBeginLatch = new CountDownLatch(1);
+        // Call a batch of close.
+        for (int i = 0; i < tryTimes; i++) {
+            Thread thread = new Thread(() -> {
+                try {
+                    allTaskBeginLatch.await(5, TimeUnit.SECONDS);
+                } catch (InterruptedException e) {
+                    throw new RuntimeException(e);
+                }
+                futureList.add(topic.close(closeWithoutWaitingClientDisconnectInFirstBatch));
+            });
+            thread.start();
+            taskList.add(thread);
+        }
+        // Call another batch of close.
+        for (int i = 0; i < tryTimes; i++) {
+            Thread thread = new Thread(() -> {
+                try {
+                    allTaskBeginLatch.await(5, TimeUnit.SECONDS);
+                } catch (InterruptedException e) {
+                    throw new RuntimeException(e);
+                }
+                futureList.add(topic.close(!closeWithoutWaitingClientDisconnectInFirstBatch));
+            });
+            thread.start();
+            taskList.add(thread);
+        }
+        // Wait close task executed.
+        allTaskBeginLatch.countDown();
+        Awaitility.await().atMost(5, TimeUnit.SECONDS).until(()->{
+            for (Thread thread : taskList){
+                if (thread.isAlive()){
+                    return false;
+                }
+            }
+            return true;
+        });
+        return futureList;
+    }
 
     @DataProvider(name = "topicAndMetricsLevel")
     public Object[][] indexPatternTestData() {
@@ -330,7 +412,6 @@ public class PersistentTopicTest extends BrokerTestBase {
                 new Object[] {"persistent://prop/autoNs/test_delayed_message_metric", false},
         };
     }
-
 
     @Test(dataProvider = "topicAndMetricsLevel")
     public void testDelayedDeliveryTrackerMemoryUsageMetric(String topic, boolean exposeTopicLevelMetrics) throws Exception {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/PersistentTopicTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/PersistentTopicTest.java
@@ -348,7 +348,7 @@ public class PersistentTopicTest extends BrokerTestBase {
          * The first call: get the return value of "topic.close".
          * The other 19 calls: get the cached value which related {@link PersistentTopic#closeFutures}.
          */
-        assertEquals(futureMap.size(), 3);
+        assertTrue(futureMap.size() <= 3);
         for (List list : futureMap.values()){
             if (list.size() == 1){
                 // This is the first call, the future is the return value of `topic.close`.

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/PersistentTopicTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/PersistentTopicTest.java
@@ -73,8 +73,6 @@ import org.apache.pulsar.broker.service.BrokerService;
 import org.apache.pulsar.broker.service.BrokerTestBase;
 import org.apache.pulsar.broker.service.Topic;
 import org.apache.pulsar.broker.service.TopicPoliciesService;
-import org.apache.pulsar.broker.service.Topic;
-import org.apache.pulsar.broker.stats.prometheus.PrometheusMetricsGenerator;
 import org.apache.pulsar.client.admin.PulsarAdminException;
 import org.apache.pulsar.client.api.Consumer;
 import org.apache.pulsar.client.api.Message;


### PR DESCRIPTION
### Motivation

With the transaction feature, we send and receive messages, and at the same time, execute `admin API: unload namespace` 1000 times. Then the problem occur: Consumer could not receive any message, and there has no error log. After that we tried `admin API: get topic stats`, and the response showed only producers are registered on topic, and no consumers are registered on topic, but consumer stat is `Ready` in the client. This means that the state of the consumer is inconsistent between the broker and the client.

#### Location problem

Then we found the problem: Two PersistentTopic which have the same name registered at a broker node, consumer registered on one (aka `topic-c`), and producer registered on another one (aka `topic-p`). At this time, when we send messages, the data flow like this : 

```text
client: producer sends a message

broker: handle cmd-send

broker: find the topic by name, it is "topic-p"

broker: find all subscriptions registered on "topic-p"

broker: found one subscription, but it has no consumers registered

broker: no need to send the message to the client
``` 

But the consumer exactly registered on another topic: `topic-c`, so consumer could not receive any message.

#### Repreduce

> *How to reproduce two topics registered at the same broker node ?*

Make  `transaction buffer recover`, `admin unload namespace`, `client create consumer`, ` client create producer` executed at the same time, the process flow like this (at the step-11, the problem occurs ):

| Time | `transaction buffer recoverr` | `admin unload namespace` | `client create consumer` | `client create producer` |
| ----------- | ----------- | ----------- | ----------- | ----------- |
| 1 | TB recover |  |  |  |
| 2 | TB recover failure | topic.unload |  |  |
| 3 | topic.close(false) | topic.close(true) |  |  |
| 4 | brokerService.topics.remove(topicName) |  |  |  |
| 5 | remove topic finish |  | lookup |  |
| 6 |  |  | create `topic-c` |  |
| 7 |  |  | consumer registered on `topic-c` |  |
| 8 |  | brokerService.topics.remove(topic) |  |  |
| 9 |  | remove `topic-c` finish |  | lookup |
| 10 |  |  |  | create `topic-p`  |
| 11 |  |  |  | producer registered on `topic-p`  |

- Each column means the individual process. e.g. `client create consumer`,  `client create producer`.
- Multiple processes are going on at the same time, and all effet the `brokerService.topics`.
- Column `Time` is used only to indicate the order of each step, not the actual time.
- The important steps are explained below:

> step 3

Even if persistent topic property`isClosingOrDeleting` have already changed to `true`, it still can be executed another once, see line-1247:

https://github.com/apache/pulsar/blob/f230d15ffcd5f74cca13bd23b35ace784d6f8ce6/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java#L1240-L1249 

Whether close can be executed depends on two predicates: `is closing` or `@param closeWithoutWaitingClientDisconnect is true`. This means that method `topic.close` can be reentrant executed when `@param closeWithoutWaitingClientDisconnect` is true, and in the implementation of `admin API: unload namespace` the parameter `closeWithoutWaitingClientDisconnect` is exactly `true`.

https://github.com/apache/pulsar/blob/f230d15ffcd5f74cca13bd23b35ace784d6f8ce6/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/NamespaceService.java#L723-L725

So when `transaction buffer recover fail` and `admin unload namespace` is executed at the same time, and `transaction buffer recover fail` before `admin unload namespace`, the topic will be removed from `brokerService.topics` twice.

> step-4 / step-8

Because of the current implementation of `BrokerService. removeTopicFromCache` use cmd `map.remove(key)`, not use `map.remove(key, value)`, So this cmd can remove any value in the map, even if it's not the desired one.

https://github.com/apache/pulsar/blob/f230d15ffcd5f74cca13bd23b35ace784d6f8ce6/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java#L1956

To sum up: We should make these two changes: 

- Make method `topic.close` non-reentrant. Also prevent reentrant between `topic.close` and `topic.delete`.
- Use cmd  `map.remove(key, value)` instead of `map.remove(key)` in implementation of `BrokerService. removeTopicFromCache`. This change will apply to both scenes: `topic.close` and `topic.delete`.

### Modifications

- Use cmd  `map.remove(key, value)` instead of `map.remove(key)` in implementation of `BrokerService. 
  - fixed by PR #17526


### Documentation

- [ ] `doc-required` 
  
- [x] `doc-not-needed` 
  
- [ ] `doc` 

- [ ] `doc-complete`