### PR TITLE
[fix][sec] File tiered storage: upgrade jettison to get rid of CVE-2022-40149

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -247,6 +247,7 @@ flexible messaging model and an intuitive client API.</description>
     <objenesis.version>3.1</objenesis.version>
     <awaitility.version>4.2.0</awaitility.version>
     <reload4j.version>1.2.22</reload4j.version>
+    <jettison.version>1.5.1</jettison.version>
 
     <!-- Plugin dependencies -->
     <protobuf-maven-plugin.version>0.6.1</protobuf-maven-plugin.version>
@@ -797,6 +798,13 @@ flexible messaging model and an intuitive client API.</description>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
+
+      <dependency>
+        <groupId>org.codehaus.jettison</groupId>
+        <artifactId>jettison</artifactId>
+        <version>${jettison.version}</version>
+      </dependency>
+
 
       <dependency>
         <groupId>org.hdrhistogram</groupId>

--- a/pulsar-io/dynamodb/pom.xml
+++ b/pulsar-io/dynamodb/pom.xml
@@ -88,7 +88,7 @@
     <dependency>
       <groupId>com.amazonaws</groupId>
       <artifactId>dynamodb-streams-kinesis-adapter</artifactId>
-      <version>1.5.1</version>
+      <version>${jettison.version}</version>
     </dependency>
     <!-- /dynamodb dependencies -->
 

--- a/pulsar-io/dynamodb/pom.xml
+++ b/pulsar-io/dynamodb/pom.xml
@@ -88,7 +88,7 @@
     <dependency>
       <groupId>com.amazonaws</groupId>
       <artifactId>dynamodb-streams-kinesis-adapter</artifactId>
-      <version>${jettison.version}</version>
+      <version>1.5.1</version>
     </dependency>
     <!-- /dynamodb dependencies -->
 


### PR DESCRIPTION
### Motivation

In the file tiered storage the hadoop dependency brings in a vulnerable version of jettison ([CVE-2022-40149](https://nvd.nist.gov/vuln/detail/CVE-2022-40149)).
It has been already fixed in the nightly version without any code change (https://github.com/apache/hadoop/pull/4937/files)

### Modifications

- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
