### PR TITLE
[fix][testclient] Fix proxyProtocol parsing when value is empty, fix invalid property name

### DIFF
--- a/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceBaseArguments.java
+++ b/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceBaseArguments.java
@@ -24,6 +24,7 @@ import com.beust.jcommander.Parameter;
 import java.io.FileInputStream;
 import java.util.Properties;
 import lombok.SneakyThrows;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.pulsar.client.api.ProxyProtocol;
 
 
@@ -143,17 +144,18 @@ public abstract class PerformanceBaseArguments {
         }
 
         if (proxyServiceURL == null) {
-            proxyServiceURL = prop.getProperty("proxyServiceURL");
+            proxyServiceURL = StringUtils.trimToNull(prop.getProperty("proxyServiceUrl"));
         }
 
         if (proxyProtocol == null) {
+            String proxyProtocolString = null;
             try {
-                String proxyProtocolString = prop.getProperty("proxyProtocol");
+                proxyProtocolString = StringUtils.trimToNull(prop.getProperty("proxyProtocol"));
                 if (proxyProtocolString != null) {
-                    proxyProtocol = ProxyProtocol.valueOf(prop.getProperty("proxyProtocol"));
+                    proxyProtocol = ProxyProtocol.valueOf(proxyProtocolString.toUpperCase());
                 }
             } catch (IllegalArgumentException e) {
-                System.out.println("Incorrect proxyProtocol name");
+                System.out.println("Incorrect proxyProtocol name '" + proxyProtocolString + "'");
                 e.printStackTrace();
                 exit(-1);
             }

--- a/pulsar-testclient/src/test/resources/perf_client1.conf
+++ b/pulsar-testclient/src/test/resources/perf_client1.conf
@@ -23,5 +23,5 @@ authParams=myparams
 tlsTrustCertsFilePath=./path
 tlsAllowInsecureConnection=true
 tlsEnableHostnameVerification=true
-proxyServiceURL=https://my-proxy-pulsar:4443/
+proxyServiceUrl=https://my-proxy-pulsar:4443/
 proxyProtocol=SNI


### PR DESCRIPTION
### Motivation

An invalid change introduced to the CI workflow in PR #17881 allowed merging PRs that contained test failures. 
PR #17862 contained some minor gaps in the changes that were introduced and had failing tests. 
This got merged because the "required checks" check was broken in CI.

### Modifications

- add tests
- fix issues in parsing logic
- fix typo in property name


### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/lhotari/pulsar/pull/94

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->