### PR TITLE
[fix][flaky-test]NamespaceOwnershipListenerTests.testNamespaceBundleOwnershipListener

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiTest.java
@@ -271,7 +271,7 @@ public class AdminApiTest extends MockedPulsarServiceBaseTest {
         Awaitility.await()
                 .untilAsserted(() -> assertEquals(admin.clusters().getClusters(), Lists.newArrayList("test")));
 
-        admin.namespaces().deleteNamespace("prop-xyz/ns1");
+        deleteNamespaceGraceFully("prop-xyz/ns1", false);
         admin.clusters().deleteCluster("test");
         assertEquals(admin.clusters().getClusters(), new ArrayList<>());
 
@@ -500,7 +500,7 @@ public class AdminApiTest extends MockedPulsarServiceBaseTest {
                 String.format("%s:%d", parts[0], pulsar.getListenPortHTTPS().get()));
         Assert.assertEquals(nsMap2.size(), 2);
 
-        admin.namespaces().deleteNamespace("prop-xyz/ns1");
+        deleteNamespaceGraceFully("prop-xyz/ns1", false);
         admin.clusters().deleteCluster("test");
         assertEquals(admin.clusters().getClusters(), new ArrayList<>());
     }
@@ -702,7 +702,7 @@ public class AdminApiTest extends MockedPulsarServiceBaseTest {
     }
 
     @Test
