### PR TITLE
[improve][doc] Update workflow of submitting release note

### DIFF
--- a/wiki/release/release-note-guide.md
+++ b/wiki/release/release-note-guide.md
@@ -41,9 +41,17 @@ For the [Pulsar Release Note page](https://pulsar.apache.org/release-notes/):
 
 ## Submit release notes
 
-Follow the steps below to submit release notes for Pulsar and clients.
+Follow the steps below to submit release notes for Pulsar and clients (**Java and WebSocket**).
 
-1. On the [Pulsar Releases Page - GitHub](https://github.com/apache/pulsar/releases), add a release note for the new release.
+> **Note**
+>
+> For **C++, Python, Go, Node.js, and C#**, you do not need to take care of them since their release notes are synced from their repos to the [Pulsar Release Note page](https://pulsar.apache.org/release-notes).
+
+1. Submit a PR to add **separate** release notes for Pulsar and clients (**Java and WebSocket**) to [pulsar-site/site2/website-next/release-notes/versioned/](https://github.com/apache/pulsar-site/tree/main/site2/website-next/release-notes/versioned). 
+
+    Get this PR reviewed and merged.
+
+2. Copy the release note to the [Pulsar Releases Page - GitHub](https://github.com/apache/pulsar/releases).
 
     <table>
     <thead>
@@ -55,20 +63,16 @@ Follow the steps below to submit release notes for Pulsar and clients.
     <tbody>
       <tr>
         <td colspan="2">Pulsar core</td>
-        <td>Add a release note for it.</td>
+        <td>Copy the release note content.</td>
       </tr>
       <tr>
         <td rowspan="2">Pulsar clients</td>
-        <td> - Java<br><br> - WebSocket<br><br> - C++<br><br> - Python</td>
-        <td>Add separate release notes for them, that is, create independent sections in the release note.<br><br>Example<br><br><img title="Java client release note example" alt="Java client release note example" src="../assets/release-note-guide-1.png"></td>
-      </tr>
-      <tr>
-        <td> - Go<br><br> - Node.js<br><br> - C#</td>
-        <td>No action is needed. You do not need to take care of them since their release notes are synced from their repos to the <a href="https://pulsar.apache.org/release-notes/">Pulsar Release Note page</a>.</td>
+        <td> - Java<br><br> - WebSocket <br><br> 
+        <td>Create independent sections for each client and copy release note content.<br><br>Example<br><br><img title="Java client release note example" alt="Java client release note example" src="../assets/release-note-guide-1.png"></td>
       </tr>
     </tbody>
     </table>
 
     After the new release is published, all the information about the release is automatically added to the [Pulsar Release Note page](https://pulsar.apache.org/release-notes/).
 
-2. Check whether the release information is shown on the [Pulsar Release Note page](https://pulsar.apache.org/release-notes/) after the website is updated and built successfully.
+3. Check whether the release information is shown on the [Pulsar Release Note page](https://pulsar.apache.org/release-notes/) after the website is updated and built successfully.


### PR DESCRIPTION
Update the workflow of submitting release notes since:

- The automation process still needs to get release notes content from https://github.com/apache/pulsar-site/tree/main/site2/website-next/release-notes/versioned
- C++ and Python release notes can be fetched from their repos


### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [x] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->



<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
