### PR TITLE
[feat][pulsar-client-api] support to Cumulative Acknowledge for multiple partitions or topics in user friendly manner

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/ConsumerCumulativeAckMapTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/ConsumerCumulativeAckMapTest.java
@@ -1,0 +1,124 @@
+package org.apache.pulsar.client.api;
+
+import lombok.Cleanup;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.util.*;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+
+@Test(groups = "broker-api")
+public class ConsumerCumulativeAckMapTest extends ProducerConsumerBase{
+
+    @BeforeClass
+    @Override
+    protected void setup() throws Exception {
+        super.internalSetup();
+        super.producerBaseSetup();
+    }
+
+    @AfterClass(alwaysRun = true)
+    @Override
+    protected void cleanup() throws Exception {
+        super.internalCleanup();
+    }
+
+    @DataProvider(name = "ackReceiptEnabled")
+    public Object[][] ackReceiptEnabled() {
+        return new Object[][] { { true }, { false } };
+    }
+
+    @Test(timeOut = 30000, dataProvider = "ackReceiptEnabled")
+    public void testCumulativeAckMessageForPartitions(boolean ackReceiptEnabled) throws Exception {
+        cumulativeAckMessagesForPartitions(true,true, ackReceiptEnabled);
+        cumulativeAckMessagesForPartitions(true,false, ackReceiptEnabled);
+        cumulativeAckMessagesForPartitions(false,false, ackReceiptEnabled);
+        cumulativeAckMessagesForPartitions(false,true, ackReceiptEnabled);
+    }
+
+    private void cumulativeAckMessagesForPartitions(boolean isBatch, boolean isPartitioned, boolean ackReceiptEnabled) throws Exception {
+        final String topic = "persistent://my-property/my-ns/batch-ack-" + UUID.randomUUID();
+        final String subName = "testBatchAck-sub" + UUID.randomUUID();
+        final int messageNum = ThreadLocalRandom.current().nextInt(1, 50);
+        if (isPartitioned) {
+            admin.topics().createPartitionedTopic(topic, 3);
+        }
+
+        @Cleanup
+        Producer<String> producer = pulsarClient.newProducer(Schema.STRING)
+                .enableBatching(isBatch)
+                .batchingMaxPublishDelay(50, TimeUnit.MILLISECONDS)
+                .topic(topic).create();
+
+        @Cleanup
+        Consumer<String> consumer = pulsarClient.newConsumer(Schema.STRING)
+                .subscriptionType(SubscriptionType.Exclusive)
+                .topic(topic)
+                .negativeAckRedeliveryDelay(1001, TimeUnit.MILLISECONDS)
+                .subscriptionName(subName)
+                .enableBatchIndexAcknowledgment(ackReceiptEnabled)
+                .isAckReceiptEnabled(ackReceiptEnabled)
+                .subscribe();
+
+        sendMessagesAsyncAndWait(producer, messageNum);
+        Map<String, MessageId> partitionLatestMessageMap = new HashMap<>();
+        for (int i = 0; i < messageNum; i++) {
+            Message message = consumer.receive();
+            partitionLatestMessageMap.put(message.getTopicName(), message.getMessageId());
+        }
+        consumer.acknowledgeCumulative(partitionLatestMessageMap);
+        //Wait ack send.
+        Thread.sleep(1000);
+        consumer.redeliverUnacknowledgedMessages();
+        Message<String> msg = consumer.receive(2, TimeUnit.SECONDS);
+        Assert.assertNull(msg);
+    }
+
+    @Test(timeOut = 30000)
+    public void testInputNegativeCase() throws Exception {
+        final String topic = "persistent://my-property/my-ns/batch-ack-" + UUID.randomUUID();
+        final String subName = "testBatchAck-sub" + UUID.randomUUID();
+        @Cleanup
+        Consumer<String> consumer = pulsarClient.newConsumer(Schema.STRING)
+                .subscriptionType(SubscriptionType.Exclusive)
+                .topic(topic)
+                .negativeAckRedeliveryDelay(1001, TimeUnit.MILLISECONDS)
+                .subscriptionName(subName)
+                .subscribe();
+        Map<String, MessageId> partitionLatestMessageMap = null;
+        try {
+            consumer.acknowledgeCumulative(partitionLatestMessageMap);
+            Assert.fail("map cannot be null");
+        } catch (PulsarClientException e) {
+            // Expected
+        }
+
+        partitionLatestMessageMap = new HashMap<>();
+        partitionLatestMessageMap.put(topic, null);
+        try {
+            consumer.acknowledgeCumulative(partitionLatestMessageMap);
+            Assert.fail("messageId cannot be null");
+        } catch (PulsarClientException e) {
+            // Expected
+        }
+    }
+
+    private void sendMessagesAsyncAndWait(Producer<String> producer, int messages) throws Exception {
+        CountDownLatch latch = new CountDownLatch(messages);
+        for (int i = 0; i < messages; i++) {
+            String message = "my-message-" + i;
+            producer.sendAsync(message).thenAccept(messageId -> {
+                if (messageId != null) {
+                    latch.countDown();
+                }
+            });
+        }
+        latch.await();
+    }
+
+}

