### PR TITLE
[cleanup][broker] Use set instead of list to improve `contains` and `containsAll` performance.

### DIFF
--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -18,7 +18,6 @@
  */
 package org.apache.pulsar.broker;
 
-import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -2337,7 +2336,7 @@ public class ServiceConfiguration implements PulsarConfiguration {
         category = CATEGORY_LOAD_BALANCER,
         doc = "Supported algorithms name for namespace bundle split"
     )
-    private List<String> supportedNamespaceBundleSplitAlgorithms = Lists.newArrayList("range_equally_divide",
+    private Set<String> supportedNamespaceBundleSplitAlgorithms = Sets.newHashSet("range_equally_divide",
             "topic_count_equally_divide", "specified_positions_divide", "flow_or_qps_equally_divide");
     @FieldContext(
         dynamic = true,

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/NamespacesBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/NamespacesBase.java
@@ -1127,7 +1127,7 @@ public abstract class NamespacesBase extends AdminResource {
                 .thenAccept(__ -> {
                     checkNotNull(bundleName, "BundleRange should not be null");
                     log.info("[{}] Split namespace bundle {}/{}", clientAppId(), namespaceName, bundleName);
-                    List<String> supportedNamespaceBundleSplitAlgorithms =
+                    Set<String> supportedNamespaceBundleSplitAlgorithms =
                             pulsar().getConfig().getSupportedNamespaceBundleSplitAlgorithms();
                     if (StringUtils.isNotBlank(splitAlgorithmName)) {
                         if (!supportedNamespaceBundleSplitAlgorithms.contains(splitAlgorithmName)) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/common/naming/NamespaceBundleSplitAlgorithm.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/common/naming/NamespaceBundleSplitAlgorithm.java
@@ -18,8 +18,9 @@
  */
 package org.apache.pulsar.common.naming;
 
-import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 
 /**
@@ -32,7 +33,7 @@ public interface NamespaceBundleSplitAlgorithm {
     String SPECIFIED_POSITIONS_DIVIDE = "specified_positions_divide";
     String FLOW_OR_QPS_EQUALLY_DIVIDE = "flow_or_qps_equally_divide";
 
-    List<String> AVAILABLE_ALGORITHMS = Lists.newArrayList(RANGE_EQUALLY_DIVIDE_NAME,
+    Set<String> AVAILABLE_ALGORITHMS = Sets.newHashSet(RANGE_EQUALLY_DIVIDE_NAME,
             TOPIC_COUNT_EQUALLY_DIVIDE, SPECIFIED_POSITIONS_DIVIDE, FLOW_OR_QPS_EQUALLY_DIVIDE);
 
     NamespaceBundleSplitAlgorithm RANGE_EQUALLY_DIVIDE_ALGO = new RangeEquallyDivideBundleSplitAlgorithm();


### PR DESCRIPTION
### Motivation
Now, `AVAILABLE_ALGORITHMS` and `supportedNamespaceBundleSplitAlgorithms` use list to create, we can use set to improve `contains` and `containsAll` performance, such as:

https://github.com/apache/pulsar/blob/05a2ea87371783000f496ce8103c0ac372e4a8fe/pulsar-broker/src/main/java/org/apache/pulsar/PulsarBrokerStarter.java#L177-L188

https://github.com/apache/pulsar/blob/ebe7220dd11e234b6108935e2b6b89f4a5cc51b8/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/NamespacesBase.java#L1122-L1137

### Modifications

Use set instead of list.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)

- [x] `doc-not-needed` 
(Please explain why)

- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)
