### PR TITLE
[fix][misc] Fix invalid comment ending delimiter in flaky test issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/flaky-test.yml
+++ b/.github/ISSUE_TEMPLATE/flaky-test.yml
@@ -47,7 +47,7 @@ body:
       description: |
         A few lines of the stack trace that shows at least the exception message and the line of test code where the stacktrace occurred.
       value: |
-        <!-- optionally provide the full stacktrace ->
+        <!-- optionally provide the full stacktrace -->
 
         <details>
         <summary>Full exception stacktrace</summary>


### PR DESCRIPTION
### Motivation

The ending delimiter for a comment in the flaky test issue template is invalid.

### Modifications

Fix the invalid delimiter: replace `->` with `-->`

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)

- [x] `doc-not-needed` 
(Please explain why)

- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)
