### PR TITLE
[fix][broker]consumer backlog eviction policy should not reset read position for consumer

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BacklogQuotaManager.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BacklogQuotaManager.java
@@ -218,8 +218,8 @@ public class BacklogQuotaManager {
                     ManagedCursor slowestConsumer = mLedger.getSlowestConsumer();
                     Position oldestPosition = slowestConsumer.getMarkDeletedPosition();
                     Position oldestReadPosition = slowestConsumer.getReadPosition();
-                    if(log.isInfoEnabled()) {
-                        log.info("[{}] slowest consumer mark delete position is [{}], read position is [{}]",
+                    if (log.isDebugEnabled()) {
+                        log.debug("[{}] slowest consumer mark delete position is [{}], read position is [{}]",
                                 slowestConsumer.getName(), oldestPosition.toString(), oldestReadPosition.toString());
                     }
                     ManagedLedgerInfo.LedgerInfo ledgerInfo = mLedger.getLedgerInfo(oldestPosition.getLedgerId()).get();
@@ -229,8 +229,8 @@ public class BacklogQuotaManager {
                         slowestConsumer.asyncMarkDelete(nextPosition, new AsyncCallbacks.MarkDeleteCallback() {
                             @Override
                             public void markDeleteComplete(Object ctx) {
-                                if (log.isInfoEnabled()) {
-                                    log.info("[{}] subscription mark deleted messages at position [{}]",
+                                if (log.isDebugEnabled()) {
+                                    log.debug("[{}] subscription mark deleted messages at position [{}]",
                                             slowestConsumer.getName(), nextPosition);
                                 }
                                 countDownLatch.countDown();
@@ -258,8 +258,8 @@ public class BacklogQuotaManager {
                             slowestConsumer.asyncMarkDelete(nextPosition, new AsyncCallbacks.MarkDeleteCallback() {
                                 @Override
                                 public void markDeleteComplete(Object ctx) {
-                                    if (log.isInfoEnabled()) {
-                                        log.info("[{}] subscription mark deleted messages at position [{}]",
+                                    if (log.isDebugEnabled()) {
+                                        log.debug("[{}] subscription mark deleted messages at position [{}]",
                                                 slowestConsumer.getName(), nextPosition);
                                     }
                                     countDownLatch.countDown();


### PR DESCRIPTION
### Motivation
fix #18036

### Modifications
- The backlog eviction policy should use `asyncMarkDelete` instead of `resetCursor` in order to move the mark delete position.

### Verifying this change

- [x]  Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.
### Does this pull request potentially affect one of the following parts:

If `yes` was chosen, please highlight the changes

- Dependencies (does it add or upgrade a dependency): (no)
- The public API: (no)
- The schema: (no)
- The default values of configurations: (no)
- The wire protocol: (no)
- The rest endpoints: (no)
- The admin cli options: (no)
- Anything that affects deployment: (no)

### Documentation

Check the box below or label this PR directly.

Need to update docs?

- [ ] `doc-required`
- [x] `doc-not-needed`
- [ ] `doc` 
- [ ] `doc-complete`

### Matching PR in forked repository

PR in forked repository: https://github.com/HQebupt/pulsar/pull/5