### PR TITLE
[improve][fn] Run connectors extraction in parallel

### DIFF
--- a/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/io/ConnectorUtils.java
+++ b/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/io/ConnectorUtils.java
@@ -160,15 +160,13 @@ public class ConnectorUtils {
                 archives.add(archive);
             }
         }
-
         if (archives.isEmpty()) {
-            log.warn("Connectors archive directory is empty");
             return new TreeMap<>();
         }
 
         ExecutorService oneTimeExecutor = null;
         try {
-            int nThreads = Math.min(4, archives.size());
+            int nThreads = Math.min(Runtime.getRuntime().availableProcessors(), archives.size());
             log.info("Loading {} connector definitions with a thread pool of size {}", archives.size(), nThreads);
             oneTimeExecutor = Executors.newFixedThreadPool(nThreads,
                     new ThreadFactoryBuilder().setNameFormat("search-connectors-executor-%d").build());

--- a/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/io/ConnectorUtils.java
+++ b/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/io/ConnectorUtils.java
@@ -169,7 +169,7 @@ public class ConnectorUtils {
             int nThreads = Math.min(Runtime.getRuntime().availableProcessors(), archives.size());
             log.info("Loading {} connector definitions with a thread pool of size {}", archives.size(), nThreads);
             oneTimeExecutor = Executors.newFixedThreadPool(nThreads,
-                    new ThreadFactoryBuilder().setNameFormat("search-connectors-executor-%d").build());
+                    new ThreadFactoryBuilder().setNameFormat("connector-extraction-executor-%d").build());
             List<CompletableFuture<Map.Entry<String, Connector>>> futures = new ArrayList<>();
             for (Path archive : archives) {
                 CompletableFuture future = CompletableFuture.supplyAsync(() ->


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://docs.google.com/document/d/1d8Pw6ZbWk-_pCKdOmdvx9rnhPiyuxwq60_TrD68d7BA/edit#heading=h.trs9rsex3xom)*. 

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->

### Motivation

Improve functions worker bootstrap time with increased number of connectors. Currently all nar files are unpacked during startup to perform validation steps (e.g. if the connector class implements the correct interfaces). For that, the NarClassLoader will unpack all nars to disk sequentially which could delay startup.

On my Machine (Mac M1) I observed an improvement of ~ 3X (from 48 seconds down to 15 seconds). I know the max number of chosen threads (4) is a magic number (I have not seen improvements beyond that number), but if this is the right approach and it is worth it, we can make this number configurable (need guidance on the right config place)

Sample output:
```
2022-09-30T01:22:13,778+0000 [main] INFO  org.apache.pulsar.functions.utils.io.ConnectorUtils - Searching for connectors in /pulsar/./connectors
2022-09-30T01:22:13,779+0000 [main] INFO  org.apache.pulsar.functions.utils.io.ConnectorUtils - Loading 58 connector definitions with a thread pool of size 4
2022-09-30T01:22:13,781+0000 [search-connectors-executor-0] INFO  org.apache.pulsar.common.nar.NarUnpacker - Created directory /tmp/pulsar-nar/pulsar-io-debezium-mssql-2.10.1.8-SNAPSHOT.nar-unpacked
2022-09-30T01:22:13,781+0000 [search-connectors-executor-1] INFO  org.apache.pulsar.common.nar.NarUnpacker - Created directory /tmp/pulsar-nar/pulsar-snowflake-connector-0.1.10.nar-unpacked
2022-09-30T01:22:13,781+0000 [search-connectors-executor-2] INFO  org.apache.pulsar.common.nar.NarUnpacker - Created directory /tmp/pulsar-nar/pulsar-io-mongo-2.10.1.8-SNAPSHOT.nar-unpacked
2022-09-30T01:22:13,784+0000 [search-connectors-executor-3] INFO  org.apache.pulsar.common.nar.NarUnpacker - Created directory /tmp/pulsar-nar/pulsar-io-kinesis-2.10.1.8-SNAPSHOT.nar-unpacked
2022-09-30T01:22:13,895+0000 [search-connectors-executor-2] INFO  org.apache.pulsar.common.nar.NarUnpacker - Extracting /pulsar/./connectors/pulsar-io-mongo-2.10.1.8-SNAPSHOT.nar to /tmp/pulsar-nar/pulsar-io-mongo-2.10.1.8-SNAPSHOT.nar-unpacked/gs7wF7XmmgT1MjvpwSxFfA
```

### Modifications

Just run the connectors search function (which unpacks the nars) in parallel via a CachedThreadPool.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change is already covered by existing tests, such as the unit tests under PulsarFunctionLocalRunTest already covers this path. Also CI for each existing connector will cover the change

### Does this pull request potentially affect one of the following parts:

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)

- [x] `doc-not-needed` 
(Please explain why)

- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)

### Matching PR in forked repository

PR in forked repository: (https://github.com/aymkhalil/pulsar/pull/2)

After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.

-->
