### PR TITLE
[improve][broker] Add test case for system topic schema not compatible bug.

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/systopic/NamespaceEventsSystemTopicServiceTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/systopic/NamespaceEventsSystemTopicServiceTest.java
@@ -18,12 +18,15 @@
  */
 package org.apache.pulsar.broker.systopic;
 
+import static org.mockito.Mockito.mock;
 import com.google.common.collect.Sets;
 import java.util.HashSet;
 import lombok.Cleanup;
+import org.apache.bookkeeper.mledger.ManagedLedger;
 import org.apache.pulsar.broker.auth.MockedPulsarServiceBaseTest;
 import org.apache.pulsar.broker.service.BrokerService;
 import org.apache.pulsar.broker.service.persistent.PersistentTopic;
+import org.apache.pulsar.broker.service.persistent.SystemTopic;
 import org.apache.pulsar.client.admin.PulsarAdminException;
 import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.MessageId;
@@ -86,6 +89,16 @@ public class NamespaceEventsSystemTopicServiceTest extends MockedPulsarServiceBa
                 (PersistentTopic) pulsar.getBrokerService()
                         .getTopic(topicName, false)
                         .join().get();
+
+        Assert.assertEquals(SchemaCompatibilityStrategy.ALWAYS_COMPATIBLE, topic.getSchemaCompatibilityStrategy());
+    }
+
+    @Test
+    public void testSystemTopicSchemaCompatibility() throws Exception {
+        TopicPoliciesSystemTopicClient systemTopicClientForNamespace1 = systemTopicFactory
+                .createTopicPoliciesSystemTopicClient(NamespaceName.get(NAMESPACE1));
+        String topicName = systemTopicClientForNamespace1.getTopicName().toString();
+        SystemTopic topic = new SystemTopic(topicName, mock(ManagedLedger.class), pulsar.getBrokerService());
 
         Assert.assertEquals(SchemaCompatibilityStrategy.ALWAYS_COMPATIBLE, topic.getSchemaCompatibilityStrategy());
     }


### PR DESCRIPTION
Master Issue: #17979

Related to #17986

### Motivation

Add test case to cover system topic schema compatibility.

### Modifications

Add test case (`org.apache.pulsar.broker.systopic.NamespaceEventsSystemTopicServiceTest#testSystemTopicSchemaCompatibility`) to cover system topic schema compatibility.

The `schemaCompatibilityStrategy` of system topic should always be the same as the conf `systemTopicSchemaCompatibilityStrategy`, which is default `SchemaCompatibilityStrategy.ALWAYS_COMPATIBLE`.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change added tests and can be verified as follows:
  - `org.apache.pulsar.broker.systopic.NamespaceEventsSystemTopicServiceTest#testSystemTopicSchemaCompatibility`

### Does this pull request potentially affect one of the following parts:

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/dragonls/pulsar/pull/2
