### PR TITLE
[fix][broker] Deprecated aggregatePublisherStatsByProducerName config

### DIFF
--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -1461,9 +1461,8 @@ exposePreciseBacklogInPrometheus=false
 
 splitTopicAndPartitionLabelInPrometheus=false
 
-# If true and the client supports partial producer, aggregate publisher stats of PartitionedTopicStats by producerName.
-# Otherwise, aggregate it by list index.
-aggregatePublisherStatsByProducerName=false
+# Deprecated: it aggregates publisher stats by producerName
+aggregatePublisherStatsByProducerName=
 
 # Interval between checks to see if cluster is migrated and marks topic migrated
 # if cluster is marked migrated. Disable with value 0. (Default disabled).

--- a/conf/standalone.conf
+++ b/conf/standalone.conf
@@ -987,9 +987,9 @@ exposePreciseBacklogInPrometheus=false
 
 splitTopicAndPartitionLabelInPrometheus=false
 
-# If true, aggregate publisher stats of PartitionedTopicStats by producerName.
-# Otherwise, aggregate it by list index.
-aggregatePublisherStatsByProducerName=false
+
+# Deprecated: it aggregates publisher stats by producerName
+aggregatePublisherStatsByProducerName=
 
 ### --- Schema storage --- ###
 # The schema storage implementation used by this broker.

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -2705,11 +2705,6 @@ public class ServiceConfiguration implements PulsarConfiguration {
         doc = "Stats update initial delay in seconds"
     )
     private int statsUpdateInitialDelayInSecs = 60;
