### PR TITLE
[fix][broker]Make two status of persistent topic changes to atomic: fenced & closing

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -2970,8 +2970,13 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
     }
 
     private void unfenceTopicToResume() {
-        isFenced = false;
-        isClosingOrDeleting = false;
+        lock.writeLock().lock();
+        try {
+            isFenced = false;
+            isClosingOrDeleting = false;
+        } finally {
+            lock.writeLock().unlock();
+        }
     }
 
     @Override


### PR DESCRIPTION
### Motivation

Now both Topic statuses (`fenced` and `isClosingOrDeleting`) is modified in the following methods: 

- `fenceTopicToCloseOrDelete`: set both states to `true`
- `unfenceTopicToResume`: set both states to `false`

All calls to the `fenceTopicToCloseOrDelete` has holds the lock `persistentTopic.lock`, but when calling `unfenceTopicToResume`, maybe not holds the lock `persistentTopic.lock`.  So this could happen:


| Time  | call `fenceTopicToCloseOrDelete` | call `unfenceTopicToResume` | 
| ---- | ----------- | ----------- |
| 1 |  | set `isFenced` to `false` |
| 2 | set `isClosingOrDeleting` to `true` |  |
| 3 | set `isFenced` to `true` |  |
| 4 |  | set `isClosingOrDeleting` to `false` |

After the above process is complete, the two states are not consistent.

### Modifications

Causes `unfenceTopicToResume` to execute inside a locked block.

### Documentation

- [ ] `doc-required` 
  
- [x] `doc-not-needed` 
  
- [ ] `doc` 

- [ ] `doc-complete`