### PR TITLE
[fix][connector] Kinesis sink: fix NPE with KeyValue schema and no value

### DIFF
--- a/pulsar-io/kinesis/src/main/java/org/apache/pulsar/io/kinesis/Utils.java
+++ b/pulsar-io/kinesis/src/main/java/org/apache/pulsar/io/kinesis/Utils.java
@@ -253,10 +253,14 @@ public class Utils {
                 org.apache.pulsar.common.schema.KeyValue<GenericObject, GenericObject> keyValue =
                         (org.apache.pulsar.common.schema.KeyValue<GenericObject, GenericObject>) val;
                 Map<String, Object> jsonKeyValue = new HashMap<>();
-                jsonKeyValue.put("key", toJsonSerializable(keyValueSchema.getKeySchema(),
-                        keyValue.getKey().getNativeObject()));
-                jsonKeyValue.put("value", toJsonSerializable(keyValueSchema.getValueSchema(),
-                        keyValue.getValue().getNativeObject()));
+                if (keyValue.getKey() != null) {
+                    jsonKeyValue.put("key", toJsonSerializable(keyValueSchema.getKeySchema(),
+                            keyValue.getKey().getNativeObject()));
+                }
+                if (keyValue.getValue() != null) {
+                    jsonKeyValue.put("value", toJsonSerializable(keyValueSchema.getValueSchema(),
+                            keyValue.getValue().getNativeObject()));
+                }
                 return jsonKeyValue;
             case AVRO:
                 return JsonConverter.toJson((org.apache.avro.generic.GenericRecord) val);

--- a/pulsar-io/kinesis/src/test/java/org/apache/pulsar/io/kinesis/UtilsTest.java
+++ b/pulsar-io/kinesis/src/test/java/org/apache/pulsar/io/kinesis/UtilsTest.java
@@ -29,6 +29,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.gson.Gson;
 
 import java.nio.ByteBuffer;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -443,6 +444,78 @@ public class UtilsTest {
                 + "\"payload.value.d\":1,\"payload.value.e.a\":\"a\",\"payload.value.e.b\":true,\"payload.value.e"
                 + ".d\":1.0,\"payload.value.e.f\":1.0,\"payload.value.e.i\":1,\"payload.value.e.l\":10,\"payload.key"
                 + ".a\":\"1\",\"payload.key.b\":1,\"properties.prop-key\":\"prop-value\",\"eventTime\":1648502845803}");
+    }
+
+    @Test(dataProvider = "schemaType")
+    public void testKeyValueSerializeNoValue(SchemaType schemaType) throws Exception {
+        RecordSchemaBuilder keySchemaBuilder = org.apache.pulsar.client.api.schema.SchemaBuilder.record("key");
+        keySchemaBuilder.field("a").type(SchemaType.STRING).optional().defaultValue(null);
+        GenericSchema<GenericRecord> keySchema = Schema.generic(keySchemaBuilder.build(schemaType));
+
+        RecordSchemaBuilder valueSchemaBuilder = org.apache.pulsar.client.api.schema.SchemaBuilder.record("value");
+        valueSchemaBuilder.field("c").type(SchemaType.STRING).optional().defaultValue(null);
+        GenericSchema<GenericRecord> valueSchema = Schema.generic(valueSchemaBuilder.build(schemaType));
+
+        Schema<org.apache.pulsar.common.schema.KeyValue<GenericRecord, GenericRecord>> keyValueSchema =
+                Schema.KeyValue(keySchema, valueSchema, KeyValueEncodingType.INLINE);
+        org.apache.pulsar.common.schema.KeyValue<GenericRecord, GenericRecord>
+                keyValue = new org.apache.pulsar.common.schema.KeyValue<>(null, null);
+        GenericObject genericObject = new GenericObject() {
+            @Override
+            public SchemaType getSchemaType() {
+                return SchemaType.KEY_VALUE;
+            }
+
+            @Override
+            public Object getNativeObject() {
+                return keyValue;
+            }
+        };
+
+        Record<GenericObject> genericObjectRecord = new Record<>() {
+            @Override
+            public Optional<String> getTopicName() {
+                return Optional.of("data-ks1.table1");
+            }
+
+            @Override
+            public org.apache.pulsar.client.api.Schema getSchema() {
+                return keyValueSchema;
+            }
+
+            @Override
+            public Optional<String> getKey() {
+                return Optional.of("message-key");
+            }
+
+            @Override
+            public GenericObject getValue() {
+                return genericObject;
+            }
+
+            @Override
+            public Map<String, String> getProperties() {
+                return Collections.emptyMap();
+            }
+
+            @Override
+            public Optional<Long> getEventTime() {
+                return Optional.of(1648502845803L);
+            }
+        };
+
+        ObjectMapper objectMapper = new ObjectMapper().setSerializationInclusion(JsonInclude.Include.NON_NULL);
+        String json = Utils.serializeRecordToJsonExpandingValue(objectMapper, genericObjectRecord, false);
+
+        assertEquals(json, "{\"topicName\":\"data-ks1.table1\",\"key\":\"message-key\","
+                + "\"payload\":{},"
+                + "\"eventTime\":1648502845803}");
+
+        json = Utils.serializeRecordToJsonExpandingValue(objectMapper, genericObjectRecord, true);
+
+        assertEquals(json, "{\"topicName\":\"data-ks1.table1\",\"key\":\"message-key\","
+                + "\"payload\":{},"
+                + "\"eventTime\":1648502845803}");
     }
 
     @Test


