### PR TITLE
[fix][admin] Passing `force` parameter to `deleteNamespaceBundle` when delete namespaces

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/NamespacesBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/NamespacesBase.java
@@ -267,7 +267,7 @@ public abstract class NamespacesBase extends AdminResource {
                                             return FutureUtil.failedFuture(ex);
                                         }
                                         return admin.namespaces().deleteNamespaceBundleAsync(namespaceName.toString(),
-                                                bundle.getBundleRange());
+                                                bundle.getBundleRange(), force);
                                     }
                                     return CompletableFuture.completedFuture(null);
                                 })

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/NamespacesTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/NamespacesTest.java
@@ -847,7 +847,7 @@ public class NamespacesTest extends MockedPulsarServiceBaseTest {
         preconditionFailed.completeExceptionally(new PulsarAdminException.PreconditionFailedException(cee,
                 httpError, statusCode));
         doReturn(preconditionFailed).when(namespacesAdmin)
-                .deleteNamespaceBundleAsync(Mockito.anyString(), Mockito.anyString());
+                .deleteNamespaceBundleAsync(Mockito.anyString(), Mockito.anyString(), Mockito.anyBoolean());
 
         AsyncResponse response = mock(AsyncResponse.class);
         ArgumentCaptor<RestException> captor = ArgumentCaptor.forClass(RestException.class);
@@ -866,7 +866,8 @@ public class NamespacesTest extends MockedPulsarServiceBaseTest {
         doReturn(Optional.of(localWebServiceUrl)).when(nsSvc).getWebServiceUrl(nsBundles.getBundles().get(0), optionsHttps);
         doReturn(true).when(nsSvc).isServiceUnitOwned(nsBundles.getBundles().get(0));
         doReturn(CompletableFuture.completedFuture(null)).when(namespacesAdmin).deleteNamespaceBundleAsync(
-                testTenant + "/" + testLocalCluster + "/" + bundledNsLocal, "0x00000000_0x80000000");
+                testTenant + "/" + testLocalCluster + "/" + bundledNsLocal, "0x00000000_0x80000000",
+                false);
         response = mock(AsyncResponse.class);
         namespaces.deleteNamespaceBundle(response, testTenant, testLocalCluster, bundledNsLocal,
                 "0x80000000_0xffffffff",  false, false);


### PR DESCRIPTION
### Motivation

In the current implementation, don't pass the `force` parameter to `deleteNamespaceBundle` when deleting namespaces, we should pass the `force` parameter.

### Modifications

Passing `force` parameter to `deleteNamespaceBundle` when delete namespaces.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/coderzc/pulsar/pull/20