### PR TITLE
[doc][broker]PIP-187 Make FilterResult#RESCHEDULE to deprecated

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/plugin/EntryFilter.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/plugin/EntryFilter.java
@@ -50,7 +50,12 @@ public interface EntryFilter {
         REJECT,
         /**
          * postpone message, it should not go to this conmumer.
+         * @deprecated This is a beta API, make sure you know enough about the behavior to use it.
+         * If use Key_Shared/Exclusive/Failover subscription type, do not return {@link #RESCHEDULE},
+         * because there has no other candidate consumers.And if use Shared subscription type and maybe return
+         * {@link #RESCHEDULE}, make sure that at least one consumer can consume that entry.
          */
+        @Deprecated
         RESCHEDULE
     }
 


### PR DESCRIPTION
### Motivation

`FilterResult.RESCHEDULE` is a beta API, may be risky in the following scenarios:

- Use subscription type: `Shared`: `consumer_1` can consume 60% of the messages, and `consumer_2` can consume 60% of the messages, so there is 10% intersection between consumer_1 and consumer_2. If returns FilterResult.RESCHEDULE for more than 10% of messages, then it's possible: some message that can only be consumed by consumer_1 keeps redelivered to consumer_2, and some message that can only be consumed by consumer_2 keeps redelivered to consumer_1. Then these messages can not be consumed anymore for a long time.
  -  #17782 fixed this problem.
- Use subscription type: `Shared`: `consumer_1` can consume 40% of the messages, `consumer_2` can consume 40% of the messages, and no consumer can consume the remaining 20%. If this 20% of the messages always return `FilterResult.RESCHEDULE`, this will cause that part of the message to always be redelivered and never consumed.
- Use subscription type: `Key_Shared/Exclusive/Failover`: This API cannot be used because there is no spare consumer to consume the redelivered message.

### Modifications

#### Suggestion solution
Make `FilterResult.RESCHEDULE` to `deprecated` to avoid user use.

#### Other solution

Provide two strategies for messages that cannot be consumed: 
- Drop the message or push it into DLQ
- Choose any consumer to receive

Why not choose this solution?

Because we can create a new subscription to achieve the same effect instead use `FilterResult.RESCHEDULE`.

### Documentation

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)

- [ ] `doc-not-needed` 
(Please explain why)

- [x] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)

### Matching PR in forked repository

PR in forked repository: 

- https://github.com/poorbarcode/pulsar/pull/9
