### PR TITLE
[fix][metadata] Set revalidateAfterReconnection true for certain failures

### DIFF
--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/coordination/impl/ResourceLockImpl.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/coordination/impl/ResourceLockImpl.java
@@ -196,6 +196,7 @@ public class ResourceLockImpl<T> implements ResourceLock<T> {
                             // We failed to revalidate the lock due to connectivity issue
                             // Continue assuming we hold the lock, until we can revalidate it, either
                             // on Reconnected or SessionReestablished events.
+                            revalidateAfterReconnection = true;
                             log.warn("Failed to revalidate the lock at {}. Retrying later on reconnection {}", path,
                                     ex.getCause().getMessage());
                         }


### PR DESCRIPTION
### Motivation

In reading through the `ResourceLockImpl`, I noticed that `revalidateAfterReconnection` is always `false`. This seems like an oversight. It was introduced in #11886. 

### Modifications

* Set `revalidateAfterReconnection = true;` when there is a failure during lock validation.

### Verifying this change

I am not sure that this change will actually affect anything. In recently looking through the reconnection lo logs, I noticed the following two get logged together: 

```
2022-07-29T19:44:16,904+0000 [metadata-store-coordination-service-5-1] INFO  org.apache.pulsar.metadata.coordination.impl.LockManagerImpl - Metadata store connection has been re-established. Revalidating locks that were pending.
2022-07-29T19:44:16,984+0000 [metadata-store-coordination-service-5-1] INFO  org.apache.pulsar.metadata.coordination.impl.LockManagerImpl - Metadata store session has been re-established. Revalidating all the existing locks.
```

These logs relate to the following:

https://github.com/apache/pulsar/blob/12ca27fa800c72b0c9a6e7f2583a9daa2497add9/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/coordination/impl/LockManagerImpl.java#L125-L136

Note that the changes in this PR will affect how `lock.revalidateIfNeededAfterReconnection()` will run, but if the lock is going to be revalidated in a subsequent call because there is always another ZK notification that triggers the `lock.revalidate(lock.getValue())`, then I am not sure that this PR is important. I'll continue looking into this.

### Documentation

- [x] `doc-not-needed` 
