### PR TITLE
[improve][admin] Add new flag `--no-ledger` to stats-internal command

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
@@ -1274,7 +1274,8 @@ public class PersistentTopicsBase extends AdminResource {
     }
 
     protected CompletableFuture<PersistentTopicInternalStats> internalGetInternalStatsAsync(boolean authoritative,
-                                                                                            boolean metadata) {
+                                                                                            boolean metadata,
+                                                                                            boolean noLedger) {
         CompletableFuture<Void> ret;
         if (topicName.isGlobal()) {
             ret = validateGlobalNamespaceOwnershipAsync(namespaceName);
@@ -1290,7 +1291,7 @@ public class PersistentTopicsBase extends AdminResource {
                     return CompletableFuture.completedFuture(null);
                 })
                 .thenCompose(__ -> getTopicReferenceAsync(topicName))
-                .thenCompose(topic -> topic.getInternalStats(metadata));
+                .thenCompose(topic -> topic.getInternalStats(metadata, noLedger));
     }
 
     protected void internalGetManagedLedgerInfo(AsyncResponse asyncResponse, boolean authoritative) {
@@ -1492,7 +1493,8 @@ public class PersistentTopicsBase extends AdminResource {
         });
     }
 
-    protected void internalGetPartitionedStatsInternal(AsyncResponse asyncResponse, boolean authoritative) {
+    protected void internalGetPartitionedStatsInternal(AsyncResponse asyncResponse,
+                                                       boolean authoritative, boolean metadata, boolean noLedger) {
         CompletableFuture<Void> future;
         if (topicName.isGlobal()) {
             future = validateGlobalNamespaceOwnershipAsync(namespaceName);
@@ -1513,7 +1515,7 @@ public class PersistentTopicsBase extends AdminResource {
             for (int i = 0; i < partitionMetadata.partitions; i++) {
                 try {
                     topicStatsFutureList.add(pulsar().getAdminClient().topics()
-                            .getInternalStatsAsync((topicName.getPartition(i).toString()), false));
+                            .getInternalStatsAsync((topicName.getPartition(i).toString()), metadata, noLedger));
                 } catch (PulsarServerException e) {
                     asyncResponse.resume(new RestException(e));
                     return;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v1/NonPersistentTopics.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v1/NonPersistentTopics.java
@@ -99,14 +99,15 @@ public class NonPersistentTopics extends PersistentTopics {
             @PathParam("namespace") String namespace,
             @PathParam("topic") @Encoded String encodedTopic,
             @QueryParam("authoritative") @DefaultValue("false") boolean authoritative,
-            @QueryParam("metadata") @DefaultValue("false") boolean metadata) {
+            @QueryParam("metadata") @DefaultValue("false") boolean metadata,
+            @QueryParam("noLedger") @DefaultValue("false") boolean noLedger) {
         validateTopicName(property, cluster, namespace, encodedTopic);
         validateTopicOwnershipAsync(topicName, authoritative)
                 .thenCompose(__ -> validateTopicOperationAsync(topicName, TopicOperation.GET_STATS))
                 .thenCompose(__ -> {
                     Topic topic = getTopicReference(topicName);
                     boolean includeMetadata = metadata && hasSuperUserAccess();
-                    return topic.getInternalStats(includeMetadata);
+                    return topic.getInternalStats(includeMetadata, noLedger);
                 })
                 .thenAccept(asyncResponse::resume)
                 .exceptionally(ex -> {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v1/PersistentTopics.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v1/PersistentTopics.java
@@ -455,9 +455,10 @@ public class PersistentTopics extends PersistentTopicsBase {
             @PathParam("cluster") String cluster, @PathParam("namespace") String namespace,
             @PathParam("topic") @Encoded String encodedTopic,
             @QueryParam("authoritative") @DefaultValue("false") boolean authoritative,
-            @QueryParam("metadata") @DefaultValue("false") boolean metadata) {
+            @QueryParam("metadata") @DefaultValue("false") boolean metadata,
+            @QueryParam("noLedger") @DefaultValue("false") boolean noLedger) {
         validateTopicName(property, cluster, namespace, encodedTopic);
-        internalGetInternalStatsAsync(authoritative, metadata)
+        internalGetInternalStatsAsync(authoritative, metadata, noLedger)
                 .thenAccept(asyncResponse::resume)
                 .exceptionally(ex -> {
                     if (!isRedirectException(ex)) {
@@ -518,10 +519,12 @@ public class PersistentTopics extends PersistentTopicsBase {
             @PathParam("property") String property,
             @PathParam("cluster") String cluster, @PathParam("namespace") String namespace,
             @PathParam("topic") @Encoded String encodedTopic,
-            @QueryParam("authoritative") @DefaultValue("false") boolean authoritative) {
+            @QueryParam("authoritative") @DefaultValue("false") boolean authoritative,
+            @QueryParam("metadata") @DefaultValue("false") boolean metadata,
+            @QueryParam("noLedger") @DefaultValue("false") boolean noLedger) {
         try {
             validateTopicName(property, cluster, namespace, encodedTopic);
-            internalGetPartitionedStatsInternal(asyncResponse, authoritative);
+            internalGetPartitionedStatsInternal(asyncResponse, authoritative, metadata, noLedger);
         } catch (WebApplicationException wae) {
             asyncResponse.resume(wae);
         } catch (Exception e) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/NonPersistentTopics.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/NonPersistentTopics.java
@@ -123,14 +123,15 @@ public class NonPersistentTopics extends PersistentTopics {
             @PathParam("topic") @Encoded String encodedTopic,
             @ApiParam(value = "Whether leader broker redirected this call to this broker. For internal use.")
             @QueryParam("authoritative") @DefaultValue("false") boolean authoritative,
-            @QueryParam("metadata") @DefaultValue("false") boolean metadata) {
+            @QueryParam("metadata") @DefaultValue("false") boolean metadata,
+            @QueryParam("noLedger") @DefaultValue("false") boolean noLedger) {
         validateTopicName(tenant, namespace, encodedTopic);
         validateTopicOwnershipAsync(topicName, authoritative)
                 .thenCompose(__ -> validateTopicOperationAsync(topicName, TopicOperation.GET_STATS))
                 .thenCompose(__ -> {
                     Topic topic = getTopicReference(topicName);
                     boolean includeMetadata = metadata && hasSuperUserAccess();
-                    return topic.getInternalStats(includeMetadata);
+                    return topic.getInternalStats(includeMetadata, noLedger);
                 })
                 .thenAccept(asyncResponse::resume)
                 .exceptionally(ex -> {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/PersistentTopics.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/PersistentTopics.java
@@ -1246,9 +1246,10 @@ public class PersistentTopics extends PersistentTopicsBase {
             @PathParam("topic") @Encoded String encodedTopic,
             @ApiParam(value = "Whether leader broker redirected this call to this broker. For internal use.")
             @QueryParam("authoritative") @DefaultValue("false") boolean authoritative,
-            @QueryParam("metadata") @DefaultValue("false") boolean metadata) {
+            @QueryParam("metadata") @DefaultValue("false") boolean metadata,
+            @QueryParam("noLedger") @DefaultValue("false") boolean noLedger) {
         validateTopicName(tenant, namespace, encodedTopic);
-        internalGetInternalStatsAsync(authoritative, metadata)
+        internalGetInternalStatsAsync(authoritative, metadata, noLedger)
                 .thenAccept(asyncResponse::resume)
                 .exceptionally(ex -> {
                     if (!isRedirectException(ex)) {
@@ -1345,10 +1346,12 @@ public class PersistentTopics extends PersistentTopicsBase {
             @ApiParam(value = "Specify topic name", required = true)
             @PathParam("topic") @Encoded String encodedTopic,
             @ApiParam(value = "Whether leader broker redirected this call to this broker. For internal use.")
-            @QueryParam("authoritative") @DefaultValue("false") boolean authoritative) {
+            @QueryParam("authoritative") @DefaultValue("false") boolean authoritative,
+            @QueryParam("metadata") @DefaultValue("false") boolean metadata,
+            @QueryParam("noLedger") @DefaultValue("false") boolean noLedger) {
         try {
             validateTopicName(tenant, namespace, encodedTopic);
-            internalGetPartitionedStatsInternal(asyncResponse, authoritative);
+            internalGetPartitionedStatsInternal(asyncResponse, authoritative, metadata, noLedger);
         } catch (WebApplicationException wae) {
             asyncResponse.resume(wae);
         } catch (Exception e) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Topic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Topic.java
@@ -267,8 +267,7 @@ public interface Topic {
                                                               boolean subscriptionBacklogSize,
                                                               boolean getEarliestTimeInBacklog);
 
-    CompletableFuture<PersistentTopicInternalStats> getInternalStats(boolean includeLedgerMetadata,
-                                                                     boolean noLedger);
+    CompletableFuture<PersistentTopicInternalStats> getInternalStats(boolean includeLedgerMetadata, boolean noLedger);
 
     Position getLastPosition();
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Topic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Topic.java
@@ -267,7 +267,8 @@ public interface Topic {
                                                               boolean subscriptionBacklogSize,
                                                               boolean getEarliestTimeInBacklog);
 
-    CompletableFuture<PersistentTopicInternalStats> getInternalStats(boolean includeLedgerMetadata);
+    CompletableFuture<PersistentTopicInternalStats> getInternalStats(boolean includeLedgerMetadata,
+                                                                     boolean noLedger);
 
     Position getLastPosition();
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentTopic.java
@@ -901,7 +901,8 @@ public class NonPersistentTopic extends AbstractTopic implements Topic, TopicPol
     }
 
     @Override
-    public CompletableFuture<PersistentTopicInternalStats> getInternalStats(boolean includeLedgerMetadata) {
+    public CompletableFuture<PersistentTopicInternalStats> getInternalStats(boolean includeLedgerMetadata,
+                                                                            boolean noLedger) {
 
         PersistentTopicInternalStats stats = new PersistentTopicInternalStats();
         stats.entriesAddedCounter = ENTRIES_ADDED_COUNTER_UPDATER.get(this);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApi2Test.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApi2Test.java
@@ -367,7 +367,8 @@ public class AdminApi2Test extends MockedPulsarServiceBaseTest {
         assertEquals(topicStats.getOwnerBroker(),
                 pulsar.getAdvertisedAddress() + ":" + pulsar.getConfiguration().getWebServicePort().get());
 
-        PersistentTopicInternalStats internalStats = admin.topics().getInternalStats(nonPersistentTopicName, false);
+        PersistentTopicInternalStats internalStats = admin.topics().getInternalStats(nonPersistentTopicName, false,
+                false);
         assertEquals(internalStats.cursors.keySet(), new TreeSet<>(Lists.newArrayList("my-sub")));
 
         consumer.close();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiTest.java
@@ -885,7 +885,7 @@ public class AdminApiTest extends MockedPulsarServiceBaseTest {
         assertEquals(topicStats.getOwnerBroker(),
                 pulsar.getAdvertisedAddress() + ":" + pulsar.getConfiguration().getWebServicePort().get());
 
-        PersistentTopicInternalStats internalStats = admin.topics().getInternalStats(persistentTopicName, false);
+        PersistentTopicInternalStats internalStats = admin.topics().getInternalStats(persistentTopicName, false, false);
         assertEquals(internalStats.cursors.keySet(), new TreeSet<>(Lists.newArrayList(Codec.encode(subName))));
 
         List<Message<byte[]>> messages = admin.topics().peekMessages(persistentTopicName, subName, 3);
@@ -1237,10 +1237,10 @@ public class AdminApiTest extends MockedPulsarServiceBaseTest {
 
         Thread.sleep(1000);
 
-        PersistentTopicInternalStats internalStats0 = admin.topics().getInternalStats(partitionTopic0, false);
+        PersistentTopicInternalStats internalStats0 = admin.topics().getInternalStats(partitionTopic0, false, false);
         assertEquals(internalStats0.cursors.keySet(), new TreeSet<>(Lists.newArrayList(Codec.encode(subName))));
 
-        PersistentTopicInternalStats internalStats1 = admin.topics().getInternalStats(partitionTopic1, false);
+        PersistentTopicInternalStats internalStats1 = admin.topics().getInternalStats(partitionTopic1, false, false);
         assertEquals(internalStats1.cursors.keySet(), new TreeSet<>(Lists.newArrayList(Codec.encode(subName))));
 
         // expected internal stats
@@ -1250,7 +1250,8 @@ public class AdminApiTest extends MockedPulsarServiceBaseTest {
         expectedInternalStats.partitions.put(partitionTopic1, internalStats1);
 
         // partitioned internal stats
-        PartitionedTopicInternalStats partitionedInternalStats = admin.topics().getPartitionedInternalStats(partitionedTopicName);
+        PartitionedTopicInternalStats partitionedInternalStats = admin.topics().getPartitionedInternalStats(partitionedTopicName,
+                false, false);
 
         String expectedResult = ObjectMapperFactory.getThreadLocal().writeValueAsString(expectedInternalStats);
         String result = ObjectMapperFactory.getThreadLocal().writeValueAsString(partitionedInternalStats);
@@ -3309,7 +3310,7 @@ public class AdminApiTest extends MockedPulsarServiceBaseTest {
         admin.topics().unload(topicName);
         publishMessagesOnPersistentTopic(topicName, 10);
         admin.topics().truncate(topicName);
-        PartitionedTopicInternalStats stats = admin.topics().getPartitionedInternalStats(topicName);
+        PartitionedTopicInternalStats stats = admin.topics().getPartitionedInternalStats(topicName, false, false);
         for (Map.Entry<String, PersistentTopicInternalStats> statsEntry : stats.partitions.entrySet()) {
             assertTrue(statsEntry.getValue().ledgers.size() <= 2);
         }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/v1/V1_AdminApiTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/v1/V1_AdminApiTest.java
@@ -740,7 +740,7 @@ public class V1_AdminApiTest extends MockedPulsarServiceBaseTest {
         assertEquals(topicStats.getSubscriptions().get("my-sub").getMsgBacklog(), 10);
         assertEquals(topicStats.getPublishers().size(), 0);
 
-        PersistentTopicInternalStats internalStats = admin.topics().getInternalStats(persistentTopicName, false);
+        PersistentTopicInternalStats internalStats = admin.topics().getInternalStats(persistentTopicName, false, false);
         assertEquals(internalStats.cursors.keySet(), new TreeSet<>(Lists.newArrayList("my-sub")));
 
         List<Message<byte[]>> messages = admin.topics().peekMessages(persistentTopicName, "my-sub", 3);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BacklogQuotaManagerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BacklogQuotaManagerTest.java
@@ -230,7 +230,7 @@ public class BacklogQuotaManagerTest {
             Awaitility.await().untilAsserted(() -> {
                 // make sure ledgers are trimmed
                 PersistentTopicInternalStats internalStats =
-                        admin.topics().getInternalStats(topic1, false);
+                        admin.topics().getInternalStats(topic1, false, false);
 
                 // check there is only one ledger left
                 assertEquals(internalStats.ledgers.size(), 1);
@@ -302,7 +302,7 @@ public class BacklogQuotaManagerTest {
             MessageIdImpl finalMessageId = messageId;
             Awaitility.await().untilAsserted(() -> {
                 // make sure ledgers are trimmed
-                PersistentTopicInternalStats internalStats = admin.topics().getInternalStats(topic1, false);
+                PersistentTopicInternalStats internalStats = admin.topics().getInternalStats(topic1, false, false);
 
                 // check there is only one ledger left
                 assertEquals(internalStats.ledgers.size(), 1);
@@ -367,7 +367,7 @@ public class BacklogQuotaManagerTest {
                     .pollDelay(Duration.ofSeconds(TIME_TO_CHECK_BACKLOG_QUOTA))
                     .pollInterval(Duration.ofSeconds(1)).untilAsserted(() -> {
                 // make sure ledgers are trimmed
-                PersistentTopicInternalStats internalStats = admin.topics().getInternalStats(topic1, false);
+                PersistentTopicInternalStats internalStats = admin.topics().getInternalStats(topic1, false, false);
 
                 // check that there are 2 ledgers
                 assertEquals(internalStats.ledgers.size(), 2);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/TransactionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/TransactionTest.java
@@ -647,7 +647,7 @@ public class TransactionTest extends TransactionTestBase {
         TransactionBuffer buffer3 = new TopicTransactionBuffer(persistentTopic);
         Awaitility.await().atMost(30, TimeUnit.SECONDS).untilAsserted(() ->
                 assertEquals(buffer3.getStats(false).state, "Ready"));
-        persistentTopic.getInternalStats(false, true).thenAccept(internalStats -> {
+        persistentTopic.getInternalStats(false, false).thenAccept(internalStats -> {
             assertTrue(internalStats.cursors.isEmpty());
         });
         managedCursors.removeCursor("transaction-buffer-sub");

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/TransactionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/TransactionTest.java
@@ -647,7 +647,7 @@ public class TransactionTest extends TransactionTestBase {
         TransactionBuffer buffer3 = new TopicTransactionBuffer(persistentTopic);
         Awaitility.await().atMost(30, TimeUnit.SECONDS).untilAsserted(() ->
                 assertEquals(buffer3.getStats(false).state, "Ready"));
-        persistentTopic.getInternalStats(false).thenAccept(internalStats -> {
+        persistentTopic.getInternalStats(false, true).thenAccept(internalStats -> {
             assertTrue(internalStats.cursors.isEmpty());
         });
         managedCursors.removeCursor("transaction-buffer-sub");

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/AuthorizationProducerConsumerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/AuthorizationProducerConsumerTest.java
@@ -218,7 +218,7 @@ public class AuthorizationProducerConsumerTest extends ProducerConsumerBase {
 
         // subscriptionRole doesn't have topic-level authorization, so it will fail to get topic stats-internal info
         try {
-            sub1Admin.topics().getInternalStats(topicName, true);
+            sub1Admin.topics().getInternalStats(topicName, true, false);
             fail("should have failed with authorization exception");
         } catch (Exception e) {
             assertTrue(e.getMessage().startsWith(
@@ -252,7 +252,7 @@ public class AuthorizationProducerConsumerTest extends ProducerConsumerBase {
         assertEquals(subscriptions.size(), 2);
 
         // now, subscriptionRole have consume authorization on topic, so it will successfully get topic internal stats
-        PersistentTopicInternalStats internalStats = sub1Admin.topics().getInternalStats(topicName, true);
+        PersistentTopicInternalStats internalStats = sub1Admin.topics().getInternalStats(topicName, true, false);
         assertNotNull(internalStats);
         Long backlogSize = sub1Admin.topics().getBacklogSizeByMessageId(topicName, MessageId.earliest);
         assertEquals(backlogSize.longValue(), 0);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/BatchMessageIndexAckTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/BatchMessageIndexAckTest.java
@@ -226,7 +226,7 @@ public class BatchMessageIndexAckTest extends ProducerConsumerBase {
 
         // check the mark delete position was changed
         BatchMessageIdImpl ackedMessageId = (BatchMessageIdImpl) received.get(0);
-        PersistentTopicInternalStats stats = admin.topics().getInternalStats(topic, false);
+        PersistentTopicInternalStats stats = admin.topics().getInternalStats(topic, false, false);
         String markDeletePosition = stats.cursors.get(subscriptionName).markDeletePosition;
         Assert.assertEquals(ackedMessageId.ledgerId + ":" + ackedMessageId.entryId, markDeletePosition);
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/MultiTopicsReaderTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/MultiTopicsReaderTest.java
@@ -297,21 +297,21 @@ public class MultiTopicsReaderTest extends MockedPulsarServiceBaseTest {
                 .create();
 
         Assert.assertEquals(admin.topics().getSubscriptions(topic).size(), 2);
-        for (PersistentTopicInternalStats value : admin.topics().getPartitionedInternalStats(topic).partitions.values()) {
+        for (PersistentTopicInternalStats value : admin.topics().getPartitionedInternalStats(topic, false, false).partitions.values()) {
             Assert.assertEquals(value.cursors.size(), 2);
         }
 
         reader1.close();
 
         Assert.assertEquals(admin.topics().getSubscriptions(topic).size(), 1);
-        for (PersistentTopicInternalStats value : admin.topics().getPartitionedInternalStats(topic).partitions.values()) {
+        for (PersistentTopicInternalStats value : admin.topics().getPartitionedInternalStats(topic, false, false).partitions.values()) {
             Assert.assertEquals(value.cursors.size(), 1);
         }
 
         reader2.close();
 
         Assert.assertEquals(admin.topics().getSubscriptions(topic).size(), 0);
-        for (PersistentTopicInternalStats value : admin.topics().getPartitionedInternalStats(topic).partitions.values()) {
+        for (PersistentTopicInternalStats value : admin.topics().getPartitionedInternalStats(topic, false, false).partitions.values()) {
             Assert.assertEquals(value.cursors.size(), 0);
         }
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/ReaderTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/ReaderTest.java
@@ -341,17 +341,17 @@ public class ReaderTest extends MockedPulsarServiceBaseTest {
             .create();
 
         Assert.assertEquals(admin.topics().getStats(topic).getSubscriptions().size(), 2);
-        Assert.assertEquals(admin.topics().getInternalStats(topic, false).cursors.size(), 2);
+        Assert.assertEquals(admin.topics().getInternalStats(topic, false, false).cursors.size(), 2);
 
         reader1.close();
 
         Assert.assertEquals(admin.topics().getStats(topic).getSubscriptions().size(), 1);
-        Assert.assertEquals(admin.topics().getInternalStats(topic, false).cursors.size(), 1);
+        Assert.assertEquals(admin.topics().getInternalStats(topic, false, false).cursors.size(), 1);
 
         reader2.close();
 
         Assert.assertEquals(admin.topics().getStats(topic).getSubscriptions().size(), 0);
-        Assert.assertEquals(admin.topics().getInternalStats(topic, false).cursors.size(), 0);
+        Assert.assertEquals(admin.topics().getInternalStats(topic, false, false).cursors.size(), 0);
 
     }
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/TransactionEndToEndTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/TransactionEndToEndTest.java
@@ -479,7 +479,7 @@ public class TransactionEndToEndTest extends TransactionTestBase {
         Assert.assertNull(message);
 
         String checkTopic = TopicName.get(topic).getPartition(0).toString();
-        PersistentTopicInternalStats stats = admin.topics().getInternalStats(checkTopic, false);
+        PersistentTopicInternalStats stats = admin.topics().getInternalStats(checkTopic, false, false);
 
         Assert.assertNotEquals(stats.cursors.get(subName).markDeletePosition, stats.lastConfirmedEntry);
 
@@ -653,7 +653,7 @@ public class TransactionEndToEndTest extends TransactionTestBase {
             PersistentTopicInternalStats stats = null;
             String checkTopic = TopicName.get(topic).getPartition(i).toString();
             for (int j = 0; j < 10; j++) {
-                stats = admin.topics().getInternalStats(checkTopic, false);
+                stats = admin.topics().getInternalStats(checkTopic, false, false);
                 if (stats.lastConfirmedEntry.equals(stats.cursors.get(subName).markDeletePosition)) {
                     break;
                 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/compaction/CompactionRetentionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/compaction/CompactionRetentionTest.java
@@ -109,7 +109,7 @@ public class CompactionRetentionTest extends MockedPulsarServiceBaseTest {
         compactor.compact(topic).join();
 
         log.info(" ---- X 1: {}", mapper.writeValueAsString(
-                admin.topics().getInternalStats(topic, false)));
+                admin.topics().getInternalStats(topic, false, false)));
 
         int round = 1;
 
@@ -121,14 +121,14 @@ public class CompactionRetentionTest extends MockedPulsarServiceBaseTest {
         }
 
         log.info(" ---- X 2: {}", mapper.writeValueAsString(
-                admin.topics().getInternalStats(topic, false)));
+                admin.topics().getInternalStats(topic, false, false)));
 
         validateMessages(pulsarClient, true, topic, round, allKeys);
 
         compactor.compact(topic).join();
 
         log.info(" ---- X 3: {}", mapper.writeValueAsString(
-                admin.topics().getInternalStats(topic, false)));
+                admin.topics().getInternalStats(topic, false, false)));
 
         validateMessages(pulsarClient, true, topic, round, allKeys);
 
@@ -155,7 +155,7 @@ public class CompactionRetentionTest extends MockedPulsarServiceBaseTest {
         compactor.compact(topic).join();
 
         log.info(" ---- X 4: {}", mapper.writeValueAsString(
-                admin.topics().getInternalStats(topic, false)));
+                admin.topics().getInternalStats(topic, false, false)));
 
         validateMessages(pulsarClient, true, topic, round, keys);
 
@@ -224,7 +224,7 @@ public class CompactionRetentionTest extends MockedPulsarServiceBaseTest {
         Compactor compactor = new TwoPhaseCompactor(conf, pulsarClient, bk, compactionScheduler);
 
         log.info(" ---- X 1: {}", mapper.writeValueAsString(
-                admin.topics().getInternalStats(topic, false)));
+                admin.topics().getInternalStats(topic, false, false)));
 
         int round = 1;
 
@@ -236,14 +236,14 @@ public class CompactionRetentionTest extends MockedPulsarServiceBaseTest {
         }
 
         log.info(" ---- X 2: {}", mapper.writeValueAsString(
-                admin.topics().getInternalStats(topic, false)));
+                admin.topics().getInternalStats(topic, false, false)));
 
         validateMessages(pulsarClient, true, topic, round, allKeys);
 
         compactor.compact(topic).join();
 
         log.info(" ---- X 3: {}", mapper.writeValueAsString(
-                admin.topics().getInternalStats(topic, false)));
+                admin.topics().getInternalStats(topic, false, false)));
 
         validateMessages(pulsarClient, true, topic, round, allKeys);
     }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/compaction/CompactionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/compaction/CompactionTest.java
@@ -150,7 +150,7 @@ public class CompactionTest extends MockedPulsarServiceBaseTest {
         Compactor compactor = new TwoPhaseCompactor(conf, pulsarClient, bk, compactionScheduler);
         compactor.compact(topic).get();
 
-        PersistentTopicInternalStats internalStats = admin.topics().getInternalStats(topic, false);
+        PersistentTopicInternalStats internalStats = admin.topics().getInternalStats(topic, false, false);
         // Compacted topic ledger should have same number of entry equals to number of unique key.
         Assert.assertEquals(expected.size(), internalStats.compactedLedger.entries);
         Assert.assertTrue(internalStats.compactedLedger.ledgerId > -1);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/functions/worker/PulsarFunctionLocalRunTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/functions/worker/PulsarFunctionLocalRunTest.java
@@ -811,7 +811,7 @@ public class PulsarFunctionLocalRunTest {
         Assert.assertTrue(retryStrategically((test) -> {
             try {
                 return (admin.topics().getStats(sinkTopic).getPublishers().size() == parallelism)
-                        && (admin.topics().getInternalStats(sinkTopic, false).numberOfEntries > 4);
+                        && (admin.topics().getInternalStats(sinkTopic, false, false).numberOfEntries > 4);
             } catch (PulsarAdminException e) {
                 return false;
             }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/io/PulsarBatchSourceE2ETest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/io/PulsarBatchSourceE2ETest.java
@@ -95,7 +95,8 @@ public class PulsarBatchSourceE2ETest extends AbstractPulsarE2ETest {
 
         retryStrategically((test) -> {
             try {
-                return (admin.topics().getStats(sinkTopic2).getPublishers().size() == 1) && (admin.topics().getInternalStats(sinkTopic2, false).numberOfEntries > 4);
+                return (admin.topics().getStats(sinkTopic2).getPublishers().size() == 1) && (admin.topics().getInternalStats(sinkTopic2, false,
+                        false).numberOfEntries > 4);
             } catch (PulsarAdminException e) {
                 return false;
             }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/io/PulsarSourceE2ETest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/io/PulsarSourceE2ETest.java
@@ -99,7 +99,8 @@ public class PulsarSourceE2ETest extends AbstractPulsarE2ETest {
 
         retryStrategically((test) -> {
             try {
-                return (admin.topics().getStats(sinkTopic2).getPublishers().size() == 1) && (admin.topics().getInternalStats(sinkTopic2, false).numberOfEntries > 4);
+                return (admin.topics().getStats(sinkTopic2).getPublishers().size() == 1) && (admin.topics().getInternalStats(sinkTopic2, false,
+                        false).numberOfEntries > 4);
             } catch (PulsarAdminException e) {
                 return false;
             }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/stats/client/PulsarBrokerStatsClientTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/stats/client/PulsarBrokerStatsClientTest.java
@@ -123,7 +123,7 @@ public class PulsarBrokerStatsClientTest extends ProducerConsumerBase {
         }
 
         PersistentTopic topic = (PersistentTopic) pulsar.getBrokerService().getOrCreateTopic(topicName).get();
-        PersistentTopicInternalStats internalStats = topic.getInternalStats(true, true).get();
+        PersistentTopicInternalStats internalStats = topic.getInternalStats(true, false).get();
         assertNotNull(internalStats.ledgers.get(0).metadata);
         // For the mock test, the default ensembles is ["192.0.2.1:1234","192.0.2.2:1234","192.0.2.3:1234"]
         // The registed bookie ID is 192.168.1.1:5000

--- a/pulsar-broker/src/test/java/org/apache/pulsar/stats/client/PulsarBrokerStatsClientTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/stats/client/PulsarBrokerStatsClientTest.java
@@ -123,7 +123,7 @@ public class PulsarBrokerStatsClientTest extends ProducerConsumerBase {
         }
 
         PersistentTopic topic = (PersistentTopic) pulsar.getBrokerService().getOrCreateTopic(topicName).get();
-        PersistentTopicInternalStats internalStats = topic.getInternalStats(true).get();
+        PersistentTopicInternalStats internalStats = topic.getInternalStats(true, true).get();
         assertNotNull(internalStats.ledgers.get(0).metadata);
         // For the mock test, the default ensembles is ["192.0.2.1:1234","192.0.2.2:1234","192.0.2.3:1234"]
         // The registed bookie ID is 192.168.1.1:5000

--- a/pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/admin/Topics.java
+++ b/pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/admin/Topics.java
@@ -1189,6 +1189,7 @@ public interface Topics {
      *            topic name
      * @param metadata
      *            flag to include ledger metadata
+     * @param noLedger
      * @return the topic statistics
      *
      * @throws NotAuthorizedException
@@ -1198,7 +1199,8 @@ public interface Topics {
      * @throws PulsarAdminException
      *             Unexpected error
      */
-    PersistentTopicInternalStats getInternalStats(String topic, boolean metadata) throws PulsarAdminException;
+    PersistentTopicInternalStats getInternalStats(String topic, boolean metadata, boolean noLedger)
+            throws PulsarAdminException;
 
     /**
      * Get the internal stats for the topic.
@@ -1225,9 +1227,11 @@ public interface Topics {
      *            topic Name
      * @param metadata
      *            flag to include ledger metadata
+     * @param ledger
      * @return a future that can be used to track when the internal topic statistics are returned
      */
-    CompletableFuture<PersistentTopicInternalStats> getInternalStatsAsync(String topic, boolean metadata);
+    CompletableFuture<PersistentTopicInternalStats> getInternalStatsAsync(String topic, boolean metadata,
+                                                                          boolean ledger);
 
     /**
      * Get the internal stats for the topic asynchronously.
@@ -1376,10 +1380,12 @@ public interface Topics {
      *
      * @param topic
      *            topic name
+     * @param metadata
+     * @param noLedger
      * @return
      * @throws PulsarAdminException
      */
-    PartitionedTopicInternalStats getPartitionedInternalStats(String topic)
+    PartitionedTopicInternalStats getPartitionedInternalStats(String topic, boolean metadata, boolean noLedger)
             throws PulsarAdminException;
 
     /**
@@ -1389,7 +1395,9 @@ public interface Topics {
      *            topic Name
      * @return a future that can be used to track when the partitioned topic statistics are returned
      */
-    CompletableFuture<PartitionedTopicInternalStats> getPartitionedInternalStatsAsync(String topic);
+    CompletableFuture<PartitionedTopicInternalStats> getPartitionedInternalStatsAsync(String topic,
+                                                                                      boolean metadata,
+                                                                                      boolean ledger);
 
     /**
      * Delete a subscription.

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/TopicsImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/TopicsImpl.java
@@ -641,24 +641,27 @@ public class TopicsImpl extends BaseResource implements Topics {
 
     @Override
     public PersistentTopicInternalStats getInternalStats(String topic) throws PulsarAdminException {
-        return getInternalStats(topic, false);
+        return getInternalStats(topic, false, false);
     }
 
     @Override
-    public PersistentTopicInternalStats getInternalStats(String topic, boolean metadata) throws PulsarAdminException {
-        return sync(() -> getInternalStatsAsync(topic, metadata));
+    public PersistentTopicInternalStats getInternalStats(String topic, boolean metadata, boolean noLedger)
+            throws PulsarAdminException {
+        return sync(() -> getInternalStatsAsync(topic, metadata, noLedger));
     }
 
     @Override
     public CompletableFuture<PersistentTopicInternalStats> getInternalStatsAsync(String topic) {
-        return getInternalStatsAsync(topic, false);
+        return getInternalStatsAsync(topic, false, true);
     }
 
     @Override
-    public CompletableFuture<PersistentTopicInternalStats> getInternalStatsAsync(String topic, boolean metadata) {
+    public CompletableFuture<PersistentTopicInternalStats> getInternalStatsAsync(String topic, boolean metadata,
+                                                                                 boolean noLedger) {
         TopicName tn = validateTopic(topic);
         WebTarget path = topicPath(tn, "internalStats");
         path = path.queryParam("metadata", metadata);
+        path = path.queryParam("noLedger", noLedger);
         return asyncGetRequest(path, new FutureCallback<PersistentTopicInternalStats>(){});
     }
 
@@ -736,15 +739,19 @@ public class TopicsImpl extends BaseResource implements Topics {
     }
 
     @Override
-    public PartitionedTopicInternalStats getPartitionedInternalStats(String topic)
+    public PartitionedTopicInternalStats getPartitionedInternalStats(String topic, boolean metadata, boolean noLedger)
             throws PulsarAdminException {
-        return sync(() -> getPartitionedInternalStatsAsync(topic));
+        return sync(() -> getPartitionedInternalStatsAsync(topic, metadata, noLedger));
     }
 
     @Override
-    public CompletableFuture<PartitionedTopicInternalStats> getPartitionedInternalStatsAsync(String topic) {
+    public CompletableFuture<PartitionedTopicInternalStats> getPartitionedInternalStatsAsync(String topic,
+                                                                                             boolean metadata,
+                                                                                             boolean noLedger) {
         TopicName tn = validateTopic(topic);
         WebTarget path = topicPath(tn, "partitioned-internalStats");
+        path = path.queryParam("metadata", metadata);
+        path = path.queryParam("noLedger", noLedger);
         return asyncGetRequest(path, new FutureCallback<PartitionedTopicInternalStats>(){});
     }
 

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/TopicsImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/TopicsImpl.java
@@ -652,7 +652,7 @@ public class TopicsImpl extends BaseResource implements Topics {
 
     @Override
     public CompletableFuture<PersistentTopicInternalStats> getInternalStatsAsync(String topic) {
-        return getInternalStatsAsync(topic, false, true);
+        return getInternalStatsAsync(topic, false, false);
     }
 
     @Override

--- a/pulsar-client-tools-test/src/test/java/org/apache/pulsar/admin/cli/PulsarAdminToolTest.java
+++ b/pulsar-client-tools-test/src/test/java/org/apache/pulsar/admin/cli/PulsarAdminToolTest.java
@@ -74,7 +74,6 @@ import org.apache.pulsar.client.admin.TopicPolicies;
 import org.apache.pulsar.client.admin.Topics;
 import org.apache.pulsar.client.admin.Transactions;
 import org.apache.pulsar.client.admin.internal.OffloadProcessStatusImpl;
-import org.apache.pulsar.client.admin.internal.PulsarAdminBuilderImpl;
 import org.apache.pulsar.client.admin.internal.PulsarAdminImpl;
 import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.client.api.SubscriptionType;
@@ -1479,7 +1478,7 @@ public class PulsarAdminToolTest {
         verify(mockTopics).getStats("persistent://myprop/clust/ns1/ds1", false, false, false);
 
         cmdTopics.run(split("stats-internal persistent://myprop/clust/ns1/ds1"));
-        verify(mockTopics).getInternalStats("persistent://myprop/clust/ns1/ds1", false);
+        verify(mockTopics).getInternalStats("persistent://myprop/clust/ns1/ds1", false, false);
 
         cmdTopics.run(split("get-backlog-quotas persistent://myprop/clust/ns1/ds1 -ap"));
         verify(mockTopics).getBacklogQuotaMap("persistent://myprop/clust/ns1/ds1", true);
@@ -1527,7 +1526,7 @@ public class PulsarAdminToolTest {
                 true, false, false, false);
 
         cmdTopics.run(split("partitioned-stats-internal persistent://myprop/clust/ns1/ds1"));
-        verify(mockTopics).getPartitionedInternalStats("persistent://myprop/clust/ns1/ds1");
+        verify(mockTopics).getPartitionedInternalStats("persistent://myprop/clust/ns1/ds1", false, false);
 
         cmdTopics.run(split("clear-backlog persistent://myprop/clust/ns1/ds1 -s sub1"));
         verify(mockTopics).skipAllMessages("persistent://myprop/clust/ns1/ds1", "sub1");
@@ -1864,7 +1863,7 @@ public class PulsarAdminToolTest {
         stats.ledgers.add(newLedger(0, 10, 1000));
         stats.ledgers.add(newLedger(1, 10, 2000));
         stats.ledgers.add(newLedger(2, 10, 3000));
-        when(mockTopics.getInternalStats("persistent://myprop/clust/ns1/ds1", false)).thenReturn(stats);
+        when(mockTopics.getInternalStats("persistent://myprop/clust/ns1/ds1", false, false)).thenReturn(stats);
         cmdTopics.run(split("offload persistent://myprop/clust/ns1/ds1 -s 1k"));
         verify(mockTopics).triggerOffload("persistent://myprop/clust/ns1/ds1", new MessageIdImpl(2, 0, -1));
 
@@ -1986,7 +1985,7 @@ public class PulsarAdminToolTest {
         verify(mockTopics).getStats("persistent://myprop/clust/ns1/ds1", false);
 
         topics.run(split("stats-internal persistent://myprop/clust/ns1/ds1"));
-        verify(mockTopics).getInternalStats("persistent://myprop/clust/ns1/ds1", false);
+        verify(mockTopics).getInternalStats("persistent://myprop/clust/ns1/ds1", false, false);
 
         topics.run(split("info-internal persistent://myprop/clust/ns1/ds1"));
         verify(mockTopics).getInternalInfo("persistent://myprop/clust/ns1/ds1");
@@ -1995,7 +1994,7 @@ public class PulsarAdminToolTest {
         verify(mockTopics).getPartitionedStats("persistent://myprop/clust/ns1/ds1", true);
 
         topics.run(split("partitioned-stats-internal persistent://myprop/clust/ns1/ds1"));
-        verify(mockTopics).getPartitionedInternalStats("persistent://myprop/clust/ns1/ds1");
+        verify(mockTopics).getPartitionedInternalStats("persistent://myprop/clust/ns1/ds1", false, false);
 
         topics.run(split("skip-all persistent://myprop/clust/ns1/ds1 -s sub1"));
         verify(mockTopics).skipAllMessages("persistent://myprop/clust/ns1/ds1", "sub1");
@@ -2074,7 +2073,7 @@ public class PulsarAdminToolTest {
         verify(mockTopics).getStats("non-persistent://myprop/ns1/ds1", false, false, false);
 
         topics.run(split("stats-internal non-persistent://myprop/ns1/ds1"));
-        verify(mockTopics).getInternalStats("non-persistent://myprop/ns1/ds1", false);
+        verify(mockTopics).getInternalStats("non-persistent://myprop/ns1/ds1", false, false);
 
         topics.run(split("create-partitioned-topic non-persistent://myprop/ns1/ds1 --partitions 32"));
         verify(mockTopics).createPartitionedTopic("non-persistent://myprop/ns1/ds1", 32, null);

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdPersistentTopics.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdPersistentTopics.java
@@ -356,6 +356,9 @@ public class CmdPersistentTopics extends CmdBase {
         @Parameter(description = "persistent://tenant/namespace/topic", required = true)
         private java.util.List<String> params;
 
+        @Parameter(names = { "-nl", "--no-ledger" }, description = "Flag to include ledgers list")
+        private boolean noLedger = false;
+
         @Parameter(names = { "-m",
         "--metadata" }, description = "Flag to include ledger metadata")
         private boolean metadata = false;
@@ -363,7 +366,7 @@ public class CmdPersistentTopics extends CmdBase {
         @Override
         void run() throws PulsarAdminException {
             String persistentTopic = validatePersistentTopic(params);
-            print(getPersistentTopics().getInternalStats(persistentTopic, metadata));
+            print(getPersistentTopics().getInternalStats(persistentTopic, metadata, noLedger));
         }
     }
 
@@ -405,10 +408,16 @@ public class CmdPersistentTopics extends CmdBase {
         @Parameter(description = "persistent://tenant/namespace/topic", required = true)
         private java.util.List<String> params;
 
+        @Parameter(names = { "-nl", "--no-ledger" }, description = "Flag to include ledgers list")
+        private boolean noLedger = false;
+
+        @Parameter(names = { "-m",  "--metadata" }, description = "Flag to include ledger metadata")
+        private boolean metadata = false;
+
         @Override
         void run() throws Exception {
             String persistentTopic = validatePersistentTopic(params);
-            print(getPersistentTopics().getPartitionedInternalStats(persistentTopic));
+            print(getPersistentTopics().getPartitionedInternalStats(persistentTopic, metadata, noLedger));
         }
     }
 

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdTopics.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdTopics.java
@@ -803,14 +803,16 @@ public class CmdTopics extends CmdBase {
         @Parameter(description = "persistent://tenant/namespace/topic", required = true)
         private java.util.List<String> params;
 
-        @Parameter(names = { "-m",
-        "--metadata" }, description = "Flag to include ledger metadata")
+        @Parameter(names = { "-nl", "--no-ledger" }, description = "Flag to include ledgers list")
+        private boolean noLedger = false;
+
+        @Parameter(names = { "-m",  "--metadata" }, description = "Flag to include ledger metadata")
         private boolean metadata = false;
 
         @Override
         void run() throws PulsarAdminException {
             String topic = validateTopicName(params);
-            print(getTopics().getInternalStats(topic, metadata));
+            print(getTopics().getInternalStats(topic, metadata, noLedger));
         }
     }
 
@@ -871,10 +873,16 @@ public class CmdTopics extends CmdBase {
         @Parameter(description = "persistent://tenant/namespace/topic", required = true)
         private java.util.List<String> params;
 
+        @Parameter(names = { "-nl", "--no-ledger" }, description = "Flag to include ledgers list")
+        private boolean noLedger = false;
+
+        @Parameter(names = { "-m",  "--metadata" }, description = "Flag to include ledger metadata")
+        private boolean metadata = false;
+
         @Override
         void run() throws Exception {
             String topic = validateTopicName(params);
-            print(getTopics().getPartitionedInternalStats(topic));
+            print(getTopics().getPartitionedInternalStats(topic, metadata, noLedger));
         }
     }
 
@@ -1456,7 +1464,7 @@ public class CmdTopics extends CmdBase {
             String persistentTopic = validatePersistentTopic(params);
             long sizeThreshold = validateSizeString(sizeThresholdStr);
 
-            PersistentTopicInternalStats stats = getTopics().getInternalStats(persistentTopic, false);
+            PersistentTopicInternalStats stats = getTopics().getInternalStats(persistentTopic, false, false);
             if (stats.ledgers.size() < 1) {
                 throw new PulsarAdminException("Topic doesn't have any data");
             }

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/functions/PulsarFunctionsTest.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/functions/PulsarFunctionsTest.java
@@ -1592,9 +1592,9 @@ public abstract class PulsarFunctionsTest extends PulsarFunctionsTestBase {
                 log.info("Output topic stats: {}",
                         Json.pretty(pulsarAdmin.topics().getStats(outputTopic, true)));
                 log.info("Input topic internal-stats: {}",
-                        Json.pretty(pulsarAdmin.topics().getInternalStats(inputTopic, true)));
+                        Json.pretty(pulsarAdmin.topics().getInternalStats(inputTopic, true, false)));
                 log.info("Output topic internal-stats: {}",
-                        Json.pretty(pulsarAdmin.topics().getInternalStats(outputTopic, true)));
+                        Json.pretty(pulsarAdmin.topics().getInternalStats(outputTopic, true, false)));
             } else {
                 String logMsg = new String(msg.getValue(), UTF_8);
                 log.info("Received message: '{}'", logMsg);


### PR DESCRIPTION
### Motivation

Admin command `stats-internal` support hiding ledgers list.

If there are thousands of ledgers, it's meaningless  to print so much ledgers.

In additional, `partitioned-stats-internal` also support this feature.

### Modifications
Add new command line parameter `-nl  --no-ledger`, default to false, which means printing ledgers list default.


### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)

- [x] `doc-not-needed` 
(Please explain why)

- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE 

After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.

-->
