### PR TITLE
[improve][test] Improve KeySharedSubscriptionTest to reduce the execution time

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/KeySharedSubscriptionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/KeySharedSubscriptionTest.java
@@ -44,6 +44,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import lombok.Cleanup;
@@ -63,8 +64,9 @@ import org.awaitility.Awaitility;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.AfterMethod;
-import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
@@ -109,7 +111,7 @@ public class KeySharedSubscriptionTest extends ProducerConsumerBase {
         };
     }
 
-    @BeforeMethod(alwaysRun = true)
+    @BeforeClass(alwaysRun = true)
     @Override
     protected void setup() throws Exception {
         super.internalSetup();
@@ -117,10 +119,20 @@ public class KeySharedSubscriptionTest extends ProducerConsumerBase {
         this.conf.setSubscriptionKeySharedUseConsistentHashing(true);
     }
 
-    @AfterMethod(alwaysRun = true)
+    @AfterClass(alwaysRun = true)
     @Override
     protected void cleanup() throws Exception {
         super.internalCleanup();
+    }
+
+    @AfterMethod(alwaysRun = true)
+    public void resetDefaultNamespace() throws Exception {
+        List<String> list = admin.namespaces().getTopics("public/default");
+        for (String topicName : list){
+            if (!pulsar.getBrokerService().isSystemTopic(topicName)) {
+                admin.topics().delete(topicName, false);
+            }
+        }
     }
 
     private static final Random random = new Random(System.nanoTime());
@@ -441,12 +453,18 @@ public class KeySharedSubscriptionTest extends ProducerConsumerBase {
     public void testDisableKeySharedSubscription() throws PulsarClientException {
         this.conf.getSubscriptionTypesEnabled().remove("Key_Shared");
         String topic = "persistent://public/default/key_shared_disabled";
-        pulsarClient.newConsumer()
-            .topic(topic)
-            .subscriptionName("key_shared")
-            .subscriptionType(SubscriptionType.Key_Shared)
-            .ackTimeout(10, TimeUnit.SECONDS)
-            .subscribe();
+        try {
+            @Cleanup
+            Consumer c = pulsarClient.newConsumer()
+                    .topic(topic)
+                    .subscriptionName("key_shared")
+                    .subscriptionType(SubscriptionType.Key_Shared)
+                    .ackTimeout(10, TimeUnit.SECONDS)
+                    .subscribe();
+        } finally {
+            // reset subscription types.
+            this.conf.getSubscriptionTypesEnabled().add("Key_Shared");
+        }
     }
 
     @Test
@@ -481,6 +499,7 @@ public class KeySharedSubscriptionTest extends ProducerConsumerBase {
         String slowKey = "slowKey";
 
         List<PulsarClient> clients = new ArrayList<>();
+        List<Consumer> consumers = new ArrayList<>();
         try {
             AtomicInteger receivedMessages = new AtomicInteger();
 
@@ -490,7 +509,7 @@ public class KeySharedSubscriptionTest extends ProducerConsumerBase {
                         .build();
                 clients.add(client);
 
-                client.newConsumer(Schema.INT32)
+                Consumer c = client.newConsumer(Schema.INT32)
                         .topic(topic)
                         .subscriptionName("key_shared")
                         .subscriptionType(SubscriptionType.Key_Shared)
@@ -509,6 +528,7 @@ public class KeySharedSubscriptionTest extends ProducerConsumerBase {
                             }
                         })
                         .subscribe();
+                consumers.add(c);
             }
 
             @Cleanup
@@ -535,6 +555,10 @@ public class KeySharedSubscriptionTest extends ProducerConsumerBase {
             Awaitility.await().untilAsserted(() -> {
                 assertEquals((double) receivedMessages.get(), N * 0.9, N * 0.3);
             });
+
+            for (Consumer c : consumers) {
+                c.close();
+            }
         } finally {
             for (PulsarClient c : clients) {
                 c.close();
@@ -1108,6 +1132,7 @@ public class KeySharedSubscriptionTest extends ProducerConsumerBase {
                 .subscriptionType(SubscriptionType.Key_Shared);
 
         // Create 3 consumers with same name
+        @Cleanup
         Consumer<String> c1 = cb.subscribe();
 
         @Cleanup
@@ -1115,6 +1140,7 @@ public class KeySharedSubscriptionTest extends ProducerConsumerBase {
         @Cleanup
         Consumer<String> c3 = cb.subscribe();
 
+        @Cleanup
         Producer<String> p = pulsarClient.newProducer(Schema.STRING)
                 .topic(topicName)
                 .create();
@@ -1398,7 +1424,7 @@ public class KeySharedSubscriptionTest extends ProducerConsumerBase {
     }
 
     @Test
-    public void testStickyKeyRangesRestartConsumers() throws PulsarClientException, InterruptedException {
+    public void testStickyKeyRangesRestartConsumers() throws Exception {
         final String topic = TopicName.get("persistent", "public", "default",
                 "testStickyKeyRangesRestartConsumers" + UUID.randomUUID()).toString();
 
@@ -1411,6 +1437,7 @@ public class KeySharedSubscriptionTest extends ProducerConsumerBase {
         CountDownLatch count1 = new CountDownLatch(2);
         CountDownLatch count2 = new CountDownLatch(13); // consumer 2 usually receive the fix messages
         CountDownLatch count3 = new CountDownLatch(numMessages);
+        @Cleanup
         Consumer<String> consumer1 = pulsarClient.newConsumer(
                         Schema.STRING)
                 .topic(topic)
@@ -1431,6 +1458,7 @@ public class KeySharedSubscriptionTest extends ProducerConsumerBase {
                 })
                 .subscribe();
 
+        @Cleanup
         Consumer<String> consumer2 = pulsarClient.newConsumer(
                         Schema.STRING)
                 .topic(topic)
@@ -1451,13 +1479,13 @@ public class KeySharedSubscriptionTest extends ProducerConsumerBase {
                 })
                 .subscribe();
 
-        pulsar.getExecutor().submit(() -> {
+        Future producerFuture = pulsar.getExecutor().submit(() -> {
             try
             {
                 try (Producer<String> producer = pulsarClient.newProducer(Schema.STRING)
                         .topic(topic)
                         .enableBatching(false)
-                        .create();) {
+                        .create()) {
                     for (int i = 0; i < numMessages; i++)
                     {
                         String key = "test" + i;
@@ -1484,8 +1512,8 @@ public class KeySharedSubscriptionTest extends ProducerConsumerBase {
         Thread.sleep(3000);
 
         // start consuming again...
-
-        pulsarClient.newConsumer(Schema.STRING)
+        @Cleanup
+        Consumer consumer3 = pulsarClient.newConsumer(Schema.STRING)
                 .topic(topic)
                 .subscriptionName(subscriptionName)
                 .subscriptionInitialPosition(SubscriptionInitialPosition.Earliest)
@@ -1502,7 +1530,8 @@ public class KeySharedSubscriptionTest extends ProducerConsumerBase {
                     });
                 })
                 .subscribe();
-        pulsarClient.newConsumer(Schema.STRING)
+        @Cleanup
+        Consumer consumer4 = pulsarClient.newConsumer(Schema.STRING)
                 .topic(topic)
                 .subscriptionName(subscriptionName)
                 .subscriptionInitialPosition(SubscriptionInitialPosition.Earliest)
@@ -1522,5 +1551,7 @@ public class KeySharedSubscriptionTest extends ProducerConsumerBase {
         // wait for all the messages to be delivered
         count3.await();
         assertTrue(sentMessages.isEmpty(), "didn't receive " + sentMessages);
+
+        producerFuture.get();
     }
 }


### PR DESCRIPTION
Fixes #17635

- #17635

### Modifications

- Use the `namespace-clean` instead `pulsar-restart`, saves `pulsar.start()` and `pulsar.stop()` time before and after each method. 

After improve, `KeySharedSubscriptionTest` cost  210s

```
[INFO] Tests run: 43, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 210.841 s - in org.apache.pulsar.client.api.KeySharedSubscriptionTest
```

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: 

- https://github.com/poorbarcode/pulsar/pull/23