-    @FieldContext(
-        category = CATEGORY_METRICS,
-        doc = "If true, aggregate publisher stats of PartitionedTopicStats by producerName"
-    )
-    private boolean aggregatePublisherStatsByProducerName = false;
 
     /**** --- Ledger Offloading. --- ****/
     /****

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Producer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Producer.java
@@ -100,8 +100,7 @@ public class Producer {
             boolean isEncrypted, Map<String, String> metadata, SchemaVersion schemaVersion, long epoch,
             boolean userProvidedProducerName,
             ProducerAccessMode accessMode,
-            Optional<Long> topicEpoch,
-            boolean supportsPartialProducer) {
+            Optional<Long> topicEpoch) {
         final ServiceConfiguration serviceConf =  cnx.getBrokerService().pulsar().getConfiguration();
 
         this.topic = topic;
@@ -129,15 +128,6 @@ public class Producer {
         stats.setClientVersion(cnx.getClientVersion());
         stats.setProducerName(producerName);
         stats.producerId = producerId;
-        if (serviceConf.isAggregatePublisherStatsByProducerName() && stats.getProducerName() != null) {
-            // If true and the client supports partial producer,
-            // aggregate publisher stats of PartitionedTopicStats by producerName.
-            // Otherwise, aggregate it by list index.
-            stats.setSupportsPartialProducer(supportsPartialProducer);
-        } else {
-            // aggregate publisher stats of PartitionedTopicStats by list index.
-            stats.setSupportsPartialProducer(false);
-        }
         stats.metadata = this.metadata;
         stats.accessMode = Commands.convertProducerAccessMode(accessMode);
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
@@ -1236,7 +1236,6 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
         final boolean isTxnEnabled = cmdProducer.isTxnEnabled();
         final String initialSubscriptionName =
                 cmdProducer.hasInitialSubscriptionName() ? cmdProducer.getInitialSubscriptionName() : null;
-        final boolean supportsPartialProducer = supportsPartialProducer();
 
         TopicName topicName = validateTopicName(cmdProducer.getTopic(), requestId, cmdProducer);
         if (topicName == null) {
@@ -1392,7 +1391,7 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
 
                                 buildProducerAndAddTopic(topic, producerId, producerName, requestId, isEncrypted,
                                     metadata, schemaVersion, epoch, userProvidedProducerName, topicName,
-                                    producerAccessMode, topicEpoch, supportsPartialProducer, producerFuture);
+                                    producerAccessMode, topicEpoch, producerFuture);
                             });
                         }).exceptionally(exception -> {
                             Throwable cause = exception.getCause();
@@ -1464,12 +1463,12 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
                              boolean isEncrypted, Map<String, String> metadata, SchemaVersion schemaVersion, long epoch,
                              boolean userProvidedProducerName, TopicName topicName,
                              ProducerAccessMode producerAccessMode,
-                             Optional<Long> topicEpoch, boolean supportsPartialProducer,
+                             Optional<Long> topicEpoch,
                              CompletableFuture<Producer> producerFuture){
         CompletableFuture<Void> producerQueuedFuture = new CompletableFuture<>();
         Producer producer = new Producer(topic, ServerCnx.this, producerId, producerName,
                 getPrincipal(), isEncrypted, metadata, schemaVersion, epoch,
-                userProvidedProducerName, producerAccessMode, topicEpoch, supportsPartialProducer);
+                userProvidedProducerName, producerAccessMode, topicEpoch);
 
         topic.addProducer(producer, producerQueuedFuture).thenAccept(newTopicEpoch -> {
             if (isActive()) {
@@ -3014,10 +3013,6 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
 
     boolean supportBrokerMetadata() {
         return features != null && features.isSupportsBrokerEntryMetadata();
-    }
-
-    boolean supportsPartialProducer() {
-        return features != null && features.isSupportsPartialProducer();
     }
 
     @Override

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApi2Test.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApi2Test.java
@@ -2696,7 +2696,6 @@ public class AdminApi2Test extends MockedPulsarServiceBaseTest {
         cleanup();
         setup();
 
-        conf.setAggregatePublisherStatsByProducerName(true);
         final String topic = topicType + "://prop-xyz/ns1/test-partitioned-stats-aggregation-by-producer-name";
         admin.topics().createPartitionedTopic(topic, 10);
 
@@ -2746,12 +2745,10 @@ public class AdminApi2Test extends MockedPulsarServiceBaseTest {
         assertEquals(topicStats.getPartitions().values().stream().mapToInt(e -> e.getPublishers().size()).sum(), 10);
         assertEquals(topicStats.getPartitions().values().stream().map(e -> e.getPublishers().get(0).getProducerName()).distinct().count(), 2);
         assertEquals(topicStats.getPublishers().size(), 2);
-        topicStats.getPublishers().forEach(p -> assertTrue(p.isSupportsPartialProducer()));
     }
 
     @Test(dataProvider = "topicType")
     public void testPartitionedStatsAggregationByProducerNamePerPartition(String topicType) throws Exception {
-        conf.setAggregatePublisherStatsByProducerName(true);
         final String topic = topicType + "://prop-xyz/ns1/test-partitioned-stats-aggregation-by-producer-name-per-pt";
         admin.topics().createPartitionedTopic(topic, 2);
 
@@ -2770,7 +2767,6 @@ public class AdminApi2Test extends MockedPulsarServiceBaseTest {
         assertEquals(topicStats.getPartitions().values().stream().mapToInt(e -> e.getPublishers().size()).sum(), 2);
         assertEquals(topicStats.getPartitions().values().stream().map(e -> e.getPublishers().get(0).getProducerName()).distinct().count(), 2);
         assertEquals(topicStats.getPublishers().size(), 2);
-        topicStats.getPublishers().forEach(p -> assertTrue(p.isSupportsPartialProducer()));
     }
 
     @Test(dataProvider = "topicType")

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentTopicTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentTopicTest.java
@@ -438,7 +438,7 @@ public class PersistentTopicTest extends MockedBookKeeperTestCase {
         // 1. simple add producer
         Producer producer = new Producer(topic, serverCnx, 1 /* producer id */, "prod-name",
                 role, false, null, SchemaVersion.Latest, 0, false,
-                ProducerAccessMode.Shared, Optional.empty(), true);
+                ProducerAccessMode.Shared, Optional.empty());
         topic.addProducer(producer, new CompletableFuture<>());
         assertEquals(topic.getProducers().size(), 1);
 
