### PR TITLE
[fix][sec] Upgrade JacksonXML to 2.13.4

### DIFF
--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -246,14 +246,14 @@ The Apache Software License, Version 2.0
  * JCommander -- com.beust-jcommander-1.82.jar
  * High Performance Primitive Collections for Java -- com.carrotsearch-hppc-0.9.1.jar
  * Jackson
-     - com.fasterxml.jackson.core-jackson-annotations-2.13.3.jar
-     - com.fasterxml.jackson.core-jackson-core-2.13.3.jar
-     - com.fasterxml.jackson.core-jackson-databind-2.13.3.jar
-     - com.fasterxml.jackson.dataformat-jackson-dataformat-yaml-2.13.3.jar
-     - com.fasterxml.jackson.jaxrs-jackson-jaxrs-base-2.13.3.jar
-     - com.fasterxml.jackson.jaxrs-jackson-jaxrs-json-provider-2.13.3.jar
-     - com.fasterxml.jackson.module-jackson-module-jaxb-annotations-2.13.3.jar
-     - com.fasterxml.jackson.module-jackson-module-jsonSchema-2.13.3.jar
+     - com.fasterxml.jackson.core-jackson-annotations-2.13.4.jar
+     - com.fasterxml.jackson.core-jackson-core-2.13.4.jar
+     - com.fasterxml.jackson.core-jackson-databind-2.13.4.jar
+     - com.fasterxml.jackson.dataformat-jackson-dataformat-yaml-2.13.4.jar
+     - com.fasterxml.jackson.jaxrs-jackson-jaxrs-base-2.13.4.jar
+     - com.fasterxml.jackson.jaxrs-jackson-jaxrs-json-provider-2.13.4.jar
+     - com.fasterxml.jackson.module-jackson-module-jaxb-annotations-2.13.4.jar
+     - com.fasterxml.jackson.module-jackson-module-jsonSchema-2.13.4.jar
  * Caffeine -- com.github.ben-manes.caffeine-caffeine-2.9.1.jar
  * Conscrypt -- org.conscrypt-conscrypt-openjdk-uber-2.5.2.jar
  * Proto Google Common Protos -- com.google.api.grpc-proto-google-common-protos-2.0.1.jar

--- a/pom.xml
+++ b/pom.xml
@@ -139,7 +139,7 @@ flexible messaging model and an intuitive client API.</description>
     <log4j2.version>2.18.0</log4j2.version>
     <bouncycastle.version>1.69</bouncycastle.version>
     <bouncycastlefips.version>1.0.2</bouncycastlefips.version>
-    <jackson.version>2.13.3</jackson.version>
+    <jackson.version>2.13.4</jackson.version>
     <reflections.version>0.9.11</reflections.version>
     <swagger.version>1.6.2</swagger.version>
     <puppycrawl.checkstyle.version>8.37</puppycrawl.checkstyle.version>

--- a/pulsar-sql/presto-distribution/LICENSE
+++ b/pulsar-sql/presto-distribution/LICENSE
@@ -207,19 +207,19 @@ This projects includes binary packages with the following licenses:
 The Apache Software License, Version 2.0
 
   * Jackson
-    - jackson-annotations-2.13.3.jar
-    - jackson-core-2.13.3.jar
-    - jackson-databind-2.13.3.jar
-    - jackson-dataformat-smile-2.13.3.jar
-    - jackson-datatype-guava-2.13.3.jar
-    - jackson-datatype-jdk8-2.13.3.jar
-    - jackson-datatype-joda-2.13.3.jar
-    - jackson-datatype-jsr310-2.13.3.jar
-    - jackson-dataformat-yaml-2.13.3.jar
-    - jackson-jaxrs-base-2.13.3.jar
-    - jackson-jaxrs-json-provider-2.13.3.jar
-    - jackson-module-jaxb-annotations-2.13.3.jar
-    - jackson-module-jsonSchema-2.13.3.jar
+    - jackson-annotations-2.13.4.jar
+    - jackson-core-2.13.4.jar
+    - jackson-databind-2.13.4.jar
+    - jackson-dataformat-smile-2.13.4.jar
+    - jackson-datatype-guava-2.13.4.jar
+    - jackson-datatype-jdk8-2.13.4.jar
+    - jackson-datatype-joda-2.13.4.jar
+    - jackson-datatype-jsr310-2.13.4.jar
+    - jackson-dataformat-yaml-2.13.4.jar
+    - jackson-jaxrs-base-2.13.4.jar
+    - jackson-jaxrs-json-provider-2.13.4.jar
+    - jackson-module-jaxb-annotations-2.13.4.jar
+    - jackson-module-jsonSchema-2.13.4.jar
  * Guava
     - guava-31.0.1-jre.jar
     - listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.jar
@@ -445,7 +445,7 @@ The Apache Software License, Version 2.0
   * Snappy
     - snappy-java-1.1.8.4.jar
   * Jackson
-    - jackson-module-parameter-names-2.13.3.jar
+    - jackson-module-parameter-names-2.13.4.jar
   * Java Assist
     - javassist-3.25.0-GA.jar
   * Java Native Access


### PR DESCRIPTION
### Motivation

Current version of JacksonXML (2.13.3) is vulnerable to [CVE-2022-42004](http://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2022-42004)
Note that Pulsar is not directly vulnerable since the CVE exists only if `DeserializationFeature.UNWRAP_SINGLE_VALUE_ARRAYS` is used. And Pulsar doesn't use it.

### Modifications
* Upgrade to 2.13.4. It's a minor 

- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
