### PR TITLE
[fix][ml]persistentMarkDeletePosition is ahead of markDeletePosition in ManagedCursor when handling seek request

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
@@ -230,7 +230,7 @@ public class ManagedCursorImpl implements ManagedCursor {
         }
 
         public void triggerComplete() {
-            // Trigger the final callback after having (eventually) triggered the switchin-ledger operation. This
+            // Trigger the final callback after having (eventually) triggered the switching-ledger operation. This
             // will ensure that no race condition will happen between the next mark-delete and the switching
             // operation.
             if (callbackGroup != null) {
@@ -1277,8 +1277,9 @@ public class ManagedCursorImpl implements ManagedCursor {
 
         persistentMarkDeletePosition = null;
         inProgressMarkDeletePersistPosition = null;
-        lastMarkDeleteEntry = new MarkDeleteEntry(newPosition, getProperties(), null, null);
-        internalAsyncMarkDelete(newPosition, isCompactionCursor() ? getProperties() : Collections.emptyMap(),
+        PositionImpl newMarkDeletePosition = ledger.getPreviousPosition(newPosition);
+        lastMarkDeleteEntry = new MarkDeleteEntry(newMarkDeletePosition, getProperties(), null, null);
+        internalAsyncMarkDelete(newMarkDeletePosition, isCompactionCursor() ? getProperties() : Collections.emptyMap(),
                 new MarkDeleteCallback() {
             @Override
             public void markDeleteComplete(Object ctx) {
@@ -2005,7 +2006,7 @@ public class ManagedCursorImpl implements ManagedCursor {
 
         LAST_MARK_DELETE_ENTRY_UPDATER.updateAndGet(this, last -> {
             if (last != null && last.newPosition.compareTo(mdEntry.newPosition) > 0) {
-                // keep the current value since it's later then the mdEntry.newPosition
+                // keep the current value since it's later than the mdEntry.newPosition
                 return last;
             } else {
                 return mdEntry;

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/SubscriptionSeekTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/SubscriptionSeekTest.java
@@ -35,6 +35,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.bookkeeper.mledger.ManagedCursor;
 import org.apache.pulsar.broker.service.persistent.PersistentSubscription;
 import org.apache.pulsar.broker.service.persistent.PersistentTopic;
 import org.apache.pulsar.client.admin.PulsarAdminException;
@@ -110,6 +111,9 @@ public class SubscriptionSeekTest extends BrokerTestBase {
         Awaitility.await().until(consumer::isConnected);
         consumer.seek(messageIds.get(5));
         assertEquals(sub.getNumberOfEntriesInBacklog(false), 5);
+
+        ManagedCursor cursor = topicRef.getSubscription("my-subscription").getCursor();
+        assertEquals(cursor.getMarkDeletedPosition(), cursor.getPersistentMarkDeletedPosition());
 
         MessageIdImpl messageId = (MessageIdImpl) messageIds.get(5);
         MessageIdImpl beforeEarliest = new MessageIdImpl(


### PR DESCRIPTION
### Motivation
When the client seek a position, it will update the read posistion and mark delete position in the cursor. And meanwhile, it will persist the mark delete position to Bookie, then record the persistent mark delete position in the field `persistentMarkDeletePosition`. 

However, The persistent mark delete position `persistentMarkDeletePosition` is ahead of `markDeletePosition` after seek , which is obviously unreasonable.

https://github.com/apache/pulsar/blob/cbbcd41cfc80793cf025ef98390339395ecd48ac/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java#L125-L132

### Modifications
- Persistent the previous seek position as new persistent mark delete position into Bookie.
- Clean up code

### Verifying this change

- [x]  Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.
### Does this pull request potentially affect one of the following parts:

If `yes` was chosen, please highlight the changes

- Dependencies (does it add or upgrade a dependency): (no)
- The public API: (no)
- The schema: (no)
- The default values of configurations: (no)
- The wire protocol: (no)
- The rest endpoints: (no)
- The admin cli options: (no)
- Anything that affects deployment: (no)

### Documentation
Check the box below and label this PR (if you have committer privilege).

Need to update docs? 
- [x] `doc-not-needed` 

### Matching PR in forked repository

PR in forked repository: https://github.com/HQebupt/pulsar/pull/6