### PR TITLE
[fix][sql] Fix jline version to 3.21.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -291,6 +291,12 @@ flexible messaging model and an intuitive client API.</description>
     <dependencies>
 
       <dependency>
+        <groupId>org.jline</groupId>
+        <artifactId>jline</artifactId>
+        <version>${jline3.version}</version>
+      </dependency>
+
+      <dependency>
         <groupId>org.asynchttpclient</groupId>
         <artifactId>async-http-client</artifactId>
         <version>${asynchttpclient.version}</version>

--- a/pulsar-broker/src/main/java/org/apache/pulsar/PulsarStandalone.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/PulsarStandalone.java
@@ -439,7 +439,7 @@ public class PulsarStandalone implements AutoCloseable {
             log.info("Starting BK with RocksDb metadata store");
             metadataStoreUrl = "rocksdb://" + Paths.get(metadataDir).toAbsolutePath();
         } else {
-            log.info("Starting BK with metadata store:", metadataStoreUrl);
+            log.info("Starting BK with metadata store: {}", metadataStoreUrl);
         }
 
         ServerConfiguration bkServerConf = new ServerConfiguration();

--- a/pulsar-client-tools/pom.xml
+++ b/pulsar-client-tools/pom.xml
@@ -126,7 +126,6 @@
     <dependency>
       <groupId>org.jline</groupId>
       <artifactId>jline</artifactId>
-      <version>${jline3.version}</version>
     </dependency>
     <dependency>
       <groupId>net.java.dev.jna</groupId>

--- a/pulsar-sql/pom.xml
+++ b/pulsar-sql/pom.xml
@@ -63,6 +63,23 @@
                 <version>${okio.version}</version>
             </dependency>
 
+            <!-- force specific version of jline, see https://github.com/scala/scala/pull/9807 -->
+            <dependency>
+                <groupId>org.jline</groupId>
+                <artifactId>jline-reader</artifactId>
+                <version>${jline3.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jline</groupId>
+                <artifactId>jline-terminal</artifactId>
+                <version>${jline3.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jline</groupId>
+                <artifactId>jline-terminal-jna</artifactId>
+                <version>${jline3.version}</version>
+            </dependency>
+
             <!-- force specific version of slf4j -->
             <dependency>
                 <groupId>org.slf4j</groupId>

--- a/pulsar-sql/presto-distribution/LICENSE
+++ b/pulsar-sql/presto-distribution/LICENSE
@@ -492,9 +492,9 @@ BSD License
     - asm-tree-6.2.1.jar
     - asm-util-6.2.1.jar
  * JLine
-   - jline-reader-3.17.1.jar
-   - jline-terminal-3.17.1.jar
-   - jline-terminal-jna-3.17.1.jar
+   - jline-reader-3.21.0.jar
+   - jline-terminal-3.21.0.jar
+   - jline-terminal-jna-3.21.0.jar
 
 MIT License
  * PCollections

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/tls/ClientTlsTest.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/tls/ClientTlsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information


### PR DESCRIPTION
Using jline before 3.21.0 may cause a "Bad address" failure on Apple M1 environment. We're using 3.21.0 globally, so forcibly apply this version to pulsar-sql dependencies.

See also https://github.com/scala/scala/pull/9807.

### Does this pull request potentially affect one of the following parts:

*If the box was checked, please highlight the changes*

- [x] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
