### PR TITLE
[fix][client] In method LastCumulativeAck#update, bitSetRecyclable does not update when messageId is equal.

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PersistentAcknowledgmentsGroupingTracker.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PersistentAcknowledgmentsGroupingTracker.java
@@ -658,6 +658,16 @@ class LastCumulativeAck {
     private boolean flushRequired = false;
 
     public synchronized void update(final MessageIdImpl messageId, final BitSetRecyclable bitSetRecyclable) {
+        if (messageId.equals(this.messageId)) {
+            if (this.bitSetRecyclable != null && bitSetRecyclable != null
+                    && bitSetRecyclable.nextSetBit(0) > this.bitSetRecyclable.nextSetBit(0)) {
+                this.bitSetRecyclable.recycle();
+                set(messageId, bitSetRecyclable);
+                flushRequired = true;
+            }
+            return;
+        }
+
         if (messageId.compareTo(this.messageId) > 0) {
             if (this.bitSetRecyclable != null && this.bitSetRecyclable != bitSetRecyclable) {
                 this.bitSetRecyclable.recycle();

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/LastCumulativeAckTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/LastCumulativeAckTest.java
@@ -30,6 +30,28 @@ import org.testng.annotations.Test;
 public class LastCumulativeAckTest {
 
     @Test
+    public void testUpdateBitSetRecyclable() {
+        final LastCumulativeAck lastCumulativeAck = new LastCumulativeAck();
+        final MessageIdImpl messageId1 = new MessageIdImpl(0L, 1L, 10);
+        final BitSetRecyclable bitSetRecyclable1 = BitSetRecyclable.create();
+        bitSetRecyclable1.set(0, 10);
+        bitSetRecyclable1.clear(0, 3);
+        lastCumulativeAck.update(messageId1, bitSetRecyclable1);
+        assertTrue(lastCumulativeAck.isFlushRequired());
+        assertSame(lastCumulativeAck.getMessageId(), messageId1);
+        assertSame(lastCumulativeAck.getBitSetRecyclable(), bitSetRecyclable1);
+
+        // In the same message, the batch index is incremented.
+        final BitSetRecyclable bitSetRecyclable2 = BitSetRecyclable.create();
+        bitSetRecyclable2.set(0, 10);
+        bitSetRecyclable2.clear(0, 6);
+        lastCumulativeAck.update(messageId1, bitSetRecyclable2);
+        assertTrue(lastCumulativeAck.isFlushRequired());
+        assertSame(lastCumulativeAck.getMessageId(), messageId1);
+        assertSame(lastCumulativeAck.getBitSetRecyclable(), bitSetRecyclable2);
+    }
+
+    @Test
     public void testUpdate() {
         final LastCumulativeAck lastCumulativeAck = new LastCumulativeAck();
         assertFalse(lastCumulativeAck.isFlushRequired());


### PR DESCRIPTION
### Motivation
In method LastCumulativeAck#update, bitSetRecyclable does not update when messageId is equal:
https://github.com/apache/pulsar/blob/fa328a42d5770a27237d926eac97385284876174/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PersistentAcknowledgmentsGroupingTracker.java#L660-L669

### Modifications
When the messageId is equal, but the batch index is larger, the bitSetRecyclable should be updated：
```
   public synchronized void update(final MessageIdImpl messageId, final BitSetRecyclable bitSetRecyclable) {
        if (messageId.equals(this.messageId)) {
            if (this.bitSetRecyclable != null && bitSetRecyclable != null
                    && bitSetRecyclable.nextSetBit(0) > this.bitSetRecyclable.nextSetBit(0)) {
                this.bitSetRecyclable.recycle();
                set(messageId, bitSetRecyclable);
                flushRequired = true;
            }
            return;
        }

        if (messageId.compareTo(this.messageId) > 0) {
            if (this.bitSetRecyclable != null && this.bitSetRecyclable != bitSetRecyclable) {
                this.bitSetRecyclable.recycle();
            }
            set(messageId, bitSetRecyclable);
            flushRequired = true;
        }
    }
```


### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/lordcheng10/pulsar/pull/36 <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
