### PR TITLE
[improve][pulsar-io-kafka] Add option to copy Kafka headers to Pulsar properties

### DIFF
--- a/pulsar-io/kafka/src/main/java/org/apache/pulsar/io/kafka/KafkaBytesSource.java
+++ b/pulsar-io/kafka/src/main/java/org/apache/pulsar/io/kafka/KafkaBytesSource.java
@@ -124,13 +124,15 @@ public class KafkaBytesSource extends KafkaAbstractSource<ByteBuffer> {
             return new KeyValueKafkaRecord(consumerRecord,
                     new KeyValue<>(key, value),
                     currentKeySchema,
-                    currentValueSchema);
+                    currentValueSchema,
+                    copyKafkaHeaders(consumerRecord));
 
         } else {
             Object value = consumerRecord.value();
             return new KafkaRecord(consumerRecord,
                     extractSimpleValue(value),
-                    getSchemaFromObject(value, valueSchema));
+                    getSchemaFromObject(value, valueSchema),
+                    copyKafkaHeaders(consumerRecord));
 
         }
     }

--- a/pulsar-io/kafka/src/main/java/org/apache/pulsar/io/kafka/KafkaSourceConfig.java
+++ b/pulsar-io/kafka/src/main/java/org/apache/pulsar/io/kafka/KafkaSourceConfig.java
@@ -147,6 +147,12 @@ public class KafkaSourceConfig implements Serializable {
             "The consumer config properties to be passed to Consumer. Note that other properties specified "
                 + "in the connector config file take precedence over this config.")
     private Map<String, Object> consumerConfigProperties;
+    @FieldDoc(
+        defaultValue = "false",
+        help =
+            "If true the Kafka message headers will be copied into Pulsar message properties. Since Pulsar properties "
+                + "is a Map<String, String>, byte array values in the Kafka headers will be base64 encoded. ")
+    private boolean copyHeadersEnabled = false;
 
     public static KafkaSourceConfig load(String yamlFile) throws IOException {
         ObjectMapper mapper = new ObjectMapper(new YAMLFactory());

--- a/pulsar-io/kafka/src/main/java/org/apache/pulsar/io/kafka/KafkaStringSource.java
+++ b/pulsar-io/kafka/src/main/java/org/apache/pulsar/io/kafka/KafkaStringSource.java
@@ -33,7 +33,8 @@ public class KafkaStringSource extends KafkaAbstractSource<String> {
     public KafkaRecord buildRecord(ConsumerRecord<Object, Object> consumerRecord) {
         KafkaRecord record = new KafkaRecord(consumerRecord,
                 new String((byte[]) consumerRecord.value(), StandardCharsets.UTF_8),
-                Schema.STRING);
+                Schema.STRING,
+                copyKafkaHeaders(consumerRecord));
         return record;
     }
 

--- a/pulsar-io/kafka/src/test/java/org/apache/pulsar/io/kafka/KafkaBytesSourceTest.java
+++ b/pulsar-io/kafka/src/test/java/org/apache/pulsar/io/kafka/KafkaBytesSourceTest.java
@@ -28,6 +28,7 @@ import static org.testng.Assert.assertTrue;
 
 import com.google.common.collect.ImmutableMap;
 import io.confluent.kafka.serializers.KafkaAvroDeserializer;
+import java.nio.charset.StandardCharsets;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.common.serialization.ByteBufferDeserializer;
@@ -44,6 +45,7 @@ import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.common.schema.KeyValue;
 import org.apache.pulsar.common.schema.KeyValueEncodingType;
 import org.apache.pulsar.io.core.SourceContext;
+import org.bouncycastle.util.encoders.Base64;
 import org.mockito.Mockito;
 import org.testng.annotations.Test;
 
@@ -113,6 +115,64 @@ public class KafkaBytesSourceTest {
                 StringDeserializer.class.getName(), Schema.STRING,
                 ByteBuffer.wrap(new IntegerSerializer().serialize("test", 10)),
                 ByteBuffer.wrap(new StringSerializer().serialize("test", "test")));
+    }
+
+    @Test
+    public void testCopyKafkaHeadersEnabled() throws Exception {
+        ByteBuffer key = ByteBuffer.wrap(new IntegerSerializer().serialize("test", 10));
+        ByteBuffer value = ByteBuffer.wrap(new StringSerializer().serialize("test", "test"));
+        KafkaBytesSource source = new KafkaBytesSource();
+        Map<String, Object> config = new HashMap<>();
+        config.put("copyHeadersEnabled", true);
+        config.put("topic","test");
+        config.put("bootstrapServers","localhost:9092");
+        config.put("groupId", "test");
+        config.put("valueDeserializationClass", IntegerDeserializer.class.getName());
+        config.put("keyDeserializationClass", StringDeserializer.class.getName());
+        config.put("consumerConfigProperties", ImmutableMap.builder()
+                .put("schema.registry.url", "http://localhost:8081")
+                .build());
+        source.open(config, Mockito.mock(SourceContext.class));
+        ConsumerRecord record = new ConsumerRecord<Object, Object>("test", 88, 99, key, value);
+        record.headers().add("k1", "v1".getBytes(StandardCharsets.UTF_8));
+        record.headers().add("k2", new byte[]{0xF});
+
+        Map<String, String> props = source.copyKafkaHeaders(record);
+        assertEquals(props.size(), 5);
+        assertTrue(props.containsKey("__kafka_topic"));
+        assertTrue(props.containsKey("__kafka_partition"));
+        assertTrue(props.containsKey("__kafka_offset"));
+        assertTrue(props.containsKey("k1"));
+        assertTrue(props.containsKey("k2"));
+
+        assertEquals(props.get("__kafka_topic"), "test");
+        assertEquals(props.get("__kafka_partition"), "88");
+        assertEquals(props.get("__kafka_offset"), "99");
+        assertEquals(Base64.decode(props.get("k1")), "v1".getBytes(StandardCharsets.UTF_8));
+        assertEquals(Base64.decode(props.get("k2")), new byte[]{0xF});
+    }
+
+    @Test
+    public void testCopyKafkaHeadersDisabled() throws Exception {
+        ByteBuffer key = ByteBuffer.wrap(new IntegerSerializer().serialize("test", 10));
+        ByteBuffer value = ByteBuffer.wrap(new StringSerializer().serialize("test", "test"));
+        KafkaBytesSource source = new KafkaBytesSource();
+        Map<String, Object> config = new HashMap<>();
+        config.put("topic","test");
+        config.put("bootstrapServers","localhost:9092");
+        config.put("groupId", "test");
+        config.put("valueDeserializationClass", IntegerDeserializer.class.getName());
+        config.put("keyDeserializationClass", StringDeserializer.class.getName());
+        config.put("consumerConfigProperties", ImmutableMap.builder()
+                .put("schema.registry.url", "http://localhost:8081")
+                .build());
+        source.open(config, Mockito.mock(SourceContext.class));
+        ConsumerRecord record = new ConsumerRecord<Object, Object>("test", 88, 99, key, value);
+        record.headers().add("k1", "v1".getBytes(StandardCharsets.UTF_8));
+        record.headers().add("k2", new byte[]{0xF});
+
+        Map<String, String> props = source.copyKafkaHeaders(record);
+        assertTrue(props.isEmpty());
     }
 
     private void validateSchemaKeyValue(String keyDeserializationClass, Schema expectedKeySchema,

--- a/pulsar-io/kafka/src/test/java/org/apache/pulsar/io/kafka/source/KafkaAbstractSourceTest.java
+++ b/pulsar-io/kafka/src/test/java/org/apache/pulsar/io/kafka/source/KafkaAbstractSourceTest.java
@@ -21,6 +21,7 @@ package org.apache.pulsar.io.kafka.source;
 
 
 import com.google.common.collect.ImmutableMap;
+import java.util.Collections;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.common.security.auth.SecurityProtocol;
@@ -55,10 +56,10 @@ public class KafkaAbstractSourceTest {
         public KafkaRecord buildRecord(ConsumerRecord<Object, Object> consumerRecord) {
             KafkaRecord record = new KafkaRecord(consumerRecord,
                     new String((byte[]) consumerRecord.value(), StandardCharsets.UTF_8),
-                    Schema.STRING);
+                    Schema.STRING,
+                    Collections.emptyMap());
             return record;
         }
-
     }
 
     @Test


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://docs.google.com/document/d/1d8Pw6ZbWk-_pCKdOmdvx9rnhPiyuxwq60_TrD68d7BA/edit#heading=h.trs9rsex3xom)*. 

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->

