### PR TITLE
[fix][flask-test] Fix and improve LookupRetryTest

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/LookupRetryTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/LookupRetryTest.java
@@ -88,7 +88,7 @@ public class LookupRetryTest extends MockedPulsarServiceBaseTest {
         };
     }
 
-    @AfterClass
+    @AfterClass(alwaysRun = true)
     @Override
     protected void cleanup() throws Exception {
         super.internalCleanup();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/LookupRetryTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/LookupRetryTest.java
@@ -20,14 +20,12 @@ package org.apache.pulsar.client.impl;
 
 import static org.apache.pulsar.common.protocol.Commands.newLookupErrorResponse;
 import static org.apache.pulsar.common.protocol.Commands.newPartitionMetadataResponse;
-
 import com.google.common.collect.Sets;
 import java.util.Queue;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
-
 import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.broker.ServiceConfiguration;
 import org.apache.pulsar.broker.auth.MockedPulsarServiceBaseTest;
@@ -44,20 +42,18 @@ import org.apache.pulsar.common.api.proto.ServerError;
 import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.policies.data.ClusterData;
 import org.apache.pulsar.common.policies.data.TenantInfoImpl;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.testng.Assert;
-import org.testng.annotations.AfterMethod;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 public class LookupRetryTest extends MockedPulsarServiceBaseTest {
-    private static final Logger log = LoggerFactory.getLogger(LookupRetryTest.class);
     private static final String subscription = "reader-sub";
     private final AtomicInteger connectionsCreated = new AtomicInteger(0);
     private final ConcurrentHashMap<String, Queue<LookupError>> failureMap = new ConcurrentHashMap<>();
 
-    @BeforeMethod
+    @BeforeClass
     @Override
     protected void setup() throws Exception {
         conf.setTopicLevelPoliciesEnabled(false);
@@ -69,8 +65,6 @@ public class LookupRetryTest extends MockedPulsarServiceBaseTest {
         admin.tenants().createTenant("public",
                 new TenantInfoImpl(Sets.newHashSet("appid1", "appid2"), Sets.newHashSet("test")));
         admin.namespaces().createNamespace("public/default", Sets.newHashSet("test"));
-
-        connectionsCreated.set(0);
     }
 
     @Override
@@ -94,10 +88,16 @@ public class LookupRetryTest extends MockedPulsarServiceBaseTest {
         };
     }
 
-    @AfterMethod(alwaysRun = true)
+    @AfterClass
     @Override
     protected void cleanup() throws Exception {
         super.internalCleanup();
+    }
+
+    @BeforeMethod(alwaysRun = true)
+    public void reset() {
+        connectionsCreated.set(0);
+        failureMap.clear();
     }
 
     PulsarClient newClient() throws Exception {
@@ -244,7 +244,6 @@ public class LookupRetryTest extends MockedPulsarServiceBaseTest {
 
         try (PulsarClient pulsarClient = PulsarClient.builder().serviceUrl(lookupUrl)
                 .maxNumberOfRejectedRequestPerConnection(100)
-                .maxNumberOfRejectedRequestPerConnection(1)
                 .connectionTimeout(2, TimeUnit.SECONDS)
                 .operationTimeout(1, TimeUnit.SECONDS)
                 .lookupTimeout(10, TimeUnit.SECONDS)


### PR DESCRIPTION
Fixes #17785

### Motivation

The `failureMap` need to be clear after run per unit test.

### Modifications

Clear `failureMap` after run per unit test, and only run once `setup()`/`cleanup()` to reduce execution time.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)

- [x] `doc-not-needed` 
(Please explain why)

- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)

### Matching PR in forked repository

PR in forked repository: https://github.com/coderzc/pulsar/pull/6