### PR TITLE
Make BookieId work with PulsarRegistrationDriver (second take)

### DIFF
--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/bookkeeper/BookieServiceInfoSerde.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/bookkeeper/BookieServiceInfoSerde.java
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.bookkeeper.discover.BookieServiceInfo;
+import org.apache.bookkeeper.discover.BookieServiceInfoUtils;
 import org.apache.bookkeeper.proto.DataFormats.BookieServiceInfoFormat;
 import org.apache.pulsar.metadata.api.MetadataSerde;
 import org.apache.pulsar.metadata.api.Stat;
@@ -63,7 +64,57 @@ public class BookieServiceInfoSerde implements MetadataSerde<BookieServiceInfo> 
     }
 
     @Override
-    public BookieServiceInfo deserialize(String path, byte[] content, Stat stat) throws IOException {
-        return null;
+    public BookieServiceInfo deserialize(String path, byte[] bookieServiceInfo, Stat stat) throws IOException {
+        // see https://github.com/apache/bookkeeper/blob/
+        // 034ef8566ad037937a4d58a28f70631175744f53/bookkeeper-server/
+        // src/main/java/org/apache/bookkeeper/discover/ZKRegistrationClient.java#L311
+        String bookieId = extractBookiedIdFromPath(path);
+        if (bookieServiceInfo == null || bookieServiceInfo.length == 0) {
+            return BookieServiceInfoUtils.buildLegacyBookieServiceInfo(bookieId);
+        }
+
+        BookieServiceInfoFormat builder = BookieServiceInfoFormat.parseFrom(bookieServiceInfo);
+        BookieServiceInfo bsi = new BookieServiceInfo();
+        List<BookieServiceInfo.Endpoint> endpoints = builder.getEndpointsList().stream()
+                .map(e -> {
+                    BookieServiceInfo.Endpoint endpoint = new BookieServiceInfo.Endpoint();
+                    endpoint.setId(e.getId());
+                    endpoint.setPort(e.getPort());
+                    endpoint.setHost(e.getHost());
+                    endpoint.setProtocol(e.getProtocol());
+                    endpoint.setAuth(e.getAuthList());
+                    endpoint.setExtensions(e.getExtensionsList());
+                    return endpoint;
+                })
+                .collect(Collectors.toList());
+
+        bsi.setEndpoints(endpoints);
+        bsi.setProperties(builder.getPropertiesMap());
+
+        return bsi;
+
+    }
+
+    /**
+     * Extract the BookieId
+     * The path should look like /ledgers/available/bookieId
+     * or /ledgers/available/readonly/bookieId.
+     * But the prefix depends on the configuration.
+     * @param path
+     * @return the bookieId
+     */
+    private static String extractBookiedIdFromPath(String path) throws IOException {
+        // https://github.com/apache/bookkeeper/blob/
+        // 034ef8566ad037937a4d58a28f70631175744f53/bookkeeper-server/
+        // src/main/java/org/apache/bookkeeper/discover/ZKRegistrationClient.java#L258
+        if (path == null) {
+            path = "";
+        }
+        int last = path.lastIndexOf("/");
+        if (last >= 0) {
+            return path.substring(last + 1);
+        } else {
+            throw new IOException("The path " + path + " doesn't look like a valid path for a BookieServiceInfo node");
+        }
     }
 }

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/bookkeeper/PulsarRegistrationClient.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/bookkeeper/PulsarRegistrationClient.java
@@ -25,15 +25,21 @@ import io.netty.util.concurrent.DefaultThreadFactory;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
+import org.apache.bookkeeper.client.BKException;
+import org.apache.bookkeeper.discover.BookieServiceInfo;
 import org.apache.bookkeeper.discover.RegistrationClient;
 import org.apache.bookkeeper.net.BookieId;
+import org.apache.bookkeeper.versioning.LongVersion;
 import org.apache.bookkeeper.versioning.Version;
 import org.apache.bookkeeper.versioning.Versioned;
+import org.apache.pulsar.metadata.api.MetadataCache;
 import org.apache.pulsar.metadata.api.MetadataStore;
 import org.apache.pulsar.metadata.api.Notification;
 import org.apache.pulsar.metadata.api.NotificationType;
