### PR TITLE
[fix][broker][branch-2.9] Fix system topic schema not compatible bug

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractTopic.java
@@ -158,6 +158,10 @@ public abstract class AbstractTopic implements Topic {
         this.preciseTopicPublishRateLimitingEnable =
                 brokerService.pulsar().getConfiguration().isPreciseTopicPublishRateLimiterEnable();
         updatePublishDispatcher(Optional.empty());
+        if (isSystemTopic()) {
+            schemaCompatibilityStrategy =
+                    brokerService.pulsar().getConfig().getSystemTopicSchemaCompatibilityStrategy();
+        }
     }
 
     protected boolean isProducersExceeded() {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/systopic/NamespaceEventsSystemTopicServiceTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/systopic/NamespaceEventsSystemTopicServiceTest.java
@@ -18,11 +18,14 @@
  */
 package org.apache.pulsar.broker.systopic;
 
+import static org.mockito.Mockito.mock;
 import com.google.common.collect.Sets;
 import lombok.Cleanup;
+import org.apache.bookkeeper.mledger.ManagedLedger;
 import org.apache.pulsar.broker.auth.MockedPulsarServiceBaseTest;
 import org.apache.pulsar.broker.service.BrokerService;
 import org.apache.pulsar.broker.service.persistent.PersistentTopic;
+import org.apache.pulsar.broker.service.persistent.SystemTopic;
 import org.apache.pulsar.client.admin.PulsarAdminException;
 import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.MessageId;
@@ -86,6 +89,16 @@ public class NamespaceEventsSystemTopicServiceTest extends MockedPulsarServiceBa
                 (PersistentTopic) pulsar.getBrokerService()
                         .getTopic(topicName, false)
                         .join().get();
+
+        Assert.assertEquals(SchemaCompatibilityStrategy.ALWAYS_COMPATIBLE, topic.getSchemaCompatibilityStrategy());
+    }
+
+    @Test
+    public void testSystemTopicSchemaCompatibility() throws Exception {
+        TopicPoliciesSystemTopicClient systemTopicClientForNamespace1 = systemTopicFactory
+                .createTopicPoliciesSystemTopicClient(NamespaceName.get(NAMESPACE1));
+        String topicName = systemTopicClientForNamespace1.getTopicName().toString();
+        SystemTopic topic = new SystemTopic(topicName, mock(ManagedLedger.class), pulsar.getBrokerService());
 
         Assert.assertEquals(SchemaCompatibilityStrategy.ALWAYS_COMPATIBLE, topic.getSchemaCompatibilityStrategy());
     }


### PR DESCRIPTION
Fixes #17979

### Motivation

While upgrading broker version from 2.8.2 to 2.9.3, broker log shows lots of `Unable to read schema` error, which should not happen.

#12598 has tried to fix the same bug but not completely. `schemaCompatibilityStrategy` in `org.apache.pulsar.broker.service.AbstractTopic` is `SchemaCompatibilityStrategy.FULL` defaultly and only be updated in `org.apache.pulsar.broker.service.AbstractTopic#setSchemaCompatibilityStrategy`.

https://github.com/apache/pulsar/blob/4abd4d23e8ab498e0c72c4e062063d6409f66da9/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractTopic.java#L552-L567

Once `org.apache.pulsar.broker.service.AbstractTopic#setSchemaCompatibilityStrategy` not called, the `schemaCompatibilityStrategy` of system topics will always be `SchemaCompatibilityStrategy.FULL`, which should be `brokerService.pulsar().getConfig().getSystemTopicSchemaCompatibilityStrategy()` (default `SchemaCompatibilityStrategy.ALWAYS_COMPATIBLE`) instead.

This bug only exists in branch 2.9 after #13557 meged. The master code is fine.

### Modifications

Add `schemaCompatibilityStrategy` update logic if the topic is system topic, as #12598 did, in constructor of `AbstractTopic`.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change added tests and can be verified as follows:
  - `org.apache.pulsar.broker.systopic.NamespaceEventsSystemTopicServiceTest#testSystemTopicSchemaCompatibility`

### Does this pull request potentially affect one of the following parts:

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/dragonls/pulsar/pull/1
