### PR TITLE
[fix][c++][branch-2.9]Fix wrong consumers size: execute `callback` before executing `readerCreatedCallback_`

### DIFF
--- a/pulsar-client-cpp/lib/ReaderImpl.cc
+++ b/pulsar-client-cpp/lib/ReaderImpl.cc
@@ -84,8 +84,8 @@ void ReaderImpl::start(const MessageId& startMessageId,
     consumer_->getConsumerCreatedFuture().addListener(
         [this, self, callback](Result result, const ConsumerImplBaseWeakPtr& weakConsumerPtr) {
             if (result == ResultOk) {
-                readerCreatedCallback_(result, Reader(self));
                 callback(weakConsumerPtr);
+                readerCreatedCallback_(result, Reader(self));
             } else {
                 readerCreatedCallback_(result, {});
             }


### PR DESCRIPTION
Fixes #17325

### Modifications

Cherry-pick #17325 to branch-2.9

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)

- [x] `doc-not-needed` 
(Please explain why)

- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)
