### PR TITLE
[improve] Split clientAppId() usage for better client request log.

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/FunctionsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/FunctionsBase.java
@@ -194,7 +194,7 @@ public class FunctionsBase extends AdminResource {
             )
             final @FormDataParam("functionConfig") FunctionConfig functionConfig) {
         functions().registerFunction(tenant, namespace, functionName, uploadedInputStream, fileDetail,
-            functionPkgUrl, functionConfig, clientAppId(), clientAuthData());
+            functionPkgUrl, functionConfig, clientRole(), clientAuthData());
     }
 
     @PUT
@@ -322,7 +322,7 @@ public class FunctionsBase extends AdminResource {
             final @FormDataParam("updateOptions") UpdateOptionsImpl updateOptions) throws IOException {
 
         functions().updateFunction(tenant, namespace, functionName, uploadedInputStream, fileDetail,
-                functionPkgUrl, functionConfig, clientAppId(), clientAuthData(), updateOptions);
+                functionPkgUrl, functionConfig, clientRole(), clientAuthData(), updateOptions);
     }
 
 
@@ -343,7 +343,7 @@ public class FunctionsBase extends AdminResource {
             final @PathParam("namespace") String namespace,
             @ApiParam(value = "The name of a Pulsar Function")
             final @PathParam("functionName") String functionName) {
-        functions().deregisterFunction(tenant, namespace, functionName, clientAppId(), clientAuthData());
+        functions().deregisterFunction(tenant, namespace, functionName, clientRole(), clientAuthData());
     }
 
     @GET
@@ -365,7 +365,7 @@ public class FunctionsBase extends AdminResource {
             final @PathParam("namespace") String namespace,
             @ApiParam(value = "The name of a Pulsar Function")
             final @PathParam("functionName") String functionName) throws IOException {
-        return functions().getFunctionInfo(tenant, namespace, functionName, clientAppId(), clientAuthData());
+        return functions().getFunctionInfo(tenant, namespace, functionName, clientRole(), clientAuthData());
     }
 
     @GET
@@ -389,7 +389,7 @@ public class FunctionsBase extends AdminResource {
                     + " the stats of all instances is returned") final @PathParam("instanceId")
                     String instanceId) throws IOException {
         return functions().getFunctionInstanceStatus(tenant, namespace, functionName,
-                instanceId, uri.getRequestUri(), clientAppId(), clientAuthData());
+                instanceId, uri.getRequestUri(), clientRole(), clientAuthData());
     }
 
     @GET
@@ -413,7 +413,7 @@ public class FunctionsBase extends AdminResource {
             @ApiParam(value = "The name of a Pulsar Function")
             final @PathParam("functionName") String functionName) throws IOException {
         return functions().getFunctionStatus(tenant, namespace, functionName, uri.getRequestUri(),
-                clientAppId(), clientAuthData());
+                clientRole(), clientAuthData());
     }
 
     @GET
@@ -437,7 +437,7 @@ public class FunctionsBase extends AdminResource {
             @ApiParam(value = "The name of a Pulsar Function")
             final @PathParam("functionName") String functionName) throws IOException {
         return functions().getFunctionStats(tenant, namespace, functionName,
-                uri.getRequestUri(), clientAppId(), clientAuthData());
+                uri.getRequestUri(), clientRole(), clientAuthData());
     }
 
     @GET
@@ -461,7 +461,7 @@ public class FunctionsBase extends AdminResource {
                     + " (if instance-id is not provided, the stats of all instances is returned") final @PathParam(
                     "instanceId") String instanceId) throws IOException {
         return functions().getFunctionsInstanceStats(tenant, namespace, functionName, instanceId,
-                uri.getRequestUri(), clientAppId(), clientAuthData());
+                uri.getRequestUri(), clientRole(), clientAuthData());
     }
 
     @GET
@@ -480,7 +480,7 @@ public class FunctionsBase extends AdminResource {
             final @PathParam("tenant") String tenant,
             @ApiParam(value = "The namespace of a Pulsar Function")
             final @PathParam("namespace") String namespace) {
-        return functions().listFunctions(tenant, namespace, clientAppId(), clientAuthData());
+        return functions().listFunctions(tenant, namespace, clientRole(), clientAuthData());
     }
 
     @POST
@@ -509,7 +509,7 @@ public class FunctionsBase extends AdminResource {
                     + " consumes from which you want to inject the data to") final @FormDataParam("topic")
                     String topic) {
         return functions().triggerFunction(tenant, namespace, functionName, triggerValue,
-                triggerStream, topic, clientAppId(), clientAuthData());
+                triggerStream, topic, clientRole(), clientAuthData());
     }
 
     @GET
@@ -533,7 +533,7 @@ public class FunctionsBase extends AdminResource {
             final @PathParam("functionName") String functionName,
             @ApiParam(value = "The stats key")
             final @PathParam("key") String key) {
-        return functions().getFunctionState(tenant, namespace, functionName, key, clientAppId(), clientAuthData());
+        return functions().getFunctionState(tenant, namespace, functionName, key, clientRole(), clientAuthData());
     }
 
     @POST
@@ -553,7 +553,7 @@ public class FunctionsBase extends AdminResource {
                                  final @PathParam("functionName") String functionName,
                                  final @PathParam("key") String key,
                                  final @FormDataParam("state") FunctionState stateJson) {
-        functions().putFunctionState(tenant, namespace, functionName, key, stateJson, clientAppId(), clientAuthData());
+        functions().putFunctionState(tenant, namespace, functionName, key, stateJson, clientRole(), clientAuthData());
     }
 
     @POST
@@ -574,7 +574,7 @@ public class FunctionsBase extends AdminResource {
                     "The instanceId of a Pulsar Function (if instance-id is not provided, all instances are restarted")
             final @PathParam("instanceId") String instanceId) {
         functions().restartFunctionInstance(tenant, namespace, functionName, instanceId,
-                uri.getRequestUri(), clientAppId(), clientAuthData());
+                uri.getRequestUri(), clientRole(), clientAuthData());
     }
 
     @POST
@@ -593,7 +593,7 @@ public class FunctionsBase extends AdminResource {
             final @PathParam("namespace") String namespace,
             @ApiParam(value = "The name of a Pulsar Function")
             final @PathParam("functionName") String functionName) {
-        functions().restartFunctionInstances(tenant, namespace, functionName, clientAppId(), clientAuthData());
+        functions().restartFunctionInstances(tenant, namespace, functionName, clientRole(), clientAuthData());
     }
 
     @POST
@@ -613,7 +613,7 @@ public class FunctionsBase extends AdminResource {
                     "The instanceId of a Pulsar Function (if instance-id is not provided, all instances are stopped. ")
             final @PathParam("instanceId") String instanceId) {
         functions().stopFunctionInstance(tenant, namespace, functionName, instanceId,
-                uri.getRequestUri(), clientAppId(), clientAuthData());
+                uri.getRequestUri(), clientRole(), clientAuthData());
     }
 
     @POST
