### PR TITLE
[ci] Temporarily remove required jobs to unblock CI

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -49,35 +49,35 @@ github:
         # Contexts are the names of checks that must pass.
         # See ./github/workflows/README.md for more documentation on this list.
         contexts:
-          - build
-          - cpp-tests
+#          - build
+#          - cpp-tests
           - Changed files check
           - Build and License check
-          - CI - Unit - Brokers - Broker Group 1
-          - CI - Unit - Brokers - Broker Group 2
-          - CI - Unit - Brokers - Broker Group 3
-          - CI - Unit - Brokers - Client Api
-          - CI - Unit - Brokers - Client Impl
-          - CI - Unit - Other
-          - CI - Unit - Proxy
-          - Build Pulsar java-test-image docker image
-          - CI - Integration - Backwards Compatibility
-          - CI - Integration - Cli
-          - CI - Integration - Messaging
-          - CI - Integration - Shade on Java 8
-          - CI - Integration - Shade on Java 11
-          - CI - Integration - Shade on Java 17
-          - CI - Integration - Standalone
-          - CI - Integration - Transaction
-          - Build Pulsar docker image
-          - CI - System - Function
-          - CI - System - Pulsar Connectors - Process
-          - CI - System - Pulsar Connectors - Thread
-          - CI - System - Pulsar IO
-          - CI - System - Schema
-          - CI - System - Tiered FileSystem
-          - CI - System - Tiered JCloud
-          - CI - System - Sql
+#          - CI - Unit - Brokers - Broker Group 1
+#          - CI - Unit - Brokers - Broker Group 2
+#          - CI - Unit - Brokers - Broker Group 3
+#          - CI - Unit - Brokers - Client Api
+#          - CI - Unit - Brokers - Client Impl
+#          - CI - Unit - Other
+#          - CI - Unit - Proxy
+#          - Build Pulsar java-test-image docker image
+#          - CI - Integration - Backwards Compatibility
+#          - CI - Integration - Cli
+#          - CI - Integration - Messaging
+#          - CI - Integration - Shade on Java 8
+#          - CI - Integration - Shade on Java 11
+#          - CI - Integration - Shade on Java 17
+#          - CI - Integration - Standalone
+#          - CI - Integration - Transaction
+#          - Build Pulsar docker image
+#          - CI - System - Function
+#          - CI - System - Pulsar Connectors - Process
+#          - CI - System - Pulsar Connectors - Thread
+#          - CI - System - Pulsar IO
+#          - CI - System - Schema
+#          - CI - System - Tiered FileSystem
+#          - CI - System - Tiered JCloud
+#          - CI - System - Sql
 
       required_pull_request_reviews:
         dismiss_stale_reviews: false

--- a/.asf.yaml
+++ b/.asf.yaml
@@ -51,8 +51,8 @@ github:
         contexts:
 #          - build
 #          - cpp-tests
-          - Changed files check
-          - Build and License check
+#          - Changed files check
+#          - Build and License check
 #          - CI - Unit - Brokers - Broker Group 1
 #          - CI - Unit - Brokers - Broker Group 2
 #          - CI - Unit - Brokers - Broker Group 3


### PR DESCRIPTION
### Motivation

Following the action plan defined in https://lists.apache.org/thread/yh72bmlf2w97593c5d5pqf3jz1ldb501 .
A lazy consensus was reached on this matter to fix CI following the action plan.

We need to temporary unblock changes to make the CI more stable

### Modifications

* Keep only the build as a required workflow

- [x] `doc-not-needed` 