### PR TITLE
[fix][broker] Fix system service namespace create internal event topic.

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
@@ -1595,7 +1595,8 @@ public class BrokerService implements Closeable {
                     RetentionPolicies retentionPolicies = null;
                     OffloadPoliciesImpl topicLevelOffloadPolicies = null;
 
-                    if (pulsar.getConfig().isTopicLevelPoliciesEnabled()) {
+                    if (pulsar.getConfig().isTopicLevelPoliciesEnabled()
+                            && !NamespaceService.isSystemServiceNamespace(namespace.toString())) {
                         try {
                             TopicPolicies topicPolicies = pulsar.getTopicPoliciesService().getTopicPolicies(topicName);
                             if (topicPolicies != null) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/SystemTopicBasedTopicPoliciesService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/SystemTopicBasedTopicPoliciesService.java
@@ -101,6 +101,10 @@ public class SystemTopicBasedTopicPoliciesService implements TopicPoliciesServic
 
     private CompletableFuture<Void> sendTopicPolicyEvent(TopicName topicName, ActionType actionType,
                                                          TopicPolicies policies) {
+        if (NamespaceService.isHeartbeatNamespace(topicName.getNamespaceObject())) {
+            return CompletableFuture.failedFuture(
+                    new BrokerServiceException.NotAllowedException("Not allowed to send event to health check topic"));
+        }
         CompletableFuture<Void> result = new CompletableFuture<>();
         try {
             createSystemTopicFactoryIfNeeded();

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/PulsarWebResource.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/PulsarWebResource.java
@@ -1283,7 +1283,7 @@ public abstract class PulsarWebResource {
         if (realCause instanceof WebApplicationException) {
             asyncResponse.resume(realCause);
         } else if (realCause instanceof BrokerServiceException.NotAllowedException) {
-            asyncResponse.resume(new RestException(Status.CONFLICT, realCause));
+            asyncResponse.resume(new RestException(Status.METHOD_NOT_ALLOWED, realCause));
         } else if (realCause instanceof MetadataStoreException.NotFoundException) {
             asyncResponse.resume(new RestException(Status.NOT_FOUND, realCause));
         } else if (realCause instanceof MetadataStoreException.BadVersionException) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/PulsarWebResource.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/PulsarWebResource.java
@@ -1283,7 +1283,7 @@ public abstract class PulsarWebResource {
         if (realCause instanceof WebApplicationException) {
             asyncResponse.resume(realCause);
         } else if (realCause instanceof BrokerServiceException.NotAllowedException) {
-            asyncResponse.resume(new RestException(Status.METHOD_NOT_ALLOWED, realCause));
+            asyncResponse.resume(new RestException(Status.CONFLICT, realCause));
         } else if (realCause instanceof MetadataStoreException.NotFoundException) {
             asyncResponse.resume(new RestException(Status.NOT_FOUND, realCause));
         } else if (realCause instanceof MetadataStoreException.BadVersionException) {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApi2Test.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApi2Test.java
@@ -558,7 +558,7 @@ public class AdminApi2Test extends MockedPulsarServiceBaseTest {
      * @param namespaceName
      * @throws Exception
      */
-    @Test(dataProvider = "namespaceNames", timeOut = 10000)
+    @Test(dataProvider = "namespaceNames", timeOut = 30000)
     public void testResetCursorOnPosition(String namespaceName) throws Exception {
         final String topicName = "persistent://prop-xyz/use/" + namespaceName + "/resetPosition";
         final int totalProducedMessages = 50;

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/systopic/PartitionedSystemTopicTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/systopic/PartitionedSystemTopicTest.java
@@ -196,7 +196,7 @@ public class PartitionedSystemTopicTest extends BrokerTestBase {
             pulsar.getBrokerService()
                     .getTopic(topicName.getPartition(partition).toString(), true).join();
         }
-        Assert.assertThrows(PulsarAdminException.NotAllowedException.class, () -> {
+        Assert.assertThrows(PulsarAdminException.ConflictException.class, () -> {
             admin.topicPolicies().setMaxConsumers(topicName.toString(), 2);
         });
     }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/systopic/PartitionedSystemTopicTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/systopic/PartitionedSystemTopicTest.java
@@ -38,6 +38,7 @@ import org.apache.pulsar.broker.service.BrokerTestBase;
 import org.apache.pulsar.broker.service.Topic;
 import org.apache.pulsar.broker.service.persistent.PersistentTopic;
 import org.apache.pulsar.client.admin.ListTopicsOptions;
+import org.apache.pulsar.client.admin.PulsarAdminException;
 import org.apache.pulsar.client.api.Consumer;
 import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.MessageId;
@@ -176,6 +177,32 @@ public class PartitionedSystemTopicTest extends BrokerTestBase {
         Awaitility.await().pollDelay(5, TimeUnit.SECONDS).untilAsserted(() -> {
             Assert.assertEquals(persistentTopic.getManagedLedger().getConfig().getLedgerOffloader(),
                     NullLedgerOffloader.INSTANCE);
+        });
+    }
+
+    @Test
+    public void testSystemNamespaceNotCreateChangeEventsTopic() throws Exception {
+        admin.brokers().healthcheck(TopicVersion.V2);
+        NamespaceName namespaceName = NamespaceService.getHeartbeatNamespaceV2(pulsar.getAdvertisedAddress(),
+                pulsar.getConfig());
+        TopicName topicName = TopicName.get("persistent", namespaceName, SystemTopicNames.NAMESPACE_EVENTS_LOCAL_NAME);
+        Optional<Topic> optionalTopic = pulsar.getBrokerService()
+                .getTopic(topicName.getPartition(1).toString(), false).join();
+        Assert.assertTrue(optionalTopic.isEmpty());
+    }
+
+    @Test
+    public void testHeartbeatTopicNotAllowedToSendEvent() throws Exception {
+        admin.brokers().healthcheck(TopicVersion.V2);
+        NamespaceName namespaceName = NamespaceService.getHeartbeatNamespaceV2(pulsar.getAdvertisedAddress(),
+                pulsar.getConfig());
+        TopicName topicName = TopicName.get("persistent", namespaceName, SystemTopicNames.NAMESPACE_EVENTS_LOCAL_NAME);
+        for (int partition = 0; partition < PARTITIONS; partition ++) {
+            pulsar.getBrokerService()
+                    .getTopic(topicName.getPartition(partition).toString(), true).join();
+        }
+        Assert.assertThrows(PulsarAdminException.ConflictException.class, () -> {
+            admin.topicPolicies().setMaxConsumers(topicName.toString(), 2);
         });
     }
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/systopic/PartitionedSystemTopicTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/systopic/PartitionedSystemTopicTest.java
@@ -196,7 +196,7 @@ public class PartitionedSystemTopicTest extends BrokerTestBase {
             pulsar.getBrokerService()
                     .getTopic(topicName.getPartition(partition).toString(), true).join();
         }
-        Assert.assertThrows(PulsarAdminException.ConflictException.class, () -> {
+        Assert.assertThrows(PulsarAdminException.NotAllowedException.class, () -> {
             admin.topicPolicies().setMaxConsumers(topicName.toString(), 2);
         });
     }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/systopic/PartitionedSystemTopicTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/systopic/PartitionedSystemTopicTest.java
@@ -173,11 +173,6 @@ public class PartitionedSystemTopicTest extends BrokerTestBase {
         LedgerOffloader ledgerOffloader = Mockito.mock(LedgerOffloader.class);
         config.setLedgerOffloader(ledgerOffloader);
         Assert.assertEquals(config.getLedgerOffloader(), ledgerOffloader);
-        admin.topicPolicies().setMaxConsumers(topicName.toString(), 2);
-        Awaitility.await().pollDelay(5, TimeUnit.SECONDS).untilAsserted(() -> {
-            Assert.assertEquals(persistentTopic.getManagedLedger().getConfig().getLedgerOffloader(),
-                    NullLedgerOffloader.INSTANCE);
-        });
     }
 
     @Test


### PR DESCRIPTION
### Motivation

Fix system service namespace(heartbeat namespace) creates internal `__change_events` topics:

```
2022-09-28T17:04:24,833 - INFO  - [metadata-store-12-1:ServerCnx@1474] - [/127.0.0.1:50223] Created new producer: Producer{topic=SystemTopic{topic=persistent://pulsar/localhost:50220/healthcheck}, client=/127.0.0.1:50223, producerName=test-0-0, producerId=0}
2022-09-28T17:04:24,845 - INFO  - [pulsar-io-6-3:ConsumerImpl@822] - [persistent://pulsar/localhost:50220/__change_events-partition-0][multiTopicsReader-895a02f0d4] Subscribing to topic on cnx [id: 0xc6ef1b83, L:/127.0.0.1:50223 - R:localhost/127.0.0.1:50218], consumerId 0
2022-09-28T17:04:24,848 - INFO  - [pulsar-io-6-3:ConsumerImpl@822] - [persistent://pulsar/localhost:50220/__change_events-partition-1][multiTopicsReader-895a02f0d4] Subscribing to topic on cnx [id: 0xc6ef1b83, L:/127.0.0.1:50223 - R:localhost/127.0.0.1:50218], consumerId 1
2022-09-28T17:04:24,849 - INFO  - [pulsar-io-6-3:ConsumerImpl@822] - [persistent://pulsar/localhost:50220/__change_events-partition-2][multiTopicsReader-895a02f0d4] Subscribing to topic on cnx [id: 0xc6ef1b83, L:/127.0.0.1:50223 - R:localhost/127.0.0.1:50218], consumerId 2
2022-09-28T17:04:24,853 - INFO  - [pulsar-io-6-3:ConsumerImpl@822] - [persistent://pulsar/localhost:50220/__change_events-partition-3][multiTopicsReader-895a02f0d4] Subscribing to topic on cnx [id: 0xc6ef1b83, L:/127.0.0.1:50223 - R:localhost/127.0.0.1:50218], consumerId 3
2022-09-28T17:04:24,853 - INFO  - [pulsar-io-6-3:ConsumerImpl@822] - [persistent://pulsar/localhost:50220/__change_events-partition-4][multiTopicsReader-895a02f0d4] Subscribing to topic on cnx [id: 0xc6ef1b83, L:/127.0.0.1:50223 - R:localhost/127.0.0.1:50218], consumerId 4
2022-09-28T17:04:24,856 - INFO  - [pulsar-io-6-3:ProducerImpl@1694] - [persistent://pulsar/localhost:50220/healthcheck] [test-0-0] Created producer on cnx [id: 0xc6ef1b83, L:/127.0.0.1:50223 - R:localhost/127.0.0.1:50218]
```

### Documentation

- [x] `doc-not-needed` 
(Please explain why)


### Matching PR in forked repository

PR in forked repository:  https://github.com/Technoboy-/pulsar/pull/8
