### PR TITLE
[improve][broker] log sessionId with zk-session-watcher for debugging

### DIFF
--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/ZKSessionWatcher.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/ZKSessionWatcher.java
@@ -149,8 +149,8 @@ public class ZKSessionWatcher implements AutoCloseable, Watcher {
                 currentStatus = SessionEvent.SessionLost;
                 sessionListener.accept(currentStatus);
             } else if (currentStatus != SessionEvent.SessionLost) {
-                log.warn("ZooKeeper client is disconnected. Waiting to reconnect, time remaining = {} seconds",
-                        timeRemainingMillis / 1000.0);
+                log.warn("[{}] ZooKeeper client is disconnected. Waiting to reconnect, time remaining = {} seconds",
+                        zk.getSessionId(), timeRemainingMillis / 1000.0);
                 if (currentStatus == SessionEvent.SessionReestablished) {
                     currentStatus = SessionEvent.ConnectionLost;
                     sessionListener.accept(currentStatus);


### PR DESCRIPTION
### Motivation

Right now, zk-quorum recovers after leader restart within zk-session-timeout but still it can cause restart for some brokers even if it's not expected. It's really helpful if zk-session-watcher also prints session-id if it has been changed while disconnecting so, it can help admin to configure right synclimit at zk-server configuration or doing additional debugging.

### Modifications

Printing sessionId when zk is disconnecting.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