<!-- Either this PR fixes an issue, -->

Fixes #17760

### Motivation

Users of Kafka source today can't access their Kafka headers in Pulsar. This patch adds a config to enable this copy to take place in addition to some standard, useful Kafka headers. 

### Modifications

* A new `KafkaSourceConfig` flag is added: `copyHeadersEnabled` of type `boolean` and default value of `false`
* If the flag is toggle on, the following Kafka headers will be copied over to Pulsars properties.
 * `__kafka_topic` : the name of the Kafka topic consumed by the source.
 * `__kafka_partition`: the number of paritioed on the consumed kafka topics
 * `__kafka_offset`: the current offset of the kafka message currently consumed by the source
 * User defined header: The customer headers a Kafka producer could generated as pairs of `<String, byte[]>`. Since Pulsar properties are of type `<String, String>`, the Kafka byte[] values are based64 encoded.  

### Verifying this change

- [X] Make sure that the change passes the CI checks.

This change added tests and can be verified as follows:
  - *Added unit tests to check the Kafka source respects the configs and generated the expected Pulsar properties map*
  - ~~*Extended integration test for Avro Kafka source to generate headers and verify them on Pulsar side*~~
**Update** : The integ test is blocked by https://github.com/confluentinc/schema-registry/issues/2390 and will be disabled for now.
### Does this pull request potentially affect one of the following parts:
If yes was chosen, please highlight the changes
- Dependencies (add or upgrade a dependency) (no)
- The public API (no)
- The schema (no)
- The default values of configurations (no)
- The binary protocol (no)
- The REST endpoints (no)
- The admin CLI options (no)
- Anything that affects deployment (no)

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [] `doc-required` 
(Your PR needs to update docs and you will update later)

- [X] `doc-not-needed` 
Will be generated automatically 

- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)

### Matching PR in forked repository

PR in forked repository: https://github.com/aymkhalil/pulsar/pull/1 

<!-- ENTER URL HERE 

After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.

-->
