### PR TITLE
[fix][cli] Check numMessages after incrementing counter 

### DIFF
--- a/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceReader.java
+++ b/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceReader.java
@@ -154,16 +154,17 @@ public class PerformanceReader {
                     PerfClientUtils.exit(0);
                 }
             }
-            if (arguments.numMessages > 0 && totalMessagesReceived.sum() >= arguments.numMessages) {
-                log.info("------------- DONE (reached the maximum number: [{}] of consumption) --------------",
-                        arguments.numMessages);
-                PerfClientUtils.exit(0);
-            }
             messagesReceived.increment();
             bytesReceived.add(msg.getData().length);
 
             totalMessagesReceived.increment();
             totalBytesReceived.add(msg.getData().length);
+
+            if (arguments.numMessages > 0 && totalMessagesReceived.sum() >= arguments.numMessages) {
+                log.info("------------- DONE (reached the maximum number: [{}] of consumption) --------------",
+                        arguments.numMessages);
+                PerfClientUtils.exit(0);
+            }
 
             if (limiter != null) {
                 limiter.acquire();


### PR DESCRIPTION
Fixes #17823

### Motivation

If PerformanceReader can read exactly as many messages as specified by `num-messages`, it does not stop but waits for another message.

### Modifications

Check the number of total messages after incrementing the counter.

### Verifying this change

- [x] Make sure that the change passes the CI checks.


This change added tests and can be verified as follows:
  - Added integration tests for `pulsar-perf read` 
 

### Does this pull request potentially affect one of the following parts:

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)

- [x] `doc-not-needed` 
This is a bugfix

- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)

### Matching PR in forked repository

PR in forked repository: https://github.com/andrasbeni/pulsar/pull/6
