### PR TITLE
[improve][broker] Set log level to `warn` when topic policy reader occurs AlreadyClosedException

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/SystemTopicBasedTopicPoliciesService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/SystemTopicBasedTopicPoliciesService.java
@@ -395,7 +395,7 @@ public class SystemTopicBasedTopicPoliciesService implements TopicPoliciesServic
                   } else {
                       Throwable cause = FutureUtil.unwrapCompletionException(ex);
                       if (cause instanceof PulsarClientException.AlreadyClosedException) {
-                          log.error("Read more topic policies exception, close the read now!", ex);
+                          log.warn("Read more topic policies exception, close the read now!", ex);
                           cleanCacheAndCloseReader(
                                   reader.getSystemTopic().getTopicName().getNamespaceObject(), false);
                       } else {


### PR DESCRIPTION
### Motivation

The AlreadyClosedException is a normal exception; the `ERROR` level log may trigger the monitor and confuse the user.
So suggest changing to `WARN`:
```
Sep 17 12:08:49 168-11-26-111 pulsar[23776]: 2022-09-17T12:08:49,510+0800 [broker-client-shared-internal-executor-6-1] ERROR org.apache.pulsar.broker.service.SystemTopicBasedTopicPoliciesService - Read more topic policies exception, close the read now!
Sep 17 12:08:49 168-11-26-111 pulsar[23776]: java.util.concurrent.CompletionException: org.apache.pulsar.client.api.PulsarClientException$AlreadyClosedException: The consumer which subscribes the topic MultiTopicsConsumer-6d140 with subscription name multiTopicsReader-9de778b249 was already closed when cleaning and closing the consumers
Sep 17 12:08:49 168-11-26-111 pulsar[23776]: at java.util.concurrent.CompletableFuture.encodeThrowable(CompletableFuture.java:331) ~[?:?]
Sep 17 12:08:49 168-11-26-111 pulsar[23776]: at java.util.concurrent.CompletableFuture.completeThrowable(CompletableFuture.java:346) ~[?:?]
Sep 17 12:08:49 168-11-26-111 pulsar[23776]: at java.util.concurrent.CompletableFuture$UniApply.tryFire(CompletableFuture.java:632) ~[?:?]
Sep 17 12:08:49 168-11-26-111 pulsar[23776]: at java.util.concurrent.CompletableFuture.postComplete(CompletableFuture.java:506) ~[?:?]
Sep 17 12:08:49 168-11-26-111 pulsar[23776]: at java.util.concurrent.CompletableFuture.completeExceptionally(CompletableFuture.java:2088) ~[?:?]
Sep 17 12:08:49 168-11-26-111 pulsar[23776]: at org.apache.pulsar.client.impl.ConsumerBase.failPendingReceives(ConsumerBase.java:274) 
Sep 17 12:08:49 168-11-26-111 pulsar[23776]: at org.apache.pulsar.client.impl.ConsumerBase.lambda$failPendingReceive$1(ConsumerBase.java:257) 
Sep 17 12:08:49 168-11-26-111 pulsar[23776]: at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128) ~[?:?]
Sep 17 12:08:49 168-11-26-111 pulsar[23776]: at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628) ~[?:?]
Sep 17 12:08:49 168-11-26-111 pulsar[23776]: at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
Sep 17 12:08:49 168-11-26-111 pulsar[23776]: at java.lang.Thread.run(Thread.java:829) ~[?:?]
Sep 17 12:08:49 168-11-26-111 pulsar[23776]: Caused by: org.apache.pulsar.client.api.PulsarClientException$AlreadyClosedException: The consumer which subscribes the topic MultiTopicsConsumer-6d140 with subscription name multiTopicsReader-9de778b249 was already closed when cleaning and closing the consumers
Sep 17 12:08:49 168-11-26-111 pulsar[23776]: at org.apache.pulsar.client.impl.ConsumerBase.failPendingReceives(ConsumerBase.java:276) 
Sep 17 12:08:49 168-11-26-111 pulsar[23776]: ... 5 more
```

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)

- [x] `doc-not-needed` 
(Please explain why)

- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)

### Matching PR in forked repository

PR in forked repository: (https://github.com/Technoboy-/pulsar/pull/7)

