### PR TITLE
[improve][CI] Ensure that ssh-access is only activated for PRs outside of apache/pulsar repo

### DIFF
--- a/.github/workflows/pulsar-ci-flaky.yaml
+++ b/.github/workflows/pulsar-ci-flaky.yaml
@@ -75,7 +75,7 @@ jobs:
 
       - name: Setup ssh access to build runner VM
         # ssh access is enabled for builds in own forks
-        if: ${{ github.repository != 'apache/pulsar' }}
+        if: ${{ github.repository != 'apache/pulsar' && github.event_name == 'pull_request' }}
         uses: ./.github/actions/ssh-access
         with:
           limit-access-to-actor: true

--- a/.github/workflows/pulsar-ci.yaml
+++ b/.github/workflows/pulsar-ci.yaml
@@ -75,7 +75,7 @@ jobs:
 
       - name: Setup ssh access to build runner VM
         # ssh access is enabled for builds in own forks
-        if: ${{ github.repository != 'apache/pulsar' }}
+        if: ${{ github.repository != 'apache/pulsar' && github.event_name == 'pull_request' }}
         uses: ./.github/actions/ssh-access
         with:
           limit-access-to-actor: true
@@ -119,7 +119,7 @@ jobs:
       - name: Wait for ssh connection when build fails
         # ssh access is enabled for builds in own forks
         uses: ./.github/actions/ssh-access
-        if: ${{ failure() && github.repository != 'apache/pulsar' }}
+        if: ${{ failure() && github.repository != 'apache/pulsar' && github.event_name == 'pull_request' }}
         continue-on-error: true
         with:
           action: wait
@@ -163,7 +163,7 @@ jobs:
 
       - name: Setup ssh access to build runner VM
         # ssh access is enabled for builds in own forks
-        if: ${{ github.repository != 'apache/pulsar' }}
+        if: ${{ github.repository != 'apache/pulsar' && github.event_name == 'pull_request' }}
         uses: ./.github/actions/ssh-access
         with:
           limit-access-to-actor: true
@@ -235,7 +235,7 @@ jobs:
       - name: Wait for ssh connection when build fails
         # ssh access is enabled for builds in own forks
         uses: ./.github/actions/ssh-access
-        if: ${{ failure() && github.repository != 'apache/pulsar' }}
+        if: ${{ failure() && github.repository != 'apache/pulsar' && github.event_name == 'pull_request' }}
         continue-on-error: true
         with:
           action: wait
@@ -257,6 +257,7 @@ jobs:
 
       - name: Setup ssh access to build runner VM
         # ssh access is enabled for builds in own forks
+        if: ${{ github.repository != 'apache/pulsar' && github.event_name == 'pull_request' }}
         uses: ./.github/actions/ssh-access
         with:
           limit-access-to-actor: true
@@ -299,7 +300,7 @@ jobs:
       - name: Wait for ssh connection when build fails
         # ssh access is enabled for builds in own forks
         uses: ./.github/actions/ssh-access
-        if: ${{ failure() && github.repository != 'apache/pulsar' }}
+        if: ${{ failure() && github.repository != 'apache/pulsar' && github.event_name == 'pull_request' }}
         continue-on-error: true
         with:
           action: wait
@@ -354,7 +355,7 @@ jobs:
 
       - name: Setup ssh access to build runner VM
         # ssh access is enabled for builds in own forks
-        if: ${{ github.repository != 'apache/pulsar' }}
+        if: ${{ github.repository != 'apache/pulsar' && github.event_name == 'pull_request' }}
         uses: ./.github/actions/ssh-access
         with:
           limit-access-to-actor: true
@@ -438,7 +439,7 @@ jobs:
       - name: Wait for ssh connection when build fails
         # ssh access is enabled for builds in own forks
         uses: ./.github/actions/ssh-access
-        if: ${{ failure() && github.repository != 'apache/pulsar' }}
+        if: ${{ failure() && github.repository != 'apache/pulsar' && github.event_name == 'pull_request' }}
         continue-on-error: true
         with:
           action: wait
