### PR TITLE
[branch-2.11] Ensure JDK8 compatibilty for Pulsar java clients

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -280,6 +280,7 @@ flexible messaging model and an intuitive client API.</description>
     <lightproto-maven-plugin.version>0.4</lightproto-maven-plugin.version>
     <dependency-check-maven.version>7.1.0</dependency-check-maven.version>
     <roaringbitmap.version>0.9.15</roaringbitmap.version>
+    <extra-enforcer-rules.version>1.6.1</extra-enforcer-rules.version>
 
     <!-- Used to configure rename.netty.native. Libs -->
     <rename.netty.native.libs>rename-netty-native-libs.sh</rename.netty.native.libs>

--- a/pom.xml
+++ b/pom.xml
@@ -253,7 +253,7 @@ flexible messaging model and an intuitive client API.</description>
     <exec-maven-plugin.version>3.0.0</exec-maven-plugin.version>
     <license-maven-plugin.version>4.0.rc2</license-maven-plugin.version>
     <directory-maven-plugin.version>1.0</directory-maven-plugin.version>
-    <maven-enforcer-plugin.version>3.0.0</maven-enforcer-plugin.version>
+    <maven-enforcer-plugin.version>3.1.0</maven-enforcer-plugin.version>
     <!-- surefire.version is defined in apache parent pom -->
     <!-- it is used for surefire, failsafe and surefire-report plugins -->
     <!-- do not upgrade surefire.version to 3.0.0-M5 since it runs slowly and breaks tests. -->

--- a/pulsar-client-all/pom.xml
+++ b/pulsar-client-all/pom.xml
@@ -397,6 +397,33 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <version>${maven-enforcer-plugin.version}</version>
+        <executions>
+          <execution>
+            <id>enforce-bytecode-version</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <configuration>
+              <rules>
+                <enforceBytecodeVersion>
+                  <maxJdkVersion>1.8</maxJdkVersion>
+                </enforceBytecodeVersion>
+              </rules>
+            </configuration>
+          </execution>
+        </executions>
+        <dependencies>
+          <dependency>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>extra-enforcer-rules</artifactId>
+            <version>1.6.1</version>
+          </dependency>
+        </dependencies>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/pulsar-client-all/pom.xml
+++ b/pulsar-client-all/pom.xml
@@ -410,7 +410,7 @@
             <configuration>
               <rules>
                 <enforceBytecodeVersion>
-                  <maxJdkVersion>1.8</maxJdkVersion>
+                  <maxJdkVersion>${pulsar.client.compiler.release}</maxJdkVersion>
                 </enforceBytecodeVersion>
               </rules>
             </configuration>
@@ -420,7 +420,7 @@
           <dependency>
             <groupId>org.codehaus.mojo</groupId>
             <artifactId>extra-enforcer-rules</artifactId>
-            <version>1.6.1</version>
+            <version>${extra-enforcer-rules.version}</version>
           </dependency>
         </dependencies>
       </plugin>

--- a/pulsar-package-management/core/pom.xml
+++ b/pulsar-package-management/core/pom.xml
@@ -53,6 +53,14 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <!-- This module is distributed with the Pulsar Admin Client -->
+                    <release>${pulsar.client.compiler.release}</release>
+                </configuration>
+            </plugin>
+            <plugin>
                 <groupId>com.github.spotbugs</groupId>
                 <artifactId>spotbugs-maven-plugin</artifactId>
                 <configuration>


### PR DESCRIPTION
### Motivation

`pulsar-package-core` module is built with the maven compiler release flag equals to 17. However this module is used by the `pulsar-client-admin-original` module and we need to ensure binary compatibility to JDK8 for all the java client artifacts.
See more context here https://github.com/apache/pulsar/pull/17855

I did a simple test simulating an upgrade to Pulsar 2.11.0 in a JDK8 java application, like this

```
public static void main(String[] args) throws Exception {
        @Cleanup
        final PulsarAdmin admin = PulsarAdmin.builder()
                .serviceHttpUrl("http://localhost:8080")
                .build();
        final PackageMetadata mypackage = admin.packages().getMetadata("mypackage");

    }
```

and I got this error

```
java.lang.UnsupportedClassVersionError: org/apache/pulsar/packages/management/core/common/PackageName has been compiled by a more recent version of the Java Runtime (class file version 61.0), this version of the Java Runtime only recognizes class file versions up to 52.0
    at java.lang.ClassLoader.defineClass1 (Native Method)
    at java.lang.ClassLoader.defineClass (ClassLoader.java:757)
    at java.security.SecureClassLoader.defineClass (SecureClassLoader.java:142)
    at java.net.URLClassLoader.defineClass (URLClassLoader.java:473)
    at java.net.URLClassLoader.access$100 (URLClassLoader.java:74)
    at java.net.URLClassLoader$1.run (URLClassLoader.java:369)
    at java.net.URLClassLoader$1.run (URLClassLoader.java:363)
    at java.security.AccessController.doPrivileged (Native Method)
    at java.net.URLClassLoader.findClass (URLClassLoader.java:362)
    at java.lang.ClassLoader.loadClass (ClassLoader.java:419)
    at java.lang.ClassLoader.loadClass (ClassLoader.java:352)
    at org.apache.pulsar.client.admin.internal.PackagesImpl.getMetadataAsync (PackagesImpl.java:69)
    at org.apache.pulsar.client.admin.internal.PackagesImpl.lambda$getMetadata$0 (PackagesImpl.java:64)
    at org.apache.pulsar.client.admin.internal.BaseResource.sync (BaseResource.java:292)
    at org.apache.pulsar.client.admin.internal.PackagesImpl.getMetadata (PackagesImpl.java:64)
    at com.nicoloboschi.MainClient.main (MainClient.java:26)
 ```

### Modifications
- Set the release flag to 8 for the packages-core module
- Added the enforcer to the pulsar-client-all module to verify binary compatibility to jdk8

- [x] `doc-not-needed` 
