### PR TITLE
[fix][sec] Bump commons-text to 1.10.0 fix CVE-2022-42889

### DIFF
--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -284,7 +284,7 @@ The Apache Software License, Version 2.0
     - org.apache.commons-commons-collections4-4.4.jar
     - org.apache.commons-commons-compress-1.21.jar
     - org.apache.commons-commons-lang3-3.11.jar
-    - org.apache.commons-commons-text-1.9.jar
+    - org.apache.commons-commons-text-1.10.0.jar
  * Netty
     - io.netty-netty-buffer-4.1.77.Final.jar
     - io.netty-netty-codec-4.1.77.Final.jar

--- a/pom.xml
+++ b/pom.xml
@@ -121,7 +121,7 @@ flexible messaging model and an intuitive client API.</description>
     <bookkeeper.version>4.15.1</bookkeeper.version>
     <zookeeper.version>3.8.0</zookeeper.version>
     <commons-cli.version>1.5.0</commons-cli.version>
-    <commons-text.version>1.9</commons-text.version>
+    <commons-text.version>1.10.0</commons-text.version>
     <snappy.version>1.1.8.4</snappy.version> <!-- ZooKeeper server -->
     <dropwizardmetrics.version>4.1.12.1</dropwizardmetrics.version> <!-- ZooKeeper server -->
     <curator.version>5.1.0</curator.version>


### PR DESCRIPTION
### Motivation
Fixes CVE-2022-42889

### Modifications
Bump apache commons-text version to 1.10.0.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: 