### PR TITLE
[improve][misc] Highlight change to threading

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -56,6 +56,7 @@ This change added tests and can be verified as follows:
 - [ ] The public API
 - [ ] The schema
 - [ ] The default values of configurations
+- [ ] The threading model
 - [ ] The binary protocol
 - [ ] The REST endpoints
 - [ ] The admin CLI options
@@ -83,6 +84,6 @@ apache/pulsar CI based on GitHub Actions has constrained resources and quota.
 GitHub Actions provides separate quota for pull requests that are executed in 
 a forked repository.
 
-The tests will be run in the forked repository until all PR review comments have
+The tests will be run in the forkedrepository until all PR review comments have
 been handled, the tests pass and the PR is approved by a reviewer.
 -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -84,6 +84,6 @@ apache/pulsar CI based on GitHub Actions has constrained resources and quota.
 GitHub Actions provides separate quota for pull requests that are executed in 
 a forked repository.
 
-The tests will be run in the forkedrepository until all PR review comments have
+The tests will be run in the forked repository until all PR review comments have
 been handled, the tests pass and the PR is approved by a reviewer.
 -->


### PR DESCRIPTION
Whenever a PR changes the threading model we need to make clear that we should track these changes

### Motivation

I want follow changes in the threading model in order to help understand and document Pulsar's internal architecture.

Adding a checkbox should hopefully make developers more thoughtful about explicitly noting changes to the threading model.

### Modifications

Adds a checkbox about "the threading model"

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change is to the PULL REQUEST TEMPLATE no test coverage required.

### Does this pull request potentially affect one of the following parts:

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

