### PR TITLE
[fix][client]Fix scheduledExecutorProvider not shutdown

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PulsarClientImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PulsarClientImpl.java
@@ -892,7 +892,7 @@ public class PulsarClientImpl implements PulsarClient {
                 }
             }
         }
-        if (createdScheduledProviders && !scheduledExecutorProvider.isShutdown()) {
+        if (createdScheduledProviders && scheduledExecutorProvider != null && !scheduledExecutorProvider.isShutdown()) {
             try {
                 scheduledExecutorProvider.shutdownNow();
             } catch (Throwable t) {

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PulsarClientImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PulsarClientImpl.java
@@ -892,9 +892,9 @@ public class PulsarClientImpl implements PulsarClient {
                 }
             }
         }
-        if (createdScheduledProviders && scheduledExecutorProvider != null && !scheduledExecutorProvider.isShutdown()) {
+        if (createdScheduledProviders && !scheduledExecutorProvider.isShutdown()) {
             try {
-                externalExecutorProvider.shutdownNow();
+                scheduledExecutorProvider.shutdownNow();
             } catch (Throwable t) {
                 log.warn("Failed to shutdown scheduledExecutorProvider", t);
                 pulsarClientException = PulsarClientException.unwrap(t);


### PR DESCRIPTION
### Motivation


* Fix `org.apache.pulsar.client.impl.PulsarClientImpl#scheduledExecutorProvider` not shutdown

### Modifications

* Shut down  `scheduledExecutorProvider`

### Verifying this change

- [x] Make sure that the change passes the CI checks.


### Documentation

- [x] `doc-not-needed` 