### PR TITLE
[feat][build] Support ARM64-based docker images

### DIFF
--- a/docker/pulsar/Dockerfile
+++ b/docker/pulsar/Dockerfile
@@ -72,11 +72,14 @@ RUN mkdir -p /etc/apt/keyrings \
      && apt-get -y install temurin-17-jdk \
      && export architecture=$(uname -m | sed -r 's/aarch64/arm64/g' |  awk '!/arm64/{$0="amd64"}1') \
      && echo networkaddress.cache.ttl=1 >> /usr/lib/jvm/temurin-17-jdk-$architecture/conf/security/java.security \
-     && apt-get -y --purge autoremove \
+
+# Cleanup apt
+RUN apt-get -y --purge autoremove \
      && apt-get autoclean \
      && apt-get clean \
-     && rm -rf /var/lib/apt/lists/* \
-     && pip3 install pyyaml==5.4.1
+     && rm -rf /var/lib/apt/lists/*
+
+RUN pip3 install pyyaml==5.4.1
 
 # Pulsar currently writes to the below directories, assuming the default configuration.
 # Note that number 4 is the reason that pulsar components need write access to the /pulsar directory.

--- a/docker/pulsar/Dockerfile
+++ b/docker/pulsar/Dockerfile
@@ -70,8 +70,8 @@ RUN mkdir -p /etc/apt/keyrings \
      && apt-get update \
      && apt-get -y dist-upgrade \
      && apt-get -y install temurin-17-jdk \
-     && export architecture=$(uname -m | sed -r 's/aarch64/arm64/g' |  awk '!/arm64/{$0="amd64"}1') \
-     && echo networkaddress.cache.ttl=1 >> /usr/lib/jvm/temurin-17-jdk-$architecture/conf/security/java.security \
+     && export ARCH=$(uname -m | sed -r 's/aarch64/arm64/g' |  awk '!/arm64/{$0="amd64"}1') \
+     && echo networkaddress.cache.ttl=1 >> /usr/lib/jvm/temurin-17-jdk-$ARCH/conf/security/java.security \
 
 # Cleanup apt
 RUN apt-get -y --purge autoremove \

--- a/docker/pulsar/Dockerfile
+++ b/docker/pulsar/Dockerfile
@@ -70,7 +70,8 @@ RUN mkdir -p /etc/apt/keyrings \
      && apt-get update \
      && apt-get -y dist-upgrade \
      && apt-get -y install temurin-17-jdk \
-     && echo networkaddress.cache.ttl=1 >> /usr/lib/jvm/temurin-17-jdk-$(uname -m)/conf/security/java.security \
+     && export architecture=$(uname -m | sed -r 's/aarch64/arm64/g' |  awk '!/arm64/{$0="amd64"}1') \
+     && echo networkaddress.cache.ttl=1 >> /usr/lib/jvm/temurin-17-jdk-$architecture/conf/security/java.security \
      && apt-get -y --purge autoremove \
      && apt-get autoclean \
      && apt-get clean \

--- a/docker/pulsar/Dockerfile
+++ b/docker/pulsar/Dockerfile
@@ -70,15 +70,12 @@ RUN mkdir -p /etc/apt/keyrings \
      && apt-get update \
      && apt-get -y dist-upgrade \
      && apt-get -y install temurin-17-jdk \
-     && export JAVA_HOME="/usr/lib/jvm/temurin-17-jdk-$(uname -m)"
-
-# Cleanup apt
-RUN apt-get -y --purge autoremove \
+     && echo networkaddress.cache.ttl=1 >> /usr/lib/jvm/temurin-17-jdk-$(uname -m)/conf/security/java.security \
+     && apt-get -y --purge autoremove \
      && apt-get autoclean \
      && apt-get clean \
-     && rm -rf /var/lib/apt/lists/*
-
-RUN pip3 install pyyaml==5.4.1
+     && rm -rf /var/lib/apt/lists/* \
+     && pip3 install pyyaml==5.4.1
 
 # Pulsar currently writes to the below directories, assuming the default configuration.
 # Note that number 4 is the reason that pulsar components need write access to the /pulsar directory.
@@ -88,11 +85,9 @@ RUN pip3 install pyyaml==5.4.1
 # 4. /pulsar - hadoop writes to this directory
 RUN mkdir /pulsar && chmod g+w /pulsar
 
-RUN echo networkaddress.cache.ttl=1 >> ${JAVA_HOME}/conf/security/java.security
 ADD target/python-client/ /pulsar/pulsar-client
 
 ENV PULSAR_ROOT_LOGGER=INFO,CONSOLE
-
 
 COPY --from=pulsar /pulsar /pulsar
 WORKDIR /pulsar

--- a/docker/pulsar/Dockerfile
+++ b/docker/pulsar/Dockerfile
@@ -69,7 +69,8 @@ RUN mkdir -p /etc/apt/keyrings \
      && echo "deb [signed-by=/etc/apt/keyrings/adoptium.asc] https://packages.adoptium.net/artifactory/deb $(awk -F= '/^VERSION_CODENAME/{print$2}' /etc/os-release) main" | tee /etc/apt/sources.list.d/adoptium.list \
      && apt-get update \
      && apt-get -y dist-upgrade \
-     && apt-get -y install temurin-17-jdk
+     && apt-get -y install temurin-17-jdk \
+     && export JAVA_HOME="/usr/lib/jvm/temurin-17-jdk-$(uname -m)"
 
 # Cleanup apt
 RUN apt-get -y --purge autoremove \
@@ -87,8 +88,7 @@ RUN pip3 install pyyaml==5.4.1
 # 4. /pulsar - hadoop writes to this directory
 RUN mkdir /pulsar && chmod g+w /pulsar
 
-ENV JAVA_HOME /usr/lib/jvm/temurin-17-jdk-amd64
-RUN echo networkaddress.cache.ttl=1 >> /usr/lib/jvm/temurin-17-jdk-amd64/conf/security/java.security
+RUN echo networkaddress.cache.ttl=1 >> ${JAVA_HOME}/conf/security/java.security
 ADD target/python-client/ /pulsar/pulsar-client
 
 ENV PULSAR_ROOT_LOGGER=INFO,CONSOLE

--- a/docker/pulsar/pom.xml
+++ b/docker/pulsar/pom.xml
@@ -31,6 +31,7 @@
   <packaging>pom</packaging>
 
   <properties>
+    <pythonClientBuildArch>x86_64</pythonClientBuildArch>
     <skipBuildPythonClient>false</skipBuildPythonClient>
     <skipCopyPythonClients>false</skipCopyPythonClients>
   </properties>
@@ -79,7 +80,7 @@
                   <executable>${project.basedir}/../../pulsar-client-cpp/docker/build-wheels.sh</executable>
                   <arguments>
                     <!-- build python 3.8 -->
-                    <argument>3.8 cp38-cp38 manylinux2014 x86_64</argument>
+                    <argument>3.8 cp38-cp38 manylinux2014 ${pythonClientBuildArch}</argument>
                   </arguments>
                 </configuration>
               </execution>

--- a/docker/pulsar/scripts/install-pulsar-client.sh
+++ b/docker/pulsar/scripts/install-pulsar-client.sh
@@ -20,10 +20,13 @@
 
 set -x
 
+# TODO: remove these lines once grpcio doesn't need to compile from source on ARM64 platform
+ARCH=$(uname -m | sed -r 's/aarch64/arm64/g' |  awk '!/arm64/{$0="amd64"}1')
+if [ "${ARCH}" == "arm64" ]; then
+  apt update
+  apt -y install build-essential python3-dev
+fi
+
 PYTHON_MAJOR_MINOR=$(python3 -V | sed -E 's/.* ([[:digit:]]+)\.([[:digit:]]+).*/\1\2/')
 WHEEL_FILE=$(ls /pulsar/pulsar-client | grep "cp${PYTHON_MAJOR_MINOR}")
 pip3 install /pulsar/pulsar-client/${WHEEL_FILE}[all]