### PR DESCRIPTION
### Motivation

In the Kinesis sink with `FULL_MESSAGE_IN_JSON_EXPAND_VALUE`, a message with KeyValue schema and with value=NULL you get this NPE
```
2022-10-07T07:27:33,698+0000 [public/default/kinesis-sink-0] INFO  org.apache.pulsar.functions.instance.JavaInstanceRunnable - Encountered exception in sink write: 
java.lang.NullPointerException: null
	at org.apache.pulsar.io.kinesis.Utils.toJsonSerializable(Utils.java:250) ~[HsqgvoaXuefCgCSXYBQtdA/:?]
	at org.apache.pulsar.io.kinesis.Utils.serializeRecordToJsonExpandingValue(Utils.java:222) ~[HsqgvoaXuefCgCSXYBQtdA/:?]
	at org.apache.pulsar.io.kinesis.KinesisSink.createKinesisMessage(KinesisSink.java:308) ~[HsqgvoaXuefCgCSXYBQtdA/:?]
	at org.apache.pulsar.io.kinesis.KinesisSink.write(KinesisSink.java:135) ~[HsqgvoaXuefCgCSXYBQtdA/:?]
	at org.apache.pulsar.functions.instance.JavaInstanceRunnable.sendOutputMessage(JavaInstanceRunnable.java:424) ~[?:?]
	at org.apache.pulsar.functions.instance.JavaInstanceRunnable.handleResult(JavaInstanceRunnable.java:394) ~[?:?]
	at org.apache.pulsar.functions.instance.JavaInstanceRunnable.run(JavaInstanceRunnable.java:335) ~[?:?]
	at java.lang.Thread.run(Thread.java:829) ~[?:?]
2022-10-07T07:27:33,712+0000 [public/default/kinesis-sink-0] ERROR org.apache.pulsar.functions.instance.JavaInstanceRunnable - [public/default/kinesis-sink:0] Uncaught exception in Java Instance
java.lang.RuntimeException: Failed to process message: 31:4:-1:0
	at org.apache.pulsar.functions.source.PulsarSource.lambda$buildRecord$1(PulsarSource.java:152) ~[com.datastax.oss-pulsar-functions-instance-2.10.2.1.jar:2.10.2.1]
	at org.apache.pulsar.functions.source.PulsarRecord.fail(PulsarRecord.java:117) ~[com.datastax.oss-pulsar-functions-instance-2.10.2.1.jar:2.10.2.1]
	at org.apache.pulsar.functions.instance.JavaInstanceRunnable.sendOutputMessage(JavaInstanceRunnable.java:429) ~[com.datastax.oss-pulsar-functions-instance-2.10.2.1.jar:2.10.2.1]
	at org.apache.pulsar.functions.instance.JavaInstanceRunnable.handleResult(JavaInstanceRunnable.java:394) ~[com.datastax.oss-pulsar-functions-instance-2.10.2.1.jar:2.10.2.1]
	at org.apache.pulsar.functions.instance.JavaInstanceRunnable.run(JavaInstanceRunnable.java:335) ~[com.datastax.oss-pulsar-functions-instance-2.10.2.1.jar:2.10.2.1]
	at java.lang.Thread.run(Thread.java:829) ~[?:?]
```
### Modifications

* Added NPE check for the KeyValue schema when serializing to JSON. If the key/value is null, the "key"/"value" entry is omitted from the final payload 

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->