### PR TITLE
[feat][build] Print out more info for bin/pulsar version

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/PulsarVersionStarter.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/PulsarVersionStarter.java
@@ -56,5 +56,9 @@ public class PulsarVersionStarter {
             return;
         }
         System.out.println("Current version of pulsar is: " + PulsarVersion.getVersion());
+        System.out.println("Git Revision " + PulsarVersion.getGitSha());
+        System.out.println("Git Branch " + PulsarVersion.getGitBranch());
+        System.out.println("Built by " + PulsarVersion.getBuildUser() + " on " + PulsarVersion.getBuildHost() + " at "
+                + PulsarVersion.getBuildTime());
     }
 }


### PR DESCRIPTION
### Motivation

The current `bin/pulsar version` script only prints out the version string. When running custom builds of Pulsar, this is sometimes not enough to know which version you have. Since the `PulsarVersion` class already has more information, I propose we print out all of its information in the same format that the broker logs the information.

Here is a sample output for this specific PR:

```shell
$ bin/pulsar version
Current version of pulsar is: 2.11.0-SNAPSHOT
Git Revision 4414e3d76c27e821e75f30eae853862b04e63200
Git Branch print-more-version-info
Built by Michael Marshall <mmarshall@apache.org> on mmarshall-rmbp16 at 2020-01-22T09:10:15-0600
```

### Modifications

* Add more output to the `bin/pulsar version` command.

### Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

### Documentation

- [x] `doc-not-needed` 
(Please explain why)

### Matching PR in forked repository

PR in forked repository: https://github.com/michaeljmarshall/pulsar/pull/3
