### PR TITLE
[fix][cpp][branch-2.9] Fix zlib dowload path.

### DIFF
--- a/pulsar-client-cpp/docker/alpine/Dockerfile
+++ b/pulsar-client-cpp/docker/alpine/Dockerfile
@@ -44,11 +44,11 @@ RUN curl -O -L https://boostorg.jfrog.io/artifactory/main/release/1.72.0/source/
 
 # ZLib
 RUN curl -O -L https://zlib.net/fossils/zlib-1.2.13.tar.gz  && \
-    tar xfz zlib-1.2.12.tar.gz && \
-    cd zlib-1.2.12 && \
+    tar xfz zlib-1.2.13.tar.gz && \
+    cd zlib-1.2.13 && \
     CFLAGS="-fPIC -O3" ./configure && \
     make -j4 && make install && \
-    rm -rf /zlib-1.2.12.tar.gz /zlib-1.2.12
+    rm -rf /zlib-1.2.13.tar.gz /zlib-1.2.13
 
 # Compile OpenSSL
 RUN curl -O -L https://github.com/openssl/openssl/archive/OpenSSL_1_1_0j.tar.gz && \

--- a/pulsar-client-cpp/docker/alpine/Dockerfile
+++ b/pulsar-client-cpp/docker/alpine/Dockerfile
@@ -43,7 +43,7 @@ RUN curl -O -L https://boostorg.jfrog.io/artifactory/main/release/1.72.0/source/
     rm -rf /boost_1_72_0.tar.gz /boost_1_72_0
 
 # ZLib
-RUN curl -O -L https://zlib.net/zlib-1.2.12.tar.gz  && \
+RUN curl -O -L https://zlib.net/fossils/zlib-1.2.13.tar.gz  && \
     tar xfz zlib-1.2.12.tar.gz && \
     cd zlib-1.2.12 && \
     CFLAGS="-fPIC -O3" ./configure && \

--- a/pulsar-client-cpp/docker/alpine/Dockerfile-alpine-3.8
+++ b/pulsar-client-cpp/docker/alpine/Dockerfile-alpine-3.8
@@ -44,11 +44,11 @@ RUN curl -O -L https://boostorg.jfrog.io/artifactory/main/release/1.72.0/source/
 
 # ZLib
 RUN curl -O -L https://zlib.net/fossils/zlib-1.2.13.tar.gz  && \
-    tar xfz zlib-1.2.12.tar.gz && \
-    cd zlib-1.2.12 && \
+    tar xfz zlib-1.2.13.tar.gz && \
+    cd zlib-1.2.13 && \
     CFLAGS="-fPIC -O3" ./configure && \
     make -j4 && make install && \
-    rm -rf /zlib-1.2.12.tar.gz /zlib-1.2.12
+    rm -rf /zlib-1.2.13.tar.gz /zlib-1.2.13
 
 # Compile OpenSSL
 RUN curl -O -L https://github.com/openssl/openssl/archive/OpenSSL_1_1_0j.tar.gz && \

--- a/pulsar-client-cpp/docker/alpine/Dockerfile-alpine-3.8
+++ b/pulsar-client-cpp/docker/alpine/Dockerfile-alpine-3.8
@@ -43,7 +43,7 @@ RUN curl -O -L https://boostorg.jfrog.io/artifactory/main/release/1.72.0/source/
     rm -rf /boost_1_72_0.tar.gz /boost_1_72_0
 
 # ZLib
-RUN curl -O -L https://zlib.net/zlib-1.2.12.tar.gz  && \
+RUN curl -O -L https://zlib.net/fossils/zlib-1.2.13.tar.gz  && \
     tar xfz zlib-1.2.12.tar.gz && \
     cd zlib-1.2.12 && \
     CFLAGS="-fPIC -O3" ./configure && \

--- a/pulsar-client-cpp/docker/manylinux1/Dockerfile
+++ b/pulsar-client-cpp/docker/manylinux1/Dockerfile
@@ -46,7 +46,7 @@ RUN curl -O -L https://www.cpan.org/src/5.0/perl-5.10.0.tar.gz && \
 ####################################
 
 # ZLib
-RUN curl -O -L https://zlib.net/zlib-1.2.12.tar.gz && \
+RUN curl -O -L https://zlib.net/fossils/zlib-1.2.13.tar.gz && \
     tar xvfz zlib-1.2.12.tar.gz && \
     cd zlib-1.2.12 && \
     CFLAGS="-fPIC -O3" ./configure && \

--- a/pulsar-client-cpp/docker/manylinux1/Dockerfile
+++ b/pulsar-client-cpp/docker/manylinux1/Dockerfile
@@ -47,11 +47,11 @@ RUN curl -O -L https://www.cpan.org/src/5.0/perl-5.10.0.tar.gz && \
 
 # ZLib
 RUN curl -O -L https://zlib.net/fossils/zlib-1.2.13.tar.gz && \
-    tar xvfz zlib-1.2.12.tar.gz && \
-    cd zlib-1.2.12 && \
+    tar xvfz zlib-1.2.13.tar.gz && \
+    cd zlib-1.2.13 && \
     CFLAGS="-fPIC -O3" ./configure && \
     make && make install && \
-    rm -rf /zlib-1.2.12.tar.gz /zlib-1.2.12
+    rm -rf /zlib-1.2.13.tar.gz /zlib-1.2.13
 
 # Compile OpenSSL
 RUN curl -O -L https://github.com/openssl/openssl/archive/OpenSSL_1_1_0j.tar.gz && \

