### PR TITLE
[fix][broker] Unregister topic policy listener if managed ledger close failed

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -1323,6 +1323,7 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
                 public void closeFailed(ManagedLedgerException exception, Object ctx) {
                     log.error("[{}] Failed to close managed ledger, proceeding anyway.", topic, exception);
                     brokerService.removeTopicFromCache(topic);
+                    unregisterTopicPolicyListener();
                     closeFuture.complete(null);
                 }
             }, null);


### PR DESCRIPTION
### Motivation

After the topic closed failed due to metadata BadVersionException, we should unregister the topic policy listener.
Otherwise, the topic policy listener will get leaked.

<img width="1206" alt="image" src="https://user-images.githubusercontent.com/12592133/190181897-7601060b-0274-4b66-9c14-be9ae49947b9.png">
