### PR TITLE
[fix][broker] Fix incorrect bundle split count metric

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/ModularLoadManagerImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/ModularLoadManagerImpl.java
@@ -750,6 +750,7 @@ public class ModularLoadManagerImpl implements ModularLoadManager {
         synchronized (bundleSplitStrategy) {
             final Set<String> bundlesToBeSplit = bundleSplitStrategy.findBundlesToSplit(loadData, pulsar);
             NamespaceBundleFactory namespaceBundleFactory = pulsar.getNamespaceService().getNamespaceBundleFactory();
+            int splitCount = 0;
             for (String bundleName : bundlesToBeSplit) {
                 try {
                     final String namespaceName = LoadManagerShared.getNamespaceNameFromBundleName(bundleName);
@@ -771,13 +772,14 @@ public class ModularLoadManagerImpl implements ModularLoadManager {
                     pulsar.getAdminClient().namespaces().splitNamespaceBundle(namespaceName, bundleRange,
                         unloadSplitBundles, null);
 
+                    splitCount++;
                     log.info("Successfully split namespace bundle {}", bundleName);
                 } catch (Exception e) {
                     log.error("Failed to split namespace bundle {}", bundleName, e);
                 }
             }
 
-            updateBundleSplitMetrics(bundlesToBeSplit);
+            updateBundleSplitMetrics(splitCount);
         }
 
     }
@@ -785,10 +787,10 @@ public class ModularLoadManagerImpl implements ModularLoadManager {
     /**
      * As leader broker, update bundle split metrics.
      *
-     * @param bundlesToBeSplit
+     * @param bundlesSplit the number of bundles splits
      */
-    private void updateBundleSplitMetrics(Set<String> bundlesToBeSplit) {
-        bundleSplitCount += bundlesToBeSplit.size();
+    private void updateBundleSplitMetrics(int bundlesSplit) {
+        bundleSplitCount += bundlesSplit;
 
         List<Metrics> metrics = new ArrayList<>();
         Map<String, String> dimensions = new HashMap<>();

--- a/site2/docs/reference-metrics.md
+++ b/site2/docs/reference-metrics.md
@@ -401,7 +401,7 @@ All the bundleUnloading metrics are labeled with the following labels:
 
 | Name                          | Type    | Description                                                |
 |-------------------------------|---------|------------------------------------------------------------|
-| pulsar_lb_bundles_split_total | Counter | bundle split count in this bundle splitting check interval |
+| pulsar_lb_bundles_split_total | Counter | The total count of bundle split in this leader broker |
 
 #### Bundle metrics
 All the bundle metrics are labeled with the following labels:

--- a/site2/website/versioned_docs/version-2.10.0-deprecated/reference-metrics.md
+++ b/site2/website/versioned_docs/version-2.10.0-deprecated/reference-metrics.md
@@ -343,7 +343,7 @@ All the bundleUnloading metrics are labelled with the following labels:
 
 | Name | Type | Description |
 | --- | --- | --- |
-| pulsar_lb_bundles_split_count | Counter | bundle split count in this bundle splitting check interval |
+| pulsar_lb_bundles_split_count | Counter | The total count of bundle split in this leader broker |
 
 #### Bundle metrics
 All the bundle metrics are labelled with the following labels:

--- a/site2/website/versioned_docs/version-2.6.0/reference-metrics.md
+++ b/site2/website/versioned_docs/version-2.6.0/reference-metrics.md
@@ -277,7 +277,7 @@ All the bundleUnloading metrics are labelled with the following labels:
 
 | Name | Type | Description |
 | --- | --- | --- |
-| pulsar_lb_bundles_split_count | Counter | bundle split count in this bundle splitting check interval |
+| pulsar_lb_bundles_split_count | Counter | The total count of bundle split in this leader broker |
 
 ### Subscription metrics
 

--- a/site2/website/versioned_docs/version-2.6.1/reference-metrics.md
+++ b/site2/website/versioned_docs/version-2.6.1/reference-metrics.md
@@ -277,7 +277,7 @@ All the bundleUnloading metrics are labelled with the following labels:
 
 | Name | Type | Description |
 | --- | --- | --- |
-| pulsar_lb_bundles_split_count | Counter | bundle split count in this bundle splitting check interval |
+| pulsar_lb_bundles_split_count | Counter | The total count of bundle split in this leader broker |
 
 ### Subscription metrics
 

--- a/site2/website/versioned_docs/version-2.6.2/reference-metrics.md
+++ b/site2/website/versioned_docs/version-2.6.2/reference-metrics.md
@@ -277,7 +277,7 @@ All the bundleUnloading metrics are labelled with the following labels:
 
 | Name | Type | Description |
 | --- | --- | --- |
-| pulsar_lb_bundles_split_count | Counter | bundle split count in this bundle splitting check interval |
+| pulsar_lb_bundles_split_count | Counter | The total count of bundle split in this leader broker |
 
 ### Subscription metrics
 

--- a/site2/website/versioned_docs/version-2.6.3/reference-metrics.md
+++ b/site2/website/versioned_docs/version-2.6.3/reference-metrics.md
@@ -277,7 +277,7 @@ All the bundleUnloading metrics are labelled with the following labels:
 
 | Name | Type | Description |
 | --- | --- | --- |
-| pulsar_lb_bundles_split_count | Counter | bundle split count in this bundle splitting check interval |
+| pulsar_lb_bundles_split_count | Counter | The total count of bundle split in this leader broker |
 
 ### Subscription metrics
 

--- a/site2/website/versioned_docs/version-2.6.4/reference-metrics.md
+++ b/site2/website/versioned_docs/version-2.6.4/reference-metrics.md
@@ -277,7 +277,7 @@ All the bundleUnloading metrics are labelled with the following labels:
 
 | Name | Type | Description |
 | --- | --- | --- |
-| pulsar_lb_bundles_split_count | Counter | bundle split count in this bundle splitting check interval |
+| pulsar_lb_bundles_split_count | Counter | The total count of bundle split in this leader broker |
 
 ### Subscription metrics
 

--- a/site2/website/versioned_docs/version-2.7.0/reference-metrics.md
+++ b/site2/website/versioned_docs/version-2.7.0/reference-metrics.md
@@ -275,7 +275,7 @@ All the bundleUnloading metrics are labelled with the following labels:
 
 | Name | Type | Description |
 | --- | --- | --- |
-| pulsar_lb_bundles_split_count | Counter | bundle split count in this bundle splitting check interval |
+| pulsar_lb_bundles_split_count | Counter | The total count of bundle split in this leader broker |
 
 ### Subscription metrics
 

--- a/site2/website/versioned_docs/version-2.7.1/reference-metrics.md
+++ b/site2/website/versioned_docs/version-2.7.1/reference-metrics.md
@@ -277,7 +277,7 @@ All the bundleUnloading metrics are labelled with the following labels:
 
 | Name | Type | Description |
 | --- | --- | --- |
-| pulsar_lb_bundles_split_count | Counter | bundle split count in this bundle splitting check interval |
+| pulsar_lb_bundles_split_count | Counter | The total count of bundle split in this leader broker |
 
 ### Subscription metrics
 

--- a/site2/website/versioned_docs/version-2.7.2/reference-metrics.md
+++ b/site2/website/versioned_docs/version-2.7.2/reference-metrics.md
@@ -277,7 +277,7 @@ All the bundleUnloading metrics are labelled with the following labels:
 
 | Name | Type | Description |
 | --- | --- | --- |
-| pulsar_lb_bundles_split_count | Counter | bundle split count in this bundle splitting check interval |
+| pulsar_lb_bundles_split_count | Counter | The total count of bundle split in this leader broker |
 
 ### Subscription metrics
 

--- a/site2/website/versioned_docs/version-2.7.3/reference-metrics.md
+++ b/site2/website/versioned_docs/version-2.7.3/reference-metrics.md
@@ -297,7 +297,7 @@ All the bundleUnloading metrics are labelled with the following labels:
 
 | Name | Type | Description |
 | --- | --- | --- |
-| pulsar_lb_bundles_split_count | Counter | bundle split count in this bundle splitting check interval |
+| pulsar_lb_bundles_split_count | Counter | The total count of bundle split in this leader broker |
 
 ### Subscription metrics
 

--- a/site2/website/versioned_docs/version-2.7.4/reference-metrics.md
+++ b/site2/website/versioned_docs/version-2.7.4/reference-metrics.md
@@ -297,7 +297,7 @@ All the bundleUnloading metrics are labelled with the following labels:
 
 | Name | Type | Description |
 | --- | --- | --- |
-| pulsar_lb_bundles_split_count | Counter | bundle split count in this bundle splitting check interval |
+| pulsar_lb_bundles_split_count | Counter | The total count of bundle split in this leader broker |
 
 ### Subscription metrics
 

--- a/site2/website/versioned_docs/version-2.8.0-deprecated/reference-metrics.md
+++ b/site2/website/versioned_docs/version-2.8.0-deprecated/reference-metrics.md
@@ -296,7 +296,7 @@ All the bundleUnloading metrics are labelled with the following labels:
 
 | Name | Type | Description |
 | --- | --- | --- |
-| pulsar_lb_bundles_split_count | Counter | bundle split count in this bundle splitting check interval |
+| pulsar_lb_bundles_split_count | Counter | The total count of bundle split in this leader broker |
 
 ### Subscription metrics
 

--- a/site2/website/versioned_docs/version-2.8.1-deprecated/reference-metrics.md
+++ b/site2/website/versioned_docs/version-2.8.1-deprecated/reference-metrics.md
@@ -299,7 +299,7 @@ All the bundleUnloading metrics are labelled with the following labels:
 
 | Name | Type | Description |
 | --- | --- | --- |
-| pulsar_lb_bundles_split_count | Counter | bundle split count in this bundle splitting check interval |
+| pulsar_lb_bundles_split_count | Counter | The total count of bundle split in this leader broker |
 
 ### Subscription metrics
 

--- a/site2/website/versioned_docs/version-2.8.2-deprecated/reference-metrics.md
+++ b/site2/website/versioned_docs/version-2.8.2-deprecated/reference-metrics.md
@@ -308,7 +308,7 @@ All the bundleUnloading metrics are labelled with the following labels:
 
 | Name | Type | Description |
 | --- | --- | --- |
-| pulsar_lb_bundles_split_count | Counter | bundle split count in this bundle splitting check interval |
+| pulsar_lb_bundles_split_count | Counter | The total count of bundle split in this leader broker |
 
 ### Subscription metrics
 

--- a/site2/website/versioned_docs/version-2.8.3-deprecated/reference-metrics.md
+++ b/site2/website/versioned_docs/version-2.8.3-deprecated/reference-metrics.md
@@ -308,7 +308,7 @@ All the bundleUnloading metrics are labelled with the following labels:
 
 | Name | Type | Description |
 | --- | --- | --- |
-| pulsar_lb_bundles_split_count | Counter | bundle split count in this bundle splitting check interval |
+| pulsar_lb_bundles_split_count | Counter | The total count of bundle split in this leader broker |
 
 ### Subscription metrics
 

--- a/site2/website/versioned_docs/version-2.9.0-deprecated/reference-metrics.md
+++ b/site2/website/versioned_docs/version-2.9.0-deprecated/reference-metrics.md
@@ -329,7 +329,7 @@ All the bundleUnloading metrics are labelled with the following labels:
 
 | Name | Type | Description |
 | --- | --- | --- |
-| pulsar_lb_bundles_split_count | Counter | bundle split count in this bundle splitting check interval |
+| pulsar_lb_bundles_split_count | Counter | The total count of bundle split in this leader broker |
 
 ### Subscription metrics
 

--- a/site2/website/versioned_docs/version-2.9.1-deprecated/reference-metrics.md
+++ b/site2/website/versioned_docs/version-2.9.1-deprecated/reference-metrics.md
@@ -329,7 +329,7 @@ All the bundleUnloading metrics are labelled with the following labels:
 
 | Name | Type | Description |
 | --- | --- | --- |
-| pulsar_lb_bundles_split_count | Counter | bundle split count in this bundle splitting check interval |
+| pulsar_lb_bundles_split_count | Counter | The total count of bundle split in this leader broker |
 
 ### Subscription metrics
 

--- a/site2/website/versioned_docs/version-2.9.2-deprecated/reference-metrics.md
+++ b/site2/website/versioned_docs/version-2.9.2-deprecated/reference-metrics.md
@@ -329,7 +329,7 @@ All the bundleUnloading metrics are labelled with the following labels:
 
 | Name | Type | Description |
 | --- | --- | --- |
-| pulsar_lb_bundles_split_count | Counter | bundle split count in this bundle splitting check interval |
+| pulsar_lb_bundles_split_count | Counter | The total count of bundle split in this leader broker |
 
 ### Subscription metrics
 


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://docs.google.com/document/d/1d8Pw6ZbWk-_pCKdOmdvx9rnhPiyuxwq60_TrD68d7BA/edit#heading=h.trs9rsex3xom)*. 

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->

### Motivation

Suppose there is a non-partitioned topic has more than 1000 producers (1000 is `loadBalancerNamespaceBundleMaxSessions` default value), `pulsar_lb_bundles_split_count` metric will increase constantly due to corresponding bundle reached maxBundleSessions, even the bundle range is 1 (upper - lower) that actually will skip this bundle.

### Modifications

Only increase `pulsar_lb_bundles_split_count` metric if bundle splits succeed.

### Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] Anything that affects deployment

### Documentation

- [x] `doc`

### Matching PR in forked repository

PR in forked repository: https://github.com/Shawyeok/pulsar/pull/2

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
