### PR TITLE
[improve][client] Add partitioned-stats api to avoid partition abstraction

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SimpleProducerConsumerStatTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SimpleProducerConsumerStatTest.java
@@ -491,8 +491,8 @@ public class SimpleProducerConsumerStatTest extends ProducerConsumerBase {
         // Acknowledge the consumption of all messages at once
         consumer.acknowledgeCumulative(msg);
 
-        MultiTopicConsumerStats cStat = (MultiTopicConsumerStats) consumer.getStats();
-        PartitionedTopicProducerStats pStat = (PartitionedTopicProducerStats) producer.getStats();
+        ConsumerStats cStat = consumer.getStats();
+        ProducerStats pStat = producer.getStats();
         retryStrategically((test) -> !pStat.getPartitionStats().isEmpty(), 5, 100);
         retryStrategically((test) -> !cStat.getPartitionStats().isEmpty(), 5, 100);
         Map<String, ProducerStats> prodStatsMap = pStat.getPartitionStats();

--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/ConsumerStats.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/ConsumerStats.java
@@ -19,6 +19,7 @@
 package org.apache.pulsar.client.api;
 
 import java.io.Serializable;
+import java.util.Collections;
 import java.util.Map;
 import org.apache.pulsar.common.classification.InterfaceAudience;
 import org.apache.pulsar.common.classification.InterfaceStability;
@@ -114,4 +115,11 @@ public interface ConsumerStats extends Serializable {
      * @return
      */
     Map<Long, Integer> getMsgNumInSubReceiverQueue();
+
+    /**
+     * @return stats for each partition if topic is partitioned topic
+     */
+    default Map<String, ConsumerStats> getPartitionStats() {
+        return Collections.emptyMap();
+    }
 }

--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/ProducerStats.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/ProducerStats.java
@@ -19,6 +19,8 @@
 package org.apache.pulsar.client.api;
 
 import java.io.Serializable;
+import java.util.Collections;
+import java.util.Map;
 import org.apache.pulsar.common.classification.InterfaceAudience;
 import org.apache.pulsar.common.classification.InterfaceStability;
 
@@ -115,4 +117,11 @@ public interface ProducerStats extends Serializable {
      * @return current pending send-message queue size of the producer
      */
     int getPendingQueueSize();
+
+    /**
+     * @return stats for each partition if topic is partitioned topic
+     */
+    default Map<String, ProducerStats> getPartitionStats() {
+        return Collections.emptyMap();
+    }
 }


### PR DESCRIPTION
### Motivation

As discussed in https://github.com/apache/pulsar/pull/18212, that PR introduced support to get partitioned-topic stats with a partitioned-topic stats interface. However, the Producer and Consumer still return [ProducerStats](https://github.com/apache/pulsar/blob/master/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/Producer.java#L164) and [ConsumerStats](https://github.com/apache/pulsar/blob/master/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/Consumer.java#L658). So, it's better to introduce API to get partitioned-stats in both `ProducerStats` and `ConsumerStats` so, user can call the API without casting to `MultiTopicConsumerStats` or `PartitionedTopicProducerStats`.

### Modifications

1. Add default `getPartitionStats()` API to producer/cosnumer stats which will not impact existing implementation.
2. If producer/consumer is partitioned then API will return collection of partitioned-topic stats.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
