### PR TITLE
[fix][broker] Fix unable to start multiple bookies for BKCluster

### DIFF
--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/bookkeeper/BKCluster.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/bookkeeper/BKCluster.java
@@ -201,13 +201,13 @@ public class BKCluster implements AutoCloseable {
     private ServerConfiguration newServerConfiguration(int index) throws Exception {
         File dataDir;
         if (clusterConf.dataDir != null) {
-            dataDir = new File(clusterConf.dataDir);
+            dataDir = new File(clusterConf.dataDir + "/" + index);
         } else {
             // Use temp dir and clean it up later
             dataDir = createTempDir("bookie",  "test-" + index);
         }
 
-        if (clusterConf.clearOldData) {
+        if (clusterConf.clearOldData && dataDir.exists()) {
             cleanDirectory(dataDir);
         }
 

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/bookkeeper/BKCluster.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/bookkeeper/BKCluster.java
@@ -201,7 +201,11 @@ public class BKCluster implements AutoCloseable {
     private ServerConfiguration newServerConfiguration(int index) throws Exception {
         File dataDir;
         if (clusterConf.dataDir != null) {
-            dataDir = new File(clusterConf.dataDir + "/" + index);
+            if (index == 0) {
+                dataDir = new File(clusterConf.dataDir);
+            } else {
+                dataDir = new File(clusterConf.dataDir + "/" + index);
+            }
         } else {
             // Use temp dir and clean it up later
             dataDir = createTempDir("bookie",  "test-" + index);


### PR DESCRIPTION
Fixes #16846

### Motivation

Fix unable to start multiple bookies when `clusterConf.dataDir != null`.
The PR #16847 missing this case modification.

### Modifications

Add index subPath for per bookie dataDir.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/coderzc/pulsar/pull/15