### PR TITLE
[fix][client-cpp] Fix static compilation that includes openssl

### DIFF
--- a/pulsar-client-cpp/pkg/deb/Dockerfile
+++ b/pulsar-client-cpp/pkg/deb/Dockerfile
@@ -76,7 +76,9 @@ RUN curl -O -L https://github.com/openssl/openssl/archive/OpenSSL_1_1_1n.tar.gz 
     cd openssl-OpenSSL_1_1_1n/ && \
     ./Configure -fPIC --prefix=/usr/local/ssl/ linux-x86_64 && \
     make -j8 && make install && \
-    rm -rf /OpenSSL_1_1_1n.tar.gz /openssl-OpenSSL_1_1_1n
+    rm -rf /OpenSSL_1_1_1n.tar.gz /openssl-OpenSSL_1_1_1n && \
+    echo /usr/local/ssl/lib >> /etc/ld.so.conf.d/ssl.conf && \
+    ldconfig -v
 
 # LibCurl
 RUN curl -O -L  https://github.com/curl/curl/releases/download/curl-7_61_0/curl-7.61.0.tar.gz && \

--- a/pulsar-client-cpp/pkg/rpm/Dockerfile
+++ b/pulsar-client-cpp/pkg/rpm/Dockerfile
@@ -77,7 +77,9 @@ RUN curl -O -L https://github.com/openssl/openssl/archive/OpenSSL_1_1_1n.tar.gz 
     cd openssl-OpenSSL_1_1_1n/ && \
     ./Configure -fPIC --prefix=/usr/local/ssl/ linux-x86_64 && \
     make -j8 && make install && \
-    rm -rf /OpenSSL_1_1_1n.tar.gz /openssl-OpenSSL_1_1_1n
+    rm -rf /OpenSSL_1_1_1n.tar.gz /openssl-OpenSSL_1_1_1n && \
+    echo /usr/local/ssl/lib >> /etc/ld.so.conf.d/ssl.conf && \
+    ldconfig -v
 
 # LibCurl
 RUN curl -O -L  https://github.com/curl/curl/releases/download/curl-7_61_0/curl-7.61.0.tar.gz && \


### PR DESCRIPTION
### Motivation

Master branch is broken at the moment.
```
../lib/.libs/libcurl.so: undefined reference to `SSL_CTX_set_keylog_callback@OPENSSL_1_1_1'
../lib/.libs/libcurl.so: undefined reference to `SSL_CTX_set_ciphersuites@OPENSSL_1_1_1'
collect2: error: ld returned 1 exit status
make[2]: *** [curl] Error 1
Makefile:839: recipe for target 'curl' failed
make[2]: Leaving directory '/curl-7.61.0/src'
make[1]: *** [all-recursive] Error 1
Makefile:1878: recipe for target 'all-recursive' failed
make[1]: Leaving directory '/curl-7.61.0/src'
Makefile:927: recipe for target 'all-recursive' failed
make: *** [all-recursive] Error 1
```

### Modifications

Fix the static compilation that intends to include a locally built version of openssl. The linking configuration was invalid.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)

- [x] `doc-not-needed` 
(Please explain why)

- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)
