### PR TITLE
[fix][doc] Fix M1 JVM Installation Instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,46 +138,6 @@ components in the Pulsar ecosystem, including connectors, adapters, and other la
 > Note: this project includes a [Maven Wrapper](https://maven.apache.org/wrapper/) that can be used instead of a system installed Maven.
 > Use it by replacing `mvn` by `./mvnw` on Linux and `mvnw.cmd` on Windows in the commands below.
 
-### Install JDK on M1
-In the current version, Pulsar uses a BookKeeper version which in turn uses RocksDB. RocksDB is compiled to work on x86 architecture and not ARM. Therefore, Pulsar can only work with x86 JDK. This is planned to be fixed in future versions of Pulsar.
-
-One of the ways to easily install an x86 JDK is to use [SDKMan](http://sdkman.io) as outlined in the following steps:
-
-1. Install [SDKMan](http://sdkman.io).
-
-Follow the instructions on the SDKMan website.
-
-2. Turn on Rosetta2 compatibility for SDKMan by editing `~/.sdkman/etc/config` and changing the following property from `false` to `true`.
-
-```properties
-sdkman_rosetta2_compatible=true
-```
-
-3. Close the current shell / terminal window and open a new one.
-4. Make sure you don't have any previously installed JVM of the same version by listing existing installed versions.
-
-```shell
-sdk list java|grep installed
-```
-
-Example output:
-
-```text
-               | >>> | 17.0.3.6.1   | amzn    | installed  | 17.0.3.6.1-amzn
-```
-
-If you have any Java 17 version installed, uninstall it.
-
-```shell
-sdk uinstall java 17.0.3.6.1
-```
-
-5. Install any Java versions greater than Java 8.
-
-```shell
-sdk install java 17.0.3.6.1-amzn
-```
-
 ### Build
 Compile and install:
 

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ components in the Pulsar ecosystem, including connectors, adapters, and other la
 
 ## Build Pulsar
 
-Requirements:
+### Requirements
 
 - JDK
 
@@ -138,6 +138,47 @@ Requirements:
 > Note: this project includes a [Maven Wrapper](https://maven.apache.org/wrapper/) that can be used instead of a system installed Maven.
 > Use it by replacing `mvn` by `./mvnw` on Linux and `mvnw.cmd` on Windows in the commands below.
 
+### Install JDK on M1
+In the current version, Pulsar uses a BookKeeper version which in turn uses RocksDB. RocksDB is compiled to work on x86 architecture and not ARM. Therefore, Pulsar can only work with x86 JDK. This is planned to be fixed in future versions of Pulsar.
+
+One of the ways to easily install an x86 JDK is to use [SDKMan](http://sdkman.io) as outlined in the following steps:
+
+1. Install [SDKMan](http://sdkman.io).
+
+Follow the instructions on the SDKMan website.
+
+2. Turn on Rosetta2 compatibility for SDKMan by editing `~/.sdkman/etc/config` and changing the following property from `false` to `true`.
+
+```properties
+sdkman_rosetta2_compatible=true
+```
+
+3. Close the current shell / terminal window and open a new one.
+4. Make sure you don't have any previously installed JVM of the same version by listing existing installed versions.
+
+```shell
+sdk list java|grep installed
+```
+
+Example output:
+
+```text
+               | >>> | 17.0.3.6.1   | amzn    | installed  | 17.0.3.6.1-amzn
+```
+
+If you have any Java 17 version installed, uninstall it.
+
+```shell
+sdk uinstall java 17.0.3.6.1
+```
+
+5. Install any Java versions greater than Java 8.
+
+```shell
+sdk install java 17.0.3.6.1-amzn
+```
+
+### Build
 Compile and install:
 
 ```bash
@@ -150,7 +191,7 @@ Compile and install individual module
 $ mvn -pl module-name (e.g: pulsar-broker) install -DskipTests
 ```
 
-## Minimal build (This skips most of external connectors and tiered storage handlers)
+### Minimal build (This skips most of external connectors and tiered storage handlers)
 
 ```
 mvn install -Pcore-modules,-main -DskipTests

--- a/site2/website/versioned_docs/version-2.10.x/getting-started-standalone.md
+++ b/site2/website/versioned_docs/version-2.10.x/getting-started-standalone.md
@@ -37,13 +37,7 @@ One of the ways to easily install an x86 JDK is to use [SDKMan](http://sdkman.io
 
 1. Install [SDKMan](http://sdkman.io).
 
- * Method 1: follow instructions on the SDKMan website.
- 
- * Method 2: if you have [Homebrew](https://brew.sh) installed, enter the following command.
-
-```shell
-brew install sdkman
-```
+Follow the instructions on the SDKMan website.
 
 2. Turn on Rosetta2 compatibility for SDKMan by editing `~/.sdkman/etc/config` and changing the following property from `false` to `true`.
 


### PR DESCRIPTION
### Modifications

Fix the documentation of installing JVM on M1 - remove one installation method of sdkman (using brew) and add the deleted instructions to building Pulsar on README

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)

- [ ] `doc-not-needed` 
(Please explain why)

- [x] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)
