### PR TITLE
[feat][ci] Check PR title with semantic

### DIFF
--- a/.github/workflows/ci-documentbot.yml
+++ b/.github/workflows/ci-documentbot.yml
@@ -44,3 +44,50 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           LABEL_WATCH_LIST: 'doc,doc-required,doc-not-needed,doc-complete'
           LABEL_MISSING: 'doc-label-missing'
+
+  check-pr-title:
+    if: github.event.action == 'opened' || github.event.action == 'edited'
+    name: Check PR title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v4
+        continue-on-error: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            feat
+            improve
+            fix
+            cleanup
+            refactor
+            revert
+
+          scopes: |
+            admin
+            broker
+            cli
+            io
+            fn
+            meta
+            monitor
+            proxy
+            schema
+            sec
+            sql
+            storage
+            offload
+            txn
+            java
+            cpp
+            py
+            ws
+            test
+            ci
+            build
+            misc
+            doc
+            blog
+            site
+
+          headerPattern: '^(?:\[(\w+)\])?(?:\[(\w+)\])? (.+)$'


### PR DESCRIPTION
Signed-off-by: mango <xu.weiKyrie@foxmail.com>

Master Issue: #15311

### Motivation

Follow the guide of [PIP 198](https://docs.google.com/document/d/1sJlUNAHnYAbvu9UtEgCrn_oVTnVc1M5nHC19x1bFab4/edit#) and [Guide](https://docs.google.com/document/d/1d8Pw6ZbWk-_pCKdOmdvx9rnhPiyuxwq60_TrD68d7BA/edit?pli=1#heading=h.wu6ygjne8e35), we support a job to standardize PR naming convention using GitHub Action, but this PR finished only one task(Create “check PR title” job in GitHub check), other task involves modifying [docbot](https://github.com/apache/pulsar-test-infra/tree/master/docbot), so we will commit another PR to solve.

### Modifications

Add a job to check PR title with [semantic GitHub Action](https://github.com/amannn/action-semantic-pull-request) 

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

Check the box below or label this PR directly.

Need to update docs? 

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)
  
- [x] `doc-not-needed` 
Modify github workflow
  
- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)