### PR TITLE
[fix][storage] Fix port conflict in bookkeeper.conf

### DIFF
--- a/conf/bookkeeper.conf
+++ b/conf/bookkeeper.conf
@@ -572,7 +572,7 @@ compactionRateByBytes=1000000
 statsProviderClass=org.apache.bookkeeper.stats.prometheus.PrometheusMetricsProvider
 
 # Default port for Prometheus metrics exporter
-prometheusStatsHttpPort=8001
+prometheusStatsHttpPort=8000
 
 #############################################################################
 ## Read-only mode support
@@ -694,7 +694,7 @@ httpServerEnabled=false
 
 # The http server port to listen on. Default value is 8080.
 # Use `8000` as the port to keep it consistent with prometheus stats provider
-httpServerPort=8000
+httpServerPort=8001
 
 # The http server class
 httpServerClass=org.apache.bookkeeper.http.vertx.VertxHttpServer

--- a/conf/bookkeeper.conf
+++ b/conf/bookkeeper.conf
@@ -572,7 +572,7 @@ compactionRateByBytes=1000000
 statsProviderClass=org.apache.bookkeeper.stats.prometheus.PrometheusMetricsProvider
 
 # Default port for Prometheus metrics exporter
-prometheusStatsHttpPort=8000
+prometheusStatsHttpPort=8001
 
 #############################################################################
 ## Read-only mode support


### PR DESCRIPTION
### Motivation
`prometheusStatsHttpPort=8000` in the `bookkeeper.conf`
and` metricsProvider.httpPort=8000` in the `zookeeper.conf`, there will be a port conflict when deploying a cluster.

### Modification
Change the prometheusStatsHttpPort=8001

### Reproduce
1. modify the configuration in `broker.conf`

> metadataStoreUrl=127.0.0.1:2181
clusterName=cluster-a
managedLedgerDefaultEnsembleSize=1
managedLedgerDefaultWriteQuorum=1
managedLedgerDefaultAckQuorum=1

2. start zookeeper
```shell
bin/pulsar zookeeper.
```
3. init the cluster metadata
```shell
 bin/pulsar initialize-cluster-metadata \
          --cluster cluster-a \
          --zookeeper 127.0.0.1:2181 \
          --configuration-store 127.0.0.1:2181 \
          --web-service-url http://127.0.0.1:8080 \
          --broker-service-url pulsar://127.0.0.1:6650 \
```
4. start broker
```shell
bin/pulsar broker
```
5. start bookie
```shell
bin/pulsar bookie
``` 

## Screenshot
<img width="1523" alt="image" src="https://user-images.githubusercontent.com/55571188/195774124-1b470b88-7575-4de6-869c-39d75bde251d.png">

### Documentation


- [x] `doc-not-needed` 
