### PR TITLE
[fix][doc] Remove redundant steps in doc generation

### DIFF
--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdGenerateDocument.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdGenerateDocument.java
@@ -100,13 +100,9 @@ public class CmdGenerateDocument extends CmdBase {
         }
 
         private void generateDocument(StringBuilder sb, String module, JCommander obj) {
-            sb.append("------------\n\n");
             sb.append("# ").append(module).append("\n\n");
-            sb.append("### Usage\n\n");
-            sb.append("`$").append(module).append("`\n\n");
-            sb.append("------------\n\n");
             sb.append(usageFormatter.getCommandDescription(module)).append("\n");
-            sb.append("\n\n```bdocs-tab:example_shell\n")
+            sb.append("\n\n```shell\n")
                     .append("$ pulsar-admin ").append(module).append(" subcommand")
                     .append("\n```");
             sb.append("\n\n");
@@ -117,10 +113,8 @@ public class CmdGenerateDocument extends CmdBase {
             cmdObj.jcommander.getCommands().forEach((subK, subV) -> {
                 sb.append("\n\n## <em>").append(subK).append("</em>\n\n");
                 sb.append(cmdObj.getUsageFormatter().getCommandDescription(subK)).append("\n\n");
-                sb.append("### Usage\n\n");
-                sb.append("------------\n\n");
                 sb.append("**Command:**\n\n");
-                sb.append("```bdocs-tab:example_shell\n$ pulsar-admin ").append(module).append(" ")
+                sb.append("```shell\n$ pulsar-admin ").append(module).append(" ")
                         .append(subK).append(" options").append("\n```\n\n");
                 List<ParameterDescription> options = cmdObj.jcommander.getCommands().get(subK).getParameters();
                 if (options.size() > 0) {

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/client/cli/CmdGenerateDocumentation.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/client/cli/CmdGenerateDocumentation.java
@@ -62,13 +62,9 @@ public class CmdGenerateDocumentation {
     protected String generateDocument(String module, JCommander parentCmd) {
         StringBuilder sb = new StringBuilder();
         JCommander cmd = parentCmd.getCommands().get(module);
-        sb.append("------------\n\n");
-        sb.append("# ").append(module).append("\n\n");
-        sb.append("### Usage\n\n");
-        sb.append("`$").append(module).append("`\n\n");
-        sb.append("------------\n\n");
+        sb.append("## ").append(module).append("\n\n");
         sb.append(parentCmd.getUsageFormatter().getCommandDescription(module)).append("\n");
-        sb.append("\n\n```bdocs-tab:example_shell\n")
+        sb.append("\n\n```shell\n")
                 .append("$ pulsar-client ").append(module).append(" [options]")
                 .append("\n```");
         sb.append("\n\n");

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/util/CmdGenerateDocs.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/util/CmdGenerateDocs.java
@@ -101,16 +101,12 @@ public class CmdGenerateDocs {
     private String generateDocument(String module, JCommander commander) {
         JCommander cmd = commander.getCommands().get(module);
         StringBuilder sb = new StringBuilder();
-        sb.append("------------\n\n");
         sb.append("# ").append(module).append("\n\n");
-        sb.append("### Usage\n\n");
-        sb.append("`$").append(module).append("`\n\n");
-        sb.append("------------\n\n");
         String desc = commander.getUsageFormatter().getCommandDescription(module);
         if (null != desc && !desc.isEmpty()) {
             sb.append(desc).append("\n");
         }
-        sb.append("\n\n```bdocs-tab:example_shell\n")
+        sb.append("\n\n```shell\n")
                 .append("$ ");
         if (null != jcommander.getProgramName() && !jcommander.getProgramName().isEmpty()) {
             sb.append(jcommander.getProgramName()).append(" ");
@@ -133,16 +129,13 @@ public class CmdGenerateDocs {
                     if (null != subDesc && !subDesc.isEmpty()) {
                         sb.append(subDesc).append("\n");
                     }
-                    sb.append("### Usage\n\n");
-                    sb.append("------------\n\n\n");
-                    sb.append("```bdocs-tab:example_shell\n$ ");
+                    sb.append("```shell\n$ ");
                     if (null != jcommander.getProgramName() && !jcommander.getProgramName().isEmpty()) {
                         sb.append(jcommander.getProgramName()).append(" ");
                     }
                     sb.append(module).append(" ").append(subK).append(" options").append("\n```\n\n");
                     List<ParameterDescription> options = cmdObj.getCommands().get(subK).getParameters();
                     if (options.size() > 0) {
-                        sb.append("Options\n\n\n");
                         sb.append("|Flag|Description|Default|\n");
                         sb.append("|---|---|---|\n");
                     }

--- a/pulsar-common/src/test/java/org/apache/pulsar/common/util/CmdGenerateDocsTest.java
+++ b/pulsar-common/src/test/java/org/apache/pulsar/common/util/CmdGenerateDocsTest.java
@@ -77,8 +77,7 @@ public class CmdGenerateDocsTest {
             cmd.run(null);
 
             String message = baoStream.toString();
-            String rightMsg = 
-                    + "# test\n"
+            String rightMsg = "# test\n"
                     + "\n"
                     + "```shell\n"
                     + "$ pulsar test options\n"

--- a/pulsar-common/src/test/java/org/apache/pulsar/common/util/CmdGenerateDocsTest.java
+++ b/pulsar-common/src/test/java/org/apache/pulsar/common/util/CmdGenerateDocsTest.java
@@ -77,20 +77,10 @@ public class CmdGenerateDocsTest {
             cmd.run(null);
 
             String message = baoStream.toString();
-            String rightMsg = "------------\n"
-                    + "\n"
+            String rightMsg = 
                     + "# test\n"
                     + "\n"
-                    + "### Usage\n"
-                    + "\n"
-                    + "`$test`\n"
-                    + "\n"
-                    + "------------\n"
-                    + "\n"
-                    + "Options\n"
-                    + "\n"
-                    + "\n"
-                    + "```bdocs-tab:example_shell\n"
+                    + "```shell\n"
                     + "$ pulsar test options\n"
                     + "```\n"
                     + "\n"

--- a/pulsar-common/src/test/java/org/apache/pulsar/common/util/CmdGenerateDocsTest.java
+++ b/pulsar-common/src/test/java/org/apache/pulsar/common/util/CmdGenerateDocsTest.java
@@ -77,8 +77,7 @@ public class CmdGenerateDocsTest {
             cmd.run(null);
 
             String message = baoStream.toString();
-            String rightMsg = "# test\n"
-                    + "\n"
+            String rightMsg = "# test\n\n"
                     + "```shell\n"
                     + "$ pulsar test options\n"
                     + "```\n"

--- a/pulsar-common/src/test/java/org/apache/pulsar/common/util/CmdGenerateDocsTest.java
+++ b/pulsar-common/src/test/java/org/apache/pulsar/common/util/CmdGenerateDocsTest.java
@@ -78,6 +78,8 @@ public class CmdGenerateDocsTest {
 
             String message = baoStream.toString();
             String rightMsg = "# test\n\n"
+                    + "Options\n\n"
+                    + "\n"
                     + "```shell\n"
                     + "$ pulsar test options\n"
                     + "```\n"

--- a/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/CmdGenerateDocumentation.java
+++ b/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/CmdGenerateDocumentation.java
@@ -97,13 +97,9 @@ public class CmdGenerateDocumentation {
     private static String generateDocument(String module, JCommander parentCmd) {
         StringBuilder sb = new StringBuilder();
         JCommander cmd = parentCmd.getCommands().get(module);
-        sb.append("------------\n\n");
-        sb.append("# ").append(module).append("\n\n");
-        sb.append("### Usage\n\n");
-        sb.append("`$").append(module).append("`\n\n");
-        sb.append("------------\n\n");
+        sb.append("## ").append(module).append("\n\n");
         sb.append(parentCmd.getUsageFormatter().getCommandDescription(module)).append("\n");
-        sb.append("\n\n```bdocs-tab:example_shell\n")
+        sb.append("\n\n```shell\n")
                 .append("$ pulsar-perf ").append(module).append(" [options]")
                 .append("\n```");
         sb.append("\n\n");

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/cli/CLITest.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/cli/CLITest.java
@@ -590,7 +590,7 @@ public class CLITest extends PulsarTestSuite {
             ContainerExecResult result = container.execCmd(
                     PulsarCluster.ADMIN_SCRIPT,
                     "documents", "generate", moduleNames[i]);
-            Assert.assertTrue(result.getStdout().contains("------------\n\n# " + moduleNames[i]));
+            Assert.assertTrue(result.getStdout().contains("# " + moduleNames[i]));
         }
     }
 


### PR DESCRIPTION
### Matching PR in forked repository

SignorMercurio#3

### Motivation

Docs for Pulsar CLI tools such as `pulsar-admin`, `pulsar-client`, `pulsar` and `pulsar-perf` are auto-generated but contains redundant steps that will produce complex but not useful TOCs(table of content). This PR aims to remove these steps.

### Modifications

Remove all `---`, `Usage` and `bdocs-tab:example_shell` parts since they are no longer useful.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)

- [ ] `doc-not-needed` 
(Please explain why)

- [x] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)
