### PR TITLE
[fix][broker] Fix memory leak in case of error conditions in PendingReadsManager

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/cache/PendingReadsManager.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/cache/PendingReadsManager.java
@@ -356,6 +356,8 @@ public class PendingReadsManager {
                                         @Override
                                         public void readEntriesFailed(ManagedLedgerException exception,
                                                                       Object dummyCtx3) {
+                                            entries.forEach(Entry::release);
+                                            entriesFromLeft.forEach(Entry::release);
                                             callback.readEntriesFailed(exception, ctx);
                                         }
                                     };
@@ -366,6 +368,7 @@ public class PendingReadsManager {
 
                                 @Override
                                 public void readEntriesFailed(ManagedLedgerException exception, Object dummyCtx4) {
+                                    entries.forEach(Entry::release);
                                     callback.readEntriesFailed(exception, ctx);
                                 }
                             };
@@ -388,6 +391,7 @@ public class PendingReadsManager {
                                         @Override
                                         public void readEntriesFailed(ManagedLedgerException exception,
                                                                       Object dummyCtx6) {
+                                            entries.forEach(Entry::release);
                                             callback.readEntriesFailed(exception, ctx);
                                         }
                                     };
@@ -410,6 +414,7 @@ public class PendingReadsManager {
                                         @Override
                                         public void readEntriesFailed(ManagedLedgerException exception,
                                                                       Object dummyCtx8) {
+                                            entries.forEach(Entry::release);
                                             callback.readEntriesFailed(exception, ctx);
                                         }
                                     };


### PR DESCRIPTION
### Motivation

In case of error conditions we are not releasing the entries returned by partial reads. 

### Modifications

Release the entries on the error handling paths.

### Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->
