### PR TITLE
[improve][misc] CI status on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,7 @@
 
 ![logo](site2/website/static/img/pulsar.svg)
 
-[![unit test](https://img.shields.io/github/workflow/status/apache/pulsar/CI%20-%20Unit?label=unit%20test)](https://github.com/apache/pulsar/actions/workflows/ci-unit.yaml)
-[![docker build](https://img.shields.io/github/workflow/status/apache/pulsar/CI%20-%20Docker%20Build?label=docker%20build)](https://hub.docker.com/r/apachepulsar/pulsar)
+[![docker pull](https://img.shields.io/docker/pulls/apachepulsar/pulsar-all.svg)](https://hub.docker.com/r/apachepulsar/pulsar)
 [![contributors](https://img.shields.io/github/contributors-anon/apache/pulsar)](https://github.com/apache/pulsar/graphs/contributors)
 [![last commit](https://img.shields.io/github/last-commit/apache/pulsar)](https://github.com/apache/pulsar/commits/master)
 [![release](https://img.shields.io/github/v/release/apache/pulsar)](https://github.com/apache/pulsar/releases)


### PR DESCRIPTION
## Motivation & Modification

1. We don't run Pulsar CI for the master branch, so although we can add a badge for it [![ci](https://github.com/apache/pulsar/actions/workflows/pulsar-ci.yaml/badge.svg)](https://github.com/apache/pulsar/actions/workflows/pulsar-ci.yaml), it's inaccurate.
2. Docker build workflow name has been changed. Also, the workflow doesn't reflect a useful status. Replace it with docker pull statistics.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)

- [ ] `doc-not-needed` 
(Please explain why)

- [x] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)

cc @lhotari @Anonymitaet 