### PR TITLE
[improve][txn]PIP-160 make txn components supports buffered writer metrics

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
@@ -112,6 +112,7 @@ import org.apache.pulsar.broker.storage.ManagedLedgerStorage;
 import org.apache.pulsar.broker.transaction.buffer.TransactionBufferProvider;
 import org.apache.pulsar.broker.transaction.buffer.impl.TransactionBufferClientImpl;
 import org.apache.pulsar.broker.transaction.pendingack.TransactionPendingAckStoreProvider;
+import org.apache.pulsar.broker.transaction.pendingack.impl.MLPendingAckStoreProvider;
 import org.apache.pulsar.broker.validator.MultipleListenerValidator;
 import org.apache.pulsar.broker.validator.TransactionBatchedWriteValidator;
 import org.apache.pulsar.broker.web.WebService;
@@ -168,6 +169,7 @@ import org.apache.pulsar.packages.management.core.impl.DefaultPackagesStorageCon
 import org.apache.pulsar.packages.management.core.impl.PackagesManagementImpl;
 import org.apache.pulsar.policies.data.loadbalancer.AdvertisedListener;
 import org.apache.pulsar.transaction.coordinator.TransactionMetadataStoreProvider;
+import org.apache.pulsar.transaction.coordinator.impl.MLTransactionMetadataStoreProvider;
 import org.apache.pulsar.websocket.WebSocketConsumerServlet;
 import org.apache.pulsar.websocket.WebSocketPingPongServlet;
 import org.apache.pulsar.websocket.WebSocketProducerServlet;
