### PR TITLE
[fix][broker] add return for PersistentMessageExpiryMonitor#findEntryFailed

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentMessageExpiryMonitor.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentMessageExpiryMonitor.java
@@ -215,6 +215,7 @@ public class PersistentMessageExpiryMonitor implements FindEntryCallback {
             } else {
                 findEntryComplete(failedReadPosition.get(), ctx);
             }
+            return;
         }
         expirationCheckInProgress = FALSE;
         updateRates();


### PR DESCRIPTION
### Motivation

`org.apache.pulsar.broker.service.persistent.PersistentMessageExpiryMonitor#findEntryFailed` lacks a return, resulting in repeated execution of some codes.

### Modifications
add return for `org.apache.pulsar.broker.service.persistent.PersistentMessageExpiryMonitor#findEntryFailed`

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)

- [x] `doc-not-needed` 
(Please explain why)

- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)

### Matching PR in forked repository

PR in forked repository: https://github.com/Pomelongan/pulsar/pull/3
