### PR TITLE
[improve][ci] Skip MacOS build for cpp-only changes

### DIFF
--- a/.github/workflows/ci-cpp-build.yaml
+++ b/.github/workflows/ci-cpp-build.yaml
@@ -57,7 +57,7 @@ jobs:
 
   cpp-build-centos7:
     needs: changed_files_job
-    name:
+    name: Build CPP Client on CentOS7
     runs-on: ubuntu-20.04
     if: ${{ needs.changed_files_job.outputs.docs_only != 'true' }}
     timeout-minutes: 120
@@ -77,7 +77,7 @@ jobs:
   cpp-build-windows:
     needs: changed_files_job
     timeout-minutes: 120
-    name: ${{ matrix.name }}
+    name: Build CPP Client on ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
     if: ${{ needs.changed_files_job.outputs.docs_only != 'true' }}
     env:
@@ -184,7 +184,7 @@ jobs:
           fi
   cpp-deb-rpm-packaging:
     needs: changed_files_job
-    name:
+    name: Build CPP Client on RPM
     runs-on: ubuntu-20.04
     timeout-minutes: 120
     if: ${{ needs.changed_files_job.outputs.docs_only != 'true' }}
@@ -233,7 +233,7 @@ jobs:
 
   build-python-wheel:
     needs: changed_files_job
-    name:
+    name: Build Python Client
     runs-on: ubuntu-20.04
     timeout-minutes: 120
     if: ${{ needs.changed_files_job.outputs.docs_only != 'true' }}

--- a/.github/workflows/pulsar-ci.yaml
+++ b/.github/workflows/pulsar-ci.yaml
@@ -813,7 +813,6 @@ jobs:
         uses: ./.github/actions/tune-runner-vm
 
       - name: Cache Maven dependencies
-        if: ${{ steps.check_changes.outputs.docs_only != 'true' }}
         uses: actions/cache@v2
         with:
           path: |

--- a/.github/workflows/pulsar-ci.yaml
+++ b/.github/workflows/pulsar-ci.yaml
@@ -124,38 +124,7 @@ jobs:
         with:
           action: wait
 
-  macos-build:
-    name:
-    runs-on: macos-11
-    timeout-minutes: 120
-    needs: [ 'changed_files_job', 'build-and-license-check' ]
-    if: ${{ needs.changed_files_job.outputs.docs_only != 'true' }}
-    steps:
-      - name: checkout
-        uses: actions/checkout@v2
 
-      - name: Tune Runner VM
-        uses: ./.github/actions/tune-runner-vm
-
-      - name: Cache Maven dependencies
-        if: ${{ steps.check_changes.outputs.docs_only != 'true' }}
-        uses: actions/cache@v2
-        with:
-          path: |
-            ~/.m2/repository/*/*/*
-            !~/.m2/repository/org/apache/pulsar
-          key: ${{ runner.os }}-m2-dependencies-all-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-m2-dependencies-all-
-
-      - name: Set up JDK 17
-        uses: actions/setup-java@v2
-        with:
-          distribution: 'temurin'
-          java-version: 17
-
-      - name: build package
-        run: mvn -B clean package -DskipTests -T 1C -ntp
 
   unit-tests:
     name: CI - Unit - ${{ matrix.name }}
@@ -829,6 +798,41 @@ jobs:
       - name: Delete docker image from GitHub Actions Artifacts
         run: |
           gh-actions-artifact-client.js delete pulsar-test-latest-version-image.zst
+  
+
+  macos-build:
+    name: Build Pulsar on MacOS
+    runs-on: macos-11
+    timeout-minutes: 120
+    needs: ['changed_files_job', 'pulsar-test-latest-version-image']
+    if: ${{ needs.changed_files_job.outputs.docs_only != 'true' && needs.changed_files_job.outputs.cpp_only != 'true' }}
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+
+      - name: Tune Runner VM
+        uses: ./.github/actions/tune-runner-vm
+
+      - name: Cache Maven dependencies
+        if: ${{ steps.check_changes.outputs.docs_only != 'true' }}
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.m2/repository/*/*/*
+            !~/.m2/repository/org/apache/pulsar
+          key: ${{ runner.os }}-m2-dependencies-all-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-m2-dependencies-all-
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'temurin'
+          java-version: 17
+
+      - name: build package
+        run: mvn -B clean package -DskipTests -T 1C -ntp
+
 
   # This job is required for pulls to be merged.
   # It depends on all other jobs in this workflow.

--- a/.github/workflows/pulsar-ci.yaml
+++ b/.github/workflows/pulsar-ci.yaml
@@ -803,7 +803,7 @@ jobs:
     name: Build Pulsar on MacOS
     runs-on: macos-11
     timeout-minutes: 120
-    needs: ['changed_files_job', 'pulsar-test-latest-version-image']
+    needs: ['changed_files_job', 'integration-tests']
     if: ${{ needs.changed_files_job.outputs.docs_only != 'true' && needs.changed_files_job.outputs.cpp_only != 'true' }}
     steps:
       - name: checkout

--- a/.github/workflows/pulsar-ci.yaml
+++ b/.github/workflows/pulsar-ci.yaml
@@ -799,7 +799,6 @@ jobs:
         run: |
           gh-actions-artifact-client.js delete pulsar-test-latest-version-image.zst
   
-
   macos-build:
     name: Build Pulsar on MacOS
     runs-on: macos-11


### PR DESCRIPTION
Fixes #17558

### Motivation

There's no need to trigger the build on MacOS for cpp-only changes.


### Modifications
- Skipped the MacOs build in case of cpp-only change
- Improved the name of non required-checks to a friendly name.

- [x] `doc-not-needed` 