@@ -455,7 +455,7 @@ public class PersistentTopicTest extends MockedBookKeeperTestCase {
         PersistentTopic failTopic = new PersistentTopic(failTopicName, ledgerMock, brokerService);
         Producer failProducer = new Producer(failTopic, serverCnx, 2 /* producer id */, "prod-name",
                 role, false, null, SchemaVersion.Latest, 0, false,
-                ProducerAccessMode.Shared, Optional.empty(), true);
+                ProducerAccessMode.Shared, Optional.empty());
         try {
             topic.addProducer(failProducer, new CompletableFuture<>());
             fail("should have failed");
@@ -466,7 +466,7 @@ public class PersistentTopicTest extends MockedBookKeeperTestCase {
         // 4. Try to remove with unequal producer
         Producer producerCopy = new Producer(topic, serverCnx, 1 /* producer id */, "prod-name",
                 role, false, null, SchemaVersion.Latest, 0, false,
-                ProducerAccessMode.Shared, Optional.empty(), true);
+                ProducerAccessMode.Shared, Optional.empty());
         topic.removeProducer(producerCopy);
         // Expect producer to be in map
         assertEquals(topic.getProducers().size(), 1);
@@ -485,9 +485,9 @@ public class PersistentTopicTest extends MockedBookKeeperTestCase {
         PersistentTopic topic = new PersistentTopic(successTopicName, ledgerMock, brokerService);
         String role = "appid1";
         Producer producer1 = new Producer(topic, serverCnx, 1 /* producer id */, "prod-name",
-                role, false, null, SchemaVersion.Latest, 0, true, ProducerAccessMode.Shared, Optional.empty(), true);
+                role, false, null, SchemaVersion.Latest, 0, true, ProducerAccessMode.Shared, Optional.empty());
         Producer producer2 = new Producer(topic, serverCnx, 2 /* producer id */, "prod-name",
-                role, false, null, SchemaVersion.Latest, 0, true, ProducerAccessMode.Shared, Optional.empty(), true);
+                role, false, null, SchemaVersion.Latest, 0, true, ProducerAccessMode.Shared, Optional.empty());
         try {
             topic.addProducer(producer1, new CompletableFuture<>()).join();
             topic.addProducer(producer2, new CompletableFuture<>()).join();
@@ -500,7 +500,7 @@ public class PersistentTopicTest extends MockedBookKeeperTestCase {
         Assert.assertEquals(topic.getProducers().size(), 1);
 
         Producer producer3 = new Producer(topic, serverCnx, 2 /* producer id */, "prod-name",
-                role, false, null, SchemaVersion.Latest, 1, false, ProducerAccessMode.Shared, Optional.empty(), true);
+                role, false, null, SchemaVersion.Latest, 1, false, ProducerAccessMode.Shared, Optional.empty());
 
         try {
             topic.addProducer(producer3, new CompletableFuture<>()).join();
@@ -516,7 +516,7 @@ public class PersistentTopicTest extends MockedBookKeeperTestCase {
         Assert.assertEquals(topic.getProducers().size(), 0);
 
         Producer producer4 = new Producer(topic, serverCnx, 2 /* producer id */, "prod-name",
-                role, false, null, SchemaVersion.Latest, 2, false, ProducerAccessMode.Shared, Optional.empty(), true);
+                role, false, null, SchemaVersion.Latest, 2, false, ProducerAccessMode.Shared, Optional.empty());
 
         topic.addProducer(producer3, new CompletableFuture<>());
         topic.addProducer(producer4, new CompletableFuture<>());
@@ -529,13 +529,13 @@ public class PersistentTopicTest extends MockedBookKeeperTestCase {
         Assert.assertEquals(topic.getProducers().size(), 0);
 
         Producer producer5 = new Producer(topic, serverCnx, 2 /* producer id */, "pulsar.repl.cluster1",
-                role, false, null, SchemaVersion.Latest, 1, false, ProducerAccessMode.Shared, Optional.empty(), true);
+                role, false, null, SchemaVersion.Latest, 1, false, ProducerAccessMode.Shared, Optional.empty());
 
         topic.addProducer(producer5, new CompletableFuture<>());
         Assert.assertEquals(topic.getProducers().size(), 1);
 
         Producer producer6 = new Producer(topic, serverCnx, 2 /* producer id */, "pulsar.repl.cluster1",
-                role, false, null, SchemaVersion.Latest, 2, false, ProducerAccessMode.Shared, Optional.empty(), true);
+                role, false, null, SchemaVersion.Latest, 2, false, ProducerAccessMode.Shared, Optional.empty());
 
         topic.addProducer(producer6, new CompletableFuture<>());
         Assert.assertEquals(topic.getProducers().size(), 1);
@@ -543,7 +543,7 @@ public class PersistentTopicTest extends MockedBookKeeperTestCase {
         topic.getProducers().values().forEach(producer -> Assert.assertEquals(producer.getEpoch(), 2));
 
         Producer producer7 = new Producer(topic, serverCnx, 2 /* producer id */, "pulsar.repl.cluster1",
-                role, false, null, SchemaVersion.Latest, 3, true, ProducerAccessMode.Shared, Optional.empty(), true);
+                role, false, null, SchemaVersion.Latest, 3, true, ProducerAccessMode.Shared, Optional.empty());
 
         topic.addProducer(producer7, new CompletableFuture<>());
         Assert.assertEquals(topic.getProducers().size(), 1);
@@ -556,20 +556,20 @@ public class PersistentTopicTest extends MockedBookKeeperTestCase {
         String role = "appid1";
         // 1. add producer1
         Producer producer = new Producer(topic, serverCnx, 1 /* producer id */, "prod-name1", role,
-                false, null, SchemaVersion.Latest, 0, false, ProducerAccessMode.Shared, Optional.empty(), true);
+                false, null, SchemaVersion.Latest, 0, false, ProducerAccessMode.Shared, Optional.empty());
         topic.addProducer(producer, new CompletableFuture<>());
         assertEquals(topic.getProducers().size(), 1);
 
         // 2. add producer2
         Producer producer2 = new Producer(topic, serverCnx, 2 /* producer id */, "prod-name2", role,
-                false, null, SchemaVersion.Latest, 0, false, ProducerAccessMode.Shared, Optional.empty(), true);
+                false, null, SchemaVersion.Latest, 0, false, ProducerAccessMode.Shared, Optional.empty());
         topic.addProducer(producer2, new CompletableFuture<>());
         assertEquals(topic.getProducers().size(), 2);
 
         // 3. add producer3 but reached maxProducersPerTopic
         try {
             Producer producer3 = new Producer(topic, serverCnx, 3 /* producer id */, "prod-name3", role,
-                    false, null, SchemaVersion.Latest, 0, false, ProducerAccessMode.Shared, Optional.empty(), true);
+                    false, null, SchemaVersion.Latest, 0, false, ProducerAccessMode.Shared, Optional.empty());
             topic.addProducer(producer3, new CompletableFuture<>()).join();
             fail("should have failed");
         } catch (Exception e) {
@@ -619,7 +619,7 @@ public class PersistentTopicTest extends MockedBookKeeperTestCase {
         doReturn(new PulsarCommandSenderImpl(null, cnx)).when(cnx).getCommandSender();
 
         return new Producer(topic, cnx, producerId, producerNameBase + producerId, role, false, null,
-                SchemaVersion.Latest, 0, false, ProducerAccessMode.Shared, Optional.empty(), true);
+                SchemaVersion.Latest, 0, false, ProducerAccessMode.Shared, Optional.empty());
     }
 
     @Test
