### PR TITLE
[fix][flaky-test]PerformanceTransactionTest.testConsumeTxnMessage

### DIFF
--- a/pulsar-testclient/src/test/java/org/apache/pulsar/testclient/PerformanceTransactionTest.java
+++ b/pulsar-testclient/src/test/java/org/apache/pulsar/testclient/PerformanceTransactionTest.java
@@ -198,7 +198,7 @@ public class PerformanceTransactionTest extends MockedPulsarServiceBaseTest {
 
     @Test
     public void testConsumeTxnMessage() throws Exception {
-        String argString = "%s -r 10 -u %s -txn -ss %s -st %s -sp %s -ntxn %d";
+        String argString = "%s -r 10 -u %s -txn -ss %s -st %s -sp %s -ntxn %d -tto 5";
         String subName = "sub";
         String topic = testTopic + UUID.randomUUID();
         String args = String.format(argString, topic, pulsar.getBrokerServiceUrl(), subName,
@@ -222,7 +222,7 @@ public class PerformanceTransactionTest extends MockedPulsarServiceBaseTest {
             } catch (Exception e) {
                 e.printStackTrace();
             }
-        });
+        }, "Performance_Consumer_Task");
         thread.start();
         thread.join();
 
@@ -240,6 +240,7 @@ public class PerformanceTransactionTest extends MockedPulsarServiceBaseTest {
         for (int i = 0; i < 5; i++) {
             Message<byte[]> message = consumer.receive(2, TimeUnit.SECONDS);
             Assert.assertNotNull(message);
+            consumer.acknowledge(message);
         }
         Message<byte[]> message = consumer.receive(2, TimeUnit.SECONDS);
         Assert.assertNull(message);


### PR DESCRIPTION
Fixes: #14109


### Motivation

The expected execution flow for this test is: 

1. send 505 messages
2. commit 10 transactions, every transaction ack 50 messages
3. receive the last 5 messages in the last transaction, wait for transaction timeout
4. confirm that the last 5 messages can be consumed by new consumer

<strong>(High light)</strong> The default value for transaction TTL is 10 seconds, and the default value for `Awaitility.await` is also 10 seconds,  so this test is not stable.

Note: This is a guess cause, the problem is not reproduced locally. But after transaction TTL is set to 11s, the probability of the problem occurring is 100%.

### Modifications

Fix flaky test
- set transaction TTL to 5s

Other changes
- define a name for the task thread
- acknowledge the last 5 messages

### Documentation

- [ ] `doc-required` 

- [x] `doc-not-needed` 

- [ ] `doc` 

- [ ] `doc-complete`

### Matching PR in forked repository

PR in forked repository: 

- https://github.com/poorbarcode/pulsar/pull/13
