### PR TITLE
docs: add developers-landing page to sidebars

### DIFF
--- a/site2/website/sidebars.json
+++ b/site2/website/sidebars.json
@@ -355,6 +355,10 @@
     {
       "type": "category",
       "label": "Development",
+      "link": {
+        "type": "doc",
+        "id": "developers-landing"
+      },
       "items": [
         "develop-tools",
         "developing-binary-protocol",


### PR DESCRIPTION
This is a followup to #17284.

cc @DaveDuggins @Anonymitaet @momo-jun @urfreespace 

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)

- [ ] `doc-not-needed` 
(Please explain why)

- [x] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)

### Matching PR in forked repository

docs only change