### PR TITLE
[fix][flaky-test]ProxyConnectionThrottlingTest.testInboundConnection

### DIFF
--- a/pulsar-proxy/pom.xml
+++ b/pulsar-proxy/pom.xml
@@ -160,6 +160,12 @@
     </dependency>
 
     <dependency>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>com.beust</groupId>
       <artifactId>jcommander</artifactId>
     </dependency>

--- a/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyConnectionThrottlingTest.java
+++ b/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyConnectionThrottlingTest.java
@@ -32,6 +32,7 @@ import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.common.configuration.PulsarConfigurationLoader;
 import org.apache.pulsar.metadata.impl.ZKMetadataStore;
+import org.awaitility.Awaitility;
 import org.mockito.Mockito;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
@@ -108,7 +109,9 @@ public class ProxyConnectionThrottlingTest extends MockedPulsarServiceBaseTest {
         } catch (Exception ex) {
             // OK
         }
-        Assert.assertEquals(ConnectionController.DefaultConnectionController.getTotalConnectionNum(), 4);
+        Awaitility.await().untilAsserted(() ->{
+            Assert.assertEquals(ConnectionController.DefaultConnectionController.getTotalConnectionNum(), 4);
+        });
         Assert.assertEquals(ConnectionController.DefaultConnectionController.getConnections().size(), 1);
         Set<String> keys = ConnectionController.DefaultConnectionController.getConnections().keySet();
         for (String key : keys) {
@@ -119,7 +122,9 @@ public class ProxyConnectionThrottlingTest extends MockedPulsarServiceBaseTest {
 
         client1.close();
 
-        Assert.assertEquals(ConnectionController.DefaultConnectionController.getTotalConnectionNum(), 2);
+        Awaitility.await().untilAsserted(() ->{
+            Assert.assertEquals(ConnectionController.DefaultConnectionController.getTotalConnectionNum(), 2);
+        });
         Assert.assertEquals(ConnectionController.DefaultConnectionController.getConnections().size(), 1);
         keys = ConnectionController.DefaultConnectionController.getConnections().keySet();
         for (String key : keys) {
@@ -129,8 +134,9 @@ public class ProxyConnectionThrottlingTest extends MockedPulsarServiceBaseTest {
         Assert.assertEquals(ProxyService.ACTIVE_CONNECTIONS.get(), 2.0d);
 
         client2.close();
-
-        Assert.assertEquals(ConnectionController.DefaultConnectionController.getTotalConnectionNum(), 0);
+        Awaitility.await().untilAsserted(() ->{
+            Assert.assertEquals(ConnectionController.DefaultConnectionController.getTotalConnectionNum(), 0);
+        });
         Assert.assertEquals(ConnectionController.DefaultConnectionController.getConnections().size(), 0);
         Assert.assertEquals(ProxyService.ACTIVE_CONNECTIONS.get(), 0.0d);
     }


### PR DESCRIPTION
Fixes:

- #17665

### Motivation
this test is executed as follows: 

1. set max connection limited 4
2. create two clients and two producers, this will create 4 connections 
3. try to create another client and producer, this will fail cause of reaches the max connections count limit

But the execution logic of `step-3` is like this:

1. increment `DefaultConnectionController.totalConnectionNum`
2. if the state `State.REACH_MAX_CONNECTION_PER_IP` founded, do close connection which will decrement `DefaultConnectionController.totalConnectionNum`

Then the problem is that the connection closes was executed asynchronously(see code below), if the main thread executes fast enough, the assert `Assert.assertEquals(ConnectionController.DefaultConnectionController.getTotalConnectionNum(), 4)` will fail, because the last connection has not close finish.

https://github.com/apache/pulsar/blob/bde5ac7fa0ec438430b5fb1912a74bcef0d73445/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/ProxyConnection.java#L153-L165

### Modifications

Change the assertion logic to executed using `Awaitility`

### Documentation

- [x] `doc-not-needed` 

### Matching PR in forked repository

PR in forked repository: 
- https://github.com/poorbarcode/pulsar/pull/17
