### PR TITLE
[fix][io] exclude logback dependency for canal connector

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ pulsar-functions/worker/src/test/resources/
 !.idea/vcs.xml
 *.iml
 *.iws
+.fleet/*
 
 # NetBeans
 nb-configuration.xml

--- a/pulsar-io/canal/pom.xml
+++ b/pulsar-io/canal/pom.xml
@@ -87,6 +87,12 @@
             <groupId>com.alibaba.otter</groupId>
             <artifactId>canal.protocol</artifactId>
             <version>${canal.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>ch.qos.logback</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>com.alibaba.otter</groupId>


### PR DESCRIPTION
### Motivation

[CVE-2017-5929](https://www.cve.org/CVERecord?id=CVE-2017-5929)

Introduced through:
com.alibaba.otter:canal.protocol@1.1.5

Fixed in:
ch.qos.logback:logback-classic@1.2.0
