### PR TITLE
Fix broken logo image in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 
 -->
 
-![logo](https://github.com/apache/pulsar-site/blob/main/site2/website-next/static/img/pulsar.svg)
+![logo](https://pulsar.apache.org/img/pulsar.svg)
 
 [![docker pull](https://img.shields.io/docker/pulls/apachepulsar/pulsar-all.svg)](https://hub.docker.com/r/apachepulsar/pulsar)
 [![contributors](https://img.shields.io/github/contributors-anon/apache/pulsar)](https://github.com/apache/pulsar/graphs/contributors)

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 
 -->
 
-![logo](site2/website/static/img/pulsar.svg)
+![logo](https://github.com/apache/pulsar-site/blob/main/site2/website-next/static/img/pulsar.svg)
 
 [![docker pull](https://img.shields.io/docker/pulls/apachepulsar/pulsar-all.svg)](https://hub.docker.com/r/apachepulsar/pulsar)
 [![contributors](https://img.shields.io/github/contributors-anon/apache/pulsar)](https://github.com/apache/pulsar/graphs/contributors)


### PR DESCRIPTION
### Motivation

The Pulsar logo url is broken in [README.md](https://github.com/apache/pulsar#readme)

### Modifications

Reference the logo image in pulsar-site

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)

- [x] `doc-not-needed` 
(Please explain why)

- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)
