### PR TITLE
[improve][java-client]Add init capacity for messages in BatchMessageContainerImpl

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/AbstractBatchMessageContainer.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/AbstractBatchMessageContainer.java
@@ -47,7 +47,7 @@ public abstract class AbstractBatchMessageContainer implements BatchMessageConta
     protected long currentTxnidLeastBits = -1L;
 
     protected static final int INITIAL_BATCH_BUFFER_SIZE = 1024;
-    protected static final int INITIAL_MESSAGES_NUM = 64;
+    protected static final int INITIAL_MESSAGES_NUM = 32;
 
     // This will be the largest size for a batch sent from this particular producer. This is used as a baseline to
     // allocate a new buffer that can hold the entire batch without needing costly reallocations

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/AbstractBatchMessageContainer.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/AbstractBatchMessageContainer.java
@@ -46,7 +46,7 @@ public abstract class AbstractBatchMessageContainer implements BatchMessageConta
     protected long currentTxnidLeastBits = -1L;
 
     protected static final int INITIAL_BATCH_BUFFER_SIZE = 1024;
-    protected static final int INITIAL_MESSAGES_NUM = 512;
+    protected static final int INITIAL_MESSAGES_NUM = 64;
 
     // This will be the largest size for a batch sent from this particular producer. This is used as a baseline to
     // allocate a new buffer that can hold the entire batch without needing costly reallocations
@@ -98,8 +98,6 @@ public abstract class AbstractBatchMessageContainer implements BatchMessageConta
         this.compressor = CompressionCodecProvider.getCompressionCodec(compressionType);
         this.maxNumMessagesInBatch = producer.getConfiguration().getBatchingMaxMessages();
         this.maxBytesInBatch = producer.getConfiguration().getBatchingMaxBytes();
-        this.maxMessagesNum = maxNumMessagesInBatch <= 0
-                ? INITIAL_MESSAGES_NUM : Math.min(INITIAL_BATCH_BUFFER_SIZE, maxNumMessagesInBatch);
     }
 
     @Override

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/AbstractBatchMessageContainer.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/AbstractBatchMessageContainer.java
@@ -46,10 +46,12 @@ public abstract class AbstractBatchMessageContainer implements BatchMessageConta
     protected long currentTxnidLeastBits = -1L;
 
     protected static final int INITIAL_BATCH_BUFFER_SIZE = 1024;
+    protected static final int INITIAL_MESSAGES_NUM = 512;
 
     // This will be the largest size for a batch sent from this particular producer. This is used as a baseline to
     // allocate a new buffer that can hold the entire batch without needing costly reallocations
     protected int maxBatchSize = INITIAL_BATCH_BUFFER_SIZE;
+    protected int maxMessagesNum = INITIAL_MESSAGES_NUM;
 
     @Override
     public boolean haveEnoughSpace(MessageImpl<?> msg) {
@@ -96,6 +98,8 @@ public abstract class AbstractBatchMessageContainer implements BatchMessageConta
         this.compressor = CompressionCodecProvider.getCompressionCodec(compressionType);
         this.maxNumMessagesInBatch = producer.getConfiguration().getBatchingMaxMessages();
         this.maxBytesInBatch = producer.getConfiguration().getBatchingMaxBytes();
+        this.maxMessagesNum = maxNumMessagesInBatch <= 0
+                ? INITIAL_MESSAGES_NUM : Math.min(INITIAL_BATCH_BUFFER_SIZE, maxNumMessagesInBatch);
     }
 
     @Override

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/AbstractBatchMessageContainer.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/AbstractBatchMessageContainer.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pulsar.client.impl;
 
+import com.google.common.annotations.VisibleForTesting;
 import java.io.IOException;
 import java.util.List;
 import lombok.extern.slf4j.Slf4j;
