### PR TITLE
[ci] Add JDK source compatibility job for building pulsar-client-all

### DIFF
--- a/.github/workflows/pulsar-ci.yaml
+++ b/.github/workflows/pulsar-ci.yaml
@@ -351,7 +351,6 @@ jobs:
               mvn -B -T 1C -ntp clean install -pl pulsar-client-all -am \
                 -DskipTests -Dcheckstyle.skip -Dspotbugs.skip -Dlicense.skip=true -Drat.skip=true && \
                 ./build/run_integration_group.sh SHADE_BUILD
-            
 
           - name: Shade on Java 17
             group: SHADE_RUN
@@ -934,38 +933,6 @@ jobs:
     runs-on: macos-11
     timeout-minutes: 120
     needs: ['changed_files_job', 'integration-tests']
-    if: ${{ needs.changed_files_job.outputs.docs_only != 'true' && needs.changed_files_job.outputs.cpp_only != 'true' }}
-    steps:
-      - name: checkout
-        uses: actions/checkout@v2
-
-      - name: Tune Runner VM
-        uses: ./.github/actions/tune-runner-vm
-
-      - name: Cache Maven dependencies
-        uses: actions/cache@v2
-        with:
-          path: |
-            ~/.m2/repository/*/*/*
-            !~/.m2/repository/org/apache/pulsar
-          key: ${{ runner.os }}-m2-dependencies-all-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-m2-dependencies-all-
-
-      - name: Set up JDK 17
-        uses: actions/setup-java@v2
-        with:
-          distribution: 'temurin'
-          java-version: 17
-
-      - name: build package
-        run: mvn -B clean package -DskipTests -T 1C -ntp
-
-  macos-build:
-    name: Build Pulsar on MacOS
-    runs-on: macos-11
-    timeout-minutes: 120
-    needs: [ 'changed_files_job', 'integration-tests' ]
     if: ${{ needs.changed_files_job.outputs.docs_only != 'true' && needs.changed_files_job.outputs.cpp_only != 'true' }}
     steps:
       - name: checkout

--- a/.github/workflows/pulsar-ci.yaml
+++ b/.github/workflows/pulsar-ci.yaml
@@ -339,12 +339,19 @@ jobs:
           - name: Shade on Java 8
             group: SHADE_RUN
             runtime_jdk: 8
-            setup: ./build/run_integration_group.sh SHADE_BUILD
+            setup: |
+              mvn -B -T 1C -ntp clean install -pl pulsar-client-all -am \
+                -DskipTests -Dcheckstyle.skip -Dspotbugs.skip -Dlicense.skip=true -Drat.skip=true && \
+                ./build/run_integration_group.sh SHADE_BUILD
 
           - name: Shade on Java 11
             group: SHADE_RUN
             runtime_jdk: 11
-            setup: ./build/run_integration_group.sh SHADE_BUILD
+            setup: |
+              mvn -B -T 1C -ntp clean install -pl pulsar-client-all -am \
+                -DskipTests -Dcheckstyle.skip -Dspotbugs.skip -Dlicense.skip=true -Drat.skip=true && \
+                ./build/run_integration_group.sh SHADE_BUILD
+            
 
           - name: Shade on Java 17
             group: SHADE_RUN
@@ -927,6 +934,38 @@ jobs:
     runs-on: macos-11
     timeout-minutes: 120
     needs: ['changed_files_job', 'integration-tests']
+    if: ${{ needs.changed_files_job.outputs.docs_only != 'true' && needs.changed_files_job.outputs.cpp_only != 'true' }}
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+
+      - name: Tune Runner VM
+        uses: ./.github/actions/tune-runner-vm
+
+      - name: Cache Maven dependencies
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.m2/repository/*/*/*
+            !~/.m2/repository/org/apache/pulsar
+          key: ${{ runner.os }}-m2-dependencies-all-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-m2-dependencies-all-
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'temurin'
+          java-version: 17
+
+      - name: build package
+        run: mvn -B clean package -DskipTests -T 1C -ntp
+
+  macos-build:
+    name: Build Pulsar on MacOS
+    runs-on: macos-11
+    timeout-minutes: 120
+    needs: [ 'changed_files_job', 'integration-tests' ]
     if: ${{ needs.changed_files_job.outputs.docs_only != 'true' && needs.changed_files_job.outputs.cpp_only != 'true' }}
     steps:
       - name: checkout


### PR DESCRIPTION
### Motivation

https://github.com/apache/pulsar/pull/17198 breaks inadvertently the jdk8 compatibility for the client and the CI didn't failed.
We already have the maven rule but it's not enough because you can still add dependency to pulsar-client that are not source compatible with JDK8.
The CI currently only verify binary compatibility.

### Modifications

* Add a simple clean install in the jdk8 and jdk11 tests to verify  all the dependent modules of `pulsar-client-all` are source compatible with JDK8 and JDK11  

- [x] `doc-not-needed` 
