### PR TITLE
[improve][broker]Skip numOfEntriesToRead entries instead of skipping a ledger

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
@@ -3461,17 +3461,7 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
     }
 
     public PositionImpl getNextValidPosition(final PositionImpl position) {
-        PositionImpl next;
-        try {
-            next = getNextValidPositionInternal(position);
-        } catch (NullPointerException e) {
-            next = lastConfirmedEntry.getNext();
-            if (log.isDebugEnabled()) {
-                log.debug("[{}] Can't find next valid position : {}, fall back to the next position of the last "
-                        + "position : {}.", position, name, next, e);
-            }
-        }
-        return next;
+        return getValidPositionAfterSkippedEntries(position, 1);
     }
     public PositionImpl getValidPositionAfterSkippedEntries(final PositionImpl position, int skippedEntryNum) {
         PositionImpl skippedPosition = position.getPositionAfterEntries(skippedEntryNum);

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
@@ -3474,6 +3474,32 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
         return next;
     }
 
+    public PositionImpl getValidPositionAfterSkippedEntries(final PositionImpl position, int skippedEntryNum) {
+        PositionImpl skippedPosition;
+        try {
+            skippedPosition = getValidPositionInternal(position, skippedEntryNum);
+        } catch (NullPointerException e) {
+            skippedPosition = lastConfirmedEntry.getNext();
+            if (log.isDebugEnabled()) {
+                log.debug("[{}] Can't find valid position : {}, fall back to the next position of the last "
+                        + "position : {}.", position, name, skippedPosition, e);
+            }
+        }
+        return skippedPosition;
+    }
+
+    public PositionImpl getValidPositionInternal(final PositionImpl position, int skippedEntryNum) {
+        PositionImpl toPosition = position.getPositionAfterEntries(skippedEntryNum);
+        while (!isValidPosition(toPosition)) {
+            Long nextLedgerId = ledgers.ceilingKey(toPosition.getLedgerId() + 1);
+            if (nextLedgerId == null) {
+                throw new NullPointerException();
+            }
+            toPosition = PositionImpl.get(nextLedgerId, 0);
+        }
+        return toPosition;
+    }
+
     public PositionImpl getNextValidPositionInternal(final PositionImpl position) {
         PositionImpl nextPosition = position.getNext();
         while (!isValidPosition(nextPosition)) {

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/OpReadEntry.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/OpReadEntry.java
@@ -19,7 +19,6 @@
 package org.apache.bookkeeper.mledger.impl;
 
 import static org.apache.bookkeeper.mledger.util.SafeRun.safeRun;
-
 import com.google.common.collect.Range;
 import io.netty.util.Recycler;
 import io.netty.util.Recycler.Handle;

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/OpReadEntry.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/OpReadEntry.java
@@ -101,7 +101,8 @@ class OpReadEntry implements ReadEntriesCallback {
             log.warn("[{}][{}] read failed from ledger at position:{} : {}", cursor.ledger.getName(), cursor.getName(),
                     readPosition, exception.getMessage());
             // Skip this read operation
-            PositionImpl nexReadPosition = cursor.ledger.getValidPositionAfterSkippedEntries(readPosition, count);
+            final ManagedLedgerImpl ledger = (ManagedLedgerImpl) cursor.getManagedLedger();
+            final PositionImpl nexReadPosition = ledger.getValidPositionAfterSkippedEntries(readPosition, count);
             // fail callback if it couldn't find next valid ledger
             if (nexReadPosition == null) {
                 callback.readEntriesFailed(exception, ctx);

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/OpReadEntry.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/OpReadEntry.java
@@ -102,12 +102,7 @@ class OpReadEntry implements ReadEntriesCallback {
             log.warn("[{}][{}] read failed from ledger at position:{} : {}", cursor.ledger.getName(), cursor.getName(),
                     readPosition, exception.getMessage());
             // skip numOfEntriesToRead entries
-            long skipEntriesNum = count;
-            PositionImpl nexReadPosition = null;
-            while (skipEntriesNum > 0) {
-                nexReadPosition = cursor.getNextAvailablePosition(readPosition);
-                skipEntriesNum -= cursor.getNumberOfEntries(Range.openClosed(readPosition, nexReadPosition));
-            }
+            PositionImpl nexReadPosition = cursor.ledger.getValidPositionAfterSkippedEntries(readPosition, count);
             // fail callback if it couldn't find next valid ledger
             if (nexReadPosition == null) {
                 callback.readEntriesFailed(exception, ctx);

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/OpReadEntry.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/OpReadEntry.java
@@ -19,7 +19,6 @@
 package org.apache.bookkeeper.mledger.impl;
 
 import static org.apache.bookkeeper.mledger.util.SafeRun.safeRun;
-import com.google.common.collect.Range;
 import io.netty.util.Recycler;
 import io.netty.util.Recycler.Handle;
 import java.util.ArrayList;
@@ -101,7 +100,7 @@ class OpReadEntry implements ReadEntriesCallback {
         } else if (cursor.config.isAutoSkipNonRecoverableData() && exception instanceof NonRecoverableLedgerException) {
             log.warn("[{}][{}] read failed from ledger at position:{} : {}", cursor.ledger.getName(), cursor.getName(),
                     readPosition, exception.getMessage());
-            // skip numOfEntriesToRead entries
+            // Skip this read operation
             PositionImpl nexReadPosition = cursor.ledger.getValidPositionAfterSkippedEntries(readPosition, count);
             // fail callback if it couldn't find next valid ledger
             if (nexReadPosition == null) {

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/PositionImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/PositionImpl.java
@@ -94,7 +94,14 @@ public class PositionImpl implements Position, Comparable<PositionImpl> {
         }
     }
 
+    /**
+     * Position after moving entryNum messages,
+     * if entryNum < 1, then return the current position.
+     * */
     public PositionImpl getPositionAfterEntries(int entryNum) {
+        if (entryNum < 1) {
+            return this;
+        }
         if (entryId < 0) {
             return PositionImpl.get(ledgerId, entryNum);
         } else {

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/PositionImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/PositionImpl.java
@@ -103,7 +103,7 @@ public class PositionImpl implements Position, Comparable<PositionImpl> {
             return this;
         }
         if (entryId < 0) {
-            return PositionImpl.get(ledgerId, entryNum);
+            return PositionImpl.get(ledgerId, entryNum - 1);
         } else {
             return PositionImpl.get(ledgerId, entryId + entryNum);
         }

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/PositionImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/PositionImpl.java
@@ -94,6 +94,14 @@ public class PositionImpl implements Position, Comparable<PositionImpl> {
         }
     }
 
+    public PositionImpl getPositionAfterEntries(int entryNum) {
+        if (entryId < 0) {
+            return PositionImpl.get(ledgerId, entryNum);
+        } else {
+            return PositionImpl.get(ledgerId, entryId + entryNum);
+        }
+    }
+
     /**
      * String representation of virtual cursor - LedgerId:EntryId.
      */


### PR DESCRIPTION
### Motivation
Skip numOfEntriesToRead entries instead of skipping a ledger.

When isAutoSkipNonRecoverableData=true, if a NonRecoverableLedgerException exception occurs when reading data, readPosition will automatically adjust to the next ledger to continue reading, which will result in a lot of existing data that cannot be read.

### Modifications

Therefore, the entry skip logic is modified to: only skip numOfEntriesToRead entries instead of skipping a ledger


### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)

- [x] `doc-not-needed` 
(Please explain why)

- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)

