### PR TITLE
[improve][broker] Make CompactedTopicImpl.findStartPointLoop work more efficiently

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/compaction/CompactedTopicImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/compaction/CompactedTopicImpl.java
@@ -21,6 +21,7 @@ package org.apache.pulsar.compaction;
 import static org.apache.pulsar.common.protocol.Commands.DEFAULT_CONSUMER_EPOCH;
 import com.github.benmanes.caffeine.cache.AsyncLoadingCache;
 import com.github.benmanes.caffeine.cache.Caffeine;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ComparisonChain;
 import io.netty.buffer.ByteBuf;
 import java.util.ArrayList;
@@ -164,7 +165,8 @@ public class CompactedTopicImpl implements CompactedTopic {
         return promise;
     }
 
-    private static void findStartPointLoop(PositionImpl p, long start, long end,
+    @VisibleForTesting
+    static void findStartPointLoop(PositionImpl p, long start, long end,
                                            CompletableFuture<Long> promise,
                                            AsyncLoadingCache<Long, MessageIdData> cache) {
         long midpoint = start + ((end - start) / 2);
@@ -178,7 +180,7 @@ public class CompactedTopicImpl implements CompactedTopic {
                     if (comparePositionAndMessageId(p, startEntry.join()) <= 0) {
                         promise.complete(start);
                     } else if (comparePositionAndMessageId(p, middleEntry.join()) <= 0) {
-                        findStartPointLoop(p, start, midpoint, promise, cache);
+                        findStartPointLoop(p, start + 1, midpoint, promise, cache);
                     } else if (comparePositionAndMessageId(p, endEntry.join()) <= 0) {
                         findStartPointLoop(p, midpoint + 1, end, promise, cache);
                     } else {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/compaction/CompactedTopicImplTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/compaction/CompactedTopicImplTest.java
@@ -40,47 +40,47 @@ public class CompactedTopicImplTest {
 
     // Sparse ledger makes multi entry has same data, this is used to construct complex environments to verify that the
     // smallest position with the correct data is found.
-    private static final TreeMap<Long,Long> ORIGIN_SPARSE_LEDGER = new TreeMap<>();
+    private static final TreeMap<Long, Long> ORIGIN_SPARSE_LEDGER = new TreeMap<>();
 
     static {
-        ORIGIN_SPARSE_LEDGER.put(0L,0L);
-        ORIGIN_SPARSE_LEDGER.put(1L,1L);
-        ORIGIN_SPARSE_LEDGER.put(2L,1001L);
-        ORIGIN_SPARSE_LEDGER.put(3L,1002L);
-        ORIGIN_SPARSE_LEDGER.put(4L,1003L);
-        ORIGIN_SPARSE_LEDGER.put(10L,1010L);
-        ORIGIN_SPARSE_LEDGER.put(20L,1020L);
-        ORIGIN_SPARSE_LEDGER.put(50L,1050L);
-        ORIGIN_SPARSE_LEDGER.put(Long.MAX_VALUE,Long.MAX_VALUE);
+        ORIGIN_SPARSE_LEDGER.put(0L, 0L);
+        ORIGIN_SPARSE_LEDGER.put(1L, 1L);
+        ORIGIN_SPARSE_LEDGER.put(2L, 1001L);
+        ORIGIN_SPARSE_LEDGER.put(3L, 1002L);
+        ORIGIN_SPARSE_LEDGER.put(4L, 1003L);
+        ORIGIN_SPARSE_LEDGER.put(10L, 1010L);
+        ORIGIN_SPARSE_LEDGER.put(20L, 1020L);
+        ORIGIN_SPARSE_LEDGER.put(50L, 1050L);
+        ORIGIN_SPARSE_LEDGER.put(Long.MAX_VALUE, Long.MAX_VALUE);
     }
 
     @DataProvider(name = "argsForFindStartPointLoop")
-    public Object[][] argsForFindStartPointLoop(){
+    public Object[][] argsForFindStartPointLoop() {
         return new Object[][]{
-            {0, 100, 0},// first value.
-            {0, 100, 1},// second value.
-            {0, 100, 1003},// not first value.
-            {0, 100, 1015},// value not exists.
-            {3, 40, 50},// less than first value & find in a range.
-            {3, 40, 1002},// first value & find in a range.
-            {3, 40, 1003},// second value & find in a range.
-            {3, 40, 1010},// not first value & find in a range.
-            {3, 40, 1015}// value not exists & find in a range.
+                {0, 100, 0},// first value.
+                {0, 100, 1},// second value.
+                {0, 100, 1003},// not first value.
+                {0, 100, 1015},// value not exists.
+                {3, 40, 50},// less than first value & find in a range.
+                {3, 40, 1002},// first value & find in a range.
+                {3, 40, 1003},// second value & find in a range.
+                {3, 40, 1010},// not first value & find in a range.
+                {3, 40, 1015}// value not exists & find in a range.
         };
     }
 
     private static CacheLoader<Long, MessageIdData> mockCacheLoader(long start, long end, final long targetMessageId,
-                                                                    AtomicLong bingoMarker){
+                                                                    AtomicLong bingoMarker) {
         // Mock ledger.
-        final TreeMap<Long,Long> sparseLedger = new TreeMap<>();
+        final TreeMap<Long, Long> sparseLedger = new TreeMap<>();
         sparseLedger.putAll(ORIGIN_SPARSE_LEDGER.subMap(start, end + 1));
-        sparseLedger.put(Long.MAX_VALUE,Long.MAX_VALUE);
+        sparseLedger.put(Long.MAX_VALUE, Long.MAX_VALUE);
 
-        Function<Long,Long> findMessageIdFunc = entryId -> sparseLedger.ceilingEntry(entryId).getValue();
+        Function<Long, Long> findMessageIdFunc = entryId -> sparseLedger.ceilingEntry(entryId).getValue();
 
         // Calculate the correct position.
-        for (long i = start; i <= end; i++){
-            if (findMessageIdFunc.apply(i) >= targetMessageId){
+        for (long i = start; i <= end; i++) {
+            if (findMessageIdFunc.apply(i) >= targetMessageId) {
                 bingoMarker.set(i);
                 break;
             }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/compaction/CompactedTopicImplTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/compaction/CompactedTopicImplTest.java
@@ -1,0 +1,113 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.compaction;
+
+import com.github.benmanes.caffeine.cache.AsyncLoadingCache;
+import com.github.benmanes.caffeine.cache.CacheLoader;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import java.util.TreeMap;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Function;
+import org.apache.bookkeeper.mledger.impl.PositionImpl;
+import org.apache.pulsar.common.api.proto.MessageIdData;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+@Test(groups = "broker-compaction")
+public class CompactedTopicImplTest {
+
+    private static final long DEFAULT_LEDGER_ID = 1;
+
+    // Sparse ledger makes multi entry has same data, this is used to construct complex environments to verify that the
+    // smallest position with the correct data is found.
+    private static final TreeMap<Long,Long> ORIGIN_SPARSE_LEDGER = new TreeMap<>();
+
+    static {
+        ORIGIN_SPARSE_LEDGER.put(0L,0L);
+        ORIGIN_SPARSE_LEDGER.put(1L,1L);
+        ORIGIN_SPARSE_LEDGER.put(2L,1001L);
+        ORIGIN_SPARSE_LEDGER.put(3L,1002L);
+        ORIGIN_SPARSE_LEDGER.put(4L,1003L);
+        ORIGIN_SPARSE_LEDGER.put(10L,1010L);
+        ORIGIN_SPARSE_LEDGER.put(20L,1020L);
+        ORIGIN_SPARSE_LEDGER.put(50L,1050L);
+        ORIGIN_SPARSE_LEDGER.put(Long.MAX_VALUE,Long.MAX_VALUE);
+    }
+
+    @DataProvider(name = "argsForFindStartPointLoop")
+    public Object[][] argsForFindStartPointLoop(){
+        return new Object[][]{
+            {0, 100, 0},// first value.
+            {0, 100, 1},// second value.
+            {0, 100, 1003},// not first value.
+            {0, 100, 1015},// value not exists.
+            {3, 40, 50},// less than first value & find in a range.
+            {3, 40, 1002},// first value & find in a range.
+            {3, 40, 1003},// second value & find in a range.
+            {3, 40, 1010},// not first value & find in a range.
+            {3, 40, 1015}// value not exists & find in a range.
+        };
+    }
+
+    private static CacheLoader<Long, MessageIdData> mockCacheLoader(long start, long end, final long targetMessageId,
+                                                                    AtomicLong bingoMarker){
+        // Mock ledger.
+        final TreeMap<Long,Long> sparseLedger = new TreeMap<>();
+        sparseLedger.putAll(ORIGIN_SPARSE_LEDGER.subMap(start, end + 1));
+        sparseLedger.put(Long.MAX_VALUE,Long.MAX_VALUE);
+
+        Function<Long,Long> findMessageIdFunc = entryId -> sparseLedger.ceilingEntry(entryId).getValue();
+
+        // Calculate the correct position.
+        for (long i = start; i <= end; i++){
+            if (findMessageIdFunc.apply(i) >= targetMessageId){
+                bingoMarker.set(i);
+                break;
+            }
+        }
+
+        return new CacheLoader<Long, MessageIdData>() {
+            @Override
+            public @Nullable MessageIdData load(@NonNull Long entryId) throws Exception {
+                MessageIdData messageIdData = new MessageIdData();
+                messageIdData.setLedgerId(DEFAULT_LEDGER_ID);
+                messageIdData.setEntryId(findMessageIdFunc.apply(entryId));
+                return messageIdData;
+            }
+        };
+    }
+
+    @Test(dataProvider = "argsForFindStartPointLoop")
+    public void testFindStartPointLoop(long start, long end, long targetMessageId) {
+        AtomicLong bingoMarker = new AtomicLong();
+        // Mock cache.
+        AsyncLoadingCache<Long, MessageIdData> cache = Caffeine.newBuilder()
+                .buildAsync(mockCacheLoader(start, end, targetMessageId, bingoMarker));
+        // Do test.
+        PositionImpl targetPosition = PositionImpl.get(DEFAULT_LEDGER_ID, targetMessageId);
+        CompletableFuture<Long> promise = new CompletableFuture<>();
+        CompactedTopicImpl.findStartPointLoop(targetPosition, start, end, promise, cache);
+        long result = promise.join();
+        Assert.assertEquals(result, bingoMarker.get());
+    }
+}

--- a/pulsar-broker/src/test/java/org/apache/pulsar/compaction/CompactedTopicImplTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/compaction/CompactedTopicImplTest.java
@@ -141,6 +141,7 @@ public class CompactedTopicImplTest {
         CompletableFuture<Long> promise = new CompletableFuture<>();
         CompactedTopicImpl.findStartPointLoop(targetPosition, start, end, promise, cacheWithCounter);
         // Do verify.
+        promise.join();
         assertEquals(loopCounter.get().intValue(), 2);
     }
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/compaction/CompactedTopicImplTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/compaction/CompactedTopicImplTest.java
@@ -118,7 +118,7 @@ public class CompactedTopicImplTest {
      * Why should we check the recursion number of "findStartPointLoop", see: #17976
      */
     @Test
-    public void testRecursionNumberOfFindStartPointLoop() throws Exception {
+    public void testRecursionNumberOfFindStartPointLoop() {
         AtomicLong bingoMarker = new AtomicLong();
         long start = 0;
         long end = 100;


### PR DESCRIPTION
### Motivation & Modifications

`CompactedTopicImpl.findStartPointLoop` uses the binary search, but the implementation had a flaw that caused several more loops to be executed. If an array like this: `[1,2,3...100]`, and we search value `2` in this array, `CompactedTopicImpl.findStartPointLoop` will execute the following loops:

```
start: 0, mid:50, end: 100
start: 0, mid:25, end: 50
start: 0, mid:12, end: 25
start: 0, mid:6, end: 12
start: 0, mid:3, end: 6
start: 0, mid:1, end: 3
start: 1, mid:1, end: 1    bingo!
```

We can optimize the loop like this:

```
start: 0, mid:50, end: 100
start: 1, mid:25, end: 50    bingo!
```

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: 

- https://github.com/poorbarcode/pulsar/pull/20
