### PR TITLE
[improve][broker] Reduce unnecessary persistence of markdelete

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
@@ -1969,7 +1969,7 @@ public class ManagedCursorImpl implements ManagedCursor {
 
     void internalMarkDelete(final MarkDeleteEntry mdEntry) {
         if (persistentMarkDeletePosition != null
-                && mdEntry.newPosition.compareTo(persistentMarkDeletePosition) < 0) {
+                && mdEntry.newPosition.compareTo(persistentMarkDeletePosition) <= 0) {
             if (log.isInfoEnabled()) {
                 log.info("Skipping updating mark delete position to {}. The persisted mark delete position {} "
                         + "is later.", mdEntry.newPosition, persistentMarkDeletePosition);
@@ -1980,7 +1980,7 @@ public class ManagedCursorImpl implements ManagedCursor {
         }
 
         PositionImpl inProgressLatest = INPROGRESS_MARKDELETE_PERSIST_POSITION_UPDATER.updateAndGet(this, current -> {
-            if (current != null && current.compareTo(mdEntry.newPosition) > 0) {
+            if (current != null && current.compareTo(mdEntry.newPosition) >= 0) {
                 return current;
             } else {
                 return mdEntry.newPosition;


### PR DESCRIPTION
### Motivation
Reduce unnecessary persistence of markdelete：
1. When mdEntry.newPosition is equal to persistentMarkDeletePosition, this persistence should be skipped：
https://github.com/apache/pulsar/blob/36806853b5a445299d8f9a6ba89905c1915345a3/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java#L1971-L1980

It should be modified to:
```
if (persistentMarkDeletePosition != null
          && mdEntry.newPosition.compareTo(persistentMarkDeletePosition) <= 0)
```

2. When mdEntry.newPosition is equal to INPROGRESS_MARKDELETE_PERSIST_POSITION_UPDATER, this persistence should also be skipped：
https://github.com/apache/pulsar/blob/36806853b5a445299d8f9a6ba89905c1915345a3/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java#L1982-L1999


It should be modified to:
```
if (current != null && current.compareTo(mdEntry.newPosition) >= 0) 
```


### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/lordcheng10/pulsar/pull/26

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
