### PR TITLE
[improve][broker] Avoid put all delayed messages to redeliver queue

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedLedgerException.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedLedgerException.java
@@ -18,6 +18,8 @@
  */
 package org.apache.bookkeeper.mledger;
 
+import java.util.Set;
+import lombok.Getter;
 import org.apache.bookkeeper.common.annotation.InterfaceAudience;
 import org.apache.bookkeeper.common.annotation.InterfaceStability;
 
@@ -189,6 +191,22 @@ public class ManagedLedgerException extends Exception {
 
         public ManagedLedgerFactoryClosedException(Throwable e) {
             super(e);
+        }
+    }
+
+
+    public static class CursorReplyFailedException extends ManagedLedgerException {
+        @Getter
+        private final Set<? extends Position> replyPositions;
+
+        public CursorReplyFailedException(ManagedLedgerException ex, Set<? extends Position> replyPositions) {
+            super(ex);
+            this.replyPositions = replyPositions;
+        }
+
+        @Override
+        public synchronized ManagedLedgerException getCause() {
+            return (ManagedLedgerException) super.getCause();
         }
     }
 

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
@@ -1435,7 +1435,8 @@ public class ManagedCursorImpl implements ManagedCursor {
                     // and not add it to the list
                     entry.release();
                     if (--pendingCallbacks == 0) {
-                        callback.readEntriesFailed(exception.get(), ctx);
+                        callback.readEntriesFailed(
+                                new ManagedLedgerException.CursorReplyFailedException(exception.get(), positions), ctx);
                     }
                 } else {
                     entries.add(entry);
@@ -1456,7 +1457,8 @@ public class ManagedCursorImpl implements ManagedCursor {
                     entries.forEach(Entry::release);
                 }
                 if (--pendingCallbacks == 0) {
-                    callback.readEntriesFailed(exception.get(), ctx);
+                    callback.readEntriesFailed(
+                            new ManagedLedgerException.CursorReplyFailedException(exception.get(), positions), ctx);
                 }
             }
         };

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumers.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumers.java
@@ -779,7 +779,7 @@ public class PersistentDispatcherMultipleConsumers extends AbstractDispatcherMul
                     (ManagedLedgerException.CursorReplyFailedException) rawException;
             cursorReplyFailedException.getReplyPositions().forEach(replyPosition ->
                     redeliveryMessages.add(replyPosition.getLedgerId(), replyPosition.getEntryId()));
-            exception = cursorReplyFailedException;
+            exception = cursorReplyFailedException.getCause();
         } else {
             exception = rawException;
         }


### PR DESCRIPTION
### Motivation

#18098 makes all delayed messages go into the redeliver queue, I think we can provide another way to avoid putting all delayed messages into the redeliver queue to solve this problem.

### Modifications

- Introduce a new exception carrying message location.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->