### PR TITLE
[cleanup][broker]remove unnecessary variable in MLTransactionMetadataStoreProvider

### DIFF
--- a/pulsar-transaction/coordinator/src/main/java/org/apache/pulsar/transaction/coordinator/impl/MLTransactionMetadataStoreProvider.java
+++ b/pulsar-transaction/coordinator/src/main/java/org/apache/pulsar/transaction/coordinator/impl/MLTransactionMetadataStoreProvider.java
@@ -27,15 +27,11 @@ import org.apache.pulsar.transaction.coordinator.TransactionMetadataStore;
 import org.apache.pulsar.transaction.coordinator.TransactionMetadataStoreProvider;
 import org.apache.pulsar.transaction.coordinator.TransactionRecoverTracker;
 import org.apache.pulsar.transaction.coordinator.TransactionTimeoutTracker;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * The provider that offers managed ledger implementation of {@link TransactionMetadataStore}.
  */
 public class MLTransactionMetadataStoreProvider implements TransactionMetadataStoreProvider {
-
-    private static final Logger log = LoggerFactory.getLogger(MLTransactionMetadataStoreProvider.class);
 
     @Override
     public CompletableFuture<TransactionMetadataStore> openStore(TransactionCoordinatorID transactionCoordinatorId,


### PR DESCRIPTION
### Motivation

Variable `log` in `MLTransactionMetadataStoreProvider` is not used.

### Modifications

remove useless variable.


### Documentation


- [ ] `doc-required` 


- [x] `doc-not-needed` 


- [ ] `doc` 


- [ ] `doc-complete`


### Matching PR in forked repository

PR in forked repository: 

- https://github.com/poorbarcode/pulsar/pull/4