-    public void properties() throws PulsarAdminException {
+    public void properties() throws Exception {
         try {
             admin.tenants().getTenantInfo("does-not-exist");
             fail("should have failed");
@@ -731,7 +731,7 @@ public class AdminApiTest extends MockedPulsarServiceBaseTest {
             assertEquals(e.getStatusCode(), 409);
             assertEquals(e.getMessage(), "The tenant still has active namespaces");
         }
-        admin.namespaces().deleteNamespace("prop-xyz/ns1");
+        deleteNamespaceGraceFully("prop-xyz/ns1", false);
         admin.tenants().deleteTenant("prop-xyz");
         assertEquals(admin.tenants().getTenants(), new ArrayList<>());
 
@@ -760,7 +760,7 @@ public class AdminApiTest extends MockedPulsarServiceBaseTest {
         assertEquals(admin.namespaces().getPolicies("prop-xyz/ns3").bundles.getNumBundles(), 4);
         assertEquals(admin.namespaces().getPolicies("prop-xyz/ns3").bundles.getBoundaries().size(), 5);
 
-        admin.namespaces().deleteNamespace("prop-xyz/ns3");
+        deleteNamespaceGraceFully("prop-xyz/ns3", false);
 
         try {
             admin.namespaces().createNamespace("non-existing/ns1");
@@ -834,7 +834,7 @@ public class AdminApiTest extends MockedPulsarServiceBaseTest {
         }
         assertTrue(i < 10);
 
-        admin.namespaces().deleteNamespace("prop-xyz/ns1");
+        deleteNamespaceGraceFully("prop-xyz/ns1", false);
         assertEquals(admin.namespaces().getNamespaces("prop-xyz"), Lists.newArrayList("prop-xyz/ns2"));
 
         try {
@@ -1260,7 +1260,7 @@ public class AdminApiTest extends MockedPulsarServiceBaseTest {
 
     @Test(dataProvider = "numBundles")
     public void testDeleteNamespaceBundle(Integer numBundles) throws Exception {
-        admin.namespaces().deleteNamespace("prop-xyz/ns1");
+        deleteNamespaceGraceFully("prop-xyz/ns1", false);
         admin.namespaces().createNamespace("prop-xyz/ns1-bundles", numBundles);
         admin.namespaces().setNamespaceReplicationClusters("prop-xyz/ns1-bundles", Set.of("test"));
 
@@ -1272,7 +1272,7 @@ public class AdminApiTest extends MockedPulsarServiceBaseTest {
 
         assertEquals(admin.namespaces().getTopics("prop-xyz/ns1-bundles"), new ArrayList<>());
 
-        admin.namespaces().deleteNamespace("prop-xyz/ns1-bundles");
+        deleteNamespaceGraceFully("prop-xyz/ns1-bundles", false);
         assertEquals(admin.namespaces().getNamespaces("prop-xyz", "test"), new ArrayList<>());
     }
 
@@ -1359,14 +1359,14 @@ public class AdminApiTest extends MockedPulsarServiceBaseTest {
         assertFalse(admin.topics().getList(namespace).isEmpty());
 
         try {
-            admin.namespaces().deleteNamespace(namespace, false);
+            deleteNamespaceGraceFully(namespace, false);
             fail("should have failed due to namespace not empty");
         } catch (PulsarAdminException e) {
             // Expected: cannot delete non-empty tenant
         }
 
         // delete namespace forcefully
-        admin.namespaces().deleteNamespace(namespace, true);
+        deleteNamespaceGraceFully(namespace, true);
         assertFalse(admin.namespaces().getNamespaces(tenant).contains(namespace));
         assertTrue(admin.namespaces().getNamespaces(tenant).isEmpty());
 
@@ -2233,7 +2233,7 @@ public class AdminApiTest extends MockedPulsarServiceBaseTest {
         assertEquals(result.someNewIntField, 0);
         assertNull(result.someNewString);
 
-        admin.namespaces().deleteNamespace("prop-xyz/ns1");
+        deleteNamespaceGraceFully("prop-xyz/ns1", false);
         admin.tenants().deleteTenant("prop-xyz");
         assertEquals(admin.tenants().getTenants(), new ArrayList<>());
     }
@@ -3144,9 +3144,9 @@ public class AdminApiTest extends MockedPulsarServiceBaseTest {
         admin.topics().delete(topic1);
         admin.topics().delete(topic2);
         admin.topics().delete(topic3);
-        admin.namespaces().deleteNamespace(namespace1);
-        admin.namespaces().deleteNamespace(namespace2);
-        admin.namespaces().deleteNamespace(namespace3);
+        deleteNamespaceGraceFully(namespace1, false);
+        deleteNamespaceGraceFully(namespace2, false);
+        deleteNamespaceGraceFully(namespace3, false);
     }
 
     @Test
@@ -3159,11 +3159,11 @@ public class AdminApiTest extends MockedPulsarServiceBaseTest {
         String ns = BrokerTestUtil.newUniqueName("prop-xyz/ns");
 
         admin.namespaces().createNamespace(ns, 24);
-        admin.namespaces().deleteNamespace(ns);
+        deleteNamespaceGraceFully(ns, false);
 
         // Re-create and re-delete
         admin.namespaces().createNamespace(ns, 32);
-        admin.namespaces().deleteNamespace(ns);
+        deleteNamespaceGraceFully(ns, false);
     }
 
     @Test

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiTlsAuthTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiTlsAuthTest.java
@@ -459,7 +459,7 @@ public class AdminApiTlsAuthTest extends MockedPulsarServiceBaseTest {
             admin.topics().delete("tenant1/ns1/foobar", true);
 
             log.info("Deleting namespace");
-            admin.namespaces().deleteNamespace("tenant1/ns1");
+            deleteNamespaceGraceFully("tenant1/ns1", false, admin);
         }
     }
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminRestTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminRestTest.java
@@ -117,7 +117,7 @@ public class AdminRestTest extends MockedPulsarServiceBaseTest {
     protected void cleanup() throws Exception {
         // cleanup.
         admin.topics().delete(topicName);
-        admin.namespaces().deleteNamespace(namespaceName);
+        deleteNamespaceGraceFully(namespaceName, false);
         admin.tenants().deleteTenant(tenantName);
         admin.clusters().deleteCluster(clusterName);
         // super cleanup.

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/MockedPulsarServiceBaseTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/MockedPulsarServiceBaseTest.java
@@ -59,6 +59,7 @@ import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.broker.ServiceConfiguration;
 import org.apache.pulsar.broker.intercept.CounterBrokerInterceptor;
 import org.apache.pulsar.broker.namespace.NamespaceService;
+import org.apache.pulsar.broker.service.BrokerTestBase;
 import org.apache.pulsar.broker.service.PulsarMetadataEventSynchronizer;
 import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.admin.PulsarAdminBuilder;
@@ -650,6 +651,22 @@ public abstract class MockedPulsarServiceBaseTest extends TestRetrySupport {
             return null;
         }
 
+    }
+
+    /**
+     * see {@link BrokerTestBase#deleteNamespaceGraceFully(String, boolean, PulsarService, PulsarAdmin)}
+     */
+    protected void deleteNamespaceGraceFully(String ns, boolean force)
+            throws Exception {
+        BrokerTestBase.deleteNamespaceGraceFully(ns, force, pulsar, admin);
+    }
+
+    /**
+     * see {@link BrokerTestBase#deleteNamespaceGraceFully(String, boolean, PulsarService, PulsarAdmin)}
+     */
+    protected void deleteNamespaceGraceFully(String ns, boolean force, PulsarAdmin admin)
+            throws Exception {
+        BrokerTestBase.deleteNamespaceGraceFully(ns, force, pulsar, admin);
     }
 
     private static final Logger log = LoggerFactory.getLogger(MockedPulsarServiceBaseTest.class);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/namespace/NamespaceOwnershipListenerTests.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/namespace/NamespaceOwnershipListenerTests.java
@@ -21,7 +21,6 @@ package org.apache.pulsar.broker.namespace;
 import com.google.common.collect.Sets;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.pulsar.broker.service.BrokerTestBase;
-import org.apache.pulsar.client.admin.PulsarAdminException;
 import org.apache.pulsar.client.api.Producer;
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.common.naming.NamespaceBundle;
@@ -34,7 +33,6 @@ import org.testng.annotations.Test;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.testng.Assert.assertTrue;
@@ -55,7 +53,7 @@ public class NamespaceOwnershipListenerTests extends BrokerTestBase {
     }
 
     @Test
-    public void testNamespaceBundleOwnershipListener() throws PulsarAdminException, InterruptedException, PulsarClientException {
+    public void testNamespaceBundleOwnershipListener() throws Exception {
 
         final CountDownLatch countDownLatch = new CountDownLatch(2);
         final AtomicBoolean onLoad = new AtomicBoolean(false);
@@ -101,11 +99,11 @@ public class NamespaceOwnershipListenerTests extends BrokerTestBase {
         Assert.assertTrue(onLoad.get());
         Assert.assertTrue(unLoad.get());
         admin.topics().delete(topic);
-        admin.namespaces().deleteNamespace(namespace);
+        deleteNamespaceGraceFully(namespace, false);
     }
 
     @Test
-    public void testGetAllPartitions() throws PulsarAdminException, ExecutionException, InterruptedException {
+    public void testGetAllPartitions() throws Exception {
         final String namespace = "prop/" + UUID.randomUUID().toString();
         admin.namespaces().createNamespace(namespace, Sets.newHashSet("test"));
         assertTrue(admin.namespaces().getNamespaces("prop").contains(namespace));
@@ -122,11 +120,11 @@ public class NamespaceOwnershipListenerTests extends BrokerTestBase {
         }
 
         admin.topics().deletePartitionedTopic(topicName);
-        admin.namespaces().deleteNamespace(namespace);
+        deleteNamespaceGraceFully(namespace, false);
     }
 
     @Test
-    public void testNamespaceBundleLookupOnwershipListener() throws PulsarAdminException, InterruptedException,
+    public void testNamespaceBundleLookupOnwershipListener() throws Exception,
             PulsarClientException {
         final CountDownLatch countDownLatch = new CountDownLatch(2);
         final AtomicInteger onLoad = new AtomicInteger(0);
@@ -172,6 +170,6 @@ public class NamespaceOwnershipListenerTests extends BrokerTestBase {
         Assert.assertEquals(onLoad.get(), 1);
         Assert.assertEquals(unLoad.get(), 1);
         admin.topics().delete(topic);
-        admin.namespaces().deleteNamespace(namespace);
+        deleteNamespaceGraceFully(namespace, false);
     }
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/resourcegroup/ResourceGroupConfigListenerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/resourcegroup/ResourceGroupConfigListenerTest.java
@@ -197,7 +197,7 @@ public class ResourceGroupConfigListenerTest extends MockedPulsarServiceBaseTest
                 assertNull(pulsar.getResourceGroupServiceManager()
                         .getNamespaceResourceGroup(NamespaceName.get(namespaceName))));
 
-        admin.namespaces().deleteNamespace(namespaceName);
+        deleteNamespaceGraceFully(namespaceName, false);
         deleteResourceGroup(rgName);
     }
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BacklogQuotaManagerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BacklogQuotaManagerTest.java
@@ -80,6 +80,14 @@ public class BacklogQuotaManagerTest {
     private static final int TIME_TO_CHECK_BACKLOG_QUOTA = 2;
     private static final int MAX_ENTRIES_PER_LEDGER = 5;
 
+    /**
+     * see {@link BrokerTestBase#deleteNamespaceGraceFully(String, boolean, PulsarService, PulsarAdmin)}
+     */
+    protected void deleteNamespaceGraceFully(String ns, boolean force)
+            throws Exception {
+        BrokerTestBase.deleteNamespaceGraceFully(ns, force, pulsar, admin);
+    }
+
     @DataProvider(name = "backlogQuotaSizeGB")
     public Object[][] backlogQuotaSizeGB() {
         return new Object[][] { { true }, { false } };
@@ -159,10 +167,10 @@ public class BacklogQuotaManagerTest {
     }
 
     @AfterMethod(alwaysRun = true)
-    void clearNamespaces() throws PulsarAdminException {
-        admin.namespaces().deleteNamespace("prop/ns-quota", true);
-        admin.namespaces().deleteNamespace("prop/quotahold", true);
-        admin.namespaces().deleteNamespace("prop/quotaholdasync", true);
+    void clearNamespaces() throws Exception {
+        deleteNamespaceGraceFully("prop/ns-quota", true);
+        deleteNamespaceGraceFully("prop/quotahold", true);
+        deleteNamespaceGraceFully("prop/quotaholdasync", true);
     }
 
     private void rolloverStats() {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerServiceBundlesCacheInvalidationTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerServiceBundlesCacheInvalidationTest.java
@@ -59,7 +59,7 @@ public class BrokerServiceBundlesCacheInvalidationTest extends BrokerTestBase {
 
         // Delete and recreate with 32 bundles
         admin.topics().delete(topic);
-        admin.namespaces().deleteNamespace(namespace, false);
+        deleteNamespaceGraceFully(namespace, false);
         admin.namespaces().createNamespace(namespace, 32);
 
         BundlesData bundlesData = admin.namespaces().getBundles(namespace);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerTestBase.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerTestBase.java
@@ -18,13 +18,32 @@
  */
 package org.apache.pulsar.broker.service;
 
+import static org.apache.pulsar.common.naming.SystemTopicNames.NAMESPACE_EVENTS_LOCAL_NAME;
+import static org.apache.pulsar.compaction.Compactor.COMPACTION_SUBSCRIPTION;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import org.apache.commons.collections4.CollectionUtils;
+import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.broker.ServiceConfiguration;
 import org.apache.pulsar.broker.auth.MockedPulsarServiceBaseTest;
+import org.apache.pulsar.broker.namespace.NamespaceEphemeralData;
+import org.apache.pulsar.broker.service.persistent.PersistentTopic;
+import org.apache.pulsar.client.admin.PulsarAdmin;
+import org.apache.pulsar.client.admin.PulsarAdminException;
+import org.apache.pulsar.common.naming.NamespaceBundle;
+import org.apache.pulsar.common.naming.NamespaceName;
 import org.apache.pulsar.common.naming.SystemTopicNames;
+import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.partition.PartitionedTopicMetadata;
 import org.apache.pulsar.common.policies.data.ClusterData;
 import org.apache.pulsar.common.policies.data.TenantInfoImpl;
 import org.apache.pulsar.metadata.api.MetadataStoreException;
+import org.apache.pulsar.metadata.api.coordination.LockManager;
+import org.awaitility.Awaitility;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -106,6 +125,104 @@ public abstract class BrokerTestBase extends MockedPulsarServiceBaseTest {
 
     protected String newTopicName() {
         return "prop/ns-abc/topic-" + Long.toHexString(random.nextLong());
+    }
+
+    /**
+     * see {@link #deleteNamespaceGraceFully}
+     */
+    protected void deleteNamespaceGraceFully(String ns, boolean force)
+            throws Exception {
+        deleteNamespaceGraceFully(ns, force, pulsar, admin);
+    }
+
+    /**
+     * Wait until system topic "__change_event" and subscription "__compaction" are created, and then delete the namespace.
+     */
+    public static void deleteNamespaceGraceFully(String ns, boolean force, PulsarService pulsar, PulsarAdmin admin)
+            throws Exception {
+        // namespace v1 should not wait system topic create.
+        if (ns.split("/").length > 2){
+            admin.namespaces().deleteNamespace(ns, force);
+            return;
+        }
+        if (!pulsar.getConfiguration().isSystemTopicEnabled()){
+            admin.namespaces().deleteNamespace(ns, force);
+            return;
+        }
+        // If no bundle has been loaded, then the System Topic will not trigger creation.
+        LockManager lockManager = pulsar.getCoordinationService().getLockManager(NamespaceEphemeralData.class);
+        List<String> lockedBundles = (List<String>) lockManager.listLocks("/namespace" + "/" + ns).join();
+        if (CollectionUtils.isEmpty(lockedBundles)){
+            admin.namespaces().deleteNamespace(ns, force);
+            return;
+        }
+        // Trigger change event topic create.
+        NamespaceName namespace = NamespaceName.get(ns);
+        NamespaceBundle namespaceBundle = mock(NamespaceBundle.class);
+        when(namespaceBundle.getNamespaceObject()).thenReturn(namespace);
+        pulsar.getTopicPoliciesService().addOwnedNamespaceBundleAsync(namespaceBundle);
+        // Wait for change event topic and compaction create finish.
+        String allowAutoTopicCreationType = pulsar.getConfiguration().getAllowAutoTopicCreationType();
+        int defaultNumPartitions = pulsar.getConfiguration().getDefaultNumPartitions();
+        ArrayList<String> expectChangeEventTopics = new ArrayList<>();
+        if ("non-partitioned".equals(allowAutoTopicCreationType)){
+            String t = String.format("persistent://%s/%s", ns, NAMESPACE_EVENTS_LOCAL_NAME);
+            expectChangeEventTopics.add(t);
+        } else {
+            for (int i = 0; i < defaultNumPartitions; i++){
+                String t = String.format("persistent://%s/%s-partition-%s", ns, NAMESPACE_EVENTS_LOCAL_NAME, i);
+                expectChangeEventTopics.add(t);
+            }
+        }
+        Awaitility.await().until(() -> {
+            boolean finished = true;
+            for (String changeEventTopicName : expectChangeEventTopics){
+                boolean bundleExists = pulsar.getNamespaceService()
+                        .checkTopicOwnership(TopicName.get(changeEventTopicName))
+                        .exceptionally(ex -> false).join();
+                if (!bundleExists){
+                    finished = false;
+                    break;
+                }
+                CompletableFuture<Optional<Topic>> completableFuture =
+                        pulsar.getBrokerService().getTopic(changeEventTopicName, false);
+                if (completableFuture == null){
+                    finished = false;
+                    break;
+                }
+                Optional<Topic> optionalTopic = completableFuture.get();
+                if (!optionalTopic.isPresent()){
+                    finished = false;
+                    break;
+                }
+                PersistentTopic changeEventTopic = (PersistentTopic) optionalTopic.get();
+                if (!changeEventTopic.isCompactionEnabled()){
+                    break;
+                }
+                if (!changeEventTopic.getSubscriptions().containsKey(COMPACTION_SUBSCRIPTION)){
+                    finished = false;
+                    break;
+                }
+            }
+            return finished;
+        });
+        int retryTimes = 3;
+        while (true) {
+            try {
+                admin.namespaces().deleteNamespace(ns, force);
+                break;
+            } catch (PulsarAdminException ex) {
+                // Do retry only if topic fenced.
+                if (ex.getStatusCode() == 500 && ex.getMessage().contains("TopicFencedException")){
+                    if (--retryTimes > 0){
+                        continue;
+                    } else {
+                        throw ex;
+                    }
+                }
+                throw ex;
+            }
+        }
     }
 
     private static final Logger LOG = LoggerFactory.getLogger(BrokerTestBase.class);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentTopicE2ETest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentTopicE2ETest.java
@@ -998,7 +998,7 @@ public class PersistentTopicE2ETest extends BrokerTestBase {
         consumer.close();
         admin.topics().deleteSubscription(topicName, subName);
         admin.topics().delete(topicName);
-        admin.namespaces().deleteNamespace(namespaceName);
+        deleteNamespaceGraceFully(namespaceName, false);
     }
 
     @Test
@@ -1090,7 +1090,7 @@ public class PersistentTopicE2ETest extends BrokerTestBase {
             consumer.close();
             admin.topics().deleteSubscription(topicName, subName);
             admin.topics().delete(topicName);
-            admin.namespaces().deleteNamespace(namespaceName, true);
+            deleteNamespaceGraceFully(namespaceName, true);
         } catch (PulsarAdminException e) {
             Assert.assertEquals(e.getStatusCode(), 500);
         }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/TransactionProduceTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/TransactionProduceTest.java
@@ -113,7 +113,7 @@ public class TransactionProduceTest extends TransactionTestBase {
         outProducer.newMessage(tnx).value(content.getBytes(UTF_8)).send();
 
         try {
-            admin.namespaces().deleteNamespace(NAMESPACE1, true);
+            deleteNamespaceGraceFully(NAMESPACE1, true);
         } catch (Exception ignore) {}
         tnx.commit().get();
     }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/TransactionTestBase.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/TransactionTestBase.java
@@ -47,6 +47,7 @@ import org.apache.pulsar.broker.ServiceConfiguration;
 import org.apache.pulsar.broker.auth.SameThreadOrderedSafeExecutor;
 import org.apache.pulsar.broker.intercept.CounterBrokerInterceptor;
 import org.apache.pulsar.broker.namespace.NamespaceService;
+import org.apache.pulsar.broker.service.BrokerTestBase;
 import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.common.naming.NamespaceName;
@@ -325,5 +326,13 @@ public abstract class TransactionTestBase extends TestRetrySupport {
         } catch (Exception e) {
             log.warn("Failed to clean up mocked pulsar service:", e);
         }
+    }
+
+    /**
+     * see {@link BrokerTestBase#deleteNamespaceGraceFully(String, boolean, PulsarService, PulsarAdmin)}
+     */
+    protected void deleteNamespaceGraceFully(String ns, boolean force)
+            throws Exception {
+        BrokerTestBase.deleteNamespaceGraceFully(ns, force, pulsarServiceList.get(0), admin);
     }
 }


### PR DESCRIPTION
Fixes: flaky test `NamespaceOwnershipListenerTests.testNamespaceBundleOwnershipListener`

- https://github.com/poorbarcode/pulsar/actions/runs/3103585851/jobs/5027176671

```
 org.apache.pulsar.client.admin.PulsarAdminException$ConflictException: Cannot delete non empty bundle
  	at org.apache.pulsar.client.admin.PulsarAdminException.wrap(PulsarAdminException.java:252)
  	at org.apache.pulsar.client.admin.internal.BaseResource.sync(BaseResource.java:351)
  	at org.apache.pulsar.client.admin.internal.NamespacesImpl.deleteNamespace(NamespacesImpl.java:226)
  	at org.apache.pulsar.broker.namespace.NamespaceOwnershipListenerTests.testNamespaceBundleOwnershipListener(NamespaceOwnershipListenerTests.java:104)
  	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
  	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
  	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
  	at java.base/java.lang.reflect.Method.invoke(Method.java:568)
  	at org.testng.internal.MethodInvocationHelper.invokeMethod(MethodInvocationHelper.java:132)
  	at org.testng.internal.InvokeMethodRunnable.runOne(InvokeMethodRunnable.java:45)
  	at org.testng.internal.InvokeMethodRunnable.call(InvokeMethodRunnable.java:73)
  	at org.testng.internal.InvokeMethodRunnable.call(InvokeMethodRunnable.java:11)
  	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
  	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
  	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
  	at java.base/java.lang.Thread.run(Thread.java:833)
  	Suppressed: org.apache.pulsar.client.admin.PulsarAdminException$ConflictException: Cannot delete non empty bundle
  		at org.apache.pulsar.client.admin.internal.BaseResource.getApiException(BaseResource.java:287)
  		at org.apache.pulsar.client.admin.internal.BaseResource$4.failed(BaseResource.java:237)
  		at org.glassfish.jersey.client.JerseyInvocation$1.failed(JerseyInvocation.java:882)
  		at org.glassfish.jersey.client.JerseyInvocation$1.completed(JerseyInvocation.java:863)
```

### Motivation

same as https://github.com/apache/pulsar/pull/17070, there have race condition:

- delete namespace bundle
- asynchronously create topic `__change_event`

### Modifications

- Make delete namespace after `__change_event` and `__change_event/__compaction` create finish.
- As more as possible, change all the namespace deletion in test, exinclude these case
  - admin API V1
  - multiple brokers in test
  - pulsar proxy
  - has disabled feature: `system topic`


### Documentation

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)

- [x] `doc-not-needed` 
(Please explain why)

- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)

### Matching PR in forked repository

PR in forked repository: 

- https://github.com/poorbarcode/pulsar/pull/11