### PR TITLE
[improve][admin] Optimize the logic of internalCreatePartitionedTopic

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/AdminResource.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/AdminResource.java
@@ -643,7 +643,11 @@ public abstract class AdminResource extends PulsarWebResource {
                 })
                 .exceptionally(ex -> {
                     log.error("[{}] Failed to create partitions for topic {}", clientAppId(), topicName, ex);
-                    resumeAsyncResponseExceptionally(asyncResponse, ex);
+                    if (ex instanceof RestException) {
+                        asyncResponse.resume(ex);
+                    } else {
+                        resumeAsyncResponseExceptionally(asyncResponse, ex);
+                    }
                     return null;
                 });
     }


### PR DESCRIPTION
### Motivation
In `org.apache.pulsar.broker.admin.AdminResource#internalCreatePartitionedTopic`:

- some logical order can be optimized. For example, can first execute `validateNamespaceOperation` for permission verification.
- some log printing can be merged.see line 613,622,655

https://github.com/apache/pulsar/blob/2bed5ff3ab9dbb8c57c0d4d29a5a6775a610d326/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/AdminResource.java#L613-L623

https://github.com/apache/pulsar/blob/2bed5ff3ab9dbb8c57c0d4d29a5a6775a610d326/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/AdminResource.java#L654-L656

### Modifications
Optimize the logical order and log printing of  `org.apache.pulsar.broker.admin.AdminResource#internalCreatePartitionedTopic`.


### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/Pomelongan/pulsar/pull/12