### PR TITLE
[improve][broker] Support setting `ForceDeleteNamespaceAllowed` dynamically

### DIFF
--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -649,6 +649,7 @@ public class ServiceConfiguration implements PulsarConfiguration {
 
     @FieldContext(
             category = CATEGORY_POLICIES,
+            dynamic = true,
             doc = "Allow forced deletion of namespaces. Default is false."
     )
     private boolean forceDeleteNamespaceAllowed = false;

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerServiceTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerServiceTest.java
@@ -1496,4 +1496,16 @@ public class BrokerServiceTest extends BrokerTestBase {
                 .subscriptionType(SubscriptionType.Shared)
                 .subscribe();
     }
+
+    @Test
+    public void testDynamicConfigurationsForceDeleteNamespaceAllowed() throws Exception {
+        super.internalCleanup();
+        conf.setForceDeleteNamespaceAllowed(false);
+        super.baseSetup();
+        admin.brokers()
+                .updateDynamicConfiguration("forceDeleteNamespaceAllowed", "true");
+        Awaitility.await().untilAsserted(()->{
+            assertTrue(conf.isForceDeleteNamespaceAllowed());
+        });
+    }
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerServiceTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerServiceTest.java
@@ -1499,9 +1499,9 @@ public class BrokerServiceTest extends BrokerTestBase {
 
     @Test
     public void testDynamicConfigurationsForceDeleteNamespaceAllowed() throws Exception {
-        super.internalCleanup();
+        cleanup();
         conf.setForceDeleteNamespaceAllowed(false);
-        super.baseSetup();
+        setup();
         admin.brokers()
                 .updateDynamicConfiguration("forceDeleteNamespaceAllowed", "true");
         Awaitility.await().untilAsserted(()->{


### PR DESCRIPTION
### Motivation

Support setting `ForceDeleteNamespaceAllowed` dynamically.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [x] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [ ] `doc-complete` <!-- Docs have been already added -->


