### PR TITLE
[fix][doc] Replace reference-configuration page with an external link

### DIFF
--- a/site2/docs/reference-configuration.md
+++ b/site2/docs/reference-configuration.md
@@ -1,9 +1,0 @@
----
-id: reference-configuration
-title: Pulsar configuration
-sidebar_label: "Pulsar configuration"
----
-
-You can manage Pulsar configuration by configuration files in the `conf` directory of a Pulsar [installation](getting-started-standalone.md).
-
-For a full list of the configuration of different components, see [Pulsar Reference](https://pulsar.apache.org/reference).

--- a/site2/website/sidebars.json
+++ b/site2/website/sidebars.json
@@ -354,7 +354,11 @@
       "items": [
         "reference-terminology",
         "reference-cli-tools",
-        "reference-configuration",
+        {
+          "type": "link",
+          "href": "https://pulsar.apache.org/reference",
+          "label": "Pulsar configuration"
+        },
         "reference-metrics",
         "reference-rest-api-overview",
         {


### PR DESCRIPTION
### Motivation

The link `Pulsar reference` points to `/reference`, which is handled by Docusaurus as an SPA page and will result in 404. This is a known limitation of Docusaurus(facebook/docusaurus#3309) and the known workaround does not work well either.

### Modifications

Therefore, we decided to use an external link in the sidebar to redirect users to `/reference` directly.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] Anything that affects deployment

### Documentation

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)

- [ ] `doc-not-needed` 
(Please explain why)

- [x] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)
