### PR TITLE
[fix] The Pulsar standalone bookie is not getting passed the config from standalone.conf

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/PulsarStandalone.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/PulsarStandalone.java
@@ -441,7 +441,11 @@ public class PulsarStandalone implements AutoCloseable {
         } else {
             log.info("Starting BK with metadata store:", metadataStoreUrl);
         }
+
+        ServerConfiguration bkServerConf = new ServerConfiguration();
+        bkServerConf.loadConf(new File(configFile).toURI().toURL());
         bkCluster = BKCluster.builder()
+                .baseServerConfiguration(bkServerConf)
                 .metadataServiceUri(metadataStoreUrl)
                 .bkPort(bkPort)
                 .numBookies(numOfBk)

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/bookkeeper/BKCluster.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/bookkeeper/BKCluster.java
@@ -71,12 +71,19 @@ public class BKCluster implements AutoCloseable {
     protected final ClientConfiguration baseClientConf;
 
     public static class BKClusterConf {
+
+        private ServerConfiguration baseServerConfiguration;
         private String metadataServiceUri;
         private int numBookies = 1;
         private String dataDir;
         private int bkPort = 0;
 
         private boolean clearOldData;
+
+        public BKClusterConf baseServerConfiguration(ServerConfiguration baseServerConfiguration) {
+            this.baseServerConfiguration = baseServerConfiguration;
+            return this;
+        }
 
         public BKClusterConf metadataServiceUri(String metadataServiceUri) {
             this.metadataServiceUri = metadataServiceUri;
@@ -115,7 +122,8 @@ public class BKCluster implements AutoCloseable {
     private BKCluster(BKClusterConf bkClusterConf) throws Exception {
         this.clusterConf = bkClusterConf;
 
-        this.baseConf = newBaseServerConfiguration();
+        this.baseConf = bkClusterConf.baseServerConfiguration != null
+                ? bkClusterConf.baseServerConfiguration : newBaseServerConfiguration();
         this.baseClientConf = newBaseClientConfiguration();
 
         this.store =


### PR DESCRIPTION
### Motivation

Pulsar standalone is not respecting the bookie config set in `conf/standalone.conf`.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
