### PR TITLE
[fix][broker]Can't consume messages for a long time due to Entry Filter

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/PositionComparators.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/PositionComparators.java
@@ -18,19 +18,14 @@
  */
 package org.apache.bookkeeper.mledger;
 
-import java.util.Comparator;
 
 public class PositionComparators {
 
-    public static final Comparator<Position> COMPARE_WITH_LEDGER_AND_ENTRY_ID = new Comparator<Position> (){
-
-        @Override
-        public int compare(Position pos1, Position pos2) {
-            int ledgerCompare = Long.compare(pos1.getLedgerId(), pos2.getLedgerId());
-            if (ledgerCompare != 0) {
-                return ledgerCompare;
-            }
-            return Long.compare(pos1.getEntryId(), pos2.getEntryId());
+    public static int compareLedgerIdAndEntryId(Position pos1, Position pos2) {
+        int ledgerCompare = Long.compare(pos1.getLedgerId(), pos2.getLedgerId());
+        if (ledgerCompare != 0) {
+            return ledgerCompare;
         }
-    };
+        return Long.compare(pos1.getEntryId(), pos2.getEntryId());
+    }
 }

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/PositionComparators.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/PositionComparators.java
@@ -1,0 +1,36 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.bookkeeper.mledger;
+
+import java.util.Comparator;
+
+public class PositionComparators {
+
+    public static final Comparator<Position> COMPARE_WITH_LEDGER_AND_ENTRY_ID = new Comparator<Position> (){
+
+        @Override
+        public int compare(Position pos1, Position pos2) {
+            int ledgerCompare = Long.compare(pos1.getLedgerId(), pos2.getLedgerId());
+            if (ledgerCompare != 0) {
+                return ledgerCompare;
+            }
+            return Long.compare(pos1.getEntryId(), pos2.getEntryId());
+        }
+    };
+}

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -1075,6 +1075,13 @@ public class ServiceConfiguration implements PulsarConfiguration {
     private int dispatcherMaxReadSizeBytes = 5 * 1024 * 1024;
 
     @FieldContext(
+        category = CATEGORY_SERVER,
+        doc = "The max seconds a consumer will be paused because the current message cannot be consumed by a consumer"
+                + " using EntryFilter. By default it is 1."
+    )
+    private int dispatcherEntryFilterRescheduledMessageDelaySeconds = 1;
+
+    @FieldContext(
         dynamic = true,
         category = CATEGORY_SERVER,
         doc = "Min number of entries to read from bookkeeper. By default it is 1 entries."

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Consumer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Consumer.java
@@ -139,6 +139,9 @@ public class Consumer {
 
     private long negtiveUnackedMsgsTimestamp;
 
+    @Getter
+    private volatile boolean closed = false;
+
     public Consumer(Subscription subscription, SubType subType, String topicName, long consumerId,
                     int priorityLevel, String consumerName,
                     boolean isDurable, TransportCnx cnx, String appId,
@@ -372,6 +375,7 @@ public class Consumer {
     public void close(boolean isResetCursor) throws BrokerServiceException {
         subscription.removeConsumer(this, isResetCursor);
         cnx.removedConsumer(this);
+        closed = true;
     }
 
     public void disconnect() {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/InMemoryAndPreventCycleFilterRedeliveryTracker.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/InMemoryAndPreventCycleFilterRedeliveryTracker.java
@@ -1,0 +1,173 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.service;
+
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+import lombok.Getter;
+import org.apache.bookkeeper.mledger.Position;
+
+/***
+ * When there are two consumers, users can specify the consumption behavior of each consumer by `Entry filter`:
+ * - `case-1`: `consumer_1` can consume 60% of the messages, `consumer_2` can consume 60% of the messages, and there
+ * is 10% intersection between `consumer_1` and `consumer_2`.
+ * - `case-2`: `consumer_1` can consume 40% of the messages, `consumer_2` can consume 40% of the messages, and no
+ * consumer can consume the remaining 20%.
+ *
+ * In case-1, when users use `FilterResult.RESCHEDULE `, and if the message that can only be consumed by `consumer_1`
+ * is delivered to `consumer_2` all the time, and the message that can only be consumed by `consumer_2` is delivered
+ * to `consumer_1` all the time, then the problem occurs:
+ * - Both consumers can not receive messages anymore.
+ * - The number of redeliveries of entries has been increasing ( redelivery by Entry Filter ).
+ *
+ * So {@link InMemoryAndPreventCycleFilterRedeliveryTracker} solve this problem by this way:
+ * When a message is redelivered by the same consumer more than 3 times, the consumption of this message by that
+ * consumer is paused for 1 second. Since tracking the consumption of all the messages cost memory too much, we trace
+ * only the messages with the smallest position.
+ */
+public class InMemoryAndPreventCycleFilterRedeliveryTracker extends InMemoryRedeliveryTracker {
+
+    /** The first redelivery record. **/
+    @Getter
+    private volatile Position redeliveryStartAt;
+    /**
+     * key: The consumer calls redelivery at {@link #redeliveryStartAt}.
+     * value: The number of times the consumer calls redelivery.
+     */
+    private final ConcurrentHashMap<Consumer, AtomicInteger> earliestEntryRedeliveryCountMapping =
+            new ConcurrentHashMap<>();
+    /**
+     *  key: paused consumer.
+     *  value: pause because of which position.
+     */
+    private final ConcurrentHashMap<Consumer, PauseConsumerInformation> pausedConsumers = new ConcurrentHashMap<>();
+
+    @Override
+    public int incrementAndGetRedeliveryCount(Position position, Consumer consumer) {
+        int newCount = super.incrementAndGetRedeliveryCount(position, consumer);
+        // Diff with super implementation: record how many times this consumer calls "redelivery" at earliest position.
+        if (position == null || consumer == null){
+            return newCount;
+        }
+        Position originalEarliestPosition = redeliveryStartAt;
+        Position actualEarliestPosition = null;
+        if (originalEarliestPosition == null) {
+            cleanEarliestInformation();
+            actualEarliestPosition = position;
+        } else {
+            int isEarlier = comparePosition(originalEarliestPosition, position);
+            if (isEarlier < 0) {
+                return newCount;
+            } else if (isEarlier > 0) {
+                cleanEarliestInformation();
+                actualEarliestPosition = position;
+            } else {
+                actualEarliestPosition = originalEarliestPosition;
+            }
+        }
+        redeliveryStartAt = actualEarliestPosition;
+        int redeliveryCount = earliestEntryRedeliveryCountMapping.computeIfAbsent(consumer, c -> new AtomicInteger())
+                .incrementAndGet();
+        if (redeliveryCount >= 3) {
+            pausedConsumers.put(consumer, new PauseConsumerInformation(actualEarliestPosition));
+        } else {
+        }
+        return newCount;
+    }
+
+    @Override
+    public void remove(Position position, Position markDeletedPosition) {
+        super.remove(position, markDeletedPosition);
+        if (redeliveryStartAt == null || comparePosition(redeliveryStartAt, position) == 0
+                || comparePosition(redeliveryStartAt, markDeletedPosition) >= 0) {
+            cleanEarliestInformation();
+        }
+    }
+
+    @Override
+    public void clear() {
+        super.clear();
+        cleanEarliestInformation();
+    }
+
+    public boolean isConsumerPaused(Consumer consumer) {
+        if (consumer == null) {
+            return false;
+        }
+        PauseConsumerInformation pauseConsumerInformation = pausedConsumers.get(consumer);
+        if (pauseConsumerInformation == null) {
+            return false;
+        }
+        if (!pauseConsumerInformation.isValid(redeliveryStartAt)) {
+            pausedConsumers.remove(consumer);
+            return false;
+        }
+        return true;
+    }
+
+    public int pausedConsumerCount() {
+        return (int) pausedConsumers.keySet().stream().map(this::isConsumerPaused).count();
+    }
+
+    private void cleanEarliestInformation() {
+        redeliveryStartAt = null;
+        // If consumer has been closed, remove this consumer.
+        List<Consumer> closedConsumers = earliestEntryRedeliveryCountMapping.keySet().stream()
+                .filter(Consumer::isClosed).toList();
+        closedConsumers.forEach(earliestEntryRedeliveryCountMapping::remove);
+        // Just reset counter to 0, because value will be removed if consumer is closed.
+        earliestEntryRedeliveryCountMapping.values().forEach(i -> i.set(0));
+        pausedConsumers.clear();
+    }
+
+    private static int comparePosition(Position pos1, Position pos2) {
+        int ledgerCompare = Long.compare(pos1.getLedgerId(), pos2.getLedgerId());
+        if (ledgerCompare != 0) {
+            return ledgerCompare;
+        }
+        return Long.compare(pos1.getEntryId(), pos2.getEntryId());
+    }
+
+    private static class PauseConsumerInformation {
+
+        private final Position cantConsumedPosition;
+
+        private final long pauseTime;
+
+        private PauseConsumerInformation(Position cantConsumedPosition) {
+            this.cantConsumedPosition = cantConsumedPosition;
+            this.pauseTime = System.currentTimeMillis();
+        }
+
+        /**
+         * If "do pause consumer" and {@link #cleanEarliestInformation} concurrently, it is possible to pause
+         * consumer that no longer needs to be paused. The way to distinguish is to determine whether
+         * "cantConsumedPosition equal to currentRedeliveryStartAt".
+         * {@link PauseConsumerInformation#isValid(Position)} resolved this problem.
+         */
+        boolean isValid(Position currentRedeliveryStartAt) {
+            if (cantConsumedPosition != currentRedeliveryStartAt) {
+                return false;
+            }
+            // Automatically becomes invalid after 1s, because users may use time to filter the Entry.
+            return System.currentTimeMillis() - pauseTime < 1000;
+        }
+    }
+}

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/InMemoryAndPreventCycleFilterRedeliveryTracker.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/InMemoryAndPreventCycleFilterRedeliveryTracker.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pulsar.broker.service;
 
+import static org.apache.bookkeeper.mledger.PositionComparators.COMPARE_WITH_LEDGER_AND_ENTRY_ID;
 import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -81,7 +82,7 @@ public class InMemoryAndPreventCycleFilterRedeliveryTracker extends InMemoryRede
             cleanEarliestInformation();
             actualEarliestPosition = position;
         } else {
-            int isEarlier = comparePosition(originalEarliestPosition, position);
+            int isEarlier = COMPARE_WITH_LEDGER_AND_ENTRY_ID.compare(originalEarliestPosition, position);
             if (isEarlier < 0) {
                 return newCount;
             } else if (isEarlier > 0) {
@@ -105,8 +106,8 @@ public class InMemoryAndPreventCycleFilterRedeliveryTracker extends InMemoryRede
     @Override
     public void remove(Position position, Position markDeletedPosition) {
         super.remove(position, markDeletedPosition);
-        if (redeliveryStartAt == null || comparePosition(redeliveryStartAt, position) == 0
-                || comparePosition(redeliveryStartAt, markDeletedPosition) >= 0) {
+        if (redeliveryStartAt == null || COMPARE_WITH_LEDGER_AND_ENTRY_ID.compare(redeliveryStartAt, position) == 0
+                || COMPARE_WITH_LEDGER_AND_ENTRY_ID.compare(redeliveryStartAt, markDeletedPosition) >= 0) {
             cleanEarliestInformation();
         }
     }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/InMemoryAndPreventCycleFilterRedeliveryTracker.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/InMemoryAndPreventCycleFilterRedeliveryTracker.java
@@ -112,6 +112,12 @@ public class InMemoryAndPreventCycleFilterRedeliveryTracker extends InMemoryRede
     }
 
     @Override
+    public void noticeConsumerClosed(Consumer consumer){
+        pausedConsumers.remove(consumer);
+        earliestEntryRedeliveryCountMapping.remove(consumer);
+    }
+
+    @Override
     public void clear() {
         super.clear();
         cleanEarliestInformation();

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/InMemoryAndPreventCycleFilterRedeliveryTracker.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/InMemoryAndPreventCycleFilterRedeliveryTracker.java
@@ -18,7 +18,6 @@
  */
 package org.apache.pulsar.broker.service;
 
-import static org.apache.bookkeeper.mledger.PositionComparators.*;
 import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -26,6 +25,7 @@ import java.util.function.Supplier;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.bookkeeper.mledger.Entry;
 import org.apache.bookkeeper.mledger.Position;
+import org.apache.bookkeeper.mledger.PositionComparators;
 
 /***
  * When there are two consumers, users can specify the consumption behavior of each consumer by `Entry filter`:
@@ -84,7 +84,7 @@ public class InMemoryAndPreventCycleFilterRedeliveryTracker extends InMemoryRede
             cleanEarliestInformation();
             actualEarliestPosition = position;
         } else {
-            int isEarlier = compareLedgerIdAndEntryId(originalEarliestPosition, position);
+            int isEarlier = PositionComparators.compareLedgerIdAndEntryId(originalEarliestPosition, position);
             if (isEarlier < 0) {
                 return newCount;
             } else if (isEarlier > 0) {
@@ -108,8 +108,8 @@ public class InMemoryAndPreventCycleFilterRedeliveryTracker extends InMemoryRede
     @Override
     public void remove(Position position, Position markDeletedPosition) {
         super.remove(position, markDeletedPosition);
-        if (redeliveryStartAt == null || compareLedgerIdAndEntryId(redeliveryStartAt, position) == 0
-                || compareLedgerIdAndEntryId(redeliveryStartAt, markDeletedPosition) >= 0) {
+        if (redeliveryStartAt == null || PositionComparators.compareLedgerIdAndEntryId(redeliveryStartAt, position) == 0
+                || PositionComparators.compareLedgerIdAndEntryId(redeliveryStartAt, markDeletedPosition) >= 0) {
             cleanEarliestInformation();
         }
     }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/InMemoryAndPreventCycleFilterRedeliveryTracker.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/InMemoryAndPreventCycleFilterRedeliveryTracker.java
@@ -18,7 +18,7 @@
  */
 package org.apache.pulsar.broker.service;
 
-import static org.apache.bookkeeper.mledger.PositionComparators.COMPARE_WITH_LEDGER_AND_ENTRY_ID;
+import static org.apache.bookkeeper.mledger.PositionComparators.*;
 import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -84,7 +84,7 @@ public class InMemoryAndPreventCycleFilterRedeliveryTracker extends InMemoryRede
             cleanEarliestInformation();
             actualEarliestPosition = position;
         } else {
-            int isEarlier = COMPARE_WITH_LEDGER_AND_ENTRY_ID.compare(originalEarliestPosition, position);
+            int isEarlier = compareLedgerIdAndEntryId(originalEarliestPosition, position);
             if (isEarlier < 0) {
                 return newCount;
             } else if (isEarlier > 0) {
@@ -108,8 +108,8 @@ public class InMemoryAndPreventCycleFilterRedeliveryTracker extends InMemoryRede
     @Override
     public void remove(Position position, Position markDeletedPosition) {
         super.remove(position, markDeletedPosition);
-        if (redeliveryStartAt == null || COMPARE_WITH_LEDGER_AND_ENTRY_ID.compare(redeliveryStartAt, position) == 0
-                || COMPARE_WITH_LEDGER_AND_ENTRY_ID.compare(redeliveryStartAt, markDeletedPosition) >= 0) {
+        if (redeliveryStartAt == null || compareLedgerIdAndEntryId(redeliveryStartAt, position) == 0
+                || compareLedgerIdAndEntryId(redeliveryStartAt, markDeletedPosition) >= 0) {
             cleanEarliestInformation();
         }
     }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/InMemoryAndPreventCycleFilterRedeliveryTracker.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/InMemoryAndPreventCycleFilterRedeliveryTracker.java
@@ -127,7 +127,7 @@ public class InMemoryAndPreventCycleFilterRedeliveryTracker extends InMemoryRede
     }
 
     @Override
-    public Consumer cherryNextConsumer(List<Entry> entries, Supplier<Consumer> nextConsumerFunc, int consumerCount){
+    public Consumer pickNextConsumer(List<Entry> entries, Supplier<Consumer> nextConsumerFunc, int consumerCount){
         if (!hasRedeliveredEntry(entries)){
             return nextConsumerFunc.get();
         }
@@ -186,14 +186,6 @@ public class InMemoryAndPreventCycleFilterRedeliveryTracker extends InMemoryRede
         // Just reset counter to 0, because value will be removed if consumer is closed.
         earliestEntryRedeliveryCountMapping.values().forEach(i -> i.set(0));
         pausedConsumers.clear();
-    }
-
-    private static int comparePosition(Position pos1, Position pos2) {
-        int ledgerCompare = Long.compare(pos1.getLedgerId(), pos2.getLedgerId());
-        if (ledgerCompare != 0) {
-            return ledgerCompare;
-        }
-        return Long.compare(pos1.getEntryId(), pos2.getEntryId());
     }
 
     private static class PauseConsumerInformation {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/InMemoryRedeliveryTracker.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/InMemoryRedeliveryTracker.java
@@ -26,10 +26,10 @@ import org.apache.bookkeeper.util.collections.ConcurrentLongLongPairHashMap.Long
 
 public class InMemoryRedeliveryTracker implements RedeliveryTracker {
 
-    private ConcurrentLongLongPairHashMap trackerCache = new ConcurrentLongLongPairHashMap(256, 1);
+    protected ConcurrentLongLongPairHashMap trackerCache = new ConcurrentLongLongPairHashMap(256, 1);
 
     @Override
-    public int incrementAndGetRedeliveryCount(Position position) {
+    public int incrementAndGetRedeliveryCount(Position position, Consumer consumer) {
         PositionImpl positionImpl = (PositionImpl) position;
         LongPair count = trackerCache.get(positionImpl.getLedgerId(), positionImpl.getEntryId());
         int newCount = (int) (count != null ? count.first + 1 : 1);
@@ -45,15 +45,15 @@ public class InMemoryRedeliveryTracker implements RedeliveryTracker {
     }
 
     @Override
-    public void remove(Position position) {
+    public void remove(Position position, Position markDeletedPosition) {
         PositionImpl positionImpl = (PositionImpl) position;
         trackerCache.remove(positionImpl.getLedgerId(), positionImpl.getEntryId());
     }
 
     @Override
-    public void removeBatch(List<Position> positions) {
+    public void removeBatch(List<Position> positions, final Position markDeletedPosition) {
         if (positions != null) {
-            positions.forEach(this::remove);
+            positions.forEach(pos -> remove(pos, markDeletedPosition));
         }
     }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/RedeliveryTracker.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/RedeliveryTracker.java
@@ -26,6 +26,8 @@ public interface RedeliveryTracker {
 
     int incrementAndGetRedeliveryCount(Position position, Consumer consumer);
 
+    default void noticeConsumerClosed(Consumer consumer){}
+
     int getRedeliveryCount(Position position);
 
     void remove(Position position, Position markDeletedPosition);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/RedeliveryTracker.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/RedeliveryTracker.java
@@ -19,6 +19,7 @@
 package org.apache.pulsar.broker.service;
 
 import java.util.List;
+import java.util.function.Supplier;
 import org.apache.bookkeeper.mledger.Entry;
 import org.apache.bookkeeper.mledger.Position;
 
@@ -46,5 +47,9 @@ public interface RedeliveryTracker {
             }
         }
         return false;
+    }
+
+    default Consumer cherryNextConsumer(Supplier<Consumer> nextConsumerFunc, int consumerCount){
+        return nextConsumerFunc.get();
     }
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/RedeliveryTracker.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/RedeliveryTracker.java
@@ -27,8 +27,6 @@ public interface RedeliveryTracker {
 
     int incrementAndGetRedeliveryCount(Position position, Consumer consumer);
 
-    default void noticeConsumerClosed(Consumer consumer){}
-
     int getRedeliveryCount(Position position);
 
     void remove(Position position, Position markDeletedPosition);
@@ -37,19 +35,9 @@ public interface RedeliveryTracker {
 
     void clear();
 
-    default boolean hasRedeliveredEntry(List<Entry> entries) {
-        for (Entry entry : entries) {
-            if (entry == null || entry.getPosition() == null || entry.getLedgerId() < 0 || entry.getEntryId() < 0) {
-                continue;
-            }
-            if (getRedeliveryCount(entry.getPosition()) > 0) {
-                return true;
-            }
-        }
-        return false;
-    }
+    default void noticeConsumerClosed(Consumer consumer){}
 
-    default Consumer cherryNextConsumer(Supplier<Consumer> nextConsumerFunc, int consumerCount){
+    default Consumer cherryNextConsumer(List<Entry> entries, Supplier<Consumer> nextConsumerFunc, int consumerCount){
         return nextConsumerFunc.get();
     }
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/RedeliveryTracker.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/RedeliveryTracker.java
@@ -37,7 +37,7 @@ public interface RedeliveryTracker {
 
     default void noticeConsumerClosed(Consumer consumer){}
 
-    default Consumer cherryNextConsumer(List<Entry> entries, Supplier<Consumer> nextConsumerFunc, int consumerCount){
+    default Consumer pickNextConsumer(List<Entry> entries, Supplier<Consumer> nextConsumerFunc, int consumerCount){
         return nextConsumerFunc.get();
     }
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/RedeliveryTrackerDisabled.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/RedeliveryTrackerDisabled.java
@@ -28,7 +28,7 @@ public class RedeliveryTrackerDisabled implements RedeliveryTracker {
     private RedeliveryTrackerDisabled() {}
 
     @Override
-    public int incrementAndGetRedeliveryCount(Position position) {
+    public int incrementAndGetRedeliveryCount(Position position, Consumer consumer) {
         return 0;
     }
 
@@ -38,12 +38,12 @@ public class RedeliveryTrackerDisabled implements RedeliveryTracker {
     }
 
     @Override
-    public void remove(Position position) {
+    public void remove(Position position, Position markDeletedPosition) {
         // no-op
     }
 
     @Override
-    public void removeBatch(List<Position> positions) {
+    public void removeBatch(List<Position> positions, Position markDeletedPosition) {
         // no-op
     }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumers.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumers.java
@@ -211,6 +211,7 @@ public class PersistentDispatcherMultipleConsumers extends AbstractDispatcherMul
                 consumer.getPendingAcks().forEach((ledgerId, entryId, batchSize, stickyKeyHash) -> {
                     addMessageToReplay(ledgerId, entryId, stickyKeyHash);
                 });
+                redeliveryTracker.noticeConsumerClosed(consumer);
                 totalAvailablePermits -= consumer.getAvailablePermits();
                 if (log.isDebugEnabled()) {
                     log.debug("[{}] Decreased totalAvailablePermits by {} in PersistentDispatcherMultipleConsumers. "

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumers.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumers.java
@@ -710,10 +710,7 @@ public class PersistentDispatcherMultipleConsumers extends AbstractDispatcherMul
     }
 
     public Consumer getNextConsumer(List<Entry> entries) {
-        if (!redeliveryTracker.hasRedeliveredEntry(entries)){
-            return super.getNextConsumer();
-        }
-        return redeliveryTracker.cherryNextConsumer(() -> super.getNextConsumer(), consumerSet.size());
+        return redeliveryTracker.cherryNextConsumer(entries, () -> super.getNextConsumer(), consumerSet.size());
     }
 
     private boolean sendChunkedMessagesToConsumers(ReadType readType,

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumers.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumers.java
@@ -713,29 +713,7 @@ public class PersistentDispatcherMultipleConsumers extends AbstractDispatcherMul
         if (!redeliveryTracker.hasRedeliveredEntry(entries)){
             return super.getNextConsumer();
         }
-        if (redeliveryTracker instanceof InMemoryAndPreventCycleFilterRedeliveryTracker tracker){
-            if (tracker.pausedConsumerCount() == consumerSet.size()){
-                if (log.isDebugEnabled()) {
-                    log.debug("No consumers are currently able to consume the first redelivery entry {}",
-                            tracker.getRedeliveryStartAt());
-                }
-                return super.getNextConsumer();
-            } else {
-                for (int i = 0; i < consumerSet.size(); i++){
-                    Consumer nextConsumer = super.getNextConsumer();
-                    if (!tracker.isConsumerPaused(nextConsumer)){
-                        return nextConsumer;
-                    }
-                }
-                if (log.isDebugEnabled()) {
-                    log.debug("No consumers are currently able to consume the first redelivery entry {}",
-                            tracker.getRedeliveryStartAt());
-                }
-                return super.getNextConsumer();
-            }
-        } else {
-            return super.getNextConsumer();
-        }
+        return redeliveryTracker.cherryNextConsumer(() -> super.getNextConsumer(), consumerSet.size());
     }
 
     private boolean sendChunkedMessagesToConsumers(ReadType readType,

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumers.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumers.java
@@ -710,7 +710,7 @@ public class PersistentDispatcherMultipleConsumers extends AbstractDispatcherMul
     }
 
     public Consumer getNextConsumer(List<Entry> entries) {
-        return redeliveryTracker.cherryNextConsumer(entries, () -> super.getNextConsumer(), consumerSet.size());
+        return redeliveryTracker.pickNextConsumer(entries, () -> super.getNextConsumer(), consumerSet.size());
     }
 
     private boolean sendChunkedMessagesToConsumers(ReadType readType,

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentSubscription.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentSubscription.java
@@ -404,7 +404,7 @@ public class PersistentSubscription extends AbstractSubscription implements Subs
             }
 
             if (dispatcher != null) {
-                dispatcher.getRedeliveryTracker().removeBatch(positions);
+                dispatcher.getRedeliveryTracker().removeBatch(positions, cursor.getMarkDeletedPosition());
             }
         }
 

--- a/site2/website/versioned_docs/version-2.10.x/reference-configuration.md
+++ b/site2/website/versioned_docs/version-2.10.x/reference-configuration.md
@@ -551,7 +551,6 @@ You can set the log level and configuration in the  [log4j2.yaml](https://github
 | dispatchThrottlingOnNonBacklogConsumerEnabled | Enable dispatch-throttling for both caught up consumers as well as consumers who have backlogs. | true |
 |dispatcherMaxReadBatchSize|The maximum number of entries to read from BookKeeper. By default, it is 100 entries.|100|
 |dispatcherMaxReadSizeBytes|The maximum size in bytes of entries to read from BookKeeper. By default, it is 5MB.|5242880|
-|dispatcherEntryFilterRescheduledMessageDelaySeconds|The max seconds a consumer will be paused because the current message cannot be consumed by a consumer. By default, it is 1.|1|
 |dispatcherMinReadBatchSize|The minimum number of entries to read from BookKeeper. By default, it is 1 entry. When there is an error occurred on reading entries from bookkeeper, the broker will backoff the batch size to this minimum number.|1|
 |dispatcherMaxRoundRobinBatchSize|The maximum number of entries to dispatch for a shared subscription. By default, it is 20 entries.|20|
 | preciseDispatcherFlowControl | Precise dispathcer flow control according to history message number of each entry. | false |

--- a/site2/website/versioned_docs/version-2.10.x/reference-configuration.md
+++ b/site2/website/versioned_docs/version-2.10.x/reference-configuration.md
@@ -551,6 +551,7 @@ You can set the log level and configuration in the  [log4j2.yaml](https://github
 | dispatchThrottlingOnNonBacklogConsumerEnabled | Enable dispatch-throttling for both caught up consumers as well as consumers who have backlogs. | true |
 |dispatcherMaxReadBatchSize|The maximum number of entries to read from BookKeeper. By default, it is 100 entries.|100|
 |dispatcherMaxReadSizeBytes|The maximum size in bytes of entries to read from BookKeeper. By default, it is 5MB.|5242880|
+|dispatcherEntryFilterRescheduledMessageDelaySeconds|The max seconds a consumer will be paused because the current message cannot be consumed by a consumer. By default, it is 1.|1|
 |dispatcherMinReadBatchSize|The minimum number of entries to read from BookKeeper. By default, it is 1 entry. When there is an error occurred on reading entries from bookkeeper, the broker will backoff the batch size to this minimum number.|1|
 |dispatcherMaxRoundRobinBatchSize|The maximum number of entries to dispatch for a shared subscription. By default, it is 20 entries.|20|
 | preciseDispatcherFlowControl | Precise dispathcer flow control according to history message number of each entry. | false |


### PR DESCRIPTION
Fixes: 
- https://github.com/apache/pulsar/issues/16978

### Motivation

When there are two consumers, users can specify the consumption behavior of each consumer by `Entry filter`:
- `case`: `consumer_1` can consume 60% of the messages, `consumer_2` can consume 60% of the messages, and there is 10% intersection between `consumer_1` and `consumer_2`


If returns FilterResult.RESCHEDULE for more than 10% of messages,  then it's possible: some message that can only be consumed by `consumer_1` keeps redelivered to `consumer_2`, and some message that can only be consumed by `consumer_2` keeps redelivered to `consumer_1`. Then the problem occurs:

- These messages can not be consumed anymore for a long time
- The number of redeliveries of these messages has been increasing ( redelivery by Entry Filter ), see code below(line: 141):

https://github.com/apache/pulsar/blob/8441f6724b1aa502df580518ae14f0c559f53547/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractBaseDispatcher.java#L140-L148

You can reproduce the problem by run `FilterEntryTest.testEntryFilterRescheduleMessageDependingOnConsumerSharedSubscription` 20 times

### Modifications

When a message is redelivered by the same consumer more than 3 times, make that consumer pause to receive this message for 1 second.
Since tracking the consumption of all the messages cost memory too much, we trace only the earliest message.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)

- [x] `doc-not-needed` 
(Please explain why)

- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)

### Matching PR in forked repository

PR in forked repository: 

- https://github.com/poorbarcode/pulsar/pull/8
