### PR TITLE
[fix] [io] Fix checkstyle issue in JDBCUtils

### DIFF
--- a/pulsar-io/jdbc/core/src/main/java/org/apache/pulsar/io/jdbc/JdbcUtils.java
+++ b/pulsar-io/jdbc/core/src/main/java/org/apache/pulsar/io/jdbc/JdbcUtils.java
@@ -121,8 +121,8 @@ public class JdbcUtils {
         TableDefinition table = TableDefinition.of(
                 tableId, Lists.newArrayList(), Lists.newArrayList(), Lists.newArrayList());
 
-        keyList = keyList == null ? Collections.emptyList(): keyList;
-        nonKeyList = nonKeyList == null ? Collections.emptyList(): nonKeyList;
+        keyList = keyList == null ? Collections.emptyList() : keyList;
+        nonKeyList = nonKeyList == null ? Collections.emptyList() : nonKeyList;
 
         try (ResultSet rs = connection.getMetaData().getColumns(
             tableId.getCatalogName(),


### PR DESCRIPTION
### Motivation

<img width="1201" alt="截屏2022-10-20 02 33 33" src="https://user-images.githubusercontent.com/25195800/196775769-e9da167a-9a55-4dbd-8ebd-f8c44b7d7765.png">


<img width="1394" alt="截屏2022-10-20 02 33 46" src="https://user-images.githubusercontent.com/25195800/196775683-a7f9a5cc-4b01-485c-bcea-e0dc8e5733d3.png">

### Modifications

Format `JDBCUtils.java`.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: 

- https://github.com/poorbarcode/pulsar/pull/28
