### PR TITLE
[fix][doc] Remove unuseful info in docs generation

### DIFF
--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/BaseGenerateDocumentation.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/BaseGenerateDocumentation.java
@@ -151,7 +151,7 @@ public abstract class BaseGenerateDocumentation {
             !> This page is automatically generated from code files.
             If you find something inaccurate, feel free to update `""";
     protected String suffix = """
-            `. Do NOT edit this markdown file manually. Manual changes will be overwritten by automatic generation.
+            `.
             """;
 
     protected String generateDocByFieldContext(String className, String type, StringBuilder sb) throws Exception {


### PR DESCRIPTION
### Motivation

There are some information that are no longer useful in the generated docs. This PR aims to remove these information in the generation steps.

![image](https://user-images.githubusercontent.com/32540679/191977815-e09c343e-3803-4756-ab0a-45e4d7a2bc3c.png)

### Modifications

Unuseful information is deleted from code.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)

- [ ] `doc-not-needed` 
(Please explain why)

- [x] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)

### Matching PR in forked repository

PR in forked repository: SignorMercurio#4
