### PR TITLE
[fix][broker] Reduce unnecessary persistence of markdelete

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
@@ -1758,7 +1758,7 @@ public class ManagedCursorImpl implements ManagedCursor {
      * @return the previous acknowledged position
      */
     PositionImpl setAcknowledgedPosition(PositionImpl newMarkDeletePosition) {
-        if (newMarkDeletePosition.compareTo(markDeletePosition) < 0) {
+        if (newMarkDeletePosition.compareTo(markDeletePosition) <= 0) {
             throw new MarkDeletingMarkedPosition(
                     "Mark deleting an already mark-deleted position. Current mark-delete: " + markDeletePosition
                             + " -- attempted mark delete: " + newMarkDeletePosition);

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
@@ -1971,7 +1971,7 @@ public class ManagedCursorImpl implements ManagedCursor {
 
     void internalMarkDelete(final MarkDeleteEntry mdEntry) {
         if (persistentMarkDeletePosition != null
-                && mdEntry.newPosition.compareTo(persistentMarkDeletePosition) <= 0) {
+                && mdEntry.newPosition.compareTo(persistentMarkDeletePosition) < 0) {
             if (log.isInfoEnabled()) {
                 log.info("Skipping updating mark delete position to {}. The persisted mark delete position {} "
                         + "is later.", mdEntry.newPosition, persistentMarkDeletePosition);

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
@@ -1758,7 +1758,7 @@ public class ManagedCursorImpl implements ManagedCursor {
      * @return the previous acknowledged position
      */
     PositionImpl setAcknowledgedPosition(PositionImpl newMarkDeletePosition) {
-        if (newMarkDeletePosition.compareTo(markDeletePosition) <= 0) {
+        if (newMarkDeletePosition.compareTo(markDeletePosition) < 0) {
             throw new MarkDeletingMarkedPosition(
                     "Mark deleting an already mark-deleted position. Current mark-delete: " + markDeletePosition
                             + " -- attempted mark delete: " + newMarkDeletePosition);
@@ -1906,7 +1906,11 @@ public class ManagedCursorImpl implements ManagedCursor {
 
         lock.writeLock().lock();
         try {
-            newPosition = setAcknowledgedPosition(newPosition);
+            // When newPosition is equal to markDeletePosition,
+            // it means that the memory of markDeletePosition has been updated, but it may not be persistent.
+            if (!newPosition.equals(markDeletePosition)) {
+                newPosition = setAcknowledgedPosition(newPosition);
+            }
         } catch (IllegalArgumentException e) {
             callback.markDeleteFailed(getManagedLedgerException(e), ctx);
             return;
@@ -1969,7 +1973,7 @@ public class ManagedCursorImpl implements ManagedCursor {
 
     void internalMarkDelete(final MarkDeleteEntry mdEntry) {
         if (persistentMarkDeletePosition != null
-                && mdEntry.newPosition.compareTo(persistentMarkDeletePosition) < 0) {
+                && mdEntry.newPosition.compareTo(persistentMarkDeletePosition) <= 0) {
             if (log.isInfoEnabled()) {
                 log.info("Skipping updating mark delete position to {}. The persisted mark delete position {} "
                         + "is later.", mdEntry.newPosition, persistentMarkDeletePosition);
@@ -1980,7 +1984,7 @@ public class ManagedCursorImpl implements ManagedCursor {
         }
 
         PositionImpl inProgressLatest = INPROGRESS_MARKDELETE_PERSIST_POSITION_UPDATER.updateAndGet(this, current -> {
-            if (current != null && current.compareTo(mdEntry.newPosition) > 0) {
+            if (current != null && current.compareTo(mdEntry.newPosition) >= 0) {
                 return current;
             } else {
                 return mdEntry.newPosition;

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
@@ -1906,8 +1906,6 @@ public class ManagedCursorImpl implements ManagedCursor {
 
         lock.writeLock().lock();
         try {
-            // When newPosition is equal to markDeletePosition,
-            // it means that the memory of markDeletePosition has been updated, but it may not be persistent.
             if (!newPosition.equals(markDeletePosition)) {
                 newPosition = setAcknowledgedPosition(newPosition);
             }

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedCursorTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedCursorTest.java
@@ -986,13 +986,8 @@ public class ManagedCursorTest extends MockedBookKeeperTestCase {
         assertFalse(cursor.hasMoreEntries());
         assertEquals(cursor.getNumberOfEntries(), 0);
 
-        // markDelete p1 again, should throw exception
-        try {
-            cursor.markDelete(p1);
-            fail("Should throw exception!");
-        } catch (ManagedLedgerException e) {
-            assertTrue(e.getMessage().contains("Mark deleting an already mark-deleted position."));
-        }
+        // markDelete p1 again
+        cursor.markDelete(p1);
     }
 
     @Test(timeOut = 20000)

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedCursorTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedCursorTest.java
@@ -975,6 +975,27 @@ public class ManagedCursorTest extends MockedBookKeeperTestCase {
     }
 
     @Test(timeOut = 20000)
+    void markDeleteThePositionTwice() throws Exception {
+        ManagedLedger ledger = factory.open("my_test_ledger", new ManagedLedgerConfig().setMaxEntriesPerLedger(10));
+        ManagedCursor cursor = ledger.openCursor("c1");
+        Position p1 = ledger.addEntry("dummy-entry-1".getBytes(Encoding));
+
+        assertEquals(cursor.getNumberOfEntries(), 1);
+
+        cursor.markDelete(p1);
+        assertFalse(cursor.hasMoreEntries());
+        assertEquals(cursor.getNumberOfEntries(), 0);
+
+        // markDelete p1 again, should throw exception
+        try {
+            cursor.markDelete(p1);
+            fail("Should throw exception!");
+        } catch (ManagedLedgerException e) {
+            assertTrue(e.getMessage().contains("Mark deleting an already mark-deleted position."));
+        }
+    }
+
+    @Test(timeOut = 20000)
     void markDeleteSkippingMessage() throws Exception {
         ManagedLedger ledger = factory.open("my_test_ledger", new ManagedLedgerConfig().setMaxEntriesPerLedger(10));
         ManagedCursor cursor = ledger.openCursor("c1");


### PR DESCRIPTION
### Motivation
When newPosition==markDeletePosition, it means that the memory in markDeletePosition has been updated, but it may not be persistent. The corresponding unit test is ManagedCursorTest#testFlushCursorAfterError.
So here just skip the setAcknowledgedPosition method, do not return.
https://github.com/apache/pulsar/blob/36806853b5a445299d8f9a6ba89905c1915345a3/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java#L1907-L1918

should be modified to:
```
    lock.writeLock().lock();
        try {
            // When newPosition is equal to markDeletePosition,
            // it means that the memory of markDeletePosition has been updated, but it may not be persistent.
            if (!newPosition.equals(markDeletePosition)) {
                newPosition = setAcknowledgedPosition(newPosition);
            }
        } catch (IllegalArgumentException e) {
            callback.markDeleteFailed(getManagedLedgerException(e), ctx);
            return;
        } finally {
            lock.writeLock().unlock();
        } 
```

Reduce unnecessary persistence of markdelete：
1. When mdEntry.newPosition is equal to persistentMarkDeletePosition, this persistence should be skipped：
https://github.com/apache/pulsar/blob/36806853b5a445299d8f9a6ba89905c1915345a3/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java#L1971-L1980

It should be modified to:
```
if (persistentMarkDeletePosition != null
          && mdEntry.newPosition.compareTo(persistentMarkDeletePosition) <= 0)
```

2. When mdEntry.newPosition is equal to INPROGRESS_MARKDELETE_PERSIST_POSITION_UPDATER, this persistence should also be skipped：
https://github.com/apache/pulsar/blob/36806853b5a445299d8f9a6ba89905c1915345a3/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java#L1982-L1999


It should be modified to:
```
if (current != null && current.compareTo(mdEntry.newPosition) >= 0) 
```


### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/lordcheng10/pulsar/pull/27<!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
