### PR TITLE
[improve][broker] allow client skips the non-continued deleted ranges stats

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v1/PersistentTopics.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v1/PersistentTopics.java
@@ -44,6 +44,7 @@ import javax.ws.rs.core.Response;
 import org.apache.pulsar.broker.admin.impl.PersistentTopicsBase;
 import org.apache.pulsar.broker.service.BrokerServiceException;
 import org.apache.pulsar.broker.web.RestException;
+import org.apache.pulsar.client.admin.GetStatsOptions;
 import org.apache.pulsar.client.impl.MessageIdImpl;
 import org.apache.pulsar.client.impl.ResetCursorData;
 import org.apache.pulsar.common.policies.data.AuthAction;
@@ -433,11 +434,15 @@ public class PersistentTopics extends PersistentTopicsBase {
             @PathParam("namespace") String namespace, @PathParam("topic") @Encoded String encodedTopic,
             @QueryParam("authoritative") @DefaultValue("false") boolean authoritative,
             @QueryParam("getPreciseBacklog") @DefaultValue("false") boolean getPreciseBacklog,
+            @ApiParam(value = "If return time of the earliest message in backlog")
             @QueryParam("getTotalNonContiguousDeletedMessagesRange") @DefaultValue("true")
             boolean getTotalNonContiguousDeletedMessagesRange) {
         validateTopicName(property, cluster, namespace, encodedTopic);
-        internalGetStatsAsync(authoritative, getPreciseBacklog, false,
-                false, getTotalNonContiguousDeletedMessagesRange)
+        GetStatsOptions getStatsOptions =
+                GetStatsOptions.builder().getPreciseBacklog(getPreciseBacklog).subscriptionBacklogSize(false)
+                        .getEarliestTimeInBacklog(false)
+                        .getTotalNonContiguousDeletedMessagesRange(getTotalNonContiguousDeletedMessagesRange).build();
+        internalGetStatsAsync(authoritative, getStatsOptions)
                 .thenAccept(asyncResponse::resume)
                 .exceptionally(ex -> {
                     // If the exception is not redirect exception we need to log it.
@@ -504,8 +509,11 @@ public class PersistentTopics extends PersistentTopicsBase {
             @QueryParam("authoritative") @DefaultValue("false") boolean authoritative) {
         try {
             validateTopicName(property, cluster, namespace, encodedTopic);
-            internalGetPartitionedStats(asyncResponse, authoritative, perPartition, false,
-                    false, false, true);
+            GetStatsOptions getStatsOptions =
+                    GetStatsOptions.builder().getPreciseBacklog(false).subscriptionBacklogSize(false)
+                            .getEarliestTimeInBacklog(false).getTotalNonContiguousDeletedMessagesRange(true).build();
+
+            internalGetPartitionedStats(asyncResponse, authoritative, perPartition, getStatsOptions);
         } catch (WebApplicationException wae) {
             asyncResponse.resume(wae);
         } catch (Exception e) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v1/PersistentTopics.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v1/PersistentTopics.java
@@ -432,9 +432,12 @@ public class PersistentTopics extends PersistentTopicsBase {
             @PathParam("property") String property, @PathParam("cluster") String cluster,
             @PathParam("namespace") String namespace, @PathParam("topic") @Encoded String encodedTopic,
             @QueryParam("authoritative") @DefaultValue("false") boolean authoritative,
-            @QueryParam("getPreciseBacklog") @DefaultValue("false") boolean getPreciseBacklog) {
+            @QueryParam("getPreciseBacklog") @DefaultValue("false") boolean getPreciseBacklog,
+            @QueryParam("getTotalNonContiguousDeletedMessagesRange") @DefaultValue("true")
+            boolean getTotalNonContiguousDeletedMessagesRange) {
         validateTopicName(property, cluster, namespace, encodedTopic);
-        internalGetStatsAsync(authoritative, getPreciseBacklog, false, false)
+        internalGetStatsAsync(authoritative, getPreciseBacklog, false,
+                false, getTotalNonContiguousDeletedMessagesRange)
                 .thenAccept(asyncResponse::resume)
                 .exceptionally(ex -> {
                     // If the exception is not redirect exception we need to log it.
@@ -501,7 +504,8 @@ public class PersistentTopics extends PersistentTopicsBase {
             @QueryParam("authoritative") @DefaultValue("false") boolean authoritative) {
         try {
             validateTopicName(property, cluster, namespace, encodedTopic);
-            internalGetPartitionedStats(asyncResponse, authoritative, perPartition, false, false, false);
+            internalGetPartitionedStats(asyncResponse, authoritative, perPartition, false,
+                    false, false, true);
         } catch (WebApplicationException wae) {
             asyncResponse.resume(wae);
         } catch (Exception e) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/NonPersistentTopics.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/NonPersistentTopics.java
@@ -213,7 +213,7 @@ public class NonPersistentTopics extends PersistentTopics {
             @QueryParam("subscriptionBacklogSize") @DefaultValue("false") boolean subscriptionBacklogSize,
             @ApiParam(value = "If return the earliest time in backlog")
             @QueryParam("getEarliestTimeInBacklog") @DefaultValue("false") boolean getEarliestTimeInBacklog,
-            @ApiParam(value = "If return If return TotalNonContiguousDeletedMessagesRange")
+            @ApiParam(value = "If return the total non-continues deleted message range")
             @QueryParam("getTotalNonContiguousDeletedMessagesRange") @DefaultValue("true")
             boolean getTotalNonContiguousDeletedMessagesRange) {
         try {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/NonPersistentTopics.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/NonPersistentTopics.java
@@ -212,7 +212,10 @@ public class NonPersistentTopics extends PersistentTopics {
                     + "not to use when there's heavy traffic.")
             @QueryParam("subscriptionBacklogSize") @DefaultValue("false") boolean subscriptionBacklogSize,
             @ApiParam(value = "If return the earliest time in backlog")
-            @QueryParam("getEarliestTimeInBacklog") @DefaultValue("false") boolean getEarliestTimeInBacklog) {
+            @QueryParam("getEarliestTimeInBacklog") @DefaultValue("false") boolean getEarliestTimeInBacklog,
+            @ApiParam(value = "If return If return TotalNonContiguousDeletedMessagesRange")
+            @QueryParam("getTotalNonContiguousDeletedMessagesRange") @DefaultValue("true")
+            boolean getTotalNonContiguousDeletedMessagesRange) {
         try {
             validatePartitionedTopicName(tenant, namespace, encodedTopic);
             if (topicName.isGlobal()) {
@@ -238,7 +241,8 @@ public class NonPersistentTopics extends PersistentTopics {
                         topicStatsFutureList
                                 .add(pulsar().getAdminClient().topics().getStatsAsync(
                                         (topicName.getPartition(i).toString()), getPreciseBacklog,
-                                        subscriptionBacklogSize, getEarliestTimeInBacklog));
+                                        subscriptionBacklogSize, getEarliestTimeInBacklog,
+                                        getTotalNonContiguousDeletedMessagesRange));
                     } catch (PulsarServerException e) {
                         asyncResponse.resume(new RestException(e));
                         return;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/PersistentTopics.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/PersistentTopics.java
@@ -1213,7 +1213,7 @@ public class PersistentTopics extends PersistentTopicsBase {
             @QueryParam("subscriptionBacklogSize") @DefaultValue("false") boolean subscriptionBacklogSize,
             @ApiParam(value = "If return time of the earliest message in backlog")
             @QueryParam("getEarliestTimeInBacklog") @DefaultValue("false") boolean getEarliestTimeInBacklog,
-            @ApiParam(value = "If return If return TotalNonContiguousDeletedMessagesRange")
+            @ApiParam(value = "If return the total non-continues deleted message range")
             @QueryParam("getTotalNonContiguousDeletedMessagesRange") @DefaultValue("true")
             boolean getTotalNonContiguousDeletedMessagesRange) {
         validateTopicName(tenant, namespace, encodedTopic);
@@ -1319,7 +1319,7 @@ public class PersistentTopics extends PersistentTopicsBase {
             @QueryParam("subscriptionBacklogSize") @DefaultValue("false") boolean subscriptionBacklogSize,
             @ApiParam(value = "If return the earliest time in backlog")
             @QueryParam("getEarliestTimeInBacklog") @DefaultValue("false") boolean getEarliestTimeInBacklog,
-            @ApiParam(value = "If return If return TotalNonContiguousDeletedMessagesRange")
+            @ApiParam(value = "If return the total non-continues deleted message range")
             @QueryParam("getTotalNonContiguousDeletedMessagesRange") @DefaultValue("true")
             boolean getTotalNonContiguousDeletedMessagesRange) {
         try {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/PersistentTopics.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/PersistentTopics.java
@@ -50,6 +50,7 @@ import org.apache.bookkeeper.mledger.impl.PositionImpl;
 import org.apache.pulsar.broker.admin.impl.PersistentTopicsBase;
 import org.apache.pulsar.broker.service.BrokerServiceException;
 import org.apache.pulsar.broker.web.RestException;
+import org.apache.pulsar.client.admin.GetStatsOptions;
 import org.apache.pulsar.client.admin.PulsarAdminException;
 import org.apache.pulsar.client.api.SubscriptionType;
 import org.apache.pulsar.client.impl.MessageIdImpl;
@@ -1217,8 +1218,12 @@ public class PersistentTopics extends PersistentTopicsBase {
             @QueryParam("getTotalNonContiguousDeletedMessagesRange") @DefaultValue("true")
             boolean getTotalNonContiguousDeletedMessagesRange) {
         validateTopicName(tenant, namespace, encodedTopic);
-        internalGetStatsAsync(authoritative, getPreciseBacklog, subscriptionBacklogSize, getEarliestTimeInBacklog,
-                getTotalNonContiguousDeletedMessagesRange)
+        GetStatsOptions getStatsOptions =
+                GetStatsOptions.builder().getPreciseBacklog(getPreciseBacklog)
+                        .subscriptionBacklogSize(subscriptionBacklogSize)
+                        .getEarliestTimeInBacklog(getEarliestTimeInBacklog)
+                        .getTotalNonContiguousDeletedMessagesRange(getTotalNonContiguousDeletedMessagesRange).build();
+        internalGetStatsAsync(authoritative, getStatsOptions)
                 .thenAccept(asyncResponse::resume)
                 .exceptionally(ex -> {
                     // If the exception is not redirect exception we need to log it.
@@ -1324,8 +1329,13 @@ public class PersistentTopics extends PersistentTopicsBase {
             boolean getTotalNonContiguousDeletedMessagesRange) {
         try {
             validatePartitionedTopicName(tenant, namespace, encodedTopic);
-            internalGetPartitionedStats(asyncResponse, authoritative, perPartition, getPreciseBacklog,
-                    subscriptionBacklogSize, getEarliestTimeInBacklog, getTotalNonContiguousDeletedMessagesRange);
+            GetStatsOptions getStatsOptions =
+                    GetStatsOptions.builder().getPreciseBacklog(getPreciseBacklog)
+                            .subscriptionBacklogSize(subscriptionBacklogSize)
+                            .getEarliestTimeInBacklog(getEarliestTimeInBacklog)
+                            .getTotalNonContiguousDeletedMessagesRange(getTotalNonContiguousDeletedMessagesRange)
+                            .build();
+            internalGetPartitionedStats(asyncResponse, authoritative, perPartition, getStatsOptions);
         } catch (WebApplicationException wae) {
             asyncResponse.resume(wae);
         } catch (Exception e) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/PersistentTopics.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/PersistentTopics.java
@@ -1212,9 +1212,13 @@ public class PersistentTopics extends PersistentTopicsBase {
                     + "not to use when there's heavy traffic.")
             @QueryParam("subscriptionBacklogSize") @DefaultValue("false") boolean subscriptionBacklogSize,
             @ApiParam(value = "If return time of the earliest message in backlog")
-            @QueryParam("getEarliestTimeInBacklog") @DefaultValue("false") boolean getEarliestTimeInBacklog) {
+            @QueryParam("getEarliestTimeInBacklog") @DefaultValue("false") boolean getEarliestTimeInBacklog,
+            @ApiParam(value = "If return If return TotalNonContiguousDeletedMessagesRange")
+            @QueryParam("getTotalNonContiguousDeletedMessagesRange") @DefaultValue("true")
+            boolean getTotalNonContiguousDeletedMessagesRange) {
         validateTopicName(tenant, namespace, encodedTopic);
-        internalGetStatsAsync(authoritative, getPreciseBacklog, subscriptionBacklogSize, getEarliestTimeInBacklog)
+        internalGetStatsAsync(authoritative, getPreciseBacklog, subscriptionBacklogSize, getEarliestTimeInBacklog,
+                getTotalNonContiguousDeletedMessagesRange)
                 .thenAccept(asyncResponse::resume)
                 .exceptionally(ex -> {
                     // If the exception is not redirect exception we need to log it.
@@ -1314,11 +1318,14 @@ public class PersistentTopics extends PersistentTopicsBase {
                     + "not to use when there's heavy traffic.")
             @QueryParam("subscriptionBacklogSize") @DefaultValue("false") boolean subscriptionBacklogSize,
             @ApiParam(value = "If return the earliest time in backlog")
-            @QueryParam("getEarliestTimeInBacklog") @DefaultValue("false") boolean getEarliestTimeInBacklog) {
+            @QueryParam("getEarliestTimeInBacklog") @DefaultValue("false") boolean getEarliestTimeInBacklog,
+            @ApiParam(value = "If return If return TotalNonContiguousDeletedMessagesRange")
+            @QueryParam("getTotalNonContiguousDeletedMessagesRange") @DefaultValue("true")
+            boolean getTotalNonContiguousDeletedMessagesRange) {
         try {
             validatePartitionedTopicName(tenant, namespace, encodedTopic);
             internalGetPartitionedStats(asyncResponse, authoritative, perPartition, getPreciseBacklog,
-                    subscriptionBacklogSize, getEarliestTimeInBacklog);
+                    subscriptionBacklogSize, getEarliestTimeInBacklog, getTotalNonContiguousDeletedMessagesRange);
         } catch (WebApplicationException wae) {
             asyncResponse.resume(wae);
         } catch (Exception e) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/resourcegroup/ResourceGroupService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/resourcegroup/ResourceGroupService.java
@@ -35,6 +35,7 @@ import org.apache.pulsar.broker.resourcegroup.ResourceGroup.BytesAndMessagesCoun
 import org.apache.pulsar.broker.resourcegroup.ResourceGroup.ResourceGroupMonitoringClass;
 import org.apache.pulsar.broker.resourcegroup.ResourceGroup.ResourceGroupRefTypes;
 import org.apache.pulsar.broker.service.BrokerService;
+import org.apache.pulsar.client.admin.GetStatsOptions;
 import org.apache.pulsar.client.admin.PulsarAdminException;
 import org.apache.pulsar.common.naming.NamespaceName;
 import org.apache.pulsar.common.naming.TopicName;
@@ -543,7 +544,10 @@ public class ResourceGroupService implements AutoCloseable{
     protected void aggregateResourceGroupLocalUsages() {
         final Summary.Timer aggrUsageTimer = rgUsageAggregationLatency.startTimer();
         BrokerService bs = this.pulsar.getBrokerService();
-        Map<String, TopicStatsImpl> topicStatsMap = bs.getTopicStats(false);
+        GetStatsOptions getStatsOptions =
+                GetStatsOptions.builder().getPreciseBacklog(false).subscriptionBacklogSize(false)
+                        .getEarliestTimeInBacklog(false).getTotalNonContiguousDeletedMessagesRange(false).build();
+        Map<String, TopicStatsImpl> topicStatsMap = bs.getTopicStats(getStatsOptions);
 
         for (Map.Entry<String, TopicStatsImpl> entry : topicStatsMap.entrySet()) {
             final String topicName = entry.getKey();

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/resourcegroup/ResourceGroupService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/resourcegroup/ResourceGroupService.java
@@ -543,7 +543,7 @@ public class ResourceGroupService implements AutoCloseable{
     protected void aggregateResourceGroupLocalUsages() {
         final Summary.Timer aggrUsageTimer = rgUsageAggregationLatency.startTimer();
         BrokerService bs = this.pulsar.getBrokerService();
-        Map<String, TopicStatsImpl> topicStatsMap = bs.getTopicStats();
+        Map<String, TopicStatsImpl> topicStatsMap = bs.getTopicStats(false);
 
         for (Map.Entry<String, TopicStatsImpl> entry : topicStatsMap.entrySet()) {
             final String topicName = entry.getKey();

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
@@ -119,6 +119,7 @@ import org.apache.pulsar.broker.stats.ClusterReplicationMetrics;
 import org.apache.pulsar.broker.stats.prometheus.metrics.ObserverGauge;
 import org.apache.pulsar.broker.stats.prometheus.metrics.Summary;
 import org.apache.pulsar.broker.validator.BindAddressValidator;
+import org.apache.pulsar.client.admin.GetStatsOptions;
 import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.admin.PulsarAdminBuilder;
 import org.apache.pulsar.client.api.ClientBuilder;
@@ -474,8 +475,11 @@ public class BrokerService implements Closeable {
 
         Map<String, TopicStatsImpl> topicStatsMap = new HashMap<>();
         topicMap.forEach((name, topic) -> {
+            GetStatsOptions getStatsOptions =
+                    GetStatsOptions.builder().getPreciseBacklog(false).subscriptionBacklogSize(false)
+                            .getEarliestTimeInBacklog(false).getTotalNonContiguousDeletedMessagesRange(true).build();
             topicStatsMap.put(name,
-                    topic.getStats(false, false, false, true));
+                    topic.getStats(getStatsOptions));
         });
         return topicStatsMap;
     }
@@ -2342,12 +2346,9 @@ public class BrokerService implements Closeable {
         return producerNameGenerator.getNextId();
     }
 
-    public Map<String, TopicStatsImpl> getTopicStats(boolean getTotalNonContiguousDeletedMessagesRange) {
+    public Map<String, TopicStatsImpl> getTopicStats(GetStatsOptions getStatsOptions) {
         HashMap<String, TopicStatsImpl> stats = new HashMap<>();
-
-        forEachTopic(topic -> stats.put(topic.getName(), topic.getStats(false,
-                false, false, getTotalNonContiguousDeletedMessagesRange)));
-
+        forEachTopic(topic -> stats.put(topic.getName(), topic.getStats(getStatsOptions)));
         return stats;
     }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
@@ -475,7 +475,7 @@ public class BrokerService implements Closeable {
         Map<String, TopicStatsImpl> topicStatsMap = new HashMap<>();
         topicMap.forEach((name, topic) -> {
             topicStatsMap.put(name,
-                    topic.getStats(false, false, false));
+                    topic.getStats(false, false, false, true));
         });
         return topicStatsMap;
     }
@@ -2342,10 +2342,11 @@ public class BrokerService implements Closeable {
         return producerNameGenerator.getNextId();
     }
 
-    public Map<String, TopicStatsImpl> getTopicStats() {
+    public Map<String, TopicStatsImpl> getTopicStats(boolean getTotalNonContiguousDeletedMessagesRange) {
         HashMap<String, TopicStatsImpl> stats = new HashMap<>();
 
-        forEachTopic(topic -> stats.put(topic.getName(), topic.getStats(false, false, false)));
+        forEachTopic(topic -> stats.put(topic.getName(), topic.getStats(false,
+                false, false, getTotalNonContiguousDeletedMessagesRange)));
 
         return stats;
     }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Topic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Topic.java
@@ -29,6 +29,7 @@ import org.apache.pulsar.broker.service.persistent.SubscribeRateLimiter;
 import org.apache.pulsar.broker.service.plugin.EntryFilterWithClassLoader;
 import org.apache.pulsar.broker.stats.ClusterReplicationMetrics;
 import org.apache.pulsar.broker.stats.NamespaceStats;
+import org.apache.pulsar.client.admin.GetStatsOptions;
 import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.client.api.transaction.TxnID;
 import org.apache.pulsar.common.api.proto.CommandSubscribe.InitialPosition;
@@ -265,13 +266,9 @@ public interface Topic {
 
     ConcurrentOpenHashMap<String, ? extends Replicator> getShadowReplicators();
 
-    TopicStatsImpl getStats(boolean getPreciseBacklog, boolean subscriptionBacklogSize,
-                            boolean getEarliestTimeInBacklog, boolean getTotalNonContiguousDeletedMessagesRange);
+    TopicStatsImpl getStats(GetStatsOptions getStatsOptions);
 
-    CompletableFuture<? extends TopicStatsImpl> asyncGetStats(boolean getPreciseBacklog,
-                                                              boolean subscriptionBacklogSize,
-                                                              boolean getEarliestTimeInBacklog,
-                                                              boolean getTotalNonContiguousDeletedMessagesRange);
+    CompletableFuture<? extends TopicStatsImpl> asyncGetStats(GetStatsOptions getStatsOptions);
 
     CompletableFuture<PersistentTopicInternalStats> getInternalStats(boolean includeLedgerMetadata);
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Topic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Topic.java
@@ -266,11 +266,12 @@ public interface Topic {
     ConcurrentOpenHashMap<String, ? extends Replicator> getShadowReplicators();
 
     TopicStatsImpl getStats(boolean getPreciseBacklog, boolean subscriptionBacklogSize,
-                            boolean getEarliestTimeInBacklog);
+                            boolean getEarliestTimeInBacklog, boolean getTotalNonContiguousDeletedMessagesRange);
 
     CompletableFuture<? extends TopicStatsImpl> asyncGetStats(boolean getPreciseBacklog,
                                                               boolean subscriptionBacklogSize,
-                                                              boolean getEarliestTimeInBacklog);
+                                                              boolean getEarliestTimeInBacklog,
+                                                              boolean getTotalNonContiguousDeletedMessagesRange);
 
     CompletableFuture<PersistentTopicInternalStats> getInternalStats(boolean includeLedgerMetadata);
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentTopic.java
@@ -846,9 +846,11 @@ public class NonPersistentTopic extends AbstractTopic implements Topic, TopicPol
 
     @Override
     public NonPersistentTopicStatsImpl getStats(boolean getPreciseBacklog, boolean subscriptionBacklogSize,
-                                                boolean getEarliestTimeInBacklog) {
+                                                boolean getEarliestTimeInBacklog,
+                                                boolean getTotalNonContiguousDeletedMessagesRange) {
         try {
-            return asyncGetStats(getPreciseBacklog, subscriptionBacklogSize, getPreciseBacklog).get();
+            return asyncGetStats(getPreciseBacklog, subscriptionBacklogSize, getPreciseBacklog,
+                    getTotalNonContiguousDeletedMessagesRange).get();
         } catch (InterruptedException | ExecutionException e) {
             log.error("[{}] Fail to get stats", topic, e);
             return null;
@@ -858,7 +860,8 @@ public class NonPersistentTopic extends AbstractTopic implements Topic, TopicPol
     @Override
     public CompletableFuture<NonPersistentTopicStatsImpl> asyncGetStats(boolean getPreciseBacklog,
                                                                         boolean subscriptionBacklogSize,
-                                                                        boolean getEarliestTimeInBacklog) {
+                                                                        boolean getEarliestTimeInBacklog,
+                                                   boolean getTotalNonContiguousDeletedMessagesRange) {
         CompletableFuture<NonPersistentTopicStatsImpl> future = new CompletableFuture<>();
         NonPersistentTopicStatsImpl stats = new NonPersistentTopicStatsImpl();
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentTopic.java
@@ -65,6 +65,7 @@ import org.apache.pulsar.broker.service.TopicPolicyListener;
 import org.apache.pulsar.broker.service.TransportCnx;
 import org.apache.pulsar.broker.stats.ClusterReplicationMetrics;
 import org.apache.pulsar.broker.stats.NamespaceStats;
+import org.apache.pulsar.client.admin.GetStatsOptions;
 import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.client.api.transaction.TxnID;
 import org.apache.pulsar.client.impl.PulsarClientImpl;
@@ -845,12 +846,9 @@ public class NonPersistentTopic extends AbstractTopic implements Topic, TopicPol
     }
 
     @Override
-    public NonPersistentTopicStatsImpl getStats(boolean getPreciseBacklog, boolean subscriptionBacklogSize,
-                                                boolean getEarliestTimeInBacklog,
-                                                boolean getTotalNonContiguousDeletedMessagesRange) {
+    public NonPersistentTopicStatsImpl getStats(GetStatsOptions getStatsOptions) {
         try {
-            return asyncGetStats(getPreciseBacklog, subscriptionBacklogSize, getPreciseBacklog,
-                    getTotalNonContiguousDeletedMessagesRange).get();
+            return asyncGetStats(getStatsOptions).get();
         } catch (InterruptedException | ExecutionException e) {
             log.error("[{}] Fail to get stats", topic, e);
             return null;
@@ -858,10 +856,7 @@ public class NonPersistentTopic extends AbstractTopic implements Topic, TopicPol
     }
 
     @Override
-    public CompletableFuture<NonPersistentTopicStatsImpl> asyncGetStats(boolean getPreciseBacklog,
-                                                                        boolean subscriptionBacklogSize,
-                                                                        boolean getEarliestTimeInBacklog,
-                                                   boolean getTotalNonContiguousDeletedMessagesRange) {
+    public CompletableFuture<NonPersistentTopicStatsImpl> asyncGetStats(GetStatsOptions getStatsOptions) {
         CompletableFuture<NonPersistentTopicStatsImpl> future = new CompletableFuture<>();
         NonPersistentTopicStatsImpl stats = new NonPersistentTopicStatsImpl();
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentSubscription.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentSubscription.java
@@ -74,6 +74,7 @@ import org.apache.pulsar.broker.service.plugin.EntryFilter;
 import org.apache.pulsar.broker.transaction.pendingack.PendingAckHandle;
 import org.apache.pulsar.broker.transaction.pendingack.impl.PendingAckHandleDisabled;
 import org.apache.pulsar.broker.transaction.pendingack.impl.PendingAckHandleImpl;
+import org.apache.pulsar.client.admin.GetStatsOptions;
 import org.apache.pulsar.client.api.Range;
 import org.apache.pulsar.client.api.transaction.TxnID;
 import org.apache.pulsar.common.api.proto.CommandAck.AckType;
@@ -1065,6 +1066,12 @@ public class PersistentSubscription extends AbstractSubscription implements Subs
         return cursor.getEstimatedSizeSinceMarkDeletePosition();
     }
 
+    public SubscriptionStatsImpl getStats(GetStatsOptions getStatsOptions) {
+        return getStats(getStatsOptions.isGetPreciseBacklog(), getStatsOptions.isSubscriptionBacklogSize(),
+                getStatsOptions.isGetEarliestTimeInBacklog(),
+                getStatsOptions.isGetTotalNonContiguousDeletedMessagesRange());
+    }
+    @Deprecated
     public SubscriptionStatsImpl getStats(Boolean getPreciseBacklog, boolean subscriptionBacklogSize,
                                           boolean getEarliestTimeInBacklog,
                                           boolean getTotalNonContiguousDeletedMessagesRange) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentSubscription.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentSubscription.java
@@ -1066,7 +1066,8 @@ public class PersistentSubscription extends AbstractSubscription implements Subs
     }
 
     public SubscriptionStatsImpl getStats(Boolean getPreciseBacklog, boolean subscriptionBacklogSize,
-                                          boolean getEarliestTimeInBacklog) {
+                                          boolean getEarliestTimeInBacklog,
+                                          boolean getTotalNonContiguousDeletedMessagesRange) {
         SubscriptionStatsImpl subStats = new SubscriptionStatsImpl();
         subStats.lastExpireTimestamp = lastExpireTimestamp;
         subStats.lastConsumedFlowTimestamp = lastConsumedFlowTimestamp;
@@ -1164,9 +1165,11 @@ public class PersistentSubscription extends AbstractSubscription implements Subs
                 });
             }
         }
-        subStats.nonContiguousDeletedMessagesRanges = cursor.getTotalNonContiguousDeletedMessagesRange();
-        subStats.nonContiguousDeletedMessagesRangesSerializedSize =
-                cursor.getNonContiguousDeletedMessagesRangeSerializedSize();
+        if (getTotalNonContiguousDeletedMessagesRange){
+            subStats.nonContiguousDeletedMessagesRanges = cursor.getTotalNonContiguousDeletedMessagesRange();
+            subStats.nonContiguousDeletedMessagesRangesSerializedSize =
+                    cursor.getNonContiguousDeletedMessagesRangeSerializedSize();
+        }
         return subStats;
     }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -1107,7 +1107,8 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
         PersistentSubscription sub = subscriptions.remove(subscriptionName);
         if (sub != null) {
             // preserve accumulative stats form removed subscription
-            SubscriptionStatsImpl stats = sub.getStats(false, false, false);
+            SubscriptionStatsImpl stats = sub.getStats(false, false,
+                    false, true);
             bytesOutFromRemovedSubscriptions.add(stats.bytesOutCounter);
             msgOutFromRemovedSubscriptions.add(stats.msgOutCounter);
         }
@@ -2025,9 +2026,11 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
 
     @Override
     public TopicStatsImpl getStats(boolean getPreciseBacklog, boolean subscriptionBacklogSize,
-                                   boolean getEarliestTimeInBacklog) {
+                                   boolean getEarliestTimeInBacklog,
+                                   boolean getTotalNonContiguousDeletedMessagesRange) {
         try {
-            return asyncGetStats(getPreciseBacklog, subscriptionBacklogSize, getEarliestTimeInBacklog).get();
+            return asyncGetStats(getPreciseBacklog, subscriptionBacklogSize, getEarliestTimeInBacklog,
+                    getTotalNonContiguousDeletedMessagesRange).get();
         } catch (InterruptedException | ExecutionException e) {
             log.error("[{}] Fail to get stats", topic, e);
             return null;
@@ -2036,7 +2039,8 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
 
     @Override
     public CompletableFuture<TopicStatsImpl> asyncGetStats(boolean getPreciseBacklog, boolean subscriptionBacklogSize,
-                                                           boolean getEarliestTimeInBacklog) {
+                                                           boolean getEarliestTimeInBacklog,
+                                                           boolean getTotalNonContiguousDeletedMessagesRange) {
 
         CompletableFuture<TopicStatsImpl> statsFuture = new CompletableFuture<>();
         TopicStatsImpl stats = new TopicStatsImpl();
@@ -2070,7 +2074,8 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
 
         subscriptions.forEach((name, subscription) -> {
             SubscriptionStatsImpl subStats =
-                    subscription.getStats(getPreciseBacklog, subscriptionBacklogSize, getEarliestTimeInBacklog);
+                    subscription.getStats(getPreciseBacklog, subscriptionBacklogSize, getEarliestTimeInBacklog,
+                            getTotalNonContiguousDeletedMessagesRange);
 
             stats.msgRateOut += subStats.msgRateOut;
             stats.msgThroughputOut += subStats.msgThroughputOut;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/NamespaceStatsAggregator.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/NamespaceStatsAggregator.java
@@ -179,7 +179,8 @@ public class NamespaceStatsAggregator {
             stats.managedLedgerStats.storageWriteRate = mlStats.getAddEntryMessagesRate();
             stats.managedLedgerStats.storageReadRate = mlStats.getReadEntriesRate();
         }
-        TopicStatsImpl tStatus = topic.getStats(getPreciseBacklog, subscriptionBacklogSize, false);
+        TopicStatsImpl tStatus = topic.getStats(getPreciseBacklog, subscriptionBacklogSize,
+                false, true);
         stats.msgInCounter = tStatus.msgInCounter;
         stats.bytesInCounter = tStatus.bytesInCounter;
         stats.msgOutCounter = tStatus.msgOutCounter;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/NamespaceStatsAggregator.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/NamespaceStatsAggregator.java
@@ -31,6 +31,7 @@ import org.apache.bookkeeper.mledger.impl.ManagedLedgerMBeanImpl;
 import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.broker.service.Topic;
 import org.apache.pulsar.broker.service.persistent.PersistentTopic;
+import org.apache.pulsar.client.admin.GetStatsOptions;
 import org.apache.pulsar.common.policies.data.BacklogQuota;
 import org.apache.pulsar.common.policies.data.stats.ConsumerStatsImpl;
 import org.apache.pulsar.common.policies.data.stats.NonPersistentSubscriptionStatsImpl;
@@ -179,8 +180,11 @@ public class NamespaceStatsAggregator {
             stats.managedLedgerStats.storageWriteRate = mlStats.getAddEntryMessagesRate();
             stats.managedLedgerStats.storageReadRate = mlStats.getReadEntriesRate();
         }
-        TopicStatsImpl tStatus = topic.getStats(getPreciseBacklog, subscriptionBacklogSize,
-                false, true);
+        GetStatsOptions getStatsOptions =
+                GetStatsOptions.builder().getPreciseBacklog(getPreciseBacklog)
+                        .subscriptionBacklogSize(subscriptionBacklogSize)
+                        .getEarliestTimeInBacklog(false).getTotalNonContiguousDeletedMessagesRange(true).build();
+        TopicStatsImpl tStatus = topic.getStats(getStatsOptions);
         stats.msgInCounter = tStatus.msgInCounter;
         stats.bytesInCounter = tStatus.bytesInCounter;
         stats.msgOutCounter = tStatus.msgOutCounter;

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiTest.java
@@ -1218,7 +1218,7 @@ public class AdminApiTest extends MockedPulsarServiceBaseTest {
         // create consumer and subscription
         @Cleanup
         Consumer<byte[]> consumer = pulsarClient.newConsumer().topic(topic).subscriptionName(subName).subscribe();
-        TopicStats topicStats = admin.topics().getStats(topic, false, false, true);
+        TopicStats topicStats = admin.topics().getStats(topic, false, false, true, true);
 
         assertEquals(topicStats.getEarliestMsgPublishTimeInBacklogs(), 0);
         assertEquals(topicStats.getSubscriptions().get(subName).getEarliestMsgPublishTimeInBacklog(), 0);
@@ -1227,7 +1227,7 @@ public class AdminApiTest extends MockedPulsarServiceBaseTest {
         publishMessagesOnPersistentTopic(topic, 10);
         Thread.sleep(1000);
 
-        topicStats = admin.topics().getStats(topic, false, false, true);
+        topicStats = admin.topics().getStats(topic, false, false, true, true);
         assertTrue(topicStats.getEarliestMsgPublishTimeInBacklogs() > 0);
         assertTrue(topicStats.getSubscriptions().get(subName).getEarliestMsgPublishTimeInBacklog() > 0);
 
@@ -1237,7 +1237,7 @@ public class AdminApiTest extends MockedPulsarServiceBaseTest {
         }
         Thread.sleep(1000);
 
-        topicStats = admin.topics().getStats(topic, false, false, true);
+        topicStats = admin.topics().getStats(topic, false, false, true, true);
         assertEquals(topicStats.getEarliestMsgPublishTimeInBacklogs(), 0);
         assertEquals(topicStats.getSubscriptions().get(subName).getEarliestMsgPublishTimeInBacklog(), 0);
     }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/PersistentTopicsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/PersistentTopicsTest.java
@@ -288,7 +288,8 @@ public class PersistentTopicsTest extends MockedPulsarServiceBaseTest {
         Assert.assertEquals(responseCaptor.getValue().getStatus(), Response.Status.NO_CONTENT.getStatusCode());
 
         response = mock(AsyncResponse.class);
-        persistentTopics.getStats(response, testTenant, testNamespace, testLocalTopicName, true, true, false, false);
+        persistentTopics.getStats(response, testTenant, testNamespace, testLocalTopicName, true, true, false, false,
+                true);
         ArgumentCaptor<TopicStats> statCaptor = ArgumentCaptor.forClass(TopicStats.class);
         verify(response, timeout(5000).times(1)).resume(statCaptor.capture());
         TopicStats topicStats = statCaptor.getValue();
@@ -306,7 +307,8 @@ public class PersistentTopicsTest extends MockedPulsarServiceBaseTest {
         Assert.assertEquals(responseCaptor.getValue().getStatus(), Response.Status.NO_CONTENT.getStatusCode());
 
         response = mock(AsyncResponse.class);
-        persistentTopics.getStats(response, testTenant, testNamespace, testLocalTopicName, true, true, false, false);
+        persistentTopics.getStats(response, testTenant, testNamespace, testLocalTopicName, true, true, false, false,
+                true);
         statCaptor = ArgumentCaptor.forClass(TopicStats.class);
         verify(response, timeout(5000).times(1)).resume(statCaptor.capture());
         topicStats = statCaptor.getValue();
@@ -325,7 +327,8 @@ public class PersistentTopicsTest extends MockedPulsarServiceBaseTest {
         Assert.assertEquals(responseCaptor.getValue().getStatus(), Response.Status.NO_CONTENT.getStatusCode());
 
         response = mock(AsyncResponse.class);
-        persistentTopics.getStats(response, testTenant, testNamespace, testLocalTopicName, true, true, false, false);
+        persistentTopics.getStats(response, testTenant, testNamespace, testLocalTopicName, true, true, false, false,
+                true);
         statCaptor = ArgumentCaptor.forClass(TopicStats.class);
         verify(response, timeout(5000).times(1)).resume(statCaptor.capture());
         topicStats = statCaptor.getValue();
@@ -344,7 +347,8 @@ public class PersistentTopicsTest extends MockedPulsarServiceBaseTest {
         Assert.assertEquals(responseCaptor.getValue().getStatus(), Response.Status.NO_CONTENT.getStatusCode());
 
         response = mock(AsyncResponse.class);
-        persistentTopics.getStats(response, testTenant, testNamespace, testLocalTopicName, true, true, false, false);
+        persistentTopics.getStats(response, testTenant, testNamespace, testLocalTopicName, true, true, false, false,
+                true);
         statCaptor = ArgumentCaptor.forClass(TopicStats.class);
         verify(response, timeout(5000).times(1)).resume(statCaptor.capture());
         topicStats = statCaptor.getValue();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/resourcegroup/RGUsageMTAggrWaitForAllMsgsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/resourcegroup/RGUsageMTAggrWaitForAllMsgsTest.java
@@ -547,7 +547,7 @@ public class RGUsageMTAggrWaitForAllMsgsTest extends ProducerConsumerBase {
                                        boolean checkConsume) throws Exception {
 
         BrokerService bs = pulsar.getBrokerService();
-        Map<String, TopicStatsImpl> topicStatsMap = bs.getTopicStats();
+        Map<String, TopicStatsImpl> topicStatsMap = bs.getTopicStats(false);
 
         log.debug("verifyProdConsStats: topicStatsMap has {} entries", topicStatsMap.size());
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/resourcegroup/RGUsageMTAggrWaitForAllMsgsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/resourcegroup/RGUsageMTAggrWaitForAllMsgsTest.java
@@ -25,6 +25,7 @@ import org.apache.pulsar.broker.resourcegroup.ResourceGroup.BytesAndMessagesCoun
 import org.apache.pulsar.broker.resourcegroup.ResourceGroup.ResourceGroupMonitoringClass;
 import org.apache.pulsar.broker.resourcegroup.ResourceGroupService.ResourceGroupUsageStatsType;
 import org.apache.pulsar.broker.service.BrokerService;
+import org.apache.pulsar.client.admin.GetStatsOptions;
 import org.apache.pulsar.client.admin.PulsarAdminException;
 import org.apache.pulsar.client.api.Consumer;
 import org.apache.pulsar.client.api.Message;
@@ -547,7 +548,10 @@ public class RGUsageMTAggrWaitForAllMsgsTest extends ProducerConsumerBase {
                                        boolean checkConsume) throws Exception {
 
         BrokerService bs = pulsar.getBrokerService();
-        Map<String, TopicStatsImpl> topicStatsMap = bs.getTopicStats(false);
+        GetStatsOptions getStatsOptions =
+                GetStatsOptions.builder().getPreciseBacklog(false).subscriptionBacklogSize(false)
+                        .getEarliestTimeInBacklog(false).getTotalNonContiguousDeletedMessagesRange(false).build();
+        Map<String, TopicStatsImpl> topicStatsMap = bs.getTopicStats(getStatsOptions);
 
         log.debug("verifyProdConsStats: topicStatsMap has {} entries", topicStatsMap.size());
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/resourcegroup/ResourceGroupUsageAggregationTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/resourcegroup/ResourceGroupUsageAggregationTest.java
@@ -27,6 +27,7 @@ import org.apache.pulsar.broker.service.BrokerService;
 import org.apache.pulsar.broker.service.Topic;
 import org.apache.pulsar.broker.service.persistent.PersistentTopic;
 import org.apache.pulsar.broker.service.resource.usage.ResourceUsage;
+import org.apache.pulsar.client.admin.GetStatsOptions;
 import org.apache.pulsar.client.admin.PulsarAdminException;
 import org.apache.pulsar.client.api.Consumer;
 import org.apache.pulsar.client.api.Message;
@@ -210,7 +211,10 @@ public class ResourceGroupUsageAggregationTest extends ProducerConsumerBase {
                                                                 throws InterruptedException, PulsarAdminException {
         BrokerService bs = pulsar.getBrokerService();
         Awaitility.await().untilAsserted(() -> {
-            TopicStatsImpl topicStats = bs.getTopicStats(false).get(topicString);
+            GetStatsOptions getStatsOptions =
+                    GetStatsOptions.builder().getPreciseBacklog(false).subscriptionBacklogSize(false)
+                            .getEarliestTimeInBacklog(false).getTotalNonContiguousDeletedMessagesRange(false).build();
+            TopicStatsImpl topicStats = bs.getTopicStats(getStatsOptions).get(topicString);
             Assert.assertNotNull(topicStats);
             if (checkProduce) {
                 Assert.assertTrue(topicStats.bytesInCounter >= sentNumBytes);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/resourcegroup/ResourceGroupUsageAggregationTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/resourcegroup/ResourceGroupUsageAggregationTest.java
@@ -210,7 +210,7 @@ public class ResourceGroupUsageAggregationTest extends ProducerConsumerBase {
                                                                 throws InterruptedException, PulsarAdminException {
         BrokerService bs = pulsar.getBrokerService();
         Awaitility.await().untilAsserted(() -> {
-            TopicStatsImpl topicStats = bs.getTopicStats().get(topicString);
+            TopicStatsImpl topicStats = bs.getTopicStats(false).get(topicString);
             Assert.assertNotNull(topicStats);
             if (checkProduce) {
                 Assert.assertTrue(topicStats.bytesInCounter >= sentNumBytes);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerServiceTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerServiceTest.java
@@ -231,7 +231,7 @@ public class BrokerServiceTest extends BrokerTestBase {
         assertNotNull(topicRef);
 
         rolloverPerIntervalStats();
-        stats = topicRef.getStats(false, false, false);
+        stats = topicRef.getStats(false, false, false, true);
         subStats = stats.getSubscriptions().values().iterator().next();
 
         // subscription stats
@@ -252,7 +252,7 @@ public class BrokerServiceTest extends BrokerTestBase {
         Thread.sleep(ASYNC_EVENT_COMPLETION_WAIT);
 
         rolloverPerIntervalStats();
-        stats = topicRef.getStats(false, false, false);
+        stats = topicRef.getStats(false, false, false, true);
         subStats = stats.getSubscriptions().values().iterator().next();
 
         // publisher stats
@@ -290,7 +290,7 @@ public class BrokerServiceTest extends BrokerTestBase {
         Thread.sleep(ASYNC_EVENT_COMPLETION_WAIT);
 
         rolloverPerIntervalStats();
-        stats = topicRef.getStats(false, false, false);
+        stats = topicRef.getStats(false, false, false, true);
         subStats = stats.getSubscriptions().values().iterator().next();
         assertEquals(stats.getOffloadedStorageSize(), 0);
 
@@ -419,13 +419,13 @@ public class BrokerServiceTest extends BrokerTestBase {
         PersistentTopic topicRef = (PersistentTopic) pulsar.getBrokerService().getTopicReference(topicName).get();
 
         assertNotNull(topicRef);
-        assertEquals(topicRef.getStats(false, false, false).storageSize, 0);
+        assertEquals(topicRef.getStats(false, false, false, true).storageSize, 0);
 
         for (int i = 0; i < 10; i++) {
             producer.send(new byte[10]);
         }
 
-        assertTrue(topicRef.getStats(false, false, false).storageSize > 0);
+        assertTrue(topicRef.getStats(false, false, false, true).storageSize > 0);
     }
 
     @Test
@@ -447,7 +447,7 @@ public class BrokerServiceTest extends BrokerTestBase {
         assertNotNull(topicRef);
 
         rolloverPerIntervalStats();
-        stats = topicRef.getStats(false, false, false);
+        stats = topicRef.getStats(false, false, false, true);
         subStats = stats.getSubscriptions().values().iterator().next();
 
         // subscription stats
@@ -465,7 +465,7 @@ public class BrokerServiceTest extends BrokerTestBase {
         Thread.sleep(ASYNC_EVENT_COMPLETION_WAIT);
 
         rolloverPerIntervalStats();
-        stats = topicRef.getStats(false, false, false);
+        stats = topicRef.getStats(false, false, false, true);
         subStats = stats.getSubscriptions().values().iterator().next();
 
         // publisher stats
@@ -500,7 +500,7 @@ public class BrokerServiceTest extends BrokerTestBase {
         Thread.sleep(ASYNC_EVENT_COMPLETION_WAIT);
 
         rolloverPerIntervalStats();
-        stats = topicRef.getStats(false, false, false);
+        stats = topicRef.getStats(false, false, false, true);
         subStats = stats.getSubscriptions().values().iterator().next();
         assertTrue(subStats.getMsgRateRedeliver() > 0.0);
         assertEquals(subStats.getMsgRateRedeliver(), subStats.getConsumers().get(0).getMsgRateRedeliver());
@@ -514,7 +514,7 @@ public class BrokerServiceTest extends BrokerTestBase {
         Thread.sleep(ASYNC_EVENT_COMPLETION_WAIT);
 
         rolloverPerIntervalStats();
-        stats = topicRef.getStats(false, false, false);
+        stats = topicRef.getStats(false, false, false, true);
         subStats = stats.getSubscriptions().values().iterator().next();
 
         assertEquals(subStats.getMsgBacklog(), 0);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerServiceTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerServiceTest.java
@@ -77,6 +77,7 @@ import org.apache.pulsar.broker.service.BrokerServiceException.PersistenceExcept
 import org.apache.pulsar.broker.service.persistent.PersistentTopic;
 import org.apache.pulsar.broker.stats.prometheus.PrometheusRawMetricsProvider;
 import org.apache.pulsar.client.admin.BrokerStats;
+import org.apache.pulsar.client.admin.GetStatsOptions;
 import org.apache.pulsar.client.admin.PulsarAdminException;
 import org.apache.pulsar.client.api.Authentication;
 import org.apache.pulsar.client.api.ClientBuilder;
@@ -231,7 +232,10 @@ public class BrokerServiceTest extends BrokerTestBase {
         assertNotNull(topicRef);
 
         rolloverPerIntervalStats();
-        stats = topicRef.getStats(false, false, false, true);
+        GetStatsOptions getStatsOptions =
+                GetStatsOptions.builder().getPreciseBacklog(false).subscriptionBacklogSize(false)
+                        .getEarliestTimeInBacklog(false).getTotalNonContiguousDeletedMessagesRange(true).build();
+        stats = topicRef.getStats(getStatsOptions);
         subStats = stats.getSubscriptions().values().iterator().next();
 
         // subscription stats
@@ -252,7 +256,7 @@ public class BrokerServiceTest extends BrokerTestBase {
         Thread.sleep(ASYNC_EVENT_COMPLETION_WAIT);
 
         rolloverPerIntervalStats();
-        stats = topicRef.getStats(false, false, false, true);
+        stats = topicRef.getStats(getStatsOptions);
         subStats = stats.getSubscriptions().values().iterator().next();
 
         // publisher stats
@@ -290,7 +294,7 @@ public class BrokerServiceTest extends BrokerTestBase {
         Thread.sleep(ASYNC_EVENT_COMPLETION_WAIT);
 
         rolloverPerIntervalStats();
-        stats = topicRef.getStats(false, false, false, true);
+        stats = topicRef.getStats(getStatsOptions);
         subStats = stats.getSubscriptions().values().iterator().next();
         assertEquals(stats.getOffloadedStorageSize(), 0);
 
@@ -419,13 +423,16 @@ public class BrokerServiceTest extends BrokerTestBase {
         PersistentTopic topicRef = (PersistentTopic) pulsar.getBrokerService().getTopicReference(topicName).get();
 
         assertNotNull(topicRef);
-        assertEquals(topicRef.getStats(false, false, false, true).storageSize, 0);
+        GetStatsOptions getStatsOptions =
+                GetStatsOptions.builder().getPreciseBacklog(false).subscriptionBacklogSize(false)
+                        .getEarliestTimeInBacklog(false).getTotalNonContiguousDeletedMessagesRange(true).build();
+        assertEquals(topicRef.getStats(getStatsOptions).storageSize, 0);
 
         for (int i = 0; i < 10; i++) {
             producer.send(new byte[10]);
         }
 
-        assertTrue(topicRef.getStats(false, false, false, true).storageSize > 0);
+        assertTrue(topicRef.getStats(getStatsOptions).storageSize > 0);
     }
 
     @Test
@@ -447,7 +454,10 @@ public class BrokerServiceTest extends BrokerTestBase {
         assertNotNull(topicRef);
 
         rolloverPerIntervalStats();
-        stats = topicRef.getStats(false, false, false, true);
+        GetStatsOptions getStatsOptions =
+                GetStatsOptions.builder().getPreciseBacklog(false).subscriptionBacklogSize(false)
+                        .getEarliestTimeInBacklog(false).getTotalNonContiguousDeletedMessagesRange(true).build();
+        stats = topicRef.getStats(getStatsOptions);
         subStats = stats.getSubscriptions().values().iterator().next();
 
         // subscription stats
@@ -465,7 +475,7 @@ public class BrokerServiceTest extends BrokerTestBase {
         Thread.sleep(ASYNC_EVENT_COMPLETION_WAIT);
 
         rolloverPerIntervalStats();
-        stats = topicRef.getStats(false, false, false, true);
+        stats = topicRef.getStats(getStatsOptions);
         subStats = stats.getSubscriptions().values().iterator().next();
 
         // publisher stats
@@ -500,7 +510,7 @@ public class BrokerServiceTest extends BrokerTestBase {
         Thread.sleep(ASYNC_EVENT_COMPLETION_WAIT);
 
         rolloverPerIntervalStats();
-        stats = topicRef.getStats(false, false, false, true);
+        stats = topicRef.getStats(getStatsOptions);
         subStats = stats.getSubscriptions().values().iterator().next();
         assertTrue(subStats.getMsgRateRedeliver() > 0.0);
         assertEquals(subStats.getMsgRateRedeliver(), subStats.getConsumers().get(0).getMsgRateRedeliver());
@@ -514,7 +524,7 @@ public class BrokerServiceTest extends BrokerTestBase {
         Thread.sleep(ASYNC_EVENT_COMPLETION_WAIT);
 
         rolloverPerIntervalStats();
-        stats = topicRef.getStats(false, false, false, true);
+        stats = topicRef.getStats(getStatsOptions);
         subStats = stats.getSubscriptions().values().iterator().next();
 
         assertEquals(subStats.getMsgBacklog(), 0);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentTopicTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentTopicTest.java
@@ -2280,7 +2280,7 @@ public class PersistentTopicTest extends MockedBookKeeperTestCase {
         sub1.addConsumer(consumer1);
         consumer1.close();
 
-        SubscriptionStatsImpl stats1 = sub1.getStats(false, false, false);
+        SubscriptionStatsImpl stats1 = sub1.getStats(false, false, false, true);
         assertEquals(stats1.keySharedMode, "AUTO_SPLIT");
         assertFalse(stats1.allowOutOfOrderDelivery);
 
@@ -2291,7 +2291,7 @@ public class PersistentTopicTest extends MockedBookKeeperTestCase {
         sub2.addConsumer(consumer2);
         consumer2.close();
 
-        SubscriptionStatsImpl stats2 = sub2.getStats(false, false, false);
+        SubscriptionStatsImpl stats2 = sub2.getStats(false, false, false, true);
         assertEquals(stats2.keySharedMode, "AUTO_SPLIT");
         assertTrue(stats2.allowOutOfOrderDelivery);
 
@@ -2303,7 +2303,7 @@ public class PersistentTopicTest extends MockedBookKeeperTestCase {
         sub3.addConsumer(consumer3);
         consumer3.close();
 
-        SubscriptionStatsImpl stats3 = sub3.getStats(false, false, false);
+        SubscriptionStatsImpl stats3 = sub3.getStats(false, false, false, true);
         assertEquals(stats3.keySharedMode, "STICKY");
         assertFalse(stats3.allowOutOfOrderDelivery);
     }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentTopicTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentTopicTest.java
@@ -19,6 +19,7 @@
 package org.apache.pulsar.broker.service.nonpersistent;
 
 import org.apache.pulsar.broker.service.BrokerTestBase;
+import org.apache.pulsar.client.admin.GetStatsOptions;
 import org.apache.pulsar.client.api.Consumer;
 import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.Producer;
@@ -63,7 +64,10 @@ public class NonPersistentTopicTest extends BrokerTestBase {
         NonPersistentTopic topic = (NonPersistentTopic) pulsar.getBrokerService().getTopicReference(topicName).get();
 
         // stats are at zero before any activity
-        TopicStats stats = topic.getStats(false, false, false, true);
+        GetStatsOptions getStatsOptions =
+                GetStatsOptions.builder().getPreciseBacklog(false).subscriptionBacklogSize(false)
+                        .getEarliestTimeInBacklog(false).getTotalNonContiguousDeletedMessagesRange(true).build();
+        TopicStats stats = topic.getStats(getStatsOptions);
         assertEquals(stats.getBytesInCounter(), 0);
         assertEquals(stats.getMsgInCounter(), 0);
         assertEquals(stats.getBytesOutCounter(), 0);
@@ -77,7 +81,7 @@ public class NonPersistentTopicTest extends BrokerTestBase {
         assertNotNull(msg);
 
         // send/receive result in non-zero stats
-        TopicStats statsBeforeUnsubscribe = topic.getStats(false, false, false, true);
+        TopicStats statsBeforeUnsubscribe = topic.getStats(getStatsOptions);
         assertTrue(statsBeforeUnsubscribe.getBytesInCounter() > 0);
         assertTrue(statsBeforeUnsubscribe.getMsgInCounter() > 0);
         assertTrue(statsBeforeUnsubscribe.getBytesOutCounter() > 0);
@@ -90,7 +94,7 @@ public class NonPersistentTopicTest extends BrokerTestBase {
         assertEquals(topic.getProducers().size(), 0);
 
         // consumer unsubscribe/producer removal does not result in stats loss
-        TopicStats statsAfterUnsubscribe = topic.getStats(false, false, false, true);
+        TopicStats statsAfterUnsubscribe = topic.getStats(getStatsOptions);
         assertEquals(statsAfterUnsubscribe.getBytesInCounter(), statsBeforeUnsubscribe.getBytesInCounter());
         assertEquals(statsAfterUnsubscribe.getMsgInCounter(), statsBeforeUnsubscribe.getMsgInCounter());
         assertEquals(statsAfterUnsubscribe.getBytesOutCounter(), statsBeforeUnsubscribe.getBytesOutCounter());

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentTopicTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentTopicTest.java
@@ -63,7 +63,7 @@ public class NonPersistentTopicTest extends BrokerTestBase {
         NonPersistentTopic topic = (NonPersistentTopic) pulsar.getBrokerService().getTopicReference(topicName).get();
 
         // stats are at zero before any activity
-        TopicStats stats = topic.getStats(false, false, false);
+        TopicStats stats = topic.getStats(false, false, false, true);
         assertEquals(stats.getBytesInCounter(), 0);
         assertEquals(stats.getMsgInCounter(), 0);
         assertEquals(stats.getBytesOutCounter(), 0);
@@ -77,7 +77,7 @@ public class NonPersistentTopicTest extends BrokerTestBase {
         assertNotNull(msg);
 
         // send/receive result in non-zero stats
-        TopicStats statsBeforeUnsubscribe = topic.getStats(false, false, false);
+        TopicStats statsBeforeUnsubscribe = topic.getStats(false, false, false, true);
         assertTrue(statsBeforeUnsubscribe.getBytesInCounter() > 0);
         assertTrue(statsBeforeUnsubscribe.getMsgInCounter() > 0);
         assertTrue(statsBeforeUnsubscribe.getBytesOutCounter() > 0);
@@ -90,7 +90,7 @@ public class NonPersistentTopicTest extends BrokerTestBase {
         assertEquals(topic.getProducers().size(), 0);
 
         // consumer unsubscribe/producer removal does not result in stats loss
-        TopicStats statsAfterUnsubscribe = topic.getStats(false, false, false);
+        TopicStats statsAfterUnsubscribe = topic.getStats(false, false, false, true);
         assertEquals(statsAfterUnsubscribe.getBytesInCounter(), statsBeforeUnsubscribe.getBytesInCounter());
         assertEquals(statsAfterUnsubscribe.getMsgInCounter(), statsBeforeUnsubscribe.getMsgInCounter());
         assertEquals(statsAfterUnsubscribe.getBytesOutCounter(), statsBeforeUnsubscribe.getBytesOutCounter());

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/PersistentTopicTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/PersistentTopicTest.java
@@ -46,6 +46,7 @@ import org.apache.bookkeeper.mledger.ManagedLedger;
 import org.apache.pulsar.broker.service.BrokerTestBase;
 import org.apache.pulsar.broker.stats.PrometheusMetricsTest;
 import org.apache.pulsar.broker.stats.prometheus.PrometheusMetricsGenerator;
+import org.apache.pulsar.client.admin.GetStatsOptions;
 import org.apache.pulsar.client.api.*;
 import org.apache.pulsar.common.naming.NamespaceBundle;
 import org.apache.pulsar.common.naming.TopicName;
@@ -209,7 +210,10 @@ public class PersistentTopicTest extends BrokerTestBase {
         PersistentTopic topic = (PersistentTopic) pulsar.getBrokerService().getTopicReference(topicName).get();
 
         // stats are at zero before any activity
-        TopicStats stats = topic.getStats(false, false, false, true);
+        GetStatsOptions getStatsOptions =
+                GetStatsOptions.builder().getPreciseBacklog(false).subscriptionBacklogSize(false)
+                        .getEarliestTimeInBacklog(false).getTotalNonContiguousDeletedMessagesRange(true).build();
+        TopicStats stats = topic.getStats(getStatsOptions);
         assertEquals(stats.getBytesInCounter(), 0);
         assertEquals(stats.getMsgInCounter(), 0);
         assertEquals(stats.getBytesOutCounter(), 0);
@@ -223,7 +227,7 @@ public class PersistentTopicTest extends BrokerTestBase {
         assertNotNull(msg);
 
         // send/receive result in non-zero stats
-        TopicStats statsBeforeUnsubscribe = topic.getStats(false, false, false, true);
+        TopicStats statsBeforeUnsubscribe = topic.getStats(getStatsOptions);
         assertTrue(statsBeforeUnsubscribe.getBytesInCounter() > 0);
         assertTrue(statsBeforeUnsubscribe.getMsgInCounter() > 0);
         assertTrue(statsBeforeUnsubscribe.getBytesOutCounter() > 0);
@@ -236,7 +240,7 @@ public class PersistentTopicTest extends BrokerTestBase {
         assertEquals(topic.getProducers().size(), 0);
 
         // consumer unsubscribe/producer removal does not result in stats loss
-        TopicStats statsAfterUnsubscribe = topic.getStats(false, false, false, true);
+        TopicStats statsAfterUnsubscribe = topic.getStats(getStatsOptions);
         assertEquals(statsAfterUnsubscribe.getBytesInCounter(), statsBeforeUnsubscribe.getBytesInCounter());
         assertEquals(statsAfterUnsubscribe.getMsgInCounter(), statsBeforeUnsubscribe.getMsgInCounter());
         assertEquals(statsAfterUnsubscribe.getBytesOutCounter(), statsBeforeUnsubscribe.getBytesOutCounter());

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/PersistentTopicTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/PersistentTopicTest.java
@@ -209,7 +209,7 @@ public class PersistentTopicTest extends BrokerTestBase {
         PersistentTopic topic = (PersistentTopic) pulsar.getBrokerService().getTopicReference(topicName).get();
 
         // stats are at zero before any activity
-        TopicStats stats = topic.getStats(false, false, false);
+        TopicStats stats = topic.getStats(false, false, false, true);
         assertEquals(stats.getBytesInCounter(), 0);
         assertEquals(stats.getMsgInCounter(), 0);
         assertEquals(stats.getBytesOutCounter(), 0);
@@ -223,7 +223,7 @@ public class PersistentTopicTest extends BrokerTestBase {
         assertNotNull(msg);
 
         // send/receive result in non-zero stats
-        TopicStats statsBeforeUnsubscribe = topic.getStats(false, false, false);
+        TopicStats statsBeforeUnsubscribe = topic.getStats(false, false, false, true);
         assertTrue(statsBeforeUnsubscribe.getBytesInCounter() > 0);
         assertTrue(statsBeforeUnsubscribe.getMsgInCounter() > 0);
         assertTrue(statsBeforeUnsubscribe.getBytesOutCounter() > 0);
@@ -236,7 +236,7 @@ public class PersistentTopicTest extends BrokerTestBase {
         assertEquals(topic.getProducers().size(), 0);
 
         // consumer unsubscribe/producer removal does not result in stats loss
-        TopicStats statsAfterUnsubscribe = topic.getStats(false, false, false);
+        TopicStats statsAfterUnsubscribe = topic.getStats(false, false, false, true);
         assertEquals(statsAfterUnsubscribe.getBytesInCounter(), statsBeforeUnsubscribe.getBytesInCounter());
         assertEquals(statsAfterUnsubscribe.getMsgInCounter(), statsBeforeUnsubscribe.getMsgInCounter());
         assertEquals(statsAfterUnsubscribe.getBytesOutCounter(), statsBeforeUnsubscribe.getBytesOutCounter());

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/TransactionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/TransactionTest.java
@@ -203,7 +203,7 @@ public class TransactionTest extends TransactionTestBase {
         Optional<Topic> optional = pulsarService.getBrokerService().getTopic(topic, false).get();
         assertTrue(optional.isPresent());
         PersistentTopic persistentTopic = (PersistentTopic) optional.get();
-        TopicStatsImpl stats = persistentTopic.getStats(false, false, false);
+        TopicStatsImpl stats = persistentTopic.getStats(false, false, false, true);
 
         assertEquals(stats.committedTxnCount, 1);
         assertEquals(stats.abortedTxnCount, 1);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/TransactionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/TransactionTest.java
@@ -103,6 +103,7 @@ import org.apache.pulsar.broker.transaction.pendingack.impl.MLPendingAckReplyCal
 import org.apache.pulsar.broker.transaction.pendingack.impl.MLPendingAckStore;
 import org.apache.pulsar.broker.transaction.pendingack.impl.MLPendingAckStoreProvider;
 import org.apache.pulsar.broker.transaction.pendingack.impl.PendingAckHandleImpl;
+import org.apache.pulsar.client.admin.GetStatsOptions;
 import org.apache.pulsar.client.admin.PulsarAdminException;
 import org.apache.pulsar.client.api.Consumer;
 import org.apache.pulsar.client.api.Message;
@@ -203,7 +204,10 @@ public class TransactionTest extends TransactionTestBase {
         Optional<Topic> optional = pulsarService.getBrokerService().getTopic(topic, false).get();
         assertTrue(optional.isPresent());
         PersistentTopic persistentTopic = (PersistentTopic) optional.get();
-        TopicStatsImpl stats = persistentTopic.getStats(false, false, false, true);
+        GetStatsOptions getStatsOptions =
+                GetStatsOptions.builder().getPreciseBacklog(false).subscriptionBacklogSize(false)
+                        .getEarliestTimeInBacklog(false).getTotalNonContiguousDeletedMessagesRange(true).build();
+        TopicStatsImpl stats = persistentTopic.getStats(getStatsOptions);
 
         assertEquals(stats.committedTxnCount, 1);
         assertEquals(stats.abortedTxnCount, 1);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/DispatcherBlockConsumerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/DispatcherBlockConsumerTest.java
@@ -53,6 +53,7 @@ import org.apache.pulsar.broker.service.BrokerService;
 import org.apache.pulsar.broker.service.CanPausedNamespaceService;
 import org.apache.pulsar.broker.service.persistent.PersistentDispatcherMultipleConsumers;
 import org.apache.pulsar.broker.service.persistent.PersistentTopic;
+import org.apache.pulsar.client.admin.GetStatsOptions;
 import org.apache.pulsar.client.impl.ConsumerImpl;
 import org.apache.pulsar.client.impl.MessageIdImpl;
 import org.apache.pulsar.common.policies.data.SubscriptionStats;
@@ -545,7 +546,10 @@ public class DispatcherBlockConsumerTest extends ProducerConsumerBase {
             assertNotNull(topicRef);
 
             rolloverPerIntervalStats();
-            stats = topicRef.getStats(false, false, false, true);
+            GetStatsOptions getStatsOptions =
+                    GetStatsOptions.builder().getPreciseBacklog(false).subscriptionBacklogSize(false)
+                            .getEarliestTimeInBacklog(false).getTotalNonContiguousDeletedMessagesRange(true).build();
+            stats = topicRef.getStats(getStatsOptions);
             subStats = stats.getSubscriptions().values().iterator().next();
 
             // subscription stats
@@ -563,7 +567,7 @@ public class DispatcherBlockConsumerTest extends ProducerConsumerBase {
             Thread.sleep(timeWaitToSync);
 
             rolloverPerIntervalStats();
-            stats = topicRef.getStats(false, false, false, true);
+            stats = topicRef.getStats(getStatsOptions);
             subStats = stats.getSubscriptions().values().iterator().next();
 
             assertTrue(subStats.getMsgBacklog() > 0);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/DispatcherBlockConsumerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/DispatcherBlockConsumerTest.java
@@ -545,7 +545,7 @@ public class DispatcherBlockConsumerTest extends ProducerConsumerBase {
             assertNotNull(topicRef);
 
             rolloverPerIntervalStats();
-            stats = topicRef.getStats(false, false, false);
+            stats = topicRef.getStats(false, false, false, true);
             subStats = stats.getSubscriptions().values().iterator().next();
 
             // subscription stats
@@ -563,7 +563,7 @@ public class DispatcherBlockConsumerTest extends ProducerConsumerBase {
             Thread.sleep(timeWaitToSync);
 
             rolloverPerIntervalStats();
-            stats = topicRef.getStats(false, false, false);
+            stats = topicRef.getStats(false, false, false, true);
             subStats = stats.getSubscriptions().values().iterator().next();
 
             assertTrue(subStats.getMsgBacklog() > 0);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/NonPersistentTopicTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/NonPersistentTopicTest.java
@@ -495,7 +495,7 @@ public class NonPersistentTopicTest extends ProducerConsumerBase {
         assertNotNull(topicRef);
 
         rolloverPerIntervalStats(pulsar);
-        stats = topicRef.getStats(false, false, false);
+        stats = topicRef.getStats(false, false, false, true);
         subStats = stats.getSubscriptions().values().iterator().next();
 
         // subscription stats
@@ -513,7 +513,7 @@ public class NonPersistentTopicTest extends ProducerConsumerBase {
         Thread.sleep(timeWaitToSync);
 
         rolloverPerIntervalStats(pulsar);
-        stats = topicRef.getStats(false, false, false);
+        stats = topicRef.getStats(false, false, false, true);
         subStats = stats.getSubscriptions().values().iterator().next();
 
         assertTrue(subStats.getMsgRateOut() > 0);
@@ -580,7 +580,7 @@ public class NonPersistentTopicTest extends ProducerConsumerBase {
             assertNotNull(replicatorR3);
 
             rolloverPerIntervalStats(replicationPulasr);
-            stats = topicRef.getStats(false, false, false);
+            stats = topicRef.getStats(false, false, false, true);
             subStats = stats.getSubscriptions().values().iterator().next();
 
             // subscription stats
@@ -651,7 +651,7 @@ public class NonPersistentTopicTest extends ProducerConsumerBase {
             Thread.sleep(timeWaitToSync);
 
             rolloverPerIntervalStats(replicationPulasr);
-            stats = topicRef.getStats(false, false, false);
+            stats = topicRef.getStats(false, false, false, true);
             subStats = stats.getSubscriptions().values().iterator().next();
 
             assertTrue(subStats.getMsgRateOut() > 0);
@@ -849,7 +849,7 @@ public class NonPersistentTopicTest extends ProducerConsumerBase {
 
             NonPersistentTopic topic = (NonPersistentTopic) pulsar.getBrokerService().getOrCreateTopic(topicName).get();
             pulsar.getBrokerService().updateRates();
-            NonPersistentTopicStats stats = topic.getStats(false, false, false);
+            NonPersistentTopicStats stats = topic.getStats(false, false, false, true);
             NonPersistentPublisherStats npStats = stats.getPublishers().get(0);
             NonPersistentSubscriptionStats sub1Stats = stats.getSubscriptions().get("subscriber-1");
             NonPersistentSubscriptionStats sub2Stats = stats.getSubscriptions().get("subscriber-2");

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/NonPersistentTopicTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/NonPersistentTopicTest.java
@@ -48,6 +48,7 @@ import org.apache.pulsar.broker.loadbalance.impl.SimpleLoadManagerImpl;
 import org.apache.pulsar.broker.service.BrokerService;
 import org.apache.pulsar.broker.service.nonpersistent.NonPersistentReplicator;
 import org.apache.pulsar.broker.service.nonpersistent.NonPersistentTopic;
+import org.apache.pulsar.client.admin.GetStatsOptions;
 import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.impl.ConsumerImpl;
 import org.apache.pulsar.client.impl.MultiTopicsConsumerImpl;
@@ -495,7 +496,10 @@ public class NonPersistentTopicTest extends ProducerConsumerBase {
         assertNotNull(topicRef);
 
         rolloverPerIntervalStats(pulsar);
-        stats = topicRef.getStats(false, false, false, true);
+        GetStatsOptions getStatsOptions =
+                GetStatsOptions.builder().getPreciseBacklog(false).subscriptionBacklogSize(false)
+                        .getEarliestTimeInBacklog(false).getTotalNonContiguousDeletedMessagesRange(true).build();
+        stats = topicRef.getStats(getStatsOptions);
         subStats = stats.getSubscriptions().values().iterator().next();
 
         // subscription stats
@@ -513,7 +517,7 @@ public class NonPersistentTopicTest extends ProducerConsumerBase {
         Thread.sleep(timeWaitToSync);
 
         rolloverPerIntervalStats(pulsar);
-        stats = topicRef.getStats(false, false, false, true);
+        stats = topicRef.getStats(getStatsOptions);
         subStats = stats.getSubscriptions().values().iterator().next();
 
         assertTrue(subStats.getMsgRateOut() > 0);
@@ -580,7 +584,10 @@ public class NonPersistentTopicTest extends ProducerConsumerBase {
             assertNotNull(replicatorR3);
 
             rolloverPerIntervalStats(replicationPulasr);
-            stats = topicRef.getStats(false, false, false, true);
+            GetStatsOptions getStatsOptions =
+                    GetStatsOptions.builder().getPreciseBacklog(false).subscriptionBacklogSize(false)
+                            .getEarliestTimeInBacklog(false).getTotalNonContiguousDeletedMessagesRange(true).build();
+            stats = topicRef.getStats(getStatsOptions);
             subStats = stats.getSubscriptions().values().iterator().next();
 
             // subscription stats
@@ -651,7 +658,7 @@ public class NonPersistentTopicTest extends ProducerConsumerBase {
             Thread.sleep(timeWaitToSync);
 
             rolloverPerIntervalStats(replicationPulasr);
-            stats = topicRef.getStats(false, false, false, true);
+            stats = topicRef.getStats(getStatsOptions);
             subStats = stats.getSubscriptions().values().iterator().next();
 
             assertTrue(subStats.getMsgRateOut() > 0);
@@ -849,7 +856,10 @@ public class NonPersistentTopicTest extends ProducerConsumerBase {
 
             NonPersistentTopic topic = (NonPersistentTopic) pulsar.getBrokerService().getOrCreateTopic(topicName).get();
             pulsar.getBrokerService().updateRates();
-            NonPersistentTopicStats stats = topic.getStats(false, false, false, true);
+            GetStatsOptions getStatsOptions =
+                    GetStatsOptions.builder().getPreciseBacklog(false).subscriptionBacklogSize(false)
+                            .getEarliestTimeInBacklog(false).getTotalNonContiguousDeletedMessagesRange(true).build();
+            NonPersistentTopicStats stats = topic.getStats(getStatsOptions);
             NonPersistentPublisherStats npStats = stats.getPublishers().get(0);
             NonPersistentSubscriptionStats sub1Stats = stats.getSubscriptions().get("subscriber-1");
             NonPersistentSubscriptionStats sub2Stats = stats.getSubscriptions().get("subscriber-2");

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/MessageChunkingTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/MessageChunkingTest.java
@@ -159,7 +159,7 @@ public class MessageChunkingTest extends ProducerConsumerBase {
 
         pulsar.getBrokerService().updateRates();
 
-        PublisherStats producerStats = topic.getStats(false, false, false).getPublishers().get(0);
+        PublisherStats producerStats = topic.getStats(false, false, false, true).getPublishers().get(0);
 
         assertTrue(producerStats.getChunkedMessageRate() > 0);
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/MessageChunkingTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/MessageChunkingTest.java
@@ -43,6 +43,7 @@ import org.apache.bookkeeper.mledger.impl.ManagedCursorImpl;
 import org.apache.bookkeeper.mledger.impl.PositionImpl;
 import org.apache.commons.lang3.RandomUtils;
 import org.apache.pulsar.broker.service.persistent.PersistentTopic;
+import org.apache.pulsar.client.admin.GetStatsOptions;
 import org.apache.pulsar.client.api.ClientBuilder;
 import org.apache.pulsar.client.api.CompressionType;
 import org.apache.pulsar.client.api.Consumer;
@@ -158,8 +159,10 @@ public class MessageChunkingTest extends ProducerConsumerBase {
         }
 
         pulsar.getBrokerService().updateRates();
-
-        PublisherStats producerStats = topic.getStats(false, false, false, true).getPublishers().get(0);
+        GetStatsOptions getStatsOptions =
+                GetStatsOptions.builder().getPreciseBacklog(false).subscriptionBacklogSize(false)
+                        .getEarliestTimeInBacklog(false).getTotalNonContiguousDeletedMessagesRange(true).build();
+        PublisherStats producerStats = topic.getStats(getStatsOptions).getPublishers().get(0);
 
         assertTrue(producerStats.getChunkedMessageRate() > 0);
 

--- a/pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/admin/GetStatsOptions.java
+++ b/pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/admin/GetStatsOptions.java
@@ -38,4 +38,9 @@ public class GetStatsOptions {
      * Whether to get the earliest time in backlog.
      */
     private final boolean getEarliestTimeInBacklog;
+
+    /**
+     * Whether to get total NonContiguousDeletedMessagesRange.
+     */
+    private final boolean getTotalNonContiguousDeletedMessagesRange;
 }

--- a/pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/admin/Topics.java
+++ b/pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/admin/Topics.java
@@ -1182,8 +1182,14 @@ public interface Topics {
                                                 boolean subscriptionBacklogSize, boolean getEarliestTimeInBacklog,
                                                 boolean getTotalNonContiguousDeletedMessagesRange);
 
+    CompletableFuture<TopicStats> getStatsAsync(String topic, GetStatsOptions getStatsOptions);
+
     default CompletableFuture<TopicStats> getStatsAsync(String topic) {
-        return getStatsAsync(topic, false, false, false, true);
+        GetStatsOptions getStatsOptions =
+                GetStatsOptions.builder().getPreciseBacklog(false).subscriptionBacklogSize(false)
+                        .getEarliestTimeInBacklog(false).getTotalNonContiguousDeletedMessagesRange(true).build();
+
+        return getStatsAsync(topic, getStatsOptions);
     }
 
     /**

--- a/pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/admin/Topics.java
+++ b/pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/admin/Topics.java
@@ -1137,25 +1137,30 @@ public interface Topics {
 
 
     default TopicStats getStats(String topic, boolean getPreciseBacklog, boolean subscriptionBacklogSize,
-                        boolean getEarliestTimeInBacklog) throws PulsarAdminException {
+                                boolean getEarliestTimeInBacklog, boolean getTotalNonContiguousDeletedMessagesRange)
+            throws PulsarAdminException {
         GetStatsOptions getStatsOptions =
-                new GetStatsOptions(getPreciseBacklog, subscriptionBacklogSize, getEarliestTimeInBacklog);
+                new GetStatsOptions(getPreciseBacklog, subscriptionBacklogSize, getEarliestTimeInBacklog,
+                        getTotalNonContiguousDeletedMessagesRange);
         return getStats(topic, getStatsOptions);
     }
 
     default TopicStats getStats(String topic, boolean getPreciseBacklog,
-                        boolean subscriptionBacklogSize) throws PulsarAdminException {
-        GetStatsOptions getStatsOptions = new GetStatsOptions(getPreciseBacklog, subscriptionBacklogSize, false);
+                                boolean subscriptionBacklogSize) throws PulsarAdminException {
+        GetStatsOptions getStatsOptions = new GetStatsOptions(getPreciseBacklog, subscriptionBacklogSize,
+                false, true);
         return getStats(topic, getStatsOptions);
     }
 
     default TopicStats getStats(String topic, boolean getPreciseBacklog) throws PulsarAdminException {
-        GetStatsOptions getStatsOptions = new GetStatsOptions(getPreciseBacklog, false, false);
+        GetStatsOptions getStatsOptions = new GetStatsOptions(getPreciseBacklog, false,
+                false, true);
         return getStats(topic, getStatsOptions);
     }
 
     default TopicStats getStats(String topic) throws PulsarAdminException {
-        return getStats(topic, new GetStatsOptions(false, false, false));
+        return getStats(topic, new GetStatsOptions(false, false,
+                false, true));
     }
 
     /**
@@ -1174,10 +1179,11 @@ public interface Topics {
      *
      */
     CompletableFuture<TopicStats> getStatsAsync(String topic, boolean getPreciseBacklog,
-                                                boolean subscriptionBacklogSize, boolean getEarliestTimeInBacklog);
+                                                boolean subscriptionBacklogSize, boolean getEarliestTimeInBacklog,
+                                                boolean getTotalNonContiguousDeletedMessagesRange);
 
     default CompletableFuture<TopicStats> getStatsAsync(String topic) {
-        return getStatsAsync(topic, false, false, false);
+        return getStatsAsync(topic, false, false, false, true);
     }
 
     /**

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/TopicsImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/TopicsImpl.java
@@ -590,15 +590,10 @@ public class TopicsImpl extends BaseResource implements Topics {
 
     @Override
     public TopicStats getStats(String topic, GetStatsOptions getStatsOptions) throws PulsarAdminException {
-        boolean getPreciseBacklog = getStatsOptions.isGetPreciseBacklog();
-        boolean subscriptionBacklogSize = getStatsOptions.isSubscriptionBacklogSize();
-        boolean getEarliestTimeInBacklog = getStatsOptions.isGetEarliestTimeInBacklog();
-        boolean getTotalNonContiguousDeletedMessagesRange =
-                getStatsOptions.isGetTotalNonContiguousDeletedMessagesRange();
-        return sync(() -> getStatsAsync(topic, getPreciseBacklog, subscriptionBacklogSize, getEarliestTimeInBacklog,
-                getTotalNonContiguousDeletedMessagesRange));
+        return sync(() -> getStatsAsync(topic, getStatsOptions));
     }
 
+    @Deprecated
     @Override
     public CompletableFuture<TopicStats> getStatsAsync(String topic, boolean getPreciseBacklog,
                                                        boolean subscriptionBacklogSize,
@@ -644,6 +639,13 @@ public class TopicsImpl extends BaseResource implements Topics {
         }
 
         return future;
+    }
+
+    @Override
+    public CompletableFuture<TopicStats> getStatsAsync(String topic, GetStatsOptions getStatsOptions) {
+        return getStatsAsync(topic, getStatsOptions.isGetPreciseBacklog(), getStatsOptions.isSubscriptionBacklogSize(),
+                getStatsOptions.isGetEarliestTimeInBacklog(),
+                getStatsOptions.isGetTotalNonContiguousDeletedMessagesRange());
     }
 
     @Override

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/TopicsImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/TopicsImpl.java
@@ -593,18 +593,23 @@ public class TopicsImpl extends BaseResource implements Topics {
         boolean getPreciseBacklog = getStatsOptions.isGetPreciseBacklog();
         boolean subscriptionBacklogSize = getStatsOptions.isSubscriptionBacklogSize();
         boolean getEarliestTimeInBacklog = getStatsOptions.isGetEarliestTimeInBacklog();
-        return sync(() -> getStatsAsync(topic, getPreciseBacklog, subscriptionBacklogSize, getEarliestTimeInBacklog));
+        boolean getTotalNonContiguousDeletedMessagesRange =
+                getStatsOptions.isGetTotalNonContiguousDeletedMessagesRange();
+        return sync(() -> getStatsAsync(topic, getPreciseBacklog, subscriptionBacklogSize, getEarliestTimeInBacklog,
+                getTotalNonContiguousDeletedMessagesRange));
     }
 
     @Override
     public CompletableFuture<TopicStats> getStatsAsync(String topic, boolean getPreciseBacklog,
                                                        boolean subscriptionBacklogSize,
-                                                       boolean getEarliestTimeInBacklog) {
+                                                       boolean getEarliestTimeInBacklog,
+                                                       boolean getTotalNonContiguousDeletedMessagesRange) {
         TopicName tn = validateTopic(topic);
         WebTarget path = topicPath(tn, "stats")
                 .queryParam("getPreciseBacklog", getPreciseBacklog)
                 .queryParam("subscriptionBacklogSize", subscriptionBacklogSize)
-                .queryParam("getEarliestTimeInBacklog", getEarliestTimeInBacklog);
+                .queryParam("getEarliestTimeInBacklog", getEarliestTimeInBacklog)
+                .queryParam("getTotalNonContiguousDeletedMessagesRange", getTotalNonContiguousDeletedMessagesRange);
         final CompletableFuture<TopicStats> future = new CompletableFuture<>();
 
         InvocationCallback<TopicStats> persistentCB = new InvocationCallback<TopicStats>() {

--- a/pulsar-client-tools-test/src/test/java/org/apache/pulsar/admin/cli/PulsarAdminToolTest.java
+++ b/pulsar-client-tools-test/src/test/java/org/apache/pulsar/admin/cli/PulsarAdminToolTest.java
@@ -56,6 +56,7 @@ import org.apache.pulsar.client.admin.Bookies;
 import org.apache.pulsar.client.admin.BrokerStats;
 import org.apache.pulsar.client.admin.Brokers;
 import org.apache.pulsar.client.admin.Clusters;
+import org.apache.pulsar.client.admin.GetStatsOptions;
 import org.apache.pulsar.client.admin.ListNamespaceTopicsOptions;
 import org.apache.pulsar.client.admin.ListTopicsOptions;
 import org.apache.pulsar.client.admin.LongRunningProcessStatus;
@@ -1473,7 +1474,10 @@ public class PulsarAdminToolTest {
         verify(mockTopics).deleteSubscription("persistent://myprop/clust/ns1/ds1", "sub1", false);
 
         cmdTopics.run(split("stats persistent://myprop/clust/ns1/ds1"));
-        verify(mockTopics).getStats("persistent://myprop/clust/ns1/ds1", false, false, false);
+        GetStatsOptions getStatsOptions =
+                GetStatsOptions.builder().getPreciseBacklog(false).subscriptionBacklogSize(false)
+                        .getEarliestTimeInBacklog(false).getTotalNonContiguousDeletedMessagesRange(true).build();
+        verify(mockTopics).getStats("persistent://myprop/clust/ns1/ds1", getStatsOptions);
 
         cmdTopics.run(split("stats-internal persistent://myprop/clust/ns1/ds1"));
         verify(mockTopics).getInternalStats("persistent://myprop/clust/ns1/ds1", false);
@@ -2084,7 +2088,10 @@ public class PulsarAdminToolTest {
         CmdTopics topics = new CmdTopics(() -> admin);
 
         topics.run(split("stats non-persistent://myprop/ns1/ds1"));
-        verify(mockTopics).getStats("non-persistent://myprop/ns1/ds1", false, false, false);
+        GetStatsOptions getStatsOptions =
+                GetStatsOptions.builder().getPreciseBacklog(false).subscriptionBacklogSize(false)
+                        .getEarliestTimeInBacklog(false).getTotalNonContiguousDeletedMessagesRange(true).build();
+        verify(mockTopics).getStats("non-persistent://myprop/ns1/ds1", getStatsOptions);
 
         topics.run(split("stats-internal non-persistent://myprop/ns1/ds1"));
         verify(mockTopics).getInternalStats("non-persistent://myprop/ns1/ds1", false);

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdTopics.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdTopics.java
@@ -47,6 +47,7 @@ import java.util.concurrent.TimeoutException;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import lombok.Getter;
+import org.apache.pulsar.client.admin.GetStatsOptions;
 import org.apache.pulsar.client.admin.ListTopicsOptions;
 import org.apache.pulsar.client.admin.LongRunningProcessStatus;
 import org.apache.pulsar.client.admin.OffloadProcessStatus;
@@ -793,10 +794,21 @@ public class CmdTopics extends CmdBase {
                 "--get-earliest-time-in-backlog" }, description = "Set true to get earliest time in backlog")
         private boolean getEarliestTimeInBacklog = false;
 
+        @Parameter(names = {"-ncm",
+                "--get-total-non-contiguous-deleted-messages-range"}, description = "If return the total "
+                + "non-continues deleted message range")
+        private boolean getTotalNonContiguousDeletedMessagesRange = true;
+
         @Override
         void run() throws PulsarAdminException {
             String topic = validateTopicName(params);
-            print(getTopics().getStats(topic, getPreciseBacklog, subscriptionBacklogSize, getEarliestTimeInBacklog));
+            GetStatsOptions getStatsOptions =
+                    GetStatsOptions.builder().getPreciseBacklog(getPreciseBacklog)
+                            .subscriptionBacklogSize(subscriptionBacklogSize)
+                            .getEarliestTimeInBacklog(getEarliestTimeInBacklog)
+                            .getTotalNonContiguousDeletedMessagesRange(getTotalNonContiguousDeletedMessagesRange)
+                            .build();
+            print(getTopics().getStats(topic, getStatsOptions));
         }
     }
 


### PR DESCRIPTION
Fixes #18240

<!-- or this PR is one task of an issue -->

Master Issue: #18240

### Motivation

<!-- Explain here the context, and why you're making that change. What is the problem you're trying to solve. -->

### Modifications

<!-- Describe the modifications you've done. -->

add a flag getTotalNonContiguousDeletedMessagesRange to allow users can skip  the non-continued deleted ranges stats

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

https://github.com/leizhiyuan/pulsar/pull/5

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [x] The REST endpoints
- [ ] The admin CLI options
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
