### PR TITLE
[fix][broker]fix Repeated messages of shared streaming dispatcher

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SimpleProducerConsumerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SimpleProducerConsumerTest.java
@@ -2411,6 +2411,7 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
         PulsarClient newPulsarClient = newPulsarClient(lookupUrl.toString(), 0);// Creates new client connection
         Consumer<byte[]> c1 = newPulsarClient.newConsumer()
                 .topic("persistent://my-property/my-ns/my-topic2").subscriptionName("my-subscriber-name")
+                .consumerName("c1")
                 .subscriptionType(SubscriptionType.Shared).receiverQueueSize(queueSize)
                 .acknowledgmentGroupTime(0, TimeUnit.SECONDS).subscribe();
 
@@ -2418,6 +2419,7 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
         PulsarClient newPulsarClient1 = newPulsarClient(lookupUrl.toString(), 0);// Creates new client connection
         Consumer<byte[]> c2 = newPulsarClient1.newConsumer()
                 .topic("persistent://my-property/my-ns/my-topic2").subscriptionName("my-subscriber-name")
+                .consumerName("c1")
                 .subscriptionType(SubscriptionType.Shared).receiverQueueSize(queueSize)
                 .acknowledgmentGroupTime(0, TimeUnit.SECONDS).subscribe();
         List<Future<MessageId>> futures = new ArrayList<>();
@@ -2462,6 +2464,7 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
         PulsarClient newPulsarClient2 = newPulsarClient(lookupUrl.toString(), 0);// Creates new client connection
         Consumer<byte[]> c3 = newPulsarClient2.newConsumer()
                 .topic("persistent://my-property/my-ns/my-topic2").subscriptionName("my-subscriber-name")
+                .consumerName("c3")
                 .subscriptionType(SubscriptionType.Shared).receiverQueueSize(queueSize)
                 .acknowledgmentGroupTime(0, TimeUnit.SECONDS).subscribe();
 
@@ -2469,6 +2472,7 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
         PulsarClient newPulsarClient3 = newPulsarClient(lookupUrl.toString(), 0);// Creates new client connection
         Consumer<byte[]> c4 = newPulsarClient3.newConsumer()
                 .topic("persistent://my-property/my-ns/my-topic2").subscriptionName("my-subscriber-name")
+                .consumerName("c4")
                 .subscriptionType(SubscriptionType.Shared).receiverQueueSize(queueSize)
                 .acknowledgmentGroupTime(0, TimeUnit.SECONDS).subscribe();
 
@@ -2476,6 +2480,7 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
         PulsarClient newPulsarClient4 = newPulsarClient(lookupUrl.toString(), 0);// Creates new client connection
         Consumer<byte[]> c5 = newPulsarClient4.newConsumer()
                 .topic("persistent://my-property/my-ns/my-topic2").subscriptionName("my-subscriber-name")
+                .consumerName("c5")
                 .subscriptionType(SubscriptionType.Shared).receiverQueueSize(queueSize)
                 .acknowledgmentGroupTime(0, TimeUnit.SECONDS).subscribe();
 
@@ -2520,6 +2525,7 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
         c4.close();
         c5.close();
         pulsar.getConfiguration().setMaxUnackedMessagesPerConsumer(maxUnAckMsgs);
+        admin.topics().delete("persistent://my-property/my-ns/my-topic2", false);
         log.info("-- Exiting {} test --", methodName);
     }
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SimpleProducerConsumerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SimpleProducerConsumerTest.java
@@ -2411,7 +2411,6 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
         PulsarClient newPulsarClient = newPulsarClient(lookupUrl.toString(), 0);// Creates new client connection
         Consumer<byte[]> c1 = newPulsarClient.newConsumer()
                 .topic("persistent://my-property/my-ns/my-topic2").subscriptionName("my-subscriber-name")
-                .consumerName("c1")
                 .subscriptionType(SubscriptionType.Shared).receiverQueueSize(queueSize)
                 .acknowledgmentGroupTime(0, TimeUnit.SECONDS).subscribe();
 
@@ -2419,7 +2418,6 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
         PulsarClient newPulsarClient1 = newPulsarClient(lookupUrl.toString(), 0);// Creates new client connection
         Consumer<byte[]> c2 = newPulsarClient1.newConsumer()
                 .topic("persistent://my-property/my-ns/my-topic2").subscriptionName("my-subscriber-name")
-                .consumerName("c1")
                 .subscriptionType(SubscriptionType.Shared).receiverQueueSize(queueSize)
                 .acknowledgmentGroupTime(0, TimeUnit.SECONDS).subscribe();
         List<Future<MessageId>> futures = new ArrayList<>();
@@ -2464,7 +2462,6 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
         PulsarClient newPulsarClient2 = newPulsarClient(lookupUrl.toString(), 0);// Creates new client connection
         Consumer<byte[]> c3 = newPulsarClient2.newConsumer()
                 .topic("persistent://my-property/my-ns/my-topic2").subscriptionName("my-subscriber-name")
-                .consumerName("c3")
                 .subscriptionType(SubscriptionType.Shared).receiverQueueSize(queueSize)
                 .acknowledgmentGroupTime(0, TimeUnit.SECONDS).subscribe();
 
@@ -2472,7 +2469,6 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
         PulsarClient newPulsarClient3 = newPulsarClient(lookupUrl.toString(), 0);// Creates new client connection
         Consumer<byte[]> c4 = newPulsarClient3.newConsumer()
                 .topic("persistent://my-property/my-ns/my-topic2").subscriptionName("my-subscriber-name")
-                .consumerName("c4")
                 .subscriptionType(SubscriptionType.Shared).receiverQueueSize(queueSize)
                 .acknowledgmentGroupTime(0, TimeUnit.SECONDS).subscribe();
 
@@ -2480,7 +2476,6 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
         PulsarClient newPulsarClient4 = newPulsarClient(lookupUrl.toString(), 0);// Creates new client connection
         Consumer<byte[]> c5 = newPulsarClient4.newConsumer()
                 .topic("persistent://my-property/my-ns/my-topic2").subscriptionName("my-subscriber-name")
-                .consumerName("c5")
                 .subscriptionType(SubscriptionType.Shared).receiverQueueSize(queueSize)
                 .acknowledgmentGroupTime(0, TimeUnit.SECONDS).subscribe();
 
@@ -2525,7 +2520,6 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
         c4.close();
         c5.close();
         pulsar.getConfiguration().setMaxUnackedMessagesPerConsumer(maxUnAckMsgs);
-        admin.topics().delete("persistent://my-property/my-ns/my-topic2", false);
         log.info("-- Exiting {} test --", methodName);
     }
 


### PR DESCRIPTION
Fixes #16795

### Motivation

In class `PersistentDispatcherMultipleConsumers`, there is a variable `sendInProgress` that is set to `true` before the `sendMessagesToConsumers` method is executed and to `false` after the `sendMessagesToConsumers` method is executed, thus making the `readMoreEnties` inaccessible during the `sendMessagesToConsumers` method's execution. see: #16812

In subclass `PersistentStreamingDispatcherMultipleConsumers`, when reading batch entries, `sendMessagesToConsumer` is called each entry is read, which causes the variable `sendInProgress` to be set to `true` and `false` multiple times. This results in the method `readMoreEnties` can be accessed when the variable `sendInProgress` is set to false when a batch of entries is reading. This makes repeat delivery of the message, the error process is as follows:

| step | `consumer-1` | `consumer-2` |
| --- | --- | --- |
| 1 | try load messages |  |
| 2 | peek message from the queue `messagesToRedeliver` | try load messages |
| 3 | repay messages | peek message from the queue `messagesToRedeliver` |
| 4 | send message to `consumer-1` | repay messages |
| 5 |  | send message to `consumer-2` |


### Modifications

Set `sendInProgress` to `false` only after the last entry in a batch of messages has been delivered.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: 

- https://github.com/poorbarcode/pulsar/pull/34
