### PR TITLE
[fix][cpp] Revert OpenSSL version in rpm and deb package

### DIFF
--- a/pulsar-client-cpp/pkg/deb/Dockerfile
+++ b/pulsar-client-cpp/pkg/deb/Dockerfile
@@ -71,12 +71,12 @@ RUN curl -O -L https://github.com/google/snappy/releases/download/1.1.3/snappy-1
     make && make install && \
     rm -rf /snappy-1.1.3 /snappy-1.1.3.tar.gz
 
-RUN curl -O -L https://github.com/openssl/openssl/archive/OpenSSL_1_1_1n.tar.gz && \
-    tar xfz OpenSSL_1_1_1n.tar.gz && \
-    cd openssl-OpenSSL_1_1_1n/ && \
+RUN curl -O -L https://github.com/openssl/openssl/archive/OpenSSL_1_1_0j.tar.gz && \
+    tar xfz OpenSSL_1_1_0j.tar.gz && \
+    cd openssl-OpenSSL_1_1_0j/ && \
     ./Configure -fPIC --prefix=/usr/local/ssl/ linux-x86_64 && \
     make -j8 && make install && \
-    rm -rf /OpenSSL_1_1_1n.tar.gz /openssl-OpenSSL_1_1_1n
+    rm -rf /OpenSSL_1_1_0j.tar.gz /openssl-OpenSSL_1_1_0j
 
 # LibCurl
 RUN curl -O -L  https://github.com/curl/curl/releases/download/curl-7_61_0/curl-7.61.0.tar.gz && \

--- a/pulsar-client-cpp/pkg/rpm/Dockerfile
+++ b/pulsar-client-cpp/pkg/rpm/Dockerfile
@@ -72,12 +72,12 @@ RUN curl -O -L https://github.com/google/snappy/releases/download/1.1.3/snappy-1
     make && make install && \
     rm -rf /snappy-1.1.3 /snappy-1.1.3.tar.gz
 
-RUN curl -O -L https://github.com/openssl/openssl/archive/OpenSSL_1_1_1n.tar.gz && \
-    tar xfz OpenSSL_1_1_1n.tar.gz && \
-    cd openssl-OpenSSL_1_1_1n/ && \
+RUN curl -O -L https://github.com/openssl/openssl/archive/OpenSSL_1_1_0j.tar.gz && \
+    tar xfz OpenSSL_1_1_0j.tar.gz && \
+    cd openssl-OpenSSL_1_1_0j/ && \
     ./Configure -fPIC --prefix=/usr/local/ssl/ linux-x86_64 && \
     make -j8 && make install && \
-    rm -rf /OpenSSL_1_1_1n.tar.gz /openssl-OpenSSL_1_1_1n
+    rm -rf /OpenSSL_1_1_0j.tar.gz /openssl-OpenSSL_1_1_0j
 
 # LibCurl
 RUN curl -O -L  https://github.com/curl/curl/releases/download/curl-7_61_0/curl-7.61.0.tar.gz && \


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://docs.google.com/document/d/1d8Pw6ZbWk-_pCKdOmdvx9rnhPiyuxwq60_TrD68d7BA/edit#heading=h.trs9rsex3xom)*. 

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->


### Motivation

See https://github.com/apache/pulsar/pull/17538#issuecomment-1244898721
This issue has blocked the master branch. Revert the OepnSSL version in rpm and deb package to unblock the master until we find the root cause and give a fix.

### Modifications

* Revert OpenSSL version from 111n to 110j in rpm and deb package.



### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)

- [x] `doc-not-needed` 
(Please explain why)

- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)
