### PR TITLE
[fix][ci] succeed only if all needs pass

### DIFF
--- a/.github/workflows/pulsar-ci.yaml
+++ b/.github/workflows/pulsar-ci.yaml
@@ -950,14 +950,12 @@ jobs:
       - name: Check that all required jobs were completed successfully
         if: ${{ needs.changed_files_job.outputs.docs_only != 'true' }}
         run: |
-          if [[ ! ( ( \
+          if [[ ! ( \
                    "${{ needs.unit-tests.result }}" == "success" \
                 && "${{ needs.integration-tests.result }}" == "success" \
                 && "${{ needs.system-tests.result }}" == "success" \
                 && "${{ needs.macos-build.result }}" == "success" \
-               ) || ( \
-                   "${{ needs.system-tests.result }}" == "success" \
-               ) ) ]]; then
+               ) ]]; then
             echo "Required jobs haven't been completed successfully."
             exit 1            
           fi


### PR DESCRIPTION
This OR logic has been introduced by https://github.com/apache/pulsar/pull/17614.

I don't know why it's added in the first place - we shouldn't have an OR here. But anyway since pulsar-client-cpp moved out, it should be reasonable to fix the workflow.

Otherwise, if system tests passed but other tests failed or canceled, the required status can still pass.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)

- [x] `doc-not-needed` 
(Please explain why)

- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)

### Matching PR in forked repository

PR in forked repository: 