### PR TITLE
Issue 17588: Allow deletion of a namespace that was left in deleted status

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/NamespaceService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/NamespaceService.java
@@ -1238,7 +1238,7 @@ public class NamespaceService implements AutoCloseable {
 
     public CompletableFuture<List<String>> getListOfNonPersistentTopics(NamespaceName namespaceName) {
 
-        return PulsarWebResource.checkLocalOrGetPeerReplicationCluster(pulsar, namespaceName)
+        return PulsarWebResource.checkLocalOrGetPeerReplicationCluster(pulsar, namespaceName, true)
                 .thenCompose(peerClusterData -> {
                     // if peer-cluster-data is present it means namespace is owned by that peer-cluster and request
                     // should redirect to the peer-cluster

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/PulsarWebResource.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/PulsarWebResource.java
@@ -859,8 +859,8 @@ public abstract class PulsarWebResource {
         return checkLocalOrGetPeerReplicationCluster(pulsarService, namespace, false);
     }
     public static CompletableFuture<ClusterDataImpl> checkLocalOrGetPeerReplicationCluster(PulsarService pulsarService,
-                                                                                           NamespaceName namespace,
-                                                                                           boolean allowDeletedNamespace) {
+                                                                                     NamespaceName namespace,
+                                                                                     boolean allowDeletedNamespace) {
         if (!namespace.isGlobal() || NamespaceService.isHeartbeatNamespace(namespace)) {
             return CompletableFuture.completedFuture(null);
         }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/PulsarWebResource.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/PulsarWebResource.java
@@ -856,6 +856,11 @@ public abstract class PulsarWebResource {
 
     public static CompletableFuture<ClusterDataImpl> checkLocalOrGetPeerReplicationCluster(PulsarService pulsarService,
                                                                                            NamespaceName namespace) {
+        return checkLocalOrGetPeerReplicationCluster(pulsarService, namespace, false);
+    }
+    public static CompletableFuture<ClusterDataImpl> checkLocalOrGetPeerReplicationCluster(PulsarService pulsarService,
+                                                                                           NamespaceName namespace,
+                                                                                           boolean allowDeletedNamespace) {
         if (!namespace.isGlobal() || NamespaceService.isHeartbeatNamespace(namespace)) {
             return CompletableFuture.completedFuture(null);
         }
@@ -867,7 +872,7 @@ public abstract class PulsarWebResource {
                 .getPoliciesAsync(namespace).thenAccept(policiesResult -> {
             if (policiesResult.isPresent()) {
                 Policies policies = policiesResult.get();
-                if (policies.deleted) {
+                if (!allowDeletedNamespace && policies.deleted) {
                     String msg = String.format("Namespace %s is deleted", namespace.toString());
                     log.warn(msg);
                     validationFuture.completeExceptionally(new RestException(Status.PRECONDITION_FAILED,

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/NamespacesTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/NamespacesTest.java
@@ -1200,6 +1200,18 @@ public class NamespacesTest extends MockedPulsarServiceBaseTest {
         topicList = admin.topics().getList(namespace);
         assertTrue(topicList.isEmpty());
 
+        // simulate a partially deleted namespace, we should be able to recover
+        pulsar.getPulsarResources().getNamespaceResources()
+                .setPolicies(NamespaceName.get(namespace), old -> {
+            old.deleted = true;
+            return old;
+        });
+        admin.namespaces().deleteNamespace(namespace, true);
+
+        admin.namespaces().createNamespace(namespace, 100);
+        topicList = admin.topics().getList(namespace);
+        assertTrue(topicList.isEmpty());
+
         // reset back to false
         pulsar.getConfiguration().setForceDeleteNamespaceAllowed(false);
     }


### PR DESCRIPTION
Fixes #17588

### Motivation

In Pulsar 2.10.1 with #14730 we introduced a check about concurrent deletion of Namespaces.
This broke the deletion of namespaces in case of a partial failure.

When you delete a namespace we collect all the resources, then we mark the namespace as "deleted", then we do the deletion.
if some failure happens and the procedure does not complete, then the namespaces stays in "deleted" status.
And if you try to delete it again you see the error in #17588 "The namespace is deleted", because getListOfNonPersistentTopics() performs a check about the status of the namespace.  

### Modifications

Do not check the flag "Policies.deleted" while listing non-persistent topics.è


### Verifying this change

I added a test case that fails without this fix

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)

- [x] `doc-not-needed` 
It is a bug fix for a regression

- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)
