### PR TITLE
[improve][cli] Fix NPE in admin-CLI topic stats command

### DIFF
--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdPersistentTopics.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdPersistentTopics.java
@@ -347,7 +347,7 @@ public class CmdPersistentTopics extends CmdBase {
         @Override
         void run() throws PulsarAdminException {
             String persistentTopic = validatePersistentTopic(params);
-            print(persistentTopics.getStats(persistentTopic, getPreciseBacklog));
+            print(getPersistentTopics().getStats(persistentTopic, getPreciseBacklog));
         }
     }
 


### PR DESCRIPTION
### Motivation

The admin stats command throws NullPointerException when fetching stats for a topic. This PR aims to fix the issue

Stacktrace:

sudo cloud-messaging-admin persistent stats persistent://sessionsearch-k8s/global/search_history/get
java.lang.NullPointerException
	at org.apache.pulsar.admin.cli.CmdPersistentTopics$GetStats.run(CmdPersistentTopics.java:349)
	at org.apache.pulsar.admin.cli.CmdBase.run(CmdBase.java:87)
	at org.apache.pulsar.admin.cli.PulsarAdminTool.run(PulsarAdminTool.java:290)
	at org.apache.pulsar.admin.cli.PulsarAdminTool.main(PulsarAdminTool.java:339)

### Modifications

Get persistentTopics exclusively if the value is Null.

### Verifying this change

This change is already covered by existing tests, such as PulsarAdminToolTest.persistentTopics().

### Does this pull request potentially affect one of the following parts:

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->
