### PR TITLE
[cleanup][txn] Avoid unnessary method call if txn disabled.

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
@@ -88,6 +88,7 @@ import org.apache.pulsar.broker.service.persistent.PersistentSubscription;
 import org.apache.pulsar.broker.service.persistent.PersistentTopic;
 import org.apache.pulsar.broker.service.schema.SchemaRegistryService;
 import org.apache.pulsar.broker.service.schema.exceptions.IncompatibleSchemaException;
+import org.apache.pulsar.broker.transaction.buffer.TransactionBuffer;
 import org.apache.pulsar.broker.web.RestException;
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.api.transaction.TxnID;
@@ -1361,7 +1362,7 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
                         if (isTxnEnabled) {
                             checkTxnRecoverFuture = topic.checkIfTransactionBufferRecoverCompletely();
                         } else {
-                            checkTxnRecoverFuture = Topic.TRANSACTION_DISABLED;
+                            checkTxnRecoverFuture = TransactionBuffer.TRANSACTION_NOT_ENABLED;
                         }
 
                         checkTxnRecoverFuture.thenAccept(__ -> {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
@@ -1357,7 +1357,14 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
                     });
 
                     schemaVersionFuture.thenAccept(schemaVersion -> {
-                        topic.checkIfTransactionBufferRecoverCompletely(isTxnEnabled).thenAccept(future -> {
+                        CompletableFuture<Void> checkTxnRecoverFuture;
+                        if (isTxnEnabled) {
+                            checkTxnRecoverFuture = topic.checkIfTransactionBufferRecoverCompletely();
+                        } else {
+                            checkTxnRecoverFuture = Topic.TRANSACTION_DISABLED;
+                        }
+
+                        checkTxnRecoverFuture.thenAccept(__ -> {
                             CompletableFuture<Subscription> createInitSubFuture;
                             if (!Strings.isNullOrEmpty(initialSubscriptionName)
                                     && topic.isPersistent()

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Topic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Topic.java
@@ -145,12 +145,16 @@ public interface Topic {
     void removeProducer(Producer producer);
 
     /**
+     * return if transaction disabled when call checkIfTransactionBufferRecoverCompletely
+     */
+    CompletableFuture<Void> TRANSACTION_DISABLED = CompletableFuture.completedFuture(null);
+
+    /**
      * Wait TransactionBuffer Recovers completely.
      * Take snapshot after TB Recovers completely.
-     * @param isTxnEnabled
-     * @return a future which has completely if isTxn = false. Or a future return by takeSnapshot.
+     * @return a future return by takeSnapshot or TRANSACTION_DISABLED
      */
-    CompletableFuture<Void> checkIfTransactionBufferRecoverCompletely(boolean isTxnEnabled);
+    CompletableFuture<Void> checkIfTransactionBufferRecoverCompletely();
 
     /**
      * record add-latency.

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Topic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Topic.java
@@ -145,14 +145,9 @@ public interface Topic {
     void removeProducer(Producer producer);
 
     /**
-     * return if transaction disabled when call checkIfTransactionBufferRecoverCompletely
-     */
-    CompletableFuture<Void> TRANSACTION_DISABLED = CompletableFuture.completedFuture(null);
-
-    /**
      * Wait TransactionBuffer Recovers completely.
      * Take snapshot after TB Recovers completely.
-     * @return a future return by takeSnapshot or TRANSACTION_DISABLED
+     * @return a future return by takeSnapshot.
      */
     CompletableFuture<Void> checkIfTransactionBufferRecoverCompletely();
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentTopic.java
@@ -65,6 +65,7 @@ import org.apache.pulsar.broker.service.TopicPolicyListener;
 import org.apache.pulsar.broker.service.TransportCnx;
 import org.apache.pulsar.broker.stats.ClusterReplicationMetrics;
 import org.apache.pulsar.broker.stats.NamespaceStats;
+import org.apache.pulsar.broker.transaction.buffer.TransactionBuffer;
 import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.client.api.transaction.TxnID;
 import org.apache.pulsar.client.impl.PulsarClientImpl;
@@ -245,7 +246,7 @@ public class NonPersistentTopic extends AbstractTopic implements Topic, TopicPol
 
     @Override
     public CompletableFuture<Void> checkIfTransactionBufferRecoverCompletely() {
-        return TRANSACTION_DISABLED;
+        return TransactionBuffer.TRANSACTION_NOT_ENABLED;
     }
 
     @Override

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentTopic.java
@@ -244,8 +244,8 @@ public class NonPersistentTopic extends AbstractTopic implements Topic, TopicPol
     }
 
     @Override
-    public CompletableFuture<Void> checkIfTransactionBufferRecoverCompletely(boolean isTxnEnabled) {
-        return  CompletableFuture.completedFuture(null);
+    public CompletableFuture<Void> checkIfTransactionBufferRecoverCompletely() {
+        return TRANSACTION_DISABLED;
     }
 
     @Override

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -3329,6 +3329,10 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
     }
 
     public PositionImpl getMaxReadPosition() {
+        if (!transactionEnabled) {
+            return PositionImpl.LATEST;
+        }
+
         return this.transactionBuffer.getMaxReadPosition();
     }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -591,7 +591,7 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
     @Override
     public CompletableFuture<Void> checkIfTransactionBufferRecoverCompletely() {
         if (!transactionEnabled) {
-            return TRANSACTION_DISABLED;
+            return TransactionBuffer.TRANSACTION_NOT_ENABLED;
         }
 
         return getTransactionBuffer().checkIfTBRecoverCompletely();

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/TransactionBuffer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/TransactionBuffer.java
@@ -177,6 +177,11 @@ public interface TransactionBuffer {
      */
     CompletableFuture<Void> checkIfTBRecoverCompletely();
 
+    /**
+     * return if transaction is not enabled when call TransactionBuffer methods.
+     */
+    CompletableFuture<Void> TRANSACTION_NOT_ENABLED =
+            CompletableFuture.completedFuture(null);
 
 
     long getOngoingTxnCount();

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/TransactionBuffer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/TransactionBuffer.java
@@ -173,10 +173,9 @@ public interface TransactionBuffer {
     /**
      * Wait TransactionBuffer Recovers completely.
      * Take snapshot after TB Recovers completely.
-     * @param isTxn
      * @return a future which has completely if isTxn = false. Or a future return by takeSnapshot.
      */
-    CompletableFuture<Void> checkIfTBRecoverCompletely(boolean isTxn);
+    CompletableFuture<Void> checkIfTBRecoverCompletely();
 
 
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/InMemTransactionBuffer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/InMemTransactionBuffer.java
@@ -385,7 +385,7 @@ class InMemTransactionBuffer implements TransactionBuffer {
     }
 
     @Override
-    public CompletableFuture<Void> checkIfTBRecoverCompletely(boolean isTxn) {
+    public CompletableFuture<Void> checkIfTBRecoverCompletely() {
         return CompletableFuture.completedFuture(null);
     }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/TransactionBufferDisable.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/TransactionBufferDisable.java
@@ -104,7 +104,7 @@ public class TransactionBufferDisable implements TransactionBuffer {
     }
 
     @Override
-    public CompletableFuture<Void> checkIfTBRecoverCompletely(boolean isTxn) {
+    public CompletableFuture<Void> checkIfTBRecoverCompletely() {
         return CompletableFuture.completedFuture(null);
     }
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/TransactionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/TransactionTest.java
@@ -1560,7 +1560,7 @@ public class TransactionTest extends TransactionTestBase {
         persistentTopic.set(new PersistentTopic("topic-a", managedLedger, brokerService));
         try {
             // Do check.
-            persistentTopic.get().checkIfTransactionBufferRecoverCompletely(true).get(5, TimeUnit.SECONDS);
+            persistentTopic.get().checkIfTransactionBufferRecoverCompletely().get(5, TimeUnit.SECONDS);
             fail("Expect failure by TB closed, but it is finished.");
         } catch (ExecutionException executionException){
             Throwable t = executionException.getCause();


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://docs.google.com/document/d/1d8Pw6ZbWk-_pCKdOmdvx9rnhPiyuxwq60_TrD68d7BA/edit#heading=h.trs9rsex3xom)*. 

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->

<!-- Either this PR fixes an issue, -->

Fixes #18324


### Motivation

avoid unnecessary method call if txn disabled.

### Modifications
1. remove `isTxnEnabled` parameter in `TransactionBuffer.checkIfTransactionBufferRecoverCompletely`.
2. check isTxnEnabled before call txn related code in common code path.
3. remove unused constructor of `PersistentTopic`

<!-- Describe the modifications you've done. -->

### Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->


