### PR TITLE
[feat][CI] Add approval solution to reduce GitHub Actions resource consumption

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -93,8 +93,3 @@ The tests will be run in the forked repository until all PR review comments have
 been handled, the tests pass and the PR is approved by a reviewer.
 
 -->
-
-
-
-
-

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -76,3 +76,25 @@ This change added tests and can be verified as follows:
 
 - [ ] `doc-complete`
 (Docs have been already added)
+
+### Matching PR in forked repository
+
+PR in forked repository: <!-- ENTER URL HERE 
+
+After opening this PR, the build in apache/pulsar will fail and instructions will
+be provided for opening a PR in the PR author's forked repository.
+
+apache/pulsar pull requests should be first tested in your own fork since the 
+apache/pulsar CI based on GitHub Actions has constrained resources and quota.
+GitHub Actions provides separate quota for pull requests that are executed in 
+a forked repository.
+
+The tests will be run in the forked repository until all PR review comments have
+been handled, the tests pass and the PR is approved by a reviewer.
+
+-->
+
+
+
+
+

--- a/.github/workflows/ci-cpp-build.yaml
+++ b/.github/workflows/ci-cpp-build.yaml
@@ -38,7 +38,6 @@ jobs:
     outputs:
       docs_only: ${{ needs.changed_files_job.outputs.docs_only }}
       cpp_only: ${{ needs.changed_files_job.outputs.cpp_only }}
-      changed_tests: ${{ steps.changes.outputs.tests_files }}
     steps:
       - name: checkout
         uses: actions/checkout@v2
@@ -54,6 +53,12 @@ jobs:
         id: check_changes
         run: |
           echo "::set-output name=docs_only::${{ fromJSON(steps.changes.outputs.all_count) == fromJSON(steps.changes.outputs.docs_count) && fromJSON(steps.changes.outputs.docs_count) > 0 }}"
+          echo "::set-output name=cpp_only::${{ fromJSON(steps.changes.outputs.all_count) == fromJSON(steps.changes.outputs.cpp_count) && fromJSON(steps.changes.outputs.cpp_count) > 0 }}"
+
+      - name: Check if the PR has been approved for testing
+        if: ${{ steps.check_changes.outputs.docs_only != 'true' && github.repository == 'apache/pulsar' && github.event_name == 'pull_request' }}
+        run: |
+          build/pulsar_ci_tool.sh check_ready_to_test
 
   cpp-build-centos7:
     needs: changed_files_job

--- a/.github/workflows/ci-cpp-build.yaml
+++ b/.github/workflows/ci-cpp-build.yaml
@@ -53,7 +53,6 @@ jobs:
         id: check_changes
         run: |
           echo "::set-output name=docs_only::${{ fromJSON(steps.changes.outputs.all_count) == fromJSON(steps.changes.outputs.docs_count) && fromJSON(steps.changes.outputs.docs_count) > 0 }}"
-          echo "::set-output name=cpp_only::${{ fromJSON(steps.changes.outputs.all_count) == fromJSON(steps.changes.outputs.cpp_count) && fromJSON(steps.changes.outputs.cpp_count) > 0 }}"
 
       - name: Check if the PR has been approved for testing
         if: ${{ steps.check_changes.outputs.docs_only != 'true' && github.repository == 'apache/pulsar' && github.event_name == 'pull_request' }}

--- a/.github/workflows/ci-cpp-build.yaml
+++ b/.github/workflows/ci-cpp-build.yaml
@@ -33,7 +33,7 @@ concurrency:
 
 jobs:
   changed_files_job:
-    name: 'Changed files check'
+    name: Preconditions
     runs-on: ubuntu-20.04
     outputs:
       docs_only: ${{ needs.changed_files_job.outputs.docs_only }}

--- a/.github/workflows/ci-go-functions.yaml
+++ b/.github/workflows/ci-go-functions.yaml
@@ -36,7 +36,7 @@ env:
 
 jobs:
   changed_files_job:
-    name: 'Changed files check'
+    name: Preconditions
     runs-on: ubuntu-20.04
     outputs:
       docs_only: ${{ steps.check_changes.outputs.docs_only }}

--- a/.github/workflows/ci-go-functions.yaml
+++ b/.github/workflows/ci-go-functions.yaml
@@ -41,7 +41,6 @@ jobs:
     outputs:
       docs_only: ${{ steps.check_changes.outputs.docs_only }}
       cpp_only: ${{ steps.check_changes.outputs.cpp_only }}
-      changed_tests: ${{ steps.changes.outputs.tests_files }}
     steps:
       - name: checkout
         uses: actions/checkout@v2
@@ -57,6 +56,12 @@ jobs:
         id: check_changes
         run: |
           echo "::set-output name=docs_only::${{ fromJSON(steps.changes.outputs.all_count) == fromJSON(steps.changes.outputs.docs_count) && fromJSON(steps.changes.outputs.docs_count) > 0 }}"
