### PR TITLE
[improve][ci] Remove post commit builds and add manual workflows trigger

### DIFF
--- a/.github/workflows/ci-cpp-build.yaml
+++ b/.github/workflows/ci-cpp-build.yaml
@@ -25,12 +25,7 @@ on:
     paths:
       - '.github/workflows/**'
       - 'pulsar-client-cpp/**'
-  push:
-    branches:
-      - branch-*
-    paths:
-      - '.github/workflows/**'
-      - 'pulsar-client-cpp/**'
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/ci-cpp.yaml
+++ b/.github/workflows/ci-cpp.yaml
@@ -22,9 +22,7 @@ on:
   pull_request:
     branches:
       - master
-  push:
-    branches:
-      - branch-*
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/ci-go-functions.yaml
+++ b/.github/workflows/ci-go-functions.yaml
@@ -25,12 +25,7 @@ on:
     paths:
       - '.github/workflows/**'
       - 'pulsar-function-go/**'
-  push:
-    branches:
-      - branch-*
-    paths:
-      - '.github/workflows/**'
-      - 'pulsar-function-go/**'
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/pulsar-ci-flaky.yaml
+++ b/.github/workflows/pulsar-ci-flaky.yaml
@@ -22,9 +22,7 @@ on:
   pull_request:
     branches:
       - master
-  push:
-    branches:
-      - branch-*
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/pulsar-ci.yaml
+++ b/.github/workflows/pulsar-ci.yaml
@@ -22,9 +22,7 @@ on:
   pull_request:
     branches:
       - master
-  push:
-    branches:
-      - branch-*
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
### Motivation

Related to #17567. Post commit builds are triggered for every commit in the master branch and 2.11. Nobody look at them since we validate the changes in the pull. Removing these builds will help a lot reducing the CI load.

### Modifications

* Removed the push trigger and added the `workflow_dispatch`. In this way it's possible to manually run workflows [in this way](https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow)

- [x] `doc-not-needed` 