### PR TITLE
[fix][broker][branch-2.8] Fix watcher count on ZK increasing indefinitely

### DIFF
--- a/pulsar-zookeeper-utils/src/main/java/org/apache/pulsar/zookeeper/ZkUtils.java
+++ b/pulsar-zookeeper-utils/src/main/java/org/apache/pulsar/zookeeper/ZkUtils.java
@@ -18,62 +18,10 @@
  */
 package org.apache.pulsar.zookeeper;
 
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
-import org.apache.zookeeper.KeeperException;
-import org.apache.zookeeper.KeeperException.NodeExistsException;
-import org.apache.zookeeper.Watcher;
-import org.apache.zookeeper.Watcher.Event.EventType;
-import org.apache.zookeeper.ZooKeeper;
-import org.apache.zookeeper.data.Stat;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 /**
  * ZooKeeper utils.
  */
 public final class ZkUtils {
-
-    private static final Logger log = LoggerFactory.getLogger(ZkUtils.class);
-
-    /**
-     * Check if the provided <i>path</i> exists or not and wait it expired if possible.
-     *
-     * @param zk the zookeeper client instance
-     * @param path the zookeeper path
-     * @param sessionTimeoutMs session timeout in milliseconds
-     * @return true if path exists, otherwise return false
-     * @throws KeeperException when failed to access zookeeper
-     * @throws InterruptedException interrupted when waiting for znode to be expired
-     */
-    public static boolean checkNodeAndWaitExpired(ZooKeeper zk,
-                                                  String path,
-                                                  long sessionTimeoutMs) throws KeeperException, InterruptedException {
-        final CountDownLatch prevNodeLatch = new CountDownLatch(1);
-        Watcher zkPrevNodeWatcher = watchedEvent -> {
-            // check for prev node deletion.
-            if (EventType.NodeDeleted == watchedEvent.getType()) {
-                prevNodeLatch.countDown();
-            }
-        };
-        Stat stat = zk.exists(path, zkPrevNodeWatcher);
-        if (null != stat) {
-            // if the ephemeral owner isn't current zookeeper client
-            // wait for it to be expired
-            if (stat.getEphemeralOwner() != zk.getSessionId()) {
-                log.info("Previous znode : {} still exists, so waiting {} ms for znode deletion",
-                    path, sessionTimeoutMs);
-                if (!prevNodeLatch.await(sessionTimeoutMs, TimeUnit.MILLISECONDS)) {
-                    throw new NodeExistsException(path);
-                } else {
-                    return false;
-                }
-            }
-            return true;
-        } else {
-            return false;
-        }
-    }
 
     /**
      * Returns the parent path of the provided path.


### PR DESCRIPTION
### Motivation

I find some z-node only call `exist` and add watcher, but `ExistsWatchRegistration` still will be registered even though the z-node may never be created. this will lead to the watcher count on ZK increasing indefinitely.

```java
    /** Handle the special case of exists watches - they add a watcher
     * even in the case where NONODE result code is returned.
     */
    class ExistsWatchRegistration extends WatchRegistration {

        public ExistsWatchRegistration(Watcher watcher, String clientPath) {
            super(watcher, clientPath);
        }

        @Override
        protected Map<String, Set<Watcher>> getWatches(int rc) {
            return rc == 0 ? watchManager.dataWatches : watchManager.existWatches;
        }

        @Override
        protected boolean shouldAddWatch(int rc) {
            return rc == 0 || rc == KeeperException.Code.NONODE.intValue();
        }

    }
```

### Modifications

Remove watcher if `exist` return `NONODE`.
Remove unused method in ZkUtils.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: 
