### PR TITLE
[improve][common] Remove reflection from DnsResolverUtil

### DIFF
--- a/pulsar-common/src/test/java/org/apache/pulsar/common/util/netty/DnsResolverUtilTest.java
+++ b/pulsar-common/src/test/java/org/apache/pulsar/common/util/netty/DnsResolverUtilTest.java
@@ -1,0 +1,42 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.common.util.netty;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import io.netty.resolver.dns.DnsNameResolverBuilder;
+import java.security.Security;
+import org.testng.annotations.Test;
+
+public class DnsResolverUtilTest {
+    static {
+        Security.setProperty("networkaddress.cache.ttl", "31");
+        Security.setProperty("networkaddress.cache.negative.ttl", "11");
+    }
+
+    private final DnsNameResolverBuilder builder = mock(DnsNameResolverBuilder.class);
+
+    @Test
+    public void test() {
+        DnsResolverUtil.applyJdkDnsCacheSettings(builder);
+
+        verify(builder).ttl(DnsResolverUtil.MIN_TTL, 31);
+        verify(builder).negativeTtl(11);
+    }
+}

--- a/pulsar-common/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/pulsar-common/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline


### PR DESCRIPTION
## Motivation

DnsResolverUtil uses reflection to get DNS cache policy ttl and negative ttl settings from sun.net.InetAddressCachePolicy. This results in IllegalAccessException if `--add-opens java.base/sun.net=ALL-UNNAMED` has not been added to the JVM flags.

These two settings are available as system security properties as documented https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/net/doc-files/net-properties.html in the Address Cache section.

## Changes

* Replace the reflection with lookups of `networkaddress.cache.ttl` and `networkaddress.cache.negative.ttl` properties respectively

### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Does this pull request potentially affect one of the following parts:

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)

- [x] `doc-not-needed` 
(Please explain why)

- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)
