### PR TITLE
[fix][broker] Fix executeWithRetry result is null

### DIFF
--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/cache/impl/MetadataCacheImpl.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/cache/impl/MetadataCacheImpl.java
@@ -294,12 +294,12 @@ public class MetadataCacheImpl<T> implements MetadataCache<T>, Consumer<Notifica
 
     private CompletableFuture<T> executeWithRetry(Supplier<CompletableFuture<T>> op, String key) {
         CompletableFuture<T> result = new CompletableFuture<>();
-        op.get().thenAccept(r -> result.complete(r)).exceptionally((ex) -> {
+        op.get().thenAccept(result::complete).exceptionally((ex) -> {
             if (ex.getCause() instanceof BadVersionException) {
                 // if resource is updated by other than metadata-cache then metadata-cache will get bad-version
                 // exception. so, try to invalidate the cache and try one more time.
                 objCache.synchronous().invalidate(key);
-                op.get().thenAccept((c) -> result.complete(null)).exceptionally((ex1) -> {
+                op.get().thenAccept(result::complete).exceptionally((ex1) -> {
                     result.completeExceptionally(ex1.getCause());
                     return null;
                 });

--- a/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/MetadataCacheTest.java
+++ b/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/MetadataCacheTest.java
@@ -491,15 +491,21 @@ public class MetadataCacheTest extends BaseMetadataStoreTest {
 
         MyClass value1 = new MyClass("a", 1);
         objCache1.create(key1, value1).join();
-        objCache1.get(key1).join();
+        assertEquals(objCache1.get(key1).join().get().b, 1);
 
-        objCache2.readModifyUpdate(key1, v -> {
+        CompletableFuture<MyClass> future1 = objCache1.readModifyUpdate(key1, v -> {
             return new MyClass(v.a, v.b + 1);
-        }).join();
+        });
 
-        objCache1.readModifyUpdate(key1, v -> {
+        CompletableFuture<MyClass> future2 = objCache2.readModifyUpdate(key1, v -> {
             return new MyClass(v.a, v.b + 1);
-        }).join();
+        });
+
+        MyClass myClass1 = future1.join();
+        assertEquals(myClass1.b, 2);
+
+        MyClass myClass2 = future2.join();
+        assertEquals(myClass2.b, 3);
     }
 
     @Test(dataProvider = "impl")


### PR DESCRIPTION
### Motivation
In line 302 of `MetadataCacheImpl#executeWithRetry`,
the result of the future is set to a `null` value, which will lead to getting the result of `readModifyUpdate` and `readModifyUpdateOrCreate` will get a null value.
Fortunately, we haven't used this value for the time being.

https://github.com/apache/pulsar/blob/774c50b955d5be799ffbeee8c10d79f7dcb31d3b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/cache/impl/MetadataCacheImpl.java#L295-L313

### Modifications

Fix executeWithRetry result is null and modify the test to cover it.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)

- [x] `doc-not-needed` 
(Please explain why)

- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)
