### PR TITLE
[fix][sec] Upgrade protobuf to 3.19.6 to get rid of CVE-2022-3171

### DIFF
--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -506,8 +506,8 @@ MIT License
 
 Protocol Buffers License
  * Protocol Buffers
-   - com.google.protobuf-protobuf-java-3.19.2.jar -- licenses/LICENSE-protobuf.txt
-   - com.google.protobuf-protobuf-java-util-3.19.2.jar -- licenses/LICENSE-protobuf.txt
+   - com.google.protobuf-protobuf-java-3.19.6.jar -- licenses/LICENSE-protobuf.txt
+   - com.google.protobuf-protobuf-java-util-3.19.6.jar -- licenses/LICENSE-protobuf.txt
 
 CDDL-1.1 -- licenses/LICENSE-CDDL-1.1.txt
  * Java Annotations API

--- a/pom.xml
+++ b/pom.xml
@@ -146,7 +146,7 @@ flexible messaging model and an intuitive client API.</description>
     <docker-maven.version>0.40.2</docker-maven.version>
     <docker.verbose>true</docker.verbose>
     <typetools.version>0.5.0</typetools.version>
-    <protobuf3.version>3.19.2</protobuf3.version>
+    <protobuf3.version>3.19.6</protobuf3.version>
     <protoc3.version>${protobuf3.version}</protoc3.version>
     <grpc.version>1.45.1</grpc.version>
     <google-http-client.version>1.41.0</google-http-client.version>

--- a/pulsar-sql/presto-distribution/LICENSE
+++ b/pulsar-sql/presto-distribution/LICENSE
@@ -474,8 +474,8 @@ The Apache Software License, Version 2.0
 
 Protocol Buffers License
  * Protocol Buffers
-   - protobuf-java-3.19.2.jar
-   - protobuf-java-util-3.19.2.jar
+   - protobuf-java-3.19.6.jar
+   - protobuf-java-util-3.19.6.jar
    - proto-google-common-protos-2.0.1.jar
 
 BSD 3-clause "New" or "Revised" License


### PR DESCRIPTION
### Motivation

Current protobuf version (3.19.2) is vulnerable to [CVE-2022-3171](https://nvd.nist.gov/vuln/detail/CVE-2022-3171)

https://github.com/protocolbuffers/protobuf/security/advisories/GHSA-h4h5-3hr4-j3g2


### Modifications

* Upgrade to latest 3.19.x (3.19.6)
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->