### PR TITLE
[fix][txn] optimize the ack/send future in TransactionImpl

### DIFF
--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/PulsarClientException.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/PulsarClientException.java
@@ -910,6 +910,23 @@ public class PulsarClientException extends IOException {
         }
     }
 
+    public static class TransactionHasOperationFailedException extends PulsarClientException {
+        /**
+         * Constructs an {@code TransactionHasOperationFailedException}.
+         */
+        public TransactionHasOperationFailedException() {
+            super("Now allowed to commit the transaction due to failed operations of producing or acknowledgment");
+        }
+
+        /**
+         * Constructs an {@code TransactionHasOperationFailedException} with the specified detail message.
+         * @param msg The detail message.
+         */
+        public TransactionHasOperationFailedException(String msg) {
+            super(msg);
+        }
+    }
+
     // wrap an exception to enriching more info messages.
     public static Throwable wrap(Throwable t, String msg) {
         msg += "\n" + t.getMessage();
@@ -972,6 +989,8 @@ public class PulsarClientException extends IOException {
             return new MessageAcknowledgeException(msg);
         } else if (t instanceof TransactionConflictException) {
             return new TransactionConflictException(msg);
+        } else if (t instanceof  TransactionHasOperationFailedException) {
+            return new TransactionHasOperationFailedException(msg);
         } else if (t instanceof PulsarClientException) {
             return new PulsarClientException(msg);
         } else if (t instanceof CompletionException) {
@@ -1070,6 +1089,8 @@ public class PulsarClientException extends IOException {
             newException = new MemoryBufferIsFullError(msg);
         } else if (cause instanceof NotFoundException) {
             newException = new NotFoundException(msg);
+        } else if (cause instanceof TransactionHasOperationFailedException) {
+            newException = new TransactionHasOperationFailedException(msg);
         } else {
             newException = new PulsarClientException(t);
         }

--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/PulsarClientException.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/PulsarClientException.java
@@ -1154,7 +1154,8 @@ public class PulsarClientException extends IOException {
                 || t instanceof MessageAcknowledgeException
                 || t instanceof TransactionConflictException
                 || t instanceof ProducerBusyException
-                || t instanceof ConsumerBusyException) {
+                || t instanceof ConsumerBusyException
+                || t instanceof TransactionHasOperationFailedException) {
             return false;
         }
         return true;

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/transaction/TransactionImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/transaction/TransactionImpl.java
@@ -67,8 +67,8 @@ public class TransactionImpl implements Transaction , TimerTask {
     private CompletableFuture<MessageId> sendFuture;
     private CompletableFuture<Void> ackFuture;
 
-    private AtomicLong ackCount = new AtomicLong(0);
-    private AtomicLong sendCount = new AtomicLong(0);
+    private final AtomicLong ackCount = new AtomicLong(0);
+    private final AtomicLong sendCount = new AtomicLong(0);
 
     private volatile State state;
     private static final AtomicReferenceFieldUpdater<TransactionImpl, State> STATE_UPDATE =

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/transaction/TransactionImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/transaction/TransactionImpl.java
@@ -134,16 +134,22 @@ public class TransactionImpl implements Transaction , TimerTask {
 
     public void registerSendOp(CompletableFuture<MessageId> newSendFuture) {
         sendLock.lock();
-        if (sendCount.getAndIncrement() == 0) {
-            sendFuture = new CompletableFuture<>();
+        try {
+            if (sendCount.getAndIncrement() == 0) {
+                sendFuture = new CompletableFuture<>();
+            }
+        } finally {
+            sendLock.unlock();
         }
-        sendLock.unlock();
         newSendFuture.thenRun(() -> {
             sendLock.lock();
-            if (sendCount.decrementAndGet() == 0) {
-                sendFuture.complete(null);
+            try {
+                if (sendCount.decrementAndGet() == 0) {
+                    sendFuture.complete(null);
+                }
+            } finally {
+                sendLock.unlock();
             }
-            sendLock.unlock();
         });
     }
 
@@ -169,16 +175,22 @@ public class TransactionImpl implements Transaction , TimerTask {
 
     public void registerAckOp(CompletableFuture<Void> newAckFuture) {
         ackLock.lock();
-        if (ackCount.getAndIncrement() == 0) {
-            ackFuture = new CompletableFuture<>();
+        try {
+            if (ackCount.getAndIncrement() == 0) {
+                ackFuture = new CompletableFuture<>();
+            }
+        } finally {
+            ackLock.unlock();
         }
-        ackLock.unlock();
         newAckFuture.thenRun(() -> {
             ackLock.lock();
-            if (ackCount.decrementAndGet() == 0) {
-                ackFuture.complete(null);
+            try {
+                if (ackCount.decrementAndGet() == 0) {
+                    ackFuture.complete(null);
+                }
+            } finally {
+                ackLock.unlock();
             }
-            ackLock.unlock();
         });
     }
 


### PR DESCRIPTION
### Motivation
The TransactionImpl stores a lot of future. This uses a lot of memory, and can be optimized to two futures. ### Modification
Optimize the future list to single future.

### Documentation
- [x] `doc-not-needed` 

### Matching PR in forked repository

PR in forked repository: https://github.com/liangyepianzhou/pulsar/pull/5