### PR TITLE
[improve][broker] Add a constructor method for NettyServerSslContextBuilder.

### DIFF
--- a/pulsar-common/src/main/java/org/apache/pulsar/common/util/NettyServerSslContextBuilder.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/util/NettyServerSslContextBuilder.java
@@ -39,6 +39,15 @@ public class NettyServerSslContextBuilder extends SslContextAutoRefreshBuilder<S
     protected final boolean tlsRequireTrustedClientCertOnConnect;
     protected final SslProvider sslProvider;
 
+    public NettyServerSslContextBuilder(boolean allowInsecure, String trustCertsFilePath,
+                                        String certificateFilePath,
+                                        String keyFilePath, Set<String> ciphers, Set<String> protocols,
+                                        boolean requireTrustedClientCertOnConnect,
+                                        long delayInSeconds) {
+        this(null, allowInsecure, trustCertsFilePath, certificateFilePath, keyFilePath, ciphers, protocols,
+                requireTrustedClientCertOnConnect, delayInSeconds);
+    }
+
     public NettyServerSslContextBuilder(SslProvider sslProvider, boolean allowInsecure, String trustCertsFilePath,
                                         String certificateFilePath,
                                         String keyFilePath, Set<String> ciphers, Set<String> protocols,


### PR DESCRIPTION
### Motivation

As #14569 supported full ssl-provider for broker service, the `constructor` method of NettyServerSslContextBuilder adds a new param `sslProvider`.  Because `sslProvider` can be `null` as the default value, it's better to keep the original `constructor`, then plugins or users do not need to do any changes.  

### Documentation

- [x] `doc-not-needed` 
(Please explain why)

