### PR TITLE
[fix][broker] fix delete_when_subscriptions_caught_up doesn't work while have active consumers

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/InactiveTopicDeleteTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/InactiveTopicDeleteTest.java
@@ -328,7 +328,6 @@ public class InactiveTopicDeleteTest extends BrokerTestBase {
             producer.send("Pulsar".getBytes());
         }
 
-        consumer.close();
         producer.close();
 
         Thread.sleep(2000);
@@ -338,6 +337,7 @@ public class InactiveTopicDeleteTest extends BrokerTestBase {
         admin.topics().skipAllMessages(topic, "sub");
         Awaitility.await()
                 .untilAsserted(() -> Assert.assertFalse(admin.topics().getList("prop/ns-abc").contains(topic)));
+        consumer.close();
     }
 
     @Test


### PR DESCRIPTION
### Motivation

The current behavior for the `delete_when_subscriptions_caught_up` strategy is not expected. The active consumer will not be closed even if users enable `delete_when_subscriptions_caught_up` and there are no backlogs for the topic.

It should be the part that #6077 has missed. And Sijie has mentioned in the comment https://github.com/apache/pulsar/pull/6077#pullrequestreview-344643883.

To correct the behavior of `delete_when_subscriptions_caught_up`

### Modifications

Close active consumers if `delete_when_subscriptions_caught_up` is applied and there are no backlogs for the topic. So that the topic can be cleaned up properly by the topic GC thread.

### Verifying this change

Updated the existing test.

### Does this pull request potentially affect one of the following parts:

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/codelipenghui/incubator-pulsar/pull/17
