### PR TITLE
[fix][broker][branch-2.11] fix delete_when_subscriptions_caught_up doesn't work while have active consumers

### DIFF
--- a/.github/workflows/ci-cpp-build.yaml
+++ b/.github/workflows/ci-cpp-build.yaml
@@ -22,6 +22,7 @@ on:
   pull_request:
     branches:
       - master
+      - branch-2.11
     paths:
       - '.github/workflows/**'
       - 'pulsar-client-cpp/**'

--- a/.github/workflows/ci-cpp.yaml
+++ b/.github/workflows/ci-cpp.yaml
@@ -22,6 +22,7 @@ on:
   pull_request:
     branches:
       - master
+      - branch-2.11
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/pulsar-ci-flaky.yaml
+++ b/.github/workflows/pulsar-ci-flaky.yaml
@@ -22,6 +22,7 @@ on:
   pull_request:
     branches:
       - master
+      - branch-2.11
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/pulsar-ci.yaml
+++ b/.github/workflows/pulsar-ci.yaml
@@ -22,6 +22,7 @@ on:
   pull_request:
     branches:
       - master
+      - branch-2.11
   workflow_dispatch:
 
 concurrency:

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -1111,6 +1111,9 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
      *            Flag indicating whether delete should succeed if topic still has unconnected subscriptions. Set to
      *            false when called from admin API (it will delete the subs too), and set to true when called from GC
      *            thread
+     * @param failIfHasBacklogs
+     *            Flag indicating whether delete should succeed if topic has backlogs. Set to false when called from
+     *            admin API (it will delete the subs too), and set to true when called from GC thread
      * @param closeIfClientsConnected
      *            Flag indicate whether explicitly close connected
      *            producers/consumers/replicators before trying to delete topic.
@@ -1129,102 +1132,108 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
             if (isClosingOrDeleting) {
                 log.warn("[{}] Topic is already being closed or deleted", topic);
                 return FutureUtil.failedFuture(new TopicFencedException("Topic is already fenced"));
-            } else if (failIfHasSubscriptions && !subscriptions.isEmpty()) {
-                return FutureUtil.failedFuture(
-                        new TopicBusyException("Topic has subscriptions: " + subscriptions.keys()));
-            } else if (failIfHasBacklogs && hasBacklogs()) {
-                List<String> backlogSubs =
-                        subscriptions.values().stream()
-                                .filter(sub -> sub.getNumberOfEntriesInBacklog(false) > 0)
-                                .map(PersistentSubscription::getName).toList();
-                return FutureUtil.failedFuture(
-                        new TopicBusyException("Topic has subscriptions did not catch up: " + backlogSubs));
+            }
+            // We can proceed with the deletion if either:
+            //  1. No one is connected and no subscriptions
+            //  2. The topic have subscriptions but no backlogs for all subscriptions
+            //     if delete_when_no_subscriptions is applied
+            //  3. We want to kick out everyone and forcefully delete the topic.
+            //     In this case, we shouldn't care if the usageCount is 0 or not, just proceed
+            if (!closeIfClientsConnected) {
+                if (failIfHasSubscriptions && !subscriptions.isEmpty()) {
+                    return FutureUtil.failedFuture(
+                            new TopicBusyException("Topic has subscriptions: " + subscriptions.keys()));
+                } else if (failIfHasBacklogs) {
+                    if (hasBacklogs()) {
+                        List<String> backlogSubs =
+                                subscriptions.values().stream()
+                                        .filter(sub -> sub.getNumberOfEntriesInBacklog(false) > 0)
+                                        .map(PersistentSubscription::getName).toList();
+                        return FutureUtil.failedFuture(
+                                new TopicBusyException("Topic has subscriptions did not catch up: " + backlogSubs));
+                    } else if (!producers.isEmpty()) {
+                        return FutureUtil.failedFuture(new TopicBusyException(
+                                "Topic has " + producers.size() + " connected producers"));
+                    }
+                } else if (currentUsageCount() > 0) {
+                    return FutureUtil.failedFuture(new TopicBusyException(
+                            "Topic has " + currentUsageCount() + " connected producers/consumers"));
+                }
             }
 
             fenceTopicToCloseOrDelete(); // Avoid clients reconnections while deleting
             CompletableFuture<Void> closeClientFuture = new CompletableFuture<>();
+            List<CompletableFuture<Void>> futures = new ArrayList<>();
+            subscriptions.forEach((s, sub) -> futures.add(sub.disconnect()));
             if (closeIfClientsConnected) {
-                List<CompletableFuture<Void>> futures = Lists.newArrayList();
                 replicators.forEach((cluster, replicator) -> futures.add(replicator.disconnect()));
                 producers.values().forEach(producer -> futures.add(producer.disconnect()));
-                subscriptions.forEach((s, sub) -> futures.add(sub.disconnect()));
-                FutureUtil.waitForAll(futures).thenRun(() -> {
-                    closeClientFuture.complete(null);
-                }).exceptionally(ex -> {
-                    log.error("[{}] Error closing clients", topic, ex);
-                    unfenceTopicToResume();
-                    closeClientFuture.completeExceptionally(ex);
-                    return null;
-                });
-            } else {
-                closeClientFuture.complete(null);
             }
+            FutureUtil.waitForAll(futures).thenRun(() -> {
+                closeClientFuture.complete(null);
+            }).exceptionally(ex -> {
+                log.error("[{}] Error closing clients", topic, ex);
+                unfenceTopicToResume();
+                closeClientFuture.completeExceptionally(ex);
+                return null;
+            });
 
             closeClientFuture.thenAccept(delete -> {
-                // We can proceed with the deletion if either:
-                //  1. No one is connected
-                //  2. We want to kick out everyone and forcefully delete the topic.
-                //     In this case, we shouldn't care if the usageCount is 0 or not, just proceed
-                if (currentUsageCount() ==  0 || (closeIfClientsConnected && !failIfHasSubscriptions)) {
-                    CompletableFuture<Void> deleteTopicAuthenticationFuture = new CompletableFuture<>();
-                    brokerService.deleteTopicAuthenticationWithRetry(topic, deleteTopicAuthenticationFuture, 5);
+                CompletableFuture<Void> deleteTopicAuthenticationFuture = new CompletableFuture<>();
+                brokerService.deleteTopicAuthenticationWithRetry(topic, deleteTopicAuthenticationFuture, 5);
+                deleteTopicAuthenticationFuture.thenCompose(__ -> deleteSchema())
+                        .thenCompose(__ -> deleteTopicPolicies())
+                        .thenCompose(__ -> transactionBufferCleanupAndClose())
+                        .whenComplete((v, ex) -> {
+                            if (ex != null) {
+                                log.error("[{}] Error deleting topic", topic, ex);
+                                unfenceTopicToResume();
+                                deleteFuture.completeExceptionally(ex);
+                            } else {
+                                List<CompletableFuture<Void>> subsDeleteFutures = new ArrayList<>();
+                                subscriptions.forEach((sub, p) -> subsDeleteFutures.add(unsubscribe(sub)));
 
-                    deleteTopicAuthenticationFuture.thenCompose(__ -> deleteSchema())
-                            .thenCompose(__ -> deleteTopicPolicies())
-                            .thenCompose(__ -> transactionBufferCleanupAndClose())
-                            .whenComplete((v, ex) -> {
-                        if (ex != null) {
-                            log.error("[{}] Error deleting topic", topic, ex);
-                            unfenceTopicToResume();
-                            deleteFuture.completeExceptionally(ex);
-                        } else {
-                            List<CompletableFuture<Void>> subsDeleteFutures = new ArrayList<>();
-                            subscriptions.forEach((sub, p) -> subsDeleteFutures.add(unsubscribe(sub)));
+                                FutureUtil.waitForAll(subsDeleteFutures).whenComplete((f, e) -> {
+                                    if (e != null) {
+                                        log.error("[{}] Error deleting topic", topic, e);
+                                        unfenceTopicToResume();
+                                        deleteFuture.completeExceptionally(e);
+                                    } else {
+                                        ledger.asyncDelete(new AsyncCallbacks.DeleteLedgerCallback() {
+                                            @Override
+                                            public void deleteLedgerComplete(Object ctx) {
+                                                brokerService.removeTopicFromCache(PersistentTopic.this);
 
-                            FutureUtil.waitForAll(subsDeleteFutures).whenComplete((f, e) -> {
-                                if (e != null) {
-                                    log.error("[{}] Error deleting topic", topic, e);
-                                    unfenceTopicToResume();
-                                    deleteFuture.completeExceptionally(e);
-                                } else {
-                                    ledger.asyncDelete(new AsyncCallbacks.DeleteLedgerCallback() {
-                                        @Override
-                                        public void deleteLedgerComplete(Object ctx) {
-                                            brokerService.removeTopicFromCache(PersistentTopic.this);
+                                                dispatchRateLimiter.ifPresent(DispatchRateLimiter::close);
 
-                                            dispatchRateLimiter.ifPresent(DispatchRateLimiter::close);
+                                                subscribeRateLimiter.ifPresent(SubscribeRateLimiter::close);
 
-                                            subscribeRateLimiter.ifPresent(SubscribeRateLimiter::close);
+                                                unregisterTopicPolicyListener();
 
-                                            unregisterTopicPolicyListener();
-
-                                            log.info("[{}] Topic deleted", topic);
-                                            deleteFuture.complete(null);
-                                        }
-
-                                        @Override
-                                        public void deleteLedgerFailed(ManagedLedgerException exception, Object ctx) {
-                                            if (exception.getCause()
-                                                    instanceof MetadataStoreException.NotFoundException) {
-                                                log.info("[{}] Topic is already deleted {}",
-                                                        topic, exception.getMessage());
-                                                deleteLedgerComplete(ctx);
-                                            } else {
-                                                unfenceTopicToResume();
-                                                log.error("[{}] Error deleting topic", topic, exception);
-                                                deleteFuture.completeExceptionally(new PersistenceException(exception));
+                                                log.info("[{}] Topic deleted", topic);
+                                                deleteFuture.complete(null);
                                             }
-                                        }
-                                    }, null);
-                                }
-                            });
-                        }
-                    });
-                } else {
-                    unfenceTopicToResume();
-                    deleteFuture.completeExceptionally(new TopicBusyException(
-                            "Topic has " + currentUsageCount() + " connected producers/consumers"));
-                }
+
+                                            @Override
+                                            public void deleteLedgerFailed(ManagedLedgerException exception,
+                                                                           Object ctx) {
+                                                if (exception.getCause()
+                                                        instanceof MetadataStoreException.NotFoundException) {
+                                                    log.info("[{}] Topic is already deleted {}",
+                                                            topic, exception.getMessage());
+                                                    deleteLedgerComplete(ctx);
+                                                } else {
+                                                    unfenceTopicToResume();
+                                                    log.error("[{}] Error deleting topic", topic, exception);
+                                                    deleteFuture.completeExceptionally(
+                                                            new PersistenceException(exception));
+                                                }
+                                            }
+                                        }, null);
+                                    }
+                                });
+                            }
+                        });
             }).exceptionally(ex->{
                 unfenceTopicToResume();
                 deleteFuture.completeExceptionally(

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/InactiveTopicDeleteTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/InactiveTopicDeleteTest.java
@@ -328,7 +328,6 @@ public class InactiveTopicDeleteTest extends BrokerTestBase {
             producer.send("Pulsar".getBytes());
         }
 
-        consumer.close();
         producer.close();
 
         Thread.sleep(2000);
@@ -338,6 +337,7 @@ public class InactiveTopicDeleteTest extends BrokerTestBase {
         admin.topics().skipAllMessages(topic, "sub");
         Awaitility.await()
                 .untilAsserted(() -> Assert.assertFalse(admin.topics().getList("prop/ns-abc").contains(topic)));
+        consumer.close();
     }
 
     @Test

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SimpleProducerConsumerStatTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SimpleProducerConsumerStatTest.java
@@ -25,6 +25,7 @@ import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;

--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/MultiTopicConsumerStats.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/MultiTopicConsumerStats.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/PartitionedTopicProducerStats.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/PartitionedTopicProducerStats.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiTopicConsumerStatsRecorderImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiTopicConsumerStatsRecorderImpl.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PartitionedTopicProducerStatsRecorderImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PartitionedTopicProducerStatsRecorderImpl.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information


### PR DESCRIPTION
### Motivation

The current behavior for the `delete_when_subscriptions_caught_up` strategy is not expected. The active consumer will not be closed even if users enable `delete_when_subscriptions_caught_up` and there are no backlogs for the topic.

It should be the part that #6077 has missed. And Sijie has mentioned in the comment https://github.com/apache/pulsar/pull/6077#pullrequestreview-344643883.

To correct the behavior of `delete_when_subscriptions_caught_up`

### Modifications

Close active consumers if `delete_when_subscriptions_caught_up` is applied and there are no backlogs for the topic. So that the topic can be cleaned up properly by the topic GC thread.

### Verifying this change

Updated the existing test.

### Does this pull request potentially affect one of the following parts:

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->