-
-# TODO: remove these lines once grpcio doesn't need to compile from source on ARM64 platform
-apt update
-apt -y install build-essential python3-dev

--- a/docker/pulsar/scripts/install-pulsar-client.sh
+++ b/docker/pulsar/scripts/install-pulsar-client.sh
@@ -23,3 +23,7 @@ set -x
 PYTHON_MAJOR_MINOR=$(python3 -V | sed -E 's/.* ([[:digit:]]+)\.([[:digit:]]+).*/\1\2/')
 WHEEL_FILE=$(ls /pulsar/pulsar-client | grep "cp${PYTHON_MAJOR_MINOR}")
 pip3 install /pulsar/pulsar-client/${WHEEL_FILE}[all]
+
+# TODO: remove these lines once grpcio doesn't need to compile from source on ARM64 platform
+apt update
+apt -y install build-essential python3-dev

--- a/tests/docker-images/java-test-image/Dockerfile
+++ b/tests/docker-images/java-test-image/Dockerfile
@@ -47,9 +47,7 @@ RUN mkdir -p /etc/apt/keyrings \
      && apt-get update \
      && apt-get -y dist-upgrade \
      && apt-get -y install temurin-17-jdk \
-     && export JAVA_HOME="/usr/lib/jvm/temurin-17-jdk-$(uname -m)"
-
-RUN echo networkaddress.cache.ttl=1 >> ${JAVA_HOME}/conf/security/java.security
+     && echo networkaddress.cache.ttl=1 >> /usr/lib/jvm/temurin-17-jdk-$(uname -m)/conf/security/java.security
 
 # /pulsar/bin/watch-znode.py requires python3-kazoo
 # /pulsar/bin/pulsar-managed-ledger-admin requires python3-protobuf