@@ -49,12 +55,14 @@ public class PulsarRegistrationClient implements RegistrationClient {
 
     private final Map<RegistrationListener, Boolean> writableBookiesWatchers = new ConcurrentHashMap<>();
     private final Map<RegistrationListener, Boolean> readOnlyBookiesWatchers = new ConcurrentHashMap<>();
+    private final MetadataCache<BookieServiceInfo> bookieServiceInfoMetadataCache;
     private final ScheduledExecutorService executor;
 
     public PulsarRegistrationClient(MetadataStore store,
                                     String ledgersRootPath) {
         this.store = store;
         this.ledgersRootPath = ledgersRootPath;
+        this.bookieServiceInfoMetadataCache = store.getMetadataCache(BookieServiceInfoSerde.INSTANCE);
 
         // Following Bookie Network Address Changes is an expensive operation
         // as it requires additional ZooKeeper watches
@@ -152,5 +160,33 @@ public class PulsarRegistrationClient implements RegistrationClient {
             newBookieAddrs.add(bookieAddr);
         }
         return newBookieAddrs;
+    }
+
+    @Override
+    public CompletableFuture<Versioned<BookieServiceInfo>> getBookieServiceInfo(BookieId bookieId) {
+        String asWritable = bookieRegistrationPath + "/" + bookieId;
+
+        return bookieServiceInfoMetadataCache.get(asWritable)
+                .thenCompose((Optional<BookieServiceInfo> getResult) -> {
+                    if (getResult.isPresent()) {
+                        return CompletableFuture.completedFuture(new Versioned<>(getResult.get(),
+                                    new LongVersion(-1)));
+                    } else {
+                        return readBookieInfoAsReadonlyBookie(bookieId);
+                    }
+                }
+        );
+    }
+
+    final CompletableFuture<Versioned<BookieServiceInfo>> readBookieInfoAsReadonlyBookie(BookieId bookieId) {
+        String asReadonly = bookieReadonlyRegistrationPath + "/" + bookieId;
+        return bookieServiceInfoMetadataCache.get(asReadonly)
+                .thenApply((Optional<BookieServiceInfo> getResultAsReadOnly) -> {
+                    if (getResultAsReadOnly.isPresent()) {
+                        return new Versioned<>(getResultAsReadOnly.get(), new LongVersion(-1));
+                    } else {
+                        throw new CompletionException(new BKException.BKBookieHandleNotAvailableException());
+                    }
+                });
     }
 }

--- a/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/bookkeeper/PulsarRegistrationClientTest.java
+++ b/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/bookkeeper/PulsarRegistrationClientTest.java
@@ -149,6 +149,9 @@ public class PulsarRegistrationClientTest extends BaseMetadataStoreTest {
             rm.registerBookie(address, readOnly, info);
         }
 
+        // trigger loading the BookieServiceInfo in the local cache
+        rc.getAllBookies().join();
+
         int i = 0;
         for (BookieId address : addresses) {
             BookieServiceInfo bookieServiceInfo = rc.getBookieServiceInfo(address).get().getValue();


### PR DESCRIPTION
### Motivation

In Pulsar 2.10 the custom "BookieId" feature doesn't work anymore because in PulsarRegistrationDriver we are not implementing `getBookieServiceInfo`

This patch also partially resolves https://github.com/apache/pulsar/issues/17759

### Modifications

Implement `getBookieServiceInfo`
This is a new version of https://github.com/apache/pulsar/pull/17762.

The main difference is the additional commit, in which we mimic the original code in BookKeeper
see https://github.com/apache/bookkeeper/blob/034ef8566ad037937a4d58a28f70631175744f53/bookkeeper-server/src/main/java/org/apache/bookkeeper/discover/ZKRegistrationClient.java#L183

We cannot perform reads from the MetadataStore in `getBookieServiceInfo` because it is very likely that 
something will wait for the results of the returned CompletableFuture in a metadata store thread.
So we introduce a cache that is updated when the client scans the list of Bookies.

This works well in the original ZKRegistrationClient because the BookKeeper Client always looks for the available bookies
and this triggers the preloading of the local cache.

When we will upgrade to BK 4.15.1+ users will be able to leverage BP-41 flag to turn off BookKeeper Server address resolver
https://github.com/apache/bookkeeper/pull/3356


### Verifying this change

This change added tests

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)

- [x] `doc-not-needed` 
(Please explain why)

- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)

### Matching PR in forked repository

PR in forked repository:https://github.com/eolivelli/pulsar/pull/17


