### PR TITLE
[Pulsar-init] Support cluster init using proxy url and protocol

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/PulsarClusterMetadataSetup.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/PulsarClusterMetadataSetup.java
@@ -35,6 +35,7 @@ import org.apache.pulsar.bookie.rackawareness.BookieRackAffinityMapping;
 import org.apache.pulsar.broker.resources.NamespaceResources;
 import org.apache.pulsar.broker.resources.PulsarResources;
 import org.apache.pulsar.broker.resources.TenantResources;
+import org.apache.pulsar.client.api.ProxyProtocol;
 import org.apache.pulsar.common.conf.InternalConfigurationData;
 import org.apache.pulsar.common.naming.NamespaceName;
 import org.apache.pulsar.common.naming.SystemTopicNames;
@@ -137,6 +138,16 @@ public class PulsarClusterMetadataSetup {
             description = "The metadata service URI of the existing BookKeeper cluster that you want to use",
             hidden = true)
         private String bookieMetadataServiceUri;
+
+        @Parameter(names = { "-pp",
+                "--proxy-protocol" },
+                description = "Proxy protocol to select type of routing at proxy. Possible Values: [SNI]",
+                required = false)
+        private ProxyProtocol clusterProxyProtocol;
+
+        @Parameter(names = { "-pu",
+                "--proxy-url" }, description = "Proxy-server URL to which to connect.", required = false)
+        private String clusterProxyUrl;
 
         @Parameter(names = { "-h", "--help" }, description = "Show this help message")
         private boolean help = false;
@@ -298,6 +309,8 @@ public class PulsarClusterMetadataSetup {
                 .serviceUrlTls(arguments.clusterWebServiceUrlTls)
                 .brokerServiceUrl(arguments.clusterBrokerServiceUrl)
                 .brokerServiceUrlTls(arguments.clusterBrokerServiceUrlTls)
+                .proxyServiceUrl(arguments.clusterProxyUrl)
+                .proxyProtocol(arguments.clusterProxyProtocol)
                 .build();
         if (!resources.getClusterResources().clusterExists(arguments.cluster)) {
             resources.getClusterResources().createCluster(arguments.cluster, clusterData);


### PR DESCRIPTION
### Motivation
Pulsar cluster can be setup using SNI reverse proxy and Pulsar cluster metadata initialization should support cluster-metadata creation/update using proxy-protocol and URL. It will be also useful in Pulsar-helm-chart installation phase to create cluster metadata with proxy configuration as well.

### Modification
- Initialize Cluster metadata using Proxy URL and protocol.
- [ ] `doc` <!-- Your PR contains doc changes -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->