@@ -1292,7 +1292,7 @@ public class PersistentTopicTest extends MockedBookKeeperTestCase {
         // 3. delete topic with producer
         topic = (PersistentTopic) brokerService.getOrCreateTopic(successTopicName).get();
         Producer producer = new Producer(topic, serverCnx, 1 /* producer id */, "prod-name",
-                role, false, null, SchemaVersion.Latest, 0, false, ProducerAccessMode.Shared, Optional.empty(), true);
+                role, false, null, SchemaVersion.Latest, 0, false, ProducerAccessMode.Shared, Optional.empty());
         topic.addProducer(producer, new CompletableFuture<>()).join();
 
         assertTrue(topic.delete().isCompletedExceptionally());
@@ -1466,7 +1466,7 @@ public class PersistentTopicTest extends MockedBookKeeperTestCase {
             String role = "appid1";
             Thread.sleep(10); /* delay to ensure that the delete gets executed first */
             Producer producer = new Producer(topic, serverCnx, 1 /* producer id */, "prod-name",
-                    role, false, null, SchemaVersion.Latest, 0, false, ProducerAccessMode.Shared, Optional.empty(), true);
+                    role, false, null, SchemaVersion.Latest, 0, false, ProducerAccessMode.Shared, Optional.empty());
             topic.addProducer(producer, new CompletableFuture<>()).join();
             fail("Should have failed");
         } catch (Exception e) {
@@ -2253,7 +2253,7 @@ public class PersistentTopicTest extends MockedBookKeeperTestCase {
         String role = "appid1";
         Producer producer = new Producer(topic, serverCnx, 1 /* producer id */, "prod-name",
                 role, false, null, SchemaVersion.Latest, 0, false,
-                ProducerAccessMode.Shared, Optional.empty(), true);
+                ProducerAccessMode.Shared, Optional.empty());
         assertFalse(producer.isDisconnecting());
         // Disconnect the producer multiple times.
         producer.disconnect();

--- a/pulsar-client-admin-api/src/main/java/org/apache/pulsar/common/policies/data/PublisherStats.java
+++ b/pulsar-client-admin-api/src/main/java/org/apache/pulsar/common/policies/data/PublisherStats.java
@@ -44,6 +44,7 @@ public interface PublisherStats {
     long getProducerId();
 
     /** Whether partial producer is supported at client. */
+    @Deprecated
     boolean isSupportsPartialProducer();
 
     /** Producer name. */

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/stats/PublisherStatsImpl.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/stats/PublisherStatsImpl.java
@@ -49,8 +49,9 @@ public class PublisherStatsImpl implements PublisherStats {
     /** Id of this publisher. */
     public long producerId;
 
-    /** Whether partial producer is supported at client. */
-    public boolean supportsPartialProducer;
+    /** Whether partial producer is supported at client. supportsPartialProducer is true always. */
+    @Deprecated
+    public boolean supportsPartialProducer = true;
 
     /** Producer name. */
     @JsonIgnore
@@ -99,7 +100,7 @@ public class PublisherStatsImpl implements PublisherStats {
     }
 
     public String getProducerName() {
-        return producerNameOffset == -1 ? null
+        return producerNameOffset == -1 ? "null"
                 : stringBuffer.substring(producerNameOffset, producerNameOffset + producerNameLength);
     }
 

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/protocol/Commands.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/protocol/Commands.java
@@ -187,7 +187,6 @@ public class Commands {
     private static void setFeatureFlags(FeatureFlags flags) {
         flags.setSupportsAuthRefresh(true);
         flags.setSupportsBrokerEntryMetadata(true);
-        flags.setSupportsPartialProducer(true);
     }
 
     public static ByteBuf newConnect(String authMethodName, String authData, int protocolVersion, String libVersion,

--- a/pulsar-common/src/test/java/org/apache/pulsar/common/policies/data/PartitionedTopicStatsTest.java
+++ b/pulsar-common/src/test/java/org/apache/pulsar/common/policies/data/PartitionedTopicStatsTest.java
@@ -20,10 +20,14 @@ package org.apache.pulsar.common.policies.data;
 
 import static org.testng.Assert.assertEquals;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.pulsar.common.policies.data.stats.PartitionedTopicStatsImpl;
 import org.apache.pulsar.common.policies.data.stats.PublisherStatsImpl;
 import org.apache.pulsar.common.policies.data.stats.ReplicatorStatsImpl;
 import org.apache.pulsar.common.policies.data.stats.SubscriptionStatsImpl;
+import org.apache.pulsar.common.policies.data.stats.TopicStatsImpl;
+import org.apache.pulsar.common.util.ObjectMapperFactory;
 import org.testng.annotations.Test;
 
 public class PartitionedTopicStatsTest {
@@ -55,4 +59,21 @@ public class PartitionedTopicStatsTest {
         assertEquals(partitionedTopicStats.metadata.partitions, 0);
         assertEquals(partitionedTopicStats.partitions.size(), 0);
     }
+
+    @Test
+    public void jsonWriteAndReadTest() throws JsonProcessingException {
+        ObjectMapper mapper = ObjectMapperFactory.create();
+
+        final PublisherStatsImpl publisherStats1 = new PublisherStatsImpl();
+        publisherStats1.setProducerName("p1");
+        final TopicStatsImpl src = new TopicStatsImpl();
+        src.averageMsgSize = 1.0;
+        src.addPublisher(publisherStats1);
+
+        String json = mapper.writeValueAsString(src);
+        TopicStatsImpl dst = (TopicStatsImpl) mapper.readValue(json, TopicStats.class);
+        assertEquals(dst.getPublishers().get(0).getProducerName(), "p1");
+        assertEquals(dst.averageMsgSize, 1.0);
+    }
+
 }

--- a/pulsar-common/src/test/java/org/apache/pulsar/common/policies/data/PersistentTopicStatsTest.java
+++ b/pulsar-common/src/test/java/org/apache/pulsar/common/policies/data/PersistentTopicStatsTest.java
@@ -19,7 +19,6 @@
 package org.apache.pulsar.common.policies.data;
 
 import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertFalse;
 
 import org.apache.pulsar.common.policies.data.stats.PublisherStatsImpl;
 import org.apache.pulsar.common.policies.data.stats.ReplicatorStatsImpl;
@@ -87,7 +86,6 @@ public class PersistentTopicStatsTest {
         topicStats1.averageMsgSize = 1;
         topicStats1.storageSize = 1;
         final PublisherStatsImpl publisherStats1 = new PublisherStatsImpl();
-        publisherStats1.setSupportsPartialProducer(false);
         publisherStats1.setProducerName("name1");
         topicStats1.addPublisher(publisherStats1);
         topicStats1.subscriptions.put("test_ns", new SubscriptionStatsImpl());
@@ -101,7 +99,6 @@ public class PersistentTopicStatsTest {
         topicStats2.averageMsgSize = 5;
         topicStats2.storageSize = 6;
         final PublisherStatsImpl publisherStats2 = new PublisherStatsImpl();
-        publisherStats2.setSupportsPartialProducer(false);
         publisherStats2.setProducerName("name1");
         topicStats2.addPublisher(publisherStats2);
         topicStats2.subscriptions.put("test_ns", new SubscriptionStatsImpl());
@@ -132,7 +129,6 @@ public class PersistentTopicStatsTest {
         topicStats1.averageMsgSize = 1;
         topicStats1.storageSize = 1;
         final PublisherStatsImpl publisherStats1 = new PublisherStatsImpl();
-        publisherStats1.setSupportsPartialProducer(true);
         publisherStats1.setProducerName("name1");
         topicStats1.addPublisher(publisherStats1);
         topicStats1.subscriptions.put("test_ns", new SubscriptionStatsImpl());
@@ -146,7 +142,6 @@ public class PersistentTopicStatsTest {
         topicStats2.averageMsgSize = 5;
         topicStats2.storageSize = 6;
         final PublisherStatsImpl publisherStats2 = new PublisherStatsImpl();
-        publisherStats2.setSupportsPartialProducer(true);
         publisherStats2.setProducerName("name1");
         topicStats2.addPublisher(publisherStats2);
         topicStats2.subscriptions.put("test_ns", new SubscriptionStatsImpl());
@@ -178,7 +173,6 @@ public class PersistentTopicStatsTest {
         topicStats1.averageMsgSize = 1;
         topicStats1.storageSize = 1;
         final PublisherStatsImpl publisherStats1 = new PublisherStatsImpl();
-        publisherStats1.setSupportsPartialProducer(true);
         publisherStats1.msgRateIn = 1;
         publisherStats1.setProducerName("name1");
         topicStats1.addPublisher(publisherStats1);
@@ -193,7 +187,6 @@ public class PersistentTopicStatsTest {
         topicStats2.averageMsgSize = 5;
         topicStats2.storageSize = 6;
         final PublisherStatsImpl publisherStats2 = new PublisherStatsImpl();
-        publisherStats2.setSupportsPartialProducer(true);
         publisherStats2.msgRateIn = 1;
         publisherStats2.setProducerName("name1");
         topicStats2.addPublisher(publisherStats2);
@@ -208,7 +201,6 @@ public class PersistentTopicStatsTest {
         topicStats3.averageMsgSize = 0;
         topicStats3.storageSize = 0;
         final PublisherStatsImpl publisherStats3 = new PublisherStatsImpl();
-        publisherStats3.setSupportsPartialProducer(true);
         publisherStats3.msgRateIn = 1;
         publisherStats3.setProducerName("name2");
         topicStats3.addPublisher(publisherStats3);
@@ -240,37 +232,55 @@ public class PersistentTopicStatsTest {
     public void testPersistentTopicStatsByNullProducerName() {
         final TopicStatsImpl topicStats1 = new TopicStatsImpl();
         final PublisherStatsImpl publisherStats1 = new PublisherStatsImpl();
-        publisherStats1.setSupportsPartialProducer(false);
         publisherStats1.setProducerName(null);
         final PublisherStatsImpl publisherStats2 = new PublisherStatsImpl();
-        publisherStats2.setSupportsPartialProducer(false);
         publisherStats2.setProducerName(null);
         topicStats1.addPublisher(publisherStats1);
         topicStats1.addPublisher(publisherStats2);
 
-        assertEquals(topicStats1.getPublishers().size(), 2);
-        assertFalse(topicStats1.getPublishers().get(0).isSupportsPartialProducer());
-        assertFalse(topicStats1.getPublishers().get(1).isSupportsPartialProducer());
+        assertEquals(topicStats1.getPublishers().size(), 1);
 
         final TopicStatsImpl topicStats2 = new TopicStatsImpl();
         final PublisherStatsImpl publisherStats3 = new PublisherStatsImpl();
-        publisherStats3.setSupportsPartialProducer(true);
         publisherStats3.setProducerName(null);
         final PublisherStatsImpl publisherStats4 = new PublisherStatsImpl();
-        publisherStats4.setSupportsPartialProducer(true);
         publisherStats4.setProducerName(null);
         topicStats2.addPublisher(publisherStats3);
         topicStats2.addPublisher(publisherStats4);
 
-        assertEquals(topicStats2.getPublishers().size(), 2);
-        // when the producerName is null, fall back to false
-        assertFalse(topicStats2.getPublishers().get(0).isSupportsPartialProducer());
-        assertFalse(topicStats2.getPublishers().get(1).isSupportsPartialProducer());
-
+        assertEquals(topicStats2.getPublishers().size(), 1);
         final TopicStatsImpl target = new TopicStatsImpl();
         target.add(topicStats1);
         target.add(topicStats2);
 
-        assertEquals(target.getPublishers().size(), 2);
+        assertEquals(target.getPublishers().size(), 1);
+    }
+
+    @Test
+    public void testPersistentTopicStatsByDifferentPublishers() {
+        TopicStatsImpl topicStats = new TopicStatsImpl();
+        TopicStatsImpl s1 = new TopicStatsImpl();
+        TopicStatsImpl s2 = new TopicStatsImpl();
+        PublisherStatsImpl p1 = new PublisherStatsImpl();
+        PublisherStatsImpl p2 = new PublisherStatsImpl();
+        PublisherStatsImpl p3 = new PublisherStatsImpl();
+        p1.setProducerName("p1");
+        p1.setMsgRateIn(1);
+        p2.setProducerName("p2");
+        p2.setMsgRateIn(2);
+        p3.setMsgRateIn(3);
+        s1.addPublisher(p1);
+        s1.addPublisher(p2);
+        s1.addPublisher(p3);
+        s2.addPublisher(p1);
+        s2.addPublisher(p2);
+        topicStats.add(s1);
+        topicStats.add(s2);
+
+        assertEquals(topicStats.getPublishers().size(), 3);
+        assertEquals(topicStats.getPublishers().get(0).getMsgRateIn(), 2);
+        assertEquals(topicStats.getPublishers().get(1).getMsgRateIn(), 4);
+        assertEquals(topicStats.getPublishers().get(2).getMsgRateIn(), 3);
+
     }
 }

--- a/pulsar-common/src/test/java/org/apache/pulsar/common/policies/data/PublisherStatsTest.java
+++ b/pulsar-common/src/test/java/org/apache/pulsar/common/policies/data/PublisherStatsTest.java
@@ -54,7 +54,7 @@ public class PublisherStatsTest {
         assertNull(stats.getAddress());
         assertNull(stats.getClientVersion());
         assertNull(stats.getConnectedSince());
-        assertNull(stats.getProducerName());
+        assertEquals(stats.getProducerName(), "null");
         
         stats.setAddress("address");
         assertEquals(stats.getAddress(), "address");
@@ -95,7 +95,7 @@ public class PublisherStatsTest {
         assertEquals(stats.getClientVersion(), "version2");
         
         stats.setProducerName(null);
-        assertNull(stats.getProducerName());
+        assertEquals(stats.getProducerName(), "null");
 
         assertNull(stats.getAddress());
         


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://docs.google.com/document/d/1d8Pw6ZbWk-_pCKdOmdvx9rnhPiyuxwq60_TrD68d7BA/edit#heading=h.trs9rsex3xom)*. 

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->

### Motivation
The index-based publisher stat aggregation(configured by `aggregatePublisherStatsByProducerName`=false, default) can burst memory or wrongly aggregate publisher metrics if each partition stat returns a different size or order of the publisher stat list.
In the worst case, if there are many partitions and publishers created and closed concurrently, the current code can create PublisherStatsImpl objects exponentially, and this can cause a high GC time or OOM.

Issue Code reference:

https://github.com/apache/pulsar/commit/2c428f7fcc740525e8120566c0272fc863ffebf1#diff-02e50674125a597f8ae3405a884590759f2fdaa10104cea511d5ea44b6ff6490R224-R247

<!-- Explain here the context, and why you're making that change. What is the problem you're trying to solve. -->

### Modifications

- Deprecated the `aggregatePublisherStatsByProducerName` broker config because the default, the index-based aggregation is inherently wrong in a highly concurrent producer environment(where the order and size of the publisher stat list are not guaranteed to be the same). The publisher stats need to be aggregated by a unique key, the producer name(aggregatePublisherStatsByProducerName=true).
- If PublisherStatsImpl.publisherName happens to be null, it will aggregate it with the stat object with "null" name. (However, this is unlikely because the latest version of the brokers generates a globally unique name If not given.)
- Use HashMap instead List to aggregate publisher stats.
- Removed sorting from getPublisher(), as this can be expensive for a large number of publishers.
- Simplified the stat aggregation code.


<!-- Describe the modifications you've done. -->

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change added unit tests.


### Does this pull request potentially affect one of the following parts:

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [x] The public API
- [ ] The schema
- [x] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [x] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/heesung-sn/pulsar/pull/13

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
