### PR TITLE
[fix][test] Fix flaky test AdminApi2Test.resetClusters

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApi2Test.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApi2Test.java
@@ -164,7 +164,8 @@ public class AdminApi2Test extends MockedPulsarServiceBaseTest {
         pulsar.getConfiguration().setForceDeleteNamespaceAllowed(true);
         for (String tenant : admin.tenants().getTenants()) {
             for (String namespace : admin.namespaces().getNamespaces(tenant)) {
-                deleteNamespaceGraceFully(namespace, true);
+                deleteNamespaceGraceFullyByMultiPulsars(namespace, true, admin, pulsar,
+                        mockPulsarSetup.getPulsar());
             }
             admin.tenants().deleteTenant(tenant, true);
         }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/MockedPulsarServiceBaseTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/MockedPulsarServiceBaseTest.java
@@ -668,19 +668,27 @@ public abstract class MockedPulsarServiceBaseTest extends TestRetrySupport {
     }
 
     /**
-     * see {@link BrokerTestBase#deleteNamespaceGraceFully(String, boolean, PulsarService, PulsarAdmin)}
+     * see {@link BrokerTestBase#deleteNamespaceGraceFully(String, boolean, PulsarAdmin, Collection)}
      */
     protected void deleteNamespaceGraceFully(String ns, boolean force)
             throws Exception {
-        BrokerTestBase.deleteNamespaceGraceFully(ns, force, pulsar, admin);
+        BrokerTestBase.deleteNamespaceGraceFully(ns, force, admin, pulsar);
     }
 
     /**
-     * see {@link BrokerTestBase#deleteNamespaceGraceFully(String, boolean, PulsarService, PulsarAdmin)}
+     * see {@link BrokerTestBase#deleteNamespaceGraceFully(String, boolean, PulsarAdmin, Collection)}
      */
     protected void deleteNamespaceGraceFully(String ns, boolean force, PulsarAdmin admin)
             throws Exception {
-        BrokerTestBase.deleteNamespaceGraceFully(ns, force, pulsar, admin);
+        BrokerTestBase.deleteNamespaceGraceFully(ns, force, admin, pulsar);
+    }
+
+    /**
+     * see see {@link BrokerTestBase#deleteNamespaceGraceFully(String, boolean, PulsarAdmin, Collection)}
+     */
+    protected void deleteNamespaceGraceFullyByMultiPulsars(String ns, boolean force, PulsarAdmin admin,
+                                                           PulsarService...pulsars) throws Exception {
+        BrokerTestBase.deleteNamespaceGraceFully(ns, force, admin, pulsars);
     }
 
     private static final Logger log = LoggerFactory.getLogger(MockedPulsarServiceBaseTest.class);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/MockedPulsarServiceBaseTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/MockedPulsarServiceBaseTest.java
@@ -63,6 +63,7 @@ import org.apache.pulsar.broker.ServiceConfiguration;
 import org.apache.pulsar.broker.intercept.CounterBrokerInterceptor;
 import org.apache.pulsar.broker.namespace.NamespaceService;
 import org.apache.pulsar.broker.service.BrokerTestBase;
+import org.apache.pulsar.broker.service.CanPausedNamespaceService;
 import org.apache.pulsar.broker.service.PulsarMetadataEventSynchronizer;
 import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.admin.PulsarAdminBuilder;
@@ -381,7 +382,8 @@ public abstract class MockedPulsarServiceBaseTest extends TestRetrySupport {
         doReturn(configSynchronizer != null ? createConfigurationMetadataStore(configSynchronizer)
                 : createConfigurationMetadataStore()).when(pulsar).createConfigurationMetadataStore(any());
 
-        Supplier<NamespaceService> namespaceServiceSupplier = () -> spyWithClassAndConstructorArgs(NamespaceService.class, pulsar);
+        Supplier<NamespaceService> namespaceServiceSupplier =
+                () -> spyWithClassAndConstructorArgs(CanPausedNamespaceService.class, pulsar);
         doReturn(namespaceServiceSupplier).when(pulsar).getNamespaceServiceProvider();
 
         doReturn(sameThreadOrderedSafeExecutor).when(pulsar).getOrderedExecutor();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/namespace/OwnerShipForCurrentServerTestBase.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/namespace/OwnerShipForCurrentServerTestBase.java
@@ -45,6 +45,7 @@ import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.broker.ServiceConfiguration;
 import org.apache.pulsar.broker.auth.SameThreadOrderedSafeExecutor;
 import org.apache.pulsar.broker.intercept.CounterBrokerInterceptor;
+import org.apache.pulsar.broker.service.CanPausedNamespaceService;
 import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.metadata.api.extended.MetadataStoreExtended;
@@ -131,7 +132,8 @@ public class OwnerShipForCurrentServerTestBase {
         MockZooKeeperSession mockZooKeeperSession = MockZooKeeperSession.newInstance(mockZooKeeper);
         doReturn(new ZKMetadataStore(mockZooKeeperSession)).when(pulsar).createLocalMetadataStore(null);
         doReturn(new ZKMetadataStore(mockZooKeeperSession)).when(pulsar).createConfigurationMetadataStore(null);
-        Supplier<NamespaceService> namespaceServiceSupplier = () -> spyWithClassAndConstructorArgs(NamespaceService.class, pulsar);
+        Supplier<NamespaceService> namespaceServiceSupplier = () -> spyWithClassAndConstructorArgs(
+                CanPausedNamespaceService.class, pulsar);
         doReturn(namespaceServiceSupplier).when(pulsar).getNamespaceServiceProvider();
 
         SameThreadOrderedSafeExecutor executor = new SameThreadOrderedSafeExecutor();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BacklogQuotaManagerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BacklogQuotaManagerTest.java
@@ -26,6 +26,7 @@ import com.google.common.collect.Sets;
 import java.net.URL;
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Optional;
@@ -81,11 +82,27 @@ public class BacklogQuotaManagerTest {
     private static final int MAX_ENTRIES_PER_LEDGER = 5;
 
     /**
-     * see {@link BrokerTestBase#deleteNamespaceGraceFully(String, boolean, PulsarService, PulsarAdmin)}
+     * see {@link BrokerTestBase#deleteNamespaceGraceFully(String, boolean, PulsarAdmin, Collection)}
      */
     protected void deleteNamespaceGraceFully(String ns, boolean force)
             throws Exception {
-        BrokerTestBase.deleteNamespaceGraceFully(ns, force, pulsar, admin);
+        BrokerTestBase.deleteNamespaceGraceFully(ns, force, admin, pulsar);
+    }
+
+    /**
+     * see {@link BrokerTestBase#deleteNamespaceGraceFully(String, boolean, PulsarAdmin, Collection)}
+     */
+    protected void deleteNamespaceGraceFully(String ns, boolean force, PulsarAdmin admin)
+            throws Exception {
+        BrokerTestBase.deleteNamespaceGraceFully(ns, force, admin, pulsar);
+    }
+
+    /**
+     * see {@link BrokerTestBase#deleteNamespaceGraceFully(String, boolean, PulsarAdmin, Collection)}
+     */
+    protected void deleteNamespaceGraceFullyByMultiPulsars(String ns, boolean force, PulsarAdmin admin,
+                                                           PulsarService...pulsars) throws Exception {
+        BrokerTestBase.deleteNamespaceGraceFully(ns, force, admin, pulsars);
     }
 
     @DataProvider(name = "backlogQuotaSizeGB")

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerTestBase.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerTestBase.java
@@ -23,6 +23,8 @@ import static org.apache.pulsar.compaction.Compactor.COMPACTION_SUBSCRIPTION;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -133,62 +135,88 @@ public abstract class BrokerTestBase extends MockedPulsarServiceBaseTest {
     }
 
     /**
-     * see {@link #deleteNamespaceGraceFully}
+     * see {@link BrokerTestBase#deleteNamespaceGraceFully(String, boolean, PulsarAdmin, Collection)}
      */
     protected void deleteNamespaceGraceFully(String ns, boolean force)
             throws Exception {
-        deleteNamespaceGraceFully(ns, force, pulsar, admin);
+        deleteNamespaceGraceFully(ns, force, admin, pulsar);
+    }
+
+    /**
+     * see {@link BrokerTestBase#deleteNamespaceGraceFully(String, boolean, PulsarAdmin, Collection)}
+     */
+    public static void deleteNamespaceGraceFully(String ns, boolean force, PulsarAdmin admin, PulsarService...pulsars)
+            throws Exception {
+        deleteNamespaceGraceFully(ns, force, admin, Arrays.asList(pulsars));
     }
 
     /**
      * Wait until system topic "__change_event" and subscription "__compaction" are created, and then delete the namespace.
      */
-    public static void deleteNamespaceGraceFully(String ns, boolean force, PulsarService pulsar, PulsarAdmin admin)
-            throws Exception {
+    public static void deleteNamespaceGraceFully(String ns, boolean force, PulsarAdmin admin,
+                                                 Collection<PulsarService> pulsars) throws Exception {
         // namespace v1 should not wait system topic create.
         if (ns.split("/").length > 2){
             admin.namespaces().deleteNamespace(ns, force);
             return;
         }
+
         // If disabled system-topic, should not wait system topic create.
-        if (!pulsar.getConfiguration().isSystemTopicEnabled()){
-            admin.namespaces().deleteNamespace(ns, force);
-            return;
+        boolean allBrokerDisabledSystemTopic = true;
+        for (PulsarService pulsar : pulsars) {
+            if (!pulsar.getConfiguration().isSystemTopicEnabled()) {
+                continue;
+            }
+            TopicPoliciesService topicPoliciesService = pulsar.getTopicPoliciesService();
+            if (!(topicPoliciesService instanceof SystemTopicBasedTopicPoliciesService)) {
+                continue;
+            }
+            allBrokerDisabledSystemTopic = false;
         }
-        TopicPoliciesService topicPoliciesService = pulsar.getTopicPoliciesService();
-        if (!(topicPoliciesService instanceof SystemTopicBasedTopicPoliciesService)){
+        if (allBrokerDisabledSystemTopic){
             admin.namespaces().deleteNamespace(ns, force);
             return;
         }
 
-        // Prevents new events from triggering system topic creation.
-        CanPausedNamespaceService canPausedNamespaceService = (CanPausedNamespaceService) pulsar.getNamespaceService();
-        canPausedNamespaceService.pause();
+        // Stop trigger "onNamespaceBundleOwned".
+        List<CompletableFuture<SystemTopicClient.Reader<PulsarEvent>>> createReaderTasks = new ArrayList<>();
+        List<String> lockedBundles = new ArrayList<>();
+        for (PulsarService pulsar : pulsars) {
+            // Prevents new events from triggering system topic creation.
+            CanPausedNamespaceService canPausedNamespaceService = (CanPausedNamespaceService) pulsar.getNamespaceService();
+            canPausedNamespaceService.pause();
+            // Determines whether the creation of System topic is triggered.
+            // If readerCaches contains namespace, the creation of System topic already triggered.
+            SystemTopicBasedTopicPoliciesService systemTopicBasedTopicPoliciesService =
+                    (SystemTopicBasedTopicPoliciesService) pulsar.getTopicPoliciesService();
+            Map<NamespaceName, CompletableFuture<SystemTopicClient.Reader<PulsarEvent>>> readerCaches =
+                    WhiteboxImpl.getInternalState(systemTopicBasedTopicPoliciesService, "readerCaches");
+            if (readerCaches.containsKey(NamespaceName.get(ns))) {
+                createReaderTasks.add(readerCaches.get(NamespaceName.get(ns)));
+            }
 
-        // Determines whether the creation of System topic is triggered.
-        // If readerCaches contains namespace, the creation of System topic already triggered.
-        SystemTopicBasedTopicPoliciesService systemTopicBasedTopicPoliciesService =
-                (SystemTopicBasedTopicPoliciesService) pulsar.getTopicPoliciesService();
-        Map<NamespaceName, CompletableFuture<SystemTopicClient.Reader<PulsarEvent>>> readerCaches =
-                WhiteboxImpl.getInternalState(systemTopicBasedTopicPoliciesService, "readerCaches");
-        // If no bundle has been loaded, then the System Topic will not trigger creation.
-        LockManager lockManager = pulsar.getCoordinationService().getLockManager(NamespaceEphemeralData.class);
-        List<String> lockedBundles = (List<String>) lockManager.listLocks("/namespace" + "/" + ns).join();
-        FutureUtil.waitForAll(readerCaches.values()).join();
+            // If no bundle has been loaded, then the System Topic will not trigger creation.
+            LockManager lockManager = pulsar.getCoordinationService().getLockManager(NamespaceEphemeralData.class);
+            lockedBundles.addAll((List<String>) lockManager.listLocks("/namespace" + "/" + ns).join());
+        }
+        // Wait all reader-create tasks.
+        FutureUtil.waitForAll(createReaderTasks).join();
 
         // If the bundle elect has not yet been triggered, skip wait.
-        if (CollectionUtils.isEmpty(lockedBundles) && !readerCaches.containsKey(NamespaceName.get(ns))){
+        if (CollectionUtils.isEmpty(lockedBundles) && createReaderTasks.isEmpty()){
             admin.namespaces().deleteNamespace(ns, force);
             return;
         }
+
         // Trigger change event topic create.
+        PulsarService firstPulsar = pulsars.iterator().next();
         NamespaceName namespace = NamespaceName.get(ns);
         NamespaceBundle namespaceBundle = mock(NamespaceBundle.class);
         when(namespaceBundle.getNamespaceObject()).thenReturn(namespace);
-        pulsar.getTopicPoliciesService().addOwnedNamespaceBundleAsync(namespaceBundle);
+        firstPulsar.getTopicPoliciesService().addOwnedNamespaceBundleAsync(namespaceBundle);
         // Wait for change event topic and compaction create finish.
-        String allowAutoTopicCreationType = pulsar.getConfiguration().getAllowAutoTopicCreationType();
-        int defaultNumPartitions = pulsar.getConfiguration().getDefaultNumPartitions();
+        String allowAutoTopicCreationType = firstPulsar.getConfiguration().getAllowAutoTopicCreationType();
+        int defaultNumPartitions = firstPulsar.getConfiguration().getDefaultNumPartitions();
         ArrayList<String> expectChangeEventTopics = new ArrayList<>();
         if ("non-partitioned".equals(allowAutoTopicCreationType)){
             String t = String.format("persistent://%s/%s", ns, NAMESPACE_EVENTS_LOCAL_NAME);
@@ -202,7 +230,7 @@ public abstract class BrokerTestBase extends MockedPulsarServiceBaseTest {
         Awaitility.await().until(() -> {
             boolean finished = true;
             for (String changeEventTopicName : expectChangeEventTopics){
-                boolean bundleExists = pulsar.getNamespaceService()
+                boolean bundleExists = firstPulsar.getNamespaceService()
                         .checkTopicOwnership(TopicName.get(changeEventTopicName))
                         .exceptionally(ex -> false).join();
                 if (!bundleExists){
@@ -210,7 +238,7 @@ public abstract class BrokerTestBase extends MockedPulsarServiceBaseTest {
                     break;
                 }
                 CompletableFuture<Optional<Topic>> completableFuture =
-                        pulsar.getBrokerService().getTopic(changeEventTopicName, false);
+                        firstPulsar.getBrokerService().getTopic(changeEventTopicName, false);
                 if (completableFuture == null){
                     finished = false;
                     break;
@@ -231,6 +259,8 @@ public abstract class BrokerTestBase extends MockedPulsarServiceBaseTest {
             }
             return finished;
         });
+
+        // Do delete.
         int retryTimes = 3;
         while (true) {
             try {
@@ -248,7 +278,14 @@ public abstract class BrokerTestBase extends MockedPulsarServiceBaseTest {
                 throw ex;
             }
         }
-        canPausedNamespaceService.resume();
+
+        // Resume trigger "onNamespaceBundleOwned".
+        for (PulsarService pulsarService : pulsars) {
+            // Prevents new events from triggering system topic creation.
+            CanPausedNamespaceService canPausedNamespaceService =
+                    (CanPausedNamespaceService) pulsarService.getNamespaceService();
+            canPausedNamespaceService.resume();
+        }
     }
 
     private static final Logger LOG = LoggerFactory.getLogger(BrokerTestBase.class);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/CanPausedNamespaceService.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/CanPausedNamespaceService.java
@@ -1,0 +1,67 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.service;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.locks.ReentrantLock;
+import org.apache.pulsar.broker.PulsarService;
+import org.apache.pulsar.broker.namespace.NamespaceService;
+import org.apache.pulsar.common.naming.NamespaceBundle;
+
+public class CanPausedNamespaceService extends NamespaceService {
+
+    private AtomicBoolean paused = new AtomicBoolean();
+
+    private ReentrantLock lock = new ReentrantLock();
+
+    public CanPausedNamespaceService(PulsarService pulsar) {
+        super(pulsar);
+    }
+
+    @Override
+    protected void onNamespaceBundleOwned(NamespaceBundle bundle) {
+        lock.lock();
+        try {
+            if (paused.get()){
+                return;
+            }
+            super.onNamespaceBundleOwned(bundle);
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    public void pause(){
+        lock.lock();
+        try {
+            paused.set(true);
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    public void resume(){
+        lock.lock();
+        try {
+            paused.set(false);
+        } finally {
+            lock.unlock();
+        }
+    }
+}

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/CanPausedNamespaceService.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/CanPausedNamespaceService.java
@@ -18,7 +18,6 @@
  */
 package org.apache.pulsar.broker.service;
 
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.locks.ReentrantLock;
 import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.broker.namespace.NamespaceService;
@@ -26,7 +25,7 @@ import org.apache.pulsar.common.naming.NamespaceBundle;
 
 public class CanPausedNamespaceService extends NamespaceService {
 
-    private AtomicBoolean paused = new AtomicBoolean();
+    private volatile boolean paused = false;
 
     private ReentrantLock lock = new ReentrantLock();
 
@@ -38,7 +37,7 @@ public class CanPausedNamespaceService extends NamespaceService {
     protected void onNamespaceBundleOwned(NamespaceBundle bundle) {
         lock.lock();
         try {
-            if (paused.get()){
+            if (paused){
                 return;
             }
             super.onNamespaceBundleOwned(bundle);
@@ -50,7 +49,7 @@ public class CanPausedNamespaceService extends NamespaceService {
     public void pause(){
         lock.lock();
         try {
-            paused.set(true);
+            paused = true;
         } finally {
             lock.unlock();
         }
@@ -59,7 +58,7 @@ public class CanPausedNamespaceService extends NamespaceService {
     public void resume(){
         lock.lock();
         try {
-            paused.set(false);
+            paused = false;
         } finally {
             lock.unlock();
         }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/TransactionTestBase.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/TransactionTestBase.java
@@ -27,6 +27,7 @@ import com.google.common.util.concurrent.MoreExecutors;
 import io.netty.channel.EventLoopGroup;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -331,10 +332,26 @@ public abstract class TransactionTestBase extends TestRetrySupport {
     }
 
     /**
-     * see {@link BrokerTestBase#deleteNamespaceGraceFully(String, boolean, PulsarService, PulsarAdmin)}
+     * see {@link BrokerTestBase#deleteNamespaceGraceFully(String, boolean, PulsarAdmin, Collection)}
      */
     protected void deleteNamespaceGraceFully(String ns, boolean force)
             throws Exception {
-        BrokerTestBase.deleteNamespaceGraceFully(ns, force, pulsarServiceList.get(0), admin);
+        BrokerTestBase.deleteNamespaceGraceFully(ns, force, admin, pulsarServiceList);
+    }
+
+    /**
+     * see {@link BrokerTestBase#deleteNamespaceGraceFully(String, boolean, PulsarAdmin, Collection)}
+     */
+    protected void deleteNamespaceGraceFully(String ns, boolean force, PulsarAdmin admin)
+            throws Exception {
+        BrokerTestBase.deleteNamespaceGraceFully(ns, force, admin, pulsarServiceList);
+    }
+
+    /**
+     * see {@link BrokerTestBase#deleteNamespaceGraceFully(String, boolean, PulsarAdmin, Collection)}
+     */
+    protected void deleteNamespaceGraceFullyByMultiPulsars(String ns, boolean force, PulsarAdmin admin,
+                                                           Collection<PulsarService> pulsars) throws Exception {
+        BrokerTestBase.deleteNamespaceGraceFully(ns, force, admin, pulsars);
     }
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/TransactionTestBase.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/TransactionTestBase.java
@@ -48,6 +48,7 @@ import org.apache.pulsar.broker.auth.SameThreadOrderedSafeExecutor;
 import org.apache.pulsar.broker.intercept.CounterBrokerInterceptor;
 import org.apache.pulsar.broker.namespace.NamespaceService;
 import org.apache.pulsar.broker.service.BrokerTestBase;
+import org.apache.pulsar.broker.service.CanPausedNamespaceService;
 import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.common.naming.NamespaceName;
@@ -195,7 +196,8 @@ public abstract class TransactionTestBase extends TestRetrySupport {
         MockZooKeeperSession mockZooKeeperSession = MockZooKeeperSession.newInstance(mockZooKeeper);
         doReturn(new ZKMetadataStore(mockZooKeeperSession)).when(pulsar).createLocalMetadataStore(null);
         doReturn(new ZKMetadataStore(mockZooKeeperSession)).when(pulsar).createConfigurationMetadataStore(null);
-        Supplier<NamespaceService> namespaceServiceSupplier = () -> spyWithClassAndConstructorArgs(NamespaceService.class, pulsar);
+        Supplier<NamespaceService> namespaceServiceSupplier =
+                () -> spyWithClassAndConstructorArgs(CanPausedNamespaceService.class, pulsar);
         doReturn(namespaceServiceSupplier).when(pulsar).getNamespaceServiceProvider();
 
         SameThreadOrderedSafeExecutor executor = new SameThreadOrderedSafeExecutor();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/DispatcherBlockConsumerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/DispatcherBlockConsumerTest.java
@@ -50,6 +50,7 @@ import java.util.stream.Collectors;
 import lombok.Cleanup;
 import org.apache.pulsar.broker.namespace.NamespaceService;
 import org.apache.pulsar.broker.service.BrokerService;
+import org.apache.pulsar.broker.service.CanPausedNamespaceService;
 import org.apache.pulsar.broker.service.persistent.PersistentDispatcherMultipleConsumers;
 import org.apache.pulsar.broker.service.persistent.PersistentTopic;
 import org.apache.pulsar.client.impl.ConsumerImpl;
@@ -633,7 +634,8 @@ public class DispatcherBlockConsumerTest extends ProducerConsumerBase {
         // if broker unload bundle gracefully then cursor metadata recovered from zk else from ledger
         if (unloadBundleGracefully) {
             // set clean namespace which will not let broker unload bundle gracefully: stop broker
-            Supplier<NamespaceService> namespaceServiceSupplier = () -> spyWithClassAndConstructorArgs(NamespaceService.class, pulsar);
+            Supplier<NamespaceService> namespaceServiceSupplier =
+                    () -> spyWithClassAndConstructorArgs(CanPausedNamespaceService.class, pulsar);
             doReturn(namespaceServiceSupplier).when(pulsar).getNamespaceServiceProvider();
         }
         stopBroker();


### PR DESCRIPTION
Fixes #18029

- #18029

### Motivation

When the `AdminApi2Test` is executed, there have many test methods. When the next method is run, there may be an ongoing but unfinished `NamespaceService.onNamespaceBundleOwned()`, which will create system topic `__change_event`, if the instruction `namespace.delete()` is executed at the same time, the problem occurs.

### Modifications

Create a new class `CanPausedNamespaceService.java` witch can stop the subsequent execution of `NamespaceService.onNamespaceBundleOwned()`. Then, if we want to do `namespace.delete()`, we will do `pause` first.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: 
- https://github.com/poorbarcode/pulsar/pull/25
