### PR TITLE
[fix][ci] Upload to codecov only upstream pull requests

### DIFF
--- a/.github/workflows/pulsar-ci.yaml
+++ b/.github/workflows/pulsar-ci.yaml
@@ -218,6 +218,7 @@ jobs:
         uses: ./.github/actions/copy-test-reports
 
       - name: Upload to Codecov
+        if: ${{ github.repository == 'apache/pulsar' }}
         uses: codecov/codecov-action@v3
         continue-on-error: true
         with:


### PR DESCRIPTION
### Motivation
The codecov report is also uploaded in personal forks. See https://github.com/nicoloboschi/pulsar/pull/22#issuecomment-1276284696

### Modifications

* Do upload only if the pull is in the apache/pulsar repository

### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->
