### PR TITLE
[C++] Reset `havePendingPingRequest` flag for any data received from broker

### DIFF
--- a/pulsar-client-cpp/lib/ClientConnection.cc
+++ b/pulsar-client-cpp/lib/ClientConnection.cc
@@ -810,6 +810,10 @@ void ClientConnection::handleIncomingCommand() {
         }
 
         case Ready: {
+            // Since we are receiving data from the connection, we are assuming that for now the connection is
+            // still working well.
+            havePendingPingRequest_ = false;
+
             // Handle normal commands
             switch (incomingCmd_.type()) {
                 case BaseCommand::SEND_RECEIPT: {
@@ -1165,7 +1169,6 @@ void ClientConnection::handleIncomingCommand() {
 
                 case BaseCommand::PONG: {
                     LOG_DEBUG(cnxString_ << "Received response to ping message");
-                    havePendingPingRequest_ = false;
                     break;
                 }
 


### PR DESCRIPTION
### Motivation

The C++ client is waiting to receive a `Pong` response from broker and if it's not received within 30 seconds, it will forcefully close the connection, assuming the broker is unresponsive. 

Java client was changed, a long time ago, to reset the `havePendingPingRequest` every time some data is read from the socket, instead of just when receiving the Ping response.

In C++, what can happen is that if there is a lot of messages being sent to the broker, and consequently lot of responses from the broker, ***and*** the application callbacks are taking long time (either blocking or just using a lot of CPU), then the Ping response might be sitting behind a lot of broker replies and it might take more than 30 seconds to actually process it.

During this time, we are still reading data from the socket and we shouldn't be considering the connection dead.

### Modifications

In the C++ client, use the same logic used for Java client and treat any data read from the connection as a signal that the connection is healthy.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)

- [x] `doc-not-needed` 
(Please explain why)

- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)
