### PR TITLE
[fix][client] Reserve allocated buffer in BatchMessageContainer on client memory limitation.

### DIFF
--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/BatchMessageContainer.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/BatchMessageContainer.java
@@ -55,6 +55,12 @@ public interface BatchMessageContainer {
     long getCurrentBatchSize();
 
     /**
+     * Get current allocated buffer size of the message batch container in bytes.
+     * @return allocated buffer size in bytes
+     */
+    int getBatchAllocatedSize();
+
+    /**
      * Release the payload and clear the container.
      *
      * @param ex cause

--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/BatchMessageContainer.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/BatchMessageContainer.java
@@ -58,7 +58,7 @@ public interface BatchMessageContainer {
      * Get current allocated buffer size of the message batch container in bytes.
      * @return allocated buffer size in bytes
      */
-    int getBatchAllocatedSize();
+    int getBatchAllocatedSizeBytes();
 
     /**
      * Release the payload and clear the container.

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/AbstractBatchMessageContainer.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/AbstractBatchMessageContainer.java
@@ -42,7 +42,7 @@ public abstract class AbstractBatchMessageContainer implements BatchMessageConta
     protected int maxBytesInBatch;
     protected int numMessagesInBatch = 0;
     protected long currentBatchSizeBytes = 0;
-    protected int batchAllocatedSize = 0;
+    protected int batchAllocatedSizeBytes = 0;
 
     protected long currentTxnidMostBits = -1L;
     protected long currentTxnidLeastBits = -1L;
@@ -86,8 +86,8 @@ public abstract class AbstractBatchMessageContainer implements BatchMessageConta
     }
 
     @Override
-    public int getBatchAllocatedSize() {
-        return batchAllocatedSize;
+    public int getBatchAllocatedSizeBytes() {
+        return batchAllocatedSizeBytes;
     }
 
     int getMaxBatchSize() {

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/AbstractBatchMessageContainer.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/AbstractBatchMessageContainer.java
@@ -42,6 +42,7 @@ public abstract class AbstractBatchMessageContainer implements BatchMessageConta
     protected int maxBytesInBatch;
     protected int numMessagesInBatch = 0;
     protected long currentBatchSizeBytes = 0;
+    protected int batchAllocatedSize = 0;
 
     protected long currentTxnidMostBits = -1L;
     protected long currentTxnidLeastBits = -1L;
@@ -82,6 +83,11 @@ public abstract class AbstractBatchMessageContainer implements BatchMessageConta
     @Override
     public long getCurrentBatchSize() {
         return currentBatchSizeBytes;
+    }
+
+    @Override
+    public int getBatchAllocatedSize() {
+        return batchAllocatedSize;
     }
 
     int getMaxBatchSize() {

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/BatchMessageKeyBasedContainer.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/BatchMessageKeyBasedContainer.java
@@ -67,6 +67,7 @@ class BatchMessageKeyBasedContainer extends AbstractBatchMessageContainer {
         batches.clear();
         currentTxnidMostBits = -1L;
         currentTxnidLeastBits = -1L;
+        batchAllocatedSize = 0;
     }
 
     @Override
@@ -83,6 +84,11 @@ class BatchMessageKeyBasedContainer extends AbstractBatchMessageContainer {
     @Override
     public boolean isMultiBatches() {
         return true;
+    }
+
+    @Override
+    public int getBatchAllocatedSize() {
+        return batches.values().stream().mapToInt(AbstractBatchMessageContainer::getBatchAllocatedSize).sum();
     }
 
     @Override

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/BatchMessageKeyBasedContainer.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/BatchMessageKeyBasedContainer.java
@@ -67,7 +67,7 @@ class BatchMessageKeyBasedContainer extends AbstractBatchMessageContainer {
         batches.clear();
         currentTxnidMostBits = -1L;
         currentTxnidLeastBits = -1L;
-        batchAllocatedSize = 0;
+        batchAllocatedSizeBytes = 0;
     }
 
     @Override
@@ -87,8 +87,8 @@ class BatchMessageKeyBasedContainer extends AbstractBatchMessageContainer {
     }
 
     @Override
-    public int getBatchAllocatedSize() {
-        return batches.values().stream().mapToInt(AbstractBatchMessageContainer::getBatchAllocatedSize).sum();
+    public int getBatchAllocatedSizeBytes() {
+        return batches.values().stream().mapToInt(AbstractBatchMessageContainer::getBatchAllocatedSizeBytes).sum();
     }
 
     @Override

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
@@ -2056,9 +2056,9 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
         }
         final int numMessagesInBatch = batchMessageContainer.getNumMessagesInBatch();
         final long currentBatchSize = batchMessageContainer.getCurrentBatchSize();
-        final int batchAllocatedSize = batchMessageContainer.getBatchAllocatedSize();
+        final int batchAllocatedSizeBytes = batchMessageContainer.getBatchAllocatedSizeBytes();
         semaphoreRelease(numMessagesInBatch);
-        client.getMemoryLimitController().releaseMemory(currentBatchSize + batchAllocatedSize);
+        client.getMemoryLimitController().releaseMemory(currentBatchSize + batchAllocatedSizeBytes);
         batchMessageContainer.discard(ex);
     }
 


### PR DESCRIPTION
### Motivation

We should reserve the allocated buffer in BatchMessageContainer on client memory limitation.

### Modifications

In this patch, we only take care of the buffer init size and final size

* Added a variable `batchAllocatedSize` in `BatchMessageContainer` to record the current allocated buffer size.  It is used to release the allocated buffer size from memory limit controller
* Added a method `reserveBatchAllocatedSizeWhenInit()` in `BatchMessageContainer`, will be call when init the allocated buffer.  This method will initiliaze the `batchAllocatedSize`  and reserve memory to the memory limit controller.
* Added a method `updateBatchAllocatedSizeWhenLeave()` in `BatchMessageContainer`, will be call when the batch leaving the `BatchMessageContainer`. This method will update the final `batchAllocatedSize` as the size after compress.
* Then the value of `batchAllocatedSize` will be added to `OpSendMsg#uncompressedSize` for release the  `batchAllocatedSize` memory from memory limit controller when send succesfully or failed.

* The following diagram could be helpful to understand this patch
<img width="1119" alt="image" src="https://user-images.githubusercontent.com/10233437/195518546-271596ba-5daa-47fb-a7fb-cb5ae4489f61.png">



### Verifying this change

- [x] Make sure that the change passes the CI checks.
- The following tests have covered this change:
   -  `org.apache.pulsar.client.api.MemoryLimitTest`
   - `org.apache.pulsar.client.impl.ProducerMemoryLimitTest`


### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/AnonHxy/pulsar/pull/9
