### PR TITLE
[fix][metadata] Handle session events in a separate thread

### DIFF
--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/AbstractMetadataStore.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/AbstractMetadataStore.java
@@ -409,14 +409,19 @@ public abstract class AbstractMetadataStore implements MetadataStoreExtended, Co
 
     protected void receivedSessionEvent(SessionEvent event) {
         isConnected = event.isConnected();
-
-        sessionListeners.forEach(l -> {
-            try {
-                l.accept(event);
-            } catch (Throwable t) {
-                log.warn("Error in processing session event", t);
-            }
-        });
+        try {
+            executor.execute(() -> {
+                sessionListeners.forEach(l -> {
+                    try {
+                        l.accept(event);
+                    } catch (Throwable t) {
+                        log.warn("Error in processing session event " + event, t);
+                    }
+                });
+            });
+        } catch (RejectedExecutionException e) {
+            log.warn("Error in processing session event " + event, e);
+        }
     }
 
     @Override


### PR DESCRIPTION
### Motivation

- session listener might block further processing, and therefore it's better to run it in another thread
- here's an example of a stacktrace happening in a Bookie with the Pulsar metadata store classes:
  - mentioned in [another issue discussion](https://github.com/apache/pulsar/pull/17620#issuecomment-1246303451).
```
metadata-store-zk-session-watcher-21-1  Waiting Thread ID: 60
  jdk.internal.misc.Unsafe.park(Unsafe.java)
  java.util.concurrent.locks.LockSupport.park(LockSupport.java:194)
  java.util.concurrent.CompletableFuture$Signaller.block(CompletableFuture.java:1796)
  java.util.concurrent.ForkJoinPool.managedBlock(ForkJoinPool.java:3128)
  java.util.concurrent.CompletableFuture.waitingGet(CompletableFuture.java:1823)
  java.util.concurrent.CompletableFuture.join(CompletableFuture.java:2043)
  org.apache.pulsar.metadata.coordination.impl.LeaderElectionImpl.close(LeaderElectionImpl.java:233)
  org.apache.pulsar.metadata.bookkeeper.PulsarLedgerAuditorManager.close(PulsarLedgerAuditorManager.java:96)
  org.apache.bookkeeper.replication.AuditorElector.shutdown(AuditorElector.java:234)
  org.apache.bookkeeper.replication.AutoRecoveryMain.shutdown(AutoRecoveryMain.java:154)
  org.apache.bookkeeper.replication.AutoRecoveryMain.lambda$new$0(AutoRecoveryMain.java:99)
  org.apache.bookkeeper.replication.AutoRecoveryMain$$Lambda$222.onSessionExpired()
  org.apache.pulsar.metadata.bookkeeper.PulsarMetadataClientDriver.lambda$setSessionStateListener$0(PulsarMetadataClientDriver.java:68)
  org.apache.pulsar.metadata.bookkeeper.PulsarMetadataClientDriver$$Lambda$223.accept()
  org.apache.pulsar.metadata.impl.AbstractMetadataStore.lambda$receivedSessionEvent$11(AbstractMetadataStore.java:297)
  org.apache.pulsar.metadata.impl.AbstractMetadataStore$$Lambda$342.accept()
  java.util.concurrent.CopyOnWriteArrayList.forEach(CopyOnWriteArrayList.java:807)
  org.apache.pulsar.metadata.impl.AbstractMetadataStore.receivedSessionEvent(AbstractMetadataStore.java:295)
  org.apache.pulsar.metadata.impl.ZKMetadataStore.receivedSessionEvent(ZKMetadataStore.java:152)
  org.apache.pulsar.metadata.impl.ZKMetadataStore$$Lambda$148.accept()
  org.apache.pulsar.metadata.impl.ZKSessionWatcher.checkState(ZKSessionWatcher.java:150)
  org.apache.pulsar.metadata.impl.ZKSessionWatcher.checkConnectionStatus(ZKSessionWatcher.java:110)
  org.apache.pulsar.metadata.impl.ZKSessionWatcher$$Lambda$149.run()
  org.apache.pulsar.common.util.Runnables$CatchingAndLoggingRunnable.run(Runnables.java:54)
  java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
  java.util.concurrent.FutureTask.runAndReset(FutureTask.java:305)
  java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:305)
  java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
  java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
  io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
  java.lang.Thread.run(Thread.java:834)
```

### Modifications

- handle session events in a separate thread


### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)

- [x] `doc-not-needed` 
(Please explain why)

- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)
