### PR TITLE
[improve][cli] Pulsar shell: add command to set/get property of a config

### DIFF
--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/shell/config/ConfigStore.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/shell/config/ConfigStore.java
@@ -23,7 +23,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Scanner;
 import java.util.Set;
-
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -70,7 +69,7 @@ public interface ConfigStore {
         entry.setValue(builder.toString());
     }
 
-    static void updateProperty(ConfigEntry entry, String propertyName, String propertyValue) {
+    static void setProperty(ConfigEntry entry, String propertyName, String propertyValue) {
         Set<String> keys = new HashSet<>();
         StringBuilder builder = new StringBuilder();
         try (Scanner scanner = new Scanner(entry.getValue());) {
@@ -98,6 +97,28 @@ public interface ConfigStore {
             }
         }
         entry.setValue(builder.toString());
+    }
+
+    static String getProperty(ConfigEntry entry, String propertyName) {
+        try (Scanner scanner = new Scanner(entry.getValue());) {
+            while (scanner.hasNextLine()) {
+                String line = scanner.nextLine().trim();
+                if (line.isBlank() || line.startsWith("#")) {
+                    continue;
+                }
+                final String[] split = line.split("=", 2);
+                if (split.length > 0) {
+                    final String property = split[0];
+                    if (property.equals(propertyName)) {
+                        if (split.length > 1) {
+                            return split[1];
+                        }
+                        return null;
+                    }
+                }
+            }
+        }
+        return null;
     }
 
 

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/shell/config/ConfigStore.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/shell/config/ConfigStore.java
@@ -19,7 +19,11 @@
 package org.apache.pulsar.shell.config;
 
 import java.io.IOException;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Scanner;
+import java.util.Set;
+
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -50,4 +54,51 @@ public interface ConfigStore {
     void setLastUsed(String name) throws IOException;
 
     ConfigEntry getLastUsed() throws IOException;
+
+    static void cleanupValue(ConfigEntry entry) {
+        StringBuilder builder = new StringBuilder();
+        try (Scanner scanner = new Scanner(entry.getValue());) {
+            while (scanner.hasNextLine()) {
+                String line = scanner.nextLine().trim();
+                if (line.isBlank() || line.startsWith("#")) {
+                    continue;
+                }
+                builder.append(line);
+                builder.append(System.lineSeparator());
+            }
+        }
+        entry.setValue(builder.toString());
+    }
+
+    static void updateProperty(ConfigEntry entry, String propertyName, String propertyValue) {
+        Set<String> keys = new HashSet<>();
+        StringBuilder builder = new StringBuilder();
+        try (Scanner scanner = new Scanner(entry.getValue());) {
+            while (scanner.hasNextLine()) {
+                String line = scanner.nextLine().trim();
+                if (line.isBlank() || line.startsWith("#")) {
+                    continue;
+                }
+                final String[] split = line.split("=", 2);
+                if (split.length > 0) {
+                    final String property = split[0];
+                    if (!keys.add(property)) {
+                        continue;
+                    }
+                    if (property.equals(propertyName)) {
+                        line = property + "=" + propertyValue;
+                    }
+                }
+                builder.append(line);
+                builder.append(System.lineSeparator());
+            }
+            if (!keys.contains(propertyName)) {
+                builder.append(propertyName + "=" + propertyValue);
+                builder.append(System.lineSeparator());
+            }
+        }
+        entry.setValue(builder.toString());
+    }
+
+
 }

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/shell/config/FileConfigStore.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/shell/config/FileConfigStore.java
@@ -29,7 +29,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Scanner;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/shell/config/FileConfigStore.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/shell/config/FileConfigStore.java
@@ -61,7 +61,7 @@ public class FileConfigStore implements ConfigStore {
         }
         if (defaultConfig != null) {
             this.defaultConfig = new ConfigEntry(defaultConfig.getName(), defaultConfig.getValue());
-            cleanupValue(this.defaultConfig);
+            ConfigStore.cleanupValue(this.defaultConfig);
         } else {
             this.defaultConfig = null;
         }
@@ -88,24 +88,9 @@ public class FileConfigStore implements ConfigStore {
         if (DEFAULT_CONFIG.equals(entry.getName())) {
             throw new IllegalArgumentException("'" + DEFAULT_CONFIG + "' can't be modified.");
         }
-        cleanupValue(entry);
+        ConfigStore.cleanupValue(entry);
         fileConfig.configs.put(entry.getName(), entry);
         write();
-    }
-
-    private static void cleanupValue(ConfigEntry entry) {
-        StringBuilder builder = new StringBuilder();
-        try (Scanner scanner = new Scanner(entry.getValue());) {
-            while (scanner.hasNextLine()) {
-                String line = scanner.nextLine().trim();
-                if (line.startsWith("#")) {
-                    continue;
-                }
-                builder.append(line);
-                builder.append(System.lineSeparator());
-            }
-        }
-        entry.setValue(builder.toString());
     }
 
     @Override

--- a/pulsar-client-tools/src/test/java/org/apache/pulsar/shell/ConfigShellTest.java
+++ b/pulsar-client-tools/src/test/java/org/apache/pulsar/shell/ConfigShellTest.java
@@ -146,7 +146,7 @@ public class ConfigShellTest {
     }
 
     @Test
-    public void testUpdateProperty() throws Exception {
+    public void testSetGetProperty() throws Exception {
         final Path newClientConf = Files.createTempFile("client", ".conf");
 
         final byte[] content = ("webServiceUrl=http://localhost:8081/\n" +
@@ -158,13 +158,20 @@ public class ConfigShellTest {
         output.clear();
 
         assertTrue(runCommand(new String[]{"use", "myclient"}));
-        verify(pulsarShell, times(1)).reload(any());
         assertTrue(output.isEmpty());
         output.clear();
 
-        assertTrue(runCommand(new String[]{"update-property", "-p", "newConf",
+        assertTrue(runCommand(new String[]{"get-property", "-p", "webServiceUrl", "myclient"}));
+        assertEquals(output.get(0), "http://localhost:8081/");
+        output.clear();
+
+        assertTrue(runCommand(new String[]{"set-property", "-p", "newConf",
                 "-v", "myValue", "myclient"}));
         verify(pulsarShell, times(2)).reload(any());
+        output.clear();
+
+        assertTrue(runCommand(new String[]{"get-property", "-p", "newConf", "myclient"}));
+        assertEquals(output.get(0), "myValue");
         output.clear();
 
         assertTrue(runCommand(new String[]{"view", "myclient"}));
@@ -172,23 +179,32 @@ public class ConfigShellTest {
                 "=pulsar://localhost:6651/\nnewConf=myValue\n");
         output.clear();
 
-        assertTrue(runCommand(new String[]{"update-property", "-p", "newConf",
+        assertTrue(runCommand(new String[]{"set-property", "-p", "newConf",
                 "-v", "myValue2", "myclient"}));
         verify(pulsarShell, times(3)).reload(any());
         output.clear();
+
+        assertTrue(runCommand(new String[]{"get-property", "-p", "newConf", "myclient"}));
+        assertEquals(output.get(0), "myValue2");
+        output.clear();
+
 
         assertTrue(runCommand(new String[]{"view", "myclient"}));
         assertEquals(output.get(0), "webServiceUrl=http://localhost:8081/\nbrokerServiceUrl" +
                 "=pulsar://localhost:6651/\nnewConf=myValue2\n");
         output.clear();
 
-        assertTrue(runCommand(new String[]{"update-property", "-p", "newConf",
+        assertTrue(runCommand(new String[]{"set-property", "-p", "newConf",
                 "-v", "", "myclient"}));
         verify(pulsarShell, times(4)).reload(any());
         output.clear();
         assertTrue(runCommand(new String[]{"view", "myclient"}));
         assertEquals(output.get(0), "webServiceUrl=http://localhost:8081/\nbrokerServiceUrl" +
                 "=pulsar://localhost:6651/\nnewConf=\n");
+        output.clear();
+
+        assertTrue(runCommand(new String[]{"get-property", "-p", "newConf", "myclient"}));
+        assertTrue(output.isEmpty());
         output.clear();
 
     }

--- a/pulsar-client-tools/src/test/java/org/apache/pulsar/shell/ConfigShellTest.java
+++ b/pulsar-client-tools/src/test/java/org/apache/pulsar/shell/ConfigShellTest.java
@@ -58,9 +58,13 @@ public class ConfigShellTest {
         when(pulsarShell.getConfigStore()).thenReturn(
                 new FileConfigStore(tempJson.toFile(),
                         new ConfigStore.ConfigEntry(ConfigStore.DEFAULT_CONFIG, "#comment\ndefault-config=true")));
-        configShell = new ConfigShell(pulsarShell);
+        configShell = new ConfigShell(pulsarShell, ConfigStore.DEFAULT_CONFIG);
         configShell.setupState(new Properties());
 
+        setConsole();
+    }
+
+    private void setConsole() {
         configShell.getJCommander().setConsole(new Console() {
             @Override
             public void print(String msg) {
@@ -79,30 +83,29 @@ public class ConfigShellTest {
                 return new char[0];
             }
         });
-
     }
 
     @Test
     public void testDefault() throws Exception {
-        assertTrue(configShell.runCommand(new String[]{"list"}));
+        assertTrue(runCommand(new String[]{"list"}));
         assertEquals(output, Arrays.asList("default (*)"));
         output.clear();
-        assertTrue(configShell.runCommand(new String[]{"view", "default"}));
+        assertTrue(runCommand(new String[]{"view", "default"}));
         assertEquals(output.get(0), "default-config=true\n");
         output.clear();
 
         final Path newClientConf = Files.createTempFile("client", ".conf");
-        assertFalse(configShell.runCommand(new String[]{"create", "default",
+        assertFalse(runCommand(new String[]{"create", "default",
                 "--file", newClientConf.toFile().getAbsolutePath()}));
         assertEquals(output, Arrays.asList("Config 'default' already exists."));
         output.clear();
 
-        assertFalse(configShell.runCommand(new String[]{"update", "default",
+        assertFalse(runCommand(new String[]{"update", "default",
                 "--file", newClientConf.toFile().getAbsolutePath()}));
         assertEquals(output, Arrays.asList("'default' can't be updated."));
         output.clear();
 
-        assertFalse(configShell.runCommand(new String[]{"delete", "default"}));
+        assertFalse(runCommand(new String[]{"delete", "default"}));
         assertEquals(output, Arrays.asList("'default' can't be deleted."));
     }
 
@@ -113,14 +116,14 @@ public class ConfigShellTest {
         final byte[] content = ("webServiceUrl=http://localhost:8081/\n" +
                 "brokerServiceUrl=pulsar://localhost:6651/\n").getBytes(StandardCharsets.UTF_8);
         Files.write(newClientConf, content);
-        assertTrue(configShell.runCommand(new String[]{"create", "myclient",
+        assertTrue(runCommand(new String[]{"create", "myclient",
                 "--file", newClientConf.toFile().getAbsolutePath()}));
         assertTrue(output.isEmpty());
         output.clear();
 
         assertNull(pulsarShell.getConfigStore().getLastUsed());
 
-        assertTrue(configShell.runCommand(new String[]{"use", "myclient"}));
+        assertTrue(runCommand(new String[]{"use", "myclient"}));
         assertTrue(output.isEmpty());
         output.clear();
         assertEquals(pulsarShell.getConfigStore().getLastUsed(), pulsarShell.getConfigStore()
@@ -128,17 +131,74 @@ public class ConfigShellTest {
 
         verify(pulsarShell).reload(any());
 
-        assertTrue(configShell.runCommand(new String[]{"list"}));
+        assertTrue(runCommand(new String[]{"list"}));
         assertEquals(output, Arrays.asList("default", "myclient (*)"));
         output.clear();
 
-        assertFalse(configShell.runCommand(new String[]{"delete", "myclient"}));
+        assertFalse(runCommand(new String[]{"delete", "myclient"}));
         assertEquals(output, Arrays.asList("'myclient' is currently used and it can't be deleted."));
         output.clear();
 
-        assertTrue(configShell.runCommand(new String[]{"update", "myclient",
+        assertTrue(runCommand(new String[]{"update", "myclient",
                 "--file", newClientConf.toFile().getAbsolutePath()}));
         assertTrue(output.isEmpty());
         verify(pulsarShell, times(2)).reload(any());
+    }
+
+    @Test
+    public void testUpdateProperty() throws Exception {
+        final Path newClientConf = Files.createTempFile("client", ".conf");
+
+        final byte[] content = ("webServiceUrl=http://localhost:8081/\n" +
+                "brokerServiceUrl=pulsar://localhost:6651/\n").getBytes(StandardCharsets.UTF_8);
+        Files.write(newClientConf, content);
+        assertTrue(runCommand(new String[]{"create", "myclient",
+                "--file", newClientConf.toFile().getAbsolutePath()}));
+        assertTrue(output.isEmpty());
+        output.clear();
+
+        assertTrue(runCommand(new String[]{"use", "myclient"}));
+        verify(pulsarShell, times(1)).reload(any());
+        assertTrue(output.isEmpty());
+        output.clear();
+
+        assertTrue(runCommand(new String[]{"update-property", "-p", "newConf",
+                "-v", "myValue", "myclient"}));
+        verify(pulsarShell, times(2)).reload(any());
+        output.clear();
+
+        assertTrue(runCommand(new String[]{"view", "myclient"}));
+        assertEquals(output.get(0), "webServiceUrl=http://localhost:8081/\nbrokerServiceUrl" +
+                "=pulsar://localhost:6651/\nnewConf=myValue\n");
+        output.clear();
+
+        assertTrue(runCommand(new String[]{"update-property", "-p", "newConf",
+                "-v", "myValue2", "myclient"}));
+        verify(pulsarShell, times(3)).reload(any());
+        output.clear();
+
+        assertTrue(runCommand(new String[]{"view", "myclient"}));
+        assertEquals(output.get(0), "webServiceUrl=http://localhost:8081/\nbrokerServiceUrl" +
+                "=pulsar://localhost:6651/\nnewConf=myValue2\n");
+        output.clear();
+
+        assertTrue(runCommand(new String[]{"update-property", "-p", "newConf",
+                "-v", "", "myclient"}));
+        verify(pulsarShell, times(4)).reload(any());
+        output.clear();
+        assertTrue(runCommand(new String[]{"view", "myclient"}));
+        assertEquals(output.get(0), "webServiceUrl=http://localhost:8081/\nbrokerServiceUrl" +
+                "=pulsar://localhost:6651/\nnewConf=\n");
+        output.clear();
+
+    }
+
+    private boolean runCommand(String[] x) throws Exception {
+        try {
+            return configShell.runCommand(x);
+        } finally {
+            configShell.setupState(null);
+            setConsole();
+        }
     }
 }

--- a/pulsar-client-tools/src/test/java/org/apache/pulsar/shell/ConfigShellTest.java
+++ b/pulsar-client-tools/src/test/java/org/apache/pulsar/shell/ConfigShellTest.java
@@ -46,7 +46,7 @@ public class ConfigShellTest {
 
     private PulsarShell pulsarShell;
     private ConfigShell configShell;
-    private final List<String> output = new ArrayList<>();
+    private List<String> output;
 
     @BeforeMethod(alwaysRun = true)
     public void before() throws Exception {
@@ -60,7 +60,7 @@ public class ConfigShellTest {
                         new ConfigStore.ConfigEntry(ConfigStore.DEFAULT_CONFIG, "#comment\ndefault-config=true")));
         configShell = new ConfigShell(pulsarShell, ConfigStore.DEFAULT_CONFIG);
         configShell.setupState(new Properties());
-
+        output = new ArrayList<>();
         setConsole();
     }
 

--- a/site2/docs/reference-cli-tools.md
+++ b/site2/docs/reference-cli-tools.md
@@ -1014,6 +1014,21 @@ Options
 | `--url`  | URL of the config.       |  |
 | `--value`  | Inline value of the config. Base64-encoded value is supported with the prefix `base64:`. |  |
 
+#### `update-property`
+
+Update an existing configuration property.
+
+```bash
+default(localhost)> config update-property -p webServiceUrl -v http://<cluster-hostname> mycluster
+```
+
+Options
+
+| Flag               | Description                 | Default         |
+|--------------------|-----------------------------|-----------------|
+| `-p`, `--property` | Property name to update.    |  | 
+| `-v`, `--value`    | New value for the property. |  |
+
 
 #### `view`
 

--- a/site2/docs/reference-cli-tools.md
+++ b/site2/docs/reference-cli-tools.md
@@ -1014,12 +1014,12 @@ Options
 | `--url`  | URL of the config.       |  |
 | `--value`  | Inline value of the config. Base64-encoded value is supported with the prefix `base64:`. |  |
 
-#### `update-property`
+#### `set-property`
 
-Update an existing configuration property.
+Set a value for a specified configuration property.
 
 ```bash
-default(localhost)> config update-property -p webServiceUrl -v http://<cluster-hostname> mycluster
+default(localhost)> config set-property -p webServiceUrl -v http://<cluster-hostname> mycluster
 ```
 
 Options
@@ -1028,6 +1028,21 @@ Options
 |--------------------|-----------------------------|-----------------|
 | `-p`, `--property` | Property name to update.    |  | 
 | `-v`, `--value`    | New value for the property. |  |
+
+
+#### `get-property`
+
+Get the value for a specified configuration property.
+
+```bash
+default(localhost)> config get-property -p webServiceUrl mycluster
+```
+
+Options
+
+| Flag               | Description                 | Default         |
+|--------------------|-----------------------------|-----------------|
+| `-p`, `--property` | Property name to update.    |  | 
 
 
 #### `view`


### PR DESCRIPTION
### Motivation

In Pulsar shell you can only update the whole configuration but you can't modify it later. For instance, if I import a new config and then I want to enable a feature or a property, I need to read the config, copy, modify and update.
My use-case is that I want to enable custom commands in a quick way.

### Modifications

* Added new command `config set-property -p <prop> -v <value> <config>`
It updates or creates a new entry in the config. If you modify the current config, the shell will reload applying the new config.  
* Added new command `config get-property -p <prop>  <config>`
Returns the current value for the property of the config

For example, now I can enable a cli extensions directly from the shell:
```
config use my-config
config update-property -p customCommandsFactories -v <extensionname> my-config
```

- [x] `doc` 