### PR TITLE
[ci] Skip run flaky tests suite for cpp-only or doc-only changes

### DIFF
--- a/.github/workflows/pulsar-ci-flaky.yaml
+++ b/.github/workflows/pulsar-ci-flaky.yaml
@@ -23,11 +23,25 @@ on:
     branches:
       - master
     paths-ignore:
+      # Doc
+      - 'site2/**'
+      - 'deployment/**'
+      - '.asf.yaml'
+      - '*.md'
+      - '**/*.md'
+      # CPP
       - 'pulsar-client-cpp/**'
   push:
     branches:
       - branch-*
     paths-ignore:
+      # Doc
+      - 'site2/**'
+      - 'deployment/**'
+      - '.asf.yaml'
+      - '*.md'
+      - '**/*.md'
+      # CPP
       - 'pulsar-client-cpp/**'
 
 concurrency:
@@ -42,36 +56,11 @@ env:
   ARTIFACT_RETENTION_DAYS: 3
 
 jobs:
-  changed_files_job:
-    name: 'Changed files check'
-    runs-on: ubuntu-20.04
-    outputs:
-      docs_only: ${{ steps.check_changes.outputs.docs_only }}
-      cpp_only: ${{ steps.check_changes.outputs.cpp_only }}
-      changed_tests: ${{ steps.changes.outputs.tests_files }}
-    steps:
-      - name: checkout
-        uses: actions/checkout@v2
-
-      - name: Detect changed files
-        id:   changes
-        uses: apache/pulsar-test-infra/paths-filter@master
-        with:
-          filters: .github/changes-filter.yaml
-          list-files: csv
-
-      - name: Check changed files
-        id: check_changes
-        run: |
-          echo "::set-output name=docs_only::${{ fromJSON(steps.changes.outputs.all_count) == fromJSON(steps.changes.outputs.docs_count) && fromJSON(steps.changes.outputs.docs_count) > 0 }}"
-          echo "::set-output name=cpp_only::${{ fromJSON(steps.changes.outputs.all_count) == fromJSON(steps.changes.outputs.cpp_count) && fromJSON(steps.changes.outputs.cpp_count) > 0 }}"
-
-  build-and-test:
+  build-and-test-flaky:
     needs: changed_files_job
     name: Flaky tests suite
     runs-on: ubuntu-20.04
     timeout-minutes: 100
-    if: ${{ needs.changed_files_job.outputs.docs_only != 'true' }}
     steps:
       - name: checkout
         uses: actions/checkout@v2

--- a/.github/workflows/pulsar-ci-flaky.yaml
+++ b/.github/workflows/pulsar-ci-flaky.yaml
@@ -22,9 +22,13 @@ on:
   pull_request:
     branches:
       - master
+    paths-ignore:
+      - 'pulsar-client-cpp/**'
   push:
     branches:
       - branch-*
+    paths-ignore:
+      - 'pulsar-client-cpp/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
### Motivation

The new flaky suite workflow can be skipped in case of doc-only or cpp-only changes.

### Modifications

* Used `paths-ignore` copying paths from the changes-filter.yaml file
