### PR TITLE
[fix][broker][branch-2.8] Fix watcher count on ZK increasing indefinitely 

### DIFF
--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/api/NotificationType.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/api/NotificationType.java
@@ -22,5 +22,6 @@ public enum NotificationType {
     Created,
     Modified,
     ChildrenChanged,
-    Deleted
+    Deleted,
+    Invalidate
 }

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/cache/impl/MetadataCacheImpl.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/cache/impl/MetadataCacheImpl.java
@@ -25,10 +25,7 @@ import com.github.benmanes.caffeine.cache.AsyncLoadingCache;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.google.common.annotations.VisibleForTesting;
 import java.io.IOException;
-import java.util.AbstractMap.SimpleImmutableEntry;
 import java.util.List;
-import java.util.Map;
-import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
@@ -36,7 +33,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
-
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.bookkeeper.common.concurrent.FutureUtils;
@@ -49,12 +45,12 @@ import org.apache.pulsar.metadata.api.MetadataStoreException.BadVersionException
 import org.apache.pulsar.metadata.api.MetadataStoreException.ContentDeserializationException;
 import org.apache.pulsar.metadata.api.MetadataStoreException.NotFoundException;
 import org.apache.pulsar.metadata.api.Notification;
-import org.apache.pulsar.metadata.api.Stat;
 
 @Slf4j
 public class MetadataCacheImpl<T> implements MetadataCache<T>, Consumer<Notification> {
 
-    private static final long CACHE_REFRESH_TIME_MILLIS = TimeUnit.MINUTES.toMillis(5);
+    @VisibleForTesting
+    public static long cacheRefreshTimeMillis = TimeUnit.MINUTES.toMillis(5);
 
     @Getter
     private final MetadataStore store;
@@ -75,7 +71,7 @@ public class MetadataCacheImpl<T> implements MetadataCache<T>, Consumer<Notifica
         this.serde = serde;
 
         this.objCache = Caffeine.newBuilder()
-                .refreshAfterWrite(CACHE_REFRESH_TIME_MILLIS, TimeUnit.MILLISECONDS)
+                .refreshAfterWrite(cacheRefreshTimeMillis, TimeUnit.MILLISECONDS)
                 .buildAsync(new AsyncCacheLoader<String, Optional<CacheGetResult<T>>>() {
                     @Override
                     public CompletableFuture<Optional<CacheGetResult<T>>> asyncLoad(String key, Executor executor) {

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/cache/impl/MetadataCacheImpl.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/cache/impl/MetadataCacheImpl.java
@@ -49,8 +49,7 @@ import org.apache.pulsar.metadata.api.Notification;
 @Slf4j
 public class MetadataCacheImpl<T> implements MetadataCache<T>, Consumer<Notification> {
 
-    @VisibleForTesting
-    public static long cacheRefreshTimeMillis = TimeUnit.MINUTES.toMillis(5);
+    private static final long CACHE_REFRESH_TIME_MILLIS = TimeUnit.MINUTES.toMillis(5);
 
     @Getter
     private final MetadataStore store;
@@ -71,7 +70,7 @@ public class MetadataCacheImpl<T> implements MetadataCache<T>, Consumer<Notifica
         this.serde = serde;
 
         this.objCache = Caffeine.newBuilder()
-                .refreshAfterWrite(cacheRefreshTimeMillis, TimeUnit.MILLISECONDS)
+                .refreshAfterWrite(CACHE_REFRESH_TIME_MILLIS, TimeUnit.MILLISECONDS)
                 .buildAsync(new AsyncCacheLoader<String, Optional<CacheGetResult<T>>>() {
                     @Override
                     public CompletableFuture<Optional<CacheGetResult<T>>> asyncLoad(String key, Executor executor) {

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/AbstractMetadataStore.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/AbstractMetadataStore.java
@@ -57,7 +57,7 @@ public abstract class AbstractMetadataStore implements MetadataStoreExtended, Co
     private final CopyOnWriteArrayList<Consumer<SessionEvent>> sessionListeners = new CopyOnWriteArrayList<>();
     protected final ScheduledExecutorService executor;
     protected final AsyncLoadingCache<String, List<String>> childrenCache;
-    private final AsyncLoadingCache<String, Boolean> existsCache;
+    protected final AsyncLoadingCache<String, Boolean> existsCache;
     protected final CopyOnWriteArrayList<MetadataCacheImpl<?>> metadataCaches = new CopyOnWriteArrayList<>();
 
     protected abstract CompletableFuture<List<String>> getChildrenFromStore(String path);

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/AbstractMetadataStore.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/AbstractMetadataStore.java
@@ -24,9 +24,7 @@ import com.github.benmanes.caffeine.cache.AsyncCacheLoader;
 import com.github.benmanes.caffeine.cache.AsyncLoadingCache;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.google.common.annotations.VisibleForTesting;
-
 import io.netty.util.concurrent.DefaultThreadFactory;
-
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Optional;
@@ -38,9 +36,7 @@ import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
-
 import lombok.extern.slf4j.Slf4j;
-
 import org.apache.pulsar.common.util.FutureUtil;
 import org.apache.pulsar.metadata.api.MetadataCache;
 import org.apache.pulsar.metadata.api.MetadataSerde;
@@ -60,9 +56,9 @@ public abstract class AbstractMetadataStore implements MetadataStoreExtended, Co
     private final CopyOnWriteArrayList<Consumer<Notification>> listeners = new CopyOnWriteArrayList<>();
     private final CopyOnWriteArrayList<Consumer<SessionEvent>> sessionListeners = new CopyOnWriteArrayList<>();
     protected final ScheduledExecutorService executor;
-    private final AsyncLoadingCache<String, List<String>> childrenCache;
+    protected final AsyncLoadingCache<String, List<String>> childrenCache;
     private final AsyncLoadingCache<String, Boolean> existsCache;
-    private final CopyOnWriteArrayList<MetadataCacheImpl<?>> metadataCaches = new CopyOnWriteArrayList<>();
+    protected final CopyOnWriteArrayList<MetadataCacheImpl<?>> metadataCaches = new CopyOnWriteArrayList<>();
 
     protected abstract CompletableFuture<List<String>> getChildrenFromStore(String path);
 

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/ZKMetadataStore.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/ZKMetadataStore.java
@@ -186,6 +186,7 @@ public class ZKMetadataStore extends AbstractMetadataStore implements MetadataSt
                                         log.warn("Remove watcher for non-existing znode failed. rc: {}, path: {}", code0, path);
                                     }
                                 }, null);
+                        existsCache.synchronous().invalidate(path);
                     } else if (code == Code.CONNECTIONLOSS) {
                         // There is the chance that we caused a connection reset by sending or requesting a batch
                         // that passed the max ZK limit. Retry with the individual operations

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/ZKMetadataStore.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/ZKMetadataStore.java
@@ -108,6 +108,7 @@ public class ZKMetadataStore extends AbstractMetadataStore implements MetadataSt
                         // if z-node does not exist then discards cache,
                         // because we can't be received NodeCreated event
                         metadataCaches.forEach(c -> c.invalidate(path));
+                        receivedNotification(new Notification(NotificationType.Invalidate, path));
                     } else if (code == Code.CONNECTIONLOSS) {
                         // There is the chance that we caused a connection reset by sending or requesting a batch
                         // that passed the max ZK limit. Retry with the individual operations
@@ -145,6 +146,7 @@ public class ZKMetadataStore extends AbstractMetadataStore implements MetadataSt
                         // if z-node does not exist then discards cache,
                         // because we can't be received NodeCreated event
                         childrenCache.synchronous().invalidate(path);
+                        receivedNotification(new Notification(NotificationType.Invalidate, path));
                     } else if (code == Code.CONNECTIONLOSS) {
                         // There is the chance that we caused a connection reset by sending or requesting a batch
                         // that passed the max ZK limit. Retry with the individual operations

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/ZKMetadataStore.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/ZKMetadataStore.java
@@ -208,7 +208,7 @@ public class ZKMetadataStore extends AbstractMetadataStore implements MetadataSt
                                 (rc0, path0, ctx0) -> {
                                     Code code0 = Code.get(rc0);
                                     if (code0 != Code.OK && code0 != Code.NOWATCHER) {
-                                        log.warn("Remove watcher failed. rc: {}, path: {}", code0, path);
+                                        log.warn("Remove watcher for non-existing znode failed. rc: {}, path: {}", code0, path);
                                     }
                                 }, null);
                         future.complete(false);

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/ZKMetadataStore.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/ZKMetadataStore.java
@@ -116,12 +116,14 @@ public class ZKMetadataStore extends AbstractMetadataStore implements MetadataSt
                             } else {
                                 // Z-node does not exist
                                 future.complete(Optional.empty());
+                                // if z-node does not exist discards cache,
+                                // because we can't be received NodeCreated event
+                                metadataCaches.forEach(c -> c.invalidate(path));
                             }
                         }).exceptionally(ex -> {
                             future.completeExceptionally(ex);
                             return null;
                         });
-                        future.complete(Optional.empty());
                     } else if (code == Code.CONNECTIONLOSS) {
                         // There is the chance that we caused a connection reset by sending or requesting a batch
                         // that passed the max ZK limit. Retry with the individual operations
@@ -168,6 +170,9 @@ public class ZKMetadataStore extends AbstractMetadataStore implements MetadataSt
                             } else {
                                 // Z-node does not exist
                                 future.complete(Collections.emptyList());
+                                // if z-node does not exist discards cache,
+                                // because we can't be received NodeCreated event
+                                childrenCache.synchronous().invalidate(path);
                             }
                         }).exceptionally(ex -> {
                             future.completeExceptionally(ex);

--- a/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/MetadataCacheTest.java
+++ b/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/MetadataCacheTest.java
@@ -24,7 +24,6 @@ import static org.testng.Assert.assertNotSame;
 import static org.testng.Assert.assertSame;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
-
 import com.fasterxml.jackson.core.type.TypeReference;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -34,8 +33,8 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.TreeMap;
 import java.util.concurrent.CompletionException;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
-
 import lombok.AllArgsConstructor;
 import lombok.Cleanup;
 import lombok.Data;
@@ -52,6 +51,7 @@ import org.apache.pulsar.metadata.api.MetadataStoreException.ContentDeserializat
 import org.apache.pulsar.metadata.api.MetadataStoreException.NotFoundException;
 import org.apache.pulsar.metadata.api.MetadataStoreFactory;
 import org.apache.pulsar.metadata.api.Stat;
+import org.apache.pulsar.metadata.cache.impl.MetadataCacheImpl;
 import org.awaitility.Awaitility;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -103,6 +103,8 @@ public class MetadataCacheTest extends BaseMetadataStoreTest {
 
     @Test(dataProvider = "zk")
     public void crossStoreUpdates(String provider, String url) throws Exception {
+        MetadataCacheImpl.cacheRefreshTimeMillis = TimeUnit.SECONDS.toMillis(5);
+
         @Cleanup
         MetadataStore store1 = MetadataStoreFactory.create(url, MetadataStoreConfig.builder().build());
 

--- a/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/MetadataStoreTest.java
+++ b/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/MetadataStoreTest.java
@@ -23,7 +23,6 @@ import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
-
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -32,9 +31,7 @@ import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.LinkedBlockingDeque;
 import java.util.concurrent.TimeUnit;
-
 import lombok.Cleanup;
-
 import org.apache.pulsar.metadata.api.GetResult;
 import org.apache.pulsar.metadata.api.MetadataStore;
 import org.apache.pulsar.metadata.api.MetadataStoreConfig;
@@ -255,10 +252,13 @@ public class MetadataStoreTest extends BaseMetadataStoreTest {
         assertEquals(store.getChildren(key1).join(), Collections.emptyList());
         assertEquals(stat.getVersion(), 0);
 
-        Notification n = notifications.poll(3, TimeUnit.SECONDS);
-        assertNotNull(n);
-        assertEquals(n.getType(), NotificationType.Created);
-        assertEquals(n.getPath(), key1);
+        Notification n;
+        if (provider.equals("Memory")) {
+            n = notifications.poll(3, TimeUnit.SECONDS);
+            assertNotNull(n);
+            assertEquals(n.getType(), NotificationType.Created);
+            assertEquals(n.getPath(), key1);
+        }
 
         // Trigger modified notification
         stat = store.put(key1, "value-2".getBytes(), Optional.empty()).join();
@@ -274,10 +274,12 @@ public class MetadataStoreTest extends BaseMetadataStoreTest {
         assertFalse(store.get(key1Child).join().isPresent());
 
         store.put(key1Child, "value-2".getBytes(), Optional.empty()).join();
-        n = notifications.poll(3, TimeUnit.SECONDS);
-        assertNotNull(n);
-        assertEquals(n.getType(), NotificationType.Created);
-        assertEquals(n.getPath(), key1Child);
+        if (provider.equals("Memory")) {
+            n = notifications.poll(3, TimeUnit.SECONDS);
+            assertNotNull(n);
+            assertEquals(n.getType(), NotificationType.Created);
+            assertEquals(n.getPath(), key1Child);
+        }
 
         n = notifications.poll(3, TimeUnit.SECONDS);
         assertNotNull(n);

--- a/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/TestZKServer.java
+++ b/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/TestZKServer.java
@@ -19,7 +19,6 @@
 package org.apache.pulsar.metadata;
 
 import static org.testng.Assert.assertTrue;
-
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
@@ -27,15 +26,17 @@ import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.net.InetSocketAddress;
 import java.net.Socket;
-
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
-
 import org.apache.commons.io.FileUtils;
 import org.apache.zookeeper.server.NIOServerCnxnFactory;
 import org.apache.zookeeper.server.ServerCnxnFactory;
 import org.apache.zookeeper.server.SessionTracker;
-import org.apache.zookeeper.server.SessionTrackerImpl;
 import org.apache.zookeeper.server.ZooKeeperServer;
+import org.apache.zookeeper.server.admin.CommandResponse;
+import org.apache.zookeeper.server.admin.Commands;
 import org.assertj.core.util.Files;
 
 @Slf4j
@@ -155,5 +156,13 @@ public class TestZKServer implements AutoCloseable {
             }
         }
         return false;
+    }
+
+    public Collection<String> wchc(long sessionId) {
+        Commands.WatchCommand watchCommand = new Commands.WatchCommand();
+        CommandResponse response = watchCommand.run(zks, Collections.emptyMap());
+        Map<Long, Collection<String>> wchc =
+                (Map<Long, Collection<String>>) response.toMap().get("session_id_to_watched_paths");
+        return wchc.get(sessionId);
     }
 }

--- a/pulsar-zookeeper-utils/src/main/java/org/apache/pulsar/zookeeper/ZkUtils.java
+++ b/pulsar-zookeeper-utils/src/main/java/org/apache/pulsar/zookeeper/ZkUtils.java
@@ -18,62 +18,10 @@
  */
 package org.apache.pulsar.zookeeper;
 
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
-import org.apache.zookeeper.KeeperException;
-import org.apache.zookeeper.KeeperException.NodeExistsException;
-import org.apache.zookeeper.Watcher;
-import org.apache.zookeeper.Watcher.Event.EventType;
-import org.apache.zookeeper.ZooKeeper;
-import org.apache.zookeeper.data.Stat;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 /**
  * ZooKeeper utils.
  */
 public final class ZkUtils {
-
-    private static final Logger log = LoggerFactory.getLogger(ZkUtils.class);
-
-    /**
-     * Check if the provided <i>path</i> exists or not and wait it expired if possible.
-     *
-     * @param zk the zookeeper client instance
-     * @param path the zookeeper path
-     * @param sessionTimeoutMs session timeout in milliseconds
-     * @return true if path exists, otherwise return false
-     * @throws KeeperException when failed to access zookeeper
-     * @throws InterruptedException interrupted when waiting for znode to be expired
-     */
-    public static boolean checkNodeAndWaitExpired(ZooKeeper zk,
-                                                  String path,
-                                                  long sessionTimeoutMs) throws KeeperException, InterruptedException {
-        final CountDownLatch prevNodeLatch = new CountDownLatch(1);
-        Watcher zkPrevNodeWatcher = watchedEvent -> {
-            // check for prev node deletion.
-            if (EventType.NodeDeleted == watchedEvent.getType()) {
-                prevNodeLatch.countDown();
-            }
-        };
-        Stat stat = zk.exists(path, zkPrevNodeWatcher);
-        if (null != stat) {
-            // if the ephemeral owner isn't current zookeeper client
-            // wait for it to be expired
-            if (stat.getEphemeralOwner() != zk.getSessionId()) {
-                log.info("Previous znode : {} still exists, so waiting {} ms for znode deletion",
-                    path, sessionTimeoutMs);
-                if (!prevNodeLatch.await(sessionTimeoutMs, TimeUnit.MILLISECONDS)) {
-                    throw new NodeExistsException(path);
-                } else {
-                    return false;
-                }
-            }
-            return true;
-        } else {
-            return false;
-        }
-    }
 
     /**
      * Returns the parent path of the provided path.

--- a/pulsar-zookeeper-utils/src/main/java/org/apache/pulsar/zookeeper/ZooKeeperCache.java
+++ b/pulsar-zookeeper-utils/src/main/java/org/apache/pulsar/zookeeper/ZooKeeperCache.java
@@ -246,8 +246,8 @@ public abstract class ZooKeeperCache implements Watcher {
                 if (rc == Code.OK.intValue()) {
                     future.complete(true);
                 } else if (rc == Code.NONODE.intValue()) {
-                    removeAllWatches(path);
                     future.complete(false);
+                    removeAllWatches(path);
                 } else {
                     future.completeExceptionally(KeeperException.create(rc));
                 }
@@ -476,7 +476,7 @@ public abstract class ZooKeeperCache implements Watcher {
                             } else {
                                 // Z-node does not exist
                                 future.complete(Collections.emptySet());
-                                // if z-node does not exist discards cache,
+                                // if z-node does not exist then discards cache,
                                 // because we can't be received NodeCreated event
                                 invalidateChildren(path);
                             }

--- a/pulsar-zookeeper-utils/src/main/java/org/apache/pulsar/zookeeper/ZooKeeperCache.java
+++ b/pulsar-zookeeper-utils/src/main/java/org/apache/pulsar/zookeeper/ZooKeeperCache.java
@@ -246,13 +246,7 @@ public abstract class ZooKeeperCache implements Watcher {
                     future.complete(true);
                 } else if (rc == Code.NONODE.intValue()) {
                     // remove watcher if node does not exist
-                    zk.removeAllWatches(path, Watcher.WatcherType.Any, true,
-                            (rc0, path0, ctx0) -> {
-                                Code code0 = Code.get(rc0);
-                                if (code0 != Code.OK && code0 != Code.NOWATCHER) {
-                                    log.warn("Remove watcher failed. rc: {}, path: {}", code0, path);
-                                }
-                            }, null);
+                    removeAllWatches(path);
                     future.complete(false);
                 } else {
                     future.completeExceptionally(KeeperException.create(rc));
@@ -568,13 +562,7 @@ public abstract class ZooKeeperCache implements Watcher {
                 return true;
             } else {
                 // remove watcher if node does not exist
-                getZooKeeper().removeAllWatches(regPath, Watcher.WatcherType.Any, true,
-                        (rc0, path0, ctx0) -> {
-                            Code code0 = Code.get(rc0);
-                            if (code0 != Code.OK && code0 != Code.NOWATCHER) {
-                                log.warn("Remove watcher failed. rc: {}, path: {}", code0, regPath);
-                            }
-                        }, null);
+                removeAllWatches(regPath);
                 return false;
             }
         } catch (KeeperException ke) {
@@ -587,6 +575,16 @@ public abstract class ZooKeeperCache implements Watcher {
             throw new IOException("Interrupted checking and wait ephemeral znode "
                 + regPath + " expired", ie);
         }
+    }
+
+    private void removeAllWatches(String path) {
+        getZooKeeper().removeAllWatches(path, Watcher.WatcherType.Any, true,
+                (rc0, path0, ctx0) -> {
+                    Code code0 = Code.get(rc0);
+                    if (code0 != Code.OK && code0 != Code.NOWATCHER) {
+                        log.warn("Remove watcher for non-existing znode failed. rc: {}, path: {}", code0, path);
+                    }
+                }, null);
     }
 
     private static Logger log = LoggerFactory.getLogger(ZooKeeperCache.class);

--- a/pulsar-zookeeper-utils/src/test/java/org/apache/pulsar/zookeeper/ZookeeperCacheTest.java
+++ b/pulsar-zookeeper-utils/src/test/java/org/apache/pulsar/zookeeper/ZookeeperCacheTest.java
@@ -213,15 +213,10 @@ public class ZookeeperCacheTest {
         zkClient.create("/test", new byte[0], null, CreateMode.PERSISTENT);
         zkClient.create("/test/z1", new byte[0], null, CreateMode.PERSISTENT);
 
-        // Wait for cache to be updated in background
-        Awaitility.await().until(() -> notificationCount.get() >= 1);
-
-
         final int recvNotifications = notificationCount.get();
 
         assertEquals(cache.get(), new TreeSet<String>(Lists.newArrayList("z1")));
         assertEquals(cache.get("/test"), new TreeSet<String>(Lists.newArrayList("z1")));
-        assertTrue(recvNotifications == 1 || recvNotifications == 2);
 
         zkClient.delete("/test/z1", -1);
         Awaitility.await().until(() -> notificationCount.get() >= recvNotifications + 1);

--- a/testmocks/src/main/java/org/apache/zookeeper/MockZooKeeper.java
+++ b/testmocks/src/main/java/org/apache/zookeeper/MockZooKeeper.java
@@ -1163,5 +1163,21 @@ public class MockZooKeeper extends ZooKeeper {
         });
     }
 
+    @Override
+    public void removeAllWatches(String path, Watcher.WatcherType watcherType, boolean local, VoidCallback cb,
+                                 Object ctx) {
+        if (stopped) {
+            cb.processResult(KeeperException.Code.CONNECTIONLOSS.intValue(), path, ctx);
+            return;
+        }
+
+        executor.execute(() -> {
+            lock();
+            watchers.removeAll(path);
+            unlockIfLocked();
+            cb.processResult(KeeperException.Code.OK.intValue(), path, ctx);
+        });
+    }
+
     private static final Logger log = LoggerFactory.getLogger(MockZooKeeper.class);
 }


### PR DESCRIPTION
### Motivation

I find some z-node only call `exist` and add watcher, but `ExistsWatchRegistration` still will be registered even though the z-node may never be created. this will lead to the watcher count on ZK increasing indefinitely.

```java
    /** Handle the special case of exists watches - they add a watcher
     * even in the case where NONODE result code is returned.
     */
    class ExistsWatchRegistration extends WatchRegistration {

        public ExistsWatchRegistration(Watcher watcher, String clientPath) {
            super(watcher, clientPath);
        }

        @Override
        protected Map<String, Set<Watcher>> getWatches(int rc) {
            return rc == 0 ? watchManager.dataWatches : watchManager.existWatches;
        }

        @Override
        protected boolean shouldAddWatch(int rc) {
            return rc == 0 || rc == KeeperException.Code.NONODE.intValue();
        }

    }
```

### Modifications

* Remove watcher if `exist` return `NONODE`.
* Discards cache when z-node does not exist.
* Remove unused method in ZkUtils.
* Fix test

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: 
