### PR TITLE
[fix][ci][branch-2.10] Fix owasp ci failure on branch-2.10

### DIFF
--- a/src/owasp-dependency-check-suppressions.xml
+++ b/src/owasp-dependency-check-suppressions.xml
@@ -28,7 +28,7 @@
     </suppress>
     <suppress>
         <notes>Suppress all pulsar-presto-distribution vulnerabilities</notes>
-        <filePath regex="true">.*pulsar-presto-distribution-.*</filePath>
+        <filePath regex="true">.*pulsar-presto-distribution.*</filePath>
         <vulnerabilityName regex="true">.*</vulnerabilityName>
     </suppress>
     <suppress>


### PR DESCRIPTION

### Motivation

Currently owasp ci check fails on branch-2.10.
See https://github.com/Jason918/pulsar/actions/runs/3088190603/jobs/4994380011#step:8:53
```
Error:  Failed to execute goal org.owasp:dependency-check-maven:7.1.0:aggregate (default) on project distribution: 
Error:  
Error:  One or more dependencies were identified with vulnerabilities that have a CVSS score greater than or equal to '7.0': 
Error:  
Error:  pulsar-presto-distribution.tar.gz: pulsar-presto-distribution.tar: aether-connector-asynchttpclient-1.13.1.jar: CVE-2017-14063(7.5), CVE-2021-43138(7.8)
Error:  pulsar-presto-distribution.tar.gz: pulsar-presto-distribution.tar: async-http-client-1.6.5.jar: CVE-2021-43138(7.8)
Error:  pulsar-presto-distribution.tar.gz: pulsar-presto-distribution.tar: grpc-netty-1.45.1.jar: CVE-2019-16869(7.5), CVE-2015-2156(7.5), CVE-2021-37136(7.5), CVE-2021-37137(7.5), CVE-2019-20445(9.1), CVE-2019-20444(9.1)
Error:  pulsar-presto-distribution.tar.gz: pulsar-presto-distribution.tar: logback-core-1.2.3.jar: CVE-2021-42[55](https://github.com/Jason918/pulsar/actions/runs/3088190603/jobs/4994380011#step:8:56)0(6.6)
Error:  pulsar-presto-distribution.tar.gz: pulsar-presto-distribution.tar: maven-compat-3.0.5.jar: CVE-2021-26291(9.1)
Error:  pulsar-presto-distribution.tar.gz: pulsar-presto-distribution.tar: maven-core-3.0.5.jar: CVE-2021-26291(9.1)
Error:  pulsar-presto-distribution.tar.gz: pulsar-presto-distribution.tar: maven-settings-3.0.5.jar: CVE-2021-26291(9.1)
Error:  pulsar-presto-distribution.tar.gz: pulsar-presto-distribution.tar: netty-3.10.6.Final.jar: CVE-2019-16869(7.5), CVE-2021-37136(7.5), CVE-2021-37137(7.5), CVE-2019-20445(9.1), CVE-2019-20444(9.1)
Error:  pulsar-presto-distribution.tar.gz: pulsar-presto-distribution.tar: okhttp-3.14.9.jar: CVE-2021-0341(7.5)
Error:  pulsar-presto-distribution.tar.gz: pulsar-presto-distribution.tar: plexus-utils-2.0.6.jar: CVE-2017-1000487(9.8)
Error:  pulsar-presto-distribution.tar.gz: pulsar-presto-distribution.tar: presto-cli-332.jar: CVE-2020-15087(8.8)
Error:  pulsar-presto-distribution.tar.gz: pulsar-presto-distribution.tar: presto-spi-332.jar: CVE-2020-15087(8.8)
```

### Modifications

Exclude distribution and distribution/server from owasp check.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.


### Does this pull request potentially affect one of the following parts:

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)

- [x] `doc-not-needed` 
bug fix

- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)

### Matching PR in forked repository

PR in forked repository: https://github.com/Jason918/pulsar/pull/6 
branch-2.10 in my fork contains this PR. See https://github.com/Jason918/pulsar/tree/branch-2.10
<!-- ENTER URL HERE 

After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.

-->
