### PR TITLE
[improve][broker]Reduce the frequency of calls to the LockManager#listLocks method.

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/ModularLoadManagerImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/ModularLoadManagerImpl.java
@@ -480,8 +480,8 @@ public class ModularLoadManagerImpl implements ModularLoadManager {
     }
 
     private void cleanupDeadBrokersData() {
-        if(pulsar.getLeaderElectionService() == null
-                || !pulsar.getLeaderElectionService().isLeader()){
+        if (pulsar.getLeaderElectionService() == null
+                || !pulsar.getLeaderElectionService().isLeader()) {
             return;
         }
         final Set<String> activeBrokers = getAvailableBrokers();

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/ModularLoadManagerImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/ModularLoadManagerImpl.java
@@ -480,16 +480,17 @@ public class ModularLoadManagerImpl implements ModularLoadManager {
     }
 
     private void cleanupDeadBrokersData() {
+        if(pulsar.getLeaderElectionService() == null
+                || !pulsar.getLeaderElectionService().isLeader()){
+            return;
+        }
         final Set<String> activeBrokers = getAvailableBrokers();
         final Set<String> knownBrokersCopy = new HashSet<>(this.knownBrokers);
         Collection<String> newBrokers = CollectionUtils.subtract(activeBrokers, knownBrokersCopy);
         this.knownBrokers.addAll(newBrokers);
         Collection<String> deadBrokers = CollectionUtils.subtract(knownBrokersCopy, activeBrokers);
         this.knownBrokers.removeAll(deadBrokers);
-        if (pulsar.getLeaderElectionService() != null
-                && pulsar.getLeaderElectionService().isLeader()) {
-            deadBrokers.forEach(this::deleteTimeAverageDataFromMetadataStoreAsync);
-        }
+        deadBrokers.forEach(this::deleteTimeAverageDataFromMetadataStoreAsync);
     }
 
     // As the leader broker, update the broker data map in loadData by querying metadata store for the broker data put


### PR DESCRIPTION
### Motivation
In the cleanupDeadBrokersData method, the ModularLoadManagerImpl#getAvailableBrokers method will be called every time, in which LockManager#listLocks will be called:
https://github.com/apache/pulsar/blob/08df28a61694e0c9128e78facedcf24c78bb708d/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/ModularLoadManagerImpl.java#L482-L494

For non-leader nodes, it can return directly without executing the listLocks method.


### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)

- [x] `doc-not-needed` 
(Please explain why)

- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE 

After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.

-->
