### PR TITLE
[fix][doc] Optimize URLs for CLI tools page

### DIFF
--- a/site2/docs/about.md
+++ b/site2/docs/about.md
@@ -55,7 +55,7 @@ You’ll notice an Edit button at the bottom and top of each page. Click it to o
 
 :::tip
 
-For how to make contributions to documentation, see [Pulsar Documentation Contribution Guide](https://docs.google.com/document/d/11DTnNPpvcPrebLkMAFcDEIFlD8ARD-k6F-LXoIwdD9Y/edit#).
+For how to make contributions to documentation, see [Pulsar Documentation Contribution Guide](https://github.com/apache/pulsar/blob/master/site2/README.md).
 
 :::
 

--- a/site2/docs/reference-cli-tools.md
+++ b/site2/docs/reference-cli-tools.md
@@ -6,14 +6,13 @@ sidebar_label: "Pulsar CLI tools"
 
 Pulsar offers several command-line tools that you can use for managing Pulsar installations, performance testing, using command-line producers and consumers, and more.
 
-* [`pulsar-admin`](https://pulsar.apache.org/reference/#/latest/pulsar-admin/)
-* [`pulsar`](https://pulsar.apache.org/reference/#/latest/pulsar/)
-* [`pulsar-client`](https://pulsar.apache.org/reference/#/latest/pulsar-client/)
-* [`pulsar-perf`](https://pulsar.apache.org/reference/#/latest/pulsar-perf/)
-* [`pulsar-daemon`](reference-cli-pulsar-daemon.md)
+* [`pulsar-admin`](https://pulsar.apache.org/reference)
+* [`pulsar`](https://pulsar.apache.org/reference)
+* [`pulsar-client`](https://pulsar.apache.org/reference)
+* [`pulsar-daemon`](https://pulsar.apache.org/reference)
+* [`pulsar-perf`](https://pulsar.apache.org/reference)
 * [`pulsar-shell`](reference-cli-pulsar-shell.md)
-* [`bookkeeper`](reference-cli-bookkeeper.md)
-* [`broker-tool`](reference-cli-broker-tool.md) 
+* [`bookkeeper`](https://pulsar.apache.org/reference)
 
 All Pulsar command-line tools can be run from the `bin` directory of your [installed Pulsar package](getting-started-standalone.md). 
 

--- a/site2/docs/reference-cli-tools.md
+++ b/site2/docs/reference-cli-tools.md
@@ -6,13 +6,19 @@ sidebar_label: "Pulsar CLI tools"
 
 Pulsar offers several command-line tools that you can use for managing Pulsar installations, performance testing, using command-line producers and consumers, and more.
 
-* [`pulsar-admin`](https://pulsar.apache.org/reference)
-* [`pulsar`](https://pulsar.apache.org/reference)
-* [`pulsar-client`](https://pulsar.apache.org/reference)
-* [`pulsar-daemon`](https://pulsar.apache.org/reference)
-* [`pulsar-perf`](https://pulsar.apache.org/reference)
-* [`pulsar-shell`](reference-cli-pulsar-shell.md)
-* [`bookkeeper`](https://pulsar.apache.org/reference)
+* `pulsar-admin`
+* `pulsar`
+* `pulsar-client`
+* `pulsar-daemon`
+* `pulsar-perf`
+* `pulsar-shell`
+* `bookkeeper`
+
+::: tip
+
+For the latest and complete information about command-line tools, including commands, flags, descriptions, and more information, see [Pulsar Reference](https://pulsar.apache.org/reference).
+
+:::
 
 All Pulsar command-line tools can be run from the `bin` directory of your [installed Pulsar package](getting-started-standalone.md). 
 
@@ -21,5 +27,3 @@ You can get help for any CLI tool, command, or subcommand using the `--help` fla
 ```shell
 bin/pulsar broker --help
 ```
-
-


### PR DESCRIPTION
This PR:

1. Removes metadata since it should not be shown on the Reference site

<img width="1855" alt="image" src="https://user-images.githubusercontent.com/50226895/196601135-e651fde0-24a8-4c53-a621-d09ea9e1ee3d.png">

2. Removes `broker-tool` because https://github.com/apache/pulsar/pull/18051#issuecomment-1280297019

3. Update URLs to https://pulsar.apache.org/reference to make it more generic and easier to maintain 

- [x] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->