--- a/tests/docker-images/java-test-image/Dockerfile
+++ b/tests/docker-images/java-test-image/Dockerfile
@@ -47,8 +47,8 @@ RUN mkdir -p /etc/apt/keyrings \
      && apt-get update \
      && apt-get -y dist-upgrade \
      && apt-get -y install temurin-17-jdk \
-     && export architecture=$(uname -m | sed -r 's/aarch64/arm64/g' |  awk '!/arm64/{$0="amd64"}1') \
-     && echo networkaddress.cache.ttl=1 >> /usr/lib/jvm/temurin-17-jdk-$architecture/conf/security/java.security
+     && export ARCH=$(uname -m | sed -r 's/aarch64/arm64/g' |  awk '!/arm64/{$0="amd64"}1') \
+     && echo networkaddress.cache.ttl=1 >> /usr/lib/jvm/temurin-17-jdk-$ARCH/conf/security/java.security
 
 # /pulsar/bin/watch-znode.py requires python3-kazoo
 # /pulsar/bin/pulsar-managed-ledger-admin requires python3-protobuf

--- a/tests/docker-images/java-test-image/Dockerfile
+++ b/tests/docker-images/java-test-image/Dockerfile
@@ -46,10 +46,10 @@ RUN mkdir -p /etc/apt/keyrings \
      && echo "deb [signed-by=/etc/apt/keyrings/adoptium.asc] https://packages.adoptium.net/artifactory/deb $(awk -F= '/^VERSION_CODENAME/{print$2}' /etc/os-release) main" | tee /etc/apt/sources.list.d/adoptium.list \
      && apt-get update \
      && apt-get -y dist-upgrade \
-     && apt-get -y install temurin-17-jdk
+     && apt-get -y install temurin-17-jdk \
+     && export JAVA_HOME="/usr/lib/jvm/temurin-17-jdk-$(uname -m)"
 
-ENV JAVA_HOME /usr/lib/jvm/temurin-17-jdk-amd64
-RUN echo networkaddress.cache.ttl=1 >> /usr/lib/jvm/temurin-17-jdk-amd64/conf/security/java.security
+RUN echo networkaddress.cache.ttl=1 >> ${JAVA_HOME}/conf/security/java.security
 
 # /pulsar/bin/watch-znode.py requires python3-kazoo
 # /pulsar/bin/pulsar-managed-ledger-admin requires python3-protobuf

--- a/tests/docker-images/java-test-image/Dockerfile
+++ b/tests/docker-images/java-test-image/Dockerfile
@@ -47,7 +47,8 @@ RUN mkdir -p /etc/apt/keyrings \
      && apt-get update \
      && apt-get -y dist-upgrade \
      && apt-get -y install temurin-17-jdk \
