### PR TITLE
[fix][build] build pulsar-client-cpp with BUILD_TESTS=OFF

### DIFF
--- a/pulsar-client-cpp/CMakeLists.txt
+++ b/pulsar-client-cpp/CMakeLists.txt
@@ -345,9 +345,14 @@ include_directories(
   ${CURL_INCLUDE_DIRS}
   ${Protobuf_INCLUDE_DIRS}
   ${LOG4CXX_INCLUDE_PATH}
-  ${GTEST_INCLUDE_PATH}
-  ${GMOCK_INCLUDE_PATH}
 )
+
+if(BUILD_TESTS)
+  include_directories(
+    ${GTEST_INCLUDE_PATH}
+    ${GMOCK_INCLUDE_PATH}
+  )
+endif()
 
 set(COMMON_LIBS
   ${COMMON_LIBS}


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://docs.google.com/document/d/1d8Pw6ZbWk-_pCKdOmdvx9rnhPiyuxwq60_TrD68d7BA/edit#heading=h.trs9rsex3xom)*. 

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->

<!-- Either this PR fixes an issue, -->

Fixes https://github.com/apache/pulsar/issues/1964

<!-- or this PR is one task of an issue -->

### Motivation
When the pulsar-client-cpp is built with `cmake . -DBUILD_TESTS=OFF`, the cmake stil would look for the  `GTEST_INCLUDE_PATH` and `GMOCK_INCLUDE_PATH`, which leads the problem in #1964.
<!-- Explain here the context, and why you're making that change. What is the problem you're trying to solve. -->

### Modifications
* remove gtest/gmock from the `include_directories` of `CMakeLists.txt` when the `BUILD_TESTS=OFF`.
<!-- Describe the modifications you've done. -->

### Verifying this change

- [x] Make sure that the change passes the CI checks.


This change is a trivial rework / code cleanup without any test coverage.


### Does this pull request potentially affect one of the following parts:

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [x] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)

- [x] `doc-not-needed` 
(Please explain why)

- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)

### Matching PR in forked repository

PR in forked repository: https://github.com/rickif/pulsar/pull/1