+          echo "::set-output name=cpp_only::${{ fromJSON(steps.changes.outputs.all_count) == fromJSON(steps.changes.outputs.cpp_count) && fromJSON(steps.changes.outputs.cpp_count) > 0 }}"
+
+      - name: Check if the PR has been approved for testing
+        if: ${{ steps.check_changes.outputs.docs_only != 'true' && github.repository == 'apache/pulsar' && github.event_name == 'pull_request' }}
+        run: |
+          build/pulsar_ci_tool.sh check_ready_to_test
 
   check-style:
     needs: changed_files_job

--- a/.github/workflows/pulsar-ci-flaky.yaml
+++ b/.github/workflows/pulsar-ci-flaky.yaml
@@ -60,6 +60,11 @@ jobs:
           echo "::set-output name=docs_only::${{ fromJSON(steps.changes.outputs.all_count) == fromJSON(steps.changes.outputs.docs_count) && fromJSON(steps.changes.outputs.docs_count) > 0 }}"
           echo "::set-output name=cpp_only::${{ fromJSON(steps.changes.outputs.all_count) == fromJSON(steps.changes.outputs.cpp_count) && fromJSON(steps.changes.outputs.cpp_count) > 0 }}"
 
+      - name: Check if the PR has been approved for testing
+        if: ${{ steps.check_changes.outputs.docs_only != 'true' && github.repository == 'apache/pulsar' && github.event_name == 'pull_request' }}
+        run: |
+          build/pulsar_ci_tool.sh check_ready_to_test
+
   build-and-test:
     needs: changed_files_job
     name: Flaky tests suite

--- a/.github/workflows/pulsar-ci-flaky.yaml
+++ b/.github/workflows/pulsar-ci-flaky.yaml
@@ -37,7 +37,7 @@ env:
 
 jobs:
   changed_files_job:
-    name: 'Changed files check'
+    name: Preconditions
     runs-on: ubuntu-20.04
     outputs:
       docs_only: ${{ steps.check_changes.outputs.docs_only }}

--- a/.github/workflows/pulsar-ci.yaml
+++ b/.github/workflows/pulsar-ci.yaml
@@ -37,7 +37,7 @@ env:
 
 jobs:
   changed_files_job:
-    name: 'Changed files check'
+    name: Preconditions
     runs-on: ubuntu-20.04
     outputs:
       docs_only: ${{ steps.check_changes.outputs.docs_only }}

--- a/.github/workflows/pulsar-ci.yaml
+++ b/.github/workflows/pulsar-ci.yaml
@@ -60,6 +60,11 @@ jobs:
           echo "::set-output name=docs_only::${{ fromJSON(steps.changes.outputs.all_count) == fromJSON(steps.changes.outputs.docs_count) && fromJSON(steps.changes.outputs.docs_count) > 0 }}"
           echo "::set-output name=cpp_only::${{ fromJSON(steps.changes.outputs.all_count) == fromJSON(steps.changes.outputs.cpp_count) && fromJSON(steps.changes.outputs.cpp_count) > 0 }}"
 
+      - name: Check if the PR has been approved for testing
+        if: ${{ steps.check_changes.outputs.docs_only != 'true' && github.repository == 'apache/pulsar' && github.event_name == 'pull_request' }}
+        run: |
+          build/pulsar_ci_tool.sh check_ready_to_test
+
   build-and-license-check:
     needs: changed_files_job
     name: Build and License check

