### PR TITLE
[fix][functions] Fix K8S download function method with auth enabled

### DIFF
--- a/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/kubernetes/KubernetesRuntime.java
+++ b/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/kubernetes/KubernetesRuntime.java
@@ -875,17 +875,7 @@ public class KubernetesRuntime implements Runtime {
         ArrayList<String> cmd = new ArrayList<>(Arrays.asList(
                 pulsarRootDir + configAdminCLI,
                 "--admin-url",
-                pulsarAdminUrl,
-                "functions",
-                "download",
-                "--tenant",
-                tenant,
-                "--namespace",
-                namespace,
-                "--name",
-                name,
-                "--destination-file",
-                userCodeFilePath));
+                pulsarAdminUrl));
 
         // add auth plugin and parameters if necessary
         if (authenticationEnabled && authConfig != null) {
@@ -899,6 +889,18 @@ public class KubernetesRuntime implements Runtime {
                         authConfig.getClientAuthenticationParameters()));
             }
         }
+
+        cmd.addAll(Arrays.asList(
+                "functions",
+                "download",
+                "--tenant",
+                tenant,
+                "--namespace",
+                namespace,
+                "--name",
+                name,
+                "--destination-file",
+                userCodeFilePath));
 
         if (transformFunction) {
             cmd.add("--transform-function");


### PR DESCRIPTION
### Motivation

After https://github.com/apache/pulsar/commit/dab0d1f389ee66277c8350072af304895619eb9a#diff-534a0ee16ee831fd0f16fa1230ff3a6e24f6428abd378790f821867f2ec1ffb0R891 ,  functions deployed with `KubernetesRuntimeFactory` doesn't work if the authentication is enabled between components.

```
Was passed main parameter '--auth-plugin' but no main parameter was defined in your arg class
Download File Data from Pulsar
Usage: download [options]
  Options:
    --destination-file
      The file to store downloaded content
    --fqfn
      The Fully Qualified Function Name (FQFN) for the function
    --name
      The name of a Pulsar Function
    --namespace
      The namespace of a Pulsar Function
    --tenant
      The tenant of a Pulsar Function
    --transform-function
      Download the transform Function of the connector
      Default: false
```
Note that this regression is only on current master branch.

### Modifications

* Set the auth options as `pulsar-admin` CLI commands instead of `functions download` options
* Added a test

- [x] `doc-not-needed` 
