### PR TITLE
[fix][broker]Cache invalidation due to concurrent access

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/util/RangeCache.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/util/RangeCache.java
@@ -196,13 +196,11 @@ public class RangeCache<Key extends Comparable<Key>, Value extends ReferenceCoun
            if (entry == null || timestampExtractor.getTimestamp(entry.getValue()) > maxTimestamp) {
                break;
            }
-
-           entry = entries.pollFirstEntry();
-           if (entry == null) {
+           Value value = entries.remove(entry.getKey());
+           if (value == null) {
                break;
            }
 
-           Value value = entry.getValue();
            removedSize += weighter.getSize(value);
            removedCount++;
            value.release();

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/util/RangeCache.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/util/RangeCache.java
@@ -196,8 +196,9 @@ public class RangeCache<Key extends Comparable<Key>, Value extends ReferenceCoun
            if (entry == null || timestampExtractor.getTimestamp(entry.getValue()) > maxTimestamp) {
                break;
            }
-           Value value = entries.remove(entry.getKey());
-           if (value == null) {
+           Value value = entry.getValue();
+           boolean removeHits = entries.remove(entry.getKey(), value);
+           if (!removeHits) {
                break;
            }
 


### PR DESCRIPTION
Fixes #17908

### Motivation

- `ManagedCursorImpl.setReadPosition()` will trigger cleaning of caches smaller than the earliest `readPosition`
- In `ManagedLedgerFactoryImpl`, there is a scheduled task that deletes inactive cache data every second

<strong(High light)></strong>When the `cursor` updates the `readPosition` and clears the outdated ledger cache concurrency, an entry's cache is incorrectly deleted.

E.g.

| `ManagedCursorImpl.setReadPosition` | `ManagedLedgerFactory.doCacheEviction` |
|----|----|
|  | get the first `entry` in the Cache |
| invalidate position `1:1` |  |
| delete `1:1` from `EntryCache` |  |
| recycle `entry` and set `entry.timestamp` to `-1` |  |
|  | check: `entry.timestamp` > `maxTimestamp` |
|  | <strong>(High light)</strong>pop first entry from `EntryCache`: expecting `1:1`, but really `1:2` |

So entry `1:2` is incorrectly deleted.

https://github.com/apache/pulsar/blob/0c7a0d144d9e527fbd25a1d738715934fbcf38ab/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/util/RangeCache.java#L195-L208

You can reproduce the problem by running`ManagedLedgerBkTest.verifyConcurrentUsage` 200～1000 times

### Modifications

Use the instruction `remove(key)` instead of `popFirst()` to delete the target Entry

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: 
- https://github.com/poorbarcode/pulsar/pull/26
