### PR TITLE
[fix][client] When the compressed message size exceeds maxMessageSize, the information in the InvalidMessageException may be incorrect

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
@@ -459,9 +459,7 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
             int compressedSize = compressedPayload.readableBytes();
             if (compressedSize > ClientCnx.getMaxMessageSize() && !this.conf.isChunkingEnabled()) {
                 compressedPayload.release();
-                String compressedStr = (!isBatchMessagingEnabled() && conf.getCompressionType() != CompressionType.NONE)
-                                           ? "Compressed"
-                                           : "";
+                String compressedStr = conf.getCompressionType() != CompressionType.NONE ? "Compressed" : "";
                 PulsarClientException.InvalidMessageException invalidMessageException =
                         new PulsarClientException.InvalidMessageException(
                                 format("The producer %s of the topic %s sends a %s message with %d bytes that exceeds"


### PR DESCRIPTION
### Motivation
When the compressed message size exceeds maxMessageSize, the information in the InvalidMessageException may be incorrect.

When the following conditions are met, the message data will be compressed, the string variable compressedStr should be assigned the value "Compressed", but the variable is assigned the empty string:

```
1. isBatchMessagingEnabled() return true;
2. msgMetadata.hasDeliverAtTime() return true;
3. compressedSize > ClientCnx.getMaxMessageSize() is true
4. conf.getCompressionType() != CompressionType.NONE is true;
```

https://github.com/apache/pulsar/blob/9ff9703d740eb8151b8cf2eb1e7faf074e9cf3c7/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java#L454-L473


We should remove the !isBatchMessagingEnabled() condition when the compressedStr is calculated:
 ` String compressedStr = (!isBatchMessagingEnabled() && conf.getCompressionType() != CompressionType.NONE)
`

Modified to:

` String compressedStr = conf.getCompressionType() != CompressionType.NONE)
`

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)

- [x] `doc-not-needed` 
(Please explain why)

- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)

### Matching PR in forked repository

PR in forked repository: https://github.com/lordcheng10/pulsar/pull/23
