### PR TITLE
[fix][client]Fix Producer exceeds PulsarClient memory limit when sending fail timeout using CompressionType.NONE

### DIFF
--- a/pulsar-common/src/main/java/org/apache/pulsar/common/compression/CompressionCodecNone.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/compression/CompressionCodecNone.java
@@ -20,6 +20,7 @@ package org.apache.pulsar.common.compression;
 
 import io.netty.buffer.ByteBuf;
 import java.io.IOException;
+import org.apache.pulsar.common.allocator.PulsarByteBufAllocator;
 
 /**
  * No compression.
@@ -28,8 +29,13 @@ public class CompressionCodecNone implements CompressionCodec {
 
     @Override
     public ByteBuf encode(ByteBuf raw) {
-        // Provides an encoder that simply returns the same uncompressed buffer
-        return raw.retain();
+        int readableBytes = raw.readableBytes();
+        if (readableBytes == raw.capacity()) {
+            return raw.retain();
+        }
+        ByteBuf target = PulsarByteBufAllocator.DEFAULT.buffer(readableBytes, readableBytes);
+        target.writeBytes(raw);
+        return target;
     }
 
     @Override

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/compression/CompressionCodecNone.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/compression/CompressionCodecNone.java
@@ -33,8 +33,10 @@ public class CompressionCodecNone implements CompressionCodec {
         if (readableBytes == raw.capacity()) {
             return raw.retain();
         }
+        raw.markReaderIndex();
         ByteBuf target = PulsarByteBufAllocator.DEFAULT.buffer(readableBytes, readableBytes);
         target.writeBytes(raw);
+        raw.resetReaderIndex();
         return target;
     }
 

--- a/pulsar-common/src/test/java/org/apache/pulsar/common/compression/CompressorCodecTest.java
+++ b/pulsar-common/src/test/java/org/apache/pulsar/common/compression/CompressorCodecTest.java
@@ -189,4 +189,19 @@ public class CompressorCodecTest {
         compressed.release();
         uncompressed.release();
     }
+
+    @Test
+    public void testCompressionCodecNone() {
+        CompressionCodec codec = CompressionCodecProvider.getCompressionCodec( CompressionType.NONE);
+        ByteBuf uncompressed = PulsarByteBufAllocator.DEFAULT.directBuffer(100);
+
+        byte[] write = new byte[50];
+        uncompressed.writeBytes(write);
+
+        ByteBuf compressed = codec.encode(uncompressed);
+        assertEquals(compressed.capacity(), 50);
+
+        compressed.release();
+        uncompressed.release();
+    }
 }


### PR DESCRIPTION
Fixes https://github.com/apache/pulsar/issues/17662

### Motivation
* Fixes https://github.com/apache/pulsar/issues/17662

* The root cause is that:
    1. After we ever sent a big message, e.g, 2M bytes, the `AbstractBatchMessageContainer#maxBatchSize` will never be less than 2M bytes(see line171) in the following batches,  even if the message size we added is 1 bytes only.
https://github.com/apache/pulsar/blob/a98f025a35935a7a27db3f0919aa6f4453e4fb02/pulsar-client/src/main/java/org/apache/pulsar/client/impl/BatchMessageContainerImpl.java#L167-L173

    2.  So when we add the first message in the following batches,  we will always allocate a byte buffer greater or equals to 2M, see line102
https://github.com/apache/pulsar/blob/a98f025a35935a7a27db3f0919aa6f4453e4fb02/pulsar-client/src/main/java/org/apache/pulsar/client/impl/BatchMessageContainerImpl.java#L98-L103

   3. When we use `CompressionCodecNone` to encode the 2M bytes buffer it just retain the buffer,  which means the 2M bytes buffer will be added to `ProducerImpl#pendingMessages` and will be release until timeout(30s by default).  Note that we sent 1 bytes message(or batched, but it should much less that 2M),  but retain 2M bytes buffer, so it will exceed PulsarClient memory limit.



### Modifications

Copy readable bytes to a new Bytebuf if necessary, like `CompressionCodecLZ4` or other `CompressionCodec` implement

### Verifying this change

- [x] Make sure that the change passes the CI checks.


### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)

- [x] `doc-not-needed` 
(Please explain why)

- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)
