### PR TITLE
[fix][broker] Fix SystemTopicBasedTopicPoliciesService NPE issue

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/SystemTopicBasedTopicPoliciesService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/SystemTopicBasedTopicPoliciesService.java
@@ -246,7 +246,6 @@ public class SystemTopicBasedTopicPoliciesService implements TopicPoliciesServic
                 ownedBundlesCountPerNamespace.get(namespace).incrementAndGet();
                 result.complete(null);
             } else {
-                ownedBundlesCountPerNamespace.putIfAbsent(namespace, new AtomicInteger(1));
                 prepareInitPoliciesCache(namespace, result);
             }
         }
@@ -258,6 +257,7 @@ public class SystemTopicBasedTopicPoliciesService implements TopicPoliciesServic
             CompletableFuture<SystemTopicClient.Reader<PulsarEvent>> readerCompletableFuture =
                     createSystemTopicClientWithRetry(namespace);
             readerCaches.put(namespace, readerCompletableFuture);
+            ownedBundlesCountPerNamespace.putIfAbsent(namespace, new AtomicInteger(1));
             readerCompletableFuture.thenAccept(reader -> {
                 initPolicesCache(reader, result);
                 result.thenRun(() -> readMorePolicies(reader));


### PR DESCRIPTION
### Motivation
When SystemTopicBasedTopicPoliciesService#getTopicPolicies is invoked before SystemTopicBasedTopicPoliciesService#addOwnedNamespaceBundleAsync, it will cause NPE:
#### Stack trace
```
java.lang.NullPointerException: null
	at org.apache.pulsar.broker.service.SystemTopicBasedTopicPoliciesService.addOwnedNamespaceBundleAsync(SystemTopicBasedTopicPoliciesService.java:222) ~[classes/:?]
	at org.apache.pulsar.broker.service.SystemTopicBasedTopicPoliciesService$1.onLoad(SystemTopicBasedTopicPoliciesService.java:301) ~[classes/:?]
	at org.apache.pulsar.broker.namespace.NamespaceService.notifyNamespaceBundleOwnershipListener(NamespaceService.java:1052) ~[classes/:?]
	at org.apache.pulsar.broker.namespace.NamespaceService.onNamespaceBundleOwned(NamespaceService.java:1020) ~[classes/:?]
	at org.apache.pulsar.broker.namespace.OwnershipCache.lambda$tryAcquiringOwnership$1(OwnershipCache.java:200) ~[classes/:?]
	at java.util.concurrent.CompletableFuture$UniApply.tryFire(CompletableFuture.java:642) ~[?:?]
	at java.util.concurrent.CompletableFuture.postComplete(CompletableFuture.java:506) ~[?:?]
	at java.util.concurrent.CompletableFuture.complete(CompletableFuture.java:2073) ~[?:?]
	at org.apache.pulsar.metadata.coordination.impl.LockManagerImpl.lambda$acquireLock$1(LockManagerImpl.java:105) ~[classes/:?]
	at java.util.concurrent.CompletableFuture$UniRun.tryFire$$$capture(CompletableFuture.java:783) ~[?:?]
	at java.util.concurrent.CompletableFuture$UniRun.tryFire(CompletableFuture.java) ~[?:?]
	at java.util.concurrent.CompletableFuture.postComplete(CompletableFuture.java:506) ~[?:?]
	at java.util.concurrent.CompletableFuture.complete(CompletableFuture.java:2073) ~[?:?]
	at org.apache.pulsar.metadata.coordination.impl.ResourceLockImpl.lambda$acquire$2(ResourceLockImpl.java:127) ~[classes/:?]
	at java.util.concurrent.CompletableFuture$UniRun.tryFire$$$capture(CompletableFuture.java:783) ~[?:?]
	at java.util.concurrent.CompletableFuture$UniRun.tryFire(CompletableFuture.java) ~[?:?]
	at java.util.concurrent.CompletableFuture.postComplete(CompletableFuture.java:506) ~[?:?]
	at java.util.concurrent.CompletableFuture.complete(CompletableFuture.java:2073) ~[?:?]
	at org.apache.pulsar.metadata.coordination.impl.ResourceLockImpl.lambda$acquireWithNoRevalidation$6(ResourceLockImpl.java:166) ~[classes/:?]
	at java.util.concurrent.CompletableFuture$UniAccept.tryFire$$$capture(CompletableFuture.java:714) ~[?:?]
	at java.util.concurrent.CompletableFuture$UniAccept.tryFire(CompletableFuture.java) ~[?:?]
	at java.util.concurrent.CompletableFuture.postComplete(CompletableFuture.java:506) ~[?:?]
	at java.util.concurrent.CompletableFuture.complete(CompletableFuture.java:2073) ~[?:?]
	at org.apache.pulsar.metadata.impl.ZKMetadataStore.handlePutResult(ZKMetadataStore.java:214) ~[classes/:?]
	at org.apache.pulsar.metadata.impl.ZKMetadataStore.lambda$batchOperation$6(ZKMetadataStore.java:171) ~[classes/:?]
	at org.apache.pulsar.metadata.impl.PulsarZooKeeperClient$3$1.processResult(PulsarZooKeeperClient.java:490) [classes/:?]
	at org.apache.zookeeper.ClientCnxn$EventThread.processEvent(ClientCnxn.java:722) [zookeeper-3.6.3.jar:3.6.3]
	at org.apache.zookeeper.ClientCnxn$EventThread.run(ClientCnxn.java:563) [zookeeper-3.6.3.jar:3.6.3]
```

We have pushed this patch to branch-2.9(https://github.com/apache/pulsar/pull/13840), we only need to add this to branch-2.10, 2.11.

### Modifications
1. Move `ownedBundlesCountPerNamespace.putIfAbsent(namespace, new AtomicInteger(1))` in the prepareInitPoliciesCache method.

### Documentation

- [x] `no-need-doc` 
