### PR TITLE
[fix] [ml] fix wrong cursor state if repeat do close

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
@@ -2716,7 +2716,10 @@ public class ManagedCursorImpl implements ManagedCursor {
         STATE_UPDATER.updateAndGet(this, state -> {
             switch (state){
                 case Closing:
-                case Closed: return state;
+                case Closed: {
+                    notClosing.set(false);
+                    return state;
+                }
                 default: {
                     notClosing.set(true);
                     return State.Closing;

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
@@ -2709,7 +2709,7 @@ public class ManagedCursorImpl implements ManagedCursor {
 
     /**
      * Try set {@link #state} to {@link State#Closing}.
-     * @return false if the already is {@link State#Closing} or {@link State#Closed}.
+     * @return false if the {@link #state} already is {@link State#Closing} or {@link State#Closed}.
      */
     private boolean trySetStateToClosing() {
         if (STATE_UPDATER.compareAndSet(this, State.Uninitialized, State.Closing)){

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
@@ -2712,18 +2712,18 @@ public class ManagedCursorImpl implements ManagedCursor {
      * @return false if the {@link #state} already is {@link State#Closing} or {@link State#Closed}.
      */
     private boolean trySetStateToClosing() {
-        final AtomicBoolean updated = new AtomicBoolean(false);
+        final AtomicBoolean notClosing = new AtomicBoolean(false);
         STATE_UPDATER.updateAndGet(this, state -> {
             switch (state){
                 case Closing:
                 case Closed: return state;
                 default: {
-                    updated.set(true);
+                    notClosing.set(true);
                     return State.Closing;
                 }
             }
         });
-        return updated.get();
+        return notClosing.get();
     }
 
     private void flushPendingMarkDeletes() {

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
@@ -2626,6 +2626,9 @@ public class ManagedCursorImpl implements ManagedCursor {
         State oldState = STATE_UPDATER.getAndSet(this, State.Closing);
         if (oldState == State.Closed || oldState == State.Closing) {
             log.info("[{}] [{}] State is already closed", ledger.getName(), name);
+            if (oldState == State.Closed){
+                STATE_UPDATER.set(this, State.Closed);
+            }
             callback.closeComplete(ctx);
             return;
         }

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedCursorTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedCursorTest.java
@@ -143,6 +143,20 @@ public class ManagedCursorTest extends MockedBookKeeperTestCase {
         ledger.close();
     }
 
+    @Test
+    public void testRepeatCloseCursor() throws Exception {
+        ManagedLedgerConfig config = new ManagedLedgerConfig();
+        config.setMaxUnackedRangesToPersistInMetadataStore(0);
+        config.setThrottleMarkDelete(0);
+        ManagedLedger ledger = factory.open("my_test_ledger", config);
+        final ManagedCursorImpl cursor = (ManagedCursorImpl) ledger.openCursor("c1");
+        cursor.close();
+        cursor.close();
+        assertEquals(cursor.getState(), ManagedCursorImpl.State.Closed.toString());
+        // cleanup.
+        ledger.close();
+    }
+
     private static void closeCursorLedger(ManagedCursorImpl managedCursor) {
         Awaitility.await().until(managedCursor::closeCursorLedger);
     }

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedCursorTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedCursorTest.java
@@ -153,8 +153,9 @@ public class ManagedCursorTest extends MockedBookKeeperTestCase {
         cursor.close();
         cursor.close();
         assertEquals(cursor.getState(), ManagedCursorImpl.State.Closed.toString());
-        // cleanup.
+        // cleanup, "ledger.close" will trigger another "cursor.close"
         ledger.close();
+        assertEquals(cursor.getState(), ManagedCursorImpl.State.Closed.toString());
     }
 
     private static void closeCursorLedger(ManagedCursorImpl managedCursor) {


### PR DESCRIPTION
### Motivation
Do ` curosr.close` twice.

expect cursor state: `Closed`

actual cursor state: `Closing`

### Modifications

Fixed the state change logic


### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository:
- https://github.com/poorbarcode/pulsar/pull/37