@@ -822,6 +824,9 @@ public class PulsarService implements AutoCloseable, ShutdownService {
 
             // Register pulsar system namespaces and start transaction meta store service
             if (config.isTransactionCoordinatorEnabled()) {
+                MLTransactionMetadataStoreProvider.initBufferedWriterMetrics(getAdvertisedAddress());
+                MLPendingAckStoreProvider.initBufferedWriterMetrics(getAdvertisedAddress());
+
                 this.transactionBufferSnapshotService = new SystemTopicBaseTxnBufferSnapshotService(getClient());
                 this.transactionTimer =
                         new HashedWheelTimer(new DefaultThreadFactory("pulsar-transaction-timer"));

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/pendingack/impl/MLPendingAckStore.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/pendingack/impl/MLPendingAckStore.java
@@ -61,6 +61,7 @@ import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.transaction.coordinator.impl.TxnBatchedPositionImpl;
 import org.apache.pulsar.transaction.coordinator.impl.TxnLogBufferedWriter;
 import org.apache.pulsar.transaction.coordinator.impl.TxnLogBufferedWriterConfig;
+import org.apache.pulsar.transaction.coordinator.impl.TxnLogBufferedWriterMetricsStats;
 import org.jctools.queues.MessagePassingQueue;
 import org.jctools.queues.SpscArrayQueue;
 import org.slf4j.Logger;
@@ -119,7 +120,7 @@ public class MLPendingAckStore implements PendingAckStore {
     public MLPendingAckStore(ManagedLedger managedLedger, ManagedCursor cursor,
                              ManagedCursor subManagedCursor, long transactionPendingAckLogIndexMinLag,
                              TxnLogBufferedWriterConfig bufferedWriterConfig,
-                             Timer timer) {
+                             Timer timer, TxnLogBufferedWriterMetricsStats bufferedWriterMetrics) {
         this.managedLedger = managedLedger;
         this.cursor = cursor;
         this.currentLoadPosition = (PositionImpl) this.cursor.getMarkDeletedPosition();
@@ -132,7 +133,8 @@ public class MLPendingAckStore implements PendingAckStore {
         this.bufferedWriter = new TxnLogBufferedWriter(managedLedger, ((ManagedLedgerImpl) managedLedger).getExecutor(),
                 timer, PendingAckLogSerializer.INSTANCE,
                 bufferedWriterConfig.getBatchedWriteMaxRecords(), bufferedWriterConfig.getBatchedWriteMaxSize(),
-                bufferedWriterConfig.getBatchedWriteMaxDelayInMillis(), bufferedWriterConfig.isBatchEnabled());
+                bufferedWriterConfig.getBatchedWriteMaxDelayInMillis(), bufferedWriterConfig.isBatchEnabled(),
+                bufferedWriterMetrics);
         this.batchedPendingAckLogsWaitingForHandle = new ArrayList<>();
     }
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/ManagedLedgerMetricsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/ManagedLedgerMetricsTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pulsar.broker.stats;
 
+import static org.apache.pulsar.transaction.coordinator.impl.DisabledTxnLogBufferedWriterMetricsStats.DISABLED_BUFFERED_WRITER_METRICS;
 import io.netty.util.HashedWheelTimer;
 import io.netty.util.concurrent.DefaultThreadFactory;
 import java.util.List;
@@ -109,7 +110,7 @@ public class ManagedLedgerMetricsTest extends BrokerTestBase {
         managedLedgerConfig.setMaxEntriesPerLedger(2);
         MLTransactionLogImpl mlTransactionLog = new MLTransactionLogImpl(TransactionCoordinatorID.get(0),
                 pulsar.getManagedLedgerFactory(), managedLedgerConfig, txnLogBufferedWriterConfig,
-                transactionTimer);
+                transactionTimer, DISABLED_BUFFERED_WRITER_METRICS);
         mlTransactionLog.initialize().get(2, TimeUnit.SECONDS);
         ManagedLedgerMetrics metrics = new ManagedLedgerMetrics(pulsar);
         metrics.generate();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/TransactionBatchWriterMetricsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/TransactionBatchWriterMetricsTest.java
@@ -1,0 +1,289 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.stats;
+
+import static org.apache.pulsar.common.policies.data.PoliciesUtil.getBundles;
+import java.io.BufferedReader;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.pulsar.broker.PulsarService;
+import org.apache.pulsar.broker.ServiceConfiguration;
+import org.apache.pulsar.broker.auth.MockedPulsarServiceBaseTest;
+import org.apache.pulsar.broker.resources.ClusterResources;
+import org.apache.pulsar.broker.resources.NamespaceResources;
+import org.apache.pulsar.broker.resources.TenantResources;
+import org.apache.pulsar.client.api.Consumer;
+import org.apache.pulsar.client.api.Message;
+import org.apache.pulsar.client.api.Producer;
+import org.apache.pulsar.client.api.PulsarClient;
+import org.apache.pulsar.client.api.PulsarClientException;
+import org.apache.pulsar.client.api.Schema;
+import org.apache.pulsar.client.api.SubscriptionType;
+import org.apache.pulsar.client.api.transaction.Transaction;
+import org.apache.pulsar.common.naming.NamespaceName;
+import org.apache.pulsar.common.naming.SystemTopicNames;
+import org.apache.pulsar.common.naming.TopicName;
+import org.apache.pulsar.common.partition.PartitionedTopicMetadata;
+import org.apache.pulsar.common.policies.data.ClusterData;
+import org.apache.pulsar.common.policies.data.Policies;
+import org.apache.pulsar.common.policies.data.TenantInfoImpl;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+/**
+ * Test for consuming transaction messages.
+ */
+@Slf4j
+@Test(groups = "broker")
+public class TransactionBatchWriterMetricsTest extends MockedPulsarServiceBaseTest {
+
+    private final String clusterName = "test";
+    public static final NamespaceName DEFAULT_NAMESPACE = NamespaceName.get("public/default");
+    private final String topicNameSuffix = "t-rest-topic";
+    private final String topicName = DEFAULT_NAMESPACE.getPersistentTopicName(topicNameSuffix);
+
+    @BeforeClass
+    public void setup() throws Exception {
+        super.internalSetup();
+    }
+
+    @AfterClass
+    protected void cleanup() throws Exception {
+        super.internalCleanup();
+    }
+
+    @Override
+    protected void doInitConf() throws Exception {
+        super.doInitConf();
+        // enable transaction.
+        conf.setSystemTopicEnabled(true);
+        conf.setTransactionCoordinatorEnabled(true);
+        // enabled batch writer.
+        conf.setTransactionPendingAckBatchedWriteEnabled(true);
+        conf.setTransactionPendingAckBatchedWriteMaxRecords(10);
+        conf.setTransactionLogBatchedWriteEnabled(true);
+        conf.setTransactionLogBatchedWriteMaxRecords(10);
+    }
+
+    @Override
+    protected PulsarService startBroker(ServiceConfiguration conf) throws Exception {
+        PulsarService pulsar = startBrokerWithoutAuthorization(conf);
+        ensureClusterExists(pulsar, clusterName);
+        ensureTenantExists(pulsar.getPulsarResources().getTenantResources(), TopicName.PUBLIC_TENANT, clusterName);
+        ensureNamespaceExists(pulsar.getPulsarResources().getNamespaceResources(), DEFAULT_NAMESPACE,
+                clusterName);
+        ensureNamespaceExists(pulsar.getPulsarResources().getNamespaceResources(), NamespaceName.SYSTEM_NAMESPACE,
+                clusterName);
+        ensureTopicExists(pulsar.getPulsarResources().getNamespaceResources().getPartitionedTopicResources(),
+                SystemTopicNames.TRANSACTION_COORDINATOR_ASSIGN, 16);
+        return pulsar;
+    }
+
+    @Test
+    public void testTransactionMetaLogMetrics() throws Exception{
+        String metricsLabelCluster = clusterName;
+        String metricsLabelBroker = pulsar.getAdvertisedAddress().split(":")[0];
+        admin.topics().createNonPartitionedTopic(topicName);
+
+        sendAndAckSomeMessages();
+
+        // call metrics
+        Client client = ClientBuilder.newClient();
+        WebTarget target = client.target(brokerUrl + "/metrics/get");
+        Response response = target.request(MediaType.APPLICATION_JSON_TYPE).buildGet().invoke();
+        Assert.assertTrue(response.getStatus() / 200 == 1);
+        List<String> metricsLines = parseResponseEntityToList(response);
+
+        metricsLines = metricsLines.stream().filter(s -> !s.startsWith("#") && s.contains("bufferedwriter")).collect(
+                Collectors.toList());
+
+        // verify tc.
+        String metrics_key_txn_tc_record_count_sum =
+                "pulsar_txn_tc_bufferedwriter_batch_record_count_sum{cluster=\"%s\",broker=\"%s\"} ";
+        Assert.assertTrue(searchMetricsValue(metricsLines,
+                String.format(metrics_key_txn_tc_record_count_sum, metricsLabelCluster, metricsLabelBroker))
+                > 0);
+        String metrics_key_txn_tc_max_delay =
+                "pulsar_txn_tc_bufferedwriter_flush_trigger_max_delay_total{cluster=\"%s\",broker=\"%s\"} ";
+        Assert.assertTrue(searchMetricsValue(metricsLines,
+                String.format(metrics_key_txn_tc_max_delay, metricsLabelCluster, metricsLabelBroker))
+                > 0);
+        String metrics_key_txn_tc_bytes_size =
+                "pulsar_txn_tc_bufferedwriter_batch_size_bytes_sum{cluster=\"%s\",broker=\"%s\"} ";
+        Assert.assertTrue(searchMetricsValue(metricsLines,
+                String.format(metrics_key_txn_tc_bytes_size, metricsLabelCluster, metricsLabelBroker))
+                > 0);
+        // verify pending ack.
+        String metrics_key_txn_pending_ack_record_count_sum =
+                "pulsar_txn_pending_ack_store_bufferedwriter_batch_record_count_sum{cluster=\"%s\",broker=\"%s\"} ";
+        Assert.assertTrue(searchMetricsValue(metricsLines,
+                String.format(metrics_key_txn_pending_ack_record_count_sum, metricsLabelCluster, metricsLabelBroker))
+                > 0);
+        String metrics_key_txn_pending_ack_max_delay =
+                "pulsar_txn_pending_ack_store_bufferedwriter_flush_trigger_max_delay_total{cluster=\"%s\",broker=\"%s\"} ";
+        Assert.assertTrue(searchMetricsValue(metricsLines,
+                String.format(metrics_key_txn_pending_ack_max_delay, metricsLabelCluster, metricsLabelBroker))
+                > 0);
+        String metrics_key_txn_pending_ack_bytes_size =
+                "pulsar_txn_pending_ack_store_bufferedwriter_batch_size_bytes_sum{cluster=\"%s\",broker=\"%s\"} ";
+        Assert.assertTrue(searchMetricsValue(metricsLines,
+                String.format(metrics_key_txn_pending_ack_bytes_size, metricsLabelCluster, metricsLabelBroker))
+                > 0);
+
+        // cleanup.
+        response.close();
+        client.close();
+        admin.topics().delete(topicName, true);
+    }
+
+    private static Double searchMetricsValue(List<String> metricsLines, String key){
+        for (int i = 0; i < metricsLines.size(); i++){
+            String metricsLine = metricsLines.get(i);
+            if (metricsLine.startsWith("#")){
+                continue;
+            }
+            if (metricsLine.startsWith(key)){
+                return Double.valueOf(metricsLine.split(" ")[1]);
+            }
+        }
+        return null;
+    }
+
+    private void sendAndAckSomeMessages() throws Exception {
+        Producer<byte[]> producer = pulsarClient.newProducer(Schema.BYTES)
+                .topic(topicName)
+                .sendTimeout(0, TimeUnit.SECONDS)
+                .enableBatching(false)
+                .batchingMaxMessages(2)
+                .create();
+        Consumer consumer = pulsarClient.newConsumer()
+                .subscriptionType(SubscriptionType.Shared)
+                .topic(topicName)
+                .isAckReceiptEnabled(true)
+                .acknowledgmentGroupTime(0, TimeUnit.SECONDS)
+                .subscriptionName("my-subscription")
+                .subscribe();
+        producer.sendAsync("normal message x".getBytes()).get();
+        for (int i = 0; i < 100; i++){
+            Transaction transaction =
+                    pulsarClient.newTransaction().withTransactionTimeout(10, TimeUnit.SECONDS).build().get();
+            Message msg = consumer.receive();
+            producer.newMessage(transaction).value(("tx msg a-" + i).getBytes(StandardCharsets.UTF_8)).sendAsync();
+            producer.newMessage(transaction).value(("tx msg b-" + i).getBytes(StandardCharsets.UTF_8)).sendAsync();
+            consumer.acknowledgeAsync(msg.getMessageId(), transaction);
+            transaction.commit().get();
+        }
+    }
+
+    private static void ensureClusterExists(PulsarService pulsar, String cluster) throws Exception {
+        ClusterResources clusterResources = pulsar.getPulsarResources().getClusterResources();
+        ClusterData clusterData = ClusterData.builder()
+                .serviceUrl(pulsar.getWebServiceAddress())
+                .serviceUrlTls(pulsar.getWebServiceAddress())
+                .brokerServiceUrl(pulsar.getBrokerServiceUrl())
+                .brokerServiceUrlTls(pulsar.getBrokerServiceUrl())
+                .build();
+        if (!clusterResources.clusterExists(cluster)) {
+            clusterResources.createCluster(cluster, clusterData);
+        }
+    }
+
+    private static void ensureTopicExists(NamespaceResources.PartitionedTopicResources partitionedTopicResources,
+                                          TopicName topicName, int numPartitions) throws Exception {
+        Optional<PartitionedTopicMetadata> getResult =
+                partitionedTopicResources.getPartitionedTopicMetadataAsync(topicName).get();
+        if (!getResult.isPresent()) {
+            partitionedTopicResources.createPartitionedTopic(topicName, new PartitionedTopicMetadata(numPartitions));
+        } else {
+            PartitionedTopicMetadata existsMeta = getResult.get();
+            if (existsMeta.partitions < numPartitions) {
+                partitionedTopicResources.updatePartitionedTopicAsync(topicName,
+                        __ -> new PartitionedTopicMetadata(numPartitions)).get();
+            }
+        }
+    }
+
+    private static void ensureNamespaceExists(NamespaceResources namespaceResources, NamespaceName namespaceName,
+                                              String cluster) throws Exception {
+        if (!namespaceResources.namespaceExists(namespaceName)) {
+            Policies policies = new Policies();
+            policies.bundles = getBundles(16);
+            policies.replication_clusters = Collections.singleton(cluster);
+            namespaceResources.createPolicies(namespaceName, policies);
+        } else {
+            namespaceResources.setPolicies(namespaceName, policies -> {
+                policies.replication_clusters.add(cluster);
+                return policies;
+            });
+        }
+    }
+
+    private static void ensureTenantExists(TenantResources tenantResources, String tenant, String cluster)
+            throws Exception {
+        if (!tenantResources.tenantExists(tenant)) {
+            TenantInfoImpl publicTenant = new TenantInfoImpl(Collections.emptySet(), Collections.singleton(cluster));
+            tenantResources.createTenant(tenant, publicTenant);
+        } else {
+            tenantResources.updateTenantAsync(tenant, ti -> {
+                ti.getAllowedClusters().add(cluster);
+                return ti;
+            }).get();
+        }
+    }
+
+    private List<String> parseResponseEntityToList(Response response) throws Exception {
+        InputStream inputStream = (InputStream) response.getEntity();
+        BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(inputStream));
+        List<String> list = new ArrayList<>();
+        while (true){
+            String str = bufferedReader.readLine();
+            if (str == null){
+                break;
+            }
+            list.add(str);
+        }
+        return list;
+    }
+
+    protected PulsarClient newPulsarClient(String url, int intervalInSecs) throws PulsarClientException {
+        org.apache.pulsar.client.api.ClientBuilder clientBuilder =
+                PulsarClient.builder()
+                        .serviceUrl(url)
+                        .enableTransaction(true)
+                        .statsInterval(intervalInSecs, TimeUnit.SECONDS);
+        customizeNewPulsarClientBuilder(clientBuilder);
+        return createNewPulsarClient(clientBuilder);
+    }
+
+}

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/TransactionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/TransactionTest.java
@@ -21,6 +21,7 @@ package org.apache.pulsar.broker.transaction;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.pulsar.common.naming.SystemTopicNames.PENDING_ACK_STORE_SUFFIX;
 import static org.apache.pulsar.transaction.coordinator.impl.MLTransactionLogImpl.TRANSACTION_LOG_PREFIX;
+import static org.apache.pulsar.transaction.coordinator.impl.DisabledTxnLogBufferedWriterMetricsStats.DISABLED_BUFFERED_WRITER_METRICS;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.doAnswer;
@@ -691,7 +692,8 @@ public class TransactionTest extends TransactionTestBase {
         TransactionPendingAckStoreProvider pendingAckStoreProvider = mock(TransactionPendingAckStoreProvider.class);
         doReturn(CompletableFuture.completedFuture(
                 new MLPendingAckStore(persistentTopic.getManagedLedger(), managedCursor, null,
-                        500, bufferedWriterConfig, transactionTimer)))
+                        500, bufferedWriterConfig, transactionTimer,
+                        DISABLED_BUFFERED_WRITER_METRICS)))
                 .when(pendingAckStoreProvider).newPendingAckStore(any());
         doReturn(CompletableFuture.completedFuture(true)).when(pendingAckStoreProvider).checkInitializedBefore(any());
 
