### PR TITLE
[improve][test] Improve the ClusterMetadataSetupTest to reduce the execution time

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/zookeeper/ClusterMetadataSetupTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/zookeeper/ClusterMetadataSetupTest.java
@@ -48,14 +48,14 @@ import org.apache.pulsar.functions.worker.WorkerUtils;
 import org.apache.pulsar.metadata.api.MetadataStoreConfig;
 import org.apache.pulsar.metadata.api.extended.MetadataStoreExtended;
 import org.apache.pulsar.zookeeper.LocalBookkeeperEnsemble;
-import org.apache.pulsar.zookeeper.ZookeeperServerTest;
 import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.ZooKeeper;
 import org.apache.zookeeper.server.NIOServerCnxnFactory;
 import org.apache.zookeeper.server.ZooKeeperServer;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.AfterMethod;
-import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
@@ -405,15 +405,20 @@ public class ClusterMetadataSetupTest {
 
     }
 
-    @BeforeMethod
+    @BeforeClass
     void setup() throws Exception {
         localZkS = new ZookeeperServerTest(0);
         localZkS.start();
     }
 
-    @AfterMethod(alwaysRun = true)
+    @AfterClass
     void teardown() throws Exception {
         localZkS.close();
+    }
+
+    @AfterMethod(alwaysRun = true)
+    void cleanup() {
+        localZkS.clear();
     }
 
     static class ZookeeperServerTest implements Closeable {
@@ -448,10 +453,8 @@ public class ClusterMetadataSetupTest {
             log.info("ZooKeeper started at {}", hostPort);
         }
 
-        public void stop() throws IOException {
-            zks.shutdown();
-            serverFactory.shutdown();
-            log.info("Stoppend ZK server at {}", hostPort);
+        private void clear() {
+            zks.getZKDatabase().clear();
         }
 
         @Override


### PR DESCRIPTION
Fixes #17621 

### Modifications

Only start the ZooKeeper once and clean the ZooKeeper data after the end of each test execution.
And clean useless methods `stop()`.

Execution time after improve test:
```
[INFO] Tests run: 13, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 47.734 s - in org.apache.pulsar.broker.zookeeper.ClusterMetadataSetupTest
```

### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)

- [x] `doc-not-needed` 
(Please explain why)

- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)