@@ -483,7 +484,7 @@ jobs:
 
       - name: Setup ssh access to build runner VM
         # ssh access is enabled for builds in own forks
-        if: ${{ github.repository != 'apache/pulsar' }}
+        if: ${{ github.repository != 'apache/pulsar' && github.event_name == 'pull_request' }}
         uses: ./.github/actions/ssh-access
         with:
           limit-access-to-actor: true
@@ -555,7 +556,7 @@ jobs:
       - name: Wait for ssh connection when build fails
         # ssh access is enabled for builds in own forks
         uses: ./.github/actions/ssh-access
-        if: ${{ failure() && github.repository != 'apache/pulsar' }}
+        if: ${{ failure() && github.repository != 'apache/pulsar' && github.event_name == 'pull_request' }}
         continue-on-error: true
         with:
           action: wait
@@ -605,7 +606,7 @@ jobs:
 
       - name: Setup ssh access to build runner VM
         # ssh access is enabled for builds in own forks
-        if: ${{ github.repository != 'apache/pulsar' }}
+        if: ${{ github.repository != 'apache/pulsar' && github.event_name == 'pull_request' }}
         uses: ./.github/actions/ssh-access
         with:
           limit-access-to-actor: true
@@ -683,7 +684,7 @@ jobs:
       - name: Wait for ssh connection when build fails
         # ssh access is enabled for builds in own forks
         uses: ./.github/actions/ssh-access
-        if: ${{ failure() && github.repository != 'apache/pulsar' }}
+        if: ${{ failure() && github.repository != 'apache/pulsar' && github.event_name == 'pull_request' }}
         continue-on-error: true
         with:
           action: wait
@@ -716,7 +717,7 @@ jobs:
 
       - name: Setup ssh access to build runner VM
         # ssh access is enabled for builds in own forks
-        if: ${{ github.repository != 'apache/pulsar' }}
+        if: ${{ github.repository != 'apache/pulsar' && github.event_name == 'pull_request' }}
         uses: ./.github/actions/ssh-access
         with:
           limit-access-to-actor: true
@@ -794,7 +795,7 @@ jobs:
       - name: Wait for ssh connection when build fails
         # ssh access is enabled for builds in own forks
         uses: ./.github/actions/ssh-access
-        if: ${{ failure() && github.repository != 'apache/pulsar' }}
+        if: ${{ failure() && github.repository != 'apache/pulsar' && github.event_name == 'pull_request' }}
         continue-on-error: true
         with:
           action: wait
@@ -822,7 +823,7 @@ jobs:
       - name: Delete docker image from GitHub Actions Artifacts
         run: |
           gh-actions-artifact-client.js delete pulsar-test-latest-version-image.zst
-  
+
   macos-build:
     name: Build Pulsar on MacOS
     runs-on: macos-11
@@ -870,7 +871,7 @@ jobs:
 
       - name: Setup ssh access to build runner VM
         # ssh access is enabled for builds in own forks
-        if: ${{ github.repository != 'apache/pulsar' }}
+        if: ${{ github.repository != 'apache/pulsar' && github.event_name == 'pull_request' }}
         uses: ./.github/actions/ssh-access
         with:
           limit-access-to-actor: true
@@ -919,7 +920,7 @@ jobs:
       - name: Wait for ssh connection when build fails
         # ssh access is enabled for builds in own forks
         uses: ./.github/actions/ssh-access
-        if: ${{ failure() && github.repository != 'apache/pulsar' }}
+        if: ${{ failure() && github.repository != 'apache/pulsar' && github.event_name == 'pull_request' }}
         continue-on-error: true
         with:
           action: wait


### PR DESCRIPTION
### Motivation

- the if condition was missing for the ssh-access step in pulsar-java-test-image build job

### Modifications

- add the missing if condition to pulsar-java-test-image build job
- add additional condition so that ssh-access is limited to pull requests in a forked repository
  - this is a better default

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)

- [x] `doc-not-needed` 
(Please explain why)

- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)