@@ -71,6 +72,11 @@ public abstract class AbstractBatchMessageContainer implements BatchMessageConta
     @Override
     public int getNumMessagesInBatch() {
         return numMessagesInBatch;
+    }
+
+    @VisibleForTesting
+    public int getMaxMessagesNum() {
+        return maxMessagesNum;
     }
 
     @Override

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/BatchMessageContainerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/BatchMessageContainerImpl.java
@@ -58,7 +58,7 @@ class BatchMessageContainerImpl extends AbstractBatchMessageContainer {
     @Setter
     private long highestSequenceId = -1L;
     private ByteBuf batchedMessageMetadataAndPayload;
-    private List<MessageImpl<?>> messages = new ArrayList<>();
+    private List<MessageImpl<?>> messages = new ArrayList<>(maxMessagesNum);
     protected SendCallback previousCallback = null;
     // keep track of callbacks for individual messages being published in a batch
     protected SendCallback firstCallback;
@@ -168,12 +168,13 @@ class BatchMessageContainerImpl extends AbstractBatchMessageContainer {
         // Update the current max batch size using the uncompressed size, which is what we need in any case to
         // accumulate the batch content
         maxBatchSize = Math.max(maxBatchSize, uncompressedSize);
+        maxMessagesNum = Math.max(maxMessagesNum, numMessagesInBatch);
         return compressedPayload;
     }
 
     @Override
     public void clear() {
-        messages = new ArrayList<>();
+        messages = new ArrayList<>(maxMessagesNum);
         firstCallback = null;
         previousCallback = null;
         messageMetadata.clear();

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/BatchMessageContainerImplTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/BatchMessageContainerImplTest.java
@@ -18,14 +18,18 @@
  */
 package org.apache.pulsar.client.impl;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 import io.netty.buffer.ByteBufAllocator;
+import io.netty.util.ReferenceCountUtil;
 import java.lang.reflect.Field;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.apache.pulsar.client.api.CompressionType;
 import org.apache.pulsar.client.api.Schema;
@@ -77,5 +81,60 @@ public class BatchMessageContainerImplTest {
         final MessageImpl<byte[]> message2 = MessageImpl.create(messageMetadata2, payload2, Schema.BYTES, null);
         // after oom, our add can self-healing, won't throw exception
         batchMessageContainer.add(message2, null);
+    }
+
+    @Test
+    public void testMessagesSize() throws Exception {
+        ProducerImpl producer = mock(ProducerImpl.class);
+
+        final ProducerConfigurationData producerConfigurationData = new ProducerConfigurationData();
+        producerConfigurationData.setCompressionType(CompressionType.NONE);
+        PulsarClientImpl pulsarClient = mock(PulsarClientImpl.class);
+        MemoryLimitController memoryLimitController = mock(MemoryLimitController.class);
+        when(pulsarClient.getMemoryLimitController()).thenReturn(memoryLimitController);
+        try {
+            Field clientFiled = HandlerState.class.getDeclaredField("client");
+            clientFiled.setAccessible(true);
+            clientFiled.set(producer, pulsarClient);
+        } catch (Exception e){
+            Assert.fail(e.getMessage());
+        }
+
+        ByteBuffer payload = ByteBuffer.wrap("payload".getBytes(StandardCharsets.UTF_8));
+
+        when(producer.getConfiguration()).thenReturn(producerConfigurationData);
+        when(producer.encryptMessage(any(), any())).thenReturn(ByteBufAllocator.DEFAULT.buffer().writeBytes(payload));
+
+        final int initNum = 64;
+        BatchMessageContainerImpl batchMessageContainer = new BatchMessageContainerImpl(producer);
+        assertEquals(batchMessageContainer.getMaxMessagesNum(), initNum);
+
+        addMessagesAndCreateOpSendMsg(batchMessageContainer, 10);
+        assertEquals(batchMessageContainer.getMaxMessagesNum(), initNum);
+
+        addMessagesAndCreateOpSendMsg(batchMessageContainer, 200);
+        assertEquals(batchMessageContainer.getMaxMessagesNum(), 200);
+
+        addMessagesAndCreateOpSendMsg(batchMessageContainer, 10);
+        assertEquals(batchMessageContainer.getMaxMessagesNum(), 200);
+    }
+
+    private void addMessagesAndCreateOpSendMsg(BatchMessageContainerImpl batchMessageContainer, int num)
+            throws Exception{
+        ArrayList<MessageImpl<?>> messages = new ArrayList<>();
+        for (int i = 0; i < num; ++i) {
+            MessageMetadata messageMetadata = new MessageMetadata();
+            messageMetadata.setSequenceId(i);
+            messageMetadata.setProducerName("producer");
+            messageMetadata.setPublishTime(System.currentTimeMillis());
+            ByteBuffer payload = ByteBuffer.wrap("payload".getBytes(StandardCharsets.UTF_8));
+            MessageImpl<?> message = MessageImpl.create(messageMetadata, payload, Schema.BYTES, null);
+            messages.add(message);
+            batchMessageContainer.add(message, null);
+        }
+
+        batchMessageContainer.createOpSendMsg();
+        batchMessageContainer.clear();
+        messages.forEach(ReferenceCountUtil::safeRelease);
     }
 }

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/BatchMessageContainerImplTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/BatchMessageContainerImplTest.java
@@ -105,7 +105,7 @@ public class BatchMessageContainerImplTest {
         when(producer.getConfiguration()).thenReturn(producerConfigurationData);
         when(producer.encryptMessage(any(), any())).thenReturn(ByteBufAllocator.DEFAULT.buffer().writeBytes(payload));
 
-        final int initNum = 64;
+        final int initNum = 32;
         BatchMessageContainerImpl batchMessageContainer = new BatchMessageContainerImpl(producer);
         assertEquals(batchMessageContainer.getMaxMessagesNum(), initNum);
 


### PR DESCRIPTION
### Motivation

When adding messages to `BatchMessageContainerImpl`, it takes a lot of cpu time for the list growing of `BatchMessageContainerImpl#messages`, see below:
<img width="812" alt="image" src="https://user-images.githubusercontent.com/10233437/191954328-80e64894-30af-4c2d-ba82-38bd5e6e1751.png">



### Modifications

* Init `BatchMessageContainerImpl#messages` with capacity.

### Verifying this change

- [x] Make sure that the change passes the CI checks.



### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)

- [x] `doc-not-needed` 
(Please explain why)

- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)

### Matching PR in forked repository

PR in forked repository: https://github.com/AnonHxy/pulsar/pull/3
