### PR TITLE
[fix][broker] Fix can not delete namespace by force

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/NamespacesBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/NamespacesBase.java
@@ -218,16 +218,16 @@ public abstract class NamespacesBase extends AdminResource {
                          }))
                 .thenCompose(topics -> {
                     List<String> allTopics = topics.get(0);
-                    ArrayList<String> copyAllTopics = new ArrayList<>();
+                    ArrayList<String> allUserCreatedTopics = new ArrayList<>();
                     List<String> allPartitionedTopics = topics.get(1);
-                    ArrayList<String> copyAllPartitionTopics = new ArrayList<>();
+                    ArrayList<String> allUserCreatedPartitionTopics = new ArrayList<>();
                     boolean hasNonSystemTopic = false;
                     List<String> allSystemTopics = new ArrayList<>();
                     List<String> allPartitionedSystemTopics = new ArrayList<>();
                     for (String topic : allTopics) {
                         if (!pulsar().getBrokerService().isSystemTopic(TopicName.get(topic))) {
                             hasNonSystemTopic = true;
-                            copyAllTopics.add(topic);
+                            allUserCreatedTopics.add(topic);
                         } else {
                             allSystemTopics.add(topic);
                         }
@@ -235,7 +235,7 @@ public abstract class NamespacesBase extends AdminResource {
                     for (String topic : allPartitionedTopics) {
                         if (!pulsar().getBrokerService().isSystemTopic(TopicName.get(topic))) {
                             hasNonSystemTopic = true;
-                            copyAllPartitionTopics.add(topic);
+                            allUserCreatedPartitionTopics.add(topic);
                         } else {
                             allPartitionedSystemTopics.add(topic);
                         }
@@ -249,9 +249,9 @@ public abstract class NamespacesBase extends AdminResource {
                         old.deleted = true;
                         return  old;
                     }).thenCompose(ignore -> {
-                        return internalDeleteTopicsAsync(copyAllTopics);
+                        return internalDeleteTopicsAsync(allUserCreatedTopics);
                     }).thenCompose(ignore -> {
-                        return internalDeletePartitionedTopicsAsync(copyAllPartitionTopics);
+                        return internalDeletePartitionedTopicsAsync(allUserCreatedPartitionTopics);
                     }).thenCompose(ignore -> {
                         return internalDeleteTopicsAsync(allSystemTopics);
                     }).thenCompose(ignore__ -> {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/NamespacesBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/NamespacesBase.java
@@ -248,17 +248,17 @@ public abstract class NamespacesBase extends AdminResource {
                     return namespaceResources().setPoliciesAsync(namespaceName, old -> {
                         old.deleted = true;
                         return  old;
-                    }).thenCompose(__ -> {
+                    }).thenCompose(ignore -> {
                         return internalDeleteTopicsAsync(copyAllTopics);
-                    }).thenCompose(__ -> {
+                    }).thenCompose(ignore -> {
                         return internalDeletePartitionedTopicsAsync(copyAllPartitionTopics);
-                    }).thenCompose(__ -> {
+                    }).thenCompose(ignore -> {
                         return internalDeleteTopicsAsync(allSystemTopics);
-                    }).thenCompose(__ -> {
+                    }).thenCompose(ignore__ -> {
                         return internalDeletePartitionedTopicsAsync(allPartitionedSystemTopics);
                     });
                 })
-                .thenCompose(__ -> pulsar().getNamespaceService()
+                .thenCompose(ignore -> pulsar().getNamespaceService()
                         .getNamespaceBundleFactory().getBundlesAsync(namespaceName))
                 .thenCompose(bundles -> FutureUtil.waitForAll(bundles.getBundles().stream()
                         .map(bundle -> pulsar().getNamespaceService().getOwnerAsync(bundle)
@@ -280,7 +280,7 @@ public abstract class NamespacesBase extends AdminResource {
                                     return CompletableFuture.completedFuture(null);
                                 })
                         ).collect(Collectors.toList())))
-                .thenCompose(__ -> internalClearZkSources());
+                .thenCompose(ignore -> internalClearZkSources());
     }
 
     private CompletableFuture<Void> internalDeletePartitionedTopicsAsync(List<String> topicNames) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -1207,7 +1207,14 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
                         brokerService.deleteTopicAuthenticationWithRetry(topic, deleteTopicAuthenticationFuture, 5);
 
                         deleteTopicAuthenticationFuture.thenCompose(__ -> deleteSchema())
-                                .thenCompose(__ -> deleteTopicPolicies())
+                                .thenCompose(__ -> {
+                                    if (!this.getBrokerService().getPulsar().getBrokerService()
+                                            .isSystemTopic(TopicName.get(topic))) {
+                                        return deleteTopicPolicies();
+                                    } else {
+                                        return CompletableFuture.completedFuture(null);
+                                    }
+                                })
                                 .thenCompose(__ -> transactionBufferCleanupAndClose())
                                 .whenComplete((v, ex) -> {
                                     if (ex != null) {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/NamespacesTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/NamespacesTest.java
@@ -76,6 +76,7 @@ import org.apache.pulsar.broker.namespace.NamespaceEphemeralData;
 import org.apache.pulsar.broker.namespace.NamespaceService;
 import org.apache.pulsar.broker.namespace.OwnershipCache;
 import org.apache.pulsar.broker.service.AbstractTopic;
+import org.apache.pulsar.broker.service.SystemTopicBasedTopicPoliciesService;
 import org.apache.pulsar.broker.service.Topic;
 import org.apache.pulsar.broker.web.PulsarWebResource;
 import org.apache.pulsar.broker.web.RestException;
@@ -92,6 +93,8 @@ import org.apache.pulsar.common.api.proto.CommandSubscribe;
 import org.apache.pulsar.common.naming.NamespaceBundle;
 import org.apache.pulsar.common.naming.NamespaceBundles;
 import org.apache.pulsar.common.naming.NamespaceName;
+import org.apache.pulsar.common.naming.SystemTopicNames;
+import org.apache.pulsar.common.naming.TopicDomain;
 import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.policies.data.AuthAction;
 import org.apache.pulsar.common.policies.data.AutoTopicCreationOverride;
@@ -119,6 +122,7 @@ import org.mockito.ArgumentMatcher;
 import org.mockito.Mockito;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeClass;
@@ -1998,4 +2002,64 @@ public class NamespacesTest extends MockedPulsarServiceBaseTest {
         pulsar.getConfiguration().setForceDeleteNamespaceAllowed(forceDeleteNamespaceAllowedOriginalValue);
     }
 
+    @Test
+    public void testFinallyDeleteSystemTopicWhenDeleteNamespace() throws Exception {
+        String namespace = this.testTenant + "/delete-namespace";
+        String topic = TopicName.get(TopicDomain.persistent.toString(), this.testTenant, "delete-namespace",
+                "testFinallyDeleteSystemTopicWhenDeleteNamespace").toString();
+
+        // 0. enable topic level polices and system topic
+        pulsar.getConfig().setTopicLevelPoliciesEnabled(true);
+        pulsar.getConfig().setSystemTopicEnabled(true);
+        pulsar.getConfig().setForceDeleteNamespaceAllowed(true);
+        Field policesService = pulsar.getClass().getDeclaredField("topicPoliciesService");
+        policesService.setAccessible(true);
+        policesService.set(pulsar, new SystemTopicBasedTopicPoliciesService(pulsar));
+
+        // 1. create a test namespace.
+        admin.namespaces().createNamespace(namespace);
+        // 2. create a test topic.
+        admin.topics().createNonPartitionedTopic(topic);
+        // 3. change policy of the topic.
+        admin.topicPolicies().setMaxConsumers(topic, 5);
+        // 4. change the order of the topics in this namespace.
+        List<String> topics = pulsar.getNamespaceService().getFullListOfTopics(NamespaceName.get(namespace)).get();
+        Assert.assertTrue(topics.size() >= 2);
+        for (int i = 0; i < topics.size(); i++) {
+            if (topics.get(i).contains(SystemTopicNames.NAMESPACE_EVENTS_LOCAL_NAME)) {
+                String systemTopic = topics.get(i);
+                topics.set(i, topics.get(0));
+                topics.set(0, systemTopic);
+            }
+        }
+        NamespaceService mockNamespaceService = spy(pulsar.getNamespaceService());
+        Field namespaceServiceField = pulsar.getClass().getDeclaredField("nsService");
+        namespaceServiceField.setAccessible(true);
+        namespaceServiceField.set(pulsar, mockNamespaceService);
+        doReturn(CompletableFuture.completedFuture(topics)).when(mockNamespaceService).getFullListOfTopics(any());
+        // 5. delete the namespace
+        admin.namespaces().deleteNamespace(namespace, true);
+    }
+
+    @Test
+    public void testNotClearTopicPolicesWhenDeleteSystemTopic() throws Exception {
+        String namespace = this.testTenant + "/delete-systemTopic";
+        String topic = TopicName.get(TopicDomain.persistent.toString(), this.testTenant, "delete-systemTopic",
+                "testNotClearTopicPolicesWhenDeleteSystemTopic").toString();
+
+        // 0. enable topic level polices and system topic
+        pulsar.getConfig().setTopicLevelPoliciesEnabled(true);
+        pulsar.getConfig().setSystemTopicEnabled(true);
+        Field policesService = pulsar.getClass().getDeclaredField("topicPoliciesService");
+        policesService.setAccessible(true);
+        policesService.set(pulsar, new SystemTopicBasedTopicPoliciesService(pulsar));
+        // 1. create a test namespace.
+        admin.namespaces().createNamespace(namespace);
+        // 2. create a test topic.
+        admin.topics().createNonPartitionedTopic(topic);
+        // 3. change policy of the topic.
+        admin.topicPolicies().setMaxConsumers(topic, 5);
+        // 4. delete the policies topic and the topic wil not to clear topic polices
+        admin.topics().delete(namespace + "/" + SystemTopicNames.NAMESPACE_EVENTS_LOCAL_NAME, true);
+    }
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/NamespacesTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/NamespacesTest.java
@@ -2039,6 +2039,8 @@ public class NamespacesTest extends MockedPulsarServiceBaseTest {
         doReturn(CompletableFuture.completedFuture(topics)).when(mockNamespaceService).getFullListOfTopics(any());
         // 5. delete the namespace
         admin.namespaces().deleteNamespace(namespace, true);
+        // cleanup
+        resetBroker();
     }
 
     @Test

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/TransactionProduceTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/TransactionProduceTest.java
@@ -90,35 +90,6 @@ public class TransactionProduceTest extends TransactionTestBase {
     }
 
     @Test
-    public void testDeleteNamespaceBeforeCommit() throws Exception {
-        final String topic = NAMESPACE1 + "/testDeleteTopicBeforeCommit";
-        PulsarClient pulsarClient = this.pulsarClient;
-        Transaction tnx = pulsarClient.newTransaction()
-                .withTransactionTimeout(60, TimeUnit.SECONDS)
-                .build().get();
-        long txnIdMostBits = ((TransactionImpl) tnx).getTxnIdMostBits();
-        long txnIdLeastBits = ((TransactionImpl) tnx).getTxnIdLeastBits();
-        Assert.assertTrue(txnIdMostBits > -1);
-        Assert.assertTrue(txnIdLeastBits > -1);
-
-        @Cleanup
-        Producer<byte[]> outProducer = pulsarClient
-                .newProducer()
-                .topic(topic)
-                .sendTimeout(0, TimeUnit.SECONDS)
-                .enableBatching(false)
-                .create();
-
-        String content = "Hello Txn";
-        outProducer.newMessage(tnx).value(content.getBytes(UTF_8)).send();
-
-        try {
-            deleteNamespaceGraceFully(NAMESPACE1, true);
-        } catch (Exception ignore) {}
-        tnx.commit().get();
-    }
-
-    @Test
     public void produceAndAbortTest() throws Exception {
         produceTest(false);
     }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/TransactionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/TransactionTest.java
@@ -215,7 +215,8 @@ public class TransactionTest extends TransactionTestBase {
     public void testCreateTransactionSystemTopic() throws Exception {
         String subName = "test";
         String topicName = TopicName.get(NAMESPACE1 + "/" + "testCreateTransactionSystemTopic").toString();
-
+        admin.namespaces().deleteNamespace(NAMESPACE1, true);
+        admin.namespaces().createNamespace(NAMESPACE1);
         try {
             // init pending ack
             @Cleanup
@@ -231,7 +232,7 @@ public class TransactionTest extends TransactionTestBase {
 
         // getList does not include transaction system topic
         List<String> list = admin.topics().getList(NAMESPACE1);
-        assertEquals(list.size(), 2);
+        assertEquals(list.size(), 1);
         list.forEach(topic -> assertFalse(topic.contains(PENDING_ACK_STORE_SUFFIX)));
 
         try {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/TransactionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/TransactionTest.java
@@ -212,6 +212,16 @@ public class TransactionTest extends TransactionTestBase {
     }
 
     @Test
+    public void testDeleteNamespaceAfterUsedTransaction() throws Exception {
+        String topicName = TopicName.get(NAMESPACE1 + "/" + "testDeleteNamespaceAfterUsedTransaction").toString();
+        Producer<byte[]> producer = pulsarClient.newProducer()
+                .topic(topicName)
+                .create();
+
+        admin.namespaces().deleteNamespace(NAMESPACE1, true);
+    }
+
+    @Test
     public void testCreateTransactionSystemTopic() throws Exception {
         String subName = "test";
         String topicName = TopicName.get(NAMESPACE1 + "/" + "testCreateTransactionSystemTopic").toString();
@@ -232,7 +242,7 @@ public class TransactionTest extends TransactionTestBase {
 
         // getList does not include transaction system topic
         List<String> list = admin.topics().getList(NAMESPACE1);
-        assertEquals(list.size(), 1);
+        assertFalse(list.isEmpty());
         list.forEach(topic -> assertFalse(topic.contains(PENDING_ACK_STORE_SUFFIX)));
 
         try {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/TransactionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/TransactionTest.java
@@ -212,16 +212,6 @@ public class TransactionTest extends TransactionTestBase {
     }
 
     @Test
-    public void testDeleteNamespaceAfterUsedTransaction() throws Exception {
-        String topicName = TopicName.get(NAMESPACE1 + "/" + "testDeleteNamespaceAfterUsedTransaction").toString();
-        Producer<byte[]> producer = pulsarClient.newProducer()
-                .topic(topicName)
-                .create();
-
-        admin.namespaces().deleteNamespace(NAMESPACE1, true);
-    }
-
-    @Test
     public void testCreateTransactionSystemTopic() throws Exception {
         String subName = "test";
         String topicName = TopicName.get(NAMESPACE1 + "/" + "testCreateTransactionSystemTopic").toString();


### PR DESCRIPTION
### Motivation
1. When we delete a namespace by force if the __transaction_buffer_snapshot and __change_events be deleted first, and then the deleting of the normal topic will be failed at clearing the snapshot and clearing topic policies.
2. fix flaky test testCreateTransactionSystemTopic. Test failed due to cleaning up after class.
### Modification
1. Delete the normal topic and then delete the system topic.
2. The system topic does not need to clean up topic policies.

For modification 2, there is a supported error msg. 
![16673984912850](https://user-images.githubusercontent.com/55571188/199523972-390247ab-a6e2-40a5-a328-b6815f78494e.jpg)

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/liangyepianzhou/pulsar/pull/8