### PR TITLE
Revert "Handle unknown runtime exception while reading entries (#2993)"

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/cache/RangeEntryCacheImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/cache/RangeEntryCacheImpl.java
@@ -201,20 +201,6 @@ public class RangeEntryCacheImpl implements EntryCache {
     @Override
     public void asyncReadEntry(ReadHandle lh, PositionImpl position, final ReadEntryCallback callback,
             final Object ctx) {
-        try {
-            asyncReadEntry0(lh, position, callback, ctx);
-        } catch (Throwable t) {
-            log.warn("failed to read entries for {}-{}", lh.getId(), position, t);
-            // invalidate all entries related to ledger from the cache (it might happen if entry gets corrupt
-            // (entry.data is already deallocate due to any race-condition) so, invalidate cache and next time read from
-            // the bookie)
-            invalidateAllEntries(lh.getId());
-            callback.readEntryFailed(createManagedLedgerException(t), ctx);
-        }
-    }
-
-    private void asyncReadEntry0(ReadHandle lh, PositionImpl position, final ReadEntryCallback callback,
-            final Object ctx) {
         if (log.isDebugEnabled()) {
             log.debug("[{}] Reading entry ledger {}: {}", ml.getName(), lh.getId(), position.getEntryId());
         }
@@ -254,22 +240,8 @@ public class RangeEntryCacheImpl implements EntryCache {
     }
 
     @Override
-    public void asyncReadEntry(ReadHandle lh, long firstEntry, long lastEntry, boolean shouldCacheEntry,
-            final ReadEntriesCallback callback, Object ctx) {
-        try {
-            asyncReadEntry0(lh, firstEntry, lastEntry, shouldCacheEntry, callback, ctx);
-        } catch (Throwable t) {
-            log.warn("failed to read entries for {}--{}-{}", lh.getId(), firstEntry, lastEntry, t);
-            // invalidate all entries related to ledger from the cache (it might happen if entry gets corrupt
-            // (entry.data is already deallocate due to any race-condition) so, invalidate cache and next time read from
-            // the bookie)
-            invalidateAllEntries(lh.getId());
-            callback.readEntriesFailed(createManagedLedgerException(t), ctx);
-        }
-    }
-
     @SuppressWarnings({ "unchecked", "rawtypes" })
-    void asyncReadEntry0(ReadHandle lh, long firstEntry, long lastEntry, boolean shouldCacheEntry,
+    public void asyncReadEntry(ReadHandle lh, long firstEntry, long lastEntry, boolean shouldCacheEntry,
             final ReadEntriesCallback callback, Object ctx) {
         final long ledgerId = lh.getId();
         final int entriesToRead = (int) (lastEntry - firstEntry) + 1;


### PR DESCRIPTION
This revert commit 2c8c288a

Fixes https://github.com/apache/pulsar/issues/16907

### Motivation

I think the problem described in #2993 is already solved by https://github.com/apache/pulsar/pull/2995, we don't need this workaround fix anymore.

Also, this workaround fix will introduce another problem and I will add a comment to the code.

### Modifications

- Revert PR #2993

### Verifying this change

- [x] Make sure that the change passes the CI checks.


- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
