### PR TITLE
Fix metric messagesConsumedCounter calculation error

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
@@ -1767,16 +1767,6 @@ public class ManagedCursorImpl implements ManagedCursor {
         PositionImpl oldMarkDeletePosition = markDeletePosition;
 
         if (!newMarkDeletePosition.equals(oldMarkDeletePosition)) {
-            long skippedEntries = 0;
-            if (newMarkDeletePosition.getLedgerId() == oldMarkDeletePosition.getLedgerId()
-                    && newMarkDeletePosition.getEntryId() == oldMarkDeletePosition.getEntryId() + 1) {
-                // Mark-deleting the position next to current one
-                skippedEntries = individualDeletedMessages.contains(newMarkDeletePosition.getLedgerId(),
-                        newMarkDeletePosition.getEntryId()) ? 0 : 1;
-            } else {
-                skippedEntries = getNumberOfEntries(Range.openClosed(oldMarkDeletePosition, newMarkDeletePosition));
-            }
-
             PositionImpl positionAfterNewMarkDelete = ledger.getNextValidPosition(newMarkDeletePosition);
             // sometime ranges are connected but belongs to different ledgers so, they are placed sequentially
             // eg: (2:10..3:15] can be returned as (2:10..2:15],[3:0..3:15]. So, try to iterate over connected range and
@@ -1792,6 +1782,16 @@ public class ManagedCursorImpl implements ManagedCursor {
                     continue;
                 }
                 break;
+            }
+
+            long skippedEntries = 0;
+            if (newMarkDeletePosition.getLedgerId() == oldMarkDeletePosition.getLedgerId()
+                    && newMarkDeletePosition.getEntryId() == oldMarkDeletePosition.getEntryId() + 1) {
+                // Mark-deleting the position next to current one
+                skippedEntries = individualDeletedMessages.contains(newMarkDeletePosition.getLedgerId(),
+                        newMarkDeletePosition.getEntryId()) ? 0 : 1;
+            } else {
+                skippedEntries = getNumberOfEntries(Range.openClosed(oldMarkDeletePosition, newMarkDeletePosition));
             }
 
             if (log.isDebugEnabled()) {


### PR DESCRIPTION
### Motivation
Fix metric messagesConsumedCounter calculation error.
In the ManagedCursorImpl#setAcknowledgedPosition method, we will calculate skippedEntries based on newMarkDeletePosition and oldMarkDeletePosition, and then accumulate skippedEntries into MSG_CONSUMED_COUNTER_UPDATER: MSG_CONSUMED_COUNTER_UPDATER.addAndGet(this, skippedEntries);
But the newMarkDeletePosition here is not the final value, newMarkDeletePosition may change between calculating skippedEntries and accumulating to MSG_CONSUMED_COUNTER_UPDATER:
https://github.com/apache/pulsar/blob/bf6e815767c89512e0689562fbba0c2c453ff081/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java#L1769-L1802

### Modifications
Therefore, skippedEntries should only be calculated after newMarkDeletePosition has changed:
![image](https://user-images.githubusercontent.com/19296967/191154456-13d64a1c-842b-44c4-a71e-bfc5ec37e8dc.png)


### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)

- [x] `doc-not-needed` 
(Please explain why)

- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)

