### PR TITLE
[fix][admin] Fix NoClassDefFoundError in the pulsar admin CLI tools

### DIFF
--- a/distribution/shell/pom.xml
+++ b/distribution/shell/pom.xml
@@ -36,6 +36,12 @@
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>
+      <artifactId>pulsar-client-tools-api</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>${project.groupId}</groupId>
       <artifactId>pulsar-client-tools</artifactId>
       <version>${project.version}</version>
     </dependency>


### PR DESCRIPTION

<!--
### Contribution Checklist
  
  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://docs.google.com/document/d/1d8Pw6ZbWk-_pCKdOmdvx9rnhPiyuxwq60_TrD68d7BA/edit#heading=h.trs9rsex3xom)*. 

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->

Fixes #17683 


### Motivation

https://github.com/apache/pulsar/pull/17158 introduces a new module called `pulsar-client-tools-api`. But this module is not added to the `distribution/shell`. This leads to the no class found error when using the pulsar-admin tool.

### Modifications

* Add dependency `pulsar-client-tools-api` to the `distribution/shell`.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change can be verified as follows:

* Run `bin/pulsar-admin` and it works fine.

### Does this pull request potentially affect one of the following parts:

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)

- [x] `doc-not-needed` 
(Please explain why)

- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)
