### PR TITLE
[fix][test]fix flaky test MLPendingAckStoreTest.testMainProcess

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/pendingack/impl/MLPendingAckStoreTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/pendingack/impl/MLPendingAckStoreTest.java
@@ -256,8 +256,8 @@ public class MLPendingAckStoreTest extends TransactionTestBase {
         Assert.assertTrue(mlPendingAckStoreForRead.pendingAckLogIndex.keySet().iterator().next().getEntryId() > 19);
 
         // cleanup.
-        closePendingAckStoreWithRetry(mlPendingAckStoreForWrite, 3);
-        closePendingAckStoreWithRetry(mlPendingAckStoreForRead, 3);
+        closePendingAckStoreWithRetry(mlPendingAckStoreForWrite);
+        closePendingAckStoreWithRetry(mlPendingAckStoreForRead);
     }
 
     /**
@@ -265,19 +265,15 @@ public class MLPendingAckStoreTest extends TransactionTestBase {
      * Because when the cursor close and cursor switch ledger are concurrent executing, the bad version exception is
      * thrown.
      */
-    private void closePendingAckStoreWithRetry(MLPendingAckStore pendingAckStore, int retryTimes){
-        while (retryTimes > 0){
-            retryTimes--;
-            boolean closeSuccessful = true;
+    private void closePendingAckStoreWithRetry(MLPendingAckStore pendingAckStore){
+        Awaitility.await().until(() -> {
             try {
                 pendingAckStore.closeAsync().get();
+                return true;
             } catch (Exception ex){
-                closeSuccessful = false;
+                return false;
             }
-            if (closeSuccessful){
-                break;
-            }
-        }
+        });
     }
 
     /**


### PR DESCRIPTION
Fixes #18230

### Motivation
`ManagedCursorImpl` has a known problem: when the `cursor.close` and the `cursor.switchLedger` are concurrent executing, a bad version exception is thrown. see: 

https://github.com/apache/pulsar/blob/0c3c175eb132d4ef0fb3a12842127dcb4fa1933d/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java#L2595-L2619

In this test, it hit this problem:

- `MlPendingAckStore.clearUselessLogData` will trigger `cursor.switchLedger` if it is the first execute `mard delete`.
- `MlPendingAckStore.close` will trigger `cursor.close`

### Modifications

if `MlPendingAckStore.close` fail, just retry, it will be ok

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: 

- https://github.com/poorbarcode/pulsar/pull/36
