### PR TITLE
[fix][doc] Point Python and C++ docs to new GitHub repos

### DIFF
--- a/pulsar-client-cpp/README.md
+++ b/pulsar-client-cpp/README.md
@@ -1,0 +1,3 @@
+# NOTICE
+
+The Apache Pulsar C++ Client code now lives here: https://github.com/apache/pulsar-client-cpp

--- a/pulsar-client-cpp/python/README.md
+++ b/pulsar-client-cpp/python/README.md
@@ -1,0 +1,3 @@
+# NOTICE
+
+The Apache Pulsar Python Client code now lives here: https://github.com/apache/pulsar-client-python

--- a/site2/website/versioned_docs/version-2.1.0-incubating/client-libraries-python.md
+++ b/site2/website/versioned_docs/version-2.1.0-incubating/client-libraries-python.md
@@ -5,7 +5,7 @@ sidebar_label: "Python"
 original_id: client-libraries-python
 ---
 
-The Pulsar Python client library is a wrapper over the existing [C++ client library](client-libraries-cpp.md) and exposes all of the [same features](/api/cpp). You can find the code in the [`python` subdirectory](https://github.com/apache/incubator-pulsar/tree/master/pulsar-client-cpp/python) of the C++ client code.
+The Pulsar Python client library is a wrapper over the existing [C++ client library](client-libraries-cpp.md) and exposes all of the [same features](/api/cpp). You can find the code in the [`python` GitHub Repository](https://github.com/apache/pulsar-client-python) of the C++ client code.
 
 ## Installation
 

--- a/site2/website/versioned_docs/version-2.1.1-incubating/client-libraries-python.md
+++ b/site2/website/versioned_docs/version-2.1.1-incubating/client-libraries-python.md
@@ -5,7 +5,7 @@ sidebar_label: "Python"
 original_id: client-libraries-python
 ---
 
-The Pulsar Python client library is a wrapper over the existing [C++ client library](client-libraries-cpp.md) and exposes all of the [same features](/api/cpp). You can find the code in the [`python` subdirectory](https://github.com/apache/incubator-pulsar/tree/master/pulsar-client-cpp/python) of the C++ client code.
+The Pulsar Python client library is a wrapper over the existing [C++ client library](client-libraries-cpp.md) and exposes all of the [same features](/api/cpp). You can find the code in the [`python` GitHub Repository](https://github.com/apache/pulsar-client-python) of the C++ client code.
 
 ## Installation
 

--- a/site2/website/versioned_docs/version-2.10.x/client-libraries-cpp.md
+++ b/site2/website/versioned_docs/version-2.10.x/client-libraries-cpp.md
@@ -654,7 +654,7 @@ Client client("pulsar+ssl://my-broker.com:6651", config);
 
 ```
 
-For complete examples, refer to [C++ client examples](https://github.com/apache/pulsar/tree/master/pulsar-client-cpp/examples).
+For complete examples, refer to [C++ client examples](https://github.com/apache/pulsar-client-cpp/examples).
 
 ## Schema
 

--- a/site2/website/versioned_docs/version-2.10.x/client-libraries-cpp.md
+++ b/site2/website/versioned_docs/version-2.10.x/client-libraries-cpp.md
@@ -654,7 +654,7 @@ Client client("pulsar+ssl://my-broker.com:6651", config);
 
 ```
 
-For complete examples, refer to [C++ client examples](https://github.com/apache/pulsar-client-cpp/examples).
+For complete examples, refer to [C++ client examples](https://github.com/apache/pulsar-client-cpp/tree/main/examples).
 
 ## Schema
 

--- a/site2/website/versioned_docs/version-2.10.x/client-libraries-python.md
+++ b/site2/website/versioned_docs/version-2.10.x/client-libraries-python.md
@@ -11,7 +11,7 @@ import TabItem from '@theme/TabItem';
 ````
 
 
-Pulsar Python client library is a wrapper over the existing [C++ client library](client-libraries-cpp.md) and exposes all of the [same features](/api/cpp). You can find the code in the [Python directory](https://github.com/apache/pulsar/tree/master/pulsar-client-cpp/python) of the C++ client code.
+Pulsar Python client library is a wrapper over the existing [C++ client library](client-libraries-cpp.md) and exposes all of the [same features](/api/cpp). You can find the code in the [Python directory](https://github.com/apache/pulsar-client-python) of the C++ client code.
 
 All the methods in producer, consumer, and reader of a Python client are thread-safe.
 
@@ -19,7 +19,7 @@ All the methods in producer, consumer, and reader of a Python client are thread-
 
 ## Install
 
-You can install the [`pulsar-client`](https://pypi.python.org/pypi/pulsar-client) library either via [PyPi](https://pypi.python.org/pypi), using [pip](#installation-using-pip), or by building the library from [source](https://github.com/apache/pulsar/tree/master/pulsar-client-cpp).
+You can install the [`pulsar-client`](https://pypi.python.org/pypi/pulsar-client) library either via [PyPi](https://pypi.python.org/pypi), using [pip](#installation-using-pip), or by building the library from [source](https://github.com/apache/pulsar-client-cpp).
 
 ### Install using pip
 

--- a/site2/website/versioned_docs/version-2.10.x/client-libraries.md
+++ b/site2/website/versioned_docs/version-2.10.x/client-libraries.md
@@ -10,8 +10,8 @@ Pulsar supports the following client libraries:
 |Language|Documentation|Release note|Code repo
 |---|---|---|---
 Java |- [User doc](client-libraries-java.md) <br /><br />- [API doc](/api/client/)|[Here](/release-notes/)|[Here](https://github.com/apache/pulsar/tree/master/pulsar-client) 
-C++ | - [User doc](client-libraries-cpp.md) <br /><br />- [API doc](/api/cpp/)|[Here](/release-notes/)|[Here](https://github.com/apache/pulsar/tree/master/pulsar-client-cpp) 
-Python | - [User doc](client-libraries-python.md) <br /><br />- [API doc](/api/python/)|[Here](/release-notes/)|[Here](https://github.com/apache/pulsar/tree/master/pulsar-client-cpp/python) 
+C++ | - [User doc](client-libraries-cpp.md) <br /><br />- [API doc](/api/cpp/)|[Here](/release-notes/)|[Here](https://github.com/apache/pulsar-client-cpp) 
+Python | - [User doc](client-libraries-python.md) <br /><br />- [API doc](/api/python/)|[Here](/release-notes/)|[Here](https://github.com/apache/pulsar-client-python) 
 WebSocket| [User doc](client-libraries-websocket.md) | [Here](/release-notes/)|[Here](https://github.com/apache/pulsar/tree/master/pulsar-websocket) 
 Go client|[User doc](client-libraries-go.md)|[Here](https://github.com/apache/pulsar-client-go/blob/master/CHANGELOG) |[Here](https://github.com/apache/pulsar-client-go) 
 Node.js|[User doc](client-libraries-node.md)|[Here](https://github.com/apache/pulsar-client-node/releases) |[Here](https://github.com/apache/pulsar-client-node) 

--- a/site2/website/versioned_docs/version-2.2.0/client-libraries-python.md
+++ b/site2/website/versioned_docs/version-2.2.0/client-libraries-python.md
@@ -5,7 +5,7 @@ sidebar_label: "Python"
 original_id: client-libraries-python
 ---
 
-The Pulsar Python client library is a wrapper over the existing [C++ client library](client-libraries-cpp.md) and exposes all of the [same features](/api/cpp). You can find the code in the [`python` subdirectory](https://github.com/apache/pulsar/tree/master/pulsar-client-cpp/python) of the C++ client code.
+The Pulsar Python client library is a wrapper over the existing [C++ client library](client-libraries-cpp.md) and exposes all of the [same features](/api/cpp). You can find the code in the [`python` GitHub Repository](https://github.com/apache/pulsar-client-python) of the C++ client code.
 
 ## Installation
 

--- a/site2/website/versioned_docs/version-2.2.1/client-libraries-cpp.md
+++ b/site2/website/versioned_docs/version-2.2.1/client-libraries-cpp.md
@@ -656,7 +656,7 @@ Client client("pulsar+ssl://my-broker.com:6651", config);
 
 ```
 
-For complete examples, refer to [C++ client examples](https://github.com/apache/pulsar/tree/master/pulsar-client-cpp/examples).
+For complete examples, refer to [C++ client examples](https://github.com/apache/pulsar-client-cpp/examples).
 
 ## Schema
 

--- a/site2/website/versioned_docs/version-2.2.1/client-libraries-cpp.md
+++ b/site2/website/versioned_docs/version-2.2.1/client-libraries-cpp.md
@@ -656,7 +656,7 @@ Client client("pulsar+ssl://my-broker.com:6651", config);
 
 ```
 
-For complete examples, refer to [C++ client examples](https://github.com/apache/pulsar-client-cpp/examples).
+For complete examples, refer to [C++ client examples](https://github.com/apache/pulsar-client-cpp/tree/main/examples).
 
 ## Schema
 

--- a/site2/website/versioned_docs/version-2.2.1/client-libraries-python.md
+++ b/site2/website/versioned_docs/version-2.2.1/client-libraries-python.md
@@ -10,7 +10,7 @@ import TabItem from '@theme/TabItem';
 ````
 
 
-Pulsar Python client library is a wrapper over the existing [C++ client library](client-libraries-cpp.md) and exposes all of the [same features](/api/cpp). You can find the code in the [Python directory](https://github.com/apache/pulsar/tree/master/pulsar-client-cpp/python) of the C++ client code.
+Pulsar Python client library is a wrapper over the existing [C++ client library](client-libraries-cpp.md) and exposes all of the [same features](/api/cpp). You can find the code in the [Python directory](https://github.com/apache/pulsar-client-python) of the C++ client code.
 
 All the methods in producer, consumer, and reader of a Python client are thread-safe.
 
@@ -18,7 +18,7 @@ All the methods in producer, consumer, and reader of a Python client are thread-
 
 ## Install
 
-You can install the [`pulsar-client`](https://pypi.python.org/pypi/pulsar-client) library either via [PyPi](https://pypi.python.org/pypi), using [pip](#installation-using-pip), or by building the library from [source](https://github.com/apache/pulsar/tree/master/pulsar-client-cpp).
+You can install the [`pulsar-client`](https://pypi.python.org/pypi/pulsar-client) library either via [PyPi](https://pypi.python.org/pypi), using [pip](#installation-using-pip), or by building the library from [source](https://github.com/apache/pulsar-client-cpp).
 
 ### Install using pip
 

--- a/site2/website/versioned_docs/version-2.2.1/client-libraries.md
+++ b/site2/website/versioned_docs/version-2.2.1/client-libraries.md
@@ -9,8 +9,8 @@ Pulsar supports the following client libraries:
 |Language|Documentation|Release note|Code repo
 |---|---|---|---
 Java |- [User doc](client-libraries-java.md) <br /><br />- [API doc](https://pulsar.apache.org/api/client/)|[Here](https://pulsar.apache.org/release-notes/)|[Here](https://github.com/apache/pulsar/tree/master/pulsar-client) 
-C++ | - [User doc](client-libraries-cpp.md) <br /><br />- [API doc](https://pulsar.apache.org/api/cpp/)|[Here](https://pulsar.apache.org/release-notes/)|[Here](https://github.com/apache/pulsar/tree/master/pulsar-client-cpp) 
-Python | - [User doc](client-libraries-python.md) <br /><br />- [API doc](https://pulsar.apache.org/api/python/)|[Here](https://pulsar.apache.org/release-notes/)|[Here](https://github.com/apache/pulsar/tree/master/pulsar-client-cpp/python) 
+C++ | - [User doc](client-libraries-cpp.md) <br /><br />- [API doc](https://pulsar.apache.org/api/cpp/)|[Here](https://pulsar.apache.org/release-notes/)|[Here](https://github.com/apache/pulsar-client-cpp) 
+Python | - [User doc](client-libraries-python.md) <br /><br />- [API doc](https://pulsar.apache.org/api/python/)|[Here](https://pulsar.apache.org/release-notes/)|[Here](https://github.com/apache/pulsar-client-python) 
 WebSocket| [User doc](client-libraries-websocket.md) | [Here](https://pulsar.apache.org/release-notes/)|[Here](https://github.com/apache/pulsar/tree/master/pulsar-websocket) 
 Go client|[User doc](client-libraries-go.md)|[Here](https://github.com/apache/pulsar-client-go/blob/master/CHANGELOG) |[Here](https://github.com/apache/pulsar-client-go) 
 Node.js|[User doc](client-libraries-node.md)|[Here](https://github.com/apache/pulsar-client-node/releases) |[Here](https://github.com/apache/pulsar-client-node) 

--- a/site2/website/versioned_docs/version-2.3.0/client-libraries-python.md
+++ b/site2/website/versioned_docs/version-2.3.0/client-libraries-python.md
@@ -5,7 +5,7 @@ sidebar_label: "Python"
 original_id: client-libraries-python
 ---
 
-The Pulsar Python client library is a wrapper over the existing [C++ client library](client-libraries-cpp.md) and exposes all of the [same features](/api/cpp). You can find the code in the [`python` subdirectory](https://github.com/apache/pulsar/tree/master/pulsar-client-cpp/python) of the C++ client code.
+The Pulsar Python client library is a wrapper over the existing [C++ client library](client-libraries-cpp.md) and exposes all of the [same features](/api/cpp). You can find the code in the [`python` GitHub Repository](https://github.com/apache/pulsar-client-python) of the C++ client code.
 
 ## Installation
 

--- a/site2/website/versioned_docs/version-2.3.0/client-libraries.md
+++ b/site2/website/versioned_docs/version-2.3.0/client-libraries.md
@@ -9,8 +9,8 @@ Pulsar supports the following client libraries:
 |Language|Documentation|Release note|Code repo
 |---|---|---|---
 Java |- [User doc](client-libraries-java.md) <br /><br />- [API doc](https://pulsar.apache.org/api/client/)|[Here](https://pulsar.apache.org/release-notes/)|[Here](https://github.com/apache/pulsar/tree/master/pulsar-client) 
-C++ | - [User doc](client-libraries-cpp.md) <br /><br />- [API doc](https://pulsar.apache.org/api/cpp/)|[Here](https://pulsar.apache.org/release-notes/)|[Here](https://github.com/apache/pulsar/tree/master/pulsar-client-cpp) 
-Python | - [User doc](client-libraries-python.md) <br /><br />- [API doc](https://pulsar.apache.org/api/python/)|[Here](https://pulsar.apache.org/release-notes/)|[Here](https://github.com/apache/pulsar/tree/master/pulsar-client-cpp/python) 
+C++ | - [User doc](client-libraries-cpp.md) <br /><br />- [API doc](https://pulsar.apache.org/api/cpp/)|[Here](https://pulsar.apache.org/release-notes/)|[Here](https://github.com/apache/pulsar-client-cpp) 
+Python | - [User doc](client-libraries-python.md) <br /><br />- [API doc](https://pulsar.apache.org/api/python/)|[Here](https://pulsar.apache.org/release-notes/)|[Here](https://github.com/apache/pulsar-client-python) 
 WebSocket| [User doc](client-libraries-websocket.md) | [Here](https://pulsar.apache.org/release-notes/)|[Here](https://github.com/apache/pulsar/tree/master/pulsar-websocket) 
 Go client|[User doc](client-libraries-go.md)|[Here](https://github.com/apache/pulsar-client-go/blob/master/CHANGELOG) |[Here](https://github.com/apache/pulsar-client-go) 
 Node.js|[User doc](client-libraries-node.md)|[Here](https://github.com/apache/pulsar-client-node/releases) |[Here](https://github.com/apache/pulsar-client-node) 

--- a/site2/website/versioned_docs/version-2.3.1/client-libraries-python.md
+++ b/site2/website/versioned_docs/version-2.3.1/client-libraries-python.md
@@ -5,7 +5,7 @@ sidebar_label: "Python"
 original_id: client-libraries-python
 ---
 
-The Pulsar Python client library is a wrapper over the existing [C++ client library](client-libraries-cpp.md) and exposes all of the [same features](/api/cpp). You can find the code in the [`python` subdirectory](https://github.com/apache/pulsar/tree/master/pulsar-client-cpp/python) of the C++ client code.
+The Pulsar Python client library is a wrapper over the existing [C++ client library](client-libraries-cpp.md) and exposes all of the [same features](/api/cpp). You can find the code in the [`python` GitHub Repository](https://github.com/apache/pulsar-client-python) of the C++ client code.
 
 ## Installation
 

--- a/site2/website/versioned_docs/version-2.3.1/client-libraries.md
+++ b/site2/website/versioned_docs/version-2.3.1/client-libraries.md
@@ -9,8 +9,8 @@ Pulsar supports the following client libraries:
 |Language|Documentation|Release note|Code repo
 |---|---|---|---
 Java |- [User doc](client-libraries-java.md) <br /><br />- [API doc](https://pulsar.apache.org/api/client/)|[Here](https://pulsar.apache.org/release-notes/)|[Here](https://github.com/apache/pulsar/tree/master/pulsar-client) 
-C++ | - [User doc](client-libraries-cpp.md) <br /><br />- [API doc](https://pulsar.apache.org/api/cpp/)|[Here](https://pulsar.apache.org/release-notes/)|[Here](https://github.com/apache/pulsar/tree/master/pulsar-client-cpp) 
-Python | - [User doc](client-libraries-python.md) <br /><br />- [API doc](https://pulsar.apache.org/api/python/)|[Here](https://pulsar.apache.org/release-notes/)|[Here](https://github.com/apache/pulsar/tree/master/pulsar-client-cpp/python) 
+C++ | - [User doc](client-libraries-cpp.md) <br /><br />- [API doc](https://pulsar.apache.org/api/cpp/)|[Here](https://pulsar.apache.org/release-notes/)|[Here](https://github.com/apache/pulsar-client-cpp) 
+Python | - [User doc](client-libraries-python.md) <br /><br />- [API doc](https://pulsar.apache.org/api/python/)|[Here](https://pulsar.apache.org/release-notes/)|[Here](https://github.com/apache/pulsar-client-python) 
 WebSocket| [User doc](client-libraries-websocket.md) | [Here](https://pulsar.apache.org/release-notes/)|[Here](https://github.com/apache/pulsar/tree/master/pulsar-websocket) 
 Go client|[User doc](client-libraries-go.md)|[Here](https://github.com/apache/pulsar-client-go/blob/master/CHANGELOG) |[Here](https://github.com/apache/pulsar-client-go) 
 Node.js|[User doc](client-libraries-node.md)|[Here](https://github.com/apache/pulsar-client-node/releases) |[Here](https://github.com/apache/pulsar-client-node) 

--- a/site2/website/versioned_docs/version-2.3.2/client-libraries-cpp.md
+++ b/site2/website/versioned_docs/version-2.3.2/client-libraries-cpp.md
@@ -656,7 +656,7 @@ Client client("pulsar+ssl://my-broker.com:6651", config);
 
 ```
 
-For complete examples, refer to [C++ client examples](https://github.com/apache/pulsar/tree/master/pulsar-client-cpp/examples).
+For complete examples, refer to [C++ client examples](https://github.com/apache/pulsar-client-cpp/examples).
 
 ## Schema
 

--- a/site2/website/versioned_docs/version-2.3.2/client-libraries-cpp.md
+++ b/site2/website/versioned_docs/version-2.3.2/client-libraries-cpp.md
@@ -656,7 +656,7 @@ Client client("pulsar+ssl://my-broker.com:6651", config);
 
 ```
 
-For complete examples, refer to [C++ client examples](https://github.com/apache/pulsar-client-cpp/examples).
+For complete examples, refer to [C++ client examples](https://github.com/apache/pulsar-client-cpp/tree/main/examples).
 
 ## Schema
 

--- a/site2/website/versioned_docs/version-2.3.2/client-libraries-python.md
+++ b/site2/website/versioned_docs/version-2.3.2/client-libraries-python.md
@@ -10,7 +10,7 @@ import TabItem from '@theme/TabItem';
 ````
 
 
-Pulsar Python client library is a wrapper over the existing [C++ client library](client-libraries-cpp.md) and exposes all of the [same features](/api/cpp). You can find the code in the [Python directory](https://github.com/apache/pulsar/tree/master/pulsar-client-cpp/python) of the C++ client code.
+Pulsar Python client library is a wrapper over the existing [C++ client library](client-libraries-cpp.md) and exposes all of the [same features](/api/cpp). You can find the code in the [Python directory](https://github.com/apache/pulsar-client-python) of the C++ client code.
 
 All the methods in producer, consumer, and reader of a Python client are thread-safe.
 
@@ -18,7 +18,7 @@ All the methods in producer, consumer, and reader of a Python client are thread-
 
 ## Install
 
-You can install the [`pulsar-client`](https://pypi.python.org/pypi/pulsar-client) library either via [PyPi](https://pypi.python.org/pypi), using [pip](#installation-using-pip), or by building the library from [source](https://github.com/apache/pulsar/tree/master/pulsar-client-cpp).
+You can install the [`pulsar-client`](https://pypi.python.org/pypi/pulsar-client) library either via [PyPi](https://pypi.python.org/pypi), using [pip](#installation-using-pip), or by building the library from [source](https://github.com/apache/pulsar-client-cpp).
 
 ### Install using pip
 

--- a/site2/website/versioned_docs/version-2.4.0/client-libraries-cpp.md
+++ b/site2/website/versioned_docs/version-2.4.0/client-libraries-cpp.md
@@ -656,7 +656,7 @@ Client client("pulsar+ssl://my-broker.com:6651", config);
 
 ```
 
-For complete examples, refer to [C++ client examples](https://github.com/apache/pulsar/tree/master/pulsar-client-cpp/examples).
+For complete examples, refer to [C++ client examples](https://github.com/apache/pulsar-client-cpp/examples).
 
 ## Schema
 

--- a/site2/website/versioned_docs/version-2.4.0/client-libraries-cpp.md
+++ b/site2/website/versioned_docs/version-2.4.0/client-libraries-cpp.md
@@ -656,7 +656,7 @@ Client client("pulsar+ssl://my-broker.com:6651", config);
 
 ```
 
-For complete examples, refer to [C++ client examples](https://github.com/apache/pulsar-client-cpp/examples).
+For complete examples, refer to [C++ client examples](https://github.com/apache/pulsar-client-cpp/tree/main/examples).
 
 ## Schema
 

--- a/site2/website/versioned_docs/version-2.4.0/client-libraries-python.md
+++ b/site2/website/versioned_docs/version-2.4.0/client-libraries-python.md
@@ -5,7 +5,7 @@ sidebar_label: "Python"
 original_id: client-libraries-python
 ---
 
-The Pulsar Python client library is a wrapper over the existing [C++ client library](client-libraries-cpp.md) and exposes all of the [same features](/api/cpp). You can find the code in the [`python` subdirectory](https://github.com/apache/pulsar/tree/master/pulsar-client-cpp/python) of the C++ client code.
+The Pulsar Python client library is a wrapper over the existing [C++ client library](client-libraries-cpp.md) and exposes all of the [same features](/api/cpp). You can find the code in the [`python` GitHub Repository](https://github.com/apache/pulsar-client-python) of the C++ client code.
 
 ## Installation
 

--- a/site2/website/versioned_docs/version-2.4.0/client-libraries.md
+++ b/site2/website/versioned_docs/version-2.4.0/client-libraries.md
@@ -9,8 +9,8 @@ Pulsar supports the following client libraries:
 |Language|Documentation|Release note|Code repo
 |---|---|---|---
 Java |- [User doc](client-libraries-java.md) <br /><br />- [API doc](https://pulsar.apache.org/api/client/)|[Here](https://pulsar.apache.org/release-notes/)|[Here](https://github.com/apache/pulsar/tree/master/pulsar-client) 
-C++ | - [User doc](client-libraries-cpp.md) <br /><br />- [API doc](https://pulsar.apache.org/api/cpp/)|[Here](https://pulsar.apache.org/release-notes/)|[Here](https://github.com/apache/pulsar/tree/master/pulsar-client-cpp) 
-Python | - [User doc](client-libraries-python.md) <br /><br />- [API doc](https://pulsar.apache.org/api/python/)|[Here](https://pulsar.apache.org/release-notes/)|[Here](https://github.com/apache/pulsar/tree/master/pulsar-client-cpp/python) 
+C++ | - [User doc](client-libraries-cpp.md) <br /><br />- [API doc](https://pulsar.apache.org/api/cpp/)|[Here](https://pulsar.apache.org/release-notes/)|[Here](https://github.com/apache/pulsar-client-cpp) 
+Python | - [User doc](client-libraries-python.md) <br /><br />- [API doc](https://pulsar.apache.org/api/python/)|[Here](https://pulsar.apache.org/release-notes/)|[Here](https://github.com/apache/pulsar-client-python) 
 WebSocket| [User doc](client-libraries-websocket.md) | [Here](https://pulsar.apache.org/release-notes/)|[Here](https://github.com/apache/pulsar/tree/master/pulsar-websocket) 
 Go client|[User doc](client-libraries-go.md)|[Here](https://github.com/apache/pulsar-client-go/blob/master/CHANGELOG) |[Here](https://github.com/apache/pulsar-client-go) 
 Node.js|[User doc](client-libraries-node.md)|[Here](https://github.com/apache/pulsar-client-node/releases) |[Here](https://github.com/apache/pulsar-client-node) 

--- a/site2/website/versioned_docs/version-2.4.1/client-libraries-cpp.md
+++ b/site2/website/versioned_docs/version-2.4.1/client-libraries-cpp.md
@@ -656,7 +656,7 @@ Client client("pulsar+ssl://my-broker.com:6651", config);
 
 ```
 
-For complete examples, refer to [C++ client examples](https://github.com/apache/pulsar/tree/master/pulsar-client-cpp/examples).
+For complete examples, refer to [C++ client examples](https://github.com/apache/pulsar-client-cpp/examples).
 
 ## Schema
 

--- a/site2/website/versioned_docs/version-2.4.1/client-libraries-cpp.md
+++ b/site2/website/versioned_docs/version-2.4.1/client-libraries-cpp.md
@@ -656,7 +656,7 @@ Client client("pulsar+ssl://my-broker.com:6651", config);
 
 ```
 
-For complete examples, refer to [C++ client examples](https://github.com/apache/pulsar-client-cpp/examples).
+For complete examples, refer to [C++ client examples](https://github.com/apache/pulsar-client-cpp/tree/main/examples).
 
 ## Schema
 

--- a/site2/website/versioned_docs/version-2.4.1/client-libraries-python.md
+++ b/site2/website/versioned_docs/version-2.4.1/client-libraries-python.md
@@ -5,7 +5,7 @@ sidebar_label: "Python"
 original_id: client-libraries-python
 ---
 
-The Pulsar Python client library is a wrapper over the existing [C++ client library](client-libraries-cpp.md) and exposes all of the [same features](/api/cpp). You can find the code in the [`python` subdirectory](https://github.com/apache/pulsar/tree/master/pulsar-client-cpp/python) of the C++ client code.
+The Pulsar Python client library is a wrapper over the existing [C++ client library](client-libraries-cpp.md) and exposes all of the [same features](/api/cpp). You can find the code in the [`python` GitHub Repository](https://github.com/apache/pulsar-client-python) of the C++ client code.
 
 ## Installation
 

--- a/site2/website/versioned_docs/version-2.4.1/client-libraries.md
+++ b/site2/website/versioned_docs/version-2.4.1/client-libraries.md
@@ -9,8 +9,8 @@ Pulsar supports the following client libraries:
 |Language|Documentation|Release note|Code repo
 |---|---|---|---
 Java |- [User doc](client-libraries-java.md) <br /><br />- [API doc](https://pulsar.apache.org/api/client/)|[Here](https://pulsar.apache.org/release-notes/)|[Here](https://github.com/apache/pulsar/tree/master/pulsar-client) 
-C++ | - [User doc](client-libraries-cpp.md) <br /><br />- [API doc](https://pulsar.apache.org/api/cpp/)|[Here](https://pulsar.apache.org/release-notes/)|[Here](https://github.com/apache/pulsar/tree/master/pulsar-client-cpp) 
-Python | - [User doc](client-libraries-python.md) <br /><br />- [API doc](https://pulsar.apache.org/api/python/)|[Here](https://pulsar.apache.org/release-notes/)|[Here](https://github.com/apache/pulsar/tree/master/pulsar-client-cpp/python) 
+C++ | - [User doc](client-libraries-cpp.md) <br /><br />- [API doc](https://pulsar.apache.org/api/cpp/)|[Here](https://pulsar.apache.org/release-notes/)|[Here](https://github.com/apache/pulsar-client-cpp) 
+Python | - [User doc](client-libraries-python.md) <br /><br />- [API doc](https://pulsar.apache.org/api/python/)|[Here](https://pulsar.apache.org/release-notes/)|[Here](https://github.com/apache/pulsar-client-python) 
 WebSocket| [User doc](client-libraries-websocket.md) | [Here](https://pulsar.apache.org/release-notes/)|[Here](https://github.com/apache/pulsar/tree/master/pulsar-websocket) 
 Go client|[User doc](client-libraries-go.md)|[Here](https://github.com/apache/pulsar-client-go/blob/master/CHANGELOG) |[Here](https://github.com/apache/pulsar-client-go) 
 Node.js|[User doc](client-libraries-node.md)|[Here](https://github.com/apache/pulsar-client-node/releases) |[Here](https://github.com/apache/pulsar-client-node) 

--- a/site2/website/versioned_docs/version-2.4.2/client-libraries-cpp.md
+++ b/site2/website/versioned_docs/version-2.4.2/client-libraries-cpp.md
@@ -656,7 +656,7 @@ Client client("pulsar+ssl://my-broker.com:6651", config);
 
 ```
 
-For complete examples, refer to [C++ client examples](https://github.com/apache/pulsar/tree/master/pulsar-client-cpp/examples).
+For complete examples, refer to [C++ client examples](https://github.com/apache/pulsar-client-cpp/examples).
 
 ## Schema
 

--- a/site2/website/versioned_docs/version-2.4.2/client-libraries-cpp.md
+++ b/site2/website/versioned_docs/version-2.4.2/client-libraries-cpp.md
@@ -656,7 +656,7 @@ Client client("pulsar+ssl://my-broker.com:6651", config);
 
 ```
 
-For complete examples, refer to [C++ client examples](https://github.com/apache/pulsar-client-cpp/examples).
+For complete examples, refer to [C++ client examples](https://github.com/apache/pulsar-client-cpp/tree/main/examples).
 
 ## Schema
 

--- a/site2/website/versioned_docs/version-2.4.2/client-libraries-python.md
+++ b/site2/website/versioned_docs/version-2.4.2/client-libraries-python.md
@@ -5,7 +5,7 @@ sidebar_label: "Python"
 original_id: client-libraries-python
 ---
 
-The Pulsar Python client library is a wrapper over the existing [C++ client library](client-libraries-cpp.md) and exposes all of the [same features](/api/cpp). You can find the code in the [`python` subdirectory](https://github.com/apache/pulsar/tree/master/pulsar-client-cpp/python) of the C++ client code.
+The Pulsar Python client library is a wrapper over the existing [C++ client library](client-libraries-cpp.md) and exposes all of the [same features](/api/cpp). You can find the code in the [`python` GitHub Repository](https://github.com/apache/pulsar-client-python) of the C++ client code.
 
 ## Installation
 

--- a/site2/website/versioned_docs/version-2.4.2/client-libraries.md
+++ b/site2/website/versioned_docs/version-2.4.2/client-libraries.md
@@ -9,8 +9,8 @@ Pulsar supports the following client libraries:
 |Language|Documentation|Release note|Code repo
 |---|---|---|---
 Java |- [User doc](client-libraries-java.md) <br /><br />- [API doc](https://pulsar.apache.org/api/client/)|[Here](https://pulsar.apache.org/release-notes/)|[Here](https://github.com/apache/pulsar/tree/master/pulsar-client) 
-C++ | - [User doc](client-libraries-cpp.md) <br /><br />- [API doc](https://pulsar.apache.org/api/cpp/)|[Here](https://pulsar.apache.org/release-notes/)|[Here](https://github.com/apache/pulsar/tree/master/pulsar-client-cpp) 
-Python | - [User doc](client-libraries-python.md) <br /><br />- [API doc](https://pulsar.apache.org/api/python/)|[Here](https://pulsar.apache.org/release-notes/)|[Here](https://github.com/apache/pulsar/tree/master/pulsar-client-cpp/python) 
+C++ | - [User doc](client-libraries-cpp.md) <br /><br />- [API doc](https://pulsar.apache.org/api/cpp/)|[Here](https://pulsar.apache.org/release-notes/)|[Here](https://github.com/apache/pulsar-client-cpp) 
+Python | - [User doc](client-libraries-python.md) <br /><br />- [API doc](https://pulsar.apache.org/api/python/)|[Here](https://pulsar.apache.org/release-notes/)|[Here](https://github.com/apache/pulsar-client-python) 
 WebSocket| [User doc](client-libraries-websocket.md) | [Here](https://pulsar.apache.org/release-notes/)|[Here](https://github.com/apache/pulsar/tree/master/pulsar-websocket) 
 Go client|[User doc](client-libraries-go.md)|[Here](https://github.com/apache/pulsar-client-go/blob/master/CHANGELOG) |[Here](https://github.com/apache/pulsar-client-go) 
 Node.js|[User doc](client-libraries-node.md)|[Here](https://github.com/apache/pulsar-client-node/releases) |[Here](https://github.com/apache/pulsar-client-node) 

--- a/site2/website/versioned_docs/version-2.5.0/client-libraries-cpp.md
+++ b/site2/website/versioned_docs/version-2.5.0/client-libraries-cpp.md
@@ -203,7 +203,7 @@ Client client("pulsar+ssl://my-broker.com:6651", config);
 
 ```
 
-For complete examples, refer to [C++ client examples](https://github.com/apache/pulsar/tree/master/pulsar-client-cpp/examples).
+For complete examples, refer to [C++ client examples](https://github.com/apache/pulsar-client-cpp/examples).
 
 ## Schema
 

--- a/site2/website/versioned_docs/version-2.5.0/client-libraries-cpp.md
+++ b/site2/website/versioned_docs/version-2.5.0/client-libraries-cpp.md
@@ -203,7 +203,7 @@ Client client("pulsar+ssl://my-broker.com:6651", config);
 
 ```
 
-For complete examples, refer to [C++ client examples](https://github.com/apache/pulsar-client-cpp/examples).
+For complete examples, refer to [C++ client examples](https://github.com/apache/pulsar-client-cpp/tree/main/examples).
 
 ## Schema
 

--- a/site2/website/versioned_docs/version-2.5.0/client-libraries-python.md
+++ b/site2/website/versioned_docs/version-2.5.0/client-libraries-python.md
@@ -5,7 +5,7 @@ sidebar_label: "Python"
 original_id: client-libraries-python
 ---
 
-The Pulsar Python client library is a wrapper over the existing [C++ client library](client-libraries-cpp.md) and exposes all of the [same features](/api/cpp). You can find the code in the [`python` subdirectory](https://github.com/apache/pulsar/tree/master/pulsar-client-cpp/python) of the C++ client code.
+The Pulsar Python client library is a wrapper over the existing [C++ client library](client-libraries-cpp.md) and exposes all of the [same features](/api/cpp). You can find the code in the [`python` GitHub Repository](https://github.com/apache/pulsar-client-python) of the C++ client code.
 
 ## Installation
 

--- a/site2/website/versioned_docs/version-2.5.1/client-libraries-cpp.md
+++ b/site2/website/versioned_docs/version-2.5.1/client-libraries-cpp.md
@@ -257,7 +257,7 @@ Client client("pulsar+ssl://my-broker.com:6651", config);
 
 ```
 
-For complete examples, refer to [C++ client examples](https://github.com/apache/pulsar/tree/master/pulsar-client-cpp/examples).
+For complete examples, refer to [C++ client examples](https://github.com/apache/pulsar-client-cpp/examples).
 
 ## Schema
 

--- a/site2/website/versioned_docs/version-2.5.1/client-libraries-cpp.md
+++ b/site2/website/versioned_docs/version-2.5.1/client-libraries-cpp.md
@@ -257,7 +257,7 @@ Client client("pulsar+ssl://my-broker.com:6651", config);
 
 ```
 
-For complete examples, refer to [C++ client examples](https://github.com/apache/pulsar-client-cpp/examples).
+For complete examples, refer to [C++ client examples](https://github.com/apache/pulsar-client-cpp/tree/main/examples).
 
 ## Schema
 

--- a/site2/website/versioned_docs/version-2.5.1/client-libraries-python.md
+++ b/site2/website/versioned_docs/version-2.5.1/client-libraries-python.md
@@ -5,7 +5,7 @@ sidebar_label: "Python"
 original_id: client-libraries-python
 ---
 
-Pulsar Python client library is a wrapper over the existing [C++ client library](client-libraries-cpp.md) and exposes all of the [same features](/api/cpp). You can find the code in the [`python` subdirectory](https://github.com/apache/pulsar/tree/master/pulsar-client-cpp/python) of the C++ client code.
+Pulsar Python client library is a wrapper over the existing [C++ client library](client-libraries-cpp.md) and exposes all of the [same features](/api/cpp). You can find the code in the [`python` GitHub Repository](https://github.com/apache/pulsar-client-python) of the C++ client code.
 
 All the methods in producer, consumer, and reader of a Python client are thread-safe.
 

--- a/site2/website/versioned_docs/version-2.5.2/client-libraries-cpp.md
+++ b/site2/website/versioned_docs/version-2.5.2/client-libraries-cpp.md
@@ -257,7 +257,7 @@ Client client("pulsar+ssl://my-broker.com:6651", config);
 
 ```
 
-For complete examples, refer to [C++ client examples](https://github.com/apache/pulsar/tree/master/pulsar-client-cpp/examples).
+For complete examples, refer to [C++ client examples](https://github.com/apache/pulsar-client-cpp/examples).
 
 ## Schema
 

--- a/site2/website/versioned_docs/version-2.5.2/client-libraries-cpp.md
+++ b/site2/website/versioned_docs/version-2.5.2/client-libraries-cpp.md
@@ -257,7 +257,7 @@ Client client("pulsar+ssl://my-broker.com:6651", config);
 
 ```
 
-For complete examples, refer to [C++ client examples](https://github.com/apache/pulsar-client-cpp/examples).
+For complete examples, refer to [C++ client examples](https://github.com/apache/pulsar-client-cpp/tree/main/examples).
 
 ## Schema
 

--- a/site2/website/versioned_docs/version-2.5.2/client-libraries-python.md
+++ b/site2/website/versioned_docs/version-2.5.2/client-libraries-python.md
@@ -5,7 +5,7 @@ sidebar_label: "Python"
 original_id: client-libraries-python
 ---
 
-Pulsar Python client library is a wrapper over the existing [C++ client library](client-libraries-cpp.md) and exposes all of the [same features](/api/cpp). You can find the code in the [`python` subdirectory](https://github.com/apache/pulsar/tree/master/pulsar-client-cpp/python) of the C++ client code.
+Pulsar Python client library is a wrapper over the existing [C++ client library](client-libraries-cpp.md) and exposes all of the [same features](/api/cpp). You can find the code in the [`python` GitHub Repository](https://github.com/apache/pulsar-client-python) of the C++ client code.
 
 All the methods in producer, consumer, and reader of a Python client are thread-safe.
 

--- a/site2/website/versioned_docs/version-2.6.0/client-libraries-cpp.md
+++ b/site2/website/versioned_docs/version-2.6.0/client-libraries-cpp.md
@@ -257,7 +257,7 @@ Client client("pulsar+ssl://my-broker.com:6651", config);
 
 ```
 
-For complete examples, refer to [C++ client examples](https://github.com/apache/pulsar/tree/master/pulsar-client-cpp/examples).
+For complete examples, refer to [C++ client examples](https://github.com/apache/pulsar-client-cpp/examples).
 
 ## Schema
 

--- a/site2/website/versioned_docs/version-2.6.0/client-libraries-cpp.md
+++ b/site2/website/versioned_docs/version-2.6.0/client-libraries-cpp.md
@@ -257,7 +257,7 @@ Client client("pulsar+ssl://my-broker.com:6651", config);
 
 ```
 
-For complete examples, refer to [C++ client examples](https://github.com/apache/pulsar-client-cpp/examples).
+For complete examples, refer to [C++ client examples](https://github.com/apache/pulsar-client-cpp/tree/main/examples).
 
 ## Schema
 

--- a/site2/website/versioned_docs/version-2.6.0/client-libraries-python.md
+++ b/site2/website/versioned_docs/version-2.6.0/client-libraries-python.md
@@ -5,7 +5,7 @@ sidebar_label: "Python"
 original_id: client-libraries-python
 ---
 
-Pulsar Python client library is a wrapper over the existing [C++ client library](client-libraries-cpp.md) and exposes all of the [same features](/api/cpp). You can find the code in the [`python` subdirectory](https://github.com/apache/pulsar/tree/master/pulsar-client-cpp/python) of the C++ client code.
+Pulsar Python client library is a wrapper over the existing [C++ client library](client-libraries-cpp.md) and exposes all of the [same features](/api/cpp). You can find the code in the [`python` GitHub Repository](https://github.com/apache/pulsar-client-python) of the C++ client code.
 
 All the methods in producer, consumer, and reader of a Python client are thread-safe.
 

--- a/site2/website/versioned_docs/version-2.6.1/client-libraries-cpp.md
+++ b/site2/website/versioned_docs/version-2.6.1/client-libraries-cpp.md
@@ -257,7 +257,7 @@ Client client("pulsar+ssl://my-broker.com:6651", config);
 
 ```
 
-For complete examples, refer to [C++ client examples](https://github.com/apache/pulsar/tree/master/pulsar-client-cpp/examples).
+For complete examples, refer to [C++ client examples](https://github.com/apache/pulsar-client-cpp/examples).
 
 ## Schema
 

--- a/site2/website/versioned_docs/version-2.6.1/client-libraries-cpp.md
+++ b/site2/website/versioned_docs/version-2.6.1/client-libraries-cpp.md
@@ -257,7 +257,7 @@ Client client("pulsar+ssl://my-broker.com:6651", config);
 
 ```
 
-For complete examples, refer to [C++ client examples](https://github.com/apache/pulsar-client-cpp/examples).
+For complete examples, refer to [C++ client examples](https://github.com/apache/pulsar-client-cpp/tree/main/examples).
 
 ## Schema
 

--- a/site2/website/versioned_docs/version-2.6.1/client-libraries-python.md
+++ b/site2/website/versioned_docs/version-2.6.1/client-libraries-python.md
@@ -5,7 +5,7 @@ sidebar_label: "Python"
 original_id: client-libraries-python
 ---
 
-Pulsar Python client library is a wrapper over the existing [C++ client library](client-libraries-cpp.md) and exposes all of the [same features](/api/cpp). You can find the code in the [`python` subdirectory](https://github.com/apache/pulsar/tree/master/pulsar-client-cpp/python) of the C++ client code.
+Pulsar Python client library is a wrapper over the existing [C++ client library](client-libraries-cpp.md) and exposes all of the [same features](/api/cpp). You can find the code in the [`python` GitHub Repository](https://github.com/apache/pulsar-client-python) of the C++ client code.
 
 All the methods in producer, consumer, and reader of a Python client are thread-safe.
 

--- a/site2/website/versioned_docs/version-2.6.2/client-libraries-cpp.md
+++ b/site2/website/versioned_docs/version-2.6.2/client-libraries-cpp.md
@@ -257,7 +257,7 @@ Client client("pulsar+ssl://my-broker.com:6651", config);
 
 ```
 
-For complete examples, refer to [C++ client examples](https://github.com/apache/pulsar/tree/master/pulsar-client-cpp/examples).
+For complete examples, refer to [C++ client examples](https://github.com/apache/pulsar-client-cpp/examples).
 
 ## Schema
 

--- a/site2/website/versioned_docs/version-2.6.2/client-libraries-cpp.md
+++ b/site2/website/versioned_docs/version-2.6.2/client-libraries-cpp.md
@@ -257,7 +257,7 @@ Client client("pulsar+ssl://my-broker.com:6651", config);
 
 ```
 
-For complete examples, refer to [C++ client examples](https://github.com/apache/pulsar-client-cpp/examples).
+For complete examples, refer to [C++ client examples](https://github.com/apache/pulsar-client-cpp/tree/main/examples).
 
 ## Schema
 

--- a/site2/website/versioned_docs/version-2.6.2/client-libraries-python.md
+++ b/site2/website/versioned_docs/version-2.6.2/client-libraries-python.md
@@ -5,7 +5,7 @@ sidebar_label: "Python"
 original_id: client-libraries-python
 ---
 
-Pulsar Python client library is a wrapper over the existing [C++ client library](client-libraries-cpp.md) and exposes all of the [same features](/api/cpp). You can find the code in the [`python` subdirectory](https://github.com/apache/pulsar/tree/master/pulsar-client-cpp/python) of the C++ client code.
+Pulsar Python client library is a wrapper over the existing [C++ client library](client-libraries-cpp.md) and exposes all of the [same features](/api/cpp). You can find the code in the [`python` GitHub Repository](https://github.com/apache/pulsar-client-python) of the C++ client code.
 
 All the methods in producer, consumer, and reader of a Python client are thread-safe.
 

--- a/site2/website/versioned_docs/version-2.6.3/client-libraries-cpp.md
+++ b/site2/website/versioned_docs/version-2.6.3/client-libraries-cpp.md
@@ -257,7 +257,7 @@ Client client("pulsar+ssl://my-broker.com:6651", config);
 
 ```
 
-For complete examples, refer to [C++ client examples](https://github.com/apache/pulsar/tree/master/pulsar-client-cpp/examples).
+For complete examples, refer to [C++ client examples](https://github.com/apache/pulsar-client-cpp/examples).
 
 ## Schema
 

--- a/site2/website/versioned_docs/version-2.6.3/client-libraries-cpp.md
+++ b/site2/website/versioned_docs/version-2.6.3/client-libraries-cpp.md
@@ -257,7 +257,7 @@ Client client("pulsar+ssl://my-broker.com:6651", config);
 
 ```
 
-For complete examples, refer to [C++ client examples](https://github.com/apache/pulsar-client-cpp/examples).
+For complete examples, refer to [C++ client examples](https://github.com/apache/pulsar-client-cpp/tree/main/examples).
 
 ## Schema
 

--- a/site2/website/versioned_docs/version-2.6.3/client-libraries-python.md
+++ b/site2/website/versioned_docs/version-2.6.3/client-libraries-python.md
@@ -5,7 +5,7 @@ sidebar_label: "Python"
 original_id: client-libraries-python
 ---
 
-Pulsar Python client library is a wrapper over the existing [C++ client library](client-libraries-cpp.md) and exposes all of the [same features](/api/cpp). You can find the code in the [`python` subdirectory](https://github.com/apache/pulsar/tree/master/pulsar-client-cpp/python) of the C++ client code.
+Pulsar Python client library is a wrapper over the existing [C++ client library](client-libraries-cpp.md) and exposes all of the [same features](/api/cpp). You can find the code in the [`python` GitHub Repository](https://github.com/apache/pulsar-client-python) of the C++ client code.
 
 All the methods in producer, consumer, and reader of a Python client are thread-safe.
 

--- a/site2/website/versioned_docs/version-2.6.4/client-libraries-cpp.md
+++ b/site2/website/versioned_docs/version-2.6.4/client-libraries-cpp.md
@@ -257,7 +257,7 @@ Client client("pulsar+ssl://my-broker.com:6651", config);
 
 ```
 
-For complete examples, refer to [C++ client examples](https://github.com/apache/pulsar/tree/master/pulsar-client-cpp/examples).
+For complete examples, refer to [C++ client examples](https://github.com/apache/pulsar-client-cpp/examples).
 
 ## Schema
 

--- a/site2/website/versioned_docs/version-2.6.4/client-libraries-cpp.md
+++ b/site2/website/versioned_docs/version-2.6.4/client-libraries-cpp.md
@@ -257,7 +257,7 @@ Client client("pulsar+ssl://my-broker.com:6651", config);
 
 ```
 
-For complete examples, refer to [C++ client examples](https://github.com/apache/pulsar-client-cpp/examples).
+For complete examples, refer to [C++ client examples](https://github.com/apache/pulsar-client-cpp/tree/main/examples).
 
 ## Schema
 

--- a/site2/website/versioned_docs/version-2.6.4/client-libraries-python.md
+++ b/site2/website/versioned_docs/version-2.6.4/client-libraries-python.md
@@ -5,7 +5,7 @@ sidebar_label: "Python"
 original_id: client-libraries-python
 ---
 
-Pulsar Python client library is a wrapper over the existing [C++ client library](client-libraries-cpp.md) and exposes all of the [same features](/api/cpp). You can find the code in the [`python` subdirectory](https://github.com/apache/pulsar/tree/master/pulsar-client-cpp/python) of the C++ client code.
+Pulsar Python client library is a wrapper over the existing [C++ client library](client-libraries-cpp.md) and exposes all of the [same features](/api/cpp). You can find the code in the [`python` GitHub Repository](https://github.com/apache/pulsar-client-python) of the C++ client code.
 
 All the methods in producer, consumer, and reader of a Python client are thread-safe.
 

--- a/site2/website/versioned_docs/version-2.7.0/client-libraries-cpp.md
+++ b/site2/website/versioned_docs/version-2.7.0/client-libraries-cpp.md
@@ -257,7 +257,7 @@ Client client("pulsar+ssl://my-broker.com:6651", config);
 
 ```
 
-For complete examples, refer to [C++ client examples](https://github.com/apache/pulsar/tree/master/pulsar-client-cpp/examples).
+For complete examples, refer to [C++ client examples](https://github.com/apache/pulsar-client-cpp/examples).
 
 ## Schema
 

--- a/site2/website/versioned_docs/version-2.7.0/client-libraries-cpp.md
+++ b/site2/website/versioned_docs/version-2.7.0/client-libraries-cpp.md
@@ -257,7 +257,7 @@ Client client("pulsar+ssl://my-broker.com:6651", config);
 
 ```
 
-For complete examples, refer to [C++ client examples](https://github.com/apache/pulsar-client-cpp/examples).
+For complete examples, refer to [C++ client examples](https://github.com/apache/pulsar-client-cpp/tree/main/examples).
 
 ## Schema
 

--- a/site2/website/versioned_docs/version-2.7.0/client-libraries-python.md
+++ b/site2/website/versioned_docs/version-2.7.0/client-libraries-python.md
@@ -5,7 +5,7 @@ sidebar_label: "Python"
 original_id: client-libraries-python
 ---
 
-Pulsar Python client library is a wrapper over the existing [C++ client library](client-libraries-cpp.md) and exposes all of the [same features](/api/cpp). You can find the code in the [`python` subdirectory](https://github.com/apache/pulsar/tree/master/pulsar-client-cpp/python) of the C++ client code.
+Pulsar Python client library is a wrapper over the existing [C++ client library](client-libraries-cpp.md) and exposes all of the [same features](/api/cpp). You can find the code in the [`python` GitHub Repository](https://github.com/apache/pulsar-client-python) of the C++ client code.
 
 All the methods in producer, consumer, and reader of a Python client are thread-safe.
 

--- a/site2/website/versioned_docs/version-2.7.1/client-libraries-cpp.md
+++ b/site2/website/versioned_docs/version-2.7.1/client-libraries-cpp.md
@@ -257,7 +257,7 @@ Client client("pulsar+ssl://my-broker.com:6651", config);
 
 ```
 
-For complete examples, refer to [C++ client examples](https://github.com/apache/pulsar/tree/master/pulsar-client-cpp/examples).
+For complete examples, refer to [C++ client examples](https://github.com/apache/pulsar-client-cpp/examples).
 
 ## Schema
 

--- a/site2/website/versioned_docs/version-2.7.1/client-libraries-cpp.md
+++ b/site2/website/versioned_docs/version-2.7.1/client-libraries-cpp.md
@@ -257,7 +257,7 @@ Client client("pulsar+ssl://my-broker.com:6651", config);
 
 ```
 
-For complete examples, refer to [C++ client examples](https://github.com/apache/pulsar-client-cpp/examples).
+For complete examples, refer to [C++ client examples](https://github.com/apache/pulsar-client-cpp/tree/main/examples).
 
 ## Schema
 

--- a/site2/website/versioned_docs/version-2.7.1/client-libraries-python.md
+++ b/site2/website/versioned_docs/version-2.7.1/client-libraries-python.md
@@ -5,7 +5,7 @@ sidebar_label: "Python"
 original_id: client-libraries-python
 ---
 
-Pulsar Python client library is a wrapper over the existing [C++ client library](client-libraries-cpp.md) and exposes all of the [same features](/api/cpp). You can find the code in the [`python` subdirectory](https://github.com/apache/pulsar/tree/master/pulsar-client-cpp/python) of the C++ client code.
+Pulsar Python client library is a wrapper over the existing [C++ client library](client-libraries-cpp.md) and exposes all of the [same features](/api/cpp). You can find the code in the [`python` GitHub Repository](https://github.com/apache/pulsar-client-python) of the C++ client code.
 
 All the methods in producer, consumer, and reader of a Python client are thread-safe.
 

--- a/site2/website/versioned_docs/version-2.7.2/client-libraries-cpp.md
+++ b/site2/website/versioned_docs/version-2.7.2/client-libraries-cpp.md
@@ -257,7 +257,7 @@ Client client("pulsar+ssl://my-broker.com:6651", config);
 
 ```
 
-For complete examples, refer to [C++ client examples](https://github.com/apache/pulsar/tree/master/pulsar-client-cpp/examples).
+For complete examples, refer to [C++ client examples](https://github.com/apache/pulsar-client-cpp/examples).
 
 ## Schema
 

--- a/site2/website/versioned_docs/version-2.7.2/client-libraries-cpp.md
+++ b/site2/website/versioned_docs/version-2.7.2/client-libraries-cpp.md
@@ -257,7 +257,7 @@ Client client("pulsar+ssl://my-broker.com:6651", config);
 
 ```
 
-For complete examples, refer to [C++ client examples](https://github.com/apache/pulsar-client-cpp/examples).
+For complete examples, refer to [C++ client examples](https://github.com/apache/pulsar-client-cpp/tree/main/examples).
 
 ## Schema
 

--- a/site2/website/versioned_docs/version-2.7.2/client-libraries-python.md
+++ b/site2/website/versioned_docs/version-2.7.2/client-libraries-python.md
@@ -5,7 +5,7 @@ sidebar_label: "Python"
 original_id: client-libraries-python
 ---
 
-Pulsar Python client library is a wrapper over the existing [C++ client library](client-libraries-cpp.md) and exposes all of the [same features](/api/cpp). You can find the code in the [`python` subdirectory](https://github.com/apache/pulsar/tree/master/pulsar-client-cpp/python) of the C++ client code.
+Pulsar Python client library is a wrapper over the existing [C++ client library](client-libraries-cpp.md) and exposes all of the [same features](/api/cpp). You can find the code in the [`python` GitHub Repository](https://github.com/apache/pulsar-client-python) of the C++ client code.
 
 All the methods in producer, consumer, and reader of a Python client are thread-safe.
 

--- a/site2/website/versioned_docs/version-2.7.3/client-libraries-cpp.md
+++ b/site2/website/versioned_docs/version-2.7.3/client-libraries-cpp.md
@@ -257,7 +257,7 @@ Client client("pulsar+ssl://my-broker.com:6651", config);
 
 ```
 
-For complete examples, refer to [C++ client examples](https://github.com/apache/pulsar/tree/master/pulsar-client-cpp/examples).
+For complete examples, refer to [C++ client examples](https://github.com/apache/pulsar-client-cpp/examples).
 
 ## Schema
 

--- a/site2/website/versioned_docs/version-2.7.3/client-libraries-cpp.md
+++ b/site2/website/versioned_docs/version-2.7.3/client-libraries-cpp.md
@@ -257,7 +257,7 @@ Client client("pulsar+ssl://my-broker.com:6651", config);
 
 ```
 
-For complete examples, refer to [C++ client examples](https://github.com/apache/pulsar-client-cpp/examples).
+For complete examples, refer to [C++ client examples](https://github.com/apache/pulsar-client-cpp/tree/main/examples).
 
 ## Schema
 

--- a/site2/website/versioned_docs/version-2.7.3/client-libraries-python.md
+++ b/site2/website/versioned_docs/version-2.7.3/client-libraries-python.md
@@ -5,7 +5,7 @@ sidebar_label: "Python"
 original_id: client-libraries-python
 ---
 
-Pulsar Python client library is a wrapper over the existing [C++ client library](client-libraries-cpp.md) and exposes all of the [same features](/api/cpp). You can find the code in the [`python` subdirectory](https://github.com/apache/pulsar/tree/master/pulsar-client-cpp/python) of the C++ client code.
+Pulsar Python client library is a wrapper over the existing [C++ client library](client-libraries-cpp.md) and exposes all of the [same features](/api/cpp). You can find the code in the [`python` GitHub Repository](https://github.com/apache/pulsar-client-python) of the C++ client code.
 
 All the methods in producer, consumer, and reader of a Python client are thread-safe.
 

--- a/site2/website/versioned_docs/version-2.7.4/client-libraries-cpp.md
+++ b/site2/website/versioned_docs/version-2.7.4/client-libraries-cpp.md
@@ -257,7 +257,7 @@ Client client("pulsar+ssl://my-broker.com:6651", config);
 
 ```
 
-For complete examples, refer to [C++ client examples](https://github.com/apache/pulsar/tree/master/pulsar-client-cpp/examples).
+For complete examples, refer to [C++ client examples](https://github.com/apache/pulsar-client-cpp/examples).
 
 ## Schema
 

--- a/site2/website/versioned_docs/version-2.7.4/client-libraries-cpp.md
+++ b/site2/website/versioned_docs/version-2.7.4/client-libraries-cpp.md
@@ -257,7 +257,7 @@ Client client("pulsar+ssl://my-broker.com:6651", config);
 
 ```
 
-For complete examples, refer to [C++ client examples](https://github.com/apache/pulsar-client-cpp/examples).
+For complete examples, refer to [C++ client examples](https://github.com/apache/pulsar-client-cpp/tree/main/examples).
 
 ## Schema
 

--- a/site2/website/versioned_docs/version-2.7.4/client-libraries-python.md
+++ b/site2/website/versioned_docs/version-2.7.4/client-libraries-python.md
@@ -5,7 +5,7 @@ sidebar_label: "Python"
 original_id: client-libraries-python
 ---
 
-Pulsar Python client library is a wrapper over the existing [C++ client library](client-libraries-cpp.md) and exposes all of the [same features](/api/cpp). You can find the code in the [`python` subdirectory](https://github.com/apache/pulsar/tree/master/pulsar-client-cpp/python) of the C++ client code.
+Pulsar Python client library is a wrapper over the existing [C++ client library](client-libraries-cpp.md) and exposes all of the [same features](/api/cpp). You can find the code in the [`python` GitHub Repository](https://github.com/apache/pulsar-client-python) of the C++ client code.
 
 All the methods in producer, consumer, and reader of a Python client are thread-safe.
 

--- a/site2/website/versioned_docs/version-2.7.5/client-libraries-cpp.md
+++ b/site2/website/versioned_docs/version-2.7.5/client-libraries-cpp.md
@@ -257,7 +257,7 @@ Client client("pulsar+ssl://my-broker.com:6651", config);
 
 ```
 
-For complete examples, refer to [C++ client examples](https://github.com/apache/pulsar/tree/master/pulsar-client-cpp/examples).
+For complete examples, refer to [C++ client examples](https://github.com/apache/pulsar-client-cpp/examples).
 
 ## Schema
 

--- a/site2/website/versioned_docs/version-2.7.5/client-libraries-cpp.md
+++ b/site2/website/versioned_docs/version-2.7.5/client-libraries-cpp.md
@@ -257,7 +257,7 @@ Client client("pulsar+ssl://my-broker.com:6651", config);
 
 ```
 
-For complete examples, refer to [C++ client examples](https://github.com/apache/pulsar-client-cpp/examples).
+For complete examples, refer to [C++ client examples](https://github.com/apache/pulsar-client-cpp/tree/main/examples).
 
 ## Schema
 

--- a/site2/website/versioned_docs/version-2.7.5/client-libraries-python.md
+++ b/site2/website/versioned_docs/version-2.7.5/client-libraries-python.md
@@ -5,7 +5,7 @@ sidebar_label: "Python"
 original_id: client-libraries-python
 ---
 
-Pulsar Python client library is a wrapper over the existing [C++ client library](client-libraries-cpp.md) and exposes all of the [same features](/api/cpp). You can find the code in the [`python` subdirectory](https://github.com/apache/pulsar/tree/master/pulsar-client-cpp/python) of the C++ client code.
+Pulsar Python client library is a wrapper over the existing [C++ client library](client-libraries-cpp.md) and exposes all of the [same features](/api/cpp). You can find the code in the [`python` GitHub Repository](https://github.com/apache/pulsar-client-python) of the C++ client code.
 
 All the methods in producer, consumer, and reader of a Python client are thread-safe.
 

--- a/site2/website/versioned_docs/version-2.8.x/client-libraries-cpp.md
+++ b/site2/website/versioned_docs/version-2.8.x/client-libraries-cpp.md
@@ -365,7 +365,7 @@ Client client("pulsar+ssl://my-broker.com:6651", config);
 
 ```
 
-For complete examples, refer to [C++ client examples](https://github.com/apache/pulsar/tree/master/pulsar-client-cpp/examples).
+For complete examples, refer to [C++ client examples](https://github.com/apache/pulsar-client-cpp/examples).
 
 ## Schema
 

--- a/site2/website/versioned_docs/version-2.8.x/client-libraries-cpp.md
+++ b/site2/website/versioned_docs/version-2.8.x/client-libraries-cpp.md
@@ -365,7 +365,7 @@ Client client("pulsar+ssl://my-broker.com:6651", config);
 
 ```
 
-For complete examples, refer to [C++ client examples](https://github.com/apache/pulsar-client-cpp/examples).
+For complete examples, refer to [C++ client examples](https://github.com/apache/pulsar-client-cpp/tree/main/examples).
 
 ## Schema
 

--- a/site2/website/versioned_docs/version-2.8.x/client-libraries-python.md
+++ b/site2/website/versioned_docs/version-2.8.x/client-libraries-python.md
@@ -5,7 +5,7 @@ sidebar_label: "Python"
 original_id: client-libraries-python
 ---
 
-Pulsar Python client library is a wrapper over the existing [C++ client library](client-libraries-cpp.md) and exposes all of the [same features](/api/cpp). You can find the code in the [`python` subdirectory](https://github.com/apache/pulsar/tree/master/pulsar-client-cpp/python) of the C++ client code.
+Pulsar Python client library is a wrapper over the existing [C++ client library](client-libraries-cpp.md) and exposes all of the [same features](/api/cpp). You can find the code in the [`python` GitHub Repository](https://github.com/apache/pulsar-client-python) of the C++ client code.
 
 All the methods in producer, consumer, and reader of a Python client are thread-safe.
 

--- a/site2/website/versioned_docs/version-2.9.x/client-libraries-cpp.md
+++ b/site2/website/versioned_docs/version-2.9.x/client-libraries-cpp.md
@@ -597,7 +597,7 @@ Client client("pulsar+ssl://my-broker.com:6651", config);
 
 ```
 
-For complete examples, refer to [C++ client examples](https://github.com/apache/pulsar-client-cpp/examples).
+For complete examples, refer to [C++ client examples](https://github.com/apache/pulsar-client-cpp/tree/main/examples).
 
 ## Schema
 

--- a/site2/website/versioned_docs/version-2.9.x/client-libraries-cpp.md
+++ b/site2/website/versioned_docs/version-2.9.x/client-libraries-cpp.md
@@ -597,7 +597,7 @@ Client client("pulsar+ssl://my-broker.com:6651", config);
 
 ```
 
-For complete examples, refer to [C++ client examples](https://github.com/apache/pulsar/tree/master/pulsar-client-cpp/examples).
+For complete examples, refer to [C++ client examples](https://github.com/apache/pulsar-client-cpp/examples).
 
 ## Schema
 

--- a/site2/website/versioned_docs/version-2.9.x/client-libraries-python.md
+++ b/site2/website/versioned_docs/version-2.9.x/client-libraries-python.md
@@ -5,7 +5,7 @@ sidebar_label: "Python"
 original_id: client-libraries-python
 ---
 
-Pulsar Python client library is a wrapper over the existing [C++ client library](client-libraries-cpp.md) and exposes all of the [same features](/api/cpp). You can find the code in the [Python directory](https://github.com/apache/pulsar/tree/master/pulsar-client-cpp/python) of the C++ client code.
+Pulsar Python client library is a wrapper over the existing [C++ client library](client-libraries-cpp.md) and exposes all of the [same features](/api/cpp). You can find the code in the [Python directory](https://github.com/apache/pulsar-client-python) of the C++ client code.
 
 All the methods in producer, consumer, and reader of a Python client are thread-safe.
 
@@ -13,7 +13,7 @@ All the methods in producer, consumer, and reader of a Python client are thread-
 
 ## Install
 
-You can install the [`pulsar-client`](https://pypi.python.org/pypi/pulsar-client) library either via [PyPi](https://pypi.python.org/pypi), using [pip](#installation-using-pip), or by building the library from [source](https://github.com/apache/pulsar/tree/master/pulsar-client-cpp).
+You can install the [`pulsar-client`](https://pypi.python.org/pypi/pulsar-client) library either via [PyPi](https://pypi.python.org/pypi), using [pip](#installation-using-pip), or by building the library from [source](https://github.com/apache/pulsar-client-cpp).
 
 ### Install using pip
 


### PR DESCRIPTION
### Motivation

With the recent PIP to move the Python and C++ clients to their own GitHub repo, we need to update the documentation.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [x] `doc`