@@ -632,7 +632,7 @@ public class FunctionsBase extends AdminResource {
             final @PathParam("namespace") String namespace,
             @ApiParam(value = "The name of a Pulsar Function")
             final @PathParam("functionName") String functionName) {
-        functions().stopFunctionInstances(tenant, namespace, functionName, clientAppId(), clientAuthData());
+        functions().stopFunctionInstances(tenant, namespace, functionName, clientRole(), clientAuthData());
     }
 
     @POST
@@ -652,7 +652,7 @@ public class FunctionsBase extends AdminResource {
                     + " (if instance-id is not provided, all instances sre started. ") final @PathParam("instanceId")
                     String instanceId) {
         functions().startFunctionInstance(tenant, namespace, functionName, instanceId,
-                uri.getRequestUri(), clientAppId(), clientAuthData());
+                uri.getRequestUri(), clientRole(), clientAuthData());
     }
 
     @POST
@@ -671,7 +671,7 @@ public class FunctionsBase extends AdminResource {
             final @PathParam("namespace") String namespace,
             @ApiParam(value = "The name of a Pulsar Function")
             final @PathParam("functionName") String functionName) {
-        functions().startFunctionInstances(tenant, namespace, functionName, clientAppId(), clientAuthData());
+        functions().startFunctionInstances(tenant, namespace, functionName, clientRole(), clientAuthData());
     }
 
     @POST
@@ -683,7 +683,7 @@ public class FunctionsBase extends AdminResource {
     @Consumes(MediaType.MULTIPART_FORM_DATA)
     public void uploadFunction(final @FormDataParam("data") InputStream uploadedInputStream,
                                final @FormDataParam("path") String path) {
-        functions().uploadFunction(uploadedInputStream, path, clientAppId(), clientAuthData());
+        functions().uploadFunction(uploadedInputStream, path, clientRole(), clientAuthData());
     }
 
     @GET
@@ -693,7 +693,7 @@ public class FunctionsBase extends AdminResource {
     )
     @Path("/download")
     public StreamingOutput downloadFunction(final @QueryParam("path") String path) {
-        return functions().downloadFunction(path, clientAppId(), clientAuthData());
+        return functions().downloadFunction(path, clientRole(), clientAuthData());
     }
 
     @GET
@@ -713,7 +713,7 @@ public class FunctionsBase extends AdminResource {
             final @QueryParam("transform-function") boolean transformFunction) {
 
         return functions()
-                .downloadFunction(tenant, namespace, functionName, clientAppId(), clientAuthData(), transformFunction);
+                .downloadFunction(tenant, namespace, functionName, clientRole(), clientAuthData(), transformFunction);
     }
 
     @GET
@@ -746,7 +746,7 @@ public class FunctionsBase extends AdminResource {
     })
     @Path("/builtins/reload")
     public void reloadBuiltinFunctions() throws IOException {
-        functions().reloadBuiltinFunctions(clientAppId(), clientAuthData());
+        functions().reloadBuiltinFunctions(clientRole(), clientAuthData());
     }
 
     @GET
@@ -763,7 +763,7 @@ public class FunctionsBase extends AdminResource {
     @Path("/builtins")
     @Produces(MediaType.APPLICATION_JSON)
     public List<FunctionDefinition> getBuiltinFunction() {
-        return functions().getBuiltinFunctions(clientAppId(), clientAuthData());
+        return functions().getBuiltinFunctions(clientRole(), clientAuthData());
     }
 
     @PUT
@@ -785,6 +785,6 @@ public class FunctionsBase extends AdminResource {
                                              final @FormDataParam("delete") boolean delete) {
 
         functions().updateFunctionOnWorkerLeader(tenant, namespace, functionName, uploadedInputStream,
-                delete, uri.getRequestUri(), clientAppId(), clientAuthData());
+                delete, uri.getRequestUri(), clientRole(), clientAuthData());
     }
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PackagesBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PackagesBase.java
@@ -179,7 +179,7 @@ public class PackagesBase extends AdminResource {
             }
             getAuthorizationService()
                 .allowNamespaceOperationAsync(namespaceName, NamespaceOperation.PACKAGES, originalPrincipal(),
-                    clientAppId(), clientAuthData())
+                    clientRole(), clientAuthData())
                 .whenComplete((hasPermission, throwable) -> {
                     if (throwable != null) {
                         future.completeExceptionally(throwable);
@@ -189,7 +189,7 @@ public class PackagesBase extends AdminResource {
                         future.complete(null);
                     } else {
                         future.completeExceptionally(new RestException(Response.Status.UNAUTHORIZED, String.format(
-                            "Role %s has not the 'package' permission to do the packages operations.", clientAppId())));
+                            "Role %s has not the 'package' permission to do the packages operations.", clientRole())));
                     }
                 });
         } else {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/SchemasResourceBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/SchemasResourceBase.java
@@ -109,7 +109,7 @@ public class SchemasResourceBase extends AdminResource {
                 .thenCompose(__ -> {
                     String schemaId = getSchemaId();
                     return pulsar().getSchemaRegistryService()
-                            .deleteSchema(schemaId, defaultIfEmpty(clientAppId(), ""), force);
+                            .deleteSchema(schemaId, defaultIfEmpty(clientRole(), ""), force);
                 });
     }
 
@@ -133,7 +133,7 @@ public class SchemasResourceBase extends AdminResource {
                             .putSchemaIfAbsent(getSchemaId(),
                                     SchemaData.builder().data(data).isDeleted(false).timestamp(clock.millis())
                                             .type(SchemaType.valueOf(payload.getType()))
-                                            .user(defaultIfEmpty(clientAppId(), ""))
+                                            .user(defaultIfEmpty(clientRole(), ""))
                                             .props(payload.getProperties())
                                             .build(),
                                     schemaCompatibilityStrategy);
@@ -150,7 +150,7 @@ public class SchemasResourceBase extends AdminResource {
                             SchemaData.builder().data(payload.getSchema().getBytes(StandardCharsets.UTF_8))
                                     .isDeleted(false)
                                     .timestamp(clock.millis()).type(SchemaType.valueOf(payload.getType()))
-                                    .user(defaultIfEmpty(clientAppId(), ""))
+                                    .user(defaultIfEmpty(clientRole(), ""))
                                     .props(payload.getProperties())
                                     .build(), strategy)
                             .thenApply(v -> Pair.of(v, strategy));
@@ -166,7 +166,7 @@ public class SchemasResourceBase extends AdminResource {
                                     SchemaData.builder().data(payload.getSchema().getBytes(StandardCharsets.UTF_8))
                                             .isDeleted(false).timestamp(clock.millis())
                                             .type(SchemaType.valueOf(payload.getType()))
-                                            .user(defaultIfEmpty(clientAppId(), ""))
+                                            .user(defaultIfEmpty(clientRole(), ""))
                                             .props(payload.getProperties()).build());
                 });
     }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/SinksBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/SinksBase.java
@@ -168,7 +168,7 @@ public class SinksBase extends AdminResource {
                              )
                              final @FormDataParam("sinkConfig") SinkConfig sinkConfig) {
         sinks().registerSink(tenant, namespace, sinkName, uploadedInputStream, fileDetail,
-                sinkPkgUrl, sinkConfig, clientAppId(), clientAuthData());
+                sinkPkgUrl, sinkConfig, clientRole(), clientAuthData());
     }
 
     @PUT
