### PR TITLE
[cleanup][client] Reduce duplicate code in ConsumerBuilderImpl

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBuilderImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBuilderImpl.java
@@ -184,11 +184,7 @@ public class ConsumerBuilderImpl<T> implements ConsumerBuilder<T> {
     public ConsumerBuilder<T> topic(String... topicNames) {
         checkArgument(topicNames != null && topicNames.length > 0,
                 "Passed in topicNames should not be null or empty.");
-        Arrays.stream(topicNames).forEach(topicName ->
-                checkArgument(StringUtils.isNotBlank(topicName), "topicNames cannot have blank topic"));
-        conf.getTopicNames().addAll(Arrays.stream(topicNames).map(StringUtils::trim)
-                .collect(Collectors.toList()));
-        return this;
+        return topics(Arrays.stream(topicNames).collect(Collectors.toList()));
     }
 
     @Override
@@ -210,9 +206,7 @@ public class ConsumerBuilderImpl<T> implements ConsumerBuilder<T> {
 
     @Override
     public ConsumerBuilder<T> topicsPattern(String topicsPattern) {
-        checkArgument(conf.getTopicsPattern() == null, "Pattern has already been set.");
-        conf.setTopicsPattern(Pattern.compile(topicsPattern));
-        return this;
+        return topicsPattern(Pattern.compile(topicsPattern));
     }
 
     @Override


### PR DESCRIPTION
### Motivation
There are duplicate codes in 
`org.apache.pulsar.client.impl.ConsumerBuilderImpl#topic` and `org.apache.pulsar.client.impl.ConsumerBuilderImpl#topics`,
`org.apache.pulsar.client.impl.ConsumerBuilderImpl#topicsPattern(java.util.regex.Pattern)` and `org.apache.pulsar.client.impl.ConsumerBuilderImpl#topicsPattern(java.lang.String)`.

### Modifications
Merge the duplicate codes in 
`org.apache.pulsar.client.impl.ConsumerBuilderImpl#topic` and `org.apache.pulsar.client.impl.ConsumerBuilderImpl#topics`,
`org.apache.pulsar.client.impl.ConsumerBuilderImpl#topicsPattern(java.util.regex.Pattern)` and `org.apache.pulsar.client.impl.ConsumerBuilderImpl#topicsPattern(java.lang.String)`.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [x] `doc-complete` <!-- Docs have been already added -->


### Matching PR in forked repository

PR in forked repository: https://github.com/Pomelongan/pulsar/pull/13
