### PR TITLE
[improve] [client] support aggregate metrics for partition topic stats

### DIFF
--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/ProducerStatsRecorderImplTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/ProducerStatsRecorderImplTest.java
@@ -26,7 +26,9 @@ import org.testng.annotations.Test;
 
 import java.util.concurrent.TimeUnit;
 
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
 
@@ -73,5 +75,16 @@ public class ProducerStatsRecorderImplTest {
         recorder.incrementNumAcksReceived(latencyNs);
         recorder.cancelStatsTimeout();
         assertEquals(1000.0, recorder.getSendLatencyMillisMax(), 0.5);
+    }
+
+    @Test
+    public void testPartitionTopicAggegationStats() {
+        ProducerStatsRecorderImpl recorder1 = spy(new ProducerStatsRecorderImpl());
+        ProducerStatsRecorderImpl recorder2 = new ProducerStatsRecorderImpl();
+        when(recorder1.getSendMsgsRate()).thenReturn(1000.0);
+        when(recorder1.getSendBytesRate()).thenReturn(1000.0);
+        recorder2.updateCumulativeStats(recorder1);
+        assertTrue(recorder2.getSendBytesRate() > 0);
+        assertTrue(recorder2.getSendMsgsRate() > 0);
     }
 }


### PR DESCRIPTION
### Motivation

Right now, Producer client stats returns incorrect rate values for partition topic instead giving aggregate value across all partitions. Right now it always returns 0 but it can be aggregated for partition topic and give to client.

### Modifications

Update aggregate rate value for producer stats.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
