### PR TITLE
[improve][java-client]Shrink BatchMessageContainer maxBatchSize

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/AbstractBatchMessageContainer.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/AbstractBatchMessageContainer.java
@@ -84,6 +84,11 @@ public abstract class AbstractBatchMessageContainer implements BatchMessageConta
         return currentBatchSizeBytes;
     }
 
+    @VisibleForTesting
+    public int getMaxBatchSize() {
+        return maxBatchSize;
+    }
+
     @Override
     public List<ProducerImpl.OpSendMsg> createOpSendMsgs() throws IOException {
         throw new UnsupportedOperationException();

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/AbstractBatchMessageContainer.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/AbstractBatchMessageContainer.java
@@ -18,7 +18,6 @@
  */
 package org.apache.pulsar.client.impl;
 
-import com.google.common.annotations.VisibleForTesting;
 import java.io.IOException;
 import java.util.List;
 import lombok.extern.slf4j.Slf4j;
@@ -84,8 +83,7 @@ public abstract class AbstractBatchMessageContainer implements BatchMessageConta
         return currentBatchSizeBytes;
     }
 
-    @VisibleForTesting
-    public int getMaxBatchSize() {
+    int getMaxBatchSize() {
         return maxBatchSize;
     }
 

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/AbstractBatchMessageContainer.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/AbstractBatchMessageContainer.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pulsar.client.impl;
 
+import com.google.common.annotations.VisibleForTesting;
 import java.io.IOException;
 import java.util.List;
 import lombok.extern.slf4j.Slf4j;

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/BatchMessageContainerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/BatchMessageContainerImpl.java
@@ -188,6 +188,8 @@ class BatchMessageContainerImpl extends AbstractBatchMessageContainer {
                     maxBatchSize = shrank;
                     consecutiveShrinkTime = 0;
                 }
+            } else {
+                consecutiveShrinkTime = 0;
             }
         }
     }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/BatchMessageContainerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/BatchMessageContainerImpl.java
