### PR TITLE
[fix][sec] File tiered storage: upgrade jettison to get rid of CVE-2022-40149

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -224,6 +224,7 @@ flexible messaging model and an intuitive client API.</description>
     <skyscreamer.version>1.5.0</skyscreamer.version>
     <objenesis.version>3.1</objenesis.version>
     <awaitility.version>4.0.3</awaitility.version>
+    <jettison.version>1.5.1</jettison.version>
 
     <!-- Plugin dependencies -->
     <protobuf-maven-plugin.version>0.6.1</protobuf-maven-plugin.version>
@@ -796,6 +797,12 @@ flexible messaging model and an intuitive client API.</description>
         <version>${jackson.version}</version>
         <type>pom</type>
         <scope>import</scope>
+      </dependency>
+
+      <dependency>
+        <groupId>org.codehaus.jettison</groupId>
+        <artifactId>jettison</artifactId>
+        <version>${jettison.version}</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
### Motivation

The commit https://github.com/apache/pulsar/commit/b53bc51027b192ae42b68308f8b03950e2ec2a6d involve a compile error. So I revert it and recreate a fix.

