### PR TITLE
[fix][client] Unwrap completion exception for Lookup Services

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/HttpLookupService.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/HttpLookupService.java
@@ -148,8 +148,9 @@ public class HttpLookupService implements LookupService {
                 });
                 future.complete(new GetTopicsResult(result, topicsHash, false, true));
             }).exceptionally(ex -> {
-                log.warn("Failed to getTopicsUnderNamespace namespace {} {}.", namespace, ex.getMessage());
-                future.completeExceptionally(ex);
+                Throwable cause = FutureUtil.unwrapCompletionException(ex);
+                log.warn("Failed to getTopicsUnderNamespace namespace {} {}.", namespace, cause.getMessage());
+                future.completeExceptionally(cause);
                 return null;
             });
         return future;
@@ -193,14 +194,15 @@ public class HttpLookupService implements LookupService {
                 future.complete(Optional.of(SchemaInfoUtil.newSchemaInfo(schemaName, response)));
             }
         }).exceptionally(ex -> {
-            if (ex.getCause() instanceof NotFoundException) {
+            Throwable cause = FutureUtil.unwrapCompletionException(ex);
+            if (cause instanceof NotFoundException) {
                 future.complete(Optional.empty());
             } else {
                 log.warn("Failed to get schema for topic {} version {}",
                         topicName,
                         version != null ? Base64.getEncoder().encodeToString(version) : null,
-                        ex.getCause());
-                future.completeExceptionally(ex);
+                        cause);
+                future.completeExceptionally(cause);
             }
             return null;
         });


### PR DESCRIPTION
### Motivation

The error messages look a little bit wired while I try to use pulsar-client to run some tests.

`PulsarClientException: java.util.concurrent.CompletionException: io.netty.channel.AbstractChannel$AnnotatedConnectException`

During the broker shutdown, the error logs like following

```
2022-09-19T11:37:56,215+0800 [pulsar-client-io-1-1] WARN  org.apache.pulsar.client.impl.ConnectionPool - Failed to open connection to localhost/<unresolved>:6650 : io.netty.channel.AbstractChannel$AnnotatedConnectException: Connection refused: localhost/127.0.0.1:6650
2022-09-19T11:37:56,215+0800 [pulsar-client-io-1-1] WARN  org.apache.pulsar.client.impl.ConnectionHandler - [persistent://public/default/test] [reader-23bc11015c] Error connecting to broker: org.apache.pulsar.client.api.PulsarClientException: java.util.concurrent.CompletionException: io.netty.channel.AbstractChannel$AnnotatedConnectException: Connection refused: localhost/127.0.0.1:6650
2022-09-19T11:37:56,215+0800 [pulsar-client-io-1-1] WARN  org.apache.pulsar.client.impl.ConnectionHandler - [persistent://public/default/test] [reader-23bc11015c] Could not get connection to broker: org.apache.pulsar.client.api.PulsarClientException: java.util.concurrent.CompletionException: io.netty.channel.AbstractChannel$AnnotatedConnectException: Connection refused: localhost/127.0.0.1:6650 -- Will try again in 0.736 s
2022-09-19T11:37:56,952+0800 [pulsar-timer-6-1] INFO  org.apache.pulsar.client.impl.ConnectionHandler - [persistent://public/default/test] [reader-23bc11015c] Reconnecting after connection was closed
2022-09-19T11:37:56,953+0800 [pulsar-client-io-1-1] WARN  org.apache.pulsar.client.impl.ConnectionPool - Failed to open connection to localhost/<unresolved>:6650 : io.netty.channel.AbstractChannel$AnnotatedConnectException: Connection refused: localhost/127.0.0.1:6650
2022-09-19T11:37:56,953+0800 [pulsar-client-io-1-1] WARN  org.apache.pulsar.client.impl.ConnectionHandler - [persistent://public/default/test] [reader-23bc11015c] Error connecting to broker: org.apache.pulsar.client.api.PulsarClientException: java.util.concurrent.CompletionException: io.netty.channel.AbstractChannel$AnnotatedConnectException: Connection refused: localhost/127.0.0.1:6650
2022-09-19T11:37:56,953+0800 [pulsar-client-io-1-1] WARN  org.apache.pulsar.client.impl.ConnectionHandler - [persistent://public/default/test] [reader-23bc11015c] Could not get connection to broker: org.apache.pulsar.client.api.PulsarClientException: java.util.concurrent.CompletionException: io.netty.channel.AbstractChannel$AnnotatedConnectException: Connection refused: localhost/127.0.0.1:6650 -- Will try again in 1.583 s
```

### Modifications

Make the Lookup Services handle the completion exception property.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [x] `doc-not-needed` 
(Please explain why)

### Matching PR in forked repository

PR in forked repository: https://github.com/codelipenghui/incubator-pulsar/pull/12