--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/Consumer.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/Consumer.java
@@ -391,6 +391,21 @@ public interface Consumer<T> extends Closeable {
     void acknowledgeCumulative(MessageId messageId) throws PulsarClientException;
 
     /**
+     * Acknowledge the reception of all the messages in the stream up to (and including) the provided message for each topic or partition.
+     *
+     * <p>This method will block until the acknowledge has been sent to the brokers of each topic or partition.
+     * After that, the messages will not be re-delivered to this consumer.
+     *
+     * <p>Cumulative acknowledge cannot be used when the consumer type is set to ConsumerShared.
+     *
+     * @param topicToMessageIdMap
+     *            The {@code topicToMessageIdMap} the topic to messageId Map to be cumulatively acknowledged
+     * @throws PulsarClientException.AlreadyClosedException
+     *             if the consumer was already closed
+     */
+    void acknowledgeCumulative(Map<String, MessageId> topicToMessageIdMap) throws  PulsarClientException;
+
+    /**
      * Acknowledge the reception of all the messages in the stream up to (and including) the provided message with this
      * transaction, it will store in transaction pending ack.
      *


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://docs.google.com/document/d/1d8Pw6ZbWk-_pCKdOmdvx9rnhPiyuxwq60_TrD68d7BA/edit#heading=h.trs9rsex3xom)*. 

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->

<!-- Either this PR fixes an issue, -->

Fixes #17574 

<!-- or this PR is one task of an issue -->

Master Issue: #17574 

### Motivation
Email from Yunze Xu

Assuming users called "acknowledgeCumulative" periodically, there is a chance that some messages of the specific partition has never been passed to the method.
For example, a consumer received: P0-M0, P1-M0, P0-M1, P1-M1, P0-M2, P1-M2...
And the user acknowledged every two messages, i.e. P0-M0, P0-M1, P0-M2. Eventually, partition 1 has never been acknowledged. User must maintain its own `Map<String, MessageId&gt> cache for a partitioned topic or multi-topics consumer with the existing "acknowledgeCumulative" API.

Should we make it more friendly for users? For example, we can make "acknowledgeCumulative" accept the map to remind users to maintain the map from topic name to message ID:
java

 // the key is the partitioned topic name like my-topic-partition-0
 void acknowledgeCumulative(Map<String, MessageId> topicToMessageId);

### Modifications
add support for acknowledgeCumulative(Map<String, MessageId> topicToMessageId)

### Verifying this change
This change added tests and can be verified as follows::
org/apache/pulsar/client/api/ConsumerCumulativeAckMapTest.java

### Documentation

- [ ] `doc-not-needed` 
