### PR TITLE
[cleanup][doc] Merge the broker and proxy authentication configuration

### DIFF
--- a/site2/docs/security-athenz.md
+++ b/site2/docs/security-athenz.md
@@ -36,42 +36,17 @@ Note that you can specify any action and resource in step 2 since they are not u
 
 For more specific steps involving the Athenz UI, refer to [Example Service Access Control Setup](https://github.com/AthenZ/athenz/blob/master/docs/example_service_athenz_setup.md#server-provider-domain).
 
-## Enable Athenz authentication on brokers
+## Enable Athenz authentication on brokers/proxies
 
-:::note
-
-When you are using Athenz as an authentication provider, it's highly recommended to use [TLS encryption](security-tls-transport.md) as it can protect role tokens from being intercepted and reused. For more details involving TLS encryption, see [Architecture - Data Model](https://github.com/AthenZ/athenz/blob/master/docs/data_model).
-
-:::
-
-In the `conf/broker.conf` configuration file in your Pulsar installation, you need to provide the class name of the Athenz authentication provider as well as a comma-separated list of provider domain names.
+To configure brokers/proxies to authenticate clients using Authenz, add the following parameters to the `conf/broker.conf` and the `conf/proxy.conf` file. If you use a standalone Pulsar, you need to add these parameters to the `conf/standalone.conf` file, you need to provide the class name of the Athenz authentication provider as well as a comma-separated list of provider domain names.
 
 ```properties
 # Add the Athenz auth provider
 authenticationEnabled=true
-authorizationEnabled=true
 authenticationProviders=org.apache.pulsar.broker.authentication.AuthenticationProviderAthenz
 athenzDomainNames=pulsar
 
 # Authentication settings of the broker itself. Used when the broker connects to other brokers, either in same or other clusters
-brokerClientAuthenticationPlugin=org.apache.pulsar.client.impl.auth.AuthenticationAthenz
-brokerClientAuthenticationParameters={"tenantDomain":"shopping","tenantService":"some_app","providerDomain":"pulsar","privateKey":"file:///path/to/private.pem","keyId":"v1"}
-```
-
-> A full listing of parameters is available in the `conf/broker.conf` file, you can also find the default
-> values for those parameters in [Broker Configuration](reference-configuration.md#broker).
-
-## Enable Athenz authentication on proxies
-
-Configure the required parameters in the `conf/proxy.conf` file in your Pulsar installation.
-
-```properties
-# Add the Athenz auth provider
-authenticationEnabled=true
-authorizationEnabled=true
-authenticationProviders=org.apache.pulsar.broker.authentication.AuthenticationProviderAthenz
-athenzDomainNames=pulsar
-
 brokerClientAuthenticationPlugin=org.apache.pulsar.client.impl.auth.AuthenticationAthenz
 brokerClientAuthenticationParameters={"tenantDomain":"shopping","tenantService":"some_app","providerDomain":"pulsar","privateKey":"file:///path/to/private.pem","keyId":"v1"}
 ```
@@ -205,14 +180,9 @@ You need to add the following authentication parameters to the `conf/client.conf
 
 ```properties
 # URL for the broker
-serviceUrl=https://broker.example.com:8443/
+serviceUrl=http://broker.example.com:8080
 
 # Set Athenz auth plugin and its parameters
 authPlugin=org.apache.pulsar.client.impl.auth.AuthenticationAthenz
 authParams={"tenantDomain":"shopping","tenantService":"some_app","providerDomain":"pulsar","privateKey":"file:///path/to/private.pem","keyId":"v1"}
-
-# Enable TLS
-useTls=true
-tlsAllowInsecureConnection=false
-tlsTrustCertsFilePath=/path/to/cacert.pem
 ```

--- a/site2/docs/security-athenz.md
+++ b/site2/docs/security-athenz.md
@@ -38,7 +38,7 @@ For more specific steps involving the Athenz UI, refer to [Example Service Acces
 
 ## Enable Athenz authentication on brokers/proxies
 
-To configure brokers/proxies to authenticate clients using Authenz, add the following parameters to the `conf/broker.conf` and the `conf/proxy.conf` file. If you use a standalone Pulsar, you need to add these parameters to the `conf/standalone.conf` file, you need to provide the class name of the Athenz authentication provider as well as a comma-separated list of provider domain names. If you use a standalone Pulsar, you need to add these parameters to the `conf/standalone.conf` file.
+To configure brokers/proxies to authenticate clients using Authenz, add the following parameters to the `conf/broker.conf` and the `conf/proxy.conf` files and provide the class name of the Athenz authentication provider as well as a comma-separated list of provider domain names. If you use a standalone Pulsar, you need to add these parameters to the `conf/standalone.conf` file.
 
 ```properties
 # Add the Athenz auth provider

--- a/site2/docs/security-athenz.md
+++ b/site2/docs/security-athenz.md
@@ -38,7 +38,7 @@ For more specific steps involving the Athenz UI, refer to [Example Service Acces
 
 ## Enable Athenz authentication on brokers/proxies
 
-To configure brokers/proxies to authenticate clients using Authenz, add the following parameters to the `conf/broker.conf` and the `conf/proxy.conf` file. If you use a standalone Pulsar, you need to add these parameters to the `conf/standalone.conf` file, you need to provide the class name of the Athenz authentication provider as well as a comma-separated list of provider domain names.
+To configure brokers/proxies to authenticate clients using Authenz, add the following parameters to the `conf/broker.conf` and the `conf/proxy.conf` file. If you use a standalone Pulsar, you need to add these parameters to the `conf/standalone.conf` file, you need to provide the class name of the Athenz authentication provider as well as a comma-separated list of provider domain names. If you use a standalone Pulsar, you need to add these parameters to the `conf/standalone.conf` file.
 
 ```properties
 # Add the Athenz auth provider
@@ -46,7 +46,7 @@ authenticationEnabled=true
 authenticationProviders=org.apache.pulsar.broker.authentication.AuthenticationProviderAthenz
 athenzDomainNames=pulsar
 
-# Authentication settings of the broker itself. Used when the broker connects to other brokers, either in same or other clusters
+# Authentication settings of the broker itself. Used when the broker connects to other brokers, or when the proxy connects to brokers, either in same or other clusters
 brokerClientAuthenticationPlugin=org.apache.pulsar.client.impl.auth.AuthenticationAthenz
 brokerClientAuthenticationParameters={"tenantDomain":"shopping","tenantService":"some_app","providerDomain":"pulsar","privateKey":"file:///path/to/private.pem","keyId":"v1"}
 ```

--- a/site2/docs/security-basic-auth.md
+++ b/site2/docs/security-basic-auth.md
@@ -55,9 +55,9 @@ cat path/to/.htpasswd
 superuser:$apr1$GBIYZYFZ$MzLcPrvoUky16mLcK6UtX/
 ```
 
-## Enable basic authentication on brokers
+## Enable basic authentication on brokers/proxies
 
-To configure brokers to authenticate clients, add the following parameters to the `conf/broker.conf` file. If you use a standalone Pulsar, you need to add these parameters to the `conf/standalone.conf` file:
+To configure brokers/proxies to authenticate clients using basic, add the following parameters to the `conf/broker.conf` and the `conf/proxy.conf` file. If you use a standalone Pulsar, you need to add these parameters to the `conf/standalone.conf` file:
 
 ```conf
 # Configuration to enable Basic authentication
@@ -73,40 +73,6 @@ basicAuthConf=file:///path/to/.htpasswd
 # Authentication settings of the broker itself. Used when the broker connects to other brokers, either in same or other clusters
 brokerClientAuthenticationPlugin=org.apache.pulsar.client.impl.auth.AuthenticationBasic
 brokerClientAuthenticationParameters={"userId":"superuser","password":"admin"}
-
-# If this flag is set then the broker authenticates the original Auth data
-# else it just accepts the originalPrincipal and authorizes it (if required).
-authenticateOriginalAuthData=true
-```
-
-:::note
-
-You can also set an environment variable named `PULSAR_EXTRA_OPTS` and the value is `-Dpulsar.auth.basic.conf=/path/to/.htpasswd`. Pulsar reads this environment variable to implement HTTP basic authentication.
-
-:::
-
-## Enable basic authentication on proxies
-
-To configure proxies to authenticate clients, add the following parameters to the `conf/proxy.conf` file:
-
-```conf
-# For clients connecting to the proxy
-authenticationEnabled=true
-authenticationProviders=org.apache.pulsar.broker.authentication.AuthenticationProviderBasic
-
-basicAuthConf=file:///path/to/.htpasswd
-# basicAuthConf=/path/to/.htpasswd
-# When use the base64 format, you need to encode the .htpaswd content to bas64
-# basicAuthConf=data:;base64,YOUR-BASE64
-# basicAuthConf=YOUR-BASE64
-
-# For the proxy to connect to brokers
-brokerClientAuthenticationPlugin=org.apache.pulsar.client.impl.auth.AuthenticationBasic
-brokerClientAuthenticationParameters={"userId":"superuser","password":"admin"}
-
-# Whether client authorization credentials are forwarded to the broker for re-authorization.
-# Authentication must be enabled via authenticationEnabled=true for this to take effect.
-forwardAuthorizationCredentials=true
 ```
 
 :::note

--- a/site2/docs/security-basic-auth.md
+++ b/site2/docs/security-basic-auth.md
@@ -70,7 +70,7 @@ basicAuthConf=file:///path/to/.htpasswd
 # basicAuthConf=data:;base64,YOUR-BASE64
 # basicAuthConf=YOUR-BASE64
 
-# Authentication settings of the broker itself. Used when the broker connects to other brokers, either in same or other clusters
+# Authentication settings of the broker itself. Used when the broker connects to other brokers, or when the proxy connects to brokers, either in same or other clusters
 brokerClientAuthenticationPlugin=org.apache.pulsar.client.impl.auth.AuthenticationBasic
 brokerClientAuthenticationParameters={"userId":"superuser","password":"admin"}
 ```

--- a/site2/docs/security-jwt.md
+++ b/site2/docs/security-jwt.md
@@ -91,9 +91,9 @@ The token itself does not have any permission associated. You need to [enable au
 
 :::
 
-## Enable JWT authentication on brokers
+## Enable JWT authentication on brokers/proxies
 
-To configure brokers to authenticate clients using JWT, add the following parameters to the `conf/broker.conf` or `conf/standalone.conf` file.
+To configure brokers/proxies to authenticate clients using JWT, add the following parameters to the `conf/broker.conf` and the `conf/proxy.conf` file. If you use a standalone Pulsar, you need to add these parameters to the `conf/standalone.conf` file:
 
 ```properties
 # Configuration to enable authentication
@@ -107,11 +107,6 @@ brokerClientAuthenticationParameters={"token":"eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ0
 # brokerClientAuthenticationParameters={"token":"your-token-string"}
 # brokerClientAuthenticationParameters=token:your-token-string
 # brokerClientAuthenticationParameters=file:///path/to/token
-brokerClientTrustCertsFilePath=/path/my-ca/certs/ca.cert.pem
-
-# If this flag is set then the broker authenticates the original Auth data
-# else it just accepts the originalPrincipal and authorizes it (if required).
-authenticateOriginalAuthData=true
 
 # If using secret key (Note: key files must be DER-encoded)
 tokenSecretKey=file:///path/to/secret.key
@@ -121,37 +116,6 @@ tokenSecretKey=file:///path/to/secret.key
 # If using public/private (Note: key files must be DER-encoded)
 # tokenPublicKey=file:///path/to/public.key
 ```
-
-:::note
-
-Equivalent to `brokerClientAuthenticationParameters`, you need to configure `authParams` in the `conf/client.conf` file.
-
-:::
-
-## Enable JWT authentication on proxies
-
-To configure proxies to authenticate clients using JWT, add the following parameters to the `conf/proxy.conf` file.
-
-```properties
-# For clients connecting to the proxy
-authenticationEnabled=true
-authenticationProviders=org.apache.pulsar.broker.authentication.AuthenticationProviderToken
-tokenSecretKey=file:///path/to/secret.key
-
-# For the proxy to connect to brokers
-brokerClientAuthenticationPlugin=org.apache.pulsar.client.impl.auth.AuthenticationToken
-brokerClientAuthenticationParameters={"token":"eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ0ZXN0LXVzZXIifQ.9OHgE9ZUDeBTZs7nSMEFIuGNEX18FLR3qvy8mqxSxXw"}
-# Either configure the token string or specify to read it from a file. The following three available formats are all valid:
-# brokerClientAuthenticationParameters={"token":"your-token-string"}
-# brokerClientAuthenticationParameters=token:your-token-string
-# brokerClientAuthenticationParameters=file:///path/to/token
-```
-
-:::note
-
-The proxy uses its own token when connecting to brokers. You need to configure the role token for this key pair in the `proxyRoles` of the brokers. For more details, see [authorization](security-authorization.md).
-
-:::
 
 ## Configure JWT authentication in CLI Tools
 

--- a/site2/docs/security-jwt.md
+++ b/site2/docs/security-jwt.md
@@ -100,7 +100,7 @@ To configure brokers/proxies to authenticate clients using JWT, add the followin
 authenticationEnabled=true
 authenticationProviders=org.apache.pulsar.broker.authentication.AuthenticationProviderToken
 
-# Authentication settings of the broker itself. Used when the broker connects to other brokers, either in same or other clusters
+# Authentication settings of the broker itself. Used when the broker connects to other brokers, or when the proxy connects to brokers, either in same or other clusters
 brokerClientAuthenticationPlugin=org.apache.pulsar.client.impl.auth.AuthenticationToken
 brokerClientAuthenticationParameters={"token":"eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ0ZXN0LXVzZXIifQ.9OHgE9ZUDeBTZs7nSMEFIuGNEX18FLR3qvy8mqxSxXw"}
 # Either configure the token string or specify to read it from a file. The following three available formats are all valid:

--- a/site2/docs/security-kerberos.md
+++ b/site2/docs/security-kerberos.md
@@ -56,7 +56,7 @@ authenticationProviders=org.apache.pulsar.broker.authentication.AuthenticationPr
 saslJaasClientAllowedIds=.*client.* ## regex for principals that are allowed to connect to brokers
 saslJaasServerSectionName=PulsarBroker ## corresponds to the section in the JAAS configuration file for brokers
 
-## Authentication settings of the broker itself. Used when the broker connects to other brokers
+# Authentication settings of the broker itself. Used when the broker connects to other brokers, or when the proxy connects to brokers, either in same or other clusters
 brokerClientAuthenticationPlugin=org.apache.pulsar.client.impl.auth.AuthenticationSasl
 brokerClientAuthenticationParameters={"saslJaasClientSectionName":"PulsarClient", "serverType":"broker"}
 ```

--- a/site2/docs/security-oauth2.md
+++ b/site2/docs/security-oauth2.md
@@ -15,18 +15,26 @@ After communicating with the OAuth 2.0 server, the Pulsar client gets an access 
 
 ## Enable OAuth2 authentication on brokers/proxies
 
-To configure brokers to authenticate clients using OAuth2， add the following parameters to the `conf/broker.conf` and `conf/proxy.conf` file.
+To configure brokers/proxies to authenticate clients using OAuth2, add the following parameters to the `conf/broker.conf` and the `conf/proxy.conf` file. If you use a standalone Pulsar, you need to add these parameters to the `conf/standalone.conf` file:
 
 ```properties
 # Configuration to enable authentication
 authenticationEnabled=true
 authenticationProviders=org.apache.pulsar.broker.authentication.AuthenticationProviderToken
-tokenPublicKey=/path/to/publicKey
+
 # Authentication settings of the broker itself. Used when the broker connects to other brokers,
 # either in same or other clusters
 brokerClientAuthenticationPlugin=org.apache.pulsar.client.impl.auth.oauth2.AuthenticationOAuth2
-brokerClientAuthenticationParameters={"privateKey":"/path/to/privateKey",\
-  "audience":"https://dev-kt-aa9ne.us.auth0.com/api/v2/","issuerUrl":"https://dev-kt-aa9ne.us.auth0.com"}
+brokerClientAuthenticationParameters={"privateKey":"file:///path/to/privateKey","audience":"https://dev-kt-aa9ne.us.auth0.com/api/v2/","issuerUrl":"https://dev-kt-aa9ne.us.auth0.com"}
+# brokerClientAuthenticationParameters={"privateKey":"data:application/json;base64,privateKey-body-to-base64","audience":"https://dev-kt-aa9ne.us.auth0.com/api/v2/","issuerUrl":"https://dev-kt-aa9ne.us.auth0.com"}
+
+# If using secret key (Note: key files must be DER-encoded)
+tokenSecretKey=file:///path/to/secret.key
+# The key can also be passed inline:
+# tokenSecretKey=data:;base64,FLFyW0oLJ2Fi22KKCm21J18mbAdztfSHN/lAT5ucEKU=
+
+# If using public/private (Note: key files must be DER-encoded)
+# tokenPublicKey=file:///path/to/public.key
 ```
 
 ## Configure OAuth2 authentication in Pulsar clients

--- a/site2/docs/security-oauth2.md
+++ b/site2/docs/security-oauth2.md
@@ -22,8 +22,7 @@ To configure brokers/proxies to authenticate clients using OAuth2, add the follo
 authenticationEnabled=true
 authenticationProviders=org.apache.pulsar.broker.authentication.AuthenticationProviderToken
 
-# Authentication settings of the broker itself. Used when the broker connects to other brokers,
-# either in same or other clusters
+# Authentication settings of the broker itself. Used when the broker connects to other brokers, or when the proxy connects to brokers, either in same or other clusters
 brokerClientAuthenticationPlugin=org.apache.pulsar.client.impl.auth.oauth2.AuthenticationOAuth2
 brokerClientAuthenticationParameters={"privateKey":"file:///path/to/privateKey","audience":"https://dev-kt-aa9ne.us.auth0.com/api/v2/","issuerUrl":"https://dev-kt-aa9ne.us.auth0.com"}
 # brokerClientAuthenticationParameters={"privateKey":"data:application/json;base64,privateKey-body-to-base64","audience":"https://dev-kt-aa9ne.us.auth0.com/api/v2/","issuerUrl":"https://dev-kt-aa9ne.us.auth0.com"}

--- a/site2/docs/security-overview.md
+++ b/site2/docs/security-overview.md
@@ -28,7 +28,7 @@ Encryption ensures that if an attacker gets access to your data, the attacker ca
 
 Authentication is the process of verifying the identity of clients. In Pulsar, the authentication provider is responsible for properly identifying clients and associating them with role tokens. Note that if you only enable authentication, an authenticated role token can access all resources in the cluster. 
 
-**How it works in Pulsar**
+### How it works in Pulsar
 
 Pulsar provides a pluggable authentication framework, and Pulsar brokers/proxies use this mechanism to authenticate clients.
 
@@ -38,13 +38,15 @@ The way how each client passes its authentication data to brokers varies dependi
   - If a client supports authentication refreshing and the credential is expired, brokers send the `CommandAuthChallenge` command to exchange the authentication data with the client. If the next check finds that the previous authentication exchange has not been returned, brokers disconnect the client.
   - If a client does not support authentication refreshing and the credential is expired, brokers disconnect the client.
 
-:::note
+### Authentication data limitations on the proxies
 
-When you use proxies between clients and brokers, brokers only authenticate proxies (known as **self-authentication**) by default. To forward the authentication data from clients to brokers for client authentication (known as **original authentication**), you need to:
-1. Set `forwardAuthorizationCredentials` to `true` in the `conf/proxy.conf` file.
-2. Set `authenticateOriginalAuthData` to `true` in the `conf/broker.conf` file, which ensures that brokers recheck the client authentication.
+When you use proxies between clients and brokers, there are two authentication data, one from proxies, one from clients, brokers only authenticate proxies (known as **self-authentication**) by default. To forward the authentication data from clients to brokers for client authentication (known as **original authentication**).
 
-:::
+**Important:** If your authentication data contains an expiration time, or your authorization provider depends on the authentication data, you must to:
+
+1. Ensure your authentication data of proxies no expiration time, brokers don't support refreshing this authentication data.
+2. Set `forwardAuthorizationCredentials` to `true` in the `conf/proxy.conf` file.
+3. Set `authenticateOriginalAuthData` to `true` in the `conf/broker.conf` file, which ensures that brokers recheck the client authentication.
 
 **What's next?**
 
@@ -59,7 +61,7 @@ When you use proxies between clients and brokers, brokers only authenticate prox
 
 :::note
 
-Starting from 2.11.0, [TLS authentication](security-tls-authentication.md) includes [TLS encryption](security-tls-transport.md) by default. If you configure TLS authentication first, then TLS encryption automatically applies; if you configure TLS encryption first, you can select any one of the above authentication providers.
+Starting from 2.11.0, if you can configure [Mutual TLS](security-tls-transport.md) with any one of the above authentication providers.
 
 :::
 

--- a/site2/docs/security-overview.md
+++ b/site2/docs/security-overview.md
@@ -40,11 +40,13 @@ The way how each client passes its authentication data to brokers varies dependi
 
 ### Authentication data limitations on the proxies
 
-When you use proxies between clients and brokers, there are two authentication data, one from proxies, one from clients, brokers only authenticate proxies (known as **self-authentication**) by default. To forward the authentication data from clients to brokers for client authentication (known as **original authentication**).
+When you use proxies between clients and brokers, there are two authentication data:
+* authentication data from proxies that brokers default to authenticate - known as **self-authentication**.
+* authentication data from clients that proxies forward to brokers for authenticating - known as **original authentication**.
 
-**Important:** If your authentication data contains an expiration time, or your authorization provider depends on the authentication data, you must to:
+**Important:** If your authentication data contains an expiration time, or your authorization provider depends on the authentication data, you must:
 
-1. Ensure your authentication data of proxies no expiration time, brokers don't support refreshing this authentication data.
+1. Ensure your authentication data of proxies has no expiration time since brokers don't support refreshing this authentication data.
 2. Set `forwardAuthorizationCredentials` to `true` in the `conf/proxy.conf` file.
 3. Set `authenticateOriginalAuthData` to `true` in the `conf/broker.conf` file, which ensures that brokers recheck the client authentication.
 
@@ -61,7 +63,7 @@ When you use proxies between clients and brokers, there are two authentication d
 
 :::note
 
-Starting from 2.11.0, if you can configure [Mutual TLS](security-tls-transport.md) with any one of the above authentication providers.
+Starting from 2.11.0, you can configure [Mutual TLS](security-tls-transport.md) with any one of the above authentication providers.
 
 :::
 


### PR DESCRIPTION
### Motivation

Authentication documentation has too many duplicate configurations and some unnecessary configurations.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [x] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
