### PR TITLE
[fix][CI] Follow-up fix for don't run "Pulsar CI checks completed" too early

### DIFF
--- a/.github/workflows/pulsar-ci.yaml
+++ b/.github/workflows/pulsar-ci.yaml
@@ -859,6 +859,7 @@ jobs:
   # It cleans up the binaries in the same job in order to not spin up another runner for basically doing nothing.
   pulsar-ci-checks-completed:
     name: "Pulsar CI checks completed"
+    if: always()
     runs-on: ubuntu-20.04
     timeout-minutes: 10
     needs: [
@@ -866,9 +867,23 @@ jobs:
       'unit-tests',
       'integration-tests',
       'system-tests',
+      'flaky-system-tests',
       'macos-build'
     ]
     steps:
+      - name: Check that all required jobs were completed successfully
+        if: ${{ needs.changed_files_job.outputs.docs_only != 'true' }}
+        run: |
+          if [[ ! ( \
+                "${{ needs.unit-tests.result }}" == "success" \
+                && "${{ needs.integration-tests.result }}" == "success" \
+                && "${{ needs.system-tests.result }}" == "success" \
+                && "${{ needs.macos-build.result }}" == "success" \
+             ) ]]; then
+            echo "Required jobs haven't been completed successfully."
+            exit 1            
+          fi
+
       - name: checkout
         if: ${{ needs.changed_files_job.outputs.docs_only != 'true' }}
         uses: actions/checkout@v2


### PR DESCRIPTION
### Motivation

- The "Pulsar CI checks completed" gets run too early also with #17584 changes

- another solution is needed to make it work as expected

### Modifications

- use `if: always()` and a solution where each required build is checked explicitly in a bash script. If the requirements aren't fulfilled, the script will fail with error code 1.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)

- [x] `doc-not-needed` 
(Please explain why)

- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)
