### PR TITLE
[doc]Make node and c++ client compatibility table a link to github

### DIFF
--- a/site2/docs/client-libraries-node.md
+++ b/site2/docs/client-libraries-node.md
@@ -20,13 +20,7 @@ Follow [these instructions](client-libraries-cpp.md#compilation) and install the
 
 ### Compatibility
 
-Compatibility between each version of the Node.js client and the C++ client is as follows:
-
-| Node.js client | C++ client     |
-| :------------- | :------------- |
-| 1.0.0          | 2.3.0 or later |
-| 1.1.0          | 2.4.0 or later |
-| 1.2.0          | 2.5.0 or later |
+Compatibility between each version of the Node.js client and the C++ client is listed on [github](https://github.com/apache/pulsar-client-node/blob/master/README.md).
 
 If an incompatible version of the C++ client is installed, you may fail to build or run this library.
 


### PR DESCRIPTION
Fixes https://github.com/apache/pulsar/issues/17786
### Motivation
* We want to make compatibility table single source because it is hard to keep all of them up-to-date.

### Modifications

* Make node and c++ client compatibility table a link to github.

### Documentation

- [x] `doc` <!-- Your PR contains doc changes -->