### PR TITLE
[BLOG] Add Pulsar Summit Asia 2022 CFP blog

### DIFF
--- a/site2/website/blog/2022-08-22-pulsar-summit-asia-2022-cfp.md
+++ b/site2/website/blog/2022-08-22-pulsar-summit-asia-2022-cfp.md
@@ -1,0 +1,54 @@
+---
+author: Sherlock Xu
+title: "Pulsar Summit Asia 2022: CFP Is Open Now!"
+date: 2022-08-22
+---
+
+Pulsar Summit is the conference dedicated to Apache Pulsar, and the messaging and event streaming community. The conference gathers an international audience of developers, data architects, data scientists, Apache Pulsar committers and contributors, as well as the messaging and streaming community. Together, they share experiences, exchange ideas and knowledge, and receive hands-on training sessions led by Pulsar experts.
+
+In January this year, Pulsar Summit Asia 2021 (delayed due to the COVID-19 pandemic) featured more than 25 interactive sessions by technologists, developers, software engineers, and software architects from StreamNative, BIGO, China Mobile, Nutanix, Tencent, and more. The conference drew over 1000 attendees around the world, including attendees from top technology, internet, and media companies, such as Tencent, TikTok, Alibaba, and Microsoft.
+
+Pulsar Summit Asia 2022 will be hosted virtually on November 19th and 20th, 2022. It is expected to cover the pivotal topics and technologies at the core of Apache Pulsar.
+
+<!--truncate-->
+
+## Join us and speak at Pulsar Summit Asia 2022
+
+Share your Pulsar story and speak at the summit! It is a great opportunity to participate and raise your profile in the rapidly growing Apache Pulsar community. We are looking for Pulsar stories that are innovative, informative, or thought-provoking. Here are some suggestions:
+
+- Use cases, operations, tools, techniques, or the Pulsar ecosystem
+- A deep dive into technologies
+- Best practices and lessons learned
+- A Pulsar success story or case study
+- Anything else related to Pulsar that inspires the audience
+
+To speak at the summit, [submit an abstract](https://sessionize.com/pulsar-summit-asia-2022/) about your session. All levels of talks (beginner, intermediate, and advanced) are welcome. Remember to keep your proposal short, relevant, and engaging. The following session formats are acceptable:
+
+- **Presentation**: 40-minute presentation, maximum of 2 speakers
+- **Panel**: 40-minute of discussion amongst 3 to 5 speakers
+- **Workshop**: 60-90 minutes, in-depth, hands-on tutorials, maximum of 2 speakers
+- **Lightning talk**: 10-minute presentation, maximum of 2 speakers
+
+You need to pre-record your session after the proposal is approved. For time zone and network reasons, we do not recommend speakers present their talk live.
+
+## Dates to remember
+
+- **CFP opens**: August 22nd, 2022
+- **CFP closes**: October 9th, 2022
+- **CFP notifications**: October 19th, 2022
+- **Schedule announcement**: November 4th, 2022
+- **Event dates**: November 19th, 2022 - November 20th, 2022
+
+## Sponsor Pulsar Summit
+
+Pulsar Summit is a conference for the community and your support is needed. Sponsoring this event provides a great opportunity for your organization to further engage with the Apache Pulsar community. For more information on becoming a sponsor, contact us at organizers@pulsar-summit.org.
+
+Help us make #PulsarSummit Asia 2022 a big success by spreading the word and submitting your proposal! Follow us on Twitter ([@pulsarsummit](https://twitter.com/PulsarSummit)) to receive the latest updates on the summit!
+
+## About Apache Pulsar
+
+Apache Pulsar is a cloud-native, distributed messaging and streaming platform that empowers companies around the world to manage trillions of events per day. The Pulsar community has witnessed rapid growth since it became a top-level Apache Software Foundation project in 2018. Over the past four years, the vibrant community keeps driving innovation and improvements to the project.
+
+## About the organizer
+
+StreamNative is the organizer of Pulsar Summit Asia 2022. Founded by the original developers of Apache Pulsar and Apache BookKeeper, StreamNative builds a cloud-native event streaming platform that enables enterprises to easily access data as real-time event streams. As the core developers of Pulsar, the StreamNative team is deeply versed in the technology, the community, and the use cases. Today, StreamNative is focusing on growing the Apache Pulsar and BookKeeper communities and bringing its deep experience across diverse Pulsar use cases to companies across the globe.


### PR DESCRIPTION
### Motivation and Modifications

Add the Pulsar Summit Asia 2022 CFP blog. Replace https://github.com/apache/pulsar/pull/17218

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)

- [x] `doc-not-needed` 
(Please explain why)

- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)

Preview:
![Screen Shot 2022-09-21 at 12 20 44](https://user-images.githubusercontent.com/65327072/191414153-9983b65e-e5e7-4fa8-813e-ea2fd1ccbc2a.png)

![Screen Shot 2022-09-21 at 12 20 56](https://user-images.githubusercontent.com/65327072/191414160-f008bc30-c577-46d8-ba9b-ecbd72a59ae4.png)
