### PR TITLE
[fix][cli] Pulsar shell: support relative paths (cliextensions)

### DIFF
--- a/bin/pulsar-shell
+++ b/bin/pulsar-shell
@@ -36,4 +36,6 @@ export PULSAR_HOME=`cd -P $BINDIR/..;pwd`
 OPTS="-Dorg.jline.terminal.jansi=false $OPTS"
 DEFAULT_CONFIG="-Dpulsar.shell.config.default=$PULSAR_CLIENT_CONF"
 
+#Change to PULSAR_HOME to support relative paths
+cd "$PULSAR_HOME"
 exec $JAVA $OPTS $DEFAULT_CONFIG org.apache.pulsar.shell.PulsarShell "$@"

--- a/bin/pulsar-shell.cmd
+++ b/bin/pulsar-shell.cmd
@@ -29,5 +29,5 @@ if ERRORLEVEL 1 (
 
 set "OPTS=%OPTS% -Dorg.jline.terminal.jansi=false"
 set "DEFAULT_CONFIG=-Dpulsar.shell.config.default="%PULSAR_CLIENT_CONF%""
-
+cd "%PULSAR_HOME%"
 "%JAVACMD%" %OPTS%  %DEFAULT_CONFIG%  org.apache.pulsar.shell.PulsarShell %*


### PR DESCRIPTION
### Motivation

The `pulsar-shell` script doesn't change the working directory to the Pulsar home one. In this way if you configure `cliExtensionsDirectory` with a relative path, it only works if you run pulsar-shell from the pulsar home directory. For instance `cd bin && ./pulsar-shell` is not able to find the cli extensions dir.

### Modifications

* Change directory to pulsar home before starting the java process (in this way it's the same as the other scripts)
The only disadvantage is that the `--file` autocompletion will suggest files from the Pulsar home directory and not from 
the real working dir. (but it's still better than the current behaviour)

- [x] `doc-not-needed` 