### PR TITLE
[fix][CI] Fix issues with approval solution for GitHub Actions

### DIFF
--- a/.github/workflows/ci-cpp-build.yaml
+++ b/.github/workflows/ci-cpp-build.yaml
@@ -56,6 +56,9 @@ jobs:
 
       - name: Check if the PR has been approved for testing
         if: ${{ steps.check_changes.outputs.docs_only != 'true' && github.repository == 'apache/pulsar' && github.event_name == 'pull_request' }}
+        env:
+          GITHUB_RUN_ATTEMPT: ${{ github.run_attempt }}
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
           build/pulsar_ci_tool.sh check_ready_to_test
 

--- a/.github/workflows/ci-go-functions.yaml
+++ b/.github/workflows/ci-go-functions.yaml
@@ -60,6 +60,9 @@ jobs:
 
       - name: Check if the PR has been approved for testing
         if: ${{ steps.check_changes.outputs.docs_only != 'true' && github.repository == 'apache/pulsar' && github.event_name == 'pull_request' }}
+        env:
+          GITHUB_RUN_ATTEMPT: ${{ github.run_attempt }}
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
           build/pulsar_ci_tool.sh check_ready_to_test
 

--- a/.github/workflows/pulsar-ci-flaky.yaml
+++ b/.github/workflows/pulsar-ci-flaky.yaml
@@ -62,6 +62,9 @@ jobs:
 
       - name: Check if the PR has been approved for testing
         if: ${{ steps.check_changes.outputs.docs_only != 'true' && github.repository == 'apache/pulsar' && github.event_name == 'pull_request' }}
+        env:
+          GITHUB_RUN_ATTEMPT: ${{ github.run_attempt }}
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
           build/pulsar_ci_tool.sh check_ready_to_test
 

--- a/.github/workflows/pulsar-ci.yaml
+++ b/.github/workflows/pulsar-ci.yaml
@@ -62,6 +62,9 @@ jobs:
 
       - name: Check if the PR has been approved for testing
         if: ${{ steps.check_changes.outputs.docs_only != 'true' && github.repository == 'apache/pulsar' && github.event_name == 'pull_request' }}
+        env:
+          GITHUB_RUN_ATTEMPT: ${{ github.run_attempt }}
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
           build/pulsar_ci_tool.sh check_ready_to_test
 


### PR DESCRIPTION
### Motivation

- The approval solution doesn't work as expected by approving the PR or by adding the ready-to-test label and adding a comment "/pulsarbot rerun-failure-checks".

### Additional context

The workaround until this PR is merged is to add a "ready-to-test" label to the PR and then close & reopen the PR.

### Modifications

- Fix the ready-to-test label check:
  - Refresh PR labels when re-running workflow - when re-running, the event JSON remains the same. The API must be used to fetch the up-to-date JSON for the PR.

- Fix the PR approval check:
  - set GITHUB_TOKEN for script so that retrieving the approval status could work

### Documentation
 
<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)

- [x] `doc-not-needed` 
(Please explain why)

- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)

### Matching PR in forked repository

PR in forked repository: https://github.com/lhotari/pulsar/pull/87