-     && echo networkaddress.cache.ttl=1 >> /usr/lib/jvm/temurin-17-jdk-$(uname -m)/conf/security/java.security
+     && export architecture=$(uname -m | sed -r 's/aarch64/arm64/g' |  awk '!/arm64/{$0="amd64"}1') \
+     && echo networkaddress.cache.ttl=1 >> /usr/lib/jvm/temurin-17-jdk-$architecture/conf/security/java.security
 
 # /pulsar/bin/watch-znode.py requires python3-kazoo
 # /pulsar/bin/pulsar-managed-ledger-admin requires python3-protobuf

--- a/tests/docker-images/latest-version-image/Dockerfile
+++ b/tests/docker-images/latest-version-image/Dockerfile
@@ -29,13 +29,7 @@ RUN apt-get install -y procps curl git build-essential
 
 ENV GOLANG_VERSION 1.15.8
 
-RUN curl -sSL https://golang.org/dl/go$GOLANG_VERSION.linux-amd64.tar.gz \
-		| tar -C /usr/local -xz
-
-# RUN wget https://dl.google.com/go/go1.13.3.linux-amd64.tar.gz && tar -xvf go1.13.3.linux-amd64.tar.gz && mv go /usr/local
-# RUN export GOROOT=/usr/local/go && export GOPATH=$HOME/go && export PATH=$GOPATH/bin:$GOROOT/bin:$PATH
-# RUN echo "export GOROOT=/usr/local/go" >> ~/.profile && echo "export GOPATH=$HOME/go" >> ~/.profile && echo "export PATH=$GOPATH/bin:$GOROOT/bin:$PATH" >> ~/.profile
-
+RUN curl -sSL https://golang.org/dl/go$GOLANG_VERSION.linux-$(uname -m).tar.gz | tar -C /usr/local -xz
 ENV PATH /usr/local/go/bin:$PATH
 
 RUN mkdir -p /go/src /go/bin && chmod -R 777 /go

--- a/tests/docker-images/latest-version-image/Dockerfile
+++ b/tests/docker-images/latest-version-image/Dockerfile
@@ -29,8 +29,8 @@ RUN apt-get install -y procps curl git build-essential
 
 ENV GOLANG_VERSION 1.15.8
 
-RUN export architecture=$(uname -m | sed -r 's/aarch64/arm64/g' |  awk '!/arm64/{$0="amd64"}1') \
-     && curl -sSL https://golang.org/dl/go$GOLANG_VERSION.linux-$architecture.tar.gz | tar -C /usr/local -xz
+RUN export ARCH=$(uname -m | sed -r 's/aarch64/arm64/g' |  awk '!/arm64/{$0="amd64"}1') \
+     && curl -sSL https://golang.org/dl/go$GOLANG_VERSION.linux-$ARCH.tar.gz | tar -C /usr/local -xz
 ENV PATH /usr/local/go/bin:$PATH
 
 RUN mkdir -p /go/src /go/bin && chmod -R 777 /go

--- a/tests/docker-images/latest-version-image/Dockerfile
+++ b/tests/docker-images/latest-version-image/Dockerfile
@@ -29,7 +29,8 @@ RUN apt-get install -y procps curl git build-essential
 
 ENV GOLANG_VERSION 1.15.8
 
-RUN curl -sSL https://golang.org/dl/go$GOLANG_VERSION.linux-$(uname -m).tar.gz | tar -C /usr/local -xz
+RUN export architecture=$(uname -m | sed -r 's/aarch64/arm64/g' |  awk '!/arm64/{$0="amd64"}1') \
+     && curl -sSL https://golang.org/dl/go$GOLANG_VERSION.linux-$architecture.tar.gz | tar -C /usr/local -xz
 ENV PATH /usr/local/go/bin:$PATH
 
 RUN mkdir -p /go/src /go/bin && chmod -R 777 /go


### PR DESCRIPTION
This refers to #12944.

### Verifying this change

```bash
mvn clean install -DskipTests
./build/build_java_test_image.sh                                                
mvn package -Pdocker,-main -am -pl docker/pulsar-all -DskipTests -DpythonClientBuildArch=aarch64
```

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)

- [x] `doc-not-needed` 
(Please explain why)

- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)

### Matching PR in forked repository

PR in forked repository: https://github.com/tisonkun/pulsar/pull/2