### PR TITLE
[improve][broker]add active status into cursor stats

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
@@ -4116,6 +4116,7 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
             cs.individuallyDeletedMessages = cursor.getIndividuallyDeletedMessages();
             cs.lastLedgerSwitchTimestamp = DateFormatter.format(cursor.getLastLedgerSwitchTimestamp());
             cs.state = cursor.getState();
+            cs.active = cursor.isActive();
             cs.numberOfEntriesSinceFirstNotAckedMessage = cursor.getNumberOfEntriesSinceFirstNotAckedMessage();
             cs.totalNonContiguousDeletedMessagesRange = cursor.getTotalNonContiguousDeletedMessagesRange();
             cs.properties = cursor.getProperties();

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -2210,6 +2210,7 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
             cs.individuallyDeletedMessages = cursor.getIndividuallyDeletedMessages();
             cs.lastLedgerSwitchTimestamp = DateFormatter.format(cursor.getLastLedgerSwitchTimestamp());
             cs.state = cursor.getState();
+            cs.active = cursor.isActive();
             cs.numberOfEntriesSinceFirstNotAckedMessage = cursor.getNumberOfEntriesSinceFirstNotAckedMessage();
             cs.totalNonContiguousDeletedMessagesRange = cursor.getTotalNonContiguousDeletedMessagesRange();
             cs.properties = cursor.getProperties();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/stats/client/PulsarBrokerStatsClientTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/stats/client/PulsarBrokerStatsClientTest.java
@@ -135,6 +135,7 @@ public class PulsarBrokerStatsClientTest extends ProducerConsumerBase {
                 && (cursor.totalNonContiguousDeletedMessagesRange) < numberOfMsgs / 2);
         assertFalse(cursor.subscriptionHavePendingRead);
         assertFalse(cursor.subscriptionHavePendingReplayRead);
+        assertTrue(cursor.active);
         producer.close();
         consumer.close();
         log.info("-- Exiting {} test --", methodName);

--- a/pulsar-client-admin-api/src/main/java/org/apache/pulsar/common/policies/data/ManagedLedgerInternalStats.java
+++ b/pulsar-client-admin-api/src/main/java/org/apache/pulsar/common/policies/data/ManagedLedgerInternalStats.java
@@ -94,6 +94,7 @@ public class ManagedLedgerInternalStats {
         public String individuallyDeletedMessages;
         public String lastLedgerSwitchTimestamp;
         public String state;
+        public boolean active;
         public long numberOfEntriesSinceFirstNotAckedMessage;
         public int totalNonContiguousDeletedMessagesRange;
         public boolean subscriptionHavePendingRead;


### PR DESCRIPTION
### Motivation
The active state indicates whether a cursor is active. And it affects the cache hit rate, because inactive cursors will be evicted from the entry cache. This active state helps to troubleshoot issues with low cache hit rate.
Also it is meaningful for configuring a suitable values for `managedLedgerCursorBackloggedThreshold` in `ServiceConfiguration`

```
# Configure the threshold (in number of entries) from where a cursor should be considered 'backlogged'
# and thus should be set as inactive.
managedLedgerCursorBackloggedThreshold=1000
```

### Modifications
Add active status into cursor stats.
It will get the following sample data when getting the `internalStats` of a partitioned topic.

```
{
    "entriesAddedCounter": 6,
    "numberOfEntries": 10302152,
    "totalSize": 63786554161,
    "currentLedgerEntries": 6,
    "currentLedgerSize": 31182,
    "lastLedgerCreatedTimestamp": "2022-09-29T14:48:52.825+08:00",
    "waitingCursorsCount": 0,
    "pendingAddEntriesCount": 0,
    "lastConfirmedEntry": "1359228:5",
    "lastIndex": 1165055506,
    "state": "LedgerOpened",
    "ledgers": [
        {
            "ledgerId": 1356881,
            "entries": 50000,
            "size": 309705120,
            "offloaded": false,
            "underReplicated": false
        }
    ],
    "cursors": {
        "cg_test_map_cache1": {
            "markDeletePosition": "1356881:3399",
            "readPosition": "1356881:3400",
            "waitingReadOp": false,
            "pendingReadOps": 0,
            "messagesConsumedCounter": -10298746,
            "cursorLedger": -1,
            "cursorLedgerLastEntry": -1,
            "individuallyDeletedMessages": "[]",
            "lastLedgerSwitchTimestamp": "2022-09-29T14:48:52.859+08:00",
            "state": "NoLedger",
            "numberOfEntriesSinceFirstNotAckedMessage": 1,
            "totalNonContiguousDeletedMessagesRange": 0,
            "subscriptionHavePendingRead": false,
            "subscriptionHavePendingReplayRead": false,
            "active": false,
            "properties": {
                "index": 846056487
            }
        },
        "cg_test_map_cache2": {
            "markDeletePosition": "1359208:79",
            "readPosition": "1359228:6",
            "waitingReadOp": false,
            "pendingReadOps": 0,
            "messagesConsumedCounter": -8,
            "cursorLedger": 1359234,
            "cursorLedgerLastEntry": 1,
            "individuallyDeletedMessages": "[]",
            "lastLedgerSwitchTimestamp": "2022-09-29T14:48:52.859+08:00",
            "state": "Open",
            "numberOfEntriesSinceFirstNotAckedMessage": 15,
            "totalNonContiguousDeletedMessagesRange": 0,
            "subscriptionHavePendingRead": false,
            "subscriptionHavePendingReplayRead": false,
            "active": true,
            "properties": {
                "index": 1165055008
            }
        }
    },
    "schemaLedgers": [],
    "compactedLedger": {
        "ledgerId": -1,
        "entries": -1,
        "size": -1,
        "offloaded": false,
        "underReplicated": false
    }
}
```

### Verifying this change

- [x]  Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.
### Does this pull request potentially affect one of the following parts:

If `yes` was chosen, please highlight the changes

- Dependencies (does it add or upgrade a dependency): (no)
- The public API: (no)
- The schema: (no)
- The default values of configurations: (no)
- The wire protocol: (no)
- The rest endpoints: (no)
- The admin cli options: (no)
- Anything that affects deployment: (no)

### Documentation

Check the box below or label this PR directly.

Need to update docs?

- [ ] `doc-required`
- [x] `doc-not-needed`
- [ ] `doc` 
- [ ] `doc-complete`

### Matching PR in forked repository

PR in forked repository: https://github.com/HQebupt/pulsar/pull/1