### PR TITLE
[doc][proxy] Fix typo in "Document how to mitigate CVE-2022-24280"

### DIFF
--- a/site2/docs/administration-proxy.md
+++ b/site2/docs/administration-proxy.md
@@ -88,7 +88,6 @@ brokerProxyAllowedIPAddresses=10.0.0.0/8
 
 Example: limiting by multiple host name patterns and multiple ip address ranges in a `proxy.conf` file for host deployment.
 ```properties
-```properties
 # require "broker" in host name
 brokerProxyAllowedHostNames=*broker*.localdomain,*broker*.otherdomain
 # limit target ip addresses to a specific network or range demonstrating multiple supported formats


### PR DESCRIPTION
### Motivation

There was an extra line in the doc added in #17825

### Modifications

Remove the extra line

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)

- [ ] `doc-not-needed` 
(Please explain why)

- [x] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)
