### PR TITLE
[improve][test] Setup broker client for TokenOauth2AuthenticatedProducerConsumerTest

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/TokenOauth2AuthenticatedProducerConsumerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/TokenOauth2AuthenticatedProducerConsumerTest.java
@@ -35,6 +35,7 @@ import org.apache.pulsar.broker.authentication.AuthenticationProviderToken;
 import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.impl.ProducerImpl;
 import org.apache.pulsar.client.impl.auth.oauth2.AuthenticationFactoryOAuth2;
+import org.apache.pulsar.client.impl.auth.oauth2.AuthenticationOAuth2;
 import org.apache.pulsar.common.policies.data.ClusterData;
 import org.apache.pulsar.common.policies.data.TenantInfoImpl;
 import org.awaitility.Awaitility;
@@ -61,6 +62,8 @@ public class TokenOauth2AuthenticatedProducerConsumerTest extends ProducerConsum
 
     // Credentials File, which contains "client_id" and "client_secret"
     private final String CREDENTIALS_FILE = "./src/test/resources/authentication/token/credentials_file.json";
+    private final String ISSUER_URL = "https://dev-kt-aa9ne.us.auth0.com";
+    private final String AUDIENCE = "https://dev-kt-aa9ne.us.auth0.com/api/v2/";
 
     @BeforeMethod(alwaysRun = true)
     @Override
@@ -76,6 +79,13 @@ public class TokenOauth2AuthenticatedProducerConsumerTest extends ProducerConsum
         Set<String> providers = new HashSet<>();
         providers.add(AuthenticationProviderToken.class.getName());
         conf.setAuthenticationProviders(providers);
+
+        conf.setBrokerClientAuthenticationPlugin(AuthenticationOAuth2.class.getName());
+        conf.setBrokerClientAuthenticationParameters("{\n"
+                + "  \"privateKey\": \"" + CREDENTIALS_FILE + "\",\n"
+                + "  \"issuerUrl\": \"" + ISSUER_URL + "\",\n"
+                + "  \"audience\": \"" + AUDIENCE + "\",\n"
+                + "}\n");
 
         conf.setClusterName("test");
 
@@ -94,9 +104,9 @@ public class TokenOauth2AuthenticatedProducerConsumerTest extends ProducerConsum
 
         // AuthenticationOAuth2
         Authentication authentication = AuthenticationFactoryOAuth2.clientCredentials(
-                new URL("https://dev-kt-aa9ne.us.auth0.com"),
+                new URL(ISSUER_URL),
                 path.toUri().toURL(),  // key file path
-                "https://dev-kt-aa9ne.us.auth0.com/api/v2/"
+                AUDIENCE
         );
 
         admin = spy(PulsarAdmin.builder().serviceHttpUrl(brokerUrl.toString())


### PR DESCRIPTION
### Motivation

Fix `unable to authentication`:
```
2022-11-03T15:14:46,955 - INFO  - [pulsar-io-6-15:ServerCnx@318] - Closed connection from /127.0.0.1:59327
2022-11-03T15:14:46,956 - WARN  - [pulsar-io-6-14:ClientCnx@751] - [id: 0xe41747d3, L:/127.0.0.1:59327 - R:localhost/127.0.0.1:59298] Received error from server: No anonymous role, and no authentication provider configured
2022-11-03T15:14:46,956 - WARN  - [pulsar-io-6-14:ConnectionPool@285] - [[id: 0xe41747d3, L:/127.0.0.1:59327 - R:localhost/127.0.0.1:59298]] Connection handshake failed: org.apache.pulsar.client.api.PulsarClientException$AuthenticationException: No anonymous role, and no authentication provider configured
2022-11-03T15:14:46,956 - WARN  - [pulsar-io-6-14:PulsarClientImpl@686] - [persistent://my-property/my-ns/__change_events] Failed to get partitioned topic metadata
java.util.concurrent.CompletionException: org.apache.pulsar.client.api.PulsarClientException$AuthenticationException: No anonymous role, and no authentication provider configured
	at java.util.concurrent.CompletableFuture.encodeThrowable(CompletableFuture.java:332) ~[?:?]
	at java.util.concurrent.CompletableFuture.completeThrowable(CompletableFuture.java:347) ~[?:?]
	at java.util.concurrent.CompletableFuture$UniAccept.tryFire(CompletableFuture.java:708) ~[?:?]
	at java.util.concurrent.CompletableFuture.postComplete(CompletableFuture.java:510) ~[?:?]
	at java.util.concurrent.CompletableFuture.completeExceptionally(CompletableFuture.java:2162) ~[?:?]
	at org.apache.pulsar.client.impl.BinaryProtoLookupService.lambda$getPartitionedTopicMetadata$6(BinaryProtoLookupService.java:215) ~[classes/:?]
	at java.util.concurrent.CompletableFuture.uniExceptionally(CompletableFuture.java:990) ~[?:?]
	at java.util.concurrent.CompletableFuture$UniExceptionally.tryFire(CompletableFuture.java:974) ~[?:?]
	at java.util.concurrent.CompletableFuture.postComplete(CompletableFuture.java:510) ~[?:?]
	at java.util.concurrent.CompletableFuture.completeExceptionally(CompletableFuture.java:2162) ~[?:?]
	at org.apache.pulsar.client.impl.ConnectionPool.lambda$createConnection$12(ConnectionPool.java:286) ~[classes/:?]
	at java.util.concurrent.CompletableFuture.uniExceptionally(CompletableFuture.java:990) ~[?:?]
	at java.util.concurrent.CompletableFuture$UniExceptionally.tryFire(CompletableFuture.java:974) ~[?:?]
	at java.util.concurrent.CompletableFuture.postComplete(CompletableFuture.java:510) ~[?:?]
	at java.util.concurrent.CompletableFuture.completeExceptionally(CompletableFuture.java:2162) ~[?:?]
	at org.apache.pulsar.client.impl.ClientCnx.handleError(ClientCnx.java:758) ~[classes/:?]
	at org.apache.pulsar.common.protocol.PulsarDecoder.channelRead(PulsarDecoder.java:183) ~[classes/:?]
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379) ~[netty-transport-4.1.77.Final.jar:4.1.77.Final]
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365) ~[netty-transport-4.1.77.Final.jar:4.1.77.Final]
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357) ~[netty-transport-4.1.77.Final.jar:4.1.77.Final]
	at io.netty.handler.codec.ByteToMessageDecoder.fireChannelRead(ByteToMessageDecoder.java:327) ~[netty-codec-4.1.77.Final.jar:4.1.77.Final]
	at io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:299) ~[netty-codec-4.1.77.Final.jar:4.1.77.Final]
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379) ~[netty-transport-4.1.77.Final.jar:4.1.77.Final]
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365) ~[netty-transport-4.1.77.Final.jar:4.1.77.Final]
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357) ~[netty-transport-4.1.77.Final.jar:4.1.77.Final]
	at io.netty.handler.flush.FlushConsolidationHandler.channelRead(FlushConsolidationHandler.java:152) ~[netty-handler-4.1.77.Final.jar:4.1.77.Final]
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379) ~[netty-transport-4.1.77.Final.jar:4.1.77.Final]
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365) ~[netty-transport-4.1.77.Final.jar:4.1.77.Final]
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357) ~[netty-transport-4.1.77.Final.jar:4.1.77.Final]
	at io.netty.channel.DefaultChannelPipeline$HeadContext.channelRead(DefaultChannelPipeline.java:1410) ~[netty-transport-4.1.77.Final.jar:4.1.77.Final]
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379) ~[netty-transport-4.1.77.Final.jar:4.1.77.Final]
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365) ~[netty-transport-4.1.77.Final.jar:4.1.77.Final]
	at io.netty.channel.DefaultChannelPipeline.fireChannelRead(DefaultChannelPipeline.java:919) ~[netty-transport-4.1.77.Final.jar:4.1.77.Final]
	at io.netty.channel.nio.AbstractNioByteChannel$NioByteUnsafe.read(AbstractNioByteChannel.java:166) ~[netty-transport-4.1.77.Final.jar:4.1.77.Final]
	at io.netty.channel.nio.NioEventLoop.processSelectedKey(NioEventLoop.java:722) ~[netty-transport-4.1.77.Final.jar:4.1.77.Final]
	at io.netty.channel.nio.NioEventLoop.processSelectedKeysOptimized(NioEventLoop.java:658) ~[netty-transport-4.1.77.Final.jar:4.1.77.Final]
	at io.netty.channel.nio.NioEventLoop.processSelectedKeys(NioEventLoop.java:584) ~[netty-transport-4.1.77.Final.jar:4.1.77.Final]
	at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:496) ~[netty-transport-4.1.77.Final.jar:4.1.77.Final]
	at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:995) ~[netty-common-4.1.77.Final.jar:4.1.77.Final]
	at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74) ~[netty-common-4.1.77.Final.jar:4.1.77.Final]
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30) ~[netty-common-4.1.77.Final.jar:4.1.77.Final]
	at java.lang.Thread.run(Thread.java:833) ~[?:?]
Caused by: org.apache.pulsar.client.api.PulsarClientException$AuthenticationException: No anonymous role, and no authentication provider configured
	at org.apache.pulsar.client.impl.ClientCnx.handleError(ClientCnx.java:759) ~[classes/:?]
	... 26 more
2022-11-03T15:14:46,956 - WARN  - [pulsar-io-6-14:RetryUtil@55] - Execution with retry fail, because of org.apache.pulsar.client.api.PulsarClientException$AuthenticationException: No anonymous role, and no authentication provider configured, will retry in 2731 ms
2022-11-03T15:14:46,956 - ERROR - [pulsar-io-6-14:ClientCnx@760] - [id: 0xe41747d3, L:/127.0.0.1:59327 ! R:localhost/127.0.0.1:59298] Failed to authenticate the client
2022-11-03T15:14:46,956 - WARN  - [pulsar-io-6-14:ClientCnx@772] - [id: 0xe41747d3, L:/127.0.0.1:59327 ! R:localhost/127.0.0.1:59298] Received unknown request id from server: -1
2022-11-03T15:14:46,957 - INFO  - [pulsar-io-6-14:ClientCnx@294] - [id: 0xe41747d3, L:/127.0.0.1:59327 ! R:localhost/127.0.0.1:59298] Disconnected
2022-11-03T15:14:47,437 - INFO  - [pulsar-timer-48-1:ConnectionHandler@124] - [persistent://my-property/my-ns/my-topic] [test-0-0] Reconnecting after connection was closed
2022-11-03T15:14:47,478 - WARN  - [pulsar-client-io-42-1:ConnectionPool@293] - Failed to open connection to localhost/<unresolved>:59298 : java.nio.channels.ClosedChannelException
2022-11-03T15:14:47,478 - WARN  - [pulsar-client-io-42-1:ConnectionHandler@93] - [persistent://my-property/my-ns/my-topic] [test-0-0] Error connecting to broker: org.apache.pulsar.client.api.PulsarClientException: java.util.concurrent.CompletionException: java.nio.channels.ClosedChannelException
2022-11-03T15:14:47,478 - WARN  - [pulsar-client-io-42-1:ConnectionHandler@119] - [persistent://my-property/my-ns/my-topic] [test-0-0] Could not get connection to broker: org.apache.pulsar.client.api.PulsarClientException: java.util.concurrent.CompletionException: java.nio.channels.ClosedChannelException -- Will try again in 2.905 s
2022-11-03T15:14:47,481 - INFO  - [pulsar-io-6-17:ServerCnx@306] - New connection from /127.0.0.1:59329
2022-11-03T15:14:47,485 - INFO  - [pulsar-io-6-17:ServerCnx@318] - Closed connection from /127.0.0.1:59329
2022-11-03T15:14:49,539 - INFO  - [main:MockedPulsarServiceBaseTest@310] - Stopping Pulsar broker. brokerServiceUrl: pulsar://localhost:59298 webServiceAddress: http://localhost:59305
2022-11-03T15:14:49,540 - INFO  - [main:PulsarService@410] - Closing PulsarService
2022-11-03T15:14:49,545 - INFO  - [main:AbstractConnector@383] - Stopped ServerConnector@37e55819{HTTP/1.1, (http/1.1)}{0.0.0.0:0}
2022-11-03T15:14:49,545 - INFO  - [main:AbstractConnector@383] - Stopped ServerConnector@1e6cb932{SSL, (ssl, http/1.1)}{0.0.0.0:0}
2022-11-03T15:14:49,546 - INFO  - [main:HouseKeeper@149] - node0 Stopped scavenging
2022-11-03T15:14:49,546 - INFO  - [main:ContextHandler@1159] - Stopped o.e.j.s.h.ContextHandler@68df8c6{/static,null,STOPPED}
2022-11-03T15:14:49,547 - INFO  - [main:ContextHandler@1159] - Stopped o.e.j.s.ServletContextHandler@6106dfb6{/metrics,null,STOPPED}
2022-11-03T15:14:49,548 - INFO  - [main:ContextHandler@1159] - Stopped o.e.j.s.ServletContextHandler@1bb172dd{/topics,null,STOPPED}
2022-11-03T15:14:49,549 - INFO  - [main:ContextHandler@1159] - Stopped o.e.j.s.ServletContextHandler@71316cd7{/lookup,null,STOPPED}
2022-11-03T15:14:49,550 - INFO  - [main:ContextHandler@1159] - Stopped o.e.j.s.ServletContextHandler@46994f26{/admin/v3,null,STOPPED}
2022-11-03T15:14:49,550 - INFO  - [main:ContextHandler@1159] - Stopped o.e.j.s.ServletContextHandler@1cdd31a4{/admin/v2,null,STOPPED}
2022-11-03T15:14:49,551 - INFO  - [main:ContextHandler@1159] - Stopped o.e.j.s.ServletContextHandler@7dddfc35{/admin,null,STOPPED}
2022-11-03T15:14:49,552 - INFO  - [main:ContextHandler@1159] - Stopped o.e.j.s.ServletContextHandler@14239223{/,null,STOPPED}
2022-11-03T15:14:49,553 - INFO  - [main:WebService@343] - Web service closed
2022-11-03T15:14:49,555 - INFO  - [main:BrokerService@759] - Shutting down Pulsar Broker service
2022-11-03T15:14:49,555 - INFO  - [main:BrokerService@922] - Unloading namespace-bundles...
2022-11-03T15:14:49,558 - INFO  - [metadata-store-12-1:LockManagerImpl@95] - Released resource lock on /loadbalance/brokers/localhost:59305
2022-11-03T15:14:49,563 - INFO  - [main:OwnedBundle@133] - Disabling ownership: pulsar/test/localhost:59305/0x00000000_0xffffffff
2022-11-03T15:14:49,568 - INFO  - [metadata-store-12-1:OwnershipCache$OwnedServiceUnitCacheLoader@103] - Resource lock for /namespace/pulsar/test/localhost:59305/0x00000000_0xffffffff has expired
2022-11-03T15:14:49,570 - INFO  - [metadata-store-12-1:LockManagerImpl@95] - Released resource lock on /namespace/pulsar/test/localhost:59305/0x00000000_0xffffffff
2022-11-03T15:14:49,570 - INFO  - [metadata-store-12-1:OwnedBundle@157] - Unloading pulsar/test/localhost:59305/0x00000000_0xffffffff namespace-bundle with 0 topics completed in 7.0 ms
2022-11-03T15:14:49,570 - INFO  - [main:OwnedBundle@133] - Disabling ownership: my-property/my-ns/0x00000000_0xffffffff
2022-11-03T15:14:49,571 - INFO  - [main:BrokerService@2051] - [persistent://my-property/my-ns/my-topic] Unloading topic
2022-11-03T15:14:49,572 - INFO  - [main:PersistentSubscription@888] - [persistent://my-property/my-ns/my-topic][my-subscriber-name] Successfully closed subscription [ManagedCursorImpl{ledger=my-property/my-ns/persistent/my-topic, name=my-subscriber-name, ackPos=3:9, readPos=3:10}]
2022-11-03T15:14:49,572 - INFO  - [main:PersistentSubscription@907] - [persistent://my-property/my-ns/my-topic][my-subscriber-name] Successfully disconnected and closed subscription
2022-11-03T15:14:49,573 - INFO  - [main:ManagedLedgerImpl@1461] - [my-property/my-ns/persistent/my-topic] Closing managed ledger
2022-11-03T15:14:49,582 - INFO  - [bookkeeper-ml-scheduler-OrderedScheduler-2-0:ManagedCursorImpl$24@2530] - [my-property/my-ns/persistent/my-topic][my-subscriber-name] Closed cursor at md-position=3:9
2022-11-03T15:14:49,587 - INFO  - [bookkeeper-ml-scheduler-OrderedScheduler-2-0:PersistentTopic@1378] - [persistent://my-property/my-ns/my-topic] Topic closed
2022-11-03T15:14:49,591 - INFO  - [mock-pulsar-bk-OrderedExecutor-0-0:ManagedCursorImpl@3107] - [my-property/my-ns/persistent/my-topic][my-subscriber-name] Successfully closed & deleted ledger 4 in cursor
2022-11-03T15:14:49,592 - INFO  - [metadata-store-12-1:OwnershipCache$OwnedServiceUnitCacheLoader@103] - Resource lock for /namespace/my-property/my-ns/0x00000000_0xffffffff has expired
2022-11-03T15:14:49,593 - INFO  - [metadata-store-12-1:LockManagerImpl@95] - Released resource lock on /namespace/my-property/my-ns/0x00000000_0xffffffff
2022-11-03T15:14:49,594 - INFO  - [metadata-store-12-1:OwnedBundle@157] - Unloading my-property/my-ns/0x00000000_0xffffffff namespace-bundle with 1 topics completed in 23.0 ms
2022-11-03T15:14:49,595 - INFO  - [main:OwnedBundle@133] - Disabling ownership: pulsar/localhost:59305/0x00000000_0xffffffff
2022-11-03T15:14:49,597 - INFO  - [metadata-store-12-1:OwnershipCache$OwnedServiceUnitCacheLoader@103] - Resource lock for /namespace/pulsar/localhost:59305/0x00000000_0xffffffff has expired
2022-11-03T15:14:49,598 - INFO  - [metadata-store-12-1:LockManagerImpl@95] - Released resource lock on /namespace/pulsar/localhost:59305/0x00000000_0xffffffff
2022-11-03T15:14:49,598 - INFO  - [metadata-store-12-1:OwnedBundle@157] - Unloading pulsar/localhost:59305/0x00000000_0xffffffff namespace-bundle with 0 topics completed in 3.0 ms
2022-11-03T15:14:49,598 - INFO  - [main:BrokerService@960] - Unloading 3 namespace-bundles completed in 0.039 seconds
2022-11-03T15:14:49,599 - INFO  - [main:BrokerService@794] - Event loops shutting down gracefully...
2022-11-03T15:14:49,602 - INFO  - [main:BrokerService@807] - Event loops shutdown completed.
2022-11-03T15:14:49,602 - INFO  - [main:BrokerService@812] - Continuing to second phase in shutdown.
2022-11-03T15:14:49,604 - INFO  - [main:GracefulExecutorServicesTerminationHandler@53] - Starting termination handler for 7 executors.
2022-11-03T15:14:49,605 - INFO  - [main:GracefulExecutorServicesTerminationHandler@91] - Shutdown completed.
2022-11-03T15:14:49,607 - INFO  - [main:BrokerService@863] - Broker service completely shut down
2022-11-03T15:14:49,607 - INFO  - [main:ManagedLedgerFactoryImpl@620] - Closing 0 ledgers
2022-11-03T15:14:49,607 - INFO  - [main:ManagedLedgerFactoryImpl@644] - 0 ledgers closed
2022-11-03T15:14:49,608 - INFO  - [main:ManagedLedgerClientFactory@135] - Closed managed ledger factory
2022-11-03T15:14:49,608 - INFO  - [main:ManagedLedgerClientFactory@166] - Closed BookKeeper client
2022-11-03T15:14:49,613 - INFO  - [main:PulsarClientImpl@731] - Client closing. URL: pulsar://localhost:59298
2022-11-03T15:14:49,617 - INFO  - [main:GracefulExecutorServicesTerminationHandler@53] - Starting termination handler for 1 executors.
2022-11-03T15:14:49,617 - INFO  - [main:GracefulExecutorServicesTerminationHandler@91] - Shutdown completed.
2022-11-03T15:14:49,627 - INFO  - [main:GracefulExecutorServicesTerminationHandler@53] - Starting termination handler for 5 executors.
2022-11-03T15:14:49,627 - INFO  - [main:GracefulExecutorServicesTerminationHandler@138] - Shutting down forcefully executor java.util.concurrent.ScheduledThreadPoolExecutor@4602fa2f[Shutting down, pool size = 5, active threads = 0, queued tasks = 1, completed tasks = 16]
2022-11-03T15:14:49,628 - WARN  - [main:GracefulExecutorServicesTerminationHandler@145] - Executor java.util.concurrent.ScheduledThreadPoolExecutor@4602fa2f[Shutting down, pool size = 2, active threads = 0, queued tasks = 0, completed tasks = 16] didn't shutdown after waiting for termination.
2022-11-03T15:14:49,628 - INFO  - [main:GracefulExecutorServicesTerminationHandler@91] - Shutdown completed.
2022-11-03T15:14:49,629 - INFO  - [main:PulsarService@583] - Closed

===============================================
Default Suite
Total tests run: 1, Passes: 1, Failures: 0, Skips: 0
===============================================


Process finished with exit code 0

```

### Modifications

Add `brokerClientAuthenticationPlugin` and `brokerClientAuthenticationParameters` config.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
