### PR TITLE
[improve][broker]Improve PersistentMessageExpiryMonitor expire speed when ledger not existed

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedLedger.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedLedger.java
@@ -20,6 +20,7 @@ package org.apache.bookkeeper.mledger;
 
 import io.netty.buffer.ByteBuf;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Predicate;
 import org.apache.bookkeeper.common.annotation.InterfaceAudience;
@@ -648,6 +649,12 @@ public interface ManagedLedger {
      * will got null if corresponding ledger not exists.
      */
     CompletableFuture<LedgerInfo> getLedgerInfo(long ledgerId);
+
+    /**
+     * Get basic ledger summary.
+     * will get {@link Optional#empty()} if corresponding ledger not exists.
+     */
+    Optional<LedgerInfo> getOptionalLedgerInfo(long ledgerId);
 
     /**
      * Truncate ledgers

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedLedgerException.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedLedgerException.java
@@ -18,7 +18,6 @@
  */
 package org.apache.bookkeeper.mledger;
 
-import org.apache.bookkeeper.client.BKException;
 import org.apache.bookkeeper.common.annotation.InterfaceAudience;
 import org.apache.bookkeeper.common.annotation.InterfaceStability;
 

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedLedgerException.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedLedgerException.java
@@ -142,8 +142,18 @@ public class ManagedLedgerException extends Exception {
     }
 
     public static class NonRecoverableLedgerException extends ManagedLedgerException {
+        private Integer bkErrorCode; // null means ledger not exists or deleted
         public NonRecoverableLedgerException(String msg) {
             super(msg);
+        }
+
+        public NonRecoverableLedgerException(String msg, Integer bkErrorCode) {
+            super(msg);
+            this.bkErrorCode = bkErrorCode;
+        }
+
+        public Integer getBkErrorCode() {
+            return bkErrorCode;
         }
     }
 

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedLedgerException.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedLedgerException.java
@@ -143,27 +143,14 @@ public class ManagedLedgerException extends Exception {
     }
 
     public static class NonRecoverableLedgerException extends ManagedLedgerException {
-        private Integer bkErrorCode; // null means ledger not exists or deleted
         public NonRecoverableLedgerException(String msg) {
             super(msg);
         }
+    }
 
-        public NonRecoverableLedgerException(String msg, Integer bkErrorCode) {
+    public static class LedgerNotExistException extends NonRecoverableLedgerException {
+        public LedgerNotExistException(String msg) {
             super(msg);
-            this.bkErrorCode = bkErrorCode;
-        }
-
-        public boolean isLedgerNotExistException() {
-            if (bkErrorCode == null) {
-                return true;
-            }
-            switch (bkErrorCode) {
-                case BKException.Code.NoSuchLedgerExistsException:
-                case BKException.Code.NoSuchLedgerExistsOnMetadataServerException:
-                    return true;
-                default:
-                    return false;
-            }
         }
     }
 

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedLedgerException.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedLedgerException.java
@@ -18,6 +18,7 @@
  */
 package org.apache.bookkeeper.mledger;
 
+import org.apache.bookkeeper.client.BKException;
 import org.apache.bookkeeper.common.annotation.InterfaceAudience;
 import org.apache.bookkeeper.common.annotation.InterfaceStability;
 
@@ -152,8 +153,17 @@ public class ManagedLedgerException extends Exception {
             this.bkErrorCode = bkErrorCode;
         }
 
-        public Integer getBkErrorCode() {
-            return bkErrorCode;
+        public boolean isLedgerNotExistException() {
+            if (bkErrorCode == null) {
+                return true;
+            }
+            switch (bkErrorCode) {
+                case BKException.Code.NoSuchLedgerExistsException:
+                case BKException.Code.NoSuchLedgerExistsOnMetadataServerException:
+                    return true;
+                default:
+                    return false;
+            }
         }
     }
 

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
@@ -3760,7 +3760,7 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
         if (bkErrorCode == BKException.Code.TooManyRequestsException) {
             return new TooManyRequestsException("Too many request error from bookies");
         } else if (isBkErrorNotRecoverable(bkErrorCode)) {
-            return new NonRecoverableLedgerException(BKException.getMessage(bkErrorCode));
+            return new NonRecoverableLedgerException(BKException.getMessage(bkErrorCode), bkErrorCode);
         } else {
             return new ManagedLedgerException(BKException.getMessage(bkErrorCode));
         }

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
@@ -100,6 +100,7 @@ import org.apache.bookkeeper.mledger.ManagedLedgerException;
 import org.apache.bookkeeper.mledger.ManagedLedgerException.BadVersionException;
 import org.apache.bookkeeper.mledger.ManagedLedgerException.CursorNotFoundException;
 import org.apache.bookkeeper.mledger.ManagedLedgerException.InvalidCursorPositionException;
+import org.apache.bookkeeper.mledger.ManagedLedgerException.LedgerNotExistException;
 import org.apache.bookkeeper.mledger.ManagedLedgerException.ManagedLedgerAlreadyClosedException;
 import org.apache.bookkeeper.mledger.ManagedLedgerException.ManagedLedgerFencedException;
 import org.apache.bookkeeper.mledger.ManagedLedgerException.ManagedLedgerInterceptException;
@@ -1837,6 +1838,11 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
         return result;
     }
 
+    @Override
+    public Optional<LedgerInfo> getOptionalLedgerInfo(long ledgerId) {
+        return Optional.ofNullable(ledgers.get(ledgerId));
+    }
+
     CompletableFuture<ReadHandle> getLedgerHandle(long ledgerId) {
         CompletableFuture<ReadHandle> ledgerHandle = ledgerCache.get(ledgerId);
         if (ledgerHandle != null) {
@@ -1943,7 +1949,7 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
         } else {
             log.error("[{}] Failed to get message with ledger {}:{} the ledgerId does not belong to this topic "
                     + "or has been deleted.", name, position.getLedgerId(), position.getEntryId());
-            callback.readEntryFailed(new ManagedLedgerException.NonRecoverableLedgerException("Message not found, "
+            callback.readEntryFailed(new LedgerNotExistException("Message not found, "
                     + "the ledgerId does not belong to this topic or has been deleted"), ctx);
         }
 
@@ -3756,11 +3762,26 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
         }
     }
 
+    private static boolean isLedgerNotExistException(int rc) {
+        switch (rc) {
+            case Code.NoSuchLedgerExistsException:
+            case Code.NoSuchLedgerExistsOnMetadataServerException:
+                return true;
+
+            default:
+                return false;
+        }
+    }
+
     public static ManagedLedgerException createManagedLedgerException(int bkErrorCode) {
         if (bkErrorCode == BKException.Code.TooManyRequestsException) {
             return new TooManyRequestsException("Too many request error from bookies");
         } else if (isBkErrorNotRecoverable(bkErrorCode)) {
-            return new NonRecoverableLedgerException(BKException.getMessage(bkErrorCode), bkErrorCode);
+            if (isLedgerNotExistException(bkErrorCode)) {
+                return new LedgerNotExistException(BKException.getMessage(bkErrorCode));
+            } else {
+                return new NonRecoverableLedgerException(BKException.getMessage(bkErrorCode));
+            }
         } else {
             return new ManagedLedgerException(BKException.getMessage(bkErrorCode));
         }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentMessageExpiryMonitor.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentMessageExpiryMonitor.java
@@ -22,7 +22,6 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.LongAdder;
-import org.apache.bookkeeper.client.BKException;
 import org.apache.bookkeeper.mledger.AsyncCallbacks.FindEntryCallback;
 import org.apache.bookkeeper.mledger.AsyncCallbacks.MarkDeleteCallback;
 import org.apache.bookkeeper.mledger.ManagedCursor;
@@ -192,7 +191,7 @@ public class PersistentMessageExpiryMonitor implements FindEntryCallback {
                 && (exception instanceof NonRecoverableLedgerException)) {
             log.warn("[{}][{}] read failed from ledger at position:{} : {}", topicName, subName, failedReadPosition,
                     exception.getMessage());
-            if (isLedgerNotExistException(((NonRecoverableLedgerException) exception).getBkErrorCode())) {
+            if ((((NonRecoverableLedgerException) exception).isLedgerNotExistException())) {
                 try {
                     long failedLedgerId = failedReadPosition.get().getLedgerId();
                     Position lastPositionInLedger = PositionImpl.get(failedLedgerId,
@@ -211,19 +210,5 @@ public class PersistentMessageExpiryMonitor implements FindEntryCallback {
         }
         expirationCheckInProgress = FALSE;
         updateRates();
-    }
-
-    private boolean isLedgerNotExistException(Integer bkErrorCode) {
-        if (bkErrorCode == null) {
-            return true;
-        }
-        switch (bkErrorCode) {
-            case BKException.Code.NoSuchLedgerExistsException:
-            case BKException.Code.NoSuchLedgerExistsOnMetadataServerException:
-                return true;
-
-            default:
-                return false;
-        }
     }
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentMessageExpiryMonitor.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentMessageExpiryMonitor.java
@@ -26,8 +26,10 @@ import org.apache.bookkeeper.mledger.AsyncCallbacks.FindEntryCallback;
 import org.apache.bookkeeper.mledger.AsyncCallbacks.MarkDeleteCallback;
 import org.apache.bookkeeper.mledger.ManagedCursor;
 import org.apache.bookkeeper.mledger.ManagedLedgerException;
+import org.apache.bookkeeper.mledger.ManagedLedgerException.LedgerNotExistException;
 import org.apache.bookkeeper.mledger.ManagedLedgerException.NonRecoverableLedgerException;
 import org.apache.bookkeeper.mledger.Position;
+import org.apache.bookkeeper.mledger.impl.ManagedLedgerImpl;
 import org.apache.bookkeeper.mledger.impl.PositionImpl;
 import org.apache.pulsar.client.impl.MessageImpl;
 import org.apache.pulsar.common.api.proto.CommandSubscribe.SubType;
@@ -191,19 +193,25 @@ public class PersistentMessageExpiryMonitor implements FindEntryCallback {
                 && (exception instanceof NonRecoverableLedgerException)) {
             log.warn("[{}][{}] read failed from ledger at position:{} : {}", topicName, subName, failedReadPosition,
                     exception.getMessage());
-            if ((((NonRecoverableLedgerException) exception).isLedgerNotExistException())) {
-                try {
-                    long failedLedgerId = failedReadPosition.get().getLedgerId();
-                    Position lastPositionInLedger = PositionImpl.get(failedLedgerId,
-                            cursor.getManagedLedger().getLedgerInfo(failedLedgerId).get().getEntries() - 1);
-                    log.info("[{}][{}] ledger not existed, will complete the last position of the non-existed"
-                                    + " ledger:{}", topicName, subName, lastPositionInLedger);
-                    findEntryComplete(lastPositionInLedger, ctx);
-                } catch (Exception e) {
-                  log.warn("[{}][{}] failed to expire not existed ledger, try to just expire failed position:{} : {}",
-                          topicName, subName, failedReadPosition, e.getMessage());
-                    findEntryComplete(failedReadPosition.get(), ctx);
-                }
+            if (exception instanceof LedgerNotExistException) {
+                long failedLedgerId = failedReadPosition.get().getLedgerId();
+                ManagedLedgerImpl ledger = ((ManagedLedgerImpl) cursor.getManagedLedger());
+                Position lastPositionInLedger = ledger.getOptionalLedgerInfo(failedLedgerId)
+                        .map(ledgerInfo -> PositionImpl.get(failedLedgerId, ledgerInfo.getEntries() - 1))
+                        .orElseGet(() -> {
+                            Long nextExistingLedger = ledger.getNextValidLedger(failedReadPosition.get().getLedgerId());
+                            if (nextExistingLedger == null) {
+                                log.info("[{}] [{}] Couldn't find next next valid ledger for expiry monitor when find "
+                                                + "entry failed {}", ledger.getName(), ledger.getName(),
+                                        failedReadPosition);
+                                return (PositionImpl) failedReadPosition.get();
+                            } else {
+                                return PositionImpl.get(nextExistingLedger, -1);
+                            }
+                        });
+                log.info("[{}][{}] ledger not existed, will complete the last position of the non-existed"
+                        + " ledger:{}", topicName, subName, lastPositionInLedger);
+                findEntryComplete(lastPositionInLedger, ctx);
             } else {
                 findEntryComplete(failedReadPosition.get(), ctx);
             }

--- a/tiered-storage/jcloud/src/test/java/org/apache/bookkeeper/mledger/offload/jcloud/impl/MockManagedLedger.java
+++ b/tiered-storage/jcloud/src/test/java/org/apache/bookkeeper/mledger/offload/jcloud/impl/MockManagedLedger.java
@@ -20,6 +20,7 @@ package org.apache.bookkeeper.mledger.offload.jcloud.impl;
 
 import io.netty.buffer.ByteBuf;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Predicate;
 import lombok.extern.slf4j.Slf4j;
@@ -352,6 +353,12 @@ public class MockManagedLedger implements ManagedLedger {
     public CompletableFuture<LedgerInfo> getLedgerInfo(long ledgerId) {
         final LedgerInfo build = LedgerInfo.newBuilder().setLedgerId(ledgerId).setSize(100).setEntries(20).build();
         return CompletableFuture.completedFuture(build);
+    }
+
+    @Override
+    public Optional<LedgerInfo> getOptionalLedgerInfo(long ledgerId) {
+        final LedgerInfo build = LedgerInfo.newBuilder().setLedgerId(ledgerId).setSize(100).setEntries(20).build();
+        return Optional.of(build);
     }
 
     @Override


### PR DESCRIPTION
### Motivation

Speed up  the process of `PersistentMessageExpiryMonitor` expiring message when ledgers not exist.

For details:

Without consumer acking messages, the `PersistentMessageExpiryMonitor` expires messages process could be very slow if the ledger `PersistentMessageExpiryMonitor`  be read has been deleted from the bookkeeper.

The root cause is that,  when `autoSkipNonRecoverableData` is true and the ledger to be read has been deleted, the `expireMessages` will read entry failed and set the markDeletePosition as the failed position, see Line194.  And then waiting to be scheduled(defalut value is 5min)
https://github.com/apache/pulsar/blob/49eaa548b97eca06a6aff5d79391d49f085adb9e/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentMessageExpiryMonitor.java#L186-L196

In the next scheduled, the `PersistentMessageExpiryMonitor` will read the next position of markDeletePosition , which is also not existed because they may belong to the same ledger.

So the markDeletePosition just go forward 1 every 5min. And if there are  many deleted ledgers, it will lead to the ttl expire lose efficacy

### Modifications

If read entry failed with ledger not existed exceptions,  we will set the markDeletePosition as the last position of the deleted ledger.

### Verifying this change

- [x] Make sure that the change passes the CI checks.
- `org.apache.pulsar.broker.service.PersistentMessageFinderTest#testMessageExpiryWithTimestampNonRecoverableException` has coverd this change

### Does this pull request potentially affect one of the following parts:


### Documentation

- [x] `doc-not-needed` 
(Please explain why)

### Matching PR in forked repository

PR in forked repository: https://github.com/AnonHxy/pulsar/pull/4
