### PR TITLE
support setting bundle number for default namespace when set up cluster

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/zookeeper/ClusterMetadataSetupTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/zookeeper/ClusterMetadataSetupTest.java
@@ -22,6 +22,8 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
+
+import com.fasterxml.jackson.databind.type.TypeFactory;
 import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
@@ -44,6 +46,8 @@ import org.apache.pulsar.PulsarClusterMetadataSetup;
 import org.apache.pulsar.PulsarInitialNamespaceSetup;
 import org.apache.pulsar.broker.resources.PulsarResources;
 import org.apache.pulsar.broker.resources.TenantResources;
+import org.apache.pulsar.common.policies.data.Policies;
+import org.apache.pulsar.common.util.ObjectMapperFactory;
 import org.apache.pulsar.functions.worker.WorkerUtils;
 import org.apache.pulsar.metadata.api.MetadataStoreConfig;
 import org.apache.pulsar.metadata.api.extended.MetadataStoreExtended;
@@ -84,6 +88,40 @@ public class ClusterMetadataSetupTest {
         PulsarClusterMetadataSetup.main(args);
         SortedMap<String, String> data3 = localZkS.dumpData();
         assertEquals(data1, data3);
+    }
+
+    @DataProvider(name = "bundleNumberForDefaultNamespace")
+    public static Object[][] bundleNumberForDefaultNamespace() {
+        return new Object[][] { { 0 }, {  128 } };
+    }
+
+    @Test(dataProvider = "bundleNumberForDefaultNamespace")
+    public void testSetBundleNumberForDefaultNamespace(int bundleNumber) throws Exception {
+        String[] args = {
+                "--cluster", "testSetDefaultNamespaceBundleNumber-cluster",
+                "--zookeeper", "127.0.0.1:" + localZkS.getZookeeperPort(),
+                "--configuration-store", "127.0.0.1:" + localZkS.getZookeeperPort(),
+                "--web-service-url", "http://127.0.0.1:8080",
+                "--web-service-url-tls", "https://127.0.0.1:8443",
+                "--broker-service-url", "pulsar://127.0.0.1:6650",
+                "--broker-service-url-tls","pulsar+ssl://127.0.0.1:6651",
+                "--default-namespace-bundle-number", String.valueOf(bundleNumber)
+        };
+        PulsarClusterMetadataSetup.main(args);
+        try (ZooKeeper zk = ZooKeeperClient.newBuilder()
+                .connectString("127.0.0.1:" + localZkS.getZookeeperPort())
+                .build()) {
+            Policies policies =
+                    ObjectMapperFactory.getThreadLocal().readValue(
+                            zk.getData("/admin/policies/public/default", false, null),
+                            TypeFactory.defaultInstance().constructSimpleType(Policies.class, null));
+            assertNotNull(policies);
+            if (bundleNumber > 0) {
+                assertEquals(policies.bundles.getNumBundles(), bundleNumber);
+            } else {
+                assertEquals(policies.bundles.getNumBundles(), 16);
+            }
+        }
     }
 
     @DataProvider(name = "useMetadataStoreUrl")


### PR DESCRIPTION
### Motivation

In the actual production environment,  users may only use one default namespace (public/default). 
The number of bundles in this namespace is a default value of 16. 
1. if the cluster has more than 16 brokers, some brokers will serve no traffic 
2. if the topics in these bundles are not equal, the load will be unbalanced
In addition, the manually split bundle is complicated and auto-split may lead to unstable services. 

We expect to set a relatively large number of bundles for the default namespace when the cluster is built.

### Modifications

support setting bundle number for default namespace when setting up cluster metadata 
<strike>and the bundle number is the `defaultNumberOfNamespaceBundles`  from `broker.conf`</strike>
and the bundle number passed by a new option like `--default-namespacs-bundles-numbers`

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change added tests and can be verified as follows:
ClusterMetadataSetupTest.testSetupBundleForNamespaces


### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [x] `doc-not-needed` 
(Please explain why)

### PR in for repository
https://github.com/aloyszhang/pulsar/pull/2

