### PR TITLE
[broker][monitoring] Add per-thread CPU usage metrics.

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/ThreadsCpuMetrics.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/ThreadsCpuMetrics.java
@@ -18,7 +18,7 @@
  */
 package org.apache.pulsar.broker.stats;
 
-import io.prometheus.client.Gauge;
+import io.prometheus.client.Counter;
 import java.lang.management.ManagementFactory;
 import java.lang.management.ThreadInfo;
 import java.lang.management.ThreadMXBean;
@@ -26,19 +26,19 @@ import java.lang.management.ThreadMXBean;
 public final class ThreadsCpuMetrics {
     private static boolean supportCpuTime = true;
 
-    private static final Gauge THREAD_TOTAL_CPU_USAGE = Gauge.build()
+    private static final Counter THREAD_TOTAL_CPU_USAGE = Counter.build()
             .name("pulsar_broker_thread_total_cpu_usage")
             .help("-")
             .labelNames("thread_name")
             .unit("ns")
             .register();
-    private static final Gauge THREAD_SYSTEM_CPU_USAGE = Gauge.build()
+    private static final Counter THREAD_SYSTEM_CPU_USAGE = Counter.build()
             .name("pulsar_broker_thread_system_cpu_usage")
             .help("-")
             .labelNames("thread_name")
             .unit("ns")
             .register();
-    private static final Gauge THREAD_USER_CPU_USAGE = Gauge.build()
+    private static final Counter THREAD_USER_CPU_USAGE = Counter.build()
             .name("pulsar_broker_thread_user_cpu_usage")
             .help("-")
             .labelNames("thread_name")

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/ThreadsCpuMetrics.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/ThreadsCpuMetrics.java
@@ -1,0 +1,96 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.stats;
+
+import io.prometheus.client.Gauge;
+import java.lang.management.ManagementFactory;
+import java.lang.management.ThreadInfo;
+import java.lang.management.ThreadMXBean;
+
+public final class ThreadsCpuMetrics {
+    private static boolean supportCpuTime = true;
+
+    private static final Gauge THREAD_TOTAL_CPU_USAGE = Gauge.build()
+            .name("pulsar_broker_thread_total_cpu_usage")
+            .help("-")
+            .labelNames("thread_name")
+            .unit("ns")
+            .register();
+    private static final Gauge THREAD_SYSTEM_CPU_USAGE = Gauge.build()
+            .name("pulsar_broker_thread_system_cpu_usage")
+            .help("-")
+            .labelNames("thread_name")
+            .unit("ns")
+            .register();
+    private static final Gauge THREAD_USER_CPU_USAGE = Gauge.build()
+            .name("pulsar_broker_thread_user_cpu_usage")
+            .help("-")
+            .labelNames("thread_name")
+            .unit("ns")
+            .register();
+
+    private static final ThreadMXBean THREAD_MX_BEAN = ManagementFactory.getThreadMXBean();
+
+    private final long[] threadIds;
+
+    public static void initialize() {
+        if (!THREAD_MX_BEAN.isThreadCpuTimeSupported()) {
+            supportCpuTime = false;
+            return;
+        }
+
+        if (!THREAD_MX_BEAN.isThreadCpuTimeEnabled()) {
+            THREAD_MX_BEAN.setThreadCpuTimeEnabled(true);
+        }
+    }
+
+    public ThreadsCpuMetrics() {
+        this.threadIds = THREAD_MX_BEAN.getAllThreadIds();
+        THREAD_TOTAL_CPU_USAGE.clear();
+        THREAD_USER_CPU_USAGE.clear();
+        THREAD_SYSTEM_CPU_USAGE.clear();
+    }
+
+    /**
+     * Must call the method before PrometheusMetricsGeneratorUtils#generateSystemMetrics.
+     */
+    public void generate() {
+        if (!supportCpuTime) {
+            return;
+        }
+
+        // No stack trace
+        ThreadInfo[] threadInfos = THREAD_MX_BEAN.getThreadInfo(threadIds);
+        for (ThreadInfo info : threadInfos) {
+            long threadId = info.getThreadId();
+            long userNs = THREAD_MX_BEAN.getThreadUserTime(threadId);
+            long totalNs = THREAD_MX_BEAN.getThreadCpuTime(threadId);
+            long systemNs = totalNs - userNs;
+            String threadName = info.getThreadName();
+            int idx = threadName.indexOf("{");
+            if (idx > 0) {
+                threadName = threadName.substring(0, idx);
+            }
+
+            THREAD_TOTAL_CPU_USAGE.labels(threadName).inc(totalNs);
+            THREAD_SYSTEM_CPU_USAGE.labels(threadName).inc(systemNs);
+            THREAD_USER_CPU_USAGE.labels(threadName).inc(userNs);
+        }
+    }
+}

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/PrometheusMetricsGenerator.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/PrometheusMetricsGenerator.java
@@ -46,6 +46,7 @@ import org.apache.bookkeeper.stats.NullStatsProvider;
 import org.apache.bookkeeper.stats.StatsProvider;
 import org.apache.pulsar.PulsarVersion;
 import org.apache.pulsar.broker.PulsarService;
+import org.apache.pulsar.broker.stats.ThreadsCpuMetrics;
 import org.apache.pulsar.broker.stats.TimeWindow;
 import org.apache.pulsar.broker.stats.WindowWrap;
 import org.apache.pulsar.broker.stats.metrics.ManagedCursorMetrics;
@@ -69,6 +70,7 @@ public class PrometheusMetricsGenerator {
 
     static {
         DefaultExports.initialize();
+        ThreadsCpuMetrics.initialize();
 
         Gauge.build("jvm_memory_direct_bytes_used", "-").create().setChild(new Child() {
             @Override
@@ -186,6 +188,7 @@ public class PrometheusMetricsGenerator {
         try {
             SimpleTextOutputStream stream = new SimpleTextOutputStream(buf);
 
+            new ThreadsCpuMetrics().generate();
             generateSystemMetrics(stream, pulsar.getConfiguration().getClusterName());
 
             NamespaceStatsAggregator.generate(pulsar, includeTopicMetrics, includeConsumerMetrics,


### PR DESCRIPTION
### Motivation

Introduce the metrics for thread CPU usage which can help Pulsar maintainers to detect performance issues related to parts of threads that run with high CPU usage, especially the IO thread.

### Does this pull request potentially affect one of the following parts:

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [x] `doc-required` 
(Your PR needs to update docs and you will update later)

- [ ] `doc-not-needed` 
(Please explain why)

- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)

### Matching PR in forked repository

PR in forked repository: 