--- a/build/pulsar_ci_tool.sh
+++ b/build/pulsar_ci_tool.sh
@@ -179,6 +179,8 @@ function ci_check_ready_to_test() {
   FORK_REPO_URL=$(jq -r '.pull_request.head.repo.html_url' "$GITHUB_EVENT_PATH")
   PR_BRANCH_LABEL=$(jq -r '.pull_request.head.label' "$GITHUB_EVENT_PATH")
   PR_URL=$(jq -r '.pull_request.html_url' "$GITHUB_EVENT_PATH")
+  FORK_PR_TITLE_URL_ENCODED=$(jq -r '"[run-tests] " + .pull_request.title | @uri' "$GITHUB_EVENT_PATH")
+  FORK_PR_BODY_URL_ENCODED=$(jq -n -r "\"This PR is for running tests for upstream PR ${PR_URL}.\" | @uri")
   >&2 tee -a "$GITHUB_STEP_SUMMARY" <<EOF
 
 # Instructions for proceeding with the pull request:
@@ -191,7 +193,7 @@ pull requests that are executed in a forked repository.
    Sync your fork if it's behind.
 2. Open a pull request to your own fork. You can use this link to create the pull request in
    your own fork:
-   ${FORK_REPO_URL}/compare/master...${PR_BRANCH_LABEL}?expand=1
+   [Create PR in fork for running tests](${FORK_REPO_URL}/compare/master...${PR_BRANCH_LABEL}?expand=1&title=${FORK_PR_TITLE_URL_ENCODED}&body=${FORK_PR_BODY_URL_ENCODED})
 3. Edit the description of the pull request ${PR_URL} and add the link to the PR that you opened to your own fork
    so that the reviewer can verify that tests pass in your own fork.
 4. Ensure that tests pass in your own fork. Your own fork will be used to run the tests during the PR review

--- a/build/pulsar_ci_tool.sh
+++ b/build/pulsar_ci_tool.sh
@@ -160,7 +160,7 @@ function ci_check_ready_to_test() {
     return 1
   fi
   # check ready-to-test label
-  if ! yq eval -e '.pull_request.labels[] | .name | select(. == "ready-to-test")' "$GITHUB_EVENT_PATH" &> /dev/null; then
+  if ! jq -e '.pull_request.labels[] | .name | select(. == "ready-to-test")' "$GITHUB_EVENT_PATH" &> /dev/null; then
     # check if the PR has been approved
     PR_NUM=$(jq -r '.pull_request.number' "${GITHUB_EVENT_PATH}")
     REPO_FULL_NAME=$(jq -r '.repository.full_name' "${GITHUB_EVENT_PATH}")

--- a/build/pulsar_ci_tool.sh
+++ b/build/pulsar_ci_tool.sh
@@ -198,8 +198,10 @@ pull requests that are executed in a forked repository.
    by Apache Pulsar committers.
 6. When tests pass on the apache/pulsar side, the PR can be merged by a Apache Pulsar Committer.
 
-If you have any trouble, please join the #contributor channel on Pulsar Slack to get real-time support.
-Instructions for joining Pulsar Slack: https://pulsar.apache.org/community#section-discussions
+If you have any trouble you can get support in multiple ways:
+* by sending email to the [dev mailing list](mailto:dev@pulsar.apache.org) ([subscribe](mailto:dev-subscribe@pulsar.apache.org))
+* on the [#contributors channel on Pulsar Slack](https://apache-pulsar.slack.com/channels/contributors) ([join](https://pulsar.apache.org/community#section-discussions))
+* in apache/pulsar [GitHub discussions Q&A](https://github.com/apache/pulsar/discussions/categories/q-a)
 
 EOF
       return 1

--- a/build/pulsar_ci_tool.sh
+++ b/build/pulsar_ci_tool.sh
@@ -180,7 +180,7 @@ function ci_check_ready_to_test() {
   PR_BRANCH_LABEL=$(jq -r '.pull_request.head.label' "$GITHUB_EVENT_PATH")
   PR_URL=$(jq -r '.pull_request.html_url' "$GITHUB_EVENT_PATH")
   FORK_PR_TITLE_URL_ENCODED=$(jq -r '"[run-tests] " + .pull_request.title | @uri' "$GITHUB_EVENT_PATH")
-  FORK_PR_BODY_URL_ENCODED=$(jq -n -r "\"This PR is for running tests for upstream PR ${PR_URL}.\" | @uri")
+  FORK_PR_BODY_URL_ENCODED=$(jq -n -r "\"This PR is for running tests for upstream PR ${PR_URL}.\n\n<!-- Before creating this PR, please ensure that the fork $FORK_REPO_URL is up to date with https://github.com/apache/pulsar -->\" | @uri")
   >&2 tee -a "$GITHUB_STEP_SUMMARY" <<EOF
 
 # Instructions for proceeding with the pull request:

--- a/build/pulsar_ci_tool.sh
+++ b/build/pulsar_ci_tool.sh
@@ -202,7 +202,7 @@ If you have any trouble, please join the #contributor channel on Pulsar Slack to
 Instructions for joining Pulsar Slack: https://pulsar.apache.org/community#section-discussions
 
 EOF
-      exit 1
+      return 1
     fi
   fi
 }


### PR DESCRIPTION
### Motivation

Mailing list discussion: https://lists.apache.org/thread/gwfmxmxlhtsjn17sxxc367jcs4pcwofz


To reduce resource consumption, PRs would require approval before all tests would be run.

PR authors would be required to run tests in their own forks to make sure that tests pass and
before the PR is approved. Alternatively Apache Pulsar committers can add a ready-to-test label
to the PR to make it eligible for testing.

This way PR authors would have CI feedback without causing resource shortage to apache/pulsar CI.

### Modifications

- stop non-doc CI builds if the PR isn't approved OR doesn't have the "ready-to-test" label. 
- Provide detailed instructions for the PR author for creating PR in their own fork by simply clicking a link.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [x] `doc-required` 
(Your PR needs to update docs and you will update later)
  Contributor guide needs updates. 

- [ ] `doc-not-needed` 
(Please explain why)

- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)
