### PR TITLE
[improve][ci] add back cpp-test name

### DIFF
--- a/.github/workflows/pulsar-ci.yaml
+++ b/.github/workflows/pulsar-ci.yaml
@@ -478,7 +478,7 @@ jobs:
           gh-actions-artifact-client.js delete pulsar-java-test-image.zst
 
   cpp-tests:
-    name:
+    name: CI - CPP, Python Tests
     runs-on: ubuntu-20.04
     timeout-minutes: 120
     needs: [


### PR DESCRIPTION
In https://github.com/apache/pulsar/pull/17571#discussion_r967208132, we remove the canonical name of `cpp-test` due to a deadlock between changing the request statuses and the workflow. Now we add back the canonical name "CI - CPP, Python Tests" to eliminate the trick.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)

- [x] `doc-not-needed` 
(Please explain why)

- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)

### Matching PR in forked repository

PR in forked repository: trivial to not have one.

cc @lhotari @nicoloboschi 