### PR TITLE
[ci] Verify checkstyle and spotbugs for all modules

### DIFF
--- a/.github/workflows/pulsar-ci.yaml
+++ b/.github/workflows/pulsar-ci.yaml
@@ -104,12 +104,12 @@ jobs:
           distribution: 'temurin'
           java-version: 17
 
-      - name: Check source code license headers
-        run: mvn -B -T 8 -ntp initialize apache-rat:check license:check
+      - name: Check source code license headers, style and spotbugs
+        run: mvn -B -T 8 -ntp initialize apache-rat:check license:check checkstyle:check spotbugs:check
 
       - name: Build core-modules
         run: |
-          mvn -B -T 1C -ntp -Pcore-modules,-main clean install -DskipTests -Dlicense.skip=true -Drat.skip=true
+          mvn -B -T 1C -ntp -Pcore-modules,-main clean install -DskipTests -Dlicense.skip=true -Drat.skip=true -Dcheckstyle.skip -Dspotbugs.skip
 
       - name: Check binary licenses
         run: src/check-binary-license.sh ./distribution/server/target/apache-pulsar-*-bin.tar.gz

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/cli/PerfToolTest.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/cli/PerfToolTest.java
@@ -28,8 +28,6 @@ import org.testng.Assert;
 import org.testng.annotations.Test;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
 
 public class PerfToolTest extends TopicMessagingBase {
 


### PR DESCRIPTION
### Motivation
https://github.com/apache/pulsar/pull/17750 changes don't pass checkstyle check on a non core module. CI didn't fail because we don't check checkstyle on those modules.

### Modifications

* Added checkstyle and spotbugs checks for all the modules

- [x] `doc-not-needed` 