### PR TITLE
[fix][broker]Fix metric messagesConsumedCounter calculation error

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
@@ -1737,16 +1737,6 @@ public class ManagedCursorImpl implements ManagedCursor {
         PositionImpl oldMarkDeletePosition = markDeletePosition;
 
         if (!newMarkDeletePosition.equals(oldMarkDeletePosition)) {
-            long skippedEntries = 0;
-            if (newMarkDeletePosition.getLedgerId() == oldMarkDeletePosition.getLedgerId()
-                    && newMarkDeletePosition.getEntryId() == oldMarkDeletePosition.getEntryId() + 1) {
-                // Mark-deleting the position next to current one
-                skippedEntries = individualDeletedMessages.contains(newMarkDeletePosition.getLedgerId(),
-                        newMarkDeletePosition.getEntryId()) ? 0 : 1;
-            } else {
-                skippedEntries = getNumberOfEntries(Range.openClosed(oldMarkDeletePosition, newMarkDeletePosition));
-            }
-
             PositionImpl positionAfterNewMarkDelete = ledger.getNextValidPosition(newMarkDeletePosition);
             // sometime ranges are connected but belongs to different ledgers so, they are placed sequentially
             // eg: (2:10..3:15] can be returned as (2:10..2:15],[3:0..3:15]. So, try to iterate over connected range and
@@ -1764,6 +1754,15 @@ public class ManagedCursorImpl implements ManagedCursor {
                 break;
             }
 
+            long skippedEntries = 0;
+            if (newMarkDeletePosition.getLedgerId() == oldMarkDeletePosition.getLedgerId()
+                    && newMarkDeletePosition.getEntryId() == oldMarkDeletePosition.getEntryId() + 1) {
+                // Mark-deleting the position next to current one
+                skippedEntries = individualDeletedMessages.contains(newMarkDeletePosition.getLedgerId(),
+                        newMarkDeletePosition.getEntryId()) ? 0 : 1;
+            } else {
+                skippedEntries = getNumberOfEntries(Range.openClosed(oldMarkDeletePosition, newMarkDeletePosition));
+            }
             if (log.isDebugEnabled()) {
                 log.debug("[{}] Moved ack position from: {} to: {} -- skipped: {}", ledger.getName(),
                         oldMarkDeletePosition, newMarkDeletePosition, skippedEntries);


### PR DESCRIPTION
### Motivation
Fix metric messagesConsumedCounter calculation error.
In the ManagedCursorImpl#setAcknowledgedPosition method, we will calculate skippedEntries based on newMarkDeletePosition and oldMarkDeletePosition, and then accumulate skippedEntries into MSG_CONSUMED_COUNTER_UPDATER: MSG_CONSUMED_COUNTER_UPDATER.addAndGet(this, skippedEntries);
But the newMarkDeletePosition here is not the final value, newMarkDeletePosition may change between calculating skippedEntries and accumulating to MSG_CONSUMED_COUNTER_UPDATER:
https://github.com/apache/pulsar/blob/bf6e815767c89512e0689562fbba0c2c453ff081/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java#L1769-L1802

### Modifications
Therefore, skippedEntries should only be calculated after newMarkDeletePosition has changed:
![image](https://user-images.githubusercontent.com/19296967/191154456-13d64a1c-842b-44c4-a71e-bfc5ec37e8dc.png)


### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)

- [x] `doc-not-needed` 
(Please explain why)

- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE 

After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.

-->
