### PR TITLE
[fix][function] Fix invalid metric type "gauge "

### DIFF
--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/WorkerStatsManager.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/WorkerStatsManager.java
@@ -329,7 +329,8 @@ public class WorkerStatsManager {
     stream.write("# TYPE ");
     stream.write(PULSAR_FUNCTION_WORKER_METRICS_PREFIX);
     stream.write(metricName);
-    stream.write(" gauge \n");
+    stream.write(" gauge");
+    stream.write("\n");
 
     stream.write(PULSAR_FUNCTION_WORKER_METRICS_PREFIX);
     stream.write(metricName);


### PR DESCRIPTION
### Motivation

Prometheus load metrics error.
<img width="1909" alt="image" src="https://user-images.githubusercontent.com/26179648/196851532-c1d4c6c3-9877-47a4-80c4-d7fa92a68d9e.png">

> curl -s 'http://localhost:8080/metrics/'
<img width="636" alt="image" src="https://user-images.githubusercontent.com/26179648/196853381-0a375263-655b-4a1b-8900-582411eab2c5.png">

This bug introduce from #15558

### Modifications

Remove the space behind the metric type.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: 
