### PR TITLE
[improve][ci] Speed up execution of OTHER unit test group by removing -DtestReuseFork=false

### DIFF
--- a/build/run_unit_group.sh
+++ b/build/run_unit_group.sh
@@ -134,7 +134,7 @@ function test_group_other() {
            -Dexclude='**/ManagedLedgerTest.java,
                    **/OffloadersCacheTest.java
                   **/PrimitiveSchemaTest.java,
-                  BlobStoreManagedLedgerOffloaderTest.java' -DtestReuseFork=false
+                  BlobStoreManagedLedgerOffloaderTest.java'
 
   mvn_test -pl managed-ledger -Dinclude='**/ManagedLedgerTest.java,
                                                   **/OffloadersCacheTest.java'


### PR DESCRIPTION
### Motivation 

using `-DtestReuseFork=false` slows down test execution significantly.

- this was added in https://github.com/apache/pulsar/pull/17049/files#diff-e6ac90fc5f2373a64dc1ecaa11a9c965f9a22f128cc4ca1265972e0dc4fef9c5R137

### Modifications

remove `-DtestReuseFork=false` for OTHER unit test group

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/lhotari/pulsar/pull/100

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->