### PR TITLE
[fix][doc]correct the explanation for invalidateEntries in the EntryCache

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/cache/EntryCache.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/cache/EntryCache.java
@@ -39,7 +39,7 @@ public interface EntryCache extends Comparable<EntryCache> {
     /**
      * Insert an entry in the cache.
      *
-     * <p/>If the overall limit have been reached, this will triggered the eviction of other entries, possibly from
+     * <p/>If the overall limit have been reached, this will trigger the eviction of other entries, possibly from
      * other EntryCache instances
      *
      * @param entry
@@ -49,7 +49,7 @@ public interface EntryCache extends Comparable<EntryCache> {
     boolean insert(EntryImpl entry);
 
     /**
-     * Remove from cache all the entries related to a ledger up to lastPosition included.
+     * Remove from cache all the entries related to a ledger up to lastPosition excluded.
      *
      * @param lastPosition
      *            the position of the last entry to be invalidated (non-inclusive)


### PR DESCRIPTION
### Motivation
The method `invalidateEntries` aims to remove from cache all the entries related to a ledger up to lastPosition. And the `lastPosition` is non-inclusive as opposed to its explanation. See L173.

https://github.com/apache/pulsar/blob/e771fc885afe2cc3807fa491af2510a25377ed57/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/cache/RangeEntryCacheImpl.java#L161-L173

### Modifications
correct the explanation for `invalidateEntries`

### Verifying this change

- [x]  Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.
### Does this pull request potentially affect one of the following parts:

If `yes` was chosen, please highlight the changes

- Dependencies (does it add or upgrade a dependency): (no)
- The public API: (no)
- The schema: (no)
- The default values of configurations: (no)
- The wire protocol: (no)
- The rest endpoints: (no)
- The admin cli options: (no)
- Anything that affects deployment: (no)

### Documentation

Check the box below or label this PR directly.

Need to update docs?

- [ ] `doc-required`

- [ ] `doc-not-needed`

- [x] `doc`
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)
