### PR TITLE
[improve][broker] Avoid using common pool thread in ResourceGroup.

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/resourcegroup/ResourceGroupConfigListener.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/resourcegroup/ResourceGroupConfigListener.java
@@ -60,7 +60,7 @@ public class ResourceGroupConfigListener implements Consumer<Notification> {
     }
 
     private void loadAllResourceGroups() {
-        rgResources.listResourceGroupsAsync().whenCompleteAsync((rgList, ex) -> {
+        rgResources.listResourceGroupsAsync().whenComplete((rgList, ex) -> {
             if (ex != null) {
                 LOG.error("Exception when fetching resource groups", ex);
                 return;
@@ -81,7 +81,7 @@ public class ResourceGroupConfigListener implements Consumer<Notification> {
             final Sets.SetView<String> addList = Sets.difference(newSet, existingSet);
             for (String rgName: addList) {
                 pulsarService.getPulsarResources().getResourcegroupResources()
-                    .getResourceGroupAsync(rgName).thenAcceptAsync(optionalRg -> {
+                    .getResourceGroupAsync(rgName).thenAccept(optionalRg -> {
                     ResourceGroup rg = optionalRg.get();
                     createResourceGroup(rgName, rg);
                 }).exceptionally((ex1) -> {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/resourcegroup/ResourceGroupNamespaceConfigListener.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/resourcegroup/ResourceGroupNamespaceConfigListener.java
@@ -60,7 +60,7 @@ public class ResourceGroupNamespaceConfigListener implements Consumer<Notificati
     }
 
     private void updateNamespaceResourceGroup(NamespaceName nsName) {
-        namespaceResources.getPoliciesAsync(nsName).whenCompleteAsync((optionalPolicies, ex) -> {
+        namespaceResources.getPoliciesAsync(nsName).whenComplete((optionalPolicies, ex) -> {
             if (ex != null) {
                 LOG.error("Exception when getting namespace {}", nsName, ex);
                 return;


### PR DESCRIPTION
### Motivation

There are three places using the common-pool thread to execute the logic.  `loadAllResourceGroups` may start many threads in the foreach block.

### Documentation

- [x] `doc-not-needed` 
(Please explain why)

