### PR TITLE
[fix][test] Fix flaky test `testDoNotGetOffloadPoliciesMultipleTimesWhenTrimLedgers`

### DIFF
--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerTest.java
@@ -3620,7 +3620,7 @@ public class ManagedLedgerTest extends MockedBookKeeperTestCase {
         ledger.close();
     }
 
-    @Test(invocationCount = 300)
+    @Test
     public void testDoNotGetOffloadPoliciesMultipleTimesWhenTrimLedgers() throws Exception {
         ManagedLedgerConfig config = new ManagedLedgerConfig();
         config.setMaxEntriesPerLedger(1);

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerTest.java
@@ -3626,6 +3626,8 @@ public class ManagedLedgerTest extends MockedBookKeeperTestCase {
         LedgerOffloader ledgerOffloader = mock(NullLedgerOffloader.class);
         OffloadPoliciesImpl offloadPolicies = mock(OffloadPoliciesImpl.class);
         when(ledgerOffloader.getOffloadPolicies()).thenReturn(offloadPolicies);
+        when(ledgerOffloader.offload(any(), any(), any())).thenReturn(CompletableFuture.completedFuture(null));
+        when(ledgerOffloader.getOffloadPolicies().getManagedLedgerOffloadThresholdInBytes()).thenReturn(-1L);
         when(ledgerOffloader.getOffloadDriverName()).thenReturn("s3");
         config.setLedgerOffloader(ledgerOffloader);
         ManagedLedgerImpl ledger = (ManagedLedgerImpl)factory.open(
@@ -3645,7 +3647,10 @@ public class ManagedLedgerTest extends MockedBookKeeperTestCase {
         config.setLedgerOffloader(ledgerOffloader);
 
         ledger.internalTrimConsumedLedgers(Futures.NULL_PROMISE);
-        verify(ledgerOffloader, times(1)).getOffloadPolicies();
+        final LedgerOffloader finalLedgerOffloader = ledgerOffloader;
+        Awaitility.await().untilAsserted(() -> {
+            verify(finalLedgerOffloader, times(1)).getOffloadPolicies();
+        });
     }
 
     @Test(timeOut = 30000)

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerTest.java
@@ -31,7 +31,6 @@ import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
@@ -3651,6 +3650,7 @@ public class ManagedLedgerTest extends MockedBookKeeperTestCase {
         final LedgerOffloader finalLedgerOffloader = ledgerOffloader;
         Awaitility.await().untilAsserted(() -> {
             verify(finalLedgerOffloader, atLeastOnce()).getOffloadPolicies();
+            // When the ledger close, it will call `trimConsumedLedgersInBackground` async
             verify(finalLedgerOffloader, atMost(2)).getOffloadPolicies();
         });
     }

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerTest.java
@@ -3627,6 +3627,7 @@ public class ManagedLedgerTest extends MockedBookKeeperTestCase {
         OffloadPoliciesImpl offloadPolicies = mock(OffloadPoliciesImpl.class);
         when(ledgerOffloader.getOffloadPolicies()).thenReturn(offloadPolicies);
         when(ledgerOffloader.getOffloadPolicies().getManagedLedgerOffloadThresholdInBytes()).thenReturn(-1L);
+        when(ledgerOffloader.getOffloadPolicies().getManagedLedgerOffloadThresholdInSeconds()).thenReturn(-1L);
         when(ledgerOffloader.getOffloadDriverName()).thenReturn("s3");
         config.setLedgerOffloader(ledgerOffloader);
         ManagedLedgerImpl ledger = spy((ManagedLedgerImpl)factory.open(
@@ -3647,10 +3648,7 @@ public class ManagedLedgerTest extends MockedBookKeeperTestCase {
         config.setLedgerOffloader(ledgerOffloader);
 
         ledger.internalTrimConsumedLedgers(Futures.NULL_PROMISE);
-        final LedgerOffloader finalLedgerOffloader = ledgerOffloader;
-        Awaitility.await().untilAsserted(() -> {
-            verify(finalLedgerOffloader, times(1)).getOffloadPolicies();
-        });
+        verify(ledgerOffloader, times(1)).getOffloadPolicies();
     }
 
     @Test(timeOut = 30000)


### PR DESCRIPTION
### Motivation

Based on #https://github.com/apache/pulsar/pull/18146

https://github.com/apache/pulsar/actions/runs/3281165538/jobs/5414499054
```
Error:  Tests run: 161, Failures: 48, Errors: 0, Skipped: 50, Time elapsed: 48.407 s <<< FAILURE! - in org.apache.bookkeeper.mledger.impl.ManagedLedgerTest
  Error:  testDoNotGetOffloadPoliciesMultipleTimesWhenTrimLedgers(org.apache.bookkeeper.mledger.impl.ManagedLedgerTest)  Time elapsed: 0.196 s  <<< FAILURE!
  org.mockito.exceptions.verification.TooManyActualInvocations: 
  
  nullLedgerOffloader.getOffloadPolicies();
  Wanted 1 time:
  -> at org.apache.bookkeeper.mledger.impl.NullLedgerOffloader.getOffloadPolicies(NullLedgerOffloader.java:66)
  But was 2 times:
  -> at org.apache.bookkeeper.mledger.impl.ManagedLedgerImpl.internalTrimLedgers(ManagedLedgerImpl.java:2473)
  -> at org.apache.bookkeeper.mledger.impl.ManagedLedgerImpl.maybeOffload(ManagedLedgerImpl.java:2388)
```

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->


