### PR TITLE
[fix][test] Fix flaky test V1_ProducerConsumerTest#testActiveAndInActiveConsumerEntryCacheBehavior.

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/v1/V1_ProducerConsumerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/v1/V1_ProducerConsumerTest.java
@@ -698,6 +698,7 @@ public class V1_ProducerConsumerTest extends V1_ProducerConsumerBase {
                 .topic("persistent://my-property/use/my-ns/" + topicName)
                 .subscriptionName(sub2)
                 .subscriptionType(SubscriptionType.Shared)
+                .receiverQueueSize(1)
                 .subscribe();
         // Produce messages
         final int moreMessages = 10;


### PR DESCRIPTION
### Motivation
<img width="1371" alt="image" src="https://user-images.githubusercontent.com/19296967/196232537-95eadfef-d558-4454-97e8-2bcab9add14e.png">
In PR: https://github.com/apache/pulsar/pull/17273, when the read position is updated, the ManagedLedgerImpl#onCursorReadPositionUpdated method will be called, and finally ManagedCursorContainer#cursorUpdated will be called, thus making the slowestReaderPosition change:

https://github.com/apache/pulsar/blob/0c7a0d144d9e527fbd25a1d738715934fbcf38ab/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java#L2633-L2639

Therefore, in testActiveAndInActiveConsumerEntryCacheBehavior, as long as the server pushes data to the client, the slowestReaderPosition will change.

So here the receive queue of the slower-subscriber is set to 1 to prevent the slowestReaderPosition from changing even if the subscription is not consumed.



### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/lordcheng10/pulsar/pull/31 <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
