### PR TITLE
[fix][io] Fix builtin connector/function download filename

### DIFF
--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/api/ComponentImpl.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/api/ComponentImpl.java
@@ -324,26 +324,22 @@ public abstract class ComponentImpl implements Component<PulsarWorkerService> {
             // For externally managed schedulers, the pkgUrl/builtin stuff can be copied to bk
             // if the function worker image does not include connectors
             if (!isEmpty(builtin)) {
+                File component;
+                switch (componentType) {
+                    case SOURCE:
+                        component = worker().getConnectorsManager().getSourceArchive(builtin).toFile();
+                        break;
+                    case SINK:
+                        component = worker().getConnectorsManager().getSinkArchive(builtin).toFile();
+                        break;
+                    default:
+                        component = worker().getFunctionsManager().getFunctionArchive(builtin).toFile();
+                        break;
+                }
+                packageLocationMetaDataBuilder.setOriginalFileName(component.getName());
                 if (worker().getWorkerConfig().getUploadBuiltinSinksSources()) {
-                    File component;
-                    String archiveName;
-                    switch (componentType) {
-                        case SOURCE:
-                            archiveName = functionDetails.getSource().getBuiltin();
-                            component = worker().getConnectorsManager().getSourceArchive(archiveName).toFile();
-                            break;
-                        case SINK:
-                            archiveName = functionDetails.getSink().getBuiltin();
-                            component = worker().getConnectorsManager().getSinkArchive(archiveName).toFile();
-                            break;
-                        default:
-                            archiveName = functionDetails.getBuiltin();
-                            component = worker().getFunctionsManager().getFunctionArchive(archiveName).toFile();
-                            break;
-                    }
                     packageLocationMetaDataBuilder.setPackagePath(createPackagePath(tenant, namespace, componentName,
                             component.getName()));
-                    packageLocationMetaDataBuilder.setOriginalFileName(component.getName());
                     if (isPackageManagementEnabled) {
                         packageLocationMetaDataBuilder.setPackagePath(packageName.toString());
                         worker().getBrokerAdmin().packages().upload(metadata,

--- a/pulsar-functions/worker/src/test/java/org/apache/pulsar/functions/worker/rest/api/v3/FunctionApiV3ResourceTest.java
+++ b/pulsar-functions/worker/src/test/java/org/apache/pulsar/functions/worker/rest/api/v3/FunctionApiV3ResourceTest.java
@@ -776,6 +776,7 @@ public class FunctionApiV3ResourceTest {
                 .classLoader(mockedClassLoader)
                 .build();
         when(mockedFunctionsManager.getFunction("exclamation")).thenReturn(functionArchive);
+        when(mockedFunctionsManager.getFunctionArchive(any())).thenReturn(getPulsarApiExamplesNar().toPath());
 
         when(mockedWorkerService.getFunctionsManager()).thenReturn(mockedFunctionsManager);
 

--- a/pulsar-functions/worker/src/test/java/org/apache/pulsar/functions/worker/rest/api/v3/SinkApiV3ResourceTest.java
+++ b/pulsar-functions/worker/src/test/java/org/apache/pulsar/functions/worker/rest/api/v3/SinkApiV3ResourceTest.java
@@ -1754,14 +1754,14 @@ public class SinkApiV3ResourceTest {
             ctx.when(() -> FunctionCommon.getClassLoaderFromPackage(any(), any(), any(), any())).thenCallRealMethod();
             ctx.when(() -> FunctionCommon.isFunctionCodeBuiltin(any())).thenReturn(true);
             ctx.when(() -> FunctionCommon.extractNarClassLoader(any(), any())).thenReturn(mockedClassLoader);
-
         });
 
         ConnectorsManager mockedConnManager = mock(ConnectorsManager.class);
         Connector connector = Connector.builder()
-                .classLoader(mockedClassLoader)
-                .build();
+            .classLoader(mockedClassLoader)
+            .build();
         when(mockedConnManager.getConnector("cassandra")).thenReturn(connector);
+        when(mockedConnManager.getSinkArchive(any())).thenReturn(getPulsarIOCassandraNar().toPath());
         when(mockedWorkerService.getConnectorsManager()).thenReturn(mockedConnManager);
 
         when(mockedRuntimeFactory.externallyManaged()).thenReturn(true);


### PR DESCRIPTION

### Motivation

When using KubernetesRuntime, if uploadBuiltinSinksSources is false (non-default), the originalFileName is not set for builtin components.
But with k8s, we need a filename since the component will be downloaded. 
This results in the component currently being downloaded with the download directory as filename.
Also when using a transform function, we use the originalFileName to know if there's a builtin function to download.

### Modifications

Use the filename from the builtin component archive as originalFileName whether uploadBuiltinSinksSources is true or false.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/cbornet/pulsar/pull/4

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
