### PR TITLE
docs: update the reference link

### DIFF
--- a/site2/docs/reference-configuration.md
+++ b/site2/docs/reference-configuration.md
@@ -6,4 +6,4 @@ sidebar_label: "Pulsar configuration"
 
 You can manage Pulsar configuration by configuration files in the `conf` directory of a Pulsar [installation](getting-started-standalone.md).
 
-For a full list of the configuration of different components, see [Pulsar Reference](/reference).
+For a full list of the configuration of different components, see [Pulsar Reference](https://pulsar.apache.org/reference).


### PR DESCRIPTION
### Motivation

The reference link in https://pulsar.apache.org/docs/next/reference-configuration is broken because it's using a relative path, but referring to another site that is not managed by Docusaurus.

### Modifications

Just a quick fix to replace the relative link to an external link.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)

- [ ] `doc-not-needed` 
(Please explain why)

- [x] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)
