### PR TITLE
[fix][broker] Fix thread-safety issue with currentLedgerEntries and currentLedgerSize fields

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
@@ -216,8 +216,8 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
     private static final CompletableFuture<PositionImpl> NULL_OFFLOAD_PROMISE = CompletableFuture
             .completedFuture(PositionImpl.LATEST);
     protected volatile LedgerHandle currentLedger;
-    protected long currentLedgerEntries = 0;
-    protected long currentLedgerSize = 0;
+    protected volatile long currentLedgerEntries = 0;
+    protected volatile long currentLedgerSize = 0;
     protected volatile long lastLedgerCreatedTimestamp = 0;
     private volatile long lastLedgerCreationFailureTimestamp = 0;
     private long lastLedgerCreationInitiationTimestamp = 0;


### PR DESCRIPTION
### Motivation

- currentLedgerEntries and currentLedgerSize fields in the ManagedLedgerImpl class are currently mutated and read from multiple threads which is a problem.
  - one solution is to make the fields volatile

### Modifications

- make fields volatile
### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)

- [x] `doc-not-needed` 
(Please explain why)

- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)

### Matching PR in forked repository

PR in forked repository: https://github.com/lhotari/pulsar/pull/93
