### PR TITLE
[improve][test] Improve SimpleSchemaTest to reduce the execution time

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SimpleSchemaTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SimpleSchemaTest.java
@@ -61,8 +61,9 @@ import org.apache.pulsar.common.schema.LongSchemaVersion;
 import org.apache.pulsar.common.schema.SchemaInfo;
 import org.apache.pulsar.common.schema.SchemaType;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.AfterMethod;
-import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Factory;
 import org.testng.annotations.Test;
@@ -70,6 +71,8 @@ import org.testng.annotations.Test;
 @Test(groups = "broker-api")
 @Slf4j
 public class SimpleSchemaTest extends ProducerConsumerBase {
+
+    private static final String NAMESPACE = "my-property/my-ns";
 
     @DataProvider(name = "batchingModes")
     public static Object[][] batchingModes() {
@@ -111,7 +114,7 @@ public class SimpleSchemaTest extends ProducerConsumerBase {
     }
 
 
-    @BeforeMethod
+    @BeforeClass
     @Override
     protected void setup() throws Exception {
         conf.setSchemaValidationEnforced(schemaValidationEnforced);
@@ -120,19 +123,32 @@ public class SimpleSchemaTest extends ProducerConsumerBase {
         super.producerBaseSetup();
     }
 
-    @AfterMethod(alwaysRun = true)
+    @AfterClass(alwaysRun = true)
     @Override
     protected void cleanup() throws Exception {
         super.internalCleanup();
     }
 
+    @AfterMethod(alwaysRun = true)
+    public void resetNamespace() throws Exception {
+        List<String> list = admin.namespaces().getTopics(NAMESPACE);
+        for (String topicName : list){
+            if (!pulsar.getBrokerService().isSystemTopic(topicName)) {
+                admin.topics().delete(topicName, false);
+            }
+        }
+        PulsarClientImpl pulsarClientImpl = (PulsarClientImpl) pulsarClient;
+        pulsarClientImpl.getSchemaProviderLoadingCache().invalidateAll();
+    }
+
     @Test
     public void testString() throws Exception {
+        final String topicName = String.format("persistent://%s/my-topic1", NAMESPACE);
         try (Consumer<String> consumer = pulsarClient.newConsumer(Schema.STRING)
-                .topic("persistent://my-property/my-ns/my-topic1")
+                .topic(topicName)
                 .subscriptionName("my-subscriber-name").subscribe();
              Producer<String> producer = pulsarClient.newProducer(Schema.STRING)
-                     .topic("persistent://my-property/my-ns/my-topic1").create()) {
+                     .topic(topicName).create()) {
             int N = 10;
 
             for (int i = 0; i < N; i++) {
@@ -176,7 +192,7 @@ public class SimpleSchemaTest extends ProducerConsumerBase {
 
     @Test
     public void newProducerNewTopicNewSchema() throws Exception {
-        String topic = "my-property/my-ns/schema-test";
+        String topic = NAMESPACE + "/schema-test";
         try (Producer<V1Data> p = pulsarClient.newProducer(Schema.AVRO(V1Data.class))
                 .topic(topic).create()) {
             p.send(new V1Data(0));
@@ -185,7 +201,7 @@ public class SimpleSchemaTest extends ProducerConsumerBase {
 
     @Test
     public void newProducerTopicExistsWithoutSchema() throws Exception {
-        String topic = "my-property/my-ns/schema-test";
+        String topic = NAMESPACE + "/schema-test";
         try (Producer<byte[]> p = pulsarClient.newProducer().topic(topic).create()) {
             p.send(topic.getBytes(UTF_8));
         }
@@ -198,7 +214,7 @@ public class SimpleSchemaTest extends ProducerConsumerBase {
 
     @Test
     public void newProducerTopicExistsWithSchema() throws Exception {
-        String topic = "my-property/my-ns/schema-test";
+        String topic = NAMESPACE + "/schema-test";
         try (Producer<V1Data> p = pulsarClient.newProducer(Schema.AVRO(V1Data.class))
                 .topic(topic).create()) {
             p.send(new V1Data(1));
@@ -212,7 +228,7 @@ public class SimpleSchemaTest extends ProducerConsumerBase {
 
     @Test
     public void newProducerWithoutSchemaOnTopicWithSchema() throws Exception {
-        String topic = "my-property/my-ns/schema-test";
+        String topic = NAMESPACE + "/schema-test";
 
         try (Producer<V1Data> p = pulsarClient.newProducer(Schema.AVRO(V1Data.class))
                 .topic(topic).create()) {
@@ -256,7 +272,7 @@ public class SimpleSchemaTest extends ProducerConsumerBase {
 
     @Test
     public void newProducerForMessageSchemaOnTopicWithMultiVersionSchema() throws Exception {
-        String topic = "my-property/my-ns/schema-test";
+        String topic = NAMESPACE + "/schema-test";
         Schema<V1Data> v1Schema = Schema.AVRO(V1Data.class);
         byte[] v1SchemaBytes = v1Schema.getSchemaInfo().getSchema();
         AvroWriter<V1Data> v1Writer = new AvroWriter<>(
@@ -323,7 +339,7 @@ public class SimpleSchemaTest extends ProducerConsumerBase {
 
     @Test
     public void newNativeAvroProducerForMessageSchemaOnTopicWithMultiVersionSchema() throws Exception {
-        String topic = "my-property/my-ns/schema-test";
+        String topic = NAMESPACE + "/schema-test";
         Schema<V1Data> v1Schema = Schema.AVRO(V1Data.class);
         byte[] v1SchemaBytes = v1Schema.getSchemaInfo().getSchema();
         org.apache.avro.Schema v1SchemaAvroNative = new Parser().parse(new ByteArrayInputStream(v1SchemaBytes));
@@ -390,7 +406,7 @@ public class SimpleSchemaTest extends ProducerConsumerBase {
 
     @Test
     public void newProducerForMessageOnTopicWithDifferentSchemaType() throws Exception {
-        String topic = "my-property/my-ns/schema-test";
+        String topic = NAMESPACE + "/schema-test";
         V1Data data1 = new V1Data(2);
         V2Data data2 = new V2Data(3, 5);
         V1Data data3 = new V1Data(8);
@@ -422,7 +438,7 @@ public class SimpleSchemaTest extends ProducerConsumerBase {
 
     @Test
     public void newProducerForMessageSchemaOnTopicInitialWithNoSchema() throws Exception {
-        String topic = "my-property/my-ns/schema-test";
+        String topic = NAMESPACE + "/schema-test";
         Schema<V1Data> v1Schema = Schema.AVRO(V1Data.class);
         byte[] v1SchemaBytes = v1Schema.getSchemaInfo().getSchema();
         AvroWriter<V1Data> v1Writer = new AvroWriter<>(
@@ -462,7 +478,7 @@ public class SimpleSchemaTest extends ProducerConsumerBase {
 
     @Test
     public void newNativeAvroProducerForMessageSchemaOnTopicInitialWithNoSchema() throws Exception {
-        String topic = "my-property/my-ns/schema-test";
+        String topic = NAMESPACE + "/schema-test";
         Schema<V1Data> v1Schema = Schema.AVRO(V1Data.class);
         byte[] v1SchemaBytes = v1Schema.getSchemaInfo().getSchema();
         org.apache.avro.Schema v1SchemaAvroNative = new Parser().parse(new ByteArrayInputStream(v1SchemaBytes));
@@ -503,10 +519,12 @@ public class SimpleSchemaTest extends ProducerConsumerBase {
 
     @Test
     public void newProducerForMessageSchemaWithBatch() throws Exception {
-        String topic = "my-property/my-ns/schema-test";
+        String topic = NAMESPACE + "/schema-test";
+        @Cleanup
         Consumer<V2Data> c = pulsarClient.newConsumer(Schema.AVRO(V2Data.class))
                 .topic(topic)
                 .subscriptionName("sub1").subscribe();
+        @Cleanup
         Producer<byte[]> p = pulsarClient.newProducer(Schema.AUTO_PRODUCE_BYTES())
                 .topic(topic)
                 .enableBatching(true)
@@ -535,6 +553,7 @@ public class SimpleSchemaTest extends ProducerConsumerBase {
                 try {
                     p.newMessage(Schema.AUTO_PRODUCE_BYTES(Schema.AVRO(IncompatibleData.class)))
                             .value(content).send();
+                    fail("Expect: incompatible schema exception");
                 } catch (Exception e) {
                     Assert.assertTrue(e instanceof IncompatibleSchemaException, e.getMessage());
                 }
@@ -556,7 +575,7 @@ public class SimpleSchemaTest extends ProducerConsumerBase {
 
     @Test
     public void newNativeAvroProducerForMessageSchemaWithBatch() throws Exception {
-        String topic = "my-property/my-ns/schema-test";
+        String topic = NAMESPACE + "/schema-test";
         Schema<V1Data> v1Schema = Schema.AVRO(V1Data.class);
         byte[] v1SchemaBytes = v1Schema.getSchemaInfo().getSchema();
         org.apache.avro.Schema v1SchemaAvroNative = new Parser().parse(new ByteArrayInputStream(v1SchemaBytes));
@@ -566,9 +585,11 @@ public class SimpleSchemaTest extends ProducerConsumerBase {
         org.apache.avro.Schema v2SchemaAvroNative = new Parser().parse(new ByteArrayInputStream(v2SchemaBytes));
         AvroWriter<V2Data> v2Writer = new AvroWriter<>(v2SchemaAvroNative);
 
+        @Cleanup
         Consumer<byte[]> c = pulsarClient.newConsumer(Schema.BYTES)
                 .topic(topic)
                 .subscriptionName("sub1").subscribe();
+        @Cleanup
         Producer<byte[]> p = pulsarClient.newProducer(Schema.NATIVE_AVRO(v1SchemaAvroNative))
                 .topic(topic)
                 .enableBatching(true)
@@ -624,7 +645,7 @@ public class SimpleSchemaTest extends ProducerConsumerBase {
 
     @Test
     public void newProducerWithMultipleSchemaDisabled() throws Exception {
-        String topic = "my-property/my-ns/schema-test";
+        String topic = NAMESPACE + "/schema-test";
         AvroWriter<V1Data> v1DataAvroWriter = new AvroWriter<>(
                 ReflectData.AllowNull.get().getSchema(V1Data.class));
         try (Producer<byte[]> p = pulsarClient.newProducer()
@@ -638,7 +659,7 @@ public class SimpleSchemaTest extends ProducerConsumerBase {
 
     @Test
     public void newConsumerWithSchemaOnNewTopic() throws Exception {
-        String topic = "my-property/my-ns/schema-test";
+        String topic = NAMESPACE + "/schema-test";
 
         try (Consumer<V1Data> c = pulsarClient.newConsumer(Schema.AVRO(V1Data.class))
                 .topic(topic).subscriptionName("sub1").subscribe();
@@ -651,7 +672,7 @@ public class SimpleSchemaTest extends ProducerConsumerBase {
 
     @Test
     public void newConsumerWithSchemaOnExistingTopicWithoutSchema() {
-        String topic = "my-property/my-ns/schema-test";
+        String topic = NAMESPACE + "/schema-test";
 
         try (Producer<byte[]> p = pulsarClient.newProducer().topic(topic).create();
              Consumer<V1Data> c = pulsarClient.newConsumer(Schema.AVRO(V1Data.class))
@@ -664,7 +685,7 @@ public class SimpleSchemaTest extends ProducerConsumerBase {
 
     @Test
     public void newConsumerWithSchemaTopicHasSchema() throws Exception {
-        String topic = "my-property/my-ns/schema-test";
+        String topic = NAMESPACE + "/schema-test";
 
         try (Producer<V1Data> p = pulsarClient.newProducer(Schema.AVRO(V1Data.class)).topic(topic).create();
              Consumer<V1Data> c = pulsarClient.newConsumer(Schema.AVRO(V1Data.class))
@@ -677,7 +698,7 @@ public class SimpleSchemaTest extends ProducerConsumerBase {
 
     @Test
     public void newBytesConsumerWithTopicWithSchema() throws Exception {
-        String topic = "my-property/my-ns/schema-test";
+        String topic = NAMESPACE + "/schema-test";
 
         try (Producer<V1Data> p = pulsarClient.newProducer(Schema.AVRO(V1Data.class)).topic(topic).create();
              Consumer<byte[]> c = pulsarClient.newConsumer().topic(topic).subscriptionName("sub1").subscribe()) {
@@ -697,7 +718,7 @@ public class SimpleSchemaTest extends ProducerConsumerBase {
     }
 
     private void getSchemaVersionFromMessages(boolean batching) throws Exception {
-        String topic = "my-property/my-ns/schema-test";
+        String topic = NAMESPACE + "/schema-test";
 
         try (Producer<V1Data> p = pulsarClient.newProducer(Schema.AVRO(V1Data.class))
                 .topic(topic)
@@ -718,7 +739,7 @@ public class SimpleSchemaTest extends ProducerConsumerBase {
 
     @Test(dataProvider = "batchingModes")
     public void testAutoConsume(boolean batching) throws Exception {
-        String topic = "my-property/my-ns/schema-test-auto-consume-" + batching;
+        String topic = NAMESPACE + "/schema-test-auto-consume-" + batching;
 
         try (Producer<V1Data> p = pulsarClient.newProducer(Schema.AVRO(V1Data.class))
                 .topic(topic)
@@ -755,7 +776,7 @@ public class SimpleSchemaTest extends ProducerConsumerBase {
 
     @Test(dataProvider = "batchingModesAndValueEncodingType")
     public void testAutoKeyValueConsume(boolean batching, KeyValueEncodingType keyValueEncodingType) throws Exception {
-        String topic = "my-property/my-ns/schema-test-auto-keyvalue-consume-" + batching+"-"+keyValueEncodingType;
+        String topic = NAMESPACE + "/schema-test-auto-keyvalue-consume-" + batching+"-"+keyValueEncodingType;
 
         Schema<KeyValue<V1Data, V1Data>> pojoSchema = Schema.KeyValue(
                 Schema.AVRO(V1Data.class),
@@ -1039,7 +1060,7 @@ public class SimpleSchemaTest extends ProducerConsumerBase {
 
     @Test
     public void testAutoKeyValueConsumeGenericObject() throws Exception {
-        String topic = "my-property/my-ns/schema-test-auto-keyvalue-consume-"+ UUID.randomUUID();
+        String topic = NAMESPACE + "/schema-test-auto-keyvalue-consume-"+ UUID.randomUUID();
 
         Schema<KeyValue<V1Data, V1Data>> pojoSchema = Schema.KeyValue(
                 Schema.AVRO(V1Data.class),
@@ -1121,17 +1142,19 @@ public class SimpleSchemaTest extends ProducerConsumerBase {
 
     @Test
     public void testGetSchemaByVersion() throws PulsarClientException, PulsarAdminException, ExecutionException, InterruptedException {
-        final String topic = "persistent://my-property/my-ns/testGetSchemaByVersion";
+        final String topic = String.format("persistent://%s/testGetSchemaByVersion", NAMESPACE);
 
         @Cleanup
         PulsarClientImpl httpProtocolClient = (PulsarClientImpl) PulsarClient.builder().serviceUrl(brokerUrl.toString()).build();
         PulsarClientImpl binaryProtocolClient = (PulsarClientImpl) pulsarClient;
 
-        pulsarClient.newProducer(Schema.AVRO(V1Data.class))
+        @Cleanup
+        Producer p1 = pulsarClient.newProducer(Schema.AVRO(V1Data.class))
                 .topic(topic)
                 .create();
 
-        pulsarClient.newProducer(Schema.AVRO(V2Data.class))
+        @Cleanup
+        Producer p2 = pulsarClient.newProducer(Schema.AVRO(V2Data.class))
                 .topic(topic)
                 .create();
 
@@ -1148,7 +1171,7 @@ public class SimpleSchemaTest extends ProducerConsumerBase {
 
     @Test
     public void testGetNativeSchemaWithAutoConsumeWithMultiVersion() throws Exception {
-        final String topic = "persistent://my-property/my-ns/testGetSchemaWithMultiVersion";
+        final String topic = String.format("persistent://%s/testGetSchemaWithMultiVersion", NAMESPACE);
 
         @Cleanup
         Consumer<?> consumer = pulsarClient.newConsumer(Schema.AUTO_CONSUME())
@@ -1188,8 +1211,8 @@ public class SimpleSchemaTest extends ProducerConsumerBase {
 
     @Test(dataProvider = "topicDomain")
     public void testAutoCreatedSchema(String domain) throws Exception {
-        final String topic1 = domain + "my-property/my-ns/testAutoCreatedSchema-1";
-        final String topic2 = domain + "my-property/my-ns/testAutoCreatedSchema-2";
+        final String topic1 = domain + NAMESPACE + "/testAutoCreatedSchema-1";
+        final String topic2 = domain + NAMESPACE + "/testAutoCreatedSchema-2";
 
         pulsarClient.newProducer(Schema.BYTES).topic(topic1).create().close();
         try {
@@ -1223,7 +1246,7 @@ public class SimpleSchemaTest extends ProducerConsumerBase {
 
     @Test(dataProvider = "keyEncodingType")
     public void testAutoKeyValueConsumeGenericObjectNullValues(KeyValueEncodingType encodingType) throws Exception {
-        String topic = "my-property/my-ns/schema-test-auto-keyvalue-" + encodingType + "-null-value-consume-" + UUID.randomUUID();
+        String topic = NAMESPACE + "/schema-test-auto-keyvalue-" + encodingType + "-null-value-consume-" + UUID.randomUUID();
 
         Schema<KeyValue<V1Data, V1Data>> pojoSchema = Schema.KeyValue(
                 Schema.AVRO(V1Data.class),
@@ -1275,7 +1298,7 @@ public class SimpleSchemaTest extends ProducerConsumerBase {
         if (schemaValidationEnforced) {
             return;
         }
-        final String topic = "test-consume-avro-messages-without-schema-" + UUID.randomUUID();
+        final String topic = NAMESPACE + "/test-consume-avro-messages-without-schema-" + UUID.randomUUID();
         final Schema<V1Data> schema = Schema.AVRO(V1Data.class);
         final Consumer<V1Data> consumer = pulsarClient.newConsumer(schema)
                 .topic(topic)


### PR DESCRIPTION
Fixes #17644

- #17644

### Modifications

- Use the `topic-delete` & `client-cache-clean` instead `pulsar-restart`, saves `pulsar.start()` and `pulsar.stop()` time before and after each method. 

After improve, `SimpleSchemaTest` cost 44s
```
[INFO] Tests run: 66, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 44.052 s - in org.apache.pulsar.client.api.SimpleSchemaTest
```

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: 
- https://github.com/poorbarcode/pulsar/pull/24
