### PR TITLE
[fix][io] Remove unused import statement in the MariadbJdbcAutoSchemaSink

### DIFF
--- a/pulsar-io/jdbc/mariadb/src/main/java/org/apache/pulsar/io/jdbc/MariadbJdbcAutoSchemaSink.java
+++ b/pulsar-io/jdbc/mariadb/src/main/java/org/apache/pulsar/io/jdbc/MariadbJdbcAutoSchemaSink.java
@@ -20,7 +20,6 @@ package org.apache.pulsar.io.jdbc;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 import org.apache.pulsar.io.core.annotations.Connector;
 import org.apache.pulsar.io.core.annotations.IOType;
 


### PR DESCRIPTION
### Modifications

When install `pulsar-io-jdbc-mariadb` module occurred checkstyle error.

> mvn clean install -pl pulsar-io/jdbc/mariadb
```
[INFO] --- maven-checkstyle-plugin:3.1.2:check (checkstyle) @ pulsar-io-jdbc-mariadb ---
[INFO] There is 1 error reported by Checkstyle 8.37 with /Users/zc/IdeaProjects/pulsar/buildtools/src/main/resources/pulsar/checkstyle.xml ruleset.

[ERROR] src/main/java/org/apache/pulsar/io/jdbc/MariadbJdbcAutoSchemaSink.java:[23,8] (imports) UnusedImports: Unused import: java.util.stream.Collectors.
```

Related PR：#17950

### Modifications

Remove unused import statement in the MariadbJdbcAutoSchemaSink.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/coderzc/pulsar/pull/12