### PR TITLE
[feat][client] Add ClientConfiguration options for in memory TLS certs

### DIFF
--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/http/AsyncHttpConnector.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/http/AsyncHttpConnector.java
@@ -162,12 +162,21 @@ public class AsyncHttpConnector implements Connector {
                                 conf.getTlsCiphers(),
                                 conf.getTlsProtocols());
                     } else {
-                        sslCtx = SecurityUtility.createNettySslContextForClient(
+                        sslCtx = conf.getTlsTrustStoreStream() == null
+                                ? SecurityUtility.createNettySslContextForClient(
                                 sslProvider,
                                 conf.isTlsAllowInsecureConnection(),
                                 conf.getTlsTrustCertsFilePath(),
                                 conf.getTlsCertificateFilePath(),
                                 conf.getTlsKeyFilePath(),
+                                conf.getTlsCiphers(),
+                                conf.getTlsProtocols())
+                                : SecurityUtility.createNettySslContextForClient(
+                                sslProvider,
+                                conf.isTlsAllowInsecureConnection(),
+                                conf.getTlsTrustStoreStream(),
+                                conf.getTlsCertificates(),
+                                conf.getTlsPrivateKey(),
                                 conf.getTlsCiphers(),
                                 conf.getTlsProtocols());
                     }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/HttpClient.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/HttpClient.java
@@ -131,12 +131,21 @@ public class HttpClient implements Closeable {
                                 authData.getTlsTrustStoreStream(), authData.getTlsCertificates(),
                                 authData.getTlsPrivateKey(), conf.getTlsCiphers(), conf.getTlsProtocols());
                     } else {
-                        sslCtx = SecurityUtility.createNettySslContextForClient(
+                        sslCtx = conf.getTlsTrustStoreStream() == null
+                                ? SecurityUtility.createNettySslContextForClient(
                                 sslProvider,
                                 conf.isTlsAllowInsecureConnection(),
                                 conf.getTlsTrustCertsFilePath(),
                                 conf.getTlsCertificateFilePath(),
                                 conf.getTlsKeyFilePath(),
+                                conf.getTlsCiphers(),
+                                conf.getTlsProtocols())
+                                : SecurityUtility.createNettySslContextForClient(
+                                sslProvider,
+                                conf.isTlsAllowInsecureConnection(),
+                                conf.getTlsTrustStoreStream(),
+                                conf.getTlsCertificates(),
+                                conf.getTlsPrivateKey(),
                                 conf.getTlsCiphers(),
                                 conf.getTlsProtocols());
                     }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PulsarChannelInitializer.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PulsarChannelInitializer.java
@@ -123,12 +123,21 @@ public class PulsarChannelInitializer extends ChannelInitializer<SocketChannel> 
                                 conf.getTlsCiphers(),
                                 conf.getTlsProtocols());
                     } else {
-                        return SecurityUtility.createNettySslContextForClient(
+                        return conf.getTlsTrustStoreStream() == null
+                                ? SecurityUtility.createNettySslContextForClient(
                                 sslProvider,
                                 conf.isTlsAllowInsecureConnection(),
                                 conf.getTlsTrustCertsFilePath(),
                                 conf.getTlsCertificateFilePath(),
                                 conf.getTlsKeyFilePath(),
+                                conf.getTlsCiphers(),
+                                conf.getTlsProtocols())
+                                : SecurityUtility.createNettySslContextForClient(
+                                sslProvider,
+                                conf.isTlsAllowInsecureConnection(),
+                                conf.getTlsTrustStoreStream(),
+                                conf.getTlsCertificates(),
+                                conf.getTlsPrivateKey(),
                                 conf.getTlsCiphers(),
                                 conf.getTlsProtocols());
                     }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ClientConfigurationData.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ClientConfigurationData.java
@@ -20,9 +20,12 @@ package org.apache.pulsar.client.impl.conf;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.swagger.annotations.ApiModelProperty;
+import java.io.InputStream;
 import java.io.Serializable;
 import java.net.InetSocketAddress;
 import java.net.URI;
+import java.security.PrivateKey;
+import java.security.cert.Certificate;
 import java.time.Clock;
 import java.util.Map;
 import java.util.Objects;
@@ -161,6 +164,24 @@ public class ClientConfigurationData implements Serializable, Cloneable {
             value = "Path to the trusted TLS certificate file."
     )
     private String tlsTrustCertsFilePath = null;
+
+    @ApiModelProperty(
+            name = "tlsPrivateKey",
+            value = "The private key for the client certificate. Only used when tlsTrustStoreStream is non-null."
+    )
+    private PrivateKey tlsPrivateKey = null;
+
+    @ApiModelProperty(
+            name = "tlsCertificates",
+            value = "Client certificate chain. Only used when tlsTrustStoreStream is non-null."
+    )
+    private Certificate[] tlsCertificates = null;
+
+    @ApiModelProperty(
+            name = "tlsTrustStoreStream",
+            value = "Input-stream of the trust store. When configured, the tlsPrivateKey and tlsCertificates are used."
+    )
+    private InputStream tlsTrustStoreStream = null;
 
     @ApiModelProperty(
             name = "tlsAllowInsecureConnection",


### PR DESCRIPTION
### Motivation

Give client applications the configure TLS Certificates, Keys, and TrustStores as in memory objects.

The naming for the new configurations had two options from a consistency perspective: the `ClientConfiguration` class and the `AuthenticationDataTls` class. Both classes have relevant field names. Since `AuthenticationDataTls` already supports in memory TLS configuration, I used the names from that class. The one downside to this implementation is that the names slightly diverge from the configurations in the same `ClientConfiguration` class.

Note also that the configuration works just like `AuthenticationDataTls`: when `tlsTrustStoreStream` is set, the other in memory certs/key are used.

### Modifications

* Add `tlsPrivateKey` to `ClientConfiguration`
* Add `tlsCertificates` to `ClientConfiguration`
* Add `tlsTrustStoreStream` to `ClientConfiguration`
* Update configuration of the `NettySslContext` to optionally use these in memory configs.

### Verifying this change

This is a trivial change, but it likely requires test coverage. @nodece  is adding new test coverage here https://github.com/apache/pulsar/pull/17141. It might be worth adding tests that leverage that work so that there are not unnecessary conflicts.

### Does this pull request potentially affect one of the following parts:

- [x] The public API

This feature adds new configuration options. The fundamental 

### Documentation


- [x] `doc-not-needed`

This PR includes annotated documentation in relevant classes that will generate documentation.


### Matching PR in forked repository

PR in forked repository: https://github.com/michaeljmarshall/pulsar/pull/6