### PR TITLE
[improve][ci] Replace latest os images with fixed ones (ubuntu and macos)

### DIFF
--- a/.github/workflows/ci-cpp-build.yaml
+++ b/.github/workflows/ci-cpp-build.yaml
@@ -63,7 +63,7 @@ jobs:
   cpp-build-centos7:
     needs: changed_files_job
     name:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     if: ${{ needs.changed_files_job.outputs.docs_only != 'true' }}
     timeout-minutes: 120
 
@@ -190,7 +190,7 @@ jobs:
   cpp-deb-rpm-packaging:
     needs: changed_files_job
     name:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     timeout-minutes: 120
     if: ${{ needs.changed_files_job.outputs.docs_only != 'true' }}
 
@@ -239,7 +239,7 @@ jobs:
   build-python-wheel:
     needs: changed_files_job
     name:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     timeout-minutes: 120
     if: ${{ needs.changed_files_job.outputs.docs_only != 'true' }}
 

--- a/.github/workflows/ci-cpp.yaml
+++ b/.github/workflows/ci-cpp.yaml
@@ -37,7 +37,7 @@ jobs:
 
   cpp-tests:
     name:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     timeout-minutes: 120
 
     steps:

--- a/.github/workflows/ci-documentbot.yml
+++ b/.github/workflows/ci-documentbot.yml
@@ -36,7 +36,7 @@ jobs:
     if: ${{ github.repository == 'apache/pulsar' }}
     permissions:
       pull-requests: write 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Labeling
         uses: apache/pulsar-test-infra/docbot@master

--- a/.github/workflows/ci-go-functions.yaml
+++ b/.github/workflows/ci-go-functions.yaml
@@ -67,7 +67,7 @@ jobs:
     needs: changed_files_job
     if: ${{ needs.changed_files_job.outputs.docs_only != 'true' && needs.changed_files_job.outputs.cpp_only != 'true' }}
     name: Go ${{ matrix.go-version }} Functions style check
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         go-version: [1.15, 1.16, 1.17]

--- a/.github/workflows/ci-maven-cache-update.yaml
+++ b/.github/workflows/ci-maven-cache-update.yaml
@@ -55,16 +55,16 @@ jobs:
       matrix:
         include:
           - name: all modules
-            runs-on: ubuntu-latest
+            runs-on: ubuntu-20.04
             cache_name: 'm2-dependencies-all'
             mvn_arguments: ''
 
           - name: all modules - macos
-            runs-on: macos-latest
+            runs-on: macos-11
             cache_name: 'm2-dependencies-all'
 
           - name: core-modules
-            runs-on: ubuntu-latest
+            runs-on: ubuntu-20.04
             cache_name: 'm2-dependencies-core-modules'
             mvn_arguments: '-Pcore-modules,-main'
 

--- a/.github/workflows/ci-owasp-dep-check.yaml
+++ b/.github/workflows/ci-owasp-dep-check.yaml
@@ -37,7 +37,7 @@ jobs:
 
   owasp-dep-check:
     name:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     timeout-minutes: 120
 
     steps:

--- a/.github/workflows/ci-owasp-dependency-check.yaml
+++ b/.github/workflows/ci-owasp-dependency-check.yaml
@@ -29,7 +29,7 @@ jobs:
   run-owasp-dependency-check:
     if: ${{ github.repository == 'apache/pulsar' }}
     name: Run OWASP Dependency Check
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     timeout-minutes: 45
     strategy:
       fail-fast: false

--- a/.github/workflows/ci-pulsarbot.yaml
+++ b/.github/workflows/ci-pulsarbot.yaml
@@ -24,7 +24,7 @@ on:
 
 jobs:
   pulsarbot:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     timeout-minutes: 10
     if: github.event_name == 'issue_comment' && contains(github.event.comment.body, '/pulsarbot')
     steps:

--- a/.github/workflows/ci-stale-issue-pr.yaml
+++ b/.github/workflows/ci-stale-issue-pr.yaml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   stale:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/stale@v4
         with:

--- a/.github/workflows/pulsar-ci.yaml
+++ b/.github/workflows/pulsar-ci.yaml
@@ -128,7 +128,7 @@ jobs:
 
   macos-build:
     name:
-    runs-on: macos-latest
+    runs-on: macos-11
     timeout-minutes: 120
     needs: [ 'changed_files_job', 'build-and-license-check' ]
     if: ${{ needs.changed_files_job.outputs.docs_only != 'true' }}


### PR DESCRIPTION
Fixes #17560 

### Motivation

It's better to have control over the OS used in the CI in order to explicitly handle upgrades

### Modifications

* Moved ubuntu-latest to ubuntu-20.04
* Moved macos-latest to macos-11 

- [x] `doc-not-needed` 
