### PR TITLE
[cleanup][client]Removing null-check finalEx in ProducerImpl.OpSendMsg.sendComplete

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
@@ -1455,7 +1455,7 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
             SendCallback callback = this.callback;
             if (null != callback) {
                 Exception finalEx = e;
-                if (finalEx != null && finalEx instanceof TimeoutException) {
+                if (finalEx instanceof TimeoutException) {
                     TimeoutException te = (TimeoutException) e;
                     long sequenceId = te.getSequenceId();
                     long ns = System.nanoTime();


### PR DESCRIPTION
### Motivation

Removing check `finalEx` is null,  because condition `finalEx != null` covered by subsequent condition `finalEx instanceof TimeoutException`

### Modifications

Removing  condition `finalEx != null`

### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Does this pull request potentially affect one of the following parts:

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)

- [x] `doc-not-needed` 
(Please explain why)

- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)