@@ -757,7 +759,7 @@ public class TransactionTest extends TransactionTestBase {
         MLTransactionLogImpl mlTransactionLog =
                 new MLTransactionLogImpl(new TransactionCoordinatorID(1), null,
                         persistentTopic.getManagedLedger().getConfig(), new TxnLogBufferedWriterConfig(),
-                        transactionTimer);
+                        transactionTimer, DISABLED_BUFFERED_WRITER_METRICS);
         Class<MLTransactionLogImpl> mlTransactionLogClass = MLTransactionLogImpl.class;
         Field field = mlTransactionLogClass.getDeclaredField("cursor");
         field.setAccessible(true);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/pendingack/PendingAckMetadataTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/pendingack/PendingAckMetadataTest.java
@@ -41,6 +41,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 import static org.apache.bookkeeper.mledger.impl.ManagedLedgerImpl.State.WriteFailed;
+import static org.apache.pulsar.transaction.coordinator.impl.DisabledTxnLogBufferedWriterMetricsStats.DISABLED_BUFFERED_WRITER_METRICS;
 import static org.testng.Assert.assertTrue;
 import static org.testng.AssertJUnit.fail;
 
@@ -81,7 +82,7 @@ public class PendingAckMetadataTest extends MockedBookKeeperTestCase {
         ManagedCursor subCursor = completableFuture.get().openCursor("test");
         MLPendingAckStore pendingAckStore =
                 new MLPendingAckStore(completableFuture.get(), cursor, subCursor, 500,
-                        bufferedWriterConfig, transactionTimer);
+                        bufferedWriterConfig, transactionTimer, DISABLED_BUFFERED_WRITER_METRICS);
 
         Field field = MLPendingAckStore.class.getDeclaredField("managedLedger");
         field.setAccessible(true);