@@ -64,6 +64,8 @@ class BatchMessageContainerImpl extends AbstractBatchMessageContainer {
     protected SendCallback firstCallback;
 
     private final ByteBufAllocator allocator;
+    private static final int SHRINK_COOLING_OFF_PERIOD = 10;
+    private int consecutiveShrinkTime = 0;
 
     public BatchMessageContainerImpl() {
         this(PulsarByteBufAllocator.DEFAULT);
@@ -173,8 +175,7 @@ class BatchMessageContainerImpl extends AbstractBatchMessageContainer {
         return compressedPayload;
     }
 
-    @VisibleForTesting
-    public void updateMaxBatchSize(int uncompressedSize) {
+    void updateMaxBatchSize(int uncompressedSize) {
         if (uncompressedSize > maxBatchSize) {
             maxBatchSize = uncompressedSize;
             consecutiveShrinkTime = 0;

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/BatchMessageContainerImplTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/BatchMessageContainerImplTest.java
@@ -45,6 +45,9 @@ public class BatchMessageContainerImplTest {
     public void testUpdateMaxBatchSize() {
         int SHRINK_COOLING_OFF_PERIOD = 10;
         BatchMessageContainerImpl messageContainer = new BatchMessageContainerImpl();
+        // check init state
+        assertEquals(messageContainer.getMaxBatchSize(), 1024);
+
         // test expand
         messageContainer.updateMaxBatchSize(2048);
         assertEquals(messageContainer.getMaxBatchSize(), 2048);
@@ -61,6 +64,33 @@ public class BatchMessageContainerImplTest {
             } else {
                 assertEquals(messageContainer.getMaxBatchSize(), 2048 * 0.75);
             }
+        }
+
+        messageContainer.updateMaxBatchSize(2048);
+        // test big message sudden appearance
+        for (int i = 0; i < 15; ++i) {
+            if (i == SHRINK_COOLING_OFF_PERIOD - 2) {
+                messageContainer.updateMaxBatchSize(2000);
+            } else {
+                messageContainer.updateMaxBatchSize(2);
+            }
+            assertEquals(messageContainer.getMaxBatchSize(), 2048);
+        }
+
+        // test big and small message alternating occurrence
+        for (int i = 0; i < SHRINK_COOLING_OFF_PERIOD * 3; ++i) {
+            if (i % 2 ==0) {
+                messageContainer.updateMaxBatchSize(2);
+            } else {
+                messageContainer.updateMaxBatchSize(2000);
+            }
+            assertEquals(messageContainer.getMaxBatchSize(), 2048);
+        }
+
+        // test consecutive big message
+        for (int i = 0; i < 15; ++i) {
+            messageContainer.updateMaxBatchSize(2000);
+            assertEquals(messageContainer.getMaxBatchSize(), 2048);
         }
 
         // test expand after shrink

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/BatchMessageContainerImplTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/BatchMessageContainerImplTest.java
@@ -19,6 +19,7 @@
 package org.apache.pulsar.client.impl;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -39,6 +40,33 @@ import org.junit.Assert;
 import org.testng.annotations.Test;
 
 public class BatchMessageContainerImplTest {
+
+    @Test
+    public void testUpdateMaxBatchSize() {
+        int SHRINK_COOLING_OFF_PERIOD = 10;
+        BatchMessageContainerImpl messageContainer = new BatchMessageContainerImpl();
+        // test expand
+        messageContainer.updateMaxBatchSize(2048);
+        assertEquals(messageContainer.getMaxBatchSize(), 2048);
+
+        // test cooling-off period
+        messageContainer.updateMaxBatchSize(2);
+        assertEquals(messageContainer.getMaxBatchSize(), 2048);
+
+        // test shrink
+        for (int i = 0; i < 15; ++i) {
+            messageContainer.updateMaxBatchSize(2);
+            if (i < SHRINK_COOLING_OFF_PERIOD) {
+                assertEquals(messageContainer.getMaxBatchSize(), 2048);
+            } else {
+                assertEquals(messageContainer.getMaxBatchSize(), 2048 * 0.75);
+            }
+        }
+
+        // test expand after shrink
+        messageContainer.updateMaxBatchSize(4096);
+        assertEquals(messageContainer.getMaxBatchSize(), 4096);
+    }
 
     @Test
     public void recoveryAfterOom() {
@@ -62,7 +90,7 @@ public class BatchMessageContainerImplTest {
         doAnswer((ignore) -> {
             called.set(true);
             throw new OutOfMemoryError("test");
-        }).when(mockAllocator).compositeBuffer();
+        }).when(mockAllocator).buffer(anyInt());
         final BatchMessageContainerImpl batchMessageContainer = new BatchMessageContainerImpl(mockAllocator);
         batchMessageContainer.setProducer(producer);
         MessageMetadata messageMetadata1 = new MessageMetadata();


### PR DESCRIPTION
### Motivation

There will be memory waste when producer publishes messages with batch enable, which may cause some problems, e.g., issue https://github.com/apache/pulsar/issues/17662  and issue https://github.com/apache/pulsar/issues/14943


The PR https://github.com/apache/pulsar/pull/15033 try to fixed the memory waste problem but bringing a significant performance regression.

Here we introduce another way to solve the memory waste problem through shrinking the `maxBatchSize` of `BatchMessageContainerImpl`,  without bringing performance regression,  which will solve the two issues list above.

Following is the test result to approve it：
#### 1. Solved memory waste
Reducing the memory waste will be very helpful for this issue:  https://github.com/apache/pulsar/issues/17662
      
After applying this PR, following the steps of the issue to reproduce it, we can see that memory will not exceed the client memory limit:
    
<img width="1543" alt="image" src="https://user-images.githubusercontent.com/10233437/192524083-0da27ef6-626e-4a7c-812b-15083ff26c4c.png">

#### 2. Without bring performance regression

 *  Here is the publish throughput(msg/s) result, And we can come to conclusion that shrink will not bring performance regression comparing with compositeBuffer

|   | buffer| shrink | compositeBuffer | 
|---| ---     | ---- | ---- |
|  1   |  1,057,249.52         |   1,038,105.78       |    917,114.21     |
|  2   | 1,018,946.85      |   1,050,870.61       |    896,039.70     |
|   3  |    1,037,839.98    |    1,038,394.16      |    903,520.30     |
| avg  |   1,038,012.11    |     1,042,456.85   |     905,558.07    |    


**buffer** :  means  using `allocator.buffer()` to allocate `batchedMessageMetadataAndPayload` without shrink.
**shrink** :  means applied this PR
**compositeBuffer** : means applied  https://github.com/apache/pulsar/pull/15033, which using `allocator.compositeBuffer()` to allocate `batchedMessageMetadataAndPayload`       

### Modifications

- Shrink `AbstractBatchMessageContainer#maxBatchSize` if meet the conditions.
-  Revert `allocator.compositeBuffer()`  to `allocator.buffer(Math.min(maxBatchSize, ClientCnx.getMaxMessageSize()))` 

### Verifying this change

- [x] Make sure that the change passes the CI checks.
- Add test `org.apache.pulsar.client.impl.BatchMessageContainerImplTest#testUpdateMaxBatchSize`


### Documentation

- [x] `doc-not-needed` 
(Please explain why)

PR in forked repository: https://github.com/AnonHxy/pulsar/pull/5
