### PR TITLE
[ci] Remove post-commit trigger for old release branches (2.10 and previous)

### DIFF
--- a/.github/workflows/ci-build-macos.yaml
+++ b/.github/workflows/ci-build-macos.yaml
@@ -22,9 +22,6 @@ on:
   pull_request:
     branches:
       - branch-*
-  push:
-    branches:
-      - branch-*
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/ci-cpp-build-centos7.yaml
+++ b/.github/workflows/ci-cpp-build-centos7.yaml
@@ -25,12 +25,7 @@ on:
     paths:
       - '.github/workflows/**'
       - 'pulsar-client-cpp/**'
-  push:
-    branches:
-      - branch-*
-    paths:
-      - '.github/workflows/**'
-      - 'pulsar-client-cpp/**'
+
 jobs:
 
   cpp-build-centos7:

--- a/.github/workflows/ci-cpp-build-windows.yaml
+++ b/.github/workflows/ci-cpp-build-windows.yaml
@@ -25,12 +25,6 @@ on:
     paths:
       - '.github/workflows/**'
       - 'pulsar-client-cpp/**'
-  push:
-    branches:
-      - branch-*
-    paths:
-      - '.github/workflows/**'
-      - 'pulsar-client-cpp/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/ci-cpp.yaml
+++ b/.github/workflows/ci-cpp.yaml
@@ -22,9 +22,6 @@ on:
   pull_request:
     branches:
       - branch-*
-  push:
-    branches:
-      - branch-*
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/ci-go-functions-style.yaml
+++ b/.github/workflows/ci-go-functions-style.yaml
@@ -25,12 +25,6 @@ on:
     paths:
       - '.github/workflows/**'
       - 'pulsar-function-go/**'
-  push:
-    branches:
-      - branch-*
-    paths:
-      - '.github/workflows/**'
-      - 'pulsar-function-go/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/ci-go-functions-test.yaml
+++ b/.github/workflows/ci-go-functions-test.yaml
@@ -25,12 +25,6 @@ on:
     paths:
       - '.github/workflows/**'
       - 'pulsar-function-go/**'
-  push:
-    branches:
-      - branch-*
-    paths:
-      - '.github/workflows/**'
-      - 'pulsar-function-go/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/ci-integration-backwards-compatibility.yaml
+++ b/.github/workflows/ci-integration-backwards-compatibility.yaml
@@ -22,9 +22,6 @@ on:
   pull_request:
     branches:
       - branch-*
-  push:
-    branches:
-      - branch-*
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/ci-integration-cli.yaml
+++ b/.github/workflows/ci-integration-cli.yaml
@@ -22,9 +22,6 @@ on:
   pull_request:
     branches:
       - branch-*
-  push:
-    branches:
-      - branch-*
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/ci-integration-function.yaml
+++ b/.github/workflows/ci-integration-function.yaml
@@ -22,9 +22,6 @@ on:
   pull_request:
     branches:
       - branch-*
-  push:
-    branches:
-      - branch-*
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/ci-integration-messaging.yaml
+++ b/.github/workflows/ci-integration-messaging.yaml
@@ -22,9 +22,6 @@ on:
   pull_request:
     branches:
       - branch-*
-  push:
-    branches:
-      - branch-*
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/ci-integration-process.yaml
+++ b/.github/workflows/ci-integration-process.yaml
@@ -22,9 +22,6 @@ on:
   pull_request:
     branches:
       - branch-*
-  push:
-    branches:
-      - branch-*
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/ci-integration-pulsar-io-ora.yaml
+++ b/.github/workflows/ci-integration-pulsar-io-ora.yaml
@@ -22,9 +22,6 @@ on:
   pull_request:
     branches:
       - branch-*
-  push:
-    branches:
-      - branch-*
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/ci-integration-pulsar-io.yaml
+++ b/.github/workflows/ci-integration-pulsar-io.yaml
@@ -22,9 +22,6 @@ on:
   pull_request:
     branches:
       - branch-*
-  push:
-    branches:
-      - branch-*
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/ci-integration-schema.yaml
+++ b/.github/workflows/ci-integration-schema.yaml
@@ -22,9 +22,6 @@ on:
   pull_request:
     branches:
       - branch-*
-  push:
-    branches:
-      - branch-*
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/ci-integration-sql.yaml
+++ b/.github/workflows/ci-integration-sql.yaml
@@ -22,9 +22,6 @@ on:
   pull_request:
     branches:
       - branch-*