--- a/pulsar-transaction/coordinator/src/main/java/org/apache/pulsar/transaction/coordinator/impl/DisabledTxnLogBufferedWriterMetricsStats.java
+++ b/pulsar-transaction/coordinator/src/main/java/org/apache/pulsar/transaction/coordinator/impl/DisabledTxnLogBufferedWriterMetricsStats.java
@@ -1,0 +1,57 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.transaction.coordinator.impl;
+
+import io.prometheus.client.Collector;
+import io.prometheus.client.CollectorRegistry;
+
+public class DisabledTxnLogBufferedWriterMetricsStats extends TxnLogBufferedWriterMetricsStats {
+
+    public static final DisabledTxnLogBufferedWriterMetricsStats DISABLED_BUFFERED_WRITER_METRICS =
+            new DisabledTxnLogBufferedWriterMetricsStats();
+
+    private static class DisabledCollectorRegistry extends CollectorRegistry {
+
+        private static final DisabledCollectorRegistry INSTANCE = new DisabledCollectorRegistry();
+
+        public void register(Collector m) {
+        }
+        public void unregister(Collector m) {
+        }
+    }
+
+    private DisabledTxnLogBufferedWriterMetricsStats() {
+        super("disabled", new String[0], new String[0], DisabledCollectorRegistry.INSTANCE);
+    }
+
+    public void close() {
+    }
+
+    public void triggerFlushByRecordsCount(int recordCount, long bytesSize, long delayMillis) {
+    }
+
+    public void triggerFlushByBytesSize(int recordCount, long bytesSize, long delayMillis) {
+    }
+
+    public void triggerFlushByByMaxDelay(int recordCount, long bytesSize, long delayMillis) {
+    }
+
+    public void triggerFlushByLargeSingleData(int recordCount, long bytesSize, long delayMillis) {
+    }
+}