@@ -271,7 +271,7 @@ public class SinksBase extends AdminResource {
                            @ApiParam(value = "Update options for the Pulsar Sink")
                            final @FormDataParam("updateOptions") UpdateOptionsImpl updateOptions) {
          sinks().updateSink(tenant, namespace, sinkName, uploadedInputStream, fileDetail,
-                sinkPkgUrl, sinkConfig, clientAppId(), clientAuthData(), updateOptions);
+                sinkPkgUrl, sinkConfig, clientRole(), clientAuthData(), updateOptions);
 
     }
 
@@ -295,7 +295,7 @@ public class SinksBase extends AdminResource {
                                final @PathParam("namespace") String namespace,
                                @ApiParam(value = "The name of a Pulsar Sink")
                                final @PathParam("sinkName") String sinkName) {
-        sinks().deregisterFunction(tenant, namespace, sinkName, clientAppId(), clientAuthData());
+        sinks().deregisterFunction(tenant, namespace, sinkName, clientRole(), clientAuthData());
     }
 
     @GET
@@ -342,7 +342,7 @@ public class SinksBase extends AdminResource {
             @ApiParam(value = "The instanceId of a Pulsar Sink")
             final @PathParam("instanceId") String instanceId) throws IOException {
         return sinks().getSinkInstanceStatus(
-            tenant, namespace, sinkName, instanceId, uri.getRequestUri(), clientAppId(), clientAuthData());
+            tenant, namespace, sinkName, instanceId, uri.getRequestUri(), clientRole(), clientAuthData());
     }
 
     @GET
@@ -365,7 +365,7 @@ public class SinksBase extends AdminResource {
                                     final @PathParam("namespace") String namespace,
                                     @ApiParam(value = "The name of a Pulsar Sink")
                                     final @PathParam("sinkName") String sinkName) throws IOException {
-        return sinks().getSinkStatus(tenant, namespace, sinkName, uri.getRequestUri(), clientAppId(), clientAuthData());
+        return sinks().getSinkStatus(tenant, namespace, sinkName, uri.getRequestUri(), clientRole(), clientAuthData());
     }
 
     @GET
@@ -385,7 +385,7 @@ public class SinksBase extends AdminResource {
                                   final @PathParam("tenant") String tenant,
                                   @ApiParam(value = "The namespace of a Pulsar Sink")
                                   final @PathParam("namespace") String namespace) {
-        return sinks().listFunctions(tenant, namespace, clientAppId(), clientAuthData());
+        return sinks().listFunctions(tenant, namespace, clientRole(), clientAuthData());
     }
 
     @POST
@@ -411,7 +411,7 @@ public class SinksBase extends AdminResource {
                             @ApiParam(value = "The instanceId of a Pulsar Sink")
                             final @PathParam("instanceId") String instanceId) {
         sinks().restartFunctionInstance(tenant, namespace, sinkName, instanceId,
-                uri.getRequestUri(), clientAppId(), clientAuthData());
+                uri.getRequestUri(), clientRole(), clientAuthData());
     }
 
     @POST
@@ -432,7 +432,7 @@ public class SinksBase extends AdminResource {
                             final @PathParam("namespace") String namespace,
                             @ApiParam(value = "The name of a Pulsar Sink")
                             final @PathParam("sinkName") String sinkName) {
-        sinks().restartFunctionInstances(tenant, namespace, sinkName, clientAppId(), clientAuthData());
+        sinks().restartFunctionInstances(tenant, namespace, sinkName, clientRole(), clientAuthData());
     }
 
     @POST
@@ -456,7 +456,7 @@ public class SinksBase extends AdminResource {
                          @ApiParam(value = "The instanceId of a Pulsar Sink")
                          final @PathParam("instanceId") String instanceId) {
         sinks().stopFunctionInstance(tenant, namespace,
-                sinkName, instanceId, uri.getRequestUri(), clientAppId(), clientAuthData());
+                sinkName, instanceId, uri.getRequestUri(), clientRole(), clientAuthData());
     }
 
     @POST
@@ -477,7 +477,7 @@ public class SinksBase extends AdminResource {
                          final @PathParam("namespace") String namespace,
                          @ApiParam(value = "The name of a Pulsar Sink")
                          final @PathParam("sinkName") String sinkName) {
-        sinks().stopFunctionInstances(tenant, namespace, sinkName, clientAppId(), clientAuthData());
+        sinks().stopFunctionInstances(tenant, namespace, sinkName, clientRole(), clientAuthData());
     }
 
     @POST
@@ -501,7 +501,7 @@ public class SinksBase extends AdminResource {
                           @ApiParam(value = "The instanceId of a Pulsar Sink")
                           final @PathParam("instanceId") String instanceId) {
         sinks().startFunctionInstance(tenant, namespace, sinkName, instanceId,
-                uri.getRequestUri(), clientAppId(), clientAuthData());
+                uri.getRequestUri(), clientRole(), clientAuthData());
     }
 
     @POST
@@ -522,7 +522,7 @@ public class SinksBase extends AdminResource {
                           final @PathParam("namespace") String namespace,
                           @ApiParam(value = "The name of a Pulsar Sink")
                           final @PathParam("sinkName") String sinkName) {
-        sinks().startFunctionInstances(tenant, namespace, sinkName, clientAppId(), clientAuthData());
+        sinks().startFunctionInstances(tenant, namespace, sinkName, clientRole(), clientAuthData());
     }
 
     @GET
@@ -571,6 +571,6 @@ public class SinksBase extends AdminResource {
     })
     @Path("/reloadBuiltInSinks")
     public void reloadSinks() {
-        sinks().reloadConnectors(clientAppId(), clientAuthData());
+        sinks().reloadConnectors(clientRole(), clientAuthData());
     }
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/SourcesBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/SourcesBase.java
@@ -142,7 +142,7 @@ public class SourcesBase extends AdminResource {
             )
             final @FormDataParam("sourceConfig") SourceConfig sourceConfig) {
         sources().registerSource(tenant, namespace, sourceName, uploadedInputStream, fileDetail,
-            sourcePkgUrl, sourceConfig, clientAppId(), clientAuthData());
+            sourcePkgUrl, sourceConfig, clientRole(), clientAuthData());
     }
 
     @PUT
@@ -227,7 +227,7 @@ public class SourcesBase extends AdminResource {
             @ApiParam(value = "Update options for Pulsar Source")
             final @FormDataParam("updateOptions") UpdateOptionsImpl updateOptions) {
         sources().updateSource(tenant, namespace, sourceName, uploadedInputStream, fileDetail,
-            sourcePkgUrl, sourceConfig, clientAppId(), clientAuthData(), updateOptions);
+            sourcePkgUrl, sourceConfig, clientRole(), clientAuthData(), updateOptions);
     }
 
 
@@ -250,7 +250,7 @@ public class SourcesBase extends AdminResource {
             final @PathParam("namespace") String namespace,
             @ApiParam(value = "The name of a Pulsar Source")
             final @PathParam("sourceName") String sourceName) {
-        sources().deregisterFunction(tenant, namespace, sourceName, clientAppId(), clientAuthData());
+        sources().deregisterFunction(tenant, namespace, sourceName, clientRole(), clientAuthData());
     }
 
     @GET
@@ -294,7 +294,7 @@ public class SourcesBase extends AdminResource {
                     + " (if instance-id is not provided, the stats of all instances is returned).") final @PathParam(
                     "instanceId") String instanceId) throws IOException {
         return sources().getSourceInstanceStatus(
-            tenant, namespace, sourceName, instanceId, uri.getRequestUri(), clientAppId(), clientAuthData());
+            tenant, namespace, sourceName, instanceId, uri.getRequestUri(), clientRole(), clientAuthData());
     }
 
     @GET
@@ -316,7 +316,7 @@ public class SourcesBase extends AdminResource {
             final @PathParam("namespace") String namespace,
             @ApiParam(value = "The name of a Pulsar Source")
             final @PathParam("sourceName") String sourceName) throws IOException {
-        return sources().getSourceStatus(tenant, namespace, sourceName, uri.getRequestUri(), clientAppId(),
+        return sources().getSourceStatus(tenant, namespace, sourceName, uri.getRequestUri(), clientRole(),
                 clientAuthData());
     }
 
@@ -339,7 +339,7 @@ public class SourcesBase extends AdminResource {
             final @PathParam("tenant") String tenant,
             @ApiParam(value = "The namespace of a Pulsar Source")
             final @PathParam("namespace") String namespace) {
-        return sources().listFunctions(tenant, namespace, clientAppId(), clientAuthData());
+        return sources().listFunctions(tenant, namespace, clientRole(), clientAuthData());
     }
 
     @POST
@@ -362,7 +362,7 @@ public class SourcesBase extends AdminResource {
                     + " (if instance-id is not provided, the stats of all instances is returned).") final @PathParam(
                     "instanceId") String instanceId) {
         sources().restartFunctionInstance(tenant, namespace, sourceName, instanceId,
-                uri.getRequestUri(), clientAppId(), clientAuthData());
+                uri.getRequestUri(), clientRole(), clientAuthData());
     }
 
     @POST
@@ -383,7 +383,7 @@ public class SourcesBase extends AdminResource {
             final @PathParam("namespace") String namespace,
             @ApiParam(value = "The name of a Pulsar Source")
             final @PathParam("sourceName") String sourceName) {
-        sources().restartFunctionInstances(tenant, namespace, sourceName, clientAppId(), clientAuthData());
+        sources().restartFunctionInstances(tenant, namespace, sourceName, clientRole(), clientAuthData());
     }
 
     @POST
@@ -404,7 +404,7 @@ public class SourcesBase extends AdminResource {
             @ApiParam(value = "The instanceId of a Pulsar Source (if instance-id is not provided,"
                     + " the stats of all instances is returned).") final @PathParam("instanceId") String instanceId) {
         sources().stopFunctionInstance(tenant, namespace, sourceName, instanceId,
-                uri.getRequestUri(), clientAppId(), clientAuthData());
+                uri.getRequestUri(), clientRole(), clientAuthData());
     }
 
     @POST
@@ -425,7 +425,7 @@ public class SourcesBase extends AdminResource {
             final @PathParam("namespace") String namespace,
             @ApiParam(value = "The name of a Pulsar Source")
             final @PathParam("sourceName") String sourceName) {
-        sources().stopFunctionInstances(tenant, namespace, sourceName, clientAppId(), clientAuthData());
+        sources().stopFunctionInstances(tenant, namespace, sourceName, clientRole(), clientAuthData());
     }
 
     @POST
@@ -446,7 +446,7 @@ public class SourcesBase extends AdminResource {
             @ApiParam(value = "The instanceId of a Pulsar Source (if instance-id is not provided,"
                     + " the stats of all instances is returned).") final @PathParam("instanceId") String instanceId) {
         sources().startFunctionInstance(tenant, namespace, sourceName, instanceId,
-                uri.getRequestUri(), clientAppId(), clientAuthData());
+                uri.getRequestUri(), clientRole(), clientAuthData());
     }
 
     @POST
@@ -467,7 +467,7 @@ public class SourcesBase extends AdminResource {
             final @PathParam("namespace") String namespace,
             @ApiParam(value = "The name of a Pulsar Source")
             final @PathParam("sourceName") String sourceName) {
-        sources().startFunctionInstances(tenant, namespace, sourceName, clientAppId(), clientAuthData());
+        sources().startFunctionInstances(tenant, namespace, sourceName, clientRole(), clientAuthData());
     }
 
     @GET
@@ -520,6 +520,6 @@ public class SourcesBase extends AdminResource {
     })
     @Path("/reloadBuiltInSources")
     public void reloadSources() {
-        sources().reloadConnectors(clientAppId(), clientAuthData());
+        sources().reloadConnectors(clientRole(), clientAuthData());
     }
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/TenantsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/TenantsBase.java
@@ -62,7 +62,6 @@ public class TenantsBase extends PulsarWebResource {
     @ApiResponses(value = {@ApiResponse(code = 403, message = "The requester doesn't have admin permissions"),
             @ApiResponse(code = 404, message = "Tenant doesn't exist")})
     public void getTenants(@Suspended final AsyncResponse asyncResponse) {
-        final String clientAppId = clientAppId();
         validateSuperUserAccessAsync()
                 .thenCompose(__ -> tenantResources().listTenantsAsync())
                 .thenAccept(tenants -> {
@@ -71,7 +70,7 @@ public class TenantsBase extends PulsarWebResource {
                     deepCopy.sort(null);
                     asyncResponse.resume(deepCopy);
                 }).exceptionally(ex -> {
-                    log.error("[{}] Failed to get tenants list", clientAppId, ex);
+                    log.error("[{}] Failed to get tenants list", clientAppId(), ex);
                     resumeAsyncResponseExceptionally(asyncResponse, ex);
                     return null;
                 });
@@ -84,7 +83,6 @@ public class TenantsBase extends PulsarWebResource {
             @ApiResponse(code = 404, message = "Tenant does not exist")})
     public void getTenantAdmin(@Suspended final AsyncResponse asyncResponse,
             @ApiParam(value = "The tenant name") @PathParam("tenant") String tenant) {
-        final String clientAppId = clientAppId();
         validateSuperUserAccessAsync()
                 .thenCompose(__ -> tenantResources().getTenantAsync(tenant))
                 .thenApply(tenantInfo -> {
@@ -95,7 +93,7 @@ public class TenantsBase extends PulsarWebResource {
                 })
                 .thenAccept(asyncResponse::resume)
                 .exceptionally(ex -> {
-                    log.error("[{}] Failed to get tenant admin {}", clientAppId, ex);
+                    log.error("[{}] Failed to get tenant admin {}", clientAppId(), ex);
                     resumeAsyncResponseExceptionally(asyncResponse, ex);
                     return null;
                 });
@@ -112,11 +110,10 @@ public class TenantsBase extends PulsarWebResource {
     public void createTenant(@Suspended final AsyncResponse asyncResponse,
             @ApiParam(value = "The tenant name") @PathParam("tenant") String tenant,
             @ApiParam(value = "TenantInfo") TenantInfoImpl tenantInfo) {
-        final String clientAppId = clientAppId();
         try {
             NamedEntity.checkName(tenant);
         } catch (IllegalArgumentException e) {
-            log.warn("[{}] Failed to create tenant with invalid name {}", clientAppId, tenant, e);
+            log.warn("[{}] Failed to create tenant with invalid name {}", clientAppId(), tenant, e);
             asyncResponse.resume(new RestException(Status.PRECONDITION_FAILED, "Tenant name is not valid"));
             return;
         }
@@ -142,11 +139,11 @@ public class TenantsBase extends PulsarWebResource {
                 })
                 .thenCompose(__ -> tenantResources().createTenantAsync(tenant, tenantInfo))
                 .thenAccept(__ -> {
-                    log.info("[{}] Created tenant {}", clientAppId, tenant);
+                    log.info("[{}] Created tenant {}", clientAppId(), tenant);
                     asyncResponse.resume(Response.noContent().build());
                 })
                 .exceptionally(ex -> {
-                    log.error("[{}] Failed to create tenant {}", clientAppId, tenant, ex);
+                    log.error("[{}] Failed to create tenant {}", clientAppId(), tenant, ex);
                     resumeAsyncResponseExceptionally(asyncResponse, ex);
                     return null;
                 });
@@ -164,7 +161,6 @@ public class TenantsBase extends PulsarWebResource {
     public void updateTenant(@Suspended final AsyncResponse asyncResponse,
             @ApiParam(value = "The tenant name") @PathParam("tenant") String tenant,
             @ApiParam(value = "TenantInfo") TenantInfoImpl newTenantAdmin) {
-        final String clientAppId = clientAppId();
         validateSuperUserAccessAsync()
                 .thenCompose(__ -> validatePoliciesReadOnlyAccessAsync())
                 .thenCompose(__ -> validateClustersAsync(newTenantAdmin))
@@ -179,10 +175,10 @@ public class TenantsBase extends PulsarWebResource {
                 })
                 .thenCompose(__ -> tenantResources().updateTenantAsync(tenant, old -> newTenantAdmin))
                 .thenAccept(__ -> {
-                    log.info("[{}] Successfully updated tenant info {}", clientAppId, tenant);
+                    log.info("[{}] Successfully updated tenant info {}", clientAppId(), tenant);
                     asyncResponse.resume(Response.noContent().build());
                 }).exceptionally(ex -> {
-                    log.warn("[{}] Failed to update tenant {}", clientAppId, tenant, ex);
+                    log.warn("[{}] Failed to update tenant {}", clientAppId(), tenant, ex);
                     resumeAsyncResponseExceptionally(asyncResponse, ex);
                     return null;
                 });
@@ -198,17 +194,16 @@ public class TenantsBase extends PulsarWebResource {
     public void deleteTenant(@Suspended final AsyncResponse asyncResponse,
             @PathParam("tenant") @ApiParam(value = "The tenant name") String tenant,
             @QueryParam("force") @DefaultValue("false") boolean force) {
-        final String clientAppId = clientAppId();
         validateSuperUserAccessAsync()
                 .thenCompose(__ -> validatePoliciesReadOnlyAccessAsync())
                 .thenCompose(__ -> internalDeleteTenant(tenant, force))
                 .thenAccept(__ -> {
-                    log.info("[{}] Deleted tenant {}", clientAppId, tenant);
+                    log.info("[{}] Deleted tenant {}", clientAppId(), tenant);
                     asyncResponse.resume(Response.noContent().build());
                 })
                 .exceptionally(ex -> {
                     Throwable cause = FutureUtil.unwrapCompletionException(ex);
-                    log.error("[{}] Failed to delete tenant {}", clientAppId, tenant, cause);
+                    log.error("[{}] Failed to delete tenant {}", clientAppId(), tenant, cause);
                     if (cause instanceof IllegalStateException) {
                         asyncResponse.resume(new RestException(Status.CONFLICT, cause));
                     } else {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/Functions.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/Functions.java
@@ -75,7 +75,7 @@ public class Functions extends AdminResource {
                                      final @FormDataParam("functionDetails") String functionDetailsJson) {
 
         return functions().registerFunction(tenant, namespace, functionName, uploadedInputStream, fileDetail,
-                functionPkgUrl, functionDetailsJson, clientAppId());
+                functionPkgUrl, functionDetailsJson, clientRole());
     }
 
     @PUT
@@ -96,7 +96,7 @@ public class Functions extends AdminResource {
                                    final @FormDataParam("functionDetails") String functionDetailsJson) {
 
         return functions().updateFunction(tenant, namespace, functionName, uploadedInputStream, fileDetail,
-                functionPkgUrl, functionDetailsJson, clientAppId());
+                functionPkgUrl, functionDetailsJson, clientRole());
     }
 
 
@@ -113,7 +113,7 @@ public class Functions extends AdminResource {
     public Response deregisterFunction(final @PathParam("tenant") String tenant,
                                        final @PathParam("namespace") String namespace,
                                        final @PathParam("functionName") String functionName) {
-        return functions().deregisterFunction(tenant, namespace, functionName, clientAppId());
+        return functions().deregisterFunction(tenant, namespace, functionName, clientRole());
     }
 
     @GET
@@ -133,7 +133,7 @@ public class Functions extends AdminResource {
                                     final @PathParam("functionName") String functionName) throws IOException {
 
         return functions().getFunctionInfo(
-                tenant, namespace, functionName, clientAppId());
+                tenant, namespace, functionName, clientRole());
     }
 
     @GET
@@ -154,7 +154,7 @@ public class Functions extends AdminResource {
                                               final @PathParam("instanceId") String instanceId) throws IOException {
 
         return functions().getFunctionInstanceStatus(tenant, namespace, functionName, instanceId, uri.getRequestUri(),
-                clientAppId());
+                clientRole());
     }
 
     @GET
@@ -172,7 +172,7 @@ public class Functions extends AdminResource {
                                       final @PathParam("namespace") String namespace,
                                       final @PathParam("functionName") String functionName) throws IOException {
         return functions().getFunctionStatusV2(
-                tenant, namespace, functionName, uri.getRequestUri(), clientAppId());
+                tenant, namespace, functionName, uri.getRequestUri(), clientRole());
     }
 
     @GET
@@ -188,7 +188,7 @@ public class Functions extends AdminResource {
     @Path("/{tenant}/{namespace}")
     public Response listFunctions(final @PathParam("tenant") String tenant,
                                   final @PathParam("namespace") String namespace) {
-        return functions().listFunctions(tenant, namespace, clientAppId());
+        return functions().listFunctions(tenant, namespace, clientRole());
     }
 
     @POST
@@ -211,7 +211,7 @@ public class Functions extends AdminResource {
                                     final @FormDataParam("dataStream") InputStream triggerStream,
                                     final @FormDataParam("topic") String topic) {
         return functions().triggerFunction(tenant, namespace, functionName,
-                triggerValue, triggerStream, topic, clientAppId());
+                triggerValue, triggerStream, topic, clientRole());
     }
 
     @GET
@@ -230,7 +230,7 @@ public class Functions extends AdminResource {
                                      final @PathParam("namespace") String namespace,
                                      final @PathParam("functionName") String functionName,
                                      final @PathParam("key") String key) {
-        return functions().getFunctionState(tenant, namespace, functionName, key, clientAppId());
+        return functions().getFunctionState(tenant, namespace, functionName, key, clientRole());
     }
 
     @POST
@@ -247,7 +247,7 @@ public class Functions extends AdminResource {
                                     final @PathParam("functionName") String functionName,
                                     final @PathParam("instanceId") String instanceId) {
         return functions().restartFunctionInstance(tenant, namespace, functionName,
-                instanceId, uri.getRequestUri(), clientAppId());
+                instanceId, uri.getRequestUri(), clientRole());
     }
 
     @POST
@@ -260,7 +260,7 @@ public class Functions extends AdminResource {
     public Response restartFunction(final @PathParam("tenant") String tenant,
                                     final @PathParam("namespace") String namespace,
                                     final @PathParam("functionName") String functionName) {
-        return functions().restartFunctionInstances(tenant, namespace, functionName, clientAppId());
+        return functions().restartFunctionInstances(tenant, namespace, functionName, clientRole());
     }
 
     @POST
@@ -275,7 +275,7 @@ public class Functions extends AdminResource {
                                  final @PathParam("functionName") String functionName,
                                  final @PathParam("instanceId") String instanceId) {
         return functions().stopFunctionInstance(tenant, namespace, functionName,
-                instanceId, uri.getRequestUri(), clientAppId());
+                instanceId, uri.getRequestUri(), clientRole());
     }
 
     @POST
@@ -288,7 +288,7 @@ public class Functions extends AdminResource {
     public Response stopFunction(final @PathParam("tenant") String tenant,
                                  final @PathParam("namespace") String namespace,
                                  final @PathParam("functionName") String functionName) {
-        return functions().stopFunctionInstances(tenant, namespace, functionName, clientAppId());
+        return functions().stopFunctionInstances(tenant, namespace, functionName, clientRole());
     }
 
     @POST
@@ -300,7 +300,7 @@ public class Functions extends AdminResource {
     @Consumes(MediaType.MULTIPART_FORM_DATA)
     public Response uploadFunction(final @FormDataParam("data") InputStream uploadedInputStream,
                                    final @FormDataParam("path") String path) {
-        return functions().uploadFunction(uploadedInputStream, path, clientAppId());
+        return functions().uploadFunction(uploadedInputStream, path, clientRole());
     }
 
     @GET
@@ -310,7 +310,7 @@ public class Functions extends AdminResource {
     )
     @Path("/download")
     public Response downloadFunction(final @QueryParam("path") String path) {
-        return functions().downloadFunction(path, clientAppId());
+        return functions().downloadFunction(path, clientRole());
     }
 
     @GET

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/Worker.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/Worker.java
@@ -66,7 +66,7 @@ public class Worker extends AdminResource implements Supplier<WorkerService> {
     @Path("/cluster")
     @Produces(MediaType.APPLICATION_JSON)
     public List<WorkerInfo> getCluster() {
-        return workers().getCluster(clientAppId());
+        return workers().getCluster(clientRole());
     }
 
     @GET
@@ -81,7 +81,7 @@ public class Worker extends AdminResource implements Supplier<WorkerService> {
     @Path("/cluster/leader")
     @Produces(MediaType.APPLICATION_JSON)
     public WorkerInfo getClusterLeader() {
-        return workers().getClusterLeader(clientAppId());
+        return workers().getClusterLeader(clientRole());
     }
 
     @GET
@@ -96,7 +96,7 @@ public class Worker extends AdminResource implements Supplier<WorkerService> {
     @Path("/assignments")
     @Produces(MediaType.APPLICATION_JSON)
     public Map<String, Collection<String>> getAssignments() {
-        return workers().getAssignments(clientAppId());
+        return workers().getAssignments(clientRole());
     }
 
     @GET
@@ -112,7 +112,7 @@ public class Worker extends AdminResource implements Supplier<WorkerService> {
     @Path("/connectors")
     @Produces(MediaType.APPLICATION_JSON)
     public List<ConnectorDefinition> getConnectorsList() throws IOException {
-        return workers().getListOfConnectors(clientAppId());
+        return workers().getListOfConnectors(clientRole());
     }
 
     @PUT
@@ -126,7 +126,7 @@ public class Worker extends AdminResource implements Supplier<WorkerService> {
     })
     @Path("/rebalance")
     public void rebalance() {
-        workers().rebalance(uri.getRequestUri(), clientAppId());
+        workers().rebalance(uri.getRequestUri(), clientRole());
     }
 
     @PUT
@@ -142,7 +142,7 @@ public class Worker extends AdminResource implements Supplier<WorkerService> {
     })
     @Path("/leader/drain")
     public void drainAtLeader(@QueryParam("workerId") String workerId) {
-        workers().drain(uri.getRequestUri(), workerId, clientAppId(), true);
+        workers().drain(uri.getRequestUri(), workerId, clientRole(), true);
     }
 
     @PUT
@@ -158,7 +158,7 @@ public class Worker extends AdminResource implements Supplier<WorkerService> {
     })
     @Path("/drain")
     public void drain() {
-        workers().drain(uri.getRequestUri(), null, clientAppId(), false);
+        workers().drain(uri.getRequestUri(), null, clientRole(), false);
     }
 
     @GET
@@ -172,7 +172,7 @@ public class Worker extends AdminResource implements Supplier<WorkerService> {
     })
     @Path("/leader/drain")
     public LongRunningProcessStatus getDrainStatusFromLeader(@QueryParam("workerId") String workerId) {
-        return workers().getDrainStatus(uri.getRequestUri(), workerId, clientAppId(), true);
+        return workers().getDrainStatus(uri.getRequestUri(), workerId, clientRole(), true);
     }
 
     @GET
@@ -186,7 +186,7 @@ public class Worker extends AdminResource implements Supplier<WorkerService> {
     })
     @Path("/drain")
     public LongRunningProcessStatus getDrainStatus() {
-        return workers().getDrainStatus(uri.getRequestUri(), null, clientAppId(), false);
+        return workers().getDrainStatus(uri.getRequestUri(), null, clientRole(), false);
     }
 
     @GET
@@ -199,6 +199,6 @@ public class Worker extends AdminResource implements Supplier<WorkerService> {
     })
     @Path("/cluster/leader/ready")
     public Boolean isLeaderReady() {
-        return workers().isLeaderReady(clientAppId());
+        return workers().isLeaderReady(clientRole());
     }
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/WorkerStats.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/WorkerStats.java
@@ -56,7 +56,7 @@ public class WorkerStats extends AdminResource {
     })
     @Produces(MediaType.APPLICATION_JSON)
     public Collection<Metrics> getMetrics() throws Exception {
-        return workers().getWorkerMetrics(clientAppId());
+        return workers().getWorkerMetrics(clientRole());
     }
 
     @GET
@@ -72,6 +72,6 @@ public class WorkerStats extends AdminResource {
     })
     @Produces(MediaType.APPLICATION_JSON)
     public List<WorkerFunctionInstanceStats> getStats() throws IOException {
-        return workers().getFunctionsMetrics(clientAppId());
+        return workers().getFunctionsMetrics(clientRole());
     }
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/rest/TopicsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/rest/TopicsBase.java
@@ -757,17 +757,18 @@ public class TopicsBase extends PersistentTopicsBase {
     public void validateProducePermission() throws Exception {
         if (pulsar().getConfiguration().isAuthenticationEnabled()
                 && pulsar().getBrokerService().isAuthorizationEnabled()) {
-            if (!isClientAuthenticated(clientAppId())) {
+            String clientRole = clientRole();
+            if (!isClientAuthenticated(clientRole)) {
                 throw new RestException(Status.UNAUTHORIZED, "Need to authenticate to perform the request");
             }
 
             boolean isAuthorized = pulsar().getBrokerService().getAuthorizationService()
-                    .canProduce(topicName, originalPrincipal() == null ? clientAppId() : originalPrincipal(),
+                    .canProduce(topicName, originalPrincipal() == null ? clientRole : originalPrincipal(),
                             clientAuthData());
             if (!isAuthorized) {
                 throw new RestException(Status.UNAUTHORIZED, String.format("Unauthorized to produce to topic %s"
                                         + " with clientAppId [%s] and authdata %s", topicName.toString(),
-                        clientAppId(), clientAuthData()));
+                        clientRole, clientAuthData()));
             }
         }
     }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiGetLastMessageIdTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiGetLastMessageIdTest.java
@@ -74,7 +74,7 @@ public class AdminApiGetLastMessageIdTest extends MockedPulsarServiceBaseTest {
 
         doReturn(false).when(persistentTopics).isRequestHttps();
         doReturn(null).when(persistentTopics).originalPrincipal();
-        doReturn("test").when(persistentTopics).clientAppId();
+        doReturn("test").when(persistentTopics).clientRole();
         doReturn("persistent").when(persistentTopics).domain();
         doNothing().when(persistentTopics).validateAdminAccessForTenant(this.testTenant);
         doReturn(mock(AuthenticationDataHttps.class)).when(persistentTopics).clientAuthData();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminTest.java
@@ -128,18 +128,18 @@ public class AdminTest extends MockedPulsarServiceBaseTest {
 
         clusters = spy(Clusters.class);
         clusters.setPulsar(pulsar);
-        doReturn("test").when(clusters).clientAppId();
+        doReturn("test").when(clusters).clientRole();
         doNothing().when(clusters).validateSuperUserAccess();
 
         properties = spy(Properties.class);
         properties.setPulsar(pulsar);
-        doReturn("test").when(properties).clientAppId();
+        doReturn("test").when(properties).clientRole();
         doNothing().when(properties).validateSuperUserAccess();
 
         namespaces = spy(Namespaces.class);
         namespaces.setServletContext(new MockServletContext());
         namespaces.setPulsar(pulsar);
-        doReturn("test").when(namespaces).clientAppId();
+        doReturn("test").when(namespaces).clientRole();
         doReturn(Set.of("use", "usw", "usc", "global")).when(namespaces).clusters();
         doNothing().when(namespaces).validateAdminAccessForTenant("my-tenant");
         doNothing().when(namespaces).validateAdminAccessForTenant("other-tenant");
@@ -147,7 +147,7 @@ public class AdminTest extends MockedPulsarServiceBaseTest {
 
         brokers = spy(Brokers.class);
         brokers.setPulsar(pulsar);
-        doReturn("test").when(brokers).clientAppId();
+        doReturn("test").when(brokers).clientRole();
         doNothing().when(brokers).validateSuperUserAccess();
 
         uriField = PulsarWebResource.class.getDeclaredField("uri");
@@ -156,7 +156,7 @@ public class AdminTest extends MockedPulsarServiceBaseTest {
         persistentTopics = spy(PersistentTopics.class);
         persistentTopics.setServletContext(new MockServletContext());
         persistentTopics.setPulsar(pulsar);
-        doReturn("test").when(persistentTopics).clientAppId();
+        doReturn("test").when(persistentTopics).clientRole();
         doReturn("persistent").when(persistentTopics).domain();
         doReturn(Set.of("use", "usw", "usc")).when(persistentTopics).clusters();
         doNothing().when(persistentTopics).validateAdminAccessForTenant("my-tenant");
@@ -173,7 +173,7 @@ public class AdminTest extends MockedPulsarServiceBaseTest {
 
         doReturn(false).when(persistentTopics).isRequestHttps();
         doReturn(null).when(persistentTopics).originalPrincipal();
-        doReturn("test").when(persistentTopics).clientAppId();
+        doReturn("test").when(persistentTopics).clientRole();
         doReturn(mock(AuthenticationDataHttps.class)).when(persistentTopics).clientAuthData();
 
         schemasResource = spy(SchemasResource.class);
@@ -755,7 +755,7 @@ public class AdminTest extends MockedPulsarServiceBaseTest {
         Policies policies = new Policies();
         doReturn(policies).when(resourceQuotas).getNamespacePolicies(NamespaceName.get(property, cluster, namespace));
         doReturn(CompletableFuture.completedFuture(policies)).when(resourceQuotas).getNamespacePoliciesAsync(NamespaceName.get(property, cluster, namespace));
-        doReturn("client-id").when(resourceQuotas).clientAppId();
+        doReturn("client-id").when(resourceQuotas).clientRole();
 
         try {
             asyncRequests(ctx -> resourceQuotas.setNamespaceBundleResourceQuota(ctx, property, cluster, namespace, bundleRange, quota));
@@ -799,7 +799,7 @@ public class AdminTest extends MockedPulsarServiceBaseTest {
 
     @Test
     public void brokerStats() throws Exception {
-        doReturn("client-id").when(brokerStats).clientAppId();
+        doReturn("client-id").when(brokerStats).clientRole();
         Collection<Metrics> metrics = brokerStats.getMetrics();
         assertNotNull(metrics);
         LocalBrokerData loadReport = (LocalBrokerData) brokerStats.getLoadReport();
@@ -830,7 +830,7 @@ public class AdminTest extends MockedPulsarServiceBaseTest {
         final String topic = "ds1";
         Policies policies = new Policies();
         doReturn(policies).when(resourceQuotas).getNamespacePolicies(NamespaceName.get(property, cluster, namespace));
-        doReturn("client-id").when(resourceQuotas).clientAppId();
+        doReturn("client-id").when(resourceQuotas).clientRole();
         // create policies
         TenantInfo admin = TenantInfo.builder()
                 .allowedClusters(Collections.singleton(cluster))

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/NamespacesTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/NamespacesTest.java
@@ -168,7 +168,7 @@ public class NamespacesTest extends MockedPulsarServiceBaseTest {
         namespaces.setServletContext(new MockServletContext());
         namespaces.setPulsar(pulsar);
         doReturn(false).when(namespaces).isRequestHttps();
-        doReturn("test").when(namespaces).clientAppId();
+        doReturn("test").when(namespaces).clientRole();
         doReturn(null).when(namespaces).originalPrincipal();
         doReturn(null).when(namespaces).clientAuthData();
         doReturn(Set.of("use", "usw", "usc", "global")).when(namespaces).clusters();
@@ -1021,7 +1021,7 @@ public class NamespacesTest extends MockedPulsarServiceBaseTest {
             pulsar.getConfiguration().setAuthenticationEnabled(true);
             pulsar.getConfiguration().setAuthorizationEnabled(true);
             pulsar.getPulsarResources().getTenantResources().createTenant(tenant,
-                    new TenantInfoImpl(Set.of(namespaces.clientAppId()), Set.of("use")));
+                    new TenantInfoImpl(Set.of(namespaces.clientRole()), Set.of("use")));
 
             namespaces.validateTenantOperation(tenant, null);
         } finally {
@@ -1123,7 +1123,7 @@ public class NamespacesTest extends MockedPulsarServiceBaseTest {
         topics.setServletContext(new MockServletContext());
         topics.setPulsar(pulsar);
         doReturn(false).when(topics).isRequestHttps();
-        doReturn("test").when(topics).clientAppId();
+        doReturn("test").when(topics).clientRole();
         doReturn(null).when(topics).originalPrincipal();
         doReturn(null).when(topics).clientAuthData();
         mockWebUrl(localWebServiceUrl, testNs);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/NamespacesV2Test.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/NamespacesV2Test.java
@@ -92,7 +92,7 @@ public class NamespacesV2Test extends MockedPulsarServiceBaseTest {
         namespaces.setServletContext(new MockServletContext());
         namespaces.setPulsar(pulsar);
         doReturn(false).when(namespaces).isRequestHttps();
-        doReturn("test").when(namespaces).clientAppId();
+        doReturn("test").when(namespaces).clientRole();
         doReturn(null).when(namespaces).originalPrincipal();
         doReturn(null).when(namespaces).clientAuthData();
         doReturn(Set.of("use", "usw", "usc", "global")).when(namespaces).clusters();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/PersistentTopicsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/PersistentTopicsTest.java
@@ -128,7 +128,7 @@ public class PersistentTopicsTest extends MockedPulsarServiceBaseTest {
         persistentTopics.setPulsar(pulsar);
         doReturn(false).when(persistentTopics).isRequestHttps();
         doReturn(null).when(persistentTopics).originalPrincipal();
-        doReturn("test").when(persistentTopics).clientAppId();
+        doReturn("test").when(persistentTopics).clientRole();
         doReturn(TopicDomain.persistent.value()).when(persistentTopics).domain();
         doNothing().when(persistentTopics).validateAdminAccessForTenant(this.testTenant);
         doReturn(mock(AuthenticationDataHttps.class)).when(persistentTopics).clientAuthData();
@@ -139,7 +139,7 @@ public class PersistentTopicsTest extends MockedPulsarServiceBaseTest {
         namespaceResources = mock(NamespaceResources.class);
         doReturn(false).when(nonPersistentTopic).isRequestHttps();
         doReturn(null).when(nonPersistentTopic).originalPrincipal();
-        doReturn("test").when(nonPersistentTopic).clientAppId();
+        doReturn("test").when(nonPersistentTopic).clientRole();
         doReturn(TopicDomain.non_persistent.value()).when(nonPersistentTopic).domain();
         doNothing().when(nonPersistentTopic).validateAdminAccessForTenant(this.testTenant);
         doReturn(mock(AuthenticationDataHttps.class)).when(nonPersistentTopic).clientAuthData();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/ResourceGroupsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/ResourceGroupsTest.java
@@ -54,7 +54,7 @@ public class ResourceGroupsTest extends MockedPulsarServiceBaseTest {
         resourcegroups.setServletContext(new MockServletContext());
         resourcegroups.setPulsar(pulsar);
         doReturn(false).when(resourcegroups).isRequestHttps();
-        doReturn("test").when(resourcegroups).clientAppId();
+        doReturn("test").when(resourcegroups).clientRole();
         doReturn(null).when(resourcegroups).originalPrincipal();
         doReturn(null).when(resourcegroups).clientAuthData();
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/TopicsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/TopicsTest.java
@@ -109,7 +109,7 @@ public class TopicsTest extends MockedPulsarServiceBaseTest {
         topics = spy(new Topics());
         topics.setPulsar(pulsar);
         doReturn(TopicDomain.persistent.value()).when(topics).domain();
-        doReturn("test-app").when(topics).clientAppId();
+        doReturn("test-app").when(topics).clientRole();
         doReturn(mock(AuthenticationDataHttps.class)).when(topics).clientAuthData();
         admin.clusters().createCluster(testLocalCluster, new ClusterDataImpl());
         admin.tenants().createTenant(testTenant, new TenantInfoImpl(Set.of("role1", "role2"), Set.of(testLocalCluster)));

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/lookup/http/HttpTopicLookupv2Test.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/lookup/http/HttpTopicLookupv2Test.java
@@ -112,7 +112,7 @@ public class HttpTopicLookupv2Test {
         TopicLookup destLookup = spy(TopicLookup.class);
         doReturn(false).when(destLookup).isRequestHttps();
         destLookup.setPulsar(pulsar);
-        doReturn("null").when(destLookup).clientAppId();
+        doReturn("null").when(destLookup).clientRole();
         Field uriField = PulsarWebResource.class.getDeclaredField("uri");
         uriField.setAccessible(true);
         UriInfo uriInfo = mock(UriInfo.class);
@@ -137,7 +137,7 @@ public class HttpTopicLookupv2Test {
         MockTopicLookup destLookup = spy(MockTopicLookup.class);
         doReturn(false).when(destLookup).isRequestHttps();
         destLookup.setPulsar(pulsar);
-        doReturn("null").when(destLookup).clientAppId();
+        doReturn("null").when(destLookup).clientRole();
         Field uriField = PulsarWebResource.class.getDeclaredField("uri");
         uriField.setAccessible(true);
         UriInfo uriInfo = mock(UriInfo.class);
@@ -181,7 +181,7 @@ public class HttpTopicLookupv2Test {
         TopicLookup destLookup = spy(TopicLookup.class);
         doReturn(false).when(destLookup).isRequestHttps();
         destLookup.setPulsar(pulsar);
-        doReturn("null").when(destLookup).clientAppId();
+        doReturn("null").when(destLookup).clientRole();
         Field uriField = PulsarWebResource.class.getDeclaredField("uri");
         uriField.setAccessible(true);
         UriInfo uriInfo = mock(UriInfo.class);
@@ -213,7 +213,7 @@ public class HttpTopicLookupv2Test {
         TopicLookup destLookup = spy(TopicLookup.class);
         doReturn(false).when(destLookup).isRequestHttps();
         destLookup.setPulsar(pulsar);
-        doReturn("null").when(destLookup).clientAppId();
+        doReturn("null").when(destLookup).clientRole();
         Field uriField = PulsarWebResource.class.getDeclaredField("uri");
         uriField.setAccessible(true);
         UriInfo uriInfo = mock(UriInfo.class);


### PR DESCRIPTION

Fixes #18165


### Motivation

Current request log use clientAppId for tracing client info.

But when authentication is disabled. clientAppId always return null which makes it is difficult for problem tracing.

This patch split caller for log tracing and for client role retrieve.

### Modifications

the following usage are change from `clientAppId()` to `clientRole()`

+ `FunctionBase` 
+ `SchemasResourceBase`  
+ `TenantsBase`
+ `Functions`
+ `Worker`
+ `TopicsBase`
+ most unit test 

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

This change added tests and can be verified as follows:

### Does this pull request potentially affect one of the following parts:

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [x] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

