### PR TITLE
[fix][broker] Fix NPE when ResourceGroupService execute scheduled task.

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
@@ -419,6 +419,14 @@ public class PulsarService implements AutoCloseable, ShutdownService {
                 }
                 this.resourceUsageTransportManager = null;
             }
+            if (this.resourceGroupServiceManager != null) {
+                try {
+                    this.resourceGroupServiceManager.close();
+                } catch (Exception e) {
+                    LOG.warn("ResourceGroupServiceManager closing failed {}", e.getMessage());
+                }
+                this.resourceGroupServiceManager = null;
+            }
 
             if (this.webService != null) {
                 try {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/resourcegroup/ResourceGroupServiceTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/resourcegroup/ResourceGroupServiceTest.java
@@ -257,6 +257,14 @@ public class ResourceGroupServiceTest extends MockedPulsarServiceBaseTest {
         Assert.assertEquals(rgs.getNumResourceGroups(), 0);
     }
 
+    @Test
+    public void testClose() throws Exception {
+        ResourceGroupService service = new ResourceGroupService(pulsar, TimeUnit.MILLISECONDS, null, null);
+        service.close();
+        Assert.assertTrue(service.getAggregateLocalUsagePeriodicTask().isCancelled());
+        Assert.assertTrue(service.getCalculateQuotaPeriodicTask().isCancelled());
+    }
+
     private ResourceGroupService rgs;
     int numAnonymousQuotaCalculations;
 


### PR DESCRIPTION
### Motivation

When the broker closes,  the scheduled task in ResourceGroupService may still execute, and cause NPE:
```
Sep 17 12:09:50 168-15-22-49 pulsar[8900]: 2022-09-17T12:09:50,050+0800 [pulsar-2-4] ERROR org.apache.pulsar.common.util.Runnables - Unexpected throwable caught
Sep 17 12:09:50 168-15-22-49 pulsar[8900]: java.lang.NullPointerException: null
Sep 17 12:09:50 168-15-22-49 pulsar[8900]: at org.apache.pulsar.broker.resourcegroup.ResourceGroupService.aggregateResourceGroupLocalUsages(ResourceGroupService.java:530) 
Sep 17 12:09:50 168-15-22-49 pulsar[8900]: at org.apache.pulsar.common.util.Runnables$CatchingAndLoggingRunnable.run(Runnables.java:54) 
Sep 17 12:09:50 168-15-22-49 pulsar[8900]: at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515) ~[?:?]
Sep 17 12:09:50 168-15-22-49 pulsar[8900]: at java.util.concurrent.FutureTask.runAndReset(FutureTask.java:305) ~[?:?]
Sep 17 12:09:50 168-15-22-49 pulsar[8900]: at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:305)
Sep 17 12:09:50 168-15-22-49 pulsar[8900]: at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128) ~[?:?]
Sep 17 12:09:50 168-15-22-49 pulsar[8900]: at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628) ~[?:?]
Sep 17 12:09:50 168-15-22-49 pulsar[8900]: at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30) 
Sep 17 12:09:50 168-15-22-49 pulsar[8900]: at java.lang.Thread.run(Thread.java:829) ~[?:?]
```

### Documentation

- [x] `doc-not-needed` 
(Please explain why)


### Matching PR in forked repository

PR in forked repository: (https://github.com/Technoboy-/pulsar/pull/6)

