### PR TITLE
[cleanup][broker] remove unused method getTotalServiceUnitsLoaded

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/NamespaceService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/NamespaceService.java
@@ -1012,10 +1012,6 @@ public class NamespaceService implements AutoCloseable {
         return ownershipCache;
     }
 
-    public int getTotalServiceUnitsLoaded() {
-        return ownershipCache.getOwnedBundles().size() - this.uncountedNamespaces;
-    }
-
     public Set<NamespaceBundle> getOwnedServiceUnits() {
         return ownershipCache.getOwnedBundles().values().stream().map(OwnedBundle::getNamespaceBundle)
                 .collect(Collectors.toSet());


### PR DESCRIPTION
### Motivation
remove unused method getTotalServiceUnitsLoaded.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)

- [x] `doc-not-needed` 
(Please explain why)

- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)

### Matching PR in forked repository

PR in forked repository: 

[[run-tests][clean][broker] remove unused method getTotalServiceUnitsLoaded ](https://github.com/lordcheng10/pulsar/pull/21) 

