### PR TITLE
[fix][doc] Fix maxNumberOfRejectedRequestPerConnection doc

### DIFF
--- a/pulsar-client-1x-base/pulsar-client-1x/src/main/java/org/apache/pulsar/client/api/ClientConfiguration.java
+++ b/pulsar-client-1x-base/pulsar-client-1x/src/main/java/org/apache/pulsar/client/api/ClientConfiguration.java
@@ -319,7 +319,7 @@ public class ClientConfiguration implements Serializable {
     }
 
     /**
-     * Get configured max number of reject-request in a time-frame (30 seconds) after which connection will be closed.
+     * Get configured max number of reject-request in a time-frame (60 seconds) after which connection will be closed.
      *
      * @return
      */
@@ -328,7 +328,7 @@ public class ClientConfiguration implements Serializable {
     }
 
     /**
-     * Set max number of broker-rejected requests in a certain time-frame (30 seconds) after which current connection.
+     * Set max number of broker-rejected requests in a certain time-frame (60 seconds) after which current connection.
      * will be closed and client creates a new connection that give chance to connect a different broker <i>(default:
      * 50)</i>
      *

--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/ClientBuilder.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/ClientBuilder.java
@@ -489,7 +489,7 @@ public interface ClientBuilder extends Serializable, Cloneable {
     ClientBuilder maxLookupRedirects(int maxLookupRedirects);
 
     /**
-     * Set max number of broker-rejected requests in a certain time-frame (30 seconds) after which current connection
+     * Set max number of broker-rejected requests in a certain time-frame (60 seconds) after which current connection
      * will be closed and client creates a new connection that give chance to connect a different broker <i>(default:
      * 50)</i>.
      *

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ClientConfigurationData.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ClientConfigurationData.java
@@ -195,7 +195,7 @@ public class ClientConfigurationData implements Serializable, Cloneable {
 
     @ApiModelProperty(
             name = "maxNumberOfRejectedRequestPerConnection",
-            value = "Maximum number of rejected requests of a broker in a certain time frame (30 seconds) "
+            value = "Maximum number of rejected requests of a broker in a certain time frame (60 seconds) "
                     + "after the current connection is closed and the client "
                     + "creating a new connection to connect to a different broker."
     )

--- a/site2/docs/client-libraries-java.md
+++ b/site2/docs/client-libraries-java.md
@@ -127,7 +127,7 @@ If you create a client, you can use the `loadConf` configuration. The following 
 `tlsHostnameVerificationEnable` |boolean |  Whether to enable TLS hostname verification|false
 `concurrentLookupRequest`|int|The number of concurrent lookup requests allowed to send on each broker connection to prevent overload on broker|5000
 `maxLookupRequest`|int|The maximum number of lookup requests allowed on each broker connection to prevent overload on broker | 50000
-`maxNumberOfRejectedRequestPerConnection`|int|The maximum number of rejected requests of a broker in a certain time frame (30 seconds) after the current connection is closed and the client creates a new connection to connect to a different broker|50
+`maxNumberOfRejectedRequestPerConnection`|int|The maximum number of rejected requests of a broker in a certain time frame (60 seconds) after the current connection is closed and the client creates a new connection to connect to a different broker|50
 `keepAliveIntervalSeconds`|int|Seconds of keeping alive interval for each client broker connection|30
 `connectionTimeoutMs`|int|Duration of waiting for a connection to a broker to be established <br /><br />If the duration passes without a response from a broker, the connection attempt is dropped|10000
 `requestTimeoutMs`|int|Maximum duration for completing a request |60000

--- a/site2/website/versioned_docs/version-2.10.x/client-libraries-java.md
+++ b/site2/website/versioned_docs/version-2.10.x/client-libraries-java.md
@@ -147,7 +147,7 @@ If you create a client, you can use the `loadConf` configuration. The following 
 `tlsHostnameVerificationEnable` |boolean |  Whether to enable TLS hostname verification|false
 `concurrentLookupRequest`|int|The number of concurrent lookup requests allowed to send on each broker connection to prevent overload on broker|5000
 `maxLookupRequest`|int|The maximum number of lookup requests allowed on each broker connection to prevent overload on broker | 50000
-`maxNumberOfRejectedRequestPerConnection`|int|The maximum number of rejected requests of a broker in a certain time frame (30 seconds) after the current connection is closed and the client creates a new connection to connect to a different broker|50
+`maxNumberOfRejectedRequestPerConnection`|int|The maximum number of rejected requests of a broker in a certain time frame (60 seconds) after the current connection is closed and the client creates a new connection to connect to a different broker|50
 `keepAliveIntervalSeconds`|int|Seconds of keeping alive interval for each client broker connection|30
 `connectionTimeoutMs`|int|Duration of waiting for a connection to a broker to be established <br /><br />If the duration passes without a response from a broker, the connection attempt is dropped|10000
 `requestTimeoutMs`|int|Maximum duration for completing a request |60000

--- a/site2/website/versioned_docs/version-2.8.x/client-libraries-java.md
+++ b/site2/website/versioned_docs/version-2.8.x/client-libraries-java.md
@@ -134,7 +134,7 @@ boolean|`tlsAllowInsecureConnection`|Whether the Pulsar client accepts untrusted
 boolean | `tlsHostnameVerificationEnable` | Whether to enable TLS hostname verification|false
 int|`concurrentLookupRequest`|The number of concurrent lookup requests allowed to send on each broker connection to prevent overload on broker|5000
 int|`maxLookupRequest`|The maximum number of lookup requests allowed on each broker connection to prevent overload on broker | 50000
-int|`maxNumberOfRejectedRequestPerConnection`|The maximum number of rejected requests of a broker in a certain time frame (30 seconds) after the current connection is closed and the client creates a new connection to connect to a different broker|50
+int|`maxNumberOfRejectedRequestPerConnection`|The maximum number of rejected requests of a broker in a certain time frame (60 seconds) after the current connection is closed and the client creates a new connection to connect to a different broker|50
 int|`keepAliveIntervalSeconds`|Seconds of keeping alive interval for each client broker connection|30
 int|`connectionTimeoutMs`|Duration of waiting for a connection to a broker to be established <br /><br />If the duration passes without a response from a broker, the connection attempt is dropped|10000
 int|`requestTimeoutMs`|Maximum duration for completing a request |60000

--- a/site2/website/versioned_docs/version-2.9.x/client-libraries-java.md
+++ b/site2/website/versioned_docs/version-2.9.x/client-libraries-java.md
@@ -134,7 +134,7 @@ If you create a client, you can use the `loadConf` configuration. The following 
 `tlsHostnameVerificationEnable` |boolean |  Whether to enable TLS hostname verification|false
 `concurrentLookupRequest`|int|The number of concurrent lookup requests allowed to send on each broker connection to prevent overload on broker|5000
 `maxLookupRequest`|int|The maximum number of lookup requests allowed on each broker connection to prevent overload on broker | 50000
-`maxNumberOfRejectedRequestPerConnection`|int|The maximum number of rejected requests of a broker in a certain time frame (30 seconds) after the current connection is closed and the client creates a new connection to connect to a different broker|50
+`maxNumberOfRejectedRequestPerConnection`|int|The maximum number of rejected requests of a broker in a certain time frame (60 seconds) after the current connection is closed and the client creates a new connection to connect to a different broker|50
 `keepAliveIntervalSeconds`|int|Seconds of keeping alive interval for each client broker connection|30
 `connectionTimeoutMs`|int|Duration of waiting for a connection to a broker to be established <br /><br />If the duration passes without a response from a broker, the connection attempt is dropped|10000
 `requestTimeoutMs`|int|Maximum duration for completing a request |60000


### PR DESCRIPTION
### Motivation

> The maximum number of rejected requests of a broker in a certain time frame (30 seconds) after the current connection is closed and the client creates a new connection to connect to a different broker.

According to code, the time frame should be in the 60s instead of the 30s, see:

https://github.com/apache/pulsar/blob/7913fe5614fed853f91199f658fe2584f10e38b9/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ClientCnx.java#L157

https://github.com/apache/pulsar/blob/7913fe5614fed853f91199f658fe2584f10e38b9/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ClientCnx.java#L1134-L1145

### Modifications

30 seconds -> 60seconds

### Documentation

- [x] `doc` 
(Your PR contains doc changes)
