### PR TITLE
[improve][test] Improve TransactionEndToEndTest to reduce the execution time

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/TransactionEndToEndTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/TransactionEndToEndTest.java
@@ -103,9 +103,11 @@ public class TransactionEndToEndTest extends TransactionTestBase {
         admin.topics().createPartitionedTopic(TOPIC_MESSAGE_ACK_TEST, 1);
     }
 
-    private void resetTopicOutput() throws Exception {
+    protected void resetTopicOutput() throws Exception {
         admin.topics().deletePartitionedTopic(TOPIC_OUTPUT, true);
         admin.topics().createPartitionedTopic(TOPIC_OUTPUT, TOPIC_PARTITION);
+        admin.topics().deletePartitionedTopic(TOPIC_MESSAGE_ACK_TEST, true);
+        admin.topics().createPartitionedTopic(TOPIC_MESSAGE_ACK_TEST, 1);
     }
 
     @AfterClass(alwaysRun = true)
@@ -565,7 +567,7 @@ public class TransactionEndToEndTest extends TransactionTestBase {
         // cleanup.
         producer.close();
         consumer.close();
-        admin.topics().delete(topic, true);
+        resetTopicOutput();
         log.info("receive transaction messages count: {}", receiveCnt);
     }
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/TransactionEndToEndWithoutBatchIndexAckTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/TransactionEndToEndWithoutBatchIndexAckTest.java
@@ -20,7 +20,7 @@ package org.apache.pulsar.client.impl;
 
 import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.client.api.SubscriptionType;
-import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 /**
@@ -30,7 +30,7 @@ import org.testng.annotations.Test;
 @Test(groups = "flaky")
 public class TransactionEndToEndWithoutBatchIndexAckTest extends TransactionEndToEndTest {
 
-    @BeforeMethod
+    @BeforeClass
     protected void setup() throws Exception {
         conf.setAcknowledgmentAtBatchIndexLevelEnabled(false);
         setUpBase(1, NUM_PARTITIONS, TOPIC_OUTPUT, TOPIC_PARTITION);


### PR DESCRIPTION
Fixes
- https://github.com/apache/pulsar/issues/17623
- https://github.com/apache/pulsar/issues/17637

### Motivation

Manually release resources, including `consumer`, `producer`, `pulsar client`, `transaction`, and `topic`. This saves `setup` and `cleanup` time before and after each method. 

### Modifications

- Manually release resources instead of calling `cleanup` & `setup` each method
- remove useless method `markDeletePositionCheck`
- `Integer.valueOf(int)` instead of `new Integer(int)`, because `new Integer(int)` is deprecated

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)

- [x] `doc-not-needed` 
(Please explain why)

- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)

### Matching PR in forked repository

PR in forked repository: 

- https://github.com/poorbarcode/pulsar/pull/10
