### PR TITLE
[improve][common] Make Bookkeeper metadata options configurable

### DIFF
--- a/bin/pulsar
+++ b/bin/pulsar
@@ -348,9 +348,13 @@ ZK_OPTS=" -Dzookeeper.4lw.commands.whitelist=* -Dzookeeper.snapshot.trust.empty=
 
 LOG4J2_SHUTDOWN_HOOK_DISABLED="-Dlog4j.shutdownHookEnabled=false"
 
-# Adding pulsar metadata as a recognized provider
-BK_METADATA_OPTIONS="-Dbookkeeper.metadata.bookie.drivers=org.apache.pulsar.metadata.bookkeeper.PulsarMetadataBookieDriver -Dbookkeeper.metadata.client.drivers=org.apache.pulsar.metadata.bookkeeper.PulsarMetadataClientDriver"
-OPTS="$OPTS $BK_METADATA_OPTIONS"
+# By default, Pulsar Metadata driver will be used for Bookkeeper client and server metadata operations
+# This can be disabled by setting BK_METADATA_OPTIONS=none
+if [[ "$BK_METADATA_OPTIONS" != "none" ]]; then
+  # Adding pulsar metadata as a recognized provider
+  BK_METADATA_OPTIONS="${BK_METADATA_OPTIONS:-"-Dbookkeeper.metadata.bookie.drivers=org.apache.pulsar.metadata.bookkeeper.PulsarMetadataBookieDriver -Dbookkeeper.metadata.client.drivers=org.apache.pulsar.metadata.bookkeeper.PulsarMetadataClientDriver"}"
+  OPTS="$OPTS $BK_METADATA_OPTIONS"
+fi
 
 #Change to PULSAR_HOME to support relative paths
 cd "$PULSAR_HOME"


### PR DESCRIPTION
### Motivation

PIP-45 related PRs #12770 and #13296 introduced changes in Pulsar and Bookkeeper configuration for Pulsar so that Pulsar Metadata driver is used for metadata operations in the bookkeeper client (in broker) and in the bookkeeper server (the bookies).
It would be good to have a way to opt-out of this change and configure Pulsar and Bookies without Pulsar Metadata store and use Zookeeper directly. 

This PR will allow to use Bookkeeper defaults by setting `export BK_METADATA_OPTIONS=none`.

If one would want to configure Bookies without Pulsar Metadata, it is necessary to configure
`metadataServiceUri` in bookkeeper.conf and `bookkeeperMetadataServiceUri` in broker.conf.

For example `bookkeeper.conf`
```properties
metadataServiceUri=zk://<zk_node_1>:2181/ledgers,zk://<zk_node_2>:2181/ledgers,zk://<zk_node_3>:2181/ledgers
```

The main purpose of this PR is to make it easier to compare the behavior of Pulsar when using Pulsar Metadata driver for Bookkeeper compared to using Zookeeper directly. It is not necessary make BK_METADATA_OPTIONS configurable to achieve this. However it's better to have an option to control it since that could prevent misconfiguration in cases where it is desired to not use Pulsar metadata driver. 

The additional benefit of being able to override BK_METADATA_OPTIONS is that the Pulsar Metadata driver classes wouldn't get loaded at all when they aren't used.


### Modifications

Make `BK_METADATA_OPTIONS` configurable.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)

- [x] `doc-not-needed` 
(Please explain why)

- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)

### Matching PR in forked repository

PR in forked repository: https://github.com/lhotari/pulsar/pull/91