### PR TITLE
[improve][doc] Add doc preview reminder to PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -65,7 +65,7 @@ This change added tests and can be verified as follows:
 
 <!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->
 
-- [ ] `doc` <!-- Your PR contains doc changes -->
+- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
 - [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
 - [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
 - [ ] `doc-complete` <!-- Docs have been already added -->

--- a/.github/changes-filter.yaml
+++ b/.github/changes-filter.yaml
@@ -10,6 +10,7 @@ docs:
   - '**/*.md'
   - '.github/changes-filter.yaml'
   - '.github/ISSUE_TEMPLATE/**'
+  - 'wiki/**'
 tests:
   - added|modified: '**/src/test/java/**/*.java'
 need_owasp:


### PR DESCRIPTION
This PR adds a reminder for users to attach local preview screenshots to PR descriptions.

Context: https://github.com/apache/pulsar/pull/17853#issuecomment-1274299184

- [x] `doc` <!-- Your PR contains doc changes -->
