### PR TITLE
[improve][client] Refactor SchemaHash to reduce call of hashFunction in SchemaHash

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MessageImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MessageImpl.java
@@ -436,7 +436,7 @@ public class MessageImpl<T> implements Message<T> {
     }
 
     public SchemaHash getSchemaHash() {
-        return schemaHash == null ? SchemaHash.of(null, null) : schemaHash;
+        return schemaHash == null ? SchemaHash.of() : schemaHash;
     }
 
     public void setSchemaInfoForReplicator(SchemaInfo schemaInfo) {

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MessageImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MessageImpl.java
@@ -436,7 +436,7 @@ public class MessageImpl<T> implements Message<T> {
     }
 
     public SchemaHash getSchemaHash() {
-        return schemaHash == null ? SchemaHash.of() : schemaHash;
+        return schemaHash == null ? SchemaHash.empty() : schemaHash;
     }
 
     public void setSchemaInfoForReplicator(SchemaInfo schemaInfo) {

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MessageImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MessageImpl.java
@@ -436,7 +436,7 @@ public class MessageImpl<T> implements Message<T> {
     }
 
     public SchemaHash getSchemaHash() {
-        return schemaHash == null ? SchemaHash.of(new byte[0], null) : schemaHash;
+        return schemaHash == null ? SchemaHash.of(null, null) : schemaHash;
     }
 
     public void setSchemaInfoForReplicator(SchemaInfo schemaInfo) {

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/BooleanSchema.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/BooleanSchema.java
@@ -32,10 +32,10 @@ public class BooleanSchema extends AbstractSchema<Boolean> {
     private static final SchemaInfo SCHEMA_INFO;
 
     static {
-        SCHEMA_INFO = new SchemaInfoImpl()
-                .setName("Boolean")
-                .setType(SchemaType.BOOLEAN)
-                .setSchema(new byte[0]);
+        SCHEMA_INFO = SchemaInfoImpl.builder()
+                .name("Boolean")
+                .type(SchemaType.BOOLEAN)
+                .schema(new byte[0]).build();
         INSTANCE = new BooleanSchema();
     }
 

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/ByteBufSchema.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/ByteBufSchema.java
@@ -33,10 +33,10 @@ public class ByteBufSchema extends AbstractSchema<ByteBuf> {
     private static final SchemaInfo SCHEMA_INFO;
 
     static {
-        SCHEMA_INFO = new SchemaInfoImpl()
-            .setName("ByteBuf")
-            .setType(SchemaType.BYTES)
-            .setSchema(new byte[0]);
+        SCHEMA_INFO = SchemaInfoImpl.builder()
+            .name("ByteBuf")
+            .type(SchemaType.BYTES)
+            .schema(new byte[0]).build();
         INSTANCE = new ByteBufSchema();
     }
 

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/ByteBufferSchema.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/ByteBufferSchema.java
@@ -32,10 +32,10 @@ public class ByteBufferSchema extends AbstractSchema<ByteBuffer> {
     private static final SchemaInfo SCHEMA_INFO;
 
     static {
-        SCHEMA_INFO = new SchemaInfoImpl()
-            .setName("ByteBuffer")
-            .setType(SchemaType.BYTES)
-            .setSchema(new byte[0]);
+        SCHEMA_INFO = SchemaInfoImpl.builder()
+            .name("ByteBuffer")
+            .type(SchemaType.BYTES)
+            .schema(new byte[0]).build();
         INSTANCE = new ByteBufferSchema();
     }
 

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/ByteSchema.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/ByteSchema.java
@@ -32,10 +32,10 @@ public class ByteSchema extends AbstractSchema<Byte> {
     private static final SchemaInfo SCHEMA_INFO;
 
     static {
-        SCHEMA_INFO = new SchemaInfoImpl()
-            .setName("INT8")
-            .setType(SchemaType.INT8)
-            .setSchema(new byte[0]);
+        SCHEMA_INFO = SchemaInfoImpl.builder()
+            .name("INT8")
+            .type(SchemaType.INT8)
+            .schema(new byte[0]).build();
         INSTANCE = new ByteSchema();
     }
 

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/BytesSchema.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/BytesSchema.java
@@ -31,10 +31,10 @@ public class BytesSchema extends AbstractSchema<byte[]> {
     private static final SchemaInfo SCHEMA_INFO;
 
     static {
-        SCHEMA_INFO = new SchemaInfoImpl()
-            .setName("Bytes")
-            .setType(SchemaType.BYTES)
-            .setSchema(new byte[0]);
+        SCHEMA_INFO = SchemaInfoImpl.builder()
+            .name("Bytes")
+            .type(SchemaType.BYTES)
+            .schema(new byte[0]).build();
         INSTANCE = new BytesSchema();
     }
 

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/DateSchema.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/DateSchema.java
@@ -32,10 +32,10 @@ public class DateSchema extends AbstractSchema<Date> {
    private static final SchemaInfo SCHEMA_INFO;
 
    static {
-       SCHEMA_INFO = new SchemaInfoImpl()
-             .setName("Date")
-             .setType(SchemaType.DATE)
-             .setSchema(new byte[0]);
+       SCHEMA_INFO = SchemaInfoImpl.builder()
+             .name("Date")
+             .type(SchemaType.DATE)
+             .schema(new byte[0]).build();
        INSTANCE = new DateSchema();
    }
 

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/DoubleSchema.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/DoubleSchema.java
@@ -32,10 +32,10 @@ public class DoubleSchema extends AbstractSchema<Double> {
     private static final SchemaInfo SCHEMA_INFO;
 
     static {
-        SCHEMA_INFO = new SchemaInfoImpl()
-            .setName("Double")
-            .setType(SchemaType.DOUBLE)
-            .setSchema(new byte[0]);
+        SCHEMA_INFO = SchemaInfoImpl.builder()
+            .name("Double")
+            .type(SchemaType.DOUBLE)
+            .schema(new byte[0]).build();
         INSTANCE = new DoubleSchema();
     }
 

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/FloatSchema.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/FloatSchema.java
@@ -32,10 +32,10 @@ public class FloatSchema extends AbstractSchema<Float> {
     private static final SchemaInfo SCHEMA_INFO;
 
     static {
-        SCHEMA_INFO = new SchemaInfoImpl()
-                .setName("Float")
-                .setType(SchemaType.FLOAT)
-                .setSchema(new byte[0]);
+        SCHEMA_INFO = SchemaInfoImpl.builder()
+                .name("Float")
+                .type(SchemaType.FLOAT)
+                .schema(new byte[0]).build();
         INSTANCE = new FloatSchema();
     }
 

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/InstantSchema.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/InstantSchema.java
@@ -33,10 +33,10 @@ public class InstantSchema extends AbstractSchema<Instant> {
    private static final SchemaInfo SCHEMA_INFO;
 
    static {
-       SCHEMA_INFO = new SchemaInfoImpl()
-             .setName("Instant")
-             .setType(SchemaType.INSTANT)
-             .setSchema(new byte[0]);
+       SCHEMA_INFO = SchemaInfoImpl.builder()
+             .name("Instant")
+             .type(SchemaType.INSTANT)
+             .schema(new byte[0]).build();
        INSTANCE = new InstantSchema();
    }
 

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/IntSchema.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/IntSchema.java
@@ -32,10 +32,10 @@ public class IntSchema extends AbstractSchema<Integer> {
     private static final SchemaInfo SCHEMA_INFO;
 
     static {
-        SCHEMA_INFO = new SchemaInfoImpl()
-            .setName("INT32")
-            .setType(SchemaType.INT32)
-            .setSchema(new byte[0]);
+        SCHEMA_INFO = SchemaInfoImpl.builder()
+            .name("INT32")
+            .type(SchemaType.INT32)
+            .schema(new byte[0]).build();
         INSTANCE = new IntSchema();
     }
 

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/JSONSchema.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/JSONSchema.java
@@ -71,11 +71,12 @@ public class JSONSchema<T> extends AvroBaseStructSchema<T> {
             ObjectMapper objectMapper = new ObjectMapper();
             JsonSchemaGenerator schemaGen = new JsonSchemaGenerator(objectMapper);
             JsonSchema jsonBackwardsCompatibleSchema = schemaGen.generateSchema(pojo);
-            backwardsCompatibleSchemaInfo = new SchemaInfoImpl()
-                    .setName("")
-                    .setProperties(schemaInfo.getProperties())
-                    .setType(SchemaType.JSON)
-                    .setSchema(objectMapper.writeValueAsBytes(jsonBackwardsCompatibleSchema));
+            backwardsCompatibleSchemaInfo = SchemaInfoImpl.builder()
+                    .name("")
+                    .properties(schemaInfo.getProperties())
+                    .type(SchemaType.JSON)
+                    .schema(objectMapper.writeValueAsBytes(jsonBackwardsCompatibleSchema))
+                    .build();
         } catch (JsonProcessingException ex) {
             throw new RuntimeException(ex);
         }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/LocalDateSchema.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/LocalDateSchema.java
@@ -32,10 +32,10 @@ public class LocalDateSchema extends AbstractSchema<LocalDate> {
    private static final SchemaInfo SCHEMA_INFO;
 
    static {
-       SCHEMA_INFO = new SchemaInfoImpl()
-             .setName("LocalDate")
-             .setType(SchemaType.LOCAL_DATE)
-             .setSchema(new byte[0]);
+       SCHEMA_INFO = SchemaInfoImpl.builder()
+             .name("LocalDate")
+             .type(SchemaType.LOCAL_DATE)
+             .schema(new byte[0]).build();
        INSTANCE = new LocalDateSchema();
    }
 

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/LocalDateTimeSchema.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/LocalDateTimeSchema.java
@@ -36,10 +36,10 @@ public class LocalDateTimeSchema extends AbstractSchema<LocalDateTime> {
    public static final String DELIMITER = ":";
 
    static {
-       SCHEMA_INFO = new SchemaInfoImpl()
-             .setName("LocalDateTime")
-             .setType(SchemaType.LOCAL_DATE_TIME)
-             .setSchema(new byte[0]);
+       SCHEMA_INFO = SchemaInfoImpl.builder()
+             .name("LocalDateTime")
+             .type(SchemaType.LOCAL_DATE_TIME)
+             .schema(new byte[0]).build();
        INSTANCE = new LocalDateTimeSchema();
    }
 

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/LocalTimeSchema.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/LocalTimeSchema.java
@@ -32,10 +32,10 @@ public class LocalTimeSchema extends AbstractSchema<LocalTime> {
    private static final SchemaInfo SCHEMA_INFO;
 
    static {
-       SCHEMA_INFO = new SchemaInfoImpl()
-             .setName("LocalTime")
-             .setType(SchemaType.LOCAL_TIME)
-             .setSchema(new byte[0]);
+       SCHEMA_INFO = SchemaInfoImpl.builder()
+             .name("LocalTime")
+             .type(SchemaType.LOCAL_TIME)
+             .schema(new byte[0]).build();
        INSTANCE = new LocalTimeSchema();
    }
 

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/LongSchema.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/LongSchema.java
@@ -32,10 +32,10 @@ public class LongSchema extends AbstractSchema<Long> {
     private static final SchemaInfo SCHEMA_INFO;
 
     static {
-        SCHEMA_INFO = new SchemaInfoImpl()
-            .setName("INT64")
-            .setType(SchemaType.INT64)
-            .setSchema(new byte[0]);
+        SCHEMA_INFO = SchemaInfoImpl.builder()
+            .name("INT64")
+            .type(SchemaType.INT64)
+            .schema(new byte[0]).build();
         INSTANCE = new LongSchema();
     }
 

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/ShortSchema.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/ShortSchema.java
@@ -32,10 +32,10 @@ public class ShortSchema extends AbstractSchema<Short> {
     private static final SchemaInfo SCHEMA_INFO;
 
     static {
-        SCHEMA_INFO = new SchemaInfoImpl()
-            .setName("INT16")
-            .setType(SchemaType.INT16)
-            .setSchema(new byte[0]);
+        SCHEMA_INFO = SchemaInfoImpl.builder()
+            .name("INT16")
+            .type(SchemaType.INT16)
+            .schema(new byte[0]).build();
         INSTANCE = new ShortSchema();
     }
 

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/StringSchema.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/StringSchema.java
@@ -43,10 +43,10 @@ public class StringSchema extends AbstractSchema<String> {
         // Ensure the ordering of the static initialization
         CHARSET_KEY = "__charset";
         DEFAULT_CHARSET = StandardCharsets.UTF_8;
-        DEFAULT_SCHEMA_INFO = new SchemaInfoImpl()
-                .setName("String")
-                .setType(SchemaType.STRING)
-                .setSchema(new byte[0]);
+        DEFAULT_SCHEMA_INFO = SchemaInfoImpl.builder()
+                .name("String")
+                .type(SchemaType.STRING)
+                .schema(new byte[0]).build();
 
         UTF8 = new StringSchema(StandardCharsets.UTF_8);
     }
@@ -84,11 +84,12 @@ public class StringSchema extends AbstractSchema<String> {
         this.charset = charset;
         Map<String, String> properties = new HashMap<>();
         properties.put(CHARSET_KEY, charset.name());
-        this.schemaInfo = new SchemaInfoImpl()
-                .setName(DEFAULT_SCHEMA_INFO.getName())
-                .setType(SchemaType.STRING)
-                .setSchema(DEFAULT_SCHEMA_INFO.getSchema())
-                .setProperties(properties);
+        this.schemaInfo = SchemaInfoImpl.builder()
+                .name(DEFAULT_SCHEMA_INFO.getName())
+                .type(SchemaType.STRING)
+                .schema(DEFAULT_SCHEMA_INFO.getSchema())
+                .properties(properties)
+                .build();
     }
 
     public byte[] encode(String message) {

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/TimeSchema.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/TimeSchema.java
@@ -32,10 +32,10 @@ public class TimeSchema extends AbstractSchema<Time> {
    private static final SchemaInfo SCHEMA_INFO;
 
    static {
-       SCHEMA_INFO = new SchemaInfoImpl()
-             .setName("Time")
-             .setType(SchemaType.TIME)
-             .setSchema(new byte[0]);
+       SCHEMA_INFO = SchemaInfoImpl.builder()
+             .name("Time")
+             .type(SchemaType.TIME)
+             .schema(new byte[0]).build();
        INSTANCE = new TimeSchema();
    }
 

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/TimestampSchema.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/TimestampSchema.java
@@ -32,10 +32,10 @@ public class TimestampSchema extends AbstractSchema<Timestamp> {
    private static final SchemaInfo SCHEMA_INFO;
 
    static {
-       SCHEMA_INFO = new SchemaInfoImpl()
-             .setName("Timestamp")
-             .setType(SchemaType.TIMESTAMP)
-             .setSchema(new byte[0]);
+       SCHEMA_INFO = SchemaInfoImpl.builder()
+             .name("Timestamp")
+             .type(SchemaType.TIMESTAMP)
+             .schema(new byte[0]).build();
        INSTANCE = new TimestampSchema();
    }
 

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/schema/KeyValueSchemaInfoTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/schema/KeyValueSchemaInfoTest.java
@@ -170,11 +170,11 @@ public class KeyValueSchemaInfoTest {
             KeyValueEncodingType.SEPARATED
         );
 
-        SchemaInfo oldSchemaInfo = new SchemaInfoImpl()
-            .setName("")
-            .setType(SchemaType.KEY_VALUE)
-            .setSchema(kvSchema.getSchemaInfo().getSchema())
-            .setProperties(Collections.emptyMap());
+        SchemaInfo oldSchemaInfo = SchemaInfoImpl.builder()
+            .name("")
+            .type(SchemaType.KEY_VALUE)
+            .schema(kvSchema.getSchemaInfo().getSchema())
+            .properties(Collections.emptyMap()).build();
 
         assertEquals(
                 DefaultImplementation.getDefaultImplementation().decodeKeyValueEncodingType(oldSchemaInfo),

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/schema/StringSchemaTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/schema/StringSchemaTest.java
@@ -86,11 +86,11 @@ public class StringSchemaTest {
 
     @Test
     public void testSchemaInfoWithoutCharset() {
-        SchemaInfo si = new SchemaInfoImpl()
-            .setName("test-schema-info-without-charset")
-            .setType(SchemaType.STRING)
-            .setSchema(new byte[0])
-            .setProperties(Collections.emptyMap());
+        SchemaInfo si = SchemaInfoImpl.builder()
+            .name("test-schema-info-without-charset")
+            .type(SchemaType.STRING)
+            .schema(new byte[0])
+            .properties(Collections.emptyMap()).build();
         StringSchema schema = StringSchema.fromSchemaInfo(si);
 
         String myString = "my string for test";
@@ -121,11 +121,11 @@ public class StringSchemaTest {
     public void testSchemaInfoWithCharset(Charset charset) {
         Map<String, String> properties = new HashMap<>();
         properties.put(StringSchema.CHARSET_KEY, charset.name());
-        SchemaInfo si = new SchemaInfoImpl()
-            .setName("test-schema-info-without-charset")
-            .setType(SchemaType.STRING)
-            .setSchema(new byte[0])
-            .setProperties(properties);
+        SchemaInfo si = SchemaInfoImpl.builder()
+            .name("test-schema-info-without-charset")
+            .type(SchemaType.STRING)
+            .schema(new byte[0])
+            .properties(properties).build();
         StringSchema schema = StringSchema.fromSchemaInfo(si);
 
         String myString = "my string for test";

--- a/pulsar-common/pom.xml
+++ b/pulsar-common/pom.xml
@@ -106,11 +106,6 @@
     </dependency>
 
     <dependency>
-      <groupId>com.github.ben-manes.caffeine</groupId>
-      <artifactId>caffeine</artifactId>
-    </dependency>
-
-    <dependency>
       <groupId>io.airlift</groupId>
       <artifactId>aircompressor</artifactId>
     </dependency>

--- a/pulsar-common/pom.xml
+++ b/pulsar-common/pom.xml
@@ -106,6 +106,11 @@
     </dependency>
 
     <dependency>
+      <groupId>com.github.ben-manes.caffeine</groupId>
+      <artifactId>caffeine</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>io.airlift</groupId>
       <artifactId>aircompressor</artifactId>
     </dependency>

--- a/pulsar-common/src/main/java/org/apache/pulsar/client/impl/schema/SchemaInfoImpl.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/client/impl/schema/SchemaInfoImpl.java
@@ -48,12 +48,12 @@ public class SchemaInfoImpl implements SchemaInfo {
     /**
      * The schema data in AVRO JSON format.
      */
-    private volatile byte[] schema;
+    private final byte[] schema;
 
     /**
      * The type of schema (AVRO, JSON, PROTOBUF, etc..).
      */
-    private volatile SchemaType type;
+    private final SchemaType type;
 
     /**
      * The created time of schema.
@@ -63,13 +63,9 @@ public class SchemaInfoImpl implements SchemaInfo {
     /**
      * Additional properties of the schema definition (implementation defined).
      */
-    @Builder.Default
     private Map<String, String> properties = Collections.emptyMap();
 
-    private SchemaHash schemaHash;
-
-    private SchemaInfoImpl() {
-    }
+    private final SchemaHash schemaHash;
 
     @Builder
     public SchemaInfoImpl(String name, byte[] schema, SchemaType type, long timestamp,
@@ -78,8 +74,8 @@ public class SchemaInfoImpl implements SchemaInfo {
         this.schema = schema;
         this.type = type;
         this.timestamp = timestamp;
-        this.properties = properties;
-        this.schemaHash = SchemaHash.of(this.schema, type);
+        this.properties = properties == null ? Collections.emptyMap() : properties;
+        this.schemaHash = SchemaHash.of(this.schema, this.type);
     }
 
     public String getSchemaDefinition() {

--- a/pulsar-common/src/main/java/org/apache/pulsar/client/impl/schema/SchemaInfoImpl.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/client/impl/schema/SchemaInfoImpl.java
@@ -19,12 +19,14 @@
 package org.apache.pulsar.client.impl.schema;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import java.util.Base64;
 import java.util.Collections;
 import java.util.Map;
 import lombok.Builder;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
 import lombok.experimental.Accessors;
 import org.apache.pulsar.common.classification.InterfaceAudience;
 import org.apache.pulsar.common.classification.InterfaceStability;
@@ -39,6 +41,7 @@ import org.apache.pulsar.common.schema.SchemaType;
 @InterfaceAudience.Public
 @InterfaceStability.Stable
 @Data
+@NoArgsConstructor
 @Accessors(chain = true)
 public class SchemaInfoImpl implements SchemaInfo {
 
@@ -48,12 +51,12 @@ public class SchemaInfoImpl implements SchemaInfo {
     /**
      * The schema data in AVRO JSON format.
      */
-    private final byte[] schema;
+    private byte[] schema;
 
     /**
      * The type of schema (AVRO, JSON, PROTOBUF, etc..).
      */
-    private final SchemaType type;
+    private SchemaType type;
 
     /**
      * The created time of schema.
@@ -65,7 +68,9 @@ public class SchemaInfoImpl implements SchemaInfo {
      */
     private Map<String, String> properties = Collections.emptyMap();
 
-    private final SchemaHash schemaHash;
+    @EqualsAndHashCode.Exclude
+    @JsonIgnore
+    private transient SchemaHash schemaHash;
 
     @Builder
     public SchemaInfoImpl(String name, byte[] schema, SchemaType type, long timestamp,

--- a/pulsar-common/src/main/java/org/apache/pulsar/client/impl/schema/SchemaInfoImpl.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/client/impl/schema/SchemaInfoImpl.java
@@ -102,6 +102,19 @@ public class SchemaInfoImpl implements SchemaInfo {
         }
     }
 
+    /**
+     * Calculate the SchemaHash for compatible with `@NoArgsConstructor`.
+     * If SchemaInfoImpl is created by no-args-constructor from users, the schemaHash will be null.
+     * Note: We should remove this method as long as `@NoArgsConstructor` removed at major release to avoid null-check
+     * overhead.
+     */
+    public SchemaHash getSchemaHash() {
+        if (schemaHash == null) {
+            schemaHash = SchemaHash.of(this.schema, this.type);
+        }
+        return schemaHash;
+    }
+
     @Override
     public String toString() {
         return SchemaUtils.jsonifySchemaInfo(this);

--- a/pulsar-common/src/main/java/org/apache/pulsar/client/impl/schema/SchemaInfoImpl.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/client/impl/schema/SchemaInfoImpl.java
@@ -102,10 +102,6 @@ public class SchemaInfoImpl implements SchemaInfo {
         }
     }
 
-    public SchemaHash getSchemaHash() {
-        return schemaHash;
-    }
-
     @Override
     public String toString() {
         return SchemaUtils.jsonifySchemaInfo(this);

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/protocol/schema/SchemaHash.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/protocol/schema/SchemaHash.java
@@ -49,11 +49,7 @@ public class SchemaHash {
         if (schema == null || schema.getSchemaInfo() == null) {
             return EMPTY_SCHEMA_HASH;
         }
-        SchemaHash schemaHash = ((SchemaInfoImpl) schema.getSchemaInfo()).getSchemaHash();
-        if (schemaHash == null) {
-            schemaHash = compatibleNoArgsConstructorSchemaInfoImpl(schema.getSchemaInfo());
-        }
-        return schemaHash;
+        return ((SchemaInfoImpl) schema.getSchemaInfo()).getSchemaHash();
     }
 
     public static SchemaHash of(SchemaData schemaData) {
@@ -64,32 +60,16 @@ public class SchemaHash {
         if (schemaInfo == null) {
             return EMPTY_SCHEMA_HASH;
         }
-        SchemaHash schemaHash = ((SchemaInfoImpl) schemaInfo).getSchemaHash();
-        if (schemaHash == null) {
-            schemaHash = compatibleNoArgsConstructorSchemaInfoImpl(schemaInfo);
-        }
-        return schemaHash;
+        return ((SchemaInfoImpl) schemaInfo).getSchemaHash();
     }
 
     public static SchemaHash empty() {
         return EMPTY_SCHEMA_HASH;
     }
 
-    // Shouldn't call this method frequent, otherwise will bring performance regression
+    // Shouldn't call this method directly
     public static SchemaHash of(byte[] schemaBytes, SchemaType schemaType) {
         return new SchemaHash(hashFunction.hashBytes(schemaBytes == null ? new byte[0] : schemaBytes), schemaType);
-    }
-
-    /**
-     *  If {@link SchemaInfoImpl} is created by no-args-constructor from users, the `SchemaInfoImpl#getSchemaHash` will
-     *  be null. If so, calculate the SchemaHash
-     *
-     *  We should remove this method when `@NoArgsConstructor` of {@link SchemaInfoImpl} removed
-     * @param schemaInfo
-     * @return The calculated SchemaHash
-     */
-    private static SchemaHash compatibleNoArgsConstructorSchemaInfoImpl(SchemaInfo schemaInfo) {
-        return of(schemaInfo.getSchema(), schemaInfo.getType());
     }
 
     public byte[] asBytes() {

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/protocol/schema/SchemaHash.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/protocol/schema/SchemaHash.java
@@ -86,7 +86,7 @@ public class SchemaHash {
                 schemaInfo == null ? null : schemaInfo.getType());
     }
 
-    public static SchemaHash of() {
+    public static SchemaHash empty() {
         return of(null, null);
     }
 
@@ -95,6 +95,9 @@ public class SchemaHash {
         if (schemaBytes == null || schemaBytes.length == 0) {
             result = EmptySchemaHashFactory.get(schemaType);
             if (result == null) {
+                log.warn("Could not get schemaHash from EmptySchemaHashFactory, will create by hashFunction. Might bring"
+                                + " performance regression. schemaBytes:{}, schemaType:{}",
+                        schemaBytes == null ? "null" : "0", schemaType);
                 result = new SchemaHash(
                         hashFunction.hashBytes(schemaBytes == null ? new byte[0] : schemaBytes), schemaType);
             }

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/protocol/schema/SchemaHash.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/protocol/schema/SchemaHash.java
@@ -113,6 +113,8 @@ public class SchemaHash {
 
     private static class EmptySchemaHashFactory {
         private static final HashCode EMPTY_HASH = hashFunction.hashBytes(new byte[0]);
+
+        private static final SchemaHash NULL_SCHEMA_HASH = new SchemaHash(EMPTY_HASH, null);
         private static final SchemaHash NONE_SCHEMA_HASH = new SchemaHash(EMPTY_HASH, NONE);
         private static final SchemaHash STRING_SCHEMA_HASH = new SchemaHash(EMPTY_HASH, STRING);
         private static final SchemaHash JSON_SCHEMA_HASH = new SchemaHash(EMPTY_HASH, JSON);
@@ -140,6 +142,9 @@ public class SchemaHash {
         private static final SchemaHash AUTO_PUBLISH_SCHEMA_HASH = new SchemaHash(EMPTY_HASH, AUTO_PUBLISH);
 
         public static SchemaHash get(SchemaType schemaType) {
+            if (schemaType == null) {
+                return NULL_SCHEMA_HASH;
+            }
             switch (schemaType) {
                 case NONE:
                     return NONE_SCHEMA_HASH;

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/protocol/schema/SchemaHash.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/protocol/schema/SchemaHash.java
@@ -46,7 +46,7 @@ public class SchemaHash {
     }
 
     public static SchemaHash of(Schema schema) {
-        if (schema == null) {
+        if (schema == null || schema.getSchemaInfo() == null) {
             return EMPTY_SCHEMA_HASH;
         }
         return ((SchemaInfoImpl) schema.getSchemaInfo()).getSchemaHash();
@@ -67,6 +67,7 @@ public class SchemaHash {
         return EMPTY_SCHEMA_HASH;
     }
 
+    // Shouldn't call this method directly
     public static SchemaHash of(byte[] schemaBytes, SchemaType schemaType) {
         return new SchemaHash(hashFunction.hashBytes(schemaBytes == null ? new byte[0] : schemaBytes), schemaType);
     }

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/protocol/schema/SchemaHash.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/protocol/schema/SchemaHash.java
@@ -91,18 +91,15 @@ public class SchemaHash {
     }
 
     private static SchemaHash of(byte[] schemaBytes, SchemaType schemaType) {
-        SchemaHash result = null;
+        SchemaHash result;
         if (schemaBytes == null || schemaBytes.length == 0) {
             result = EmptySchemaHashFactory.get(schemaType);
-        }
-
-        // This should not be a common occurrence if everything goes well.
-        if (result == null) {
-            log.warn("Could not get schemaHash from EmptySchemaHashFactory, will create by hashFunction. Might bring"
-                            + " performance regression. schemaBytes length:{}, schemaType:{}",
-                    schemaBytes == null ? "null" : schemaBytes.length, schemaType);
-            result = new SchemaHash(
-                    hashFunction.hashBytes(schemaBytes == null ? new byte[0] : schemaBytes), schemaType);
+            if (result == null) {
+                result = new SchemaHash(
+                        hashFunction.hashBytes(schemaBytes == null ? new byte[0] : schemaBytes), schemaType);
+            }
+        } else {
+            result = new SchemaHash(hashFunction.hashBytes(schemaBytes), schemaType);
         }
         return result;
     }

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/protocol/schema/SchemaHash.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/protocol/schema/SchemaHash.java
@@ -25,7 +25,6 @@ import com.google.common.hash.HashFunction;
 import com.google.common.hash.Hashing;
 import java.util.Optional;
 import lombok.EqualsAndHashCode;
-import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.common.schema.SchemaInfo;
@@ -35,7 +34,6 @@ import org.apache.pulsar.common.schema.SchemaType;
  * Schema hash wrapper with a HashCode inner type.
  */
 @EqualsAndHashCode
-@Slf4j
 public class SchemaHash {
 
     private static final HashFunction hashFunction = Hashing.sha256();

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/protocol/schema/SchemaHash.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/protocol/schema/SchemaHash.java
@@ -18,38 +18,12 @@
  */
 package org.apache.pulsar.common.protocol.schema;
 
-import static org.apache.pulsar.common.schema.SchemaType.AUTO;
-import static org.apache.pulsar.common.schema.SchemaType.AUTO_CONSUME;
-import static org.apache.pulsar.common.schema.SchemaType.AUTO_PUBLISH;
-import static org.apache.pulsar.common.schema.SchemaType.AVRO;
-import static org.apache.pulsar.common.schema.SchemaType.BOOLEAN;
-import static org.apache.pulsar.common.schema.SchemaType.BYTES;
-import static org.apache.pulsar.common.schema.SchemaType.DATE;
-import static org.apache.pulsar.common.schema.SchemaType.DOUBLE;
-import static org.apache.pulsar.common.schema.SchemaType.FLOAT;
-import static org.apache.pulsar.common.schema.SchemaType.INSTANT;
-import static org.apache.pulsar.common.schema.SchemaType.INT16;
-import static org.apache.pulsar.common.schema.SchemaType.INT32;
-import static org.apache.pulsar.common.schema.SchemaType.INT64;
-import static org.apache.pulsar.common.schema.SchemaType.INT8;
-import static org.apache.pulsar.common.schema.SchemaType.JSON;
-import static org.apache.pulsar.common.schema.SchemaType.KEY_VALUE;
-import static org.apache.pulsar.common.schema.SchemaType.LOCAL_DATE;
-import static org.apache.pulsar.common.schema.SchemaType.LOCAL_DATE_TIME;
-import static org.apache.pulsar.common.schema.SchemaType.LOCAL_TIME;
-import static org.apache.pulsar.common.schema.SchemaType.NONE;
-import static org.apache.pulsar.common.schema.SchemaType.PROTOBUF;
-import static org.apache.pulsar.common.schema.SchemaType.PROTOBUF_NATIVE;
-import static org.apache.pulsar.common.schema.SchemaType.STRING;
-import static org.apache.pulsar.common.schema.SchemaType.TIME;
-import static org.apache.pulsar.common.schema.SchemaType.TIMESTAMP;
 import com.google.common.hash.HashCode;
 import com.google.common.hash.HashFunction;
 import com.google.common.hash.Hashing;
-import java.util.Optional;
 import lombok.EqualsAndHashCode;
-import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.client.api.Schema;
+import org.apache.pulsar.client.impl.schema.SchemaInfoImpl;
 import org.apache.pulsar.common.schema.SchemaInfo;
 import org.apache.pulsar.common.schema.SchemaType;
 
@@ -57,10 +31,10 @@ import org.apache.pulsar.common.schema.SchemaType;
  * Schema hash wrapper with a HashCode inner type.
  */
 @EqualsAndHashCode
-@Slf4j
 public class SchemaHash {
 
     private static final HashFunction hashFunction = Hashing.sha256();
+    private static final SchemaHash EMPTY_SCHEMA_HASH = new SchemaHash(hashFunction.hashBytes(new byte[0]), null);
 
     private final HashCode hash;
 
@@ -72,9 +46,10 @@ public class SchemaHash {
     }
 
     public static SchemaHash of(Schema schema) {
-        Optional<SchemaInfo> schemaInfo = Optional.ofNullable(schema).map(Schema::getSchemaInfo);
-        return of(schemaInfo.map(SchemaInfo::getSchema).orElse(null),
-                schemaInfo.map(SchemaInfo::getType).orElse(null));
+        if (schema == null) {
+            return EMPTY_SCHEMA_HASH;
+        }
+        return ((SchemaInfoImpl) schema.getSchemaInfo()).getSchemaHash();
     }
 
     public static SchemaHash of(SchemaData schemaData) {
@@ -82,123 +57,21 @@ public class SchemaHash {
     }
 
     public static SchemaHash of(SchemaInfo schemaInfo) {
-        return of(schemaInfo == null ? null : schemaInfo.getSchema(),
-                schemaInfo == null ? null : schemaInfo.getType());
+        if (schemaInfo == null) {
+            return EMPTY_SCHEMA_HASH;
+        }
+        return ((SchemaInfoImpl) schemaInfo).getSchemaHash();
     }
 
     public static SchemaHash empty() {
-        return of(null, null);
+        return EMPTY_SCHEMA_HASH;
     }
 
-    private static SchemaHash of(byte[] schemaBytes, SchemaType schemaType) {
-        SchemaHash result;
-        if (schemaBytes == null || schemaBytes.length == 0) {
-            result = EmptySchemaHashFactory.get(schemaType);
-            if (result == null) {
-                log.warn("Could not get schemaHash from EmptySchemaHashFactory, will create by hashFunction. Might"
-                                + " bring performance regression. schemaBytes:{}, schemaType:{}",
-                        schemaBytes == null ? "null" : "0", schemaType);
-                result = new SchemaHash(
-                        hashFunction.hashBytes(schemaBytes == null ? new byte[0] : schemaBytes), schemaType);
-            }
-        } else {
-            result = new SchemaHash(hashFunction.hashBytes(schemaBytes), schemaType);
-        }
-        return result;
+    public static SchemaHash of(byte[] schemaBytes, SchemaType schemaType) {
+        return new SchemaHash(hashFunction.hashBytes(schemaBytes == null ? new byte[0] : schemaBytes), schemaType);
     }
 
     public byte[] asBytes() {
         return hash.asBytes();
-    }
-
-    private static class EmptySchemaHashFactory {
-        private static final HashCode EMPTY_HASH = hashFunction.hashBytes(new byte[0]);
-
-        private static final SchemaHash NULL_SCHEMA_HASH = new SchemaHash(EMPTY_HASH, null);
-        private static final SchemaHash NONE_SCHEMA_HASH = new SchemaHash(EMPTY_HASH, NONE);
-        private static final SchemaHash STRING_SCHEMA_HASH = new SchemaHash(EMPTY_HASH, STRING);
-        private static final SchemaHash JSON_SCHEMA_HASH = new SchemaHash(EMPTY_HASH, JSON);
-        private static final SchemaHash PROTOBUF_SCHEMA_HASH = new SchemaHash(EMPTY_HASH, PROTOBUF);
-        private static final SchemaHash AVRO_SCHEMA_HASH = new SchemaHash(EMPTY_HASH, AVRO);
-        private static final SchemaHash BOOLEAN_SCHEMA_HASH = new SchemaHash(EMPTY_HASH, BOOLEAN);
-        private static final SchemaHash INT8_SCHEMA_HASH = new SchemaHash(EMPTY_HASH, INT8);
-        private static final SchemaHash INT16_SCHEMA_HASH = new SchemaHash(EMPTY_HASH, INT16);
-        private static final SchemaHash INT32_SCHEMA_HASH = new SchemaHash(EMPTY_HASH, INT32);
-        private static final SchemaHash INT64_SCHEMA_HASH = new SchemaHash(EMPTY_HASH, INT64);
-        private static final SchemaHash FLOAT_SCHEMA_HASH = new SchemaHash(EMPTY_HASH, FLOAT);
-        private static final SchemaHash DOUBLE_SCHEMA_HASH = new SchemaHash(EMPTY_HASH, DOUBLE);
-        private static final SchemaHash DATE_SCHEMA_HASH = new SchemaHash(EMPTY_HASH, DATE);
-        private static final SchemaHash TIME_SCHEMA_HASH = new SchemaHash(EMPTY_HASH, TIME);
-        private static final SchemaHash TIMESTAMP_SCHEMA_HASH = new SchemaHash(EMPTY_HASH, TIMESTAMP);
-        private static final SchemaHash KEY_VALUE_SCHEMA_HASH = new SchemaHash(EMPTY_HASH, KEY_VALUE);
-        private static final SchemaHash INSTANT_SCHEMA_HASH = new SchemaHash(EMPTY_HASH, INSTANT);
-        private static final SchemaHash LOCAL_DATE_SCHEMA_HASH = new SchemaHash(EMPTY_HASH, LOCAL_DATE);
-        private static final SchemaHash LOCAL_TIME_SCHEMA_HASH = new SchemaHash(EMPTY_HASH, LOCAL_TIME);
-        private static final SchemaHash LOCAL_DATE_TIME_SCHEMA_HASH = new SchemaHash(EMPTY_HASH, LOCAL_DATE_TIME);
-        private static final SchemaHash PROTOBUF_NATIVE_SCHEMA_HASH = new SchemaHash(EMPTY_HASH, PROTOBUF_NATIVE);
-        private static final SchemaHash BYTES_SCHEMA_HASH = new SchemaHash(EMPTY_HASH, BYTES);
-        private static final SchemaHash AUTO_SCHEMA_HASH = new SchemaHash(EMPTY_HASH, AUTO);
-        private static final SchemaHash AUTO_CONSUME_SCHEMA_HASH = new SchemaHash(EMPTY_HASH, AUTO_CONSUME);
-        private static final SchemaHash AUTO_PUBLISH_SCHEMA_HASH = new SchemaHash(EMPTY_HASH, AUTO_PUBLISH);
-
-        public static SchemaHash get(SchemaType schemaType) {
-            if (schemaType == null) {
-                return NULL_SCHEMA_HASH;
-            }
-            switch (schemaType) {
-                case NONE:
-                    return NONE_SCHEMA_HASH;
-                case STRING:
-                    return STRING_SCHEMA_HASH;
-                case JSON:
-                    return JSON_SCHEMA_HASH;
-                case PROTOBUF:
-                    return PROTOBUF_SCHEMA_HASH;
-                case AVRO:
-                    return AVRO_SCHEMA_HASH;
-                case BOOLEAN:
-                    return BOOLEAN_SCHEMA_HASH;
-                case INT8:
-                    return INT8_SCHEMA_HASH;
-                case INT16:
-                    return INT16_SCHEMA_HASH;
-                case INT32:
-                    return INT32_SCHEMA_HASH;
-                case INT64:
-                    return INT64_SCHEMA_HASH;
-                case FLOAT:
-                    return FLOAT_SCHEMA_HASH;
-                case DOUBLE:
-                    return DOUBLE_SCHEMA_HASH;
-                case DATE:
-                    return DATE_SCHEMA_HASH;
-                case TIME:
-                    return TIME_SCHEMA_HASH;
-                case TIMESTAMP:
-                    return TIMESTAMP_SCHEMA_HASH;
-                case KEY_VALUE:
-                    return KEY_VALUE_SCHEMA_HASH;
-                case INSTANT:
-                    return INSTANT_SCHEMA_HASH;
-                case LOCAL_DATE:
-                    return LOCAL_DATE_SCHEMA_HASH;
-                case LOCAL_TIME:
-                    return LOCAL_TIME_SCHEMA_HASH;
-                case LOCAL_DATE_TIME:
-                    return LOCAL_DATE_TIME_SCHEMA_HASH;
-                case PROTOBUF_NATIVE:
-                    return PROTOBUF_NATIVE_SCHEMA_HASH;
-                case BYTES:
-                    return BYTES_SCHEMA_HASH;
-                case AUTO:
-                    return AUTO_SCHEMA_HASH;
-                case AUTO_CONSUME:
-                    return AUTO_CONSUME_SCHEMA_HASH;
-                case AUTO_PUBLISH:
-                    return AUTO_PUBLISH_SCHEMA_HASH;
-                default:
-                    return null;
-            }
-        }
     }
 }

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/protocol/schema/SchemaHash.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/protocol/schema/SchemaHash.java
@@ -18,11 +18,37 @@
  */
 package org.apache.pulsar.common.protocol.schema;
 
+import static org.apache.pulsar.common.schema.SchemaType.AUTO;
+import static org.apache.pulsar.common.schema.SchemaType.AUTO_CONSUME;
+import static org.apache.pulsar.common.schema.SchemaType.AUTO_PUBLISH;
+import static org.apache.pulsar.common.schema.SchemaType.AVRO;
+import static org.apache.pulsar.common.schema.SchemaType.BOOLEAN;
+import static org.apache.pulsar.common.schema.SchemaType.BYTES;
+import static org.apache.pulsar.common.schema.SchemaType.DATE;
+import static org.apache.pulsar.common.schema.SchemaType.DOUBLE;
+import static org.apache.pulsar.common.schema.SchemaType.FLOAT;
+import static org.apache.pulsar.common.schema.SchemaType.INSTANT;
+import static org.apache.pulsar.common.schema.SchemaType.INT16;
+import static org.apache.pulsar.common.schema.SchemaType.INT32;
+import static org.apache.pulsar.common.schema.SchemaType.INT64;
+import static org.apache.pulsar.common.schema.SchemaType.INT8;
+import static org.apache.pulsar.common.schema.SchemaType.JSON;
+import static org.apache.pulsar.common.schema.SchemaType.KEY_VALUE;
+import static org.apache.pulsar.common.schema.SchemaType.LOCAL_DATE;
+import static org.apache.pulsar.common.schema.SchemaType.LOCAL_DATE_TIME;
+import static org.apache.pulsar.common.schema.SchemaType.LOCAL_TIME;
+import static org.apache.pulsar.common.schema.SchemaType.NONE;
+import static org.apache.pulsar.common.schema.SchemaType.PROTOBUF;
+import static org.apache.pulsar.common.schema.SchemaType.PROTOBUF_NATIVE;
+import static org.apache.pulsar.common.schema.SchemaType.STRING;
+import static org.apache.pulsar.common.schema.SchemaType.TIME;
+import static org.apache.pulsar.common.schema.SchemaType.TIMESTAMP;
 import com.google.common.hash.HashCode;
 import com.google.common.hash.HashFunction;
 import com.google.common.hash.Hashing;
 import java.util.Optional;
 import lombok.EqualsAndHashCode;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.common.schema.SchemaInfo;
 import org.apache.pulsar.common.schema.SchemaType;
@@ -31,11 +57,10 @@ import org.apache.pulsar.common.schema.SchemaType;
  * Schema hash wrapper with a HashCode inner type.
  */
 @EqualsAndHashCode
+@Slf4j
 public class SchemaHash {
 
     private static final HashFunction hashFunction = Hashing.sha256();
-
-    private static final HashCode EMPTY_HASH = hashFunction.hashBytes(new byte[0]);
 
     private final HashCode hash;
 
@@ -61,14 +86,114 @@ public class SchemaHash {
                 schemaInfo == null ? null : schemaInfo.getType());
     }
 
-    public static SchemaHash of(byte[] schemaBytes, SchemaType schemaType) {
+    public static SchemaHash of() {
+        return of(null, null);
+    }
+
+    private static SchemaHash of(byte[] schemaBytes, SchemaType schemaType) {
+        SchemaHash result = null;
         if (schemaBytes == null || schemaBytes.length == 0) {
-            return new SchemaHash(EMPTY_HASH, schemaType);
+            result = EmptySchemaHashFactory.get(schemaType);
         }
-        return new SchemaHash(hashFunction.hashBytes(schemaBytes), schemaType);
+
+        // This should not be a common occurrence if everything goes well.
+        if (result == null) {
+            log.warn("Could not get schemaHash from EmptySchemaHashFactory, will create by hashFunction. Might bring"
+                            + " performance regression. schemaBytes length:{}, schemaType:{}",
+                    schemaBytes == null ? "null" : schemaBytes.length, schemaType);
+            result = new SchemaHash(
+                    hashFunction.hashBytes(schemaBytes == null ? new byte[0] : schemaBytes), schemaType);
+        }
+        return result;
     }
 
     public byte[] asBytes() {
         return hash.asBytes();
+    }
+
+    private static class EmptySchemaHashFactory {
+        private static final HashCode EMPTY_HASH = hashFunction.hashBytes(new byte[0]);
+        private static final SchemaHash NONE_SCHEMA_HASH = new SchemaHash(EMPTY_HASH, NONE);
+        private static final SchemaHash STRING_SCHEMA_HASH = new SchemaHash(EMPTY_HASH, STRING);
+        private static final SchemaHash JSON_SCHEMA_HASH = new SchemaHash(EMPTY_HASH, JSON);
+        private static final SchemaHash PROTOBUF_SCHEMA_HASH = new SchemaHash(EMPTY_HASH, PROTOBUF);
+        private static final SchemaHash AVRO_SCHEMA_HASH = new SchemaHash(EMPTY_HASH, AVRO);
+        private static final SchemaHash BOOLEAN_SCHEMA_HASH = new SchemaHash(EMPTY_HASH, BOOLEAN);
+        private static final SchemaHash INT8_SCHEMA_HASH = new SchemaHash(EMPTY_HASH, INT8);
+        private static final SchemaHash INT16_SCHEMA_HASH = new SchemaHash(EMPTY_HASH, INT16);
+        private static final SchemaHash INT32_SCHEMA_HASH = new SchemaHash(EMPTY_HASH, INT32);
+        private static final SchemaHash INT64_SCHEMA_HASH = new SchemaHash(EMPTY_HASH, INT64);
+        private static final SchemaHash FLOAT_SCHEMA_HASH = new SchemaHash(EMPTY_HASH, FLOAT);
+        private static final SchemaHash DOUBLE_SCHEMA_HASH = new SchemaHash(EMPTY_HASH, DOUBLE);
+        private static final SchemaHash DATE_SCHEMA_HASH = new SchemaHash(EMPTY_HASH, DATE);
+        private static final SchemaHash TIME_SCHEMA_HASH = new SchemaHash(EMPTY_HASH, TIME);
+        private static final SchemaHash TIMESTAMP_SCHEMA_HASH = new SchemaHash(EMPTY_HASH, TIMESTAMP);
+        private static final SchemaHash KEY_VALUE_SCHEMA_HASH = new SchemaHash(EMPTY_HASH, KEY_VALUE);
+        private static final SchemaHash INSTANT_SCHEMA_HASH = new SchemaHash(EMPTY_HASH, INSTANT);
+        private static final SchemaHash LOCAL_DATE_SCHEMA_HASH = new SchemaHash(EMPTY_HASH, LOCAL_DATE);
+        private static final SchemaHash LOCAL_TIME_SCHEMA_HASH = new SchemaHash(EMPTY_HASH, LOCAL_TIME);
+        private static final SchemaHash LOCAL_DATE_TIME_SCHEMA_HASH = new SchemaHash(EMPTY_HASH, LOCAL_DATE_TIME);
+        private static final SchemaHash PROTOBUF_NATIVE_SCHEMA_HASH = new SchemaHash(EMPTY_HASH, PROTOBUF_NATIVE);
+        private static final SchemaHash BYTES_SCHEMA_HASH = new SchemaHash(EMPTY_HASH, BYTES);
+        private static final SchemaHash AUTO_SCHEMA_HASH = new SchemaHash(EMPTY_HASH, AUTO);
+        private static final SchemaHash AUTO_CONSUME_SCHEMA_HASH = new SchemaHash(EMPTY_HASH, AUTO_CONSUME);
+        private static final SchemaHash AUTO_PUBLISH_SCHEMA_HASH = new SchemaHash(EMPTY_HASH, AUTO_PUBLISH);
+
+        public static SchemaHash get(SchemaType schemaType) {
+            switch (schemaType) {
+                case NONE:
+                    return NONE_SCHEMA_HASH;
+                case STRING:
+                    return STRING_SCHEMA_HASH;
+                case JSON:
+                    return JSON_SCHEMA_HASH;
+                case PROTOBUF:
+                    return PROTOBUF_SCHEMA_HASH;
+                case AVRO:
+                    return AVRO_SCHEMA_HASH;
+                case BOOLEAN:
+                    return BOOLEAN_SCHEMA_HASH;
+                case INT8:
+                    return INT8_SCHEMA_HASH;
+                case INT16:
+                    return INT16_SCHEMA_HASH;
+                case INT32:
+                    return INT32_SCHEMA_HASH;
+                case INT64:
+                    return INT64_SCHEMA_HASH;
+                case FLOAT:
+                    return FLOAT_SCHEMA_HASH;
+                case DOUBLE:
+                    return DOUBLE_SCHEMA_HASH;
+                case DATE:
+                    return DATE_SCHEMA_HASH;
+                case TIME:
+                    return TIME_SCHEMA_HASH;
+                case TIMESTAMP:
+                    return TIMESTAMP_SCHEMA_HASH;
+                case KEY_VALUE:
+                    return KEY_VALUE_SCHEMA_HASH;
+                case INSTANT:
+                    return INSTANT_SCHEMA_HASH;
+                case LOCAL_DATE:
+                    return LOCAL_DATE_SCHEMA_HASH;
+                case LOCAL_TIME:
+                    return LOCAL_TIME_SCHEMA_HASH;
+                case LOCAL_DATE_TIME:
+                    return LOCAL_DATE_TIME_SCHEMA_HASH;
+                case PROTOBUF_NATIVE:
+                    return PROTOBUF_NATIVE_SCHEMA_HASH;
+                case BYTES:
+                    return BYTES_SCHEMA_HASH;
+                case AUTO:
+                    return AUTO_SCHEMA_HASH;
+                case AUTO_CONSUME:
+                    return AUTO_CONSUME_SCHEMA_HASH;
+                case AUTO_PUBLISH:
+                    return AUTO_PUBLISH_SCHEMA_HASH;
+                default:
+                    return null;
+            }
+        }
     }
 }

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/protocol/schema/SchemaHash.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/protocol/schema/SchemaHash.java
@@ -67,7 +67,7 @@ public class SchemaHash {
         return EMPTY_SCHEMA_HASH;
     }
 
-    // Shouldn't call this method directly
+    // Shouldn't call this method frequently, otherwise will bring performance regression
     public static SchemaHash of(byte[] schemaBytes, SchemaType schemaType) {
         return new SchemaHash(hashFunction.hashBytes(schemaBytes == null ? new byte[0] : schemaBytes), schemaType);
     }

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/protocol/schema/SchemaHash.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/protocol/schema/SchemaHash.java
@@ -95,8 +95,8 @@ public class SchemaHash {
         if (schemaBytes == null || schemaBytes.length == 0) {
             result = EmptySchemaHashFactory.get(schemaType);
             if (result == null) {
-                log.warn("Could not get schemaHash from EmptySchemaHashFactory, will create by hashFunction. Might bring"
-                                + " performance regression. schemaBytes:{}, schemaType:{}",
+                log.warn("Could not get schemaHash from EmptySchemaHashFactory, will create by hashFunction. Might"
+                                + " bring performance regression. schemaBytes:{}, schemaType:{}",
                         schemaBytes == null ? "null" : "0", schemaType);
                 result = new SchemaHash(
                         hashFunction.hashBytes(schemaBytes == null ? new byte[0] : schemaBytes), schemaType);

--- a/pulsar-io/kafka-connect-adaptor/src/test/java/org/apache/pulsar/io/kafka/connect/KafkaConnectSinkTest.java
+++ b/pulsar-io/kafka-connect-adaptor/src/test/java/org/apache/pulsar/io/kafka/connect/KafkaConnectSinkTest.java
@@ -692,10 +692,11 @@ public class KafkaConnectSinkTest extends ProducerConsumerBase {
 
     @Test
     public void kafkaLogicalTypesTimestampTest() {
-        Schema schema = new TestSchema(new SchemaInfoImpl()
-                .setName(Timestamp.LOGICAL_NAME)
-                .setType(SchemaType.INT64)
-                .setSchema(new byte[0]));
+        Schema schema = new TestSchema(SchemaInfoImpl.builder()
+                .name(Timestamp.LOGICAL_NAME)
+                .type(SchemaType.INT64)
+                .schema(new byte[0])
+                .build());
 
         org.apache.kafka.connect.data.Schema kafkaSchema = PulsarSchemaToKafkaSchema
                 .getKafkaConnectSchema(schema);
@@ -709,10 +710,11 @@ public class KafkaConnectSinkTest extends ProducerConsumerBase {
 
     @Test
     public void kafkaLogicalTypesTimeTest() {
-        Schema schema = new TestSchema(new SchemaInfoImpl()
-                .setName(Time.LOGICAL_NAME)
-                .setType(SchemaType.INT32)
-                .setSchema(new byte[0]));
+        Schema schema = new TestSchema(SchemaInfoImpl.builder()
+                .name(Time.LOGICAL_NAME)
+                .type(SchemaType.INT32)
+                .schema(new byte[0])
+                .build());
 
         org.apache.kafka.connect.data.Schema kafkaSchema = PulsarSchemaToKafkaSchema
                 .getKafkaConnectSchema(schema);
@@ -726,10 +728,11 @@ public class KafkaConnectSinkTest extends ProducerConsumerBase {
 
     @Test
     public void kafkaLogicalTypesDateTest() {
-        Schema schema = new TestSchema(new SchemaInfoImpl()
-                .setName(Date.LOGICAL_NAME)
-                .setType(SchemaType.INT32)
-                .setSchema(new byte[0]));
+        Schema schema = new TestSchema(SchemaInfoImpl.builder()
+                .name(Date.LOGICAL_NAME)
+                .type(SchemaType.INT32)
+                .schema(new byte[0])
+                .build());
 
         org.apache.kafka.connect.data.Schema kafkaSchema = PulsarSchemaToKafkaSchema
                 .getKafkaConnectSchema(schema);

--- a/pulsar-io/kafka-connect-adaptor/src/test/java/org/apache/pulsar/io/kafka/connect/KafkaConnectSinkTest.java
+++ b/pulsar-io/kafka-connect-adaptor/src/test/java/org/apache/pulsar/io/kafka/connect/KafkaConnectSinkTest.java
@@ -748,11 +748,12 @@ public class KafkaConnectSinkTest extends ProducerConsumerBase {
     public void kafkaLogicalTypesDecimalTest() {
         Map<String, String> props = new HashMap<>();
         props.put("scale", "10");
-        Schema schema = new TestSchema(new SchemaInfoImpl()
-                .setName(Decimal.LOGICAL_NAME)
-                .setType(SchemaType.BYTES)
-                .setProperties(props)
-                .setSchema(new byte[0]));
+        Schema schema = new TestSchema(SchemaInfoImpl.builder()
+                .name(Decimal.LOGICAL_NAME)
+                .type(SchemaType.BYTES)
+                .properties(props)
+                .schema(new byte[0])
+                .build());
 
         org.apache.kafka.connect.data.Schema kafkaSchema = PulsarSchemaToKafkaSchema
                 .getKafkaConnectSchema(schema);


### PR DESCRIPTION
Fixes https://github.com/apache/pulsar/issues/17931


### Motivation

The PR https://github.com/apache/pulsar/pull/17049 bring a significant performance regression for publish throughput. The root cause  is that  `HashFunction#hashBytes(byte[])` takes a lot of cpu time. So we need add a cache for `SchemaHash`. 

For details see line97:
https://github.com/apache/pulsar/blob/8d13ff81108b95ae5f63245e4a5edf4e097aaf47/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MessageImpl.java#L85-L99

And we can see that `hashFunction` takes a lot of cpu time from the [flame graph](https://github.com/apache/pulsar/files/9708735/before_revert.html.zip) below
![image](https://user-images.githubusercontent.com/10233437/194230199-f9790785-0e22-4bb5-977c-0e50e32ecb6f.png)
![image](https://user-images.githubusercontent.com/10233437/194230237-bab7485c-fb53-41bc-930c-3d63c17fd5bf.png)

The test result for publish throughput(msgs/s) is below：

| |master branch| master branch revert PR#17049 | master branch apply this patch|
| -- |---|---|---|
|1  |837,119.26 |1,504,240.76 | 1,570,375.90 |
| 2 | 870,065.55| 1,504,240.76| 1,594,203.19 |
| 3 | 868,281.75|1,504,240.76 | 1,589,468.89 |
|avg| 858,488.85| 1,528,647.63| 1,584,682.66|  


### Modifications

* Adding a cache for  `SchemaHash`.
* To avoid the new byte[0] allocation and instead passing a null for `SchemaHash#of`

### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/AnonHxy/pulsar/pull/8
