### PR TITLE
[fix][loadbalance] Fix the wrong NIC speed rate unit.

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/LinuxInfoUtils.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/LinuxInfoUtils.java
@@ -177,7 +177,7 @@ public class LinuxInfoUtils {
                 log.error("[LinuxInfo] Failed to get total nic limit.", e);
                 return 0d;
             }
-        }).sum(), BitRateUnit.Bit);
+        }).sum(), BitRateUnit.Megabit);
     }
 
     /**


### PR DESCRIPTION
Fixes #17885

Master Issue: #17885

### Motivation

See #17885, And I checked other usages.

### Modifications

- Change rate unit to Mbit.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)

- [x] `doc-not-needed` 
(Please explain why)

- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)

### Matching PR in forked repository

PR in forked repository: 
