### PR TITLE
[fix][test] Using another thread instead of io-thread for bookie

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/zookeeper/LocalBookkeeperEnsemble.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/zookeeper/LocalBookkeeperEnsemble.java
@@ -402,9 +402,9 @@ public class LocalBookkeeperEnsemble {
         conf.setProperty("journalMaxGroupWaitMSec", 0L);
         conf.setAllowLoopback(true);
         conf.setGcWaitTime(60000);
-        conf.setNumAddWorkerThreads(0);
-        conf.setNumReadWorkerThreads(0);
-        conf.setNumHighPriorityWorkerThreads(0);
+        conf.setNumAddWorkerThreads(1);
+        conf.setNumReadWorkerThreads(1);
+        conf.setNumHighPriorityWorkerThreads(1);
         conf.setNumJournalCallbackThreads(0);
         conf.setServerNumIOThreads(1);
         conf.setNumLongPollWorkerThreads(1);


### PR DESCRIPTION
---
Master Issue: #17520 

### Motivation

In the bookkeeper, the request processor should use a dedicated thread pool, not the io thread pool to process the request. Using io thread pool may cause some unexpected behaviors, such as a deadlock or something else. In the production, it doesn't make sense that use io thread pool to handle everything. So change the working thread to 1 to fix the problem.

### Modifications

- change AddWorkerThreads, ReadWorkerThreads, and HighPriorityWorkerThreads to 1

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API: (yes / no)
  - The schema: (yes / no / don't know)
  - The default values of configurations: (yes / no)
  - The wire protocol: (yes / no)
  - The rest endpoints: (yes / no)
  - The admin cli options: (yes / no)
  - Anything that affects deployment: (yes / no / don't know)

### Documentation

Check the box below or label this PR directly.

Need to update docs? 

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)
  
- [x] `doc-not-needed` 
(Please explain why)
  
- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)