### PR TITLE
[feat] [broker] PIP-188 support blue-green cluster migration [part-1]

### DIFF
--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -1457,6 +1457,10 @@ splitTopicAndPartitionLabelInPrometheus=false
 # Otherwise, aggregate it by list index.
 aggregatePublisherStatsByProducerName=false
 
+# Interval between checks to see if cluster is migrated and marks topic migrated
+# if cluster is marked migrated. Disable with value 0. (Default disabled).
+clusterMigrationCheckDurationSeconds=0
+
 ### --- Schema storage --- ###
 # The schema storage implementation used by this broker
 schemaRegistryStorageClassName=org.apache.pulsar.broker.service.schema.BookkeeperSchemaStorageFactory

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedLedger.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedLedger.java
@@ -443,6 +443,8 @@ public interface ManagedLedger {
 
     void asyncTerminate(TerminateCallback callback, Object ctx);
 
+    CompletableFuture<Position> asyncMigrate();
+
     /**
      * Terminate the managed ledger and return the last committed entry.
      *
@@ -533,6 +535,11 @@ public interface ManagedLedger {
      * Returns whether the managed ledger was terminated.
      */
     boolean isTerminated();
+
+    /**
+     * Returns whether the managed ledger was migrated.
+     */
+    boolean isMigrated();
 
     /**
      * Returns managed-ledger config.

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -2512,6 +2512,13 @@ public class ServiceConfiguration implements PulsarConfiguration {
     private long brokerServiceCompactionPhaseOneLoopTimeInSeconds = 30;
 
     @FieldContext(
+        category = CATEGORY_SERVER,
+        doc = "Interval between checks to see if cluster is migrated and marks topic migrated "
+                + " if cluster is marked migrated. Disable with value 0. (Default disabled)."
+    )
+    private int clusterMigrationCheckDurationSeconds = 0;
+
+    @FieldContext(
         category = CATEGORY_SCHEMA,
         doc = "Enforce schema validation on following cases:\n\n"
             + " - if a producer without a schema attempts to produce to a topic with schema, the producer will be\n"

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/ClustersBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/ClustersBase.java
@@ -41,6 +41,7 @@ import javax.ws.rs.POST;
 import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
+import javax.ws.rs.QueryParam;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.container.AsyncResponse;
 import javax.ws.rs.container.Suspended;
@@ -59,6 +60,7 @@ import org.apache.pulsar.common.naming.NamedEntity;
 import org.apache.pulsar.common.policies.data.BrokerNamespaceIsolationData;
 import org.apache.pulsar.common.policies.data.BrokerNamespaceIsolationDataImpl;
 import org.apache.pulsar.common.policies.data.ClusterData;
+import org.apache.pulsar.common.policies.data.ClusterData.ClusterUrl;
 import org.apache.pulsar.common.policies.data.ClusterDataImpl;
 import org.apache.pulsar.common.policies.data.FailureDomainImpl;
 import org.apache.pulsar.common.policies.data.NamespaceIsolationDataImpl;
@@ -214,6 +216,66 @@ public class ClustersBase extends AdminResource {
         validateSuperUserAccessAsync()
                 .thenCompose(__ -> validatePoliciesReadOnlyAccessAsync())
                 .thenCompose(__ -> clusterResources().updateClusterAsync(cluster, old -> clusterData))
+                .thenAccept(__ -> {
+                    log.info("[{}] Updated cluster {}", clientAppId(), cluster);
+                    asyncResponse.resume(Response.ok().build());
+                }).exceptionally(ex -> {
+                    log.error("[{}] Failed to update cluster {}", clientAppId(), cluster, ex);
+                    Throwable realCause = FutureUtil.unwrapCompletionException(ex);
+                    if (realCause instanceof MetadataStoreException.NotFoundException) {
+                        asyncResponse.resume(new RestException(Status.NOT_FOUND, "Cluster does not exist"));
+                        return null;
+                    }
+                    resumeAsyncResponseExceptionally(asyncResponse, ex);
+                    return null;
+                });
+    }
+
+    @POST
+    @Path("/{cluster}/migrate")
+    @ApiOperation(
+        value = "Update the configuration for a cluster migration.",
+        notes = "This operation requires Pulsar superuser privileges.")
+    @ApiResponses(value = {
+            @ApiResponse(code = 204, message = "Cluster has been updated."),
+            @ApiResponse(code = 400, message = "Cluster url must not be empty."),
+            @ApiResponse(code = 403, message = "Don't have admin permission or policies are read-only."),
+            @ApiResponse(code = 404, message = "Cluster doesn't exist."),
+            @ApiResponse(code = 500, message = "Internal server error.")
+    })
+    public void updateClusterMigration(
+        @Suspended AsyncResponse asyncResponse,
+        @ApiParam(value = "The cluster name", required = true)
+        @PathParam("cluster") String cluster,
+        @ApiParam(value = "Is cluster migrated", required = true)
+        @QueryParam("migrated") boolean isMigrated,
+        @ApiParam(
+            value = "The cluster url data",
+            required = true,
+            examples = @Example(
+                value = @ExampleProperty(
+                    mediaType = MediaType.APPLICATION_JSON,
+                    value = """
+                            {
+                               "serviceUrl": "http://pulsar.example.com:8080",
+                               "brokerServiceUrl": "pulsar://pulsar.example.com:6651"
+                            }
+                            """
+                )
+            )
+        ) ClusterUrl clusterUrl) {
+        if (isMigrated && clusterUrl.isEmpty()) {
+            asyncResponse.resume(new RestException(Status.BAD_REQUEST, "Cluster url must not be empty"));
+            return;
+        }
+        validateSuperUserAccessAsync()
+                .thenCompose(__ -> validatePoliciesReadOnlyAccessAsync())
+                .thenCompose(__ -> clusterResources().updateClusterAsync(cluster, old -> {
+                    ClusterDataImpl data = (ClusterDataImpl) old;
+                    data.setMigrated(isMigrated);
+                    data.setMigratedClusterUrl(clusterUrl);
+                    return data;
+                }))
                 .thenAccept(__ -> {
                     log.info("[{}] Updated cluster {}", clientAppId(), cluster);
                     asyncResponse.resume(Response.ok().build());

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractBaseDispatcher.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractBaseDispatcher.java
@@ -339,6 +339,19 @@ public abstract class AbstractBaseDispatcher extends EntryFilterSupport implemen
         return subscription == null ? null : subscription.getName();
     }
 
+    protected void checkAndApplyReachedEndOfTopicOrTopicMigration(List<Consumer> consumers) {
+        PersistentTopic topic = (PersistentTopic) subscription.getTopic();
+        checkAndApplyReachedEndOfTopicOrTopicMigration(topic, consumers);
+    }
+
+    public static void checkAndApplyReachedEndOfTopicOrTopicMigration(PersistentTopic topic, List<Consumer> consumers) {
+        if (topic.isMigrated()) {
+            consumers.forEach(c -> c.topicMigrated(topic.getMigratedClusterUrl()));
+        } else {
+            consumers.forEach(Consumer::reachedEndOfTopic);
+        }
+    }
+
     @Override
     public long getFilterProcessedMsgCount() {
         return this.filterProcessedMsgs.longValue();

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
@@ -582,6 +582,13 @@ public class BrokerService implements Closeable {
                     subscriptionExpiryCheckIntervalInSeconds,
                     subscriptionExpiryCheckIntervalInSeconds, TimeUnit.SECONDS);
         }
+
+        // check cluster migration
+        int interval = pulsar().getConfiguration().getClusterMigrationCheckDurationSeconds();
+        if (interval > 0) {
+            inactivityMonitor.scheduleAtFixedRate(safeRun(() -> checkClusterMigration()), interval, interval,
+                    TimeUnit.SECONDS);
+        }
     }
 
     protected void startMessageExpiryMonitor() {
@@ -1848,6 +1855,10 @@ public class BrokerService implements Closeable {
 
     public void checkGC() {
         forEachTopic(Topic::checkGC);
+    }
+
+    public void checkClusterMigration() {
+        forEachTopic(Topic::checkClusterMigration);
     }
 
     public void checkMessageExpiry() {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerServiceException.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerServiceException.java
@@ -100,6 +100,16 @@ public class BrokerServiceException extends Exception {
         }
     }
 
+    public static class TopicMigratedException extends BrokerServiceException {
+        public TopicMigratedException(String msg) {
+            super(msg);
+        }
+
+        public TopicMigratedException(Throwable t) {
+            super(t);
+        }
+    }
+
     public static class ServerMetadataException extends BrokerServiceException {
         public ServerMetadataException(Throwable t) {
             super(t);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Producer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Producer.java
@@ -43,10 +43,12 @@ import org.apache.pulsar.broker.service.Topic.PublishContext;
 import org.apache.pulsar.broker.service.nonpersistent.NonPersistentTopic;
 import org.apache.pulsar.broker.service.persistent.PersistentTopic;
 import org.apache.pulsar.client.api.transaction.TxnID;
+import org.apache.pulsar.common.api.proto.CommandTopicMigrated.ResourceType;
 import org.apache.pulsar.common.api.proto.MessageMetadata;
 import org.apache.pulsar.common.api.proto.ProducerAccessMode;
 import org.apache.pulsar.common.api.proto.ServerError;
 import org.apache.pulsar.common.naming.TopicName;
+import org.apache.pulsar.common.policies.data.ClusterData.ClusterUrl;
 import org.apache.pulsar.common.policies.data.stats.NonPersistentPublisherStatsImpl;
 import org.apache.pulsar.common.policies.data.stats.PublisherStatsImpl;
 import org.apache.pulsar.common.protocol.Commands;
@@ -663,6 +665,15 @@ public class Producer {
             });
         }
         return closeFuture;
+    }
+
+    public void topicMigrated(Optional<ClusterUrl> clusterUrl) {
+        if (clusterUrl.isPresent()) {
+            ClusterUrl url = clusterUrl.get();
+            cnx.getCommandSender().sendTopicMigrated(ResourceType.Producer, producerId, url.getBrokerServiceUrl(),
+                    url.getBrokerServiceUrlTls());
+            disconnect();
+        }
     }
 
     public void updateRates() {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/PulsarCommandSender.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/PulsarCommandSender.java
@@ -25,6 +25,7 @@ import java.util.Optional;
 import org.apache.bookkeeper.mledger.Entry;
 import org.apache.pulsar.client.api.transaction.TxnID;
 import org.apache.pulsar.common.api.proto.CommandLookupTopicResponse;
+import org.apache.pulsar.common.api.proto.CommandTopicMigrated.ResourceType;
 import org.apache.pulsar.common.api.proto.ServerError;
 import org.apache.pulsar.common.protocol.schema.SchemaVersion;
 import org.apache.pulsar.common.schema.SchemaInfo;
@@ -76,6 +77,8 @@ public interface PulsarCommandSender {
     void sendError(long requestId, ServerError error, String message);
 
     void sendReachedEndOfTopic(long consumerId);
+
+    boolean sendTopicMigrated(ResourceType type, long resourceId, String brokerUrl, String brokerUrlTls);
 
     Future<Void> sendMessagesToConsumer(long consumerId, String topicName, Subscription subscription,
                                         int partitionIdx, List<? extends Entry> entries, EntryBatchSizes batchSizes,

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Topic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Topic.java
@@ -197,6 +197,8 @@ public interface Topic {
 
     void checkGC();
 
+    CompletableFuture<Void> checkClusterMigration();
+
     void checkInactiveSubscriptions();
 
     /**

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentTopic.java
@@ -73,6 +73,7 @@ import org.apache.pulsar.common.api.proto.CommandSubscribe.SubType;
 import org.apache.pulsar.common.api.proto.KeySharedMeta;
 import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.policies.data.BacklogQuota;
+import org.apache.pulsar.common.policies.data.ClusterData.ClusterUrl;
 import org.apache.pulsar.common.policies.data.ManagedLedgerInternalStats.CursorStats;
 import org.apache.pulsar.common.policies.data.PersistentTopicInternalStats;
 import org.apache.pulsar.common.policies.data.Policies;
@@ -106,6 +107,7 @@ public class NonPersistentTopic extends AbstractTopic implements Topic, TopicPol
             AtomicLongFieldUpdater.newUpdater(NonPersistentTopic.class, "entriesAddedCounter");
     private volatile long entriesAddedCounter = 0;
 
+    private volatile boolean migrated = false;
     private static final FastThreadLocal<TopicStats> threadLocalTopicStats = new FastThreadLocal<TopicStats>() {
         @Override
         protected TopicStats initialValue() {
@@ -153,10 +155,18 @@ public class NonPersistentTopic extends AbstractTopic implements Topic, TopicPol
         registerTopicPolicyListener();
     }
 
+    private CompletableFuture<Void> updateClusterMigrated() {
+        return getMigratedClusterUrlAsync(brokerService.getPulsar()).thenAccept(url -> migrated = url.isPresent());
+    }
+
+    private Optional<ClusterUrl> getClusterMigrationUrl() {
+        return getMigratedClusterUrl(brokerService.getPulsar());
+    }
+
     public CompletableFuture<Void> initialize() {
         return brokerService.pulsar().getPulsarResources().getNamespaceResources()
                 .getPoliciesAsync(TopicName.get(topic).getNamespaceObject())
-                .thenAccept(optPolicies -> {
+                .thenCompose(optPolicies -> {
                     if (!optPolicies.isPresent()) {
                         log.warn("[{}] Policies not present and isEncryptionRequired will be set to false", topic);
                         isEncryptionRequired = false;
@@ -168,6 +178,7 @@ public class NonPersistentTopic extends AbstractTopic implements Topic, TopicPol
                     }
                     updatePublishDispatcher();
                     updateResourceGroupLimiter(optPolicies);
+                    return updateClusterMigrated();
                 });
     }
 
@@ -273,7 +284,6 @@ public class NonPersistentTopic extends AbstractTopic implements Topic, TopicPol
         return brokerService.checkTopicNsOwnership(getName()).thenCompose(__ -> {
             final CompletableFuture<Consumer> future = new CompletableFuture<>();
 
-
             if (hasBatchMessagePublished && !cnx.isBatchMessageCompatibleVersion()) {
                 if (log.isDebugEnabled()) {
                     log.debug("[{}] Consumer doesn't support batch-message {}", topic, subscriptionName);
@@ -313,6 +323,9 @@ public class NonPersistentTopic extends AbstractTopic implements Topic, TopicPol
             Consumer consumer = new Consumer(subscription, subType, topic, consumerId, priorityLevel, consumerName,
                     false, cnx, cnx.getAuthRole(), metadata, readCompacted, keySharedMeta,
                     MessageId.latest, DEFAULT_CONSUMER_EPOCH);
+            if (isMigrated()) {
+                consumer.topicMigrated(getClusterMigrationUrl());
+            }
 
             addConsumerToSubscription(subscription, consumer).thenRun(() -> {
                 if (!cnx.isActive()) {
@@ -926,6 +939,23 @@ public class NonPersistentTopic extends AbstractTopic implements Topic, TopicPol
     }
 
     @Override
+    public CompletableFuture<Void> checkClusterMigration() {
+        Optional<ClusterUrl> url = getClusterMigrationUrl();
+        if (url.isPresent()) {
+            this.migrated = true;
+            producers.forEach((__, producer) -> {
+                producer.topicMigrated(url);
+            });
+            subscriptions.forEach((__, sub) -> {
+                sub.getConsumers().forEach((consumer) -> {
+                    consumer.topicMigrated(url);
+                });
+            });
+        }
+        return CompletableFuture.completedFuture(null);
+    }
+
+    @Override
     public void checkGC() {
         if (!isDeleteWhileInactive()) {
             // This topic is not included in GC
@@ -1162,6 +1192,12 @@ public class NonPersistentTopic extends AbstractTopic implements Topic, TopicPol
 
     protected boolean isTerminated() {
         return false;
+    }
+
+
+    @Override
+    protected boolean isMigrated() {
+        return this.migrated;
     }
 
     @Override

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/CompactorSubscription.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/CompactorSubscription.java
@@ -19,13 +19,13 @@
 package org.apache.pulsar.broker.service.persistent;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static org.apache.pulsar.broker.service.AbstractBaseDispatcher.checkAndApplyReachedEndOfTopicOrTopicMigration;
 import java.util.List;
 import java.util.Map;
 import org.apache.bookkeeper.mledger.AsyncCallbacks.MarkDeleteCallback;
 import org.apache.bookkeeper.mledger.ManagedCursor;
 import org.apache.bookkeeper.mledger.ManagedLedgerException;
 import org.apache.bookkeeper.mledger.Position;
-import org.apache.pulsar.broker.service.Consumer;
 import org.apache.pulsar.common.api.proto.CommandAck.AckType;
 import org.apache.pulsar.compaction.CompactedTopic;
 import org.apache.pulsar.compaction.Compactor;
@@ -102,7 +102,7 @@ public class CompactorSubscription extends PersistentSubscription {
 
         if (topic.getManagedLedger().isTerminated() && cursor.getNumberOfEntriesInBacklog(false) == 0) {
             // Notify all consumer that the end of topic was reached
-            dispatcher.getConsumers().forEach(Consumer::reachedEndOfTopic);
+            checkAndApplyReachedEndOfTopicOrTopicMigration(topic, dispatcher.getConsumers());
         }
     }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumers.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumers.java
@@ -773,7 +773,7 @@ public class PersistentDispatcherMultipleConsumers extends AbstractDispatcherMul
             if (cursor.getNumberOfEntriesInBacklog(false) == 0) {
                 // Topic has been terminated and there are no more entries to read
                 // Notify the consumer only if all the messages were already acknowledged
-                consumerList.forEach(Consumer::reachedEndOfTopic);
+                checkAndApplyReachedEndOfTopicOrTopicMigration(consumerList);
             }
         } else if (exception.getCause() instanceof TransactionBufferException.TransactionNotSealedException
                 || exception.getCause() instanceof ManagedLedgerException.OffloadReadHandleClosedException) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherSingleActiveConsumer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherSingleActiveConsumer.java
@@ -486,7 +486,7 @@ public class PersistentDispatcherSingleActiveConsumer extends AbstractDispatcher
             if (cursor.getNumberOfEntriesInBacklog(false) == 0) {
                 // Topic has been terminated and there are no more entries to read
                 // Notify the consumer only if all the messages were already acknowledged
-                consumers.forEach(Consumer::reachedEndOfTopic);
+                checkAndApplyReachedEndOfTopicOrTopicMigration(consumers);
             }
         } else if (exception.getCause() instanceof TransactionBufferException.TransactionNotSealedException
                 || exception.getCause() instanceof ManagedLedgerException.OffloadReadHandleClosedException) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentStreamingDispatcherMultipleConsumers.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentStreamingDispatcherMultipleConsumers.java
@@ -31,7 +31,6 @@ import org.apache.bookkeeper.mledger.impl.ManagedLedgerImpl;
 import org.apache.bookkeeper.mledger.impl.PositionImpl;
 import org.apache.bookkeeper.mledger.util.SafeRun;
 import org.apache.commons.lang3.tuple.Pair;
-import org.apache.pulsar.broker.service.Consumer;
 import org.apache.pulsar.broker.service.Subscription;
 import org.apache.pulsar.broker.service.streamingdispatch.PendingReadEntryRequest;
 import org.apache.pulsar.broker.service.streamingdispatch.StreamingDispatcher;
@@ -142,7 +141,7 @@ public class PersistentStreamingDispatcherMultipleConsumers extends PersistentDi
         if (cursor.getNumberOfEntriesInBacklog(false) == 0) {
             // Topic has been terminated and there are no more entries to read
             // Notify the consumer only if all the messages were already acknowledged
-            consumerList.forEach(Consumer::reachedEndOfTopic);
+            checkAndApplyReachedEndOfTopicOrTopicMigration(consumerList);
         }
     }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentStreamingDispatcherSingleActiveConsumer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentStreamingDispatcherSingleActiveConsumer.java
@@ -97,7 +97,7 @@ public class PersistentStreamingDispatcherSingleActiveConsumer extends Persisten
         if (cursor.getNumberOfEntriesInBacklog(false) == 0) {
             // Topic has been terminated and there are no more entries to read
             // Notify the consumer only if all the messages were already acknowledged
-            consumers.forEach(Consumer::reachedEndOfTopic);
+            checkAndApplyReachedEndOfTopicOrTopicMigration(consumers);
         }
     }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentSubscription.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentSubscription.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pulsar.broker.service.persistent;
 
+import static org.apache.pulsar.broker.service.AbstractBaseDispatcher.checkAndApplyReachedEndOfTopicOrTopicMigration;
 import static org.apache.pulsar.common.naming.SystemTopicNames.isEventSystemTopic;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.MoreObjects;
@@ -426,7 +427,7 @@ public class PersistentSubscription extends AbstractSubscription implements Subs
         if (topic.getManagedLedger().isTerminated() && cursor.getNumberOfEntriesInBacklog(false) == 0) {
             // Notify all consumer that the end of topic was reached
             if (dispatcher != null) {
-                dispatcher.getConsumers().forEach(Consumer::reachedEndOfTopic);
+                checkAndApplyReachedEndOfTopicOrTopicMigration(topic, dispatcher.getConsumers());
             }
         }
     }
@@ -1214,7 +1215,7 @@ public class PersistentSubscription extends AbstractSubscription implements Subs
             // notify the consumers if there are consumers connected to this topic.
             if (null != dispatcher) {
                 // Immediately notify the consumer that there are no more available messages
-                dispatcher.getConsumers().forEach(Consumer::reachedEndOfTopic);
+                checkAndApplyReachedEndOfTopicOrTopicMigration(topic, dispatcher.getConsumers());
             }
         }
     }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -66,22 +66,17 @@ import org.apache.bookkeeper.mledger.ManagedLedgerException;
 import org.apache.bookkeeper.mledger.ManagedLedgerException.ManagedLedgerAlreadyClosedException;
 import org.apache.bookkeeper.mledger.ManagedLedgerException.ManagedLedgerFencedException;
 import org.apache.bookkeeper.mledger.ManagedLedgerException.ManagedLedgerTerminatedException;
-import org.apache.bookkeeper.mledger.ManagedLedgerException.MetaStoreException;
 import org.apache.bookkeeper.mledger.ManagedLedgerException.MetadataNotFoundException;
 import org.apache.bookkeeper.mledger.Position;
 import org.apache.bookkeeper.mledger.impl.ManagedCursorContainer;
 import org.apache.bookkeeper.mledger.impl.ManagedCursorImpl;
-import org.apache.bookkeeper.mledger.impl.ManagedLedgerFactoryImpl;
 import org.apache.bookkeeper.mledger.impl.ManagedLedgerImpl;
-import org.apache.bookkeeper.mledger.impl.MetaStore.MetaStoreCallback;
 import org.apache.bookkeeper.mledger.impl.PositionImpl;
 import org.apache.bookkeeper.mledger.impl.ShadowManagedLedgerImpl;
-import org.apache.bookkeeper.mledger.proto.MLDataFormats.ManagedLedgerInfo;
 import org.apache.bookkeeper.net.BookieId;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.pulsar.broker.PulsarServerException;
-import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.broker.namespace.NamespaceService;
 import org.apache.pulsar.broker.resources.NamespaceResources.PartitionedTopicResources;
 import org.apache.pulsar.broker.service.AbstractReplicator;
@@ -166,7 +161,6 @@ import org.apache.pulsar.compaction.CompactedTopicImpl;
 import org.apache.pulsar.compaction.Compactor;
 import org.apache.pulsar.compaction.CompactorMXBean;
 import org.apache.pulsar.metadata.api.MetadataStoreException;
-import org.apache.pulsar.metadata.api.Stat;
 import org.apache.pulsar.policies.data.loadbalancer.NamespaceBundleStats;
 import org.apache.pulsar.utils.StatsOutputStream;
 import org.slf4j.Logger;
@@ -1769,24 +1763,6 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
         return replicators.get(remoteCluster);
     }
 
-    public static CompletableFuture<Boolean> getManagedLedgerInfo(PulsarService pulsar, TopicName topic) {
-        String mlName = topic.getPersistenceNamingEncoding();
-        CompletableFuture<Boolean> future = new CompletableFuture<>();
-        ManagedLedgerFactoryImpl factory = (ManagedLedgerFactoryImpl) pulsar.getManagedLedgerFactory();
-        factory.getMetaStore().getManagedLedgerInfo(mlName, true, new MetaStoreCallback<ManagedLedgerInfo>() {
-
-            @Override
-            public void operationComplete(ManagedLedgerInfo result, Stat stat) {
-                future.complete(false);
-            }
-
-            @Override
-            public void operationFailed(MetaStoreException e) {
-                future.completeExceptionally(e);
-            }
-        });
-        return future;
-    }
     public ManagedLedger getManagedLedger() {
         return ledger;
     }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/intercept/CounterBrokerInterceptor.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/intercept/CounterBrokerInterceptor.java
@@ -40,8 +40,8 @@ import org.apache.pulsar.broker.service.ServerCnx;
 import org.apache.pulsar.broker.service.Subscription;
 import org.apache.pulsar.broker.service.Topic;
 import org.apache.pulsar.common.api.proto.BaseCommand;
-import org.apache.pulsar.common.api.proto.MessageMetadata;
 import org.apache.pulsar.common.api.proto.CommandAck;
+import org.apache.pulsar.common.api.proto.MessageMetadata;
 import org.apache.pulsar.common.api.proto.TxnAction;
 import org.eclipse.jetty.server.Response;
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ClusterMigrationTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ClusterMigrationTest.java
@@ -1,0 +1,329 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.service;
+
+import static org.apache.pulsar.broker.auth.MockedPulsarServiceBaseTest.retryStrategically;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+
+import java.lang.reflect.Method;
+import java.net.URL;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.pulsar.broker.BrokerTestUtil;
+import org.apache.pulsar.broker.PulsarService;
+import org.apache.pulsar.broker.auth.MockedPulsarServiceBaseTest;
+import org.apache.pulsar.client.admin.PulsarAdmin;
+import org.apache.pulsar.client.api.Consumer;
+import org.apache.pulsar.client.api.Message;
+import org.apache.pulsar.client.api.MessageRoutingMode;
+import org.apache.pulsar.client.api.Producer;
+import org.apache.pulsar.client.api.PulsarClient;
+import org.apache.pulsar.client.api.SubscriptionType;
+import org.apache.pulsar.common.policies.data.ClusterData;
+import org.apache.pulsar.common.policies.data.ClusterData.ClusterUrl;
+import org.apache.pulsar.common.policies.data.TenantInfoImpl;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import com.google.common.collect.Sets;
+
+import lombok.Cleanup;
+
+@Test(groups = "broker")
+public class ClusterMigrationTest {
+
+    private static final Logger log = LoggerFactory.getLogger(ClusterMigrationTest.class);
+    protected String methodName;
+
+    String namespace = "pulsar/migrationNs";
+    TestBroker broker1, broker2;
+    URL url1;
+    URL urlTls1;
+    PulsarService pulsar1;
+
+    PulsarAdmin admin1;
+
+    URL url2;
+    URL urlTls2;
+    PulsarService pulsar2;
+    PulsarAdmin admin2;
+
+    @DataProvider(name = "TopicsubscriptionTypes")
+    public Object[][] subscriptionTypes() {
+        return new Object[][] {
+                {true, SubscriptionType.Shared},
+                {true, SubscriptionType.Key_Shared},
+                {true, SubscriptionType.Shared},
+                {true, SubscriptionType.Key_Shared},
+
+                {false, SubscriptionType.Shared},
+                {false, SubscriptionType.Key_Shared},
+                {false, SubscriptionType.Shared},
+                {false, SubscriptionType.Key_Shared},
+        };
+    }
+
+    @BeforeMethod(alwaysRun = true, timeOut = 300000)
+    public void setup() throws Exception {
+
+        log.info("--- Starting ReplicatorTestBase::setup ---");
+
+        broker1 = new TestBroker();
+        broker2 = new TestBroker();
+        String clusterName = broker1.getClusterName();
+
+        pulsar1 = broker1.getPulsarService();
+        url1 = new URL(pulsar1.getWebServiceAddress());
+        urlTls1 = new URL(pulsar1.getWebServiceAddressTls());
+        admin1 = PulsarAdmin.builder().serviceHttpUrl(url1.toString()).build();
+
+        pulsar2 = broker2.getPulsarService();
+        url2 = new URL(pulsar2.getWebServiceAddress());
+        urlTls2 = new URL(pulsar2.getWebServiceAddressTls());
+        admin2 = PulsarAdmin.builder().serviceHttpUrl(url2.toString()).build();
+
+        // Start region 3
+
+        // Provision the global namespace
+        admin1.clusters().createCluster(clusterName,
+                ClusterData.builder().serviceUrl(url1.toString()).serviceUrlTls(urlTls1.toString())
+                        .brokerServiceUrl(pulsar1.getBrokerServiceUrl())
+                        .brokerServiceUrlTls(pulsar1.getBrokerServiceUrlTls()).build());
+        admin2.clusters().createCluster(clusterName,
+                ClusterData.builder().serviceUrl(url2.toString()).serviceUrlTls(urlTls2.toString())
+                        .brokerServiceUrl(pulsar2.getBrokerServiceUrl())
+                        .brokerServiceUrlTls(pulsar2.getBrokerServiceUrlTls()).build());
+
+        admin1.tenants().createTenant("pulsar",
+                new TenantInfoImpl(Sets.newHashSet("appid1", "appid2", "appid3"), Sets.newHashSet(clusterName)));
+        admin1.namespaces().createNamespace(namespace, Sets.newHashSet(clusterName));
+
+        admin2.tenants().createTenant("pulsar",
+                new TenantInfoImpl(Sets.newHashSet("appid1", "appid2", "appid3"), Sets.newHashSet(clusterName)));
+        admin2.namespaces().createNamespace(namespace, Sets.newHashSet(clusterName));
+
+        assertEquals(admin1.clusters().getCluster(clusterName).getServiceUrl(), url1.toString());
+        assertEquals(admin2.clusters().getCluster(clusterName).getServiceUrl(), url2.toString());
+        assertEquals(admin1.clusters().getCluster(clusterName).getBrokerServiceUrl(), pulsar1.getBrokerServiceUrl());
+        assertEquals(admin2.clusters().getCluster(clusterName).getBrokerServiceUrl(), pulsar2.getBrokerServiceUrl());
+
+        Thread.sleep(100);
+        log.info("--- ReplicatorTestBase::setup completed ---");
+
+    }
+
+    @AfterMethod(alwaysRun = true, timeOut = 300000)
+    protected void cleanup() throws Exception {
+        log.info("--- Shutting down ---");
+        broker1.cleanup();
+        broker2.cleanup();
+    }
+
+    @BeforeMethod(alwaysRun = true)
+    public void beforeMethod(Method m) throws Exception {
+        methodName = m.getName();
+    }
+
+    /**
+     * Test producer/consumer migration: using persistent/non-persistent topic and all types of subscriptions
+     * (1) Producer1 and consumer1 connect to cluster-1
+     * (2) Close consumer1 to build backlog and publish messages using producer1
+     * (3) Migrate topic to cluster-2
+     * (4) Validate producer-1 is connected to cluster-2
+     * (5) create consumer1, drain backlog and migrate and reconnect to cluster-2
+     * (6) Create new consumer2 with different subscription on cluster-1, 
+     *     which immediately migrate and reconnect to cluster-2
+     * (7) Create producer-2 directly to cluster-2
+     * (8) Create producer-3 on cluster-1 which should be redirected to cluster-2 
+     * (8) Publish messages using producer1, producer2, and producer3
+     * (9) Consume all messages by both consumer1 and consumer2
+     * (10) Create Producer/consumer on non-migrated cluster and verify their connection with cluster-1 
+     * (11) Restart Broker-1 and connect producer/consumer on cluster-1 
+     * @throws Exception
+     */
+    @Test(dataProvider = "TopicsubscriptionTypes")
+    public void testClusterMigration(boolean persistent, SubscriptionType subType) throws Exception {
+        log.info("--- Starting ReplicatorTest::testClusterMigration ---");
+        persistent = false;
+        final String topicName = BrokerTestUtil
+                .newUniqueName((persistent ? "persistent" : "non-persistent") + "://" + namespace + "/migrationTopic");
+
+        @Cleanup
+        PulsarClient client1 = PulsarClient.builder().serviceUrl(url1.toString()).statsInterval(0, TimeUnit.SECONDS)
+                .build();
+        // cluster-1 producer/consumer
+        Producer<byte[]> producer1 = client1.newProducer().topic(topicName).enableBatching(false)
+                .producerName("cluster1-1").messageRoutingMode(MessageRoutingMode.SinglePartition).create();
+        Consumer<byte[]> consumer1 = client1.newConsumer().topic(topicName).subscriptionType(subType)
+                .subscriptionName("s1").subscribe();
+        AbstractTopic topic1 = (AbstractTopic) pulsar1.getBrokerService().getTopic(topicName, false).getNow(null).get();
+        retryStrategically((test) -> !topic1.getProducers().isEmpty(), 5, 500);
+        retryStrategically((test) -> !topic1.getSubscriptions().isEmpty(), 5, 500);
+        assertFalse(topic1.getProducers().isEmpty());
+        assertFalse(topic1.getSubscriptions().isEmpty());
+
+        // build backlog
+        consumer1.close();
+        int n = 5;
+        for (int i = 0; i < n; i++) {
+            producer1.send("test1".getBytes());
+        }
+
+        @Cleanup
+        PulsarClient client2 = PulsarClient.builder().serviceUrl(url2.toString()).statsInterval(0, TimeUnit.SECONDS)
+                .build();
+        // cluster-2 producer/consumer
+        Producer<byte[]> producer2 = client2.newProducer().topic(topicName).enableBatching(false)
+                .producerName("cluster2-1").messageRoutingMode(MessageRoutingMode.SinglePartition).create();
+        AbstractTopic topic2 = (AbstractTopic) pulsar2.getBrokerService().getTopic(topicName, false).getNow(null).get();
+        assertFalse(topic2.getProducers().isEmpty());
+
+        ClusterUrl migratedUrl = new ClusterUrl(pulsar2.getBrokerServiceUrl(), pulsar2.getBrokerServiceUrlTls());
+        admin1.clusters().updateClusterMigration(broker2.getClusterName(), true, migratedUrl);
+
+        retryStrategically((test) -> {
+            try {
+                topic1.checkClusterMigration().get();
+                return true;
+            } catch (Exception e) {
+                // ok
+            }
+            return false;
+        }, 10, 500);
+
+        topic1.checkClusterMigration().get();
+
+        producer1.sendAsync("test1".getBytes());
+
+        // producer is disconnected from cluster-1
+        retryStrategically((test) -> topic1.getProducers().isEmpty(), 10, 500);
+        assertTrue(topic1.getProducers().isEmpty());
+
+        // create 3rd producer on cluster-1 which should be redirected to cluster-2
+        Producer<byte[]> producer3 = client1.newProducer().topic(topicName).enableBatching(false)
+                .producerName("cluster1-2").messageRoutingMode(MessageRoutingMode.SinglePartition).create();
+
+        // producer is connected with cluster-2
+        retryStrategically((test) -> topic2.getProducers().size() == 3, 10, 500);
+        assertTrue(topic2.getProducers().size() == 3);
+
+        // try to consume backlog messages from cluster-1
+        consumer1 = client1.newConsumer().topic(topicName).subscriptionName("s1").subscribe();
+        if (persistent) {
+            for (int i = 0; i < n; i++) {
+                Message<byte[]> msg = consumer1.receive();
+                assertEquals(msg.getData(), "test1".getBytes());
+                consumer1.acknowledge(msg);
+            }
+        }
+        // after consuming all messages, consumer should have disconnected
+        // from cluster-1 and reconnect with cluster-2
+        retryStrategically((test) -> !topic2.getSubscriptions().isEmpty(), 10, 500);
+        assertFalse(topic2.getSubscriptions().isEmpty());
+
+        // not also create a new consumer which should also reconnect to cluster-2
+        Consumer<byte[]> consumer2 = client1.newConsumer().topic(topicName).subscriptionType(subType)
+                .subscriptionName("s2").subscribe();
+        retryStrategically((test) -> topic2.getSubscription("s2") != null, 10, 500);
+        assertFalse(topic2.getSubscription("s2").getConsumers().isEmpty());
+
+        // publish messages to cluster-2 and consume them
+        for (int i = 0; i < n; i++) {
+            producer1.send("test2".getBytes());
+            producer2.send("test2".getBytes());
+            producer3.send("test2".getBytes());
+        }
+        log.info("Successfully published messages by migrated producers");
+        for (int i = 0; i < n * 3; i++) {
+            assertEquals(consumer1.receive(2, TimeUnit.SECONDS).getData(), "test2".getBytes());
+            assertEquals(consumer2.receive(2, TimeUnit.SECONDS).getData(), "test2".getBytes());
+
+        }
+
+        // create non-migrated topic which should connect to cluster-1
+        String diffTopic = BrokerTestUtil
+                .newUniqueName((persistent ? "persistent" : "non-persistent") + "://" + namespace + "/migrationTopic");
+        Consumer<byte[]> consumerDiff = client1.newConsumer().topic(diffTopic).subscriptionType(subType)
+                .subscriptionName("s1-d").subscribe();
+        Producer<byte[]> producerDiff = client1.newProducer().topic(diffTopic).enableBatching(false)
+                .producerName("cluster1-d").messageRoutingMode(MessageRoutingMode.SinglePartition).create();
+        AbstractTopic topicDiff = (AbstractTopic) pulsar1.getBrokerService().getTopic(diffTopic, false).getNow(null).get();
+        assertNotNull(topicDiff);
+        for (int i = 0; i < n; i++) {
+            producerDiff.send("diff".getBytes());
+            assertEquals(consumerDiff.receive(2, TimeUnit.SECONDS).getData(), "diff".getBytes());
+        }
+
+        // restart broker-1
+        broker1.restart();
+        Producer<byte[]> producer4 = client1.newProducer().topic(topicName).enableBatching(false)
+                .producerName("cluster1-4").messageRoutingMode(MessageRoutingMode.SinglePartition).create();
+        Consumer<byte[]> consumer3 = client1.newConsumer().topic(topicName).subscriptionType(subType)
+                .subscriptionName("s3").subscribe();
+        retryStrategically((test) -> topic2.getProducers().size() == 4, 10, 500);
+        assertTrue(topic2.getProducers().size() == 4);
+        retryStrategically((test) -> topic2.getSubscription("s3") != null, 10, 500);
+        assertFalse(topic2.getSubscription("s3").getConsumers().isEmpty());
+        for (int i = 0; i < n; i++) {
+            producer4.send("test3".getBytes());
+            assertEquals(consumer1.receive(2, TimeUnit.SECONDS).getData(), "test3".getBytes());
+            assertEquals(consumer2.receive(2, TimeUnit.SECONDS).getData(), "test3".getBytes());
+            assertEquals(consumer3.receive(2, TimeUnit.SECONDS).getData(), "test3".getBytes());
+        }
+
+        log.info("Successfully consumed messages by migrated consumers");
+    }
+
+    static class TestBroker extends MockedPulsarServiceBaseTest {
+
+        public TestBroker() throws Exception {
+            setup();
+        }
+
+        @Override
+        protected void setup() throws Exception {
+            super.internalSetup();
+        }
+
+        public PulsarService getPulsarService() {
+            return pulsar;
+        }
+
+        public String getClusterName() {
+            return configClusterName;
+        }
+
+        @Override
+        protected void cleanup() throws Exception {
+            internalCleanup();
+        }
+        
+        public void restart() throws Exception {
+            restartBroker();
+        }
+
+    }
+}

--- a/pulsar-client-admin-api/pom.xml
+++ b/pulsar-client-admin-api/pom.xml
@@ -43,6 +43,7 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
         </dependency>
+        
     </dependencies>
 
     <build>

--- a/pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/admin/Clusters.java
+++ b/pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/admin/Clusters.java
@@ -29,6 +29,7 @@ import org.apache.pulsar.client.admin.PulsarAdminException.NotFoundException;
 import org.apache.pulsar.client.admin.PulsarAdminException.PreconditionFailedException;
 import org.apache.pulsar.common.policies.data.BrokerNamespaceIsolationData;
 import org.apache.pulsar.common.policies.data.ClusterData;
+import org.apache.pulsar.common.policies.data.ClusterData.ClusterUrl;
 import org.apache.pulsar.common.policies.data.FailureDomain;
 import org.apache.pulsar.common.policies.data.NamespaceIsolationData;
 
@@ -207,6 +208,42 @@ public interface Clusters {
      *
      */
     CompletableFuture<Void> updatePeerClusterNamesAsync(String cluster, LinkedHashSet<String> peerClusterNames);
+
+    /**
+     * Update the configuration for a cluster migration.
+     * <p/>
+     * This operation requires Pulsar super-user privileges.
+     *
+     * @param cluster
+     *            Cluster name
+     * @param migrated
+     *            is cluster migrated
+     * @param clusterUrl
+     *            the cluster url object
+     *
+     * @throws NotAuthorizedException
+     *             You don't have admin permission to create the cluster
+     * @throws NotFoundException
+     *             Cluster doesn't exist
+     * @throws PulsarAdminException
+     *             Unexpected error
+     */
+    void updateClusterMigration(String cluster, boolean migrated, ClusterUrl clusterUrl) throws PulsarAdminException;
+
+    /**
+     * Update the configuration for a cluster migration asynchronously.
+     * <p/>
+     * This operation requires Pulsar super-user privileges.
+     *
+     * @param cluster
+     *            Cluster name
+     * @param migrated
+     *            is cluster migrated
+     * @param clusterUrl
+     *            the cluster url object
+     *
+     */
+    CompletableFuture<Void> updateClusterMigrationAsync(String cluster, boolean migrated, ClusterUrl clusterUrl);
 
     /**
      * Get peer-cluster names.

--- a/pulsar-client-admin-api/src/main/java/org/apache/pulsar/common/policies/data/ClusterData.java
+++ b/pulsar-client-admin-api/src/main/java/org/apache/pulsar/common/policies/data/ClusterData.java
@@ -19,6 +19,9 @@
 package org.apache.pulsar.common.policies.data;
 
 import java.util.LinkedHashSet;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
 import org.apache.pulsar.client.admin.utils.ReflectionUtils;
 import org.apache.pulsar.client.api.ProxyProtocol;
 
@@ -57,6 +60,10 @@ public interface ClusterData {
 
     String getListenerName();
 
+    boolean isMigrated();
+
+    ClusterUrl getMigratedClusterUrl();
+
     interface Builder {
         Builder serviceUrl(String serviceUrl);
 
@@ -92,6 +99,10 @@ public interface ClusterData {
 
         Builder listenerName(String listenerName);
 
+        Builder migrated(boolean migrated);
+
+        Builder migratedClusterUrl(ClusterUrl migratedClusterUrl);
+
         ClusterData build();
     }
 
@@ -99,5 +110,17 @@ public interface ClusterData {
 
     static Builder builder() {
         return ReflectionUtils.newBuilder("org.apache.pulsar.common.policies.data.ClusterDataImpl");
+    }
+
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    class ClusterUrl {
+        String brokerServiceUrl;
+        String brokerServiceUrlTls;
+
+        public boolean isEmpty() {
+            return brokerServiceUrl == null && brokerServiceUrlTls == null;
+        }
     }
 }

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/ClustersImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/ClustersImpl.java
@@ -34,6 +34,7 @@ import org.apache.pulsar.client.api.Authentication;
 import org.apache.pulsar.common.policies.data.BrokerNamespaceIsolationData;
 import org.apache.pulsar.common.policies.data.BrokerNamespaceIsolationDataImpl;
 import org.apache.pulsar.common.policies.data.ClusterData;
+import org.apache.pulsar.common.policies.data.ClusterData.ClusterUrl;
 import org.apache.pulsar.common.policies.data.ClusterDataImpl;
 import org.apache.pulsar.common.policies.data.FailureDomain;
 import org.apache.pulsar.common.policies.data.FailureDomainImpl;
@@ -104,6 +105,19 @@ public class ClustersImpl extends BaseResource implements Clusters {
     public CompletableFuture<Void> updatePeerClusterNamesAsync(String cluster, LinkedHashSet<String> peerClusterNames) {
         WebTarget path = adminClusters.path(cluster).path("peers");
         return asyncPostRequest(path, Entity.entity(peerClusterNames, MediaType.APPLICATION_JSON));
+    }
+
+    @Override
+    public void updateClusterMigration(String cluster, boolean isMigrated, ClusterUrl clusterUrl)
+            throws PulsarAdminException {
+        sync(() -> updateClusterMigrationAsync(cluster, isMigrated, clusterUrl));
+    }
+
+    @Override
+    public CompletableFuture<Void> updateClusterMigrationAsync(String cluster, boolean isMigrated,
+            ClusterUrl clusterUrl) {
+        WebTarget path = adminClusters.path(cluster).path("migrate").queryParam("migrated", isMigrated);
+        return asyncPostRequest(path, Entity.entity(clusterUrl, MediaType.APPLICATION_JSON));
     }
 
     @Override

--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/PulsarClientException.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/PulsarClientException.java
@@ -463,6 +463,22 @@ public class PulsarClientException extends IOException {
     }
 
     /**
+     * TopicMigration exception thrown by Pulsar client.
+     */
+    public static class TopicMigrationException extends PulsarClientException {
+        /**
+         * Constructs an {@code TopicMigrationException} with the specified detail message.
+         *
+         * @param msg
+         *        The detail message (which is saved for later retrieval
+         *        by the {@link #getMessage()} method)
+         */
+        public TopicMigrationException(String msg) {
+            super(msg);
+        }
+    }
+
+    /**
      * Producer fenced exception thrown by Pulsar client.
      */
     public static class ProducerFencedException extends PulsarClientException {

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdClusters.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdClusters.java
@@ -31,6 +31,7 @@ import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.admin.PulsarAdminException;
 import org.apache.pulsar.client.api.ProxyProtocol;
 import org.apache.pulsar.common.policies.data.ClusterData;
+import org.apache.pulsar.common.policies.data.ClusterData.ClusterUrl;
 import org.apache.pulsar.common.policies.data.ClusterDataImpl;
 import org.apache.pulsar.common.policies.data.FailureDomain;
 import org.apache.pulsar.common.policies.data.FailureDomainImpl;
@@ -139,6 +140,28 @@ public class CmdClusters extends CmdBase {
             java.util.LinkedHashSet<String> clusters = StringUtils.isBlank(peerClusterNames) ? null
                     : Sets.newLinkedHashSet(Arrays.asList(peerClusterNames.split(",")));
             getAdmin().clusters().updatePeerClusterNames(cluster, clusters);
+        }
+    }
+
+    @Parameters(commandDescription = "Update cluster migration")
+    private class UpdateClusterMigration extends CliCommand {
+        @Parameter(description = "cluster-name", required = true)
+        private java.util.List<String> params;
+
+        @Parameter(names = "--migrated", description = "Is cluster migrated", required = true)
+        private boolean migrated;
+
+        @Parameter(names = "--broker-url", description = "New migrated cluster broker service url", required = false)
+        private String brokerServiceUrl;
+
+        @Parameter(names = "--broker-url-secure", description = "New migrated cluster broker service url secure",
+                required = false)
+        private String brokerServiceUrlTls;
+
+        void run() throws PulsarAdminException {
+            String cluster = getOneArgument(params);
+            ClusterUrl clusterUrl = new ClusterUrl(brokerServiceUrl, brokerServiceUrlTls);
+            getAdmin().clusters().updateClusterMigration(cluster, migrated, clusterUrl);
         }
     }
 
@@ -401,6 +424,7 @@ public class CmdClusters extends CmdBase {
         jcommander.addCommand("delete", new Delete());
         jcommander.addCommand("list", new List());
         jcommander.addCommand("update-peer-clusters", new UpdatePeerClusters());
+        jcommander.addCommand("update-cluster-migration", new UpdateClusterMigration());
         jcommander.addCommand("get-peer-clusters", new GetPeerClusters());
         jcommander.addCommand("get-failure-domain", new GetFailureDomain());
         jcommander.addCommand("create-failure-domain", new CreateFailureDomain());

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ClientCnx.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ClientCnx.java
@@ -33,6 +33,7 @@ import io.netty.handler.codec.LengthFieldBasedFrameDecoder;
 import io.netty.util.concurrent.Promise;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
+import java.net.URISyntaxException;
 import java.nio.channels.ClosedChannelException;
 import java.util.Arrays;
 import java.util.List;
@@ -87,6 +88,8 @@ import org.apache.pulsar.common.api.proto.CommandSendError;
 import org.apache.pulsar.common.api.proto.CommandSendReceipt;
 import org.apache.pulsar.common.api.proto.CommandSuccess;
 import org.apache.pulsar.common.api.proto.CommandTcClientConnectResponse;
+import org.apache.pulsar.common.api.proto.CommandTopicMigrated;
+import org.apache.pulsar.common.api.proto.CommandTopicMigrated.ResourceType;
 import org.apache.pulsar.common.api.proto.CommandWatchTopicListSuccess;
 import org.apache.pulsar.common.api.proto.CommandWatchTopicUpdate;
 import org.apache.pulsar.common.api.proto.ServerError;
@@ -653,6 +656,26 @@ public class ClientCnx extends PulsarHandler {
         ConsumerImpl<?> consumer = consumers.get(consumerId);
         if (consumer != null) {
             consumer.setTerminated();
+        }
+    }
+
+    @Override
+    protected void handleTopicMigrated(CommandTopicMigrated commandTopicMigrated) {
+        final long resourceId = commandTopicMigrated.getResourceId();
+        final String serviceUrl = commandTopicMigrated.getBrokerServiceUrl();
+        final String serviceUrlTls = commandTopicMigrated.getBrokerServiceUrlTls();
+
+        HandlerState resource = commandTopicMigrated.getResourceType() == ResourceType.Producer
+                ? producers.get(resourceId)
+                : consumers.get(resourceId);
+        log.info("{} is migrated to {}/{}", commandTopicMigrated.getResourceType().name(), serviceUrl, serviceUrlTls);
+        if (resource != null) {
+            try {
+                resource.setRedirectedClusterURI(serviceUrl, serviceUrlTls);
+            } catch (URISyntaxException e) {
+                log.info("[{}] Invalid redirect url {}/{} for {}", remoteAddress, serviceUrl, serviceUrlTls,
+                        resourceId);
+            }
         }
     }
 

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConnectionHandler.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConnectionHandler.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pulsar.client.impl;
 
+import java.net.InetSocketAddress;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
@@ -71,7 +72,11 @@ public class ConnectionHandler {
 
         try {
             CompletableFuture<ClientCnx> cnxFuture;
-            if (state.topic == null) {
+            if (state.redirectedClusterURI != null) {
+                InetSocketAddress address = InetSocketAddress.createUnresolved(state.redirectedClusterURI.getHost(),
+                        state.redirectedClusterURI.getPort());
+                cnxFuture = state.client.getConnection(address, address);
+            } else if (state.topic == null) {
                 cnxFuture = state.client.getConnectionToServiceUrl();
             } else {
                 cnxFuture = state.client.getConnection(state.topic); //

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/HandlerState.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/HandlerState.java
@@ -18,12 +18,16 @@
  */
 package org.apache.pulsar.client.impl;
 
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 import java.util.function.UnaryOperator;
+import org.apache.commons.lang3.StringUtils;
 
 abstract class HandlerState {
     protected final PulsarClientImpl client;
     protected final String topic;
+    protected volatile URI redirectedClusterURI;
 
     private static final AtomicReferenceFieldUpdater<HandlerState, State> STATE_UPDATER =
             AtomicReferenceFieldUpdater.newUpdater(HandlerState.class, State.class, "state");
@@ -47,6 +51,11 @@ abstract class HandlerState {
         this.client = client;
         this.topic = topic;
         STATE_UPDATER.set(this, State.Uninitialized);
+    }
+
+    protected void setRedirectedClusterURI(String serviceUrl, String serviceUrlTls) throws URISyntaxException {
+        String url = client.conf.isUseTls() && StringUtils.isNotBlank(serviceUrlTls) ? serviceUrlTls : serviceUrl;
+        this.redirectedClusterURI = new URI(url);
     }
 
     // moves the state to ready if it wasn't closed

--- a/pulsar-common/pom.xml
+++ b/pulsar-common/pom.xml
@@ -162,6 +162,11 @@
       <scope>provided</scope>
       <optional>true</optional>
     </dependency>
+    
+    <dependency>
+      <groupId>com.google.protobuf</groupId>
+	  <artifactId>protobuf-java</artifactId>
+    </dependency>
 
     <!-- test -->
     <dependency>

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/ClusterDataImpl.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/ClusterDataImpl.java
@@ -142,6 +142,17 @@ public final class ClusterDataImpl implements  ClusterData, Cloneable {
             example = ""
     )
     private String listenerName;
+    @ApiModelProperty(
+            name = "migrated",
+            value = "flag to check if cluster is migrated to different cluster",
+            example = "true/false"
+    )
+    private boolean migrated;
+    @ApiModelProperty(
+            name = "migratedClusterUrl",
+            value = "url of cluster where current cluster is migrated"
+    )
+    private ClusterUrl migratedClusterUrl;
 
     public static ClusterDataImplBuilder builder() {
         return new ClusterDataImplBuilder();
@@ -188,6 +199,8 @@ public final class ClusterDataImpl implements  ClusterData, Cloneable {
         private String brokerClientTlsTrustStorePassword;
         private String brokerClientTrustCertsFilePath;
         private String listenerName;
+        private boolean migrated;
+        private ClusterUrl migratedClusterUrl;
 
         ClusterDataImplBuilder() {
         }
@@ -277,6 +290,16 @@ public final class ClusterDataImpl implements  ClusterData, Cloneable {
             return this;
         }
 
+        public ClusterDataImplBuilder migrated(boolean migrated) {
+            this.migrated = migrated;
+            return this;
+        }
+
+        public ClusterDataImplBuilder migratedClusterUrl(ClusterUrl migratedClusterUrl) {
+            this.migratedClusterUrl = migratedClusterUrl;
+            return this;
+        }
+
         public ClusterDataImpl build() {
             return new ClusterDataImpl(
                     serviceUrl,
@@ -295,7 +318,9 @@ public final class ClusterDataImpl implements  ClusterData, Cloneable {
                     brokerClientTlsTrustStore,
                     brokerClientTlsTrustStorePassword,
                     brokerClientTrustCertsFilePath,
-                    listenerName);
+                    listenerName,
+                    migrated,
+                    migratedClusterUrl);
         }
     }
 }

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/protocol/Commands.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/protocol/Commands.java
@@ -86,6 +86,7 @@ import org.apache.pulsar.common.api.proto.CommandSubscribe;
 import org.apache.pulsar.common.api.proto.CommandSubscribe.InitialPosition;
 import org.apache.pulsar.common.api.proto.CommandSubscribe.SubType;
 import org.apache.pulsar.common.api.proto.CommandTcClientConnectResponse;
+import org.apache.pulsar.common.api.proto.CommandTopicMigrated.ResourceType;
 import org.apache.pulsar.common.api.proto.FeatureFlags;
 import org.apache.pulsar.common.api.proto.IntRange;
 import org.apache.pulsar.common.api.proto.KeySharedMeta;
@@ -736,6 +737,16 @@ public class Commands {
         BaseCommand cmd = localCmd(Type.REACHED_END_OF_TOPIC);
         cmd.setReachedEndOfTopic()
             .setConsumerId(consumerId);
+        return serializeWithSize(cmd);
+    }
+
+    public static ByteBuf newTopicMigrated(ResourceType type, long resourceId, String brokerUrl, String brokerUrlTls) {
+        BaseCommand cmd = localCmd(Type.TOPIC_MIGRATED);
+        cmd.setTopicMigrated()
+            .setResourceType(type)
+            .setResourceId(resourceId)
+            .setBrokerServiceUrl(brokerUrl)
+            .setBrokerServiceUrlTls(brokerUrlTls);
         return serializeWithSize(cmd);
     }
 

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/protocol/PulsarDecoder.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/protocol/PulsarDecoder.java
@@ -76,6 +76,7 @@ import org.apache.pulsar.common.api.proto.CommandSubscribe;
 import org.apache.pulsar.common.api.proto.CommandSuccess;
 import org.apache.pulsar.common.api.proto.CommandTcClientConnectRequest;
 import org.apache.pulsar.common.api.proto.CommandTcClientConnectResponse;
+import org.apache.pulsar.common.api.proto.CommandTopicMigrated;
 import org.apache.pulsar.common.api.proto.CommandUnsubscribe;
 import org.apache.pulsar.common.api.proto.CommandWatchTopicList;
 import org.apache.pulsar.common.api.proto.CommandWatchTopicListClose;
@@ -292,6 +293,11 @@ public abstract class PulsarDecoder extends ChannelInboundHandlerAdapter {
             case REACHED_END_OF_TOPIC:
                 checkArgument(cmd.hasReachedEndOfTopic());
                 handleReachedEndOfTopic(cmd.getReachedEndOfTopic());
+                break;
+
+            case TOPIC_MIGRATED:
+                checkArgument(cmd.hasTopicMigrated());
+                handleTopicMigrated(cmd.getTopicMigrated());
                 break;
 
             case GET_LAST_MESSAGE_ID:
@@ -597,6 +603,10 @@ public abstract class PulsarDecoder extends ChannelInboundHandlerAdapter {
     }
 
     protected void handleReachedEndOfTopic(CommandReachedEndOfTopic commandReachedEndOfTopic) {
+        throw new UnsupportedOperationException();
+    }
+
+    protected void handleTopicMigrated(CommandTopicMigrated commandMigratedTopic) {
         throw new UnsupportedOperationException();
     }
 

--- a/pulsar-common/src/main/proto/PulsarApi.proto
+++ b/pulsar-common/src/main/proto/PulsarApi.proto
@@ -262,6 +262,7 @@ enum ProtocolVersion {
     v17 = 17; // Added support ack receipt
     v18 = 18; // Add client support for broker entry metadata
     v19 = 19; // Add CommandTcClientConnectRequest and CommandTcClientConnectResponse
+    v20 = 20; // Add client support for topic migration redirection CommandTopicMigrated
 }
 
 message CommandConnect {
@@ -619,6 +620,19 @@ message CommandSeek {
 message CommandReachedEndOfTopic {
     required uint64 consumer_id = 1;
 }
+
+message CommandTopicMigrated {
+	enum ResourceType {
+        Producer = 0;
+        Consumer = 1;
+    }
+    required uint64 resource_id = 1;
+    required ResourceType resource_type = 2;
+    optional string brokerServiceUrl      = 3;
+    optional string brokerServiceUrlTls   = 4;
+    
+}
+
 
 message CommandCloseProducer {
     required uint64 producer_id = 1;
@@ -1025,6 +1039,7 @@ message BaseCommand {
         WATCH_TOPIC_UPDATE = 66;
         WATCH_TOPIC_LIST_CLOSE = 67;
 
+        TOPIC_MIGRATED = 68;
     }
 
 
@@ -1106,4 +1121,6 @@ message BaseCommand {
     optional CommandWatchTopicListSuccess watchTopicListSuccess = 65;
     optional CommandWatchTopicUpdate watchTopicUpdate = 66;
     optional CommandWatchTopicListClose watchTopicListClose = 67;
+    
+    optional CommandTopicMigrated topicMigrated = 68;
 }

--- a/site2/docs/reference-pulsar-admin.md
+++ b/site2/docs/reference-pulsar-admin.md
@@ -321,6 +321,24 @@ Options
 |`--url`|service-url||
 |`--url-secure`|service-url for secure connection||
 
+### `update cluster migration`
+Update the configuration for a cluster
+
+Usage
+
+```bash
+pulsar-admin clusters update-cluster-migration cluster-name options
+```
+
+Options
+
+|Flag|Description|Default|
+|---|---|---|
+|`--migrated`|Is cluster migrated.||
+|`--broker-url`|New cluster URL for the broker service.||
+|`--broker-url-secure`|New cluster service URL for a secure connection||
+|`--url`|service-url||
+|`--url-secure`|service-url for secure connection||
 
 ### `delete`
 Deletes an existing cluster

--- a/tiered-storage/jcloud/src/test/java/org/apache/bookkeeper/mledger/offload/jcloud/impl/MockManagedLedger.java
+++ b/tiered-storage/jcloud/src/test/java/org/apache/bookkeeper/mledger/offload/jcloud/impl/MockManagedLedger.java
@@ -380,4 +380,16 @@ public class MockManagedLedger implements ManagedLedger {
     public void checkCursorsToCacheEntries() {
         // no-op
     }
+
+    @Override
+    public CompletableFuture<Position> asyncMigrate() {
+        // no-op
+        return null;
+    }
+
+    @Override
+    public boolean isMigrated() {
+        // no-op
+        return false;
+    }
 }


### PR DESCRIPTION
### Motivation
It fixes : https://github.com/apache/pulsar/issues/16551
Cluster migration or Blue-Green cluster deployment is one of the proven solutions to migrate live traffic from one cluster to another. One of the examples is applications running on Kubernetes sometimes require a Kubernetes cluster upgrade which can cause downtime for the entire application during a Kubernetes cluster upgrade. Blue-green deployment is an application release model that gradually transfers user traffic from a previous version of an app or microservice to a nearly identical new release—both of which are running in production.

The old version can be called the blue environment while the new version can be known as the green environment. Once production traffic is fully transferred from blue to green, blue can standby in case of rollback or be pulled from production and updated to become the template upon which the next update is made.

We need such capability in Apache pulsar to migrate live traffic from the blue cluster to the green cluster so, eventually, the entire traffic moves from the blue cluster to the green cluster without causing downtime for the topics.

### Modification
- Handle cluster migration for persistent/non-persistent topics
- Add CLI and REST API support to mark cluster migration

**NOTE**: This is the 1st part of the feature. 2nd PR will be submitted to handle Replicator changes which can handle cluster migration without compromising ordering and data persistent guarantee.

### Result
User can migrate Pulsar cluster without user traffic interruption.

### Does this pull request potentially affect one of the following parts:

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The binary protocol
- [x] The REST endpoints
- [x] The admin CLI options
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [x] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
