### PR TITLE
[improve][doc] Add options to stats and partitioned-stats

### DIFF
--- a/site2/docs/reference-pulsar-admin.md
+++ b/site2/docs/reference-pulsar-admin.md
@@ -2476,7 +2476,7 @@ Options
 |Flag|Description|Default|
 |---|---|---|
 |`-gpb`,`--get-precise-backlog`| Set to `true` to get precise backlog | false |
-|`-sbs`,` --get-subscription-backlog-size`| Set true to get backlog size for each subscription, locking required | false | 
+|`-sbs`,` --get-subscription-backlog-size`| Set to `true` to get backlog size for each subscription, locking required | false | 
 |`--per-partition`|Get per-partition stats|false|
 
 

--- a/site2/docs/reference-pulsar-admin.md
+++ b/site2/docs/reference-pulsar-admin.md
@@ -2434,7 +2434,7 @@ Options
 |Flag|Description|Default|
 |---|---|---|
 |`-etb`,`--get-earliest-time-in-backlog` | Set to `true` to get the earliest time in backlog | false |
-|`-gpb`,`--get-precise-backlog`| Set true to get precise backlog | false |
+|`-gpb`,`--get-precise-backlog`| Set to `true` to get precise backlog | false |
 |`-sbs`,` --get-subscription-backlog-size`| Set to `true` to get backlog size for each subscription, locking required | false | 
 
 

--- a/site2/docs/reference-pulsar-admin.md
+++ b/site2/docs/reference-pulsar-admin.md
@@ -2475,7 +2475,7 @@ Options
 
 |Flag|Description|Default|
 |---|---|---|
-|`-gpb`,`--get-precise-backlog`| Set true to get precise backlog | false |
+|`-gpb`,`--get-precise-backlog`| Set to `true` to get precise backlog | false |
 |`-sbs`,` --get-subscription-backlog-size`| Set true to get backlog size for each subscription, locking required | false | 
 |`--per-partition`|Get per-partition stats|false|
 

--- a/site2/docs/reference-pulsar-admin.md
+++ b/site2/docs/reference-pulsar-admin.md
@@ -2737,6 +2737,7 @@ pulsar-admin topics remove-message-ttl tenant/namespace/topic
 ```
 
 Options 
+
 |Flag|Description|Default|
 |---|---|---|
 |`--enable`, `-e`|Enable message deduplication on the specified topic.|false|

--- a/site2/docs/reference-pulsar-admin.md
+++ b/site2/docs/reference-pulsar-admin.md
@@ -2429,6 +2429,15 @@ Usage
 pulsar-admin topics stats topic
 ```
 
+Options
+
+|Flag|Description|Default|
+|---|---|---|
+|`-etb`,`--get-earliest-time-in-backlog` | Set true to get earliest time in backlog | false |
+|`-gpb`,`--get-precise-backlog`| Set true to get precise backlog | false |
+|`-sbs`,` --get-subscription-backlog-size`| Set true to get backlog size for each subscription, locking required | false | 
+
+
 :::note
 
 The unit of `storageSize` and `averageMsgSize` is Byte.
@@ -2466,7 +2475,10 @@ Options
 
 |Flag|Description|Default|
 |---|---|---|
+|`-gpb`,`--get-precise-backlog`| Set true to get precise backlog | false |
+|`-sbs`,` --get-subscription-backlog-size`| Set true to get backlog size for each subscription, locking required | false | 
 |`--per-partition`|Get per-partition stats|false|
+
 
 ### `partitioned-stats-internal`
 Get the internal stats for the partitioned topic and its connected producers and consumers. All the rates are computed over a 1 minute window and are relative the last completed 1 minute period.

--- a/site2/docs/reference-pulsar-admin.md
+++ b/site2/docs/reference-pulsar-admin.md
@@ -2435,7 +2435,7 @@ Options
 |---|---|---|
 |`-etb`,`--get-earliest-time-in-backlog` | Set to `true` to get the earliest time in backlog | false |
 |`-gpb`,`--get-precise-backlog`| Set true to get precise backlog | false |
-|`-sbs`,` --get-subscription-backlog-size`| Set true to get backlog size for each subscription, locking required | false | 
+|`-sbs`,` --get-subscription-backlog-size`| Set to `true` to get backlog size for each subscription, locking required | false | 
 
 
 :::note

--- a/site2/docs/reference-pulsar-admin.md
+++ b/site2/docs/reference-pulsar-admin.md
@@ -2433,7 +2433,7 @@ Options
 
 |Flag|Description|Default|
 |---|---|---|
-|`-etb`,`--get-earliest-time-in-backlog` | Set true to get earliest time in backlog | false |
+|`-etb`,`--get-earliest-time-in-backlog` | Set to `true` to get the earliest time in backlog | false |
 |`-gpb`,`--get-precise-backlog`| Set true to get precise backlog | false |
 |`-sbs`,` --get-subscription-backlog-size`| Set true to get backlog size for each subscription, locking required | false | 
 


### PR DESCRIPTION
### Motivation

I noticed there were some options not shown in the documentation but offered in the help of the tool.

### Modifications

Add the options to stats and partitioned-stats in topics.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.



This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)

- [ ] `doc-not-needed` 
(Please explain why)

- [ X] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE 

After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.

-->