-  push:
-    branches:
-      - branch-*
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/ci-integration-standalone.yaml
+++ b/.github/workflows/ci-integration-standalone.yaml
@@ -22,9 +22,6 @@ on:
   pull_request:
     branches:
       - branch-*
-  push:
-    branches:
-      - branch-*
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/ci-integration-thread.yaml
+++ b/.github/workflows/ci-integration-thread.yaml
@@ -22,9 +22,6 @@ on:
   pull_request:
     branches:
       - branch-*
-  push:
-    branches:
-      - branch-*
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/ci-integration-tiered-filesystem.yaml
+++ b/.github/workflows/ci-integration-tiered-filesystem.yaml
@@ -22,9 +22,6 @@ on:
   pull_request:
     branches:
       - branch-*
-  push:
-    branches:
-      - branch-*
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/ci-integration-tiered-jcloud.yaml
+++ b/.github/workflows/ci-integration-tiered-jcloud.yaml
@@ -22,9 +22,6 @@ on:
   pull_request:
     branches:
       - branch-*
-  push:
-    branches:
-      - branch-*
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/ci-integration-transaction.yaml
+++ b/.github/workflows/ci-integration-transaction.yaml
@@ -22,9 +22,6 @@ on:
   pull_request:
     branches:
       - branch-*
-  push:
-    branches:
-      - branch-*
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/ci-license.yaml
+++ b/.github/workflows/ci-license.yaml
@@ -22,9 +22,6 @@ on:
   pull_request:
     branches:
       - branch-*
-  push:
-    branches:
-      - branch-*
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/ci-owasp-dep-check.yaml
+++ b/.github/workflows/ci-owasp-dep-check.yaml
@@ -22,9 +22,6 @@ on:
   pull_request:
     branches:
       - branch-*
-  push:
-    branches:
-      - branch-*
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/ci-python-build-3.9-client.yaml
+++ b/.github/workflows/ci-python-build-3.9-client.yaml
@@ -25,12 +25,7 @@ on:
     paths:
       - '.github/workflows/**'
       - 'pulsar-client-cpp/**'
-  push:
-    branches:
-      - branch-*
-    paths:
-      - '.github/workflows/**'
-      - 'pulsar-client-cpp/**'
+
 jobs:
 
   build-wheel:

--- a/.github/workflows/ci-shade-test.yaml
+++ b/.github/workflows/ci-shade-test.yaml
@@ -22,9 +22,6 @@ on:
   pull_request:
     branches:
       - branch-*
-  push:
-    branches:
-      - branch-*
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/ci-unit-broker-broker-gp.yaml
+++ b/.github/workflows/ci-unit-broker-broker-gp.yaml
@@ -22,9 +22,6 @@ on:
   pull_request:
     branches:
       - branch-*
-  push:
-    branches:
-      - branch-*
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/ci-unit-broker-client-api.yaml
+++ b/.github/workflows/ci-unit-broker-client-api.yaml
@@ -22,9 +22,6 @@ on:
   pull_request:
     branches:
       - branch-*
-  push:
-    branches:
-      - branch-*
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/ci-unit-broker-client-impl.yaml
+++ b/.github/workflows/ci-unit-broker-client-impl.yaml
@@ -22,9 +22,6 @@ on:
   pull_request:
     branches:
       - branch-*
-  push:
-    branches:
-      - branch-*
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/ci-unit-broker-jdk8.yaml
+++ b/.github/workflows/ci-unit-broker-jdk8.yaml
@@ -22,9 +22,6 @@ on:
   pull_request:
     branches:
       - branch-*
-  push:
-    branches:
-      - branch-*
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/ci-unit-broker-other.yaml
+++ b/.github/workflows/ci-unit-broker-other.yaml
@@ -22,9 +22,6 @@ on:
   pull_request:
     branches:
       - branch-*
-  push:
-    branches:
-      - branch-*
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/ci-unit-proxy.yaml
+++ b/.github/workflows/ci-unit-proxy.yaml
@@ -22,9 +22,6 @@ on:
   pull_request:
     branches:
       - branch-*
-  push:
-    branches:
-      - branch-*
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/ci-unit.yaml
+++ b/.github/workflows/ci-unit.yaml
@@ -22,9 +22,6 @@ on:
   pull_request:
     branches:
       - branch-*
-  push:
-    branches:
-      - branch-*
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
### Motivation

Related to https://github.com/apache/pulsar/issues/17567. Same of https://github.com/apache/pulsar/pull/17569 but older release branches. Fixes 

### Modifications

* Removed the post-commit trigger. In order to verify the branch, you will have to open an empty pull

- [x] `doc-not-needed` 
