### PR TITLE
[fix][client][txn] Use PulsarClient HashWheelTimer to schedule producer batch trigger task

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
@@ -56,6 +56,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.pulsar.client.api.BatcherBuilder;
@@ -147,7 +148,7 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
 
     private final ConnectionHandler connectionHandler;
 
-    private ScheduledFuture<?> batchTimerTask;
+    private AtomicReference<Timeout> batchTimerTask;
 
     private Optional<Long> topicEpoch = Optional.empty();
     private final List<Throwable> previousExceptions = new CopyOnWriteArrayList<Throwable>();
@@ -238,8 +239,10 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
             }
             this.batchMessageContainer = (BatchMessageContainerBase)containerBuilder.build();
             this.batchMessageContainer.setProducer(this);
+            this.batchTimerTask = new AtomicReference<>();
         } else {
             this.batchMessageContainer = null;
+            this.batchTimerTask = null;
         }
         if (client.getConfiguration().getStatsIntervalSeconds() > 0) {
             stats = new ProducerStatsRecorderImpl(client, conf, this);
@@ -1520,26 +1523,11 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
 
                         if (!producerCreatedFuture.isDone() && isBatchMessagingEnabled()) {
                             // schedule the first batch message task
-                            batchTimerTask = cnx.ctx().executor()
-                                    .scheduleWithFixedDelay(catchingAndLoggingThrowables(() -> {
-                                        if (log.isTraceEnabled()) {
-                                            log.trace(
-                                                    "[{}] [{}] Batching the messages from the batch container from "
-                                                            + "timer thread",
-                                                    topic,
-                                                    producerName);
-                                        }
-                                        // semaphore acquired when message was enqueued to container
-                                        synchronized (ProducerImpl.this) {
-                                            // If it's closing/closed we need to ignore the send batch timer and not
-                                            // schedule next timeout.
-                                            if (getState() == State.Closing || getState() == State.Closed) {
-                                                return;
-                                            }
+                            Timeout task = client.timer()
+                                    .newTimeout(this::triggerBatchMessageAndSend,
+                                            conf.getBatchingMaxPublishDelayMicros(), TimeUnit.MICROSECONDS);
 
-                                            batchMessageAndSend();
-                                        }
-                                    }), 0, conf.getBatchingMaxPublishDelayMicros(), TimeUnit.MICROSECONDS);
+                            batchTimerTask.set(task);
                         }
                         resendMessages(cnx, epoch);
                     }
@@ -1641,6 +1629,31 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
                 });
     }
 
+    private void triggerBatchMessageAndSend(Timeout timeout) {
+        client.getInternalExecutorService().execute(catchingAndLoggingThrowables(() -> {
+            if (log.isTraceEnabled()) {
+                log.trace("[{}] [{}] Batching the messages from the batch container from " + "timer thread", topic, producerName);
+            }
+            // semaphore acquired when message was enqueued to container
+            synchronized (ProducerImpl.this) {
+                // If it's closing/closed we need to ignore the send batch timer and not
+                // schedule next timeout.
+                if (getState() == State.Closing || getState() == State.Closed) {
+                    return;
+                }
+
+                batchMessageAndSend();
+            }
+
+            Timeout task = client.timer()
+                    .newTimeout(this::triggerBatchMessageAndSend,
+                            conf.getBatchingMaxPublishDelayMicros(), TimeUnit.MICROSECONDS);
+
+            batchTimerTask.set(task);
+
+        }));
+    }
+
     @Override
     public void connectionFailed(PulsarClientException exception) {
         boolean nonRetriableError = !PulsarClientException.isRetriableError(exception);
@@ -1669,10 +1682,12 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
             sendTimeout = null;
         }
 
-        ScheduledFuture<?> batchTimerTask = this.batchTimerTask;
         if (batchTimerTask != null) {
-            batchTimerTask.cancel(false);
-            this.batchTimerTask = null;
+            Timeout batchTimerTask = this.batchTimerTask.get();
+            if (batchTimerTask != null) {
+                batchTimerTask.cancel();
+                this.batchTimerTask = null;
+            }
         }
 
         if (keyGeneratorTask != null && !keyGeneratorTask.isCancelled()) {

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
@@ -148,7 +148,7 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
 
     private final ConnectionHandler connectionHandler;
 
-    private AtomicReference<Timeout> batchTimerTask;
+    private final AtomicReference<Timeout> batchTimerTask;
 
     private Optional<Long> topicEpoch = Optional.empty();
     private final List<Throwable> previousExceptions = new CopyOnWriteArrayList<Throwable>();
@@ -1683,10 +1683,9 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
         }
 
         if (batchTimerTask != null) {
-            Timeout batchTimerTask = this.batchTimerTask.get();
+            Timeout batchTimerTask = this.batchTimerTask.getAndSet(null);
             if (batchTimerTask != null) {
                 batchTimerTask.cancel();
-                this.batchTimerTask = null;
             }
         }
 


### PR DESCRIPTION
fix when create a lot of producer (> 10000) in the same jvm which will use eventLoop to do task check

Fixes #18055


### Motivation

when broker own a lot of topic ( > 10000 ) and enable txn. 
the producer create for `TransactionBufferSystemTopicClient` enable batch for current code.
which will use broker workerGroup thread to schedule batch check task. which will cause high cpu usage.

### Modifications

use client HashWheelTimer for schedule batch check task and when trigger task execute on pulsarClient internalExecutorPool

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change is already covered by existing tests, such as *(please describe tests)*.


### Does this pull request potentially affect one of the following parts:

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [x] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

