### PR TITLE
[fix][py] Correct configuration of pattern discovery period

### DIFF
--- a/pulsar-client-cpp/python/pulsar/__init__.py
+++ b/pulsar-client-cpp/python/pulsar/__init__.py
@@ -745,6 +745,7 @@ class Client:
         conf = _pulsar.ConsumerConfiguration()
         conf.consumer_type(consumer_type)
         conf.read_compacted(is_read_compacted)
+        conf.pattern_auto_discovery_period(pattern_auto_discovery_period)
         if message_listener:
             conf.message_listener(_listener_wrapper(message_listener, schema))
         conf.receiver_queue_size(receiver_queue_size)


### PR DESCRIPTION
### Motivation

Currently, the `pattern_auto_discovery_period` for topic pattern consumers is fixed to 60 seconds, no matter what is passed into the `subscribe` function. This is a fix for that bug.

### Modifications

Pattern discovery period configuration is now passed through correctly from the `subscribe` function.
New test to exercise pattern discovery.
Removed misleading configuration in other test which does not use automated pattern discovery.
Made log level configurable in test file with environment variable.

If the changes are ok, I can backport these changes to earlier branches - we use v2.9 currently so I have a specific requirement for that version. I can also open a PR against the new v3 repository if required.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

  - A new integration test for the Python client library has been added
  - An existing test was slightly changed to remove misleading comments

### Does this pull request potentially affect one of the following parts:

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)

- [x] `doc-not-needed` 
Documentation now matches behaviour described for the `pattern_auto_discovery_period` option.

- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)

### Matching PR in forked repository

PR in forked repository: 
[Successful manual run of CI job in forked repository](https://github.com/PassFort/pulsar/actions/runs/3174910892)