--- a/pulsar-transaction/coordinator/src/main/java/org/apache/pulsar/transaction/coordinator/impl/MLTransactionLogImpl.java
+++ b/pulsar-transaction/coordinator/src/main/java/org/apache/pulsar/transaction/coordinator/impl/MLTransactionLogImpl.java
@@ -82,11 +82,14 @@ public class MLTransactionLogImpl implements TransactionLog {
 
     private final TxnLogBufferedWriterConfig txnLogBufferedWriterConfig;
 
+    private final TxnLogBufferedWriterMetricsStats bufferedWriterMetrics;
+
     public MLTransactionLogImpl(TransactionCoordinatorID tcID,
                                 ManagedLedgerFactory managedLedgerFactory,
                                 ManagedLedgerConfig managedLedgerConfig,
                                 TxnLogBufferedWriterConfig txnLogBufferedWriterConfig,
-                                Timer timer) {
+                                Timer timer,
+                                TxnLogBufferedWriterMetricsStats bufferedWriterMetrics) {
         this.topicName = getMLTransactionLogName(tcID);
         this.tcId = tcID.getId();
         this.managedLedgerFactory = managedLedgerFactory;
@@ -97,6 +100,7 @@ public class MLTransactionLogImpl implements TransactionLog {
             this.managedLedgerConfig.setDeletionAtBatchIndexLevelEnabled(true);
         }
         this.entryQueue = new SpscArrayQueue<>(2000);
+        this.bufferedWriterMetrics = bufferedWriterMetrics;
     }
 
     public static TopicName getMLTransactionLogName(TransactionCoordinatorID tcID) {
@@ -119,7 +123,8 @@ public class MLTransactionLogImpl implements TransactionLog {
                                 txnLogBufferedWriterConfig.getBatchedWriteMaxRecords(),
                                 txnLogBufferedWriterConfig.getBatchedWriteMaxSize(),
                                 txnLogBufferedWriterConfig.getBatchedWriteMaxDelayInMillis(),
-                                txnLogBufferedWriterConfig.isBatchEnabled());
+                                txnLogBufferedWriterConfig.isBatchEnabled(),
+                                bufferedWriterMetrics);
 
                         managedLedger.asyncOpenCursor(TRANSACTION_SUBSCRIPTION_NAME,
                                 CommandSubscribe.InitialPosition.Earliest, new AsyncCallbacks.OpenCursorCallback() {

--- a/pulsar-transaction/coordinator/src/test/java/org/apache/pulsar/transaction/coordinator/MLTransactionMetadataStoreTest.java
+++ b/pulsar-transaction/coordinator/src/test/java/org/apache/pulsar/transaction/coordinator/MLTransactionMetadataStoreTest.java
@@ -54,6 +54,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 
 import static org.apache.bookkeeper.mledger.impl.ManagedLedgerImpl.State.WriteFailed;
+import static org.apache.pulsar.transaction.coordinator.impl.DisabledTxnLogBufferedWriterMetricsStats.DISABLED_BUFFERED_WRITER_METRICS;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
@@ -84,7 +85,7 @@ public class MLTransactionMetadataStoreTest extends MockedBookKeeperTestCase {
         MLTransactionSequenceIdGenerator mlTransactionSequenceIdGenerator = new MLTransactionSequenceIdGenerator();
         managedLedgerConfig.setManagedLedgerInterceptor(mlTransactionSequenceIdGenerator);
         MLTransactionLogImpl mlTransactionLog = new MLTransactionLogImpl(transactionCoordinatorID, factory,
-                managedLedgerConfig, txnLogBufferedWriterConfig, transactionTimer);
+                managedLedgerConfig, txnLogBufferedWriterConfig, transactionTimer, DISABLED_BUFFERED_WRITER_METRICS);
         mlTransactionLog.initialize().get(2, TimeUnit.SECONDS);
         MLTransactionMetadataStore transactionMetadataStore =
                 new MLTransactionMetadataStore(transactionCoordinatorID, mlTransactionLog,
@@ -172,7 +173,7 @@ public class MLTransactionMetadataStoreTest extends MockedBookKeeperTestCase {
         managedLedgerConfig.setManagedLedgerInterceptor(mlTransactionSequenceIdGenerator);
         managedLedgerConfig.setMaxEntriesPerLedger(3);
         MLTransactionLogImpl mlTransactionLog = new MLTransactionLogImpl(transactionCoordinatorID, factory,
-                managedLedgerConfig, disabledBufferedWriter, transactionTimer);
+                managedLedgerConfig, disabledBufferedWriter, transactionTimer, DISABLED_BUFFERED_WRITER_METRICS);
         mlTransactionLog.initialize().get(2, TimeUnit.SECONDS);
         MLTransactionMetadataStore transactionMetadataStore =
                 new MLTransactionMetadataStore(transactionCoordinatorID, mlTransactionLog,
@@ -201,7 +202,7 @@ public class MLTransactionMetadataStoreTest extends MockedBookKeeperTestCase {
         }
         mlTransactionLog.closeAsync().get(2, TimeUnit.SECONDS);
         mlTransactionLog = new MLTransactionLogImpl(transactionCoordinatorID, factory,
-                managedLedgerConfig, disabledBufferedWriter, transactionTimer);
+                managedLedgerConfig, disabledBufferedWriter, transactionTimer, DISABLED_BUFFERED_WRITER_METRICS);
         mlTransactionLog.initialize().get(2, TimeUnit.SECONDS);
         transactionMetadataStore =
                 new MLTransactionMetadataStore(transactionCoordinatorID, mlTransactionLog,
@@ -230,7 +231,7 @@ public class MLTransactionMetadataStoreTest extends MockedBookKeeperTestCase {
         MLTransactionSequenceIdGenerator mlTransactionSequenceIdGenerator = new MLTransactionSequenceIdGenerator();
         managedLedgerConfig.setManagedLedgerInterceptor(mlTransactionSequenceIdGenerator);
         MLTransactionLogImpl mlTransactionLog = new MLTransactionLogImpl(transactionCoordinatorID, factory,
-                managedLedgerConfig, txnLogBufferedWriterConfig, transactionTimer);
+                managedLedgerConfig, txnLogBufferedWriterConfig, transactionTimer, DISABLED_BUFFERED_WRITER_METRICS);
         mlTransactionLog.initialize().get(2, TimeUnit.SECONDS);
 
         MLTransactionMetadataStore transactionMetadataStore =
@@ -282,7 +283,8 @@ public class MLTransactionMetadataStoreTest extends MockedBookKeeperTestCase {
                 transactionMetadataStore.closeAsync();
 
                 MLTransactionLogImpl txnLog2 = new MLTransactionLogImpl(transactionCoordinatorID, factory,
-                        managedLedgerConfig, txnLogBufferedWriterConfig, transactionTimer);
+                        managedLedgerConfig, txnLogBufferedWriterConfig, transactionTimer,
+                        DISABLED_BUFFERED_WRITER_METRICS);
                 txnLog2.initialize().get(2, TimeUnit.SECONDS);
 
                 MLTransactionMetadataStore transactionMetadataStoreTest =
@@ -356,7 +358,7 @@ public class MLTransactionMetadataStoreTest extends MockedBookKeeperTestCase {
         MLTransactionSequenceIdGenerator mlTransactionSequenceIdGenerator = new MLTransactionSequenceIdGenerator();
         managedLedgerConfig.setManagedLedgerInterceptor(mlTransactionSequenceIdGenerator);
         MLTransactionLogImpl mlTransactionLog = new MLTransactionLogImpl(transactionCoordinatorID, factory,
-                managedLedgerConfig, txnLogBufferedWriterConfig, transactionTimer);
+                managedLedgerConfig, txnLogBufferedWriterConfig, transactionTimer, DISABLED_BUFFERED_WRITER_METRICS);
         mlTransactionLog.initialize().get(2, TimeUnit.SECONDS);
         MLTransactionMetadataStore transactionMetadataStore =
                 new MLTransactionMetadataStore(transactionCoordinatorID, mlTransactionLog,
@@ -436,7 +438,7 @@ public class MLTransactionMetadataStoreTest extends MockedBookKeeperTestCase {
         MLTransactionSequenceIdGenerator mlTransactionSequenceIdGenerator = new MLTransactionSequenceIdGenerator();
         managedLedgerConfig.setManagedLedgerInterceptor(mlTransactionSequenceIdGenerator);
         MLTransactionLogImpl mlTransactionLog = new MLTransactionLogImpl(transactionCoordinatorID, factory,
-                managedLedgerConfig, txnLogBufferedWriterConfig, transactionTimer);
+                managedLedgerConfig, txnLogBufferedWriterConfig, transactionTimer, DISABLED_BUFFERED_WRITER_METRICS);
         mlTransactionLog.initialize().get(2, TimeUnit.SECONDS);
         MLTransactionMetadataStore transactionMetadataStore =
                 new MLTransactionMetadataStore(transactionCoordinatorID, mlTransactionLog,
@@ -454,7 +456,7 @@ public class MLTransactionMetadataStoreTest extends MockedBookKeeperTestCase {
         transactionMetadataStore.updateTxnStatus(txnID2, TxnStatus.ABORTED, TxnStatus.ABORTING, false).get();
 
         mlTransactionLog = new MLTransactionLogImpl(transactionCoordinatorID, factory,
-                managedLedgerConfig, txnLogBufferedWriterConfig, transactionTimer);
+                managedLedgerConfig, txnLogBufferedWriterConfig, transactionTimer, DISABLED_BUFFERED_WRITER_METRICS);
         mlTransactionLog.initialize().get(2, TimeUnit.SECONDS);
         transactionMetadataStore =
                 new MLTransactionMetadataStore(transactionCoordinatorID, mlTransactionLog,
@@ -476,7 +478,7 @@ public class MLTransactionMetadataStoreTest extends MockedBookKeeperTestCase {
         MLTransactionSequenceIdGenerator mlTransactionSequenceIdGenerator = new MLTransactionSequenceIdGenerator();
         managedLedgerConfig.setManagedLedgerInterceptor(mlTransactionSequenceIdGenerator);
         MLTransactionLogImpl mlTransactionLog = new MLTransactionLogImpl(transactionCoordinatorID, factory,
-                managedLedgerConfig, txnLogBufferedWriterConfig, transactionTimer);
+                managedLedgerConfig, txnLogBufferedWriterConfig, transactionTimer, DISABLED_BUFFERED_WRITER_METRICS);
         mlTransactionLog.initialize().get(2, TimeUnit.SECONDS);
         MLTransactionMetadataStore transactionMetadataStore =
                 new MLTransactionMetadataStore(transactionCoordinatorID, mlTransactionLog,

--- a/pulsar-transaction/coordinator/src/test/java/org/apache/pulsar/transaction/coordinator/impl/MLTransactionLogImplTest.java
+++ b/pulsar-transaction/coordinator/src/test/java/org/apache/pulsar/transaction/coordinator/impl/MLTransactionLogImplTest.java
@@ -46,6 +46,7 @@ import org.apache.pulsar.transaction.coordinator.TransactionTimeoutTracker;
 import org.apache.pulsar.transaction.coordinator.proto.TransactionMetadataEntry;
 import org.apache.pulsar.transaction.coordinator.proto.TxnStatus;
 import org.apache.pulsar.transaction.coordinator.test.MockedBookKeeperTestCase;
+import static org.apache.pulsar.transaction.coordinator.impl.DisabledTxnLogBufferedWriterMetricsStats.DISABLED_BUFFERED_WRITER_METRICS;
 import static org.mockito.Mockito.*;
 import org.awaitility.Awaitility;
 import org.testng.Assert;
@@ -82,7 +83,7 @@ public class MLTransactionLogImplTest extends MockedBookKeeperTestCase {
         bufferedWriterConfigForWrite.setBatchEnabled(writeWithBatch);
         TransactionCoordinatorID transactionCoordinatorID = TransactionCoordinatorID.get(0);
         MLTransactionLogImpl mlTransactionLogForWrite = new MLTransactionLogImpl(TransactionCoordinatorID.get(0), factory,
-                new ManagedLedgerConfig(), bufferedWriterConfigForWrite, transactionTimer);
+                new ManagedLedgerConfig(), bufferedWriterConfigForWrite, transactionTimer, DISABLED_BUFFERED_WRITER_METRICS);
         mlTransactionLogForWrite.initialize().get(3, TimeUnit.SECONDS);
         Map<Integer, List<CompletableFuture<Position>>> expectedMapping = new HashMap<>();
         /**
@@ -156,8 +157,9 @@ public class MLTransactionLogImplTest extends MockedBookKeeperTestCase {
         bufferedWriterConfigForRecover.setBatchedWriteMaxDelayInMillis(1000 * 3600);
         bufferedWriterConfigForRecover.setBatchedWriteMaxRecords(3);
         bufferedWriterConfigForRecover.setBatchEnabled(readWithBatch);
-        MLTransactionLogImpl mlTransactionLogForRecover = new MLTransactionLogImpl(TransactionCoordinatorID.get(0), factory,
-                new ManagedLedgerConfig(), bufferedWriterConfigForRecover, transactionTimer);
+        MLTransactionLogImpl mlTransactionLogForRecover = new MLTransactionLogImpl(TransactionCoordinatorID.get(0),
+                factory, new ManagedLedgerConfig(), bufferedWriterConfigForRecover, transactionTimer,
+                DISABLED_BUFFERED_WRITER_METRICS);
         mlTransactionLogForRecover.initialize().get(3, TimeUnit.SECONDS);
         // Recover and verify the txnID and position mappings.
         TransactionTimeoutTracker timeoutTracker = mock(TransactionTimeoutTracker.class);
@@ -234,8 +236,9 @@ public class MLTransactionLogImplTest extends MockedBookKeeperTestCase {
          * the cursor-batch-indexes is expected.
          */
         // Create another transaction log for recover.
-        MLTransactionLogImpl mlTransactionLogForDelete = new MLTransactionLogImpl(TransactionCoordinatorID.get(0), factory,
-                new ManagedLedgerConfig(), bufferedWriterConfigForRecover, transactionTimer);
+        MLTransactionLogImpl mlTransactionLogForDelete = new MLTransactionLogImpl(TransactionCoordinatorID.get(0),
+                factory, new ManagedLedgerConfig(), bufferedWriterConfigForRecover, transactionTimer,
+                DISABLED_BUFFERED_WRITER_METRICS);
         mlTransactionLogForDelete.initialize().get(3, TimeUnit.SECONDS);
         MLTransactionMetadataStore transactionMetadataStoreForDelete = new MLTransactionMetadataStore(transactionCoordinatorID,
                 mlTransactionLogForDelete, timeoutTracker, sequenceIdGenerator, Integer.MAX_VALUE);


### PR DESCRIPTION
Master Issue: #15370

### Modifications

- Make transaction `MLTransactionMetadataStoreProvider` & `MLPendingAckStoreProvider` support buffered writer metrics.
  - Motivation: #15370

----

- Delete constructor of `TxnLogBufferedWriter` without parameter `metrics`.
  - Motivation: it is unnecessary.

---- 

- Add a default `DisabledTxnLogBufferedWriterMetricsStats` implementation.

----

- Previous PR remaining code to optimize: remove the check code `if (metrics != null)`. The motivation see:
  - Motivation: https://github.com/apache/pulsar/pull/16758#discussion_r945512673

----

- Make transaction log buffered writer only create by the `MLTransactionMetadataStoreProvider` & `MLPendingAckStoreProvider`. 
  - Motivation: https://github.com/apache/pulsar/pull/16758#discussion_r961254161

### Documentation

- [ ] `doc-required` 

- [x] `doc-not-needed` 

- [ ] `doc` 

- [ ] `doc-complete`


### Matching PR in forked repository

PR in forked repository: 

- https://github.com/poorbarcode/pulsar/pull/3