### PR TITLE
[improve][client]Removing check executorProvider null

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PulsarClientImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PulsarClientImpl.java
@@ -875,7 +875,7 @@ public class PulsarClientImpl implements PulsarClient {
         PulsarClientException pulsarClientException = null;
         if (createdExecutorProviders) {
 
-            if (externalExecutorProvider != null && !externalExecutorProvider.isShutdown()) {
+            if (!externalExecutorProvider.isShutdown()) {
                 try {
                     externalExecutorProvider.shutdownNow();
                 } catch (Throwable t) {
@@ -883,7 +883,7 @@ public class PulsarClientImpl implements PulsarClient {
                     pulsarClientException = PulsarClientException.unwrap(t);
                 }
             }
-            if (internalExecutorProvider != null && !internalExecutorProvider.isShutdown()) {
+            if (!internalExecutorProvider.isShutdown()) {
                 try {
                     internalExecutorProvider.shutdownNow();
                 } catch (Throwable t) {


### PR DESCRIPTION

### Motivation


* A minor improvement by removing check null for `externalExecutorProvider` and `internalExecutorProvider` ,  because they are final variables initialized with non-null value.

### Modifications
* Removing check null for `externalExecutorProvider` and `internalExecutorProvider`

### Verifying this change

- [x] Make sure that the change passes the CI checks.



### Documentation

Check the box below or label this PR directly.

Need to update docs? 

  
- [x] `doc-not-needed` 
