### PR TITLE
[fix][broker] Fix create ns

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/PulsarStandalone.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/PulsarStandalone.java
@@ -25,7 +25,6 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Sets;
 import java.io.File;
 import java.nio.file.Paths;
-import java.util.Collections;
 import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.bookkeeper.conf.ServerConfiguration;
@@ -39,7 +38,6 @@ import org.apache.pulsar.common.naming.NamespaceName;
 import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.partition.PartitionedTopicMetadata;
 import org.apache.pulsar.common.policies.data.ClusterData;
-import org.apache.pulsar.common.policies.data.Policies;
 import org.apache.pulsar.common.policies.data.TenantInfo;
 import org.apache.pulsar.common.util.ShutdownUtil;
 import org.apache.pulsar.functions.instance.state.PulsarMetadataStateStoreProviderImpl;
@@ -394,9 +392,7 @@ public class PulsarStandalone implements AutoCloseable {
         }
 
         if (!nsr.namespaceExists(ns)) {
-            Policies nsp = new Policies();
-            nsp.replication_clusters = Collections.singleton(config.getClusterName());
-            nsr.createPolicies(ns, nsp);
+            broker.getAdminClient().namespaces().createNamespace(ns.toString());
         }
     }
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/PulsarStandaloneTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/PulsarStandaloneTest.java
@@ -26,6 +26,8 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import org.apache.pulsar.client.admin.Namespaces;
+import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.common.naming.NamespaceName;
 import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.broker.ServiceConfiguration;
@@ -61,12 +63,18 @@ public class PulsarStandaloneTest {
         when(resources.getTenantResources()).thenReturn(tr);
         when(resources.getNamespaceResources()).thenReturn(nsr);
 
+        Namespaces namespaces = mock(Namespaces.class);
+        doNothing().when(namespaces).createNamespace(any());
+        PulsarAdmin admin = mock(PulsarAdmin.class);
+        when(admin.namespaces()).thenReturn(namespaces);
+
         PulsarService broker = mock(PulsarService.class);
         when(broker.getPulsarResources()).thenReturn(resources);
         when(broker.getWebServiceAddress()).thenReturn("pulsar://localhost:8080");
         when(broker.getWebServiceAddressTls()).thenReturn(null);
         when(broker.getBrokerServiceUrl()).thenReturn("pulsar://localhost:6650");
         when(broker.getBrokerServiceUrlTls()).thenReturn(null);
+        when(broker.getAdminClient()).thenReturn(admin);
 
         ServiceConfiguration config = new ServiceConfiguration();
         config.setClusterName(cluster);
@@ -79,7 +87,8 @@ public class PulsarStandaloneTest {
         standalone.createNameSpace(cluster, tenant, ns);
         verify(cr, times(1)).createCluster(eq(cluster), any());
         verify(tr, times(1)).createTenant(eq(tenant), any());
-        verify(nsr, times(1)).createPolicies(eq(ns), any());
+        verify(admin, times(1)).namespaces();
+        verify(admin.namespaces(), times(1)).createNamespace(eq(ns.toString()));
     }
 
 }


### PR DESCRIPTION
### Motivation

Some namespace policy is ignored if the namespace is created directly by the `NamespaceResources`, because the conf file affects this policy.

### Modifications

- Use `admin` to create a namespace instead of the `NamespaceResources`

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)

- [x] `doc-not-needed` 
(Please explain why)

- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)

### Matching PR in forked repository

https://github.com/nodece/pulsar/pull/4
