### PR TITLE
[fix][io] Fix builtin sink transformation on k8s

### DIFF
--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/api/SinksImpl.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/api/SinksImpl.java
@@ -433,8 +433,8 @@ public class SinksImpl extends ComponentImpl implements Sinks<PulsarWorkerServic
                                                  Function.FunctionDetails functionDetails, String transformFunction) {
         File functionPackageFile = null;
         try {
-            String builtin = null;
-            if (!transformFunction.startsWith(Utils.BUILTIN)) {
+            String builtin = functionDetails.getBuiltin();
+            if (isBlank(builtin)) {
                 functionPackageFile = getPackageFile(transformFunction);
             }
             Function.PackageLocationMetaData.Builder functionPackageLocation =


### PR DESCRIPTION
### Motivation

Fixes a NPE with transform-function+Sink on k8s because builtin is null in `getFunctionPackageLocation`.
There is no issue when not in k8s because then the packageUrl is used for the packagePath and its value is `builtin://xxx`

### Modifications

Use the builtin from the functionDetails that was previously set in `SinkConfigUtils::convert`

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/cbornet/pulsar/pull/3

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
