### PR TITLE
[improve][broker]Avoid runtime check hasFilter in EntryFilterSupport

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractBaseDispatcher.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractBaseDispatcher.java
@@ -110,7 +110,6 @@ public abstract class AbstractBaseDispatcher extends EntryFilterSupport implemen
         int filteredMessageCount = 0;
         int filteredEntryCount = 0;
         long filteredBytesCount = 0;
-        final boolean hasFilter = CollectionUtils.isNotEmpty(entryFilters);
         List<Position> entriesToFiltered = hasFilter ? new ArrayList<>() : null;
         List<PositionImpl> entriesToRedeliver = hasFilter ? new ArrayList<>() : null;
         for (int i = 0, entriesSize = entries.size(); i < entriesSize; i++) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/EntryFilterSupport.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/EntryFilterSupport.java
@@ -35,7 +35,8 @@ public class EntryFilterSupport {
      * Entry filters in Broker.
      * Not set to final, for the convenience of testing mock.
      */
-    protected List<EntryFilterWithClassLoader> entryFilters;
+    protected final List<EntryFilterWithClassLoader> entryFilters;
+    protected final boolean hasFilter;
     protected final FilterContext filterContext;
     protected final Subscription subscription;
 
@@ -62,11 +63,12 @@ public class EntryFilterSupport {
             this.entryFilters = Collections.emptyList();
             this.filterContext = FilterContext.FILTER_CONTEXT_DISABLED;
         }
+        hasFilter = CollectionUtils.isNotEmpty(entryFilters);
     }
 
     public EntryFilter.FilterResult runFiltersForEntry(Entry entry, MessageMetadata msgMetadata,
                                                        Consumer consumer) {
-        if (CollectionUtils.isNotEmpty(entryFilters)) {
+        if (hasFilter) {
             fillContext(filterContext, msgMetadata, subscription, consumer);
             return getFilterResult(filterContext, entry, entryFilters);
         } else {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/plugin/FilterEntryTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/plugin/FilterEntryTest.java
@@ -162,12 +162,15 @@ public class FilterEntryTest extends BrokerTestBase {
         Dispatcher dispatcher = subscription.getDispatcher();
         Field field = EntryFilterSupport.class.getDeclaredField("entryFilters");
         field.setAccessible(true);
+        Field hasFilterField = EntryFilterSupport.class.getDeclaredField("hasFilter");
+        hasFilterField.setAccessible(true);
         NarClassLoader narClassLoader = mock(NarClassLoader.class);
         EntryFilter filter1 = new EntryFilterTest();
         EntryFilterWithClassLoader loader1 = spyWithClassAndConstructorArgsRecordingInvocations(EntryFilterWithClassLoader.class, filter1, narClassLoader);
         EntryFilter filter2 = new EntryFilter2Test();
         EntryFilterWithClassLoader loader2 = spyWithClassAndConstructorArgsRecordingInvocations(EntryFilterWithClassLoader.class, filter2, narClassLoader);
         field.set(dispatcher, List.of(loader1, loader2));
+        hasFilterField.set(dispatcher, true);
 
         Producer<String> producer = pulsarClient.newProducer(Schema.STRING)
                 .enableBatching(false).topic(topic).create();
@@ -287,12 +290,15 @@ public class FilterEntryTest extends BrokerTestBase {
             Dispatcher dispatcher = subscription.getDispatcher();
             Field field = EntryFilterSupport.class.getDeclaredField("entryFilters");
             field.setAccessible(true);
+            Field hasFilterField = EntryFilterSupport.class.getDeclaredField("hasFilter");
+            hasFilterField.setAccessible(true);
             NarClassLoader narClassLoader = mock(NarClassLoader.class);
             EntryFilter filter1 = new EntryFilterTest();
             EntryFilterWithClassLoader loader1 = spyWithClassAndConstructorArgs(EntryFilterWithClassLoader.class, filter1, narClassLoader);
             EntryFilter filter2 = new EntryFilter2Test();
             EntryFilterWithClassLoader loader2 = spyWithClassAndConstructorArgs(EntryFilterWithClassLoader.class, filter2, narClassLoader);
             field.set(dispatcher, List.of(loader1, loader2));
+            hasFilterField.set(dispatcher, true);
 
             for (int i = 0; i < 10; i++) {
                 producer.send("test");
@@ -360,6 +366,8 @@ public class FilterEntryTest extends BrokerTestBase {
             Dispatcher dispatcher = subscription.getDispatcher();
             Field field = EntryFilterSupport.class.getDeclaredField("entryFilters");
             field.setAccessible(true);
+            Field hasFilterField = EntryFilterSupport.class.getDeclaredField("hasFilter");
+            hasFilterField.setAccessible(true);
             NarClassLoader narClassLoader = mock(NarClassLoader.class);
             EntryFilter filter1 = new EntryFilterTest();
             EntryFilterWithClassLoader loader1 =
@@ -368,6 +376,7 @@ public class FilterEntryTest extends BrokerTestBase {
             EntryFilterWithClassLoader loader2 =
                     spyWithClassAndConstructorArgs(EntryFilterWithClassLoader.class, filter2, narClassLoader);
             field.set(dispatcher, List.of(loader1, loader2));
+            hasFilterField.set(dispatcher, true);
 
             for (int i = 0; i < numMessages; i++) {
                 if (i % 2 == 0) {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/SubscriptionStatsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/SubscriptionStatsTest.java
@@ -191,11 +191,14 @@ public class SubscriptionStatsTest extends ProducerConsumerBase {
         if (setFilter) {
             Field field = EntryFilterSupport.class.getDeclaredField("entryFilters");
             field.setAccessible(true);
+            Field hasFilterField = EntryFilterSupport.class.getDeclaredField("hasFilter");
+            hasFilterField.setAccessible(true);
             NarClassLoader narClassLoader = mock(NarClassLoader.class);
             EntryFilter filter1 = new EntryFilterTest();
             EntryFilterWithClassLoader loader1 =
                     spyWithClassAndConstructorArgs(EntryFilterWithClassLoader.class, filter1, narClassLoader);
             field.set(dispatcher, List.of(loader1));
+            hasFilterField.set(dispatcher, true);
         }
 
         for (int i = 0; i < 100; i++) {


### PR DESCRIPTION
### Motivation

A minor improve for entries fiilter by avoid runtime check has filter or not  in `EntryFilterSupport` and make the code more clear.

### Modifications

Add a protected final field `hasFilter` in `EntryFilterSupport`

### Verifying this change

- [x] Make sure that the change passes the CI checks.


### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository:https://github.com/AnonHxy/pulsar/pull/10
