### PR TITLE
[fix][broker] Fix `getPositionAfterN` infinite loop.

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
@@ -3324,7 +3324,6 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
      * @return the new position that is n entries ahead
      */
     public PositionImpl getPositionAfterN(final PositionImpl startPosition, long n, PositionBound startRange) {
-        final LedgerHandle curLedger = currentLedger;
         long entriesToSkip = n;
         long currentLedgerId;
         long currentEntryId;
@@ -3368,7 +3367,7 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
                     break;
                 }
                 Long lid = ledgers.ceilingKey(currentLedgerId + 1);
-                currentLedgerId = lid != null ? lid : curLedger.getId();
+                currentLedgerId = lid != null ? lid : currentLedger.getId();
                 currentEntryId = 0;
             }
         }

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
@@ -3338,10 +3338,10 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
         }
         boolean lastLedger = false;
         long totalEntriesInCurrentLedger;
-        while (curLedger != null && currentLedgerId <= curLedger.getId()) {
+        while (entriesToSkip >= 0) {
             // for the current ledger, the number of entries written is deduced from the lastConfirmedEntry
             // for previous ledgers, LedgerInfo in ZK has the number of entries
-            if (currentLedgerId == curLedger.getId()) {
+            if (currentLedger != null && currentLedgerId == currentLedger.getId()) {
                 lastLedger = true;
                 if (currentLedgerEntries > 0) {
                     totalEntriesInCurrentLedger = lastConfirmedEntry.getEntryId() + 1;

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
@@ -3367,7 +3367,7 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
                     break;
                 }
                 Long lid = ledgers.ceilingKey(currentLedgerId + 1);
-                currentLedgerId = lid != null ? lid : currentLedger.getId();
+                currentLedgerId = lid != null ? lid : ledgers.lastKey();
                 currentEntryId = 0;
             }
         }

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
@@ -3324,10 +3324,6 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
      * @return the new position that is n entries ahead
      */
     public PositionImpl getPositionAfterN(final PositionImpl startPosition, long n, PositionBound startRange) {
-        final PositionImpl nextValidPosition = getNextValidPosition(startPosition);
-        if (startPosition.compareTo(nextValidPosition) >= 0) {
-            return nextValidPosition;
-        }
         final LedgerHandle curLedger = currentLedger;
         long entriesToSkip = n;
         long currentLedgerId;
@@ -3336,6 +3332,7 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
             currentLedgerId = startPosition.getLedgerId();
             currentEntryId = startPosition.getEntryId();
         } else {
+            PositionImpl nextValidPosition = getNextValidPosition(startPosition);
             currentLedgerId = nextValidPosition.getLedgerId();
             currentEntryId = nextValidPosition.getEntryId();
         }

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerTest.java
@@ -2478,6 +2478,23 @@ public class ManagedLedgerTest extends MockedBookKeeperTestCase {
         log.info("Target position is {}", targetPosition);
         assertEquals(targetPosition.getLedgerId(), secondLedger);
         assertEquals(targetPosition.getEntryId(), 4);
+
+        // test for n > NumberOfEntriesInStorage
+        searchPosition = new PositionImpl(secondLedger, 0);
+        targetPosition = managedLedger.getPositionAfterN(searchPosition, 100, ManagedLedgerImpl.PositionBound.startIncluded);
+        assertEquals(targetPosition.getLedgerId(), secondLedger);
+        assertEquals(targetPosition.getEntryId(), 4);
+
+        // test for startPosition > current ledger
+        searchPosition = new PositionImpl(999, 0);
+        targetPosition = managedLedger.getPositionAfterN(searchPosition, 0, ManagedLedgerImpl.PositionBound.startIncluded);
+        assertEquals(targetPosition.getLedgerId(), secondLedger);
+        assertEquals(targetPosition.getEntryId(), 4);
+
+        searchPosition = new PositionImpl(999, 0);
+        targetPosition = managedLedger.getPositionAfterN(searchPosition, 10, ManagedLedgerImpl.PositionBound.startExcluded);
+        assertEquals(targetPosition.getLedgerId(), secondLedger);
+        assertEquals(targetPosition.getEntryId(), 4);
     }
 
     @Test


### PR DESCRIPTION

Fixes #17967

Master Issue: #17967

### Motivation

The root cause is here(line-3365)  :
https://github.com/apache/pulsar/blob/08f5766d95034ce27c44ee30e4734d2a8f078e11/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java#L3364-L3366

The `currentLedgerId` should be : 
```
currentLedgerId = lid != null ? lid : (ledgers.lastKey());
```

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/Technoboy-/pulsar/pull/9