### PR TITLE
[fix][CI] Don't run "Pulsar CI checks completed" too early and fix disk space issue in saving docker image 

### DIFF
--- a/.github/workflows/pulsar-ci.yaml
+++ b/.github/workflows/pulsar-ci.yaml
@@ -555,6 +555,15 @@ jobs:
           -Pmain,docker -Dmaven.test.skip=true -Ddocker.squash=true \
           -Dspotbugs.skip=true -Dlicense.skip=true -Dcheckstyle.skip=true -Drat.skip=true
 
+      - name: Clean up disk space
+        run: |
+          # release disk space since saving docker image consumes local disk space
+          #
+          # clean build directories
+          git clean -fdx
+          # delete maven repository
+          rm -rf ~/.m2/repository
+
       - name: save docker image apachepulsar/pulsar-test-latest-version:latest to Github artifact cache
         run: |
           $GITHUB_WORKSPACE/build/pulsar_ci_tool.sh docker_save_image_to_github_actions_artifacts apachepulsar/pulsar-test-latest-version:latest pulsar-test-latest-version-image

--- a/.github/workflows/pulsar-ci.yaml
+++ b/.github/workflows/pulsar-ci.yaml
@@ -562,13 +562,20 @@ jobs:
           echo "::group::Available diskspace before cleaning"
           time df -BM / /mnt
           echo "::endgroup::"          
-          echo "::group::Delete files"
+          echo "::group::Clean build directory"
+          # docker build changes some files to root ownership, fix this before deleting files
+          sudo chown -R $USER:$GROUP .
           # clean build directories
-          git clean -fdx
-          # delete maven repository
-          rm -rf ~/.m2/repository
+          time git clean -fdx
           echo "::endgroup::"          
-          echo "::group::Available diskspace after cleaning"
+          echo "::group::Available diskspace after cleaning build directory"
+          time df -BM / /mnt
+          echo "::endgroup::"
+          echo "::group::Delete maven repository"
+          # delete maven repository
+          time rm -rf ~/.m2/repository
+          echo "::endgroup::"          
+          echo "::group::Available diskspace after cleaning maven repository"
           time df -BM / /mnt
           echo "::endgroup::"          
 

--- a/.github/workflows/pulsar-ci.yaml
+++ b/.github/workflows/pulsar-ci.yaml
@@ -844,7 +844,6 @@ jobs:
       'system-tests',
       'macos-build'
     ]
-    if: always()
     steps:
       - name: checkout
         if: ${{ needs.changed_files_job.outputs.docs_only != 'true' }}

--- a/.github/workflows/pulsar-ci.yaml
+++ b/.github/workflows/pulsar-ci.yaml
@@ -559,10 +559,18 @@ jobs:
         run: |
           # release disk space since saving docker image consumes local disk space
           #
+          echo "::group::Available diskspace before cleaning"
+          time df -BM / /mnt
+          echo "::endgroup::"          
+          echo "::group::Delete files"
           # clean build directories
           git clean -fdx
           # delete maven repository
           rm -rf ~/.m2/repository
+          echo "::endgroup::"          
+          echo "::group::Available diskspace after cleaning"
+          time df -BM / /mnt
+          echo "::endgroup::"          
 
       - name: save docker image apachepulsar/pulsar-test-latest-version:latest to Github artifact cache
         run: |


### PR DESCRIPTION
Fixes #17583 

### Motivation

Pulsar CI is broken since "Pulsar CI checks completed" runs too early.
There's another problem that disk space runs out in "Build Pulsar docker image" with error message 
```
Error response from daemon: write /var/lib/docker/tmp/docker-export-3539721826/b4b6ffd2e938fa5512aa646b2c22044e3e0b14e74d3dc8374a9b3723a7235c53/layer.tar: no space left on device
```

### Modifications

- remove "if: always()" since it caused the job to run also when something failed
- release disk space in "Build Pulsar docker image" build job before exporting the docker image 

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)

- [x] `doc-not-needed` 
(Please explain why)

- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)
