### PR TITLE
[improve][broker]  modify the default value of loadBalancerLoadPlacementStrategy to LeastResourceUsageWithWeight

### DIFF
--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -1281,8 +1281,8 @@ defaultNamespaceBundleSplitAlgorithm=range_equally_divide
 # load shedding strategy, support OverloadShedder and ThresholdShedder, default is ThresholdShedder since 2.10.0
 loadBalancerLoadSheddingStrategy=org.apache.pulsar.broker.loadbalance.impl.ThresholdShedder
 
-# load balance placement strategy, support LeastLongTermMessageRate and LeastResourceUsageWithWeight
-loadBalancerLoadPlacementStrategy=org.apache.pulsar.broker.loadbalance.impl.LeastLongTermMessageRate
+# load balance placement strategy, support LeastLongTermMessageRate and LeastLongTermMessageRate
+loadBalancerLoadPlacementStrategy=org.apache.pulsar.broker.loadbalance.impl.LeastResourceUsageWithWeight
 
 # The broker resource usage threshold.
 # When the broker resource usage is greater than the pulsar cluster average resource usage,

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -2122,7 +2122,7 @@ public class ServiceConfiguration implements PulsarConfiguration {
             doc = "load balance placement strategy"
     )
     private String loadBalancerLoadPlacementStrategy =
-            "org.apache.pulsar.broker.loadbalance.impl.LeastLongTermMessageRate";
+            "org.apache.pulsar.broker.loadbalance.impl.LeastResourceUsageWithWeight";
 
     @FieldContext(
         dynamic = true,


### PR DESCRIPTION
### Motivation
The default value of loadBalancerLoadSheddingStrategy is ThresholdShedder, but the default value of loadBalancerLoadPlacementStrategy is LeastLongTermMessageRate.

In order to match the default value of loadBalancerLoadSheddingStrategy and loadBalancerLoadPlacementStrategy, modify the default value of loadBalancerLoadPlacementStrategy to LeastResourceUsageWithWeight:

```
    private String loadBalancerLoadPlacementStrategy =
            "org.apache.pulsar.broker.loadbalance.impl.LeastResourceUsageWithWeight";
```


### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
