### PR TITLE
[improve][ci] Avoid PR title check on synchronized

### DIFF
--- a/.github/workflows/ci-semantic-pull-request.yml
+++ b/.github/workflows/ci-semantic-pull-request.yml
@@ -25,6 +25,10 @@ on:
       - reopened
       - edited
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event.number }}
+  cancel-in-progress: true
+
 jobs:
   main:
     name: Check pull request title

--- a/.github/workflows/ci-semantic-pull-request.yml
+++ b/.github/workflows/ci-semantic-pull-request.yml
@@ -24,7 +24,6 @@ on:
       - opened
       - reopened
       - edited
-      - synchronize
 
 jobs:
   main:


### PR DESCRIPTION
cc @nicoloboschi 

### Motivation

Reduce unnecessary workflow trigger. See also https://github.com/apache/pulsar/pull/17961#discussion_r991902240.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: 