### PR TITLE
[fix][broker] AVAILABLE_PERMITS_UPDATER not updated, when writeAndFlush fails.

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
@@ -987,20 +987,6 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
                             log.debug(msg);
                         }
                     });
-
-            if (log.isDebugEnabled()) {
-                cnx.ctx().writeAndFlush(Commands.newFlow(consumerId, numMessages))
-                        .addListener(writeFuture -> {
-                            if (!writeFuture.isSuccess()) {
-                                log.debug("Consumer {} failed to send {} permits to broker: {}",
-                                        consumerId, numMessages, writeFuture.cause().getMessage());
-                            } else {
-                                log.debug("Consumer {} sent {} permits to broker", consumerId, numMessages);
-                            }
-                        });
-            } else {
-                cnx.ctx().writeAndFlush(Commands.newFlow(consumerId, numMessages), cnx.ctx().voidPromise());
-            }
         }
     }
 


### PR DESCRIPTION
### Motivation
AVAILABLE_PERMITS_UPDATER will be updated to 0 before the sendFlowPermitsToBroker method is executed:
https://github.com/apache/pulsar/blob/c55be388ad769974a1fd16d43517f4cfda19aec0/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java#L1656-L1659

In the sendFlowPermitsToBroker method, the writeAndFlush method is executed, but when the writeAndFlush fails, the AVAILABLE_PERMITS_UPDATER is not rolled back:
https://github.com/apache/pulsar/blob/c55be388ad769974a1fd16d43517f4cfda19aec0/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java#L976-L984

### Modifications
1.The increaseAvailablePermits method increases the sendFlowPermits parameter:

```
    protected void increaseAvailablePermits(ClientCnx currentCnx, int delta) {
        increaseAvailablePermits(currentCnx, delta, true);
    }

    protected void increaseAvailablePermits(ClientCnx currentCnx, int delta, boolean sendFlowPermits) {
        int available = AVAILABLE_PERMITS_UPDATER.addAndGet(this, delta);
        while (sendFlowPermits && available >= getCurrentReceiverQueueSize() / 2 && !paused) {
            if (AVAILABLE_PERMITS_UPDATER.compareAndSet(this, available, 0)) {
                sendFlowPermitsToBroker(currentCnx, available);
                break;
            } else {
                available = AVAILABLE_PERMITS_UPDATER.get(this);
            }
        }
    }
```

2.Fallback to AVAILABLE_PERMITS_UPDATER when writeAndFlush fails:

```
 cnx.ctx().writeAndFlush(Commands.newFlow(consumerId, numMessages))
                    .addListener(writeFuture -> {
                        String msg;
                        if (!writeFuture.isSuccess()) {
                            msg = String.format("Consumer {} failed to send {} permits to broker: {}"
                                    , consumerId, numMessages, writeFuture.cause().getMessage());
                            increaseAvailablePermits(cnx, numMessages, false);
                        } else {
                            msg = String.format("Consumer {} sent {} permits to broker", consumerId, numMessages);
                        }
                        if (log.isDebugEnabled()) {
                            log.debug(msg);
                        }
                    });
```



### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/lordcheng10/pulsar/pull/37 <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
