### PR TITLE
[doc] [client] [go] Add chunking to go-client doc

### DIFF
--- a/site2/docs/client-libraries-go.md
+++ b/site2/docs/client-libraries-go.md
@@ -218,7 +218,7 @@ defer client.Close()
 
 // The message chunking feature is OFF by default.
 // By default, a producer chunks the large message based on the max message size (`maxMessageSize`) configured at the broker side (for example, 5MB).
-// Client can also configure max chunked size using producer configuration ChunkMaxMessageSize.
+// Client can also configure the max chunked size using the producer configuration `ChunkMaxMessageSize`.
 // Attention, to enable chunking, you need to disable batching (DisableBatching=true) concurrently.
 producer, err := client.CreateProducer(pulsar.ProducerOptions{
   Topic:               "my-topic",

--- a/site2/docs/client-libraries-go.md
+++ b/site2/docs/client-libraries-go.md
@@ -207,7 +207,7 @@ for i := 0; i < 10; i++ {
 #### How to use chunking in producer
 
 ```go
-client, err := NewClient(pulsar.ClientOptions{
+client, err := pulsar.NewClient(pulsar.ClientOptions{
 	URL: serviceURL,
 })
 

--- a/site2/docs/client-libraries-go.md
+++ b/site2/docs/client-libraries-go.md
@@ -217,7 +217,7 @@ if err != nil {
 defer client.Close()
 
 // The message chunking feature is OFF by default.
-// By default, producer chunks the large message based on max message size (maxMessageSize) configured at broker (eg: 5MB).
+// By default, a producer chunks the large message based on the max message size (`maxMessageSize`) configured at the broker side (for example, 5MB).
 // Client can also configure max chunked size using producer configuration ChunkMaxMessageSize.
 // Attention, to enable chunking, you need to disable batching (DisableBatching=true) concurrently.
 producer, err := client.CreateProducer(pulsar.ProducerOptions{

--- a/site2/docs/client-libraries-go.md
+++ b/site2/docs/client-libraries-go.md
@@ -219,7 +219,7 @@ defer client.Close()
 // The message chunking feature is OFF by default.
 // By default, a producer chunks the large message based on the max message size (`maxMessageSize`) configured at the broker side (for example, 5MB).
 // Client can also configure the max chunked size using the producer configuration `ChunkMaxMessageSize`.
-// Attention, to enable chunking, you need to disable batching (DisableBatching=true) concurrently.
+// Note: to enable chunking, you need to disable batching (`DisableBatching=true`) concurrently.
 producer, err := client.CreateProducer(pulsar.ProducerOptions{
   Topic:               "my-topic",
   DisableBatching:     true,

--- a/site2/docs/client-libraries-go.md
+++ b/site2/docs/client-libraries-go.md
@@ -204,6 +204,34 @@ for i := 0; i < 10; i++ {
 }
 ```
 
+#### How to use chunking in producer
+
+```go
+client, err := NewClient(pulsar.ClientOptions{
+	URL: serviceURL,
+})
+
+if err != nil {
+	log.Fatal(err)
+}
+defer client.Close()
+
+// The message chunking feature is OFF by default.
+// By default, producer chunks the large message based on max message size (maxMessageSize) configured at broker (eg: 5MB).
+// Client can also configure max chunked size using producer configuration ChunkMaxMessageSize.
+// Attention, to enable chunking, you need to disable batching (DisableBatching=true) concurrently.
+producer, err := client.CreateProducer(pulsar.ProducerOptions{
+  Topic:               "my-topic",
+  DisableBatching:     true,
+  EnableChunking:      true,
+})
+
+if err != nil {
+	log.Fatal(err)
+}
+defer producer.Close()
+```
+
 #### How to use schema interface in producer
 
 ```go


### PR DESCRIPTION
Master Issue: pulsar-client-go [#865](https://github.com/apache/pulsar-client-go/pull/805)

### Motivation

Add chunking document for go-client. (Do not merge. [#865](https://github.com/apache/pulsar-client-go/pull/805) is under review now.)

### Modifications

Add chunking document for go-client.

### Documentation

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)

- [ ] `doc-not-needed` 
(Please explain why)

- [x] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)

### Matching PR in forked repository

PR in forked repository:  https://github.com/Gleiphir2769/pulsar-client-go
