### PR TITLE
[fix][security] Upgrade reload4j in file-system offloader

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -245,6 +245,7 @@ flexible messaging model and an intuitive client API.</description>
     <skyscreamer.version>1.5.0</skyscreamer.version>
     <objenesis.version>3.1</objenesis.version>
     <awaitility.version>4.2.0</awaitility.version>
+    <reload4j.version>1.2.22</reload4j.version>
 
     <!-- Plugin dependencies -->
     <protobuf-maven-plugin.version>0.6.1</protobuf-maven-plugin.version>
@@ -1292,6 +1293,12 @@ flexible messaging model and an intuitive client API.</description>
           <groupId>com.typesafe.netty</groupId>
           <artifactId>netty-reactive-streams</artifactId>
           <version>${netty-reactive-streams.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>ch.qos.reload4j</groupId>
+        <artifactId>reload4j</artifactId>
+        <version>${reload4j.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
### Motivation

Upgrade reload4j to fix https://github.com/qos-ch/reload4j/issues/53 knows as sonatype-2022-5401.
Reload4J is used only in file-system offloader (hadoop)

### Modifications

Upgrade from 1.12.18.3 to 1.22.2

- [x] `doc-not-needed`

https://github.com/nicoloboschi/pulsar/pull/15