### PR TITLE
[fix][ci] CI: fix required jobs check

### DIFF
--- a/.github/workflows/pulsar-ci.yaml
+++ b/.github/workflows/pulsar-ci.yaml
@@ -950,14 +950,12 @@ jobs:
       - name: Check that all required jobs were completed successfully
         if: ${{ needs.changed_files_job.outputs.docs_only != 'true' }}
         run: |
-          if [[ ! ( ( \
+          if [[ ! ( \
                    "${{ needs.unit-tests.result }}" == "success" \
                 && "${{ needs.integration-tests.result }}" == "success" \
                 && "${{ needs.system-tests.result }}" == "success" \
                 && "${{ needs.macos-build.result }}" == "success" \
-               ) || ( \
-                   "${{ needs.system-tests.result }}" == "success" \
-               ) ) ]]; then
+               ) ]]; then
             echo "Required jobs haven't been completed successfully."
             exit 1            
           fi


### PR DESCRIPTION
### Motivation

After https://github.com/apache/pulsar/pull/17881 the "CI checks completed" job only verify the system-tests, bypassing all the other tests. Diff https://github.com/apache/pulsar/pull/17881/files#diff-069360707fedfc682947effc8f7fac874fa378ec5c70abec25f88939c87379d3R959

I noticed it in https://github.com/apache/pulsar/pull/17915
![Screen Shot 2022-10-04 at 1 49 31 PM](https://user-images.githubusercontent.com/23314389/193812239-eba46ddd-bfc9-43ab-8ab4-1b3f84dacfae.png)
### Modifications

* Restore all the required jobs verification

Also closes #17923
- [x] `doc-not-needed` 