### PR TITLE
[fix][test] Fix flaky test: PrometheusMetricsTest.testDuplicateMetricTypeDefinitions

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
@@ -562,6 +562,8 @@ public class PulsarService implements AutoCloseable, ShutdownService {
             if (transactionExecutorProvider != null) {
                 transactionExecutorProvider.shutdownNow();
             }
+            MLPendingAckStoreProvider.closeBufferedWriterMetrics();
+            MLTransactionMetadataStoreProvider.closeBufferedWriterMetrics();
             if (this.offloaderStats != null) {
                 this.offloaderStats.close();
             }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/pendingack/impl/MLPendingAckStoreProvider.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/pendingack/impl/MLPendingAckStoreProvider.java
@@ -61,6 +61,16 @@ public class MLPendingAckStoreProvider implements TransactionPendingAckStoreProv
         }
     }
 
+    public static void closeBufferedWriterMetrics() {
+        synchronized (MLPendingAckStoreProvider.class){
+            if (bufferedWriterMetrics == DisabledTxnLogBufferedWriterMetricsStats.DISABLED_BUFFERED_WRITER_METRICS){
+                return;
+            }
+            bufferedWriterMetrics.close();
+            bufferedWriterMetrics = DisabledTxnLogBufferedWriterMetricsStats.DISABLED_BUFFERED_WRITER_METRICS;
+        }
+    }
+
     @Override
     public CompletableFuture<PendingAckStore> newPendingAckStore(PersistentSubscription subscription) {
         CompletableFuture<PendingAckStore> pendingAckStoreFuture = new CompletableFuture<>();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/PrometheusMetricsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/PrometheusMetricsTest.java
@@ -839,8 +839,7 @@ public class PrometheusMetricsTest extends BrokerTestBase {
                 } else if (metricName.endsWith("_count")) {
                     String summaryMetricName = metricName.substring(0, metricName.indexOf("_count"));
                     if (!typeDefs.containsKey(summaryMetricName)) {
-                        fail("Metric " + metricName + " does not have a corresponding summary type definition, only "
-                                + typeDefs);
+                        fail("Metric " + metricName + " does not have a corresponding summary type definition");
                     }
                 } else if (metricName.endsWith("_bucket")) {
                     String summaryMetricName = metricName.substring(0, metricName.indexOf("_bucket"));

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/PrometheusMetricsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/PrometheusMetricsTest.java
@@ -839,7 +839,8 @@ public class PrometheusMetricsTest extends BrokerTestBase {
                 } else if (metricName.endsWith("_count")) {
                     String summaryMetricName = metricName.substring(0, metricName.indexOf("_count"));
                     if (!typeDefs.containsKey(summaryMetricName)) {
-                        fail("Metric " + metricName + " does not have a corresponding summary type definition");
+                        fail("Metric " + metricName + " does not have a corresponding summary type definition, only "
+                                + typeDefs);
                     }
                 } else if (metricName.endsWith("_bucket")) {
                     String summaryMetricName = metricName.substring(0, metricName.indexOf("_bucket"));

--- a/pulsar-transaction/coordinator/src/main/java/org/apache/pulsar/transaction/coordinator/impl/MLTransactionMetadataStoreProvider.java
+++ b/pulsar-transaction/coordinator/src/main/java/org/apache/pulsar/transaction/coordinator/impl/MLTransactionMetadataStoreProvider.java
@@ -39,14 +39,24 @@ public class MLTransactionMetadataStoreProvider implements TransactionMetadataSt
             DisabledTxnLogBufferedWriterMetricsStats.DISABLED_BUFFERED_WRITER_METRICS;
 
     public static void initBufferedWriterMetrics(String brokerAdvertisedAddress){
-        if (bufferedWriterMetrics != DisabledTxnLogBufferedWriterMetricsStats.DISABLED_BUFFERED_WRITER_METRICS){
+        if (bufferedWriterMetrics != DisabledTxnLogBufferedWriterMetricsStats.DISABLED_BUFFERED_WRITER_METRICS) {
             return;
         }
         synchronized (MLTransactionMetadataStoreProvider.class){
-            if (bufferedWriterMetrics != DisabledTxnLogBufferedWriterMetricsStats.DISABLED_BUFFERED_WRITER_METRICS){
+            if (bufferedWriterMetrics != DisabledTxnLogBufferedWriterMetricsStats.DISABLED_BUFFERED_WRITER_METRICS) {
                 return;
             }
             bufferedWriterMetrics = new MLTransactionMetadataStoreBufferedWriterMetrics(brokerAdvertisedAddress);
+        }
+    }
+
+    public static void closeBufferedWriterMetrics() {
+        synchronized (MLTransactionMetadataStoreProvider.class){
+            if (bufferedWriterMetrics == DisabledTxnLogBufferedWriterMetricsStats.DISABLED_BUFFERED_WRITER_METRICS) {
+                return;
+            }
+            bufferedWriterMetrics.close();
+            bufferedWriterMetrics = DisabledTxnLogBufferedWriterMetricsStats.DISABLED_BUFFERED_WRITER_METRICS;
         }
     }
 


### PR DESCRIPTION

### Motivation
Fix #17921 
The test may fails if a previous test in the same fork started the transactions and therefore the transactions metrics are published. In the PulsarService shutdown hooks the metrics are never unregistered.

### Modifications

* Unregister transactions metrics in the PulsarService shutdown

### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->
