### PR TITLE
[improve][cli] Pulsar shell: allow to create a new config (--file) with a relative path

### DIFF
--- a/bin/pulsar-shell
+++ b/bin/pulsar-shell
@@ -34,6 +34,7 @@ BINDIR=$(dirname "$PRG")
 export PULSAR_HOME=`cd -P $BINDIR/..;pwd`
 . "$PULSAR_HOME/bin/pulsar-admin-common.sh"
 OPTS="-Dorg.jline.terminal.jansi=false $OPTS"
+OPTS="-Dpulsar.shell.working.dir=$(pwd) $OPTS"
 DEFAULT_CONFIG="-Dpulsar.shell.config.default=$PULSAR_CLIENT_CONF"
 
 #Change to PULSAR_HOME to support relative paths

--- a/bin/pulsar-shell.cmd
+++ b/bin/pulsar-shell.cmd
@@ -28,6 +28,7 @@ if ERRORLEVEL 1 (
 )
 
 set "OPTS=%OPTS% -Dorg.jline.terminal.jansi=false"
+set "OPTS=%OPTS% -Dpulsar.shell.config.default=%cd%"
 set "DEFAULT_CONFIG=-Dpulsar.shell.config.default="%PULSAR_CLIENT_CONF%""
 cd "%PULSAR_HOME%"
 "%JAVACMD%" %OPTS%  %DEFAULT_CONFIG%  org.apache.pulsar.shell.PulsarShell %*

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/shell/ConfigShell.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/shell/ConfigShell.java
@@ -50,6 +50,15 @@ import org.apache.pulsar.shell.config.ConfigStore;
 @Parameters(commandDescription = "Manage Pulsar shell configurations.")
 public class ConfigShell implements ShellCommandsProvider {
 
+    private static final String LOCAL_FILES_BASE_DIR = System.getProperty("pulsar.shell.working.dir");
+
+    static File resolveLocalFile(String input) {
+        if (LOCAL_FILES_BASE_DIR != null) {
+            return new File(LOCAL_FILES_BASE_DIR, input);
+        }
+        return new File(input);
+    }
+
 
     @Getter
     @Parameters
@@ -305,7 +314,7 @@ public class ConfigShell implements ShellCommandsProvider {
                     value = inlineValue;
                 }
             } else if (file != null) {
-                final File f = new File(file);
+                final File f = resolveLocalFile(file);
                 if (!f.exists()) {
                     print("File " + f.getAbsolutePath() + " not found.");
                     return false;

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/shell/JCommanderCompleter.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/shell/JCommanderCompleter.java
@@ -172,7 +172,7 @@ public class JCommanderCompleter {
         if (parameterCompleter != null) {
             final ParameterCompleter.Type completer = parameterCompleter.type();
             if (completer == ParameterCompleter.Type.FILES) {
-                valueCompleter = new Completers.FilesCompleter(new File(System.getProperty("user.dir")));
+                valueCompleter = new Completers.FilesCompleter(ConfigShell.resolveLocalFile("."));
             } else if (completer == ParameterCompleter.Type.CONFIGS) {
                 valueCompleter = new Completer() {
                     @Override

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/shell/JCommanderCompleter.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/shell/JCommanderCompleter.java
@@ -22,7 +22,6 @@ import static java.lang.annotation.ElementType.FIELD;
 import com.beust.jcommander.JCommander;
 import com.beust.jcommander.ParameterDescription;
 import com.beust.jcommander.WrappedParameter;
-import java.io.File;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 import java.lang.reflect.Field;


### PR DESCRIPTION
### Motivation
After https://github.com/apache/pulsar/pull/17648 it's no more possible to create/update configs from a relative path (at least is not relative to the current directory but from the Pulsar home dir which is not useful)

### Modifications

* Added current dir as system property. Pulsar shell uses it for autocompletion and for resolving the file passed with `--file`

- [x] `doc-not-needed` 
