### PR TITLE
[improve][broker] Cancel the loadShedding task when closing pulsar service

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
@@ -489,8 +489,11 @@ public class PulsarService implements AutoCloseable, ShutdownService {
                 this.leaderElectionService = null;
             }
 
-            // shutdown loadmanager before shutting down the broker
+            // shutdown the loadManager executor and cancel loadShedding task before shutting down the broker
             executorServicesShutdown.shutdown(loadManagerExecutor);
+            if (this.loadSheddingTask != null) {
+                this.loadSheddingTask.cancel();
+            }
 
             if (adminClient != null) {
                 adminClient.close();

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
@@ -489,11 +489,11 @@ public class PulsarService implements AutoCloseable, ShutdownService {
                 this.leaderElectionService = null;
             }
 
-            // shutdown the loadManager executor and cancel loadShedding task before shutting down the broker
-            executorServicesShutdown.shutdown(loadManagerExecutor);
+            // cancel loadShedding task and shutdown the loadManager executor before shutting down the broker
             if (this.loadSheddingTask != null) {
                 this.loadSheddingTask.cancel();
             }
+            executorServicesShutdown.shutdown(loadManagerExecutor);
 
             if (adminClient != null) {
                 adminClient.close();

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/LoadSheddingTask.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/LoadSheddingTask.java
@@ -50,10 +50,10 @@ public class LoadSheddingTask implements Runnable {
 
     @Override
     public void run() {
+        if (isCancel) {
+            return;
+        }
         try {
-            if (isCancel) {
-                return;
-            }
             loadManager.get().doLoadShedding();
         } catch (Exception e) {
             LOG.warn("Error during the load shedding", e);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/LoadSheddingTask.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/LoadSheddingTask.java
@@ -19,6 +19,7 @@
 package org.apache.pulsar.broker.loadbalance;
 
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import org.apache.pulsar.broker.ServiceConfiguration;
@@ -37,6 +38,8 @@ public class LoadSheddingTask implements Runnable {
 
     private volatile boolean isCancel = false;
 
+    private volatile ScheduledFuture<?> future;
+
     public LoadSheddingTask(AtomicReference<LoadManager> loadManager,
                             ScheduledExecutorService loadManagerExecutor,
                             ServiceConfiguration config) {
@@ -52,19 +55,14 @@ public class LoadSheddingTask implements Runnable {
         } catch (Exception e) {
             LOG.warn("Error during the load shedding", e);
         } finally {
-            if (!isCancel && loadManagerExecutor != null && config != null) {
-                loadManagerExecutor.schedule(
-                        new LoadSheddingTask(loadManager, loadManagerExecutor, config),
-                        config.getLoadBalancerSheddingIntervalMinutes(),
-                        TimeUnit.MINUTES);
-            }
+            start();
         }
     }
 
     public void start() {
-        if (loadManagerExecutor != null && config != null) {
-            loadManagerExecutor.schedule(
-                    new LoadSheddingTask(loadManager, loadManagerExecutor, config),
+        if (!isCancel && loadManagerExecutor != null && config != null) {
+            future = loadManagerExecutor.schedule(
+                    this,
                     config.getLoadBalancerSheddingIntervalMinutes(),
                     TimeUnit.MINUTES);
         }
@@ -72,5 +70,9 @@ public class LoadSheddingTask implements Runnable {
 
     public void cancel() {
         isCancel = true;
+        if (future != null) {
+            future.cancel(false);
+        }
     }
+
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/LoadSheddingTask.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/LoadSheddingTask.java
@@ -51,6 +51,9 @@ public class LoadSheddingTask implements Runnable {
     @Override
     public void run() {
         try {
+            if (isCancel) {
+                return;
+            }
             loadManager.get().doLoadShedding();
         } catch (Exception e) {
             LOG.warn("Error during the load shedding", e);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/PulsarServiceCloseTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/PulsarServiceCloseTest.java
@@ -1,0 +1,63 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker;
+
+import static org.mockito.Mockito.spy;
+
+import lombok.extern.slf4j.Slf4j;
+import org.apache.pulsar.broker.auth.MockedPulsarServiceBaseTest;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+@Slf4j
+public class PulsarServiceCloseTest extends MockedPulsarServiceBaseTest {
+
+    @BeforeMethod
+    @Override
+    protected void setup() throws Exception {
+        super.internalSetup();
+    }
+
+    @AfterMethod(alwaysRun = true)
+    @Override
+    protected void cleanup() throws Exception {
+        super.internalCleanup();
+        resetConfig();
+    }
+
+    protected PulsarService startBrokerWithoutAuthorization(ServiceConfiguration conf) throws Exception {
+        conf.setBrokerShutdownTimeoutMs(1000 * 60 * 5);
+        conf.setLoadBalancerSheddingIntervalMinutes(30);
+        PulsarService pulsar = spy(newPulsarService(conf));
+        setupBrokerMocks(pulsar);
+        beforePulsarStartMocks(pulsar);
+        pulsar.start();
+        log.info("Pulsar started. brokerServiceUrl: {} webServiceAddress: {}", pulsar.getBrokerServiceUrl(),
+                pulsar.getWebServiceAddress());
+        return pulsar;
+    }
+
+    @Test(timeOut = 30_000)
+    public void closeInTimeTest() throws Exception {
+        // The pulsar service is not used, so it should be closed gracefully in short time.
+        pulsar.close();
+    }
+
+}

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/PulsarServiceCloseTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/PulsarServiceCloseTest.java
@@ -39,7 +39,6 @@ public class PulsarServiceCloseTest extends MockedPulsarServiceBaseTest {
     @Override
     protected void cleanup() throws Exception {
         super.internalCleanup();
-        resetConfig();
     }
 
     protected PulsarService startBrokerWithoutAuthorization(ServiceConfiguration conf) throws Exception {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/PulsarServiceCloseTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/PulsarServiceCloseTest.java
@@ -27,20 +27,21 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.broker.auth.MockedPulsarServiceBaseTest;
 import org.apache.pulsar.broker.loadbalance.LoadSheddingTask;
 import org.awaitility.reflect.WhiteboxImpl;
-import org.testng.annotations.AfterMethod;
-import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 @Slf4j
+@Test(groups = "broker")
 public class PulsarServiceCloseTest extends MockedPulsarServiceBaseTest {
 
-    @BeforeMethod
+    @BeforeClass
     @Override
     protected void setup() throws Exception {
         super.internalSetup();
     }
 
-    @AfterMethod(alwaysRun = true)
+    @AfterClass(alwaysRun = true)
     @Override
     protected void cleanup() throws Exception {
         super.internalCleanup();


### PR DESCRIPTION
### Motivation

The PR https://github.com/apache/pulsar/pull/16408 supported loadBalancerSheddingIntervalMinutes dynamic configuration, but the scheduled load-shedding task may block pulsar service close operation, the pulsar service need to wait until the scheduled load-shedding task executed or reach broker shutdown timeout. If the load-shedding task interval time and broker shutdown timeout are long, the pulsar service close operation will waste a lot of time.

### Modifications

Cancel the scheduled task when closing the pulsar service.

### Verifying this change

Add a test to verify the pulsar service could be closed gracefully in time.

### Does this pull request potentially affect one of the following parts:

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)

- [x] `doc-not-needed` 
(Please explain why)

- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)