--- a/pulsar-client-cpp/docker/manylinux2014/Dockerfile
+++ b/pulsar-client-cpp/docker/manylinux2014/Dockerfile
@@ -49,11 +49,11 @@ RUN curl -O -L https://www.cpan.org/src/5.0/perl-5.10.0.tar.gz && \
 
 # ZLib
 RUN curl -O -L https://zlib.net/fossils/zlib-1.2.13.tar.gz && \
-    tar xvfz zlib-1.2.12.tar.gz && \
-    cd zlib-1.2.12 && \
+    tar xvfz zlib-1.2.13.tar.gz && \
+    cd zlib-1.2.13 && \
     CFLAGS="-fPIC -O3" ./configure && \
     make && make install && \
-    rm -rf /zlib-1.2.12.tar.gz /zlib-1.2.12
+    rm -rf /zlib-1.2.13.tar.gz /zlib-1.2.13
 
 # Compile OpenSSL
 RUN curl -O -L https://github.com/openssl/openssl/archive/OpenSSL_1_1_1n.tar.gz && \

--- a/pulsar-client-cpp/docker/manylinux2014/Dockerfile
+++ b/pulsar-client-cpp/docker/manylinux2014/Dockerfile
@@ -48,7 +48,7 @@ RUN curl -O -L https://www.cpan.org/src/5.0/perl-5.10.0.tar.gz && \
 ####################################
 
 # ZLib
-RUN curl -O -L https://zlib.net/zlib-1.2.12.tar.gz && \
+RUN curl -O -L https://zlib.net/fossils/zlib-1.2.13.tar.gz && \
     tar xvfz zlib-1.2.12.tar.gz && \
     cd zlib-1.2.12 && \
     CFLAGS="-fPIC -O3" ./configure && \

--- a/pulsar-client-cpp/docker/manylinux_musl/Dockerfile
+++ b/pulsar-client-cpp/docker/manylinux_musl/Dockerfile
@@ -48,7 +48,7 @@ RUN curl -O -L https://www.cpan.org/src/5.0/perl-5.10.0.tar.gz && \
 ####################################
 
 # ZLib
-RUN curl -O -L https://zlib.net/zlib-1.2.12.tar.gz && \
+RUN curl -O -L https://zlib.net/fossils/zlib-1.2.13.tar.gz && \
     tar xvfz zlib-1.2.12.tar.gz && \
     cd zlib-1.2.12 && \
     CFLAGS="-fPIC -O3" ./configure && \

--- a/pulsar-client-cpp/docker/manylinux_musl/Dockerfile
+++ b/pulsar-client-cpp/docker/manylinux_musl/Dockerfile
@@ -49,11 +49,11 @@ RUN curl -O -L https://www.cpan.org/src/5.0/perl-5.10.0.tar.gz && \
 
 # ZLib
 RUN curl -O -L https://zlib.net/fossils/zlib-1.2.13.tar.gz && \
-    tar xvfz zlib-1.2.12.tar.gz && \
-    cd zlib-1.2.12 && \
+    tar xvfz zlib-1.2.13.tar.gz && \
+    cd zlib-1.2.13 && \
     CFLAGS="-fPIC -O3" ./configure && \
     make -j8 && make install && \
-    rm -rf /zlib-1.2.12.tar.gz /zlib-1.2.12
+    rm -rf /zlib-1.2.13.tar.gz /zlib-1.2.13
 
 # Compile OpenSSL
 RUN curl -O -L https://github.com/openssl/openssl/archive/OpenSSL_1_1_1n.tar.gz && \

--- a/pulsar-client-cpp/python/build-mac-wheels.sh
+++ b/pulsar-client-cpp/python/build-mac-wheels.sh
@@ -34,7 +34,7 @@ PYTHON_VERSIONS=(
 export MACOSX_DEPLOYMENT_TARGET=11.0
 MACOSX_DEPLOYMENT_TARGET_MAJOR=${MACOSX_DEPLOYMENT_TARGET%%.*}
 
-ZLIB_VERSION=1.2.12
+ZLIB_VERSION=1.2.13
 OPENSSL_VERSION=1_1_1n
 BOOST_VERSION=1.78.0
 PROTOBUF_VERSION=3.20.0
@@ -85,7 +85,7 @@ done
 ###############################################################################
 if [ ! -f zlib-${ZLIB_VERSION}/.done ]; then
     echo "Building ZLib"
-    curl -O -L https://zlib.net/zlib-${ZLIB_VERSION}.tar.gz
+    curl -O -L https://zlib.net/fossils/zlib-${ZLIB_VERSION}.tar.gz
     tar xvfz zlib-$ZLIB_VERSION.tar.gz
     pushd zlib-$ZLIB_VERSION
       CFLAGS="-fPIC -O3 -arch arm64 -arch x86_64 -mmacosx-version-min=${MACOSX_DEPLOYMENT_TARGET}" ./configure --prefix=$PREFIX


### PR DESCRIPTION
### Motivation

branch-2.9 python CI jobs has started failing because a new version of ZLib was released and the old one was removed.

https://github.com/codelipenghui/incubator-pulsar/actions/runs/3282737027/jobs/5413121415



### Modifications
- Change the URL to point to the archive so that we won't get in the same situation on next release.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository


