### PR TITLE
[fix][meta] fix `getChildren` in MemoryMetadataStore and EtcdMetadataStore

### DIFF
--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/EtcdMetadataStore.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/EtcdMetadataStore.java
@@ -385,11 +385,12 @@ public class EtcdMetadataStore extends AbstractBatchedMetadataStore {
                     case GET_CHILDREN: {
                         OpGetChildren getChildren = op.asGetChildren();
                         GetResponse gr = txnResponse.getGetResponses().get(getIdx++);
-                        String basePath = getChildren.getPath() + "/";
+                        String basePath =
+                                getChildren.getPath().equals("/") ? "/" : getChildren.getPath() + "/";
 
                         Set<String> children = gr.getKvs().stream()
                                 .map(kv -> kv.getKey().toString(StandardCharsets.UTF_8))
-                                .map(p -> p.replace(basePath, ""))
+                                .map(p -> p.replaceFirst(basePath, ""))
                                 // Only return first-level children
                                 .map(k -> k.split("/", 2)[0])
                                 .collect(Collectors.toCollection(TreeSet::new));

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/LocalMemoryMetadataStore.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/LocalMemoryMetadataStore.java
@@ -129,7 +129,7 @@ public class LocalMemoryMetadataStore extends AbstractMetadataStore implements M
 
             Set<String> children = new TreeSet<>();
             map.subMap(firstKey, false, lastKey, false).forEach((key, value) -> {
-                String relativePath = key.replace(firstKey, "");
+                String relativePath = key.replaceFirst(firstKey, "");
 
                 // Only return first-level children
                 String child = relativePath.split("/", 2)[0];

--- a/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/MetadataStoreTest.java
+++ b/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/MetadataStoreTest.java
@@ -28,6 +28,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
@@ -499,5 +500,33 @@ public class MetadataStoreTest extends BaseMetadataStoreTest {
         Awaitility.await().until(() -> f1.isDone() && f2.isDone());
         assertTrue(f1.isCompletedExceptionally() && !f2.isCompletedExceptionally() ||
                 ! f1.isCompletedExceptionally() && f2.isCompletedExceptionally());
+    }
+
+    @Test(dataProvider = "impl")
+    public void testGetChildren(String provider, Supplier<String> urlSupplier) throws Exception {
+        @Cleanup
+        MetadataStore store = MetadataStoreFactory.create(urlSupplier.get(), MetadataStoreConfig.builder().build());
+
+        store.put("/a/a-1", "value1".getBytes(StandardCharsets.UTF_8), Optional.empty()).join();
+        store.put("/a/a-2", "value1".getBytes(StandardCharsets.UTF_8), Optional.empty()).join();
+        store.put("/b/c/b/1", "value1".getBytes(StandardCharsets.UTF_8), Optional.empty()).join();
+
+        List<String> subPaths = store.getChildren("/").get();
+        Set<String> expectedSet = "ZooKeeper".equals(provider) ? Set.of("a", "b", "zookeeper") : Set.of("a", "b");
+        for (String subPath : subPaths) {
+            assertTrue(expectedSet.contains(subPath));
+        }
+
+        List<String> subPaths2 = store.getChildren("/a").get();
+        Set<String> expectedSet2 = Set.of("a-1", "a-2");
+        for (String subPath : subPaths2) {
+            assertTrue(expectedSet2.contains(subPath));
+        }
+
+        List<String> subPaths3 = store.getChildren("/b").get();
+        Set<String> expectedSet3 = Set.of("c");
+        for (String subPath : subPaths3) {
+            assertTrue(expectedSet3.contains(subPath));
+        }
     }
 }

--- a/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/impl/LocalMemoryMetadataStoreTest.java
+++ b/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/impl/LocalMemoryMetadataStoreTest.java
@@ -86,7 +86,7 @@ public class LocalMemoryMetadataStoreTest {
             assertEquals((long) event2.getExpectedVersion(), exptectedVersion);
             assertEquals(event2.getType(), NotificationType.Modified);
         }
-        
+
         // (3) delete node
         sync.notifiedEvents.remove(path);
         store1.delete(path, Optional.of(exptectedVersion)).join();
@@ -176,7 +176,7 @@ public class LocalMemoryMetadataStoreTest {
         store1.put(path, value1, Optional.empty()).join();
 
         assertTrue(store1.exists(path).join());
-        
+
         Stat stats = store1.get(path).get().get().getStat();
         MetadataEvent event = new MetadataEvent(path, value2, EMPTY_SET, stats.getVersion(),
                 stats.getModificationTimestamp() + 1, sync.clusterName, NotificationType.Modified);


### PR DESCRIPTION
### Motivation

In the current implementation, the `getChildren` will return incorrect results when getting children paths of `/` and some special path in `MemoryMetadataStore` and `EtcdMetadataStore`, because we use `replace` lead to the `basePath` has been replaced many times.

### Modifications

Use `replaceFirst` instead of `replace`.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change is already covered by existing tests, such as *testGetChildren*.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/coderzc/pulsar/pull/16