### PR TITLE
[fix][client] Add support for loading non-serializable properties with ConsumerBuilder::loadConf

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBuilderImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBuilderImpl.java
@@ -87,7 +87,39 @@ public class ConsumerBuilderImpl<T> implements ConsumerBuilder<T> {
 
     @Override
     public ConsumerBuilder<T> loadConf(Map<String, Object> config) {
-        this.conf = ConfigurationDataUtils.loadData(config, conf, ConsumerConfigurationData.class);
+        MessageListener<T> messageListener =
+            (MessageListener<T>) config.getOrDefault("messageListener", this.conf.getMessageListener());
+        ConsumerEventListener consumerEventListener =
+            (ConsumerEventListener) config.getOrDefault("consumerEventListener", this.conf.getConsumerEventListener());
+        RedeliveryBackoff negativeAckRedeliveryBackoff = (RedeliveryBackoff) config
+            .getOrDefault("negativeAckRedeliveryBackoff", this.conf.getNegativeAckRedeliveryBackoff());
+        RedeliveryBackoff ackTimeoutRedeliveryBackoff = (RedeliveryBackoff) config
+            .getOrDefault("ackTimeoutRedeliveryBackoff", this.conf.getAckTimeoutRedeliveryBackoff());
+        CryptoKeyReader cryptoKeyReader =
+            (CryptoKeyReader) config.getOrDefault("cryptoKeyReader", this.conf.getCryptoKeyReader());
+        MessageCrypto messageCrypto =
+            (MessageCrypto) config.getOrDefault("messageCrypto", this.conf.getMessageCrypto());
+        BatchReceivePolicy batchReceivePolicy =
+            (BatchReceivePolicy) config.getOrDefault("batchReceivePolicy", this.conf.getBatchReceivePolicy());
+        KeySharedPolicy keySharedPolicy =
+            (KeySharedPolicy) config.getOrDefault("keySharedPolicy", this.conf.getKeySharedPolicy());
+        MessagePayloadProcessor payloadProcessor =
+            (MessagePayloadProcessor) config.getOrDefault("payloadProcessor", this.conf.getPayloadProcessor());
+
+        ConsumerConfigurationData<T> configurationData =
+            ConfigurationDataUtils.loadData(config, conf, ConsumerConfigurationData.class);
+
+        configurationData.setMessageListener(messageListener);
+        configurationData.setConsumerEventListener(consumerEventListener);
+        configurationData.setNegativeAckRedeliveryBackoff(negativeAckRedeliveryBackoff);
+        configurationData.setAckTimeoutRedeliveryBackoff(ackTimeoutRedeliveryBackoff);
+        configurationData.setCryptoKeyReader(cryptoKeyReader);
+        configurationData.setMessageCrypto(messageCrypto);
+        configurationData.setBatchReceivePolicy(batchReceivePolicy);
+        configurationData.setKeySharedPolicy(keySharedPolicy);
+        configurationData.setPayloadProcessor(payloadProcessor);
+
+        this.conf = configurationData;
         return this;
     }
 

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/ConsumerBuilderImplTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/ConsumerBuilderImplTest.java
@@ -61,7 +61,7 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertSame;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 
@@ -505,16 +505,16 @@ public class ConsumerBuilderImplTest {
         assertTrue(configurationData.isStartPaused());
         assertTrue(configurationData.isAutoScaledReceiverQueueSizeEnabled());
 
-        assertNull(configurationData.getMessageListener());
-        assertNull(configurationData.getConsumerEventListener());
-        assertNull(configurationData.getNegativeAckRedeliveryBackoff());
-        assertNull(configurationData.getAckTimeoutRedeliveryBackoff());
-        assertNull(configurationData.getMessageListener());
-        assertNull(configurationData.getMessageCrypto());
-        assertNull(configurationData.getCryptoKeyReader());
-        assertNull(configurationData.getBatchReceivePolicy());
-        assertNull(configurationData.getKeySharedPolicy());
-        assertNull(configurationData.getPayloadProcessor());
+        assertSame(configurationData.getMessageListener(), messageListener);
+        assertSame(configurationData.getConsumerEventListener(), consumerEventListener);
+        assertSame(configurationData.getNegativeAckRedeliveryBackoff(), negativeAckRedeliveryBackoff);
+        assertSame(configurationData.getAckTimeoutRedeliveryBackoff(), ackTimeoutRedeliveryBackoff);
+        assertSame(configurationData.getMessageListener(), messageListener);
+        assertSame(configurationData.getMessageCrypto(), messageCrypto);
+        assertSame(configurationData.getCryptoKeyReader(), cryptoKeyReader);
+        assertSame(configurationData.getBatchReceivePolicy(), batchReceivePolicy);
+        assertSame(configurationData.getKeySharedPolicy(), keySharedPolicy);
+        assertSame(configurationData.getPayloadProcessor(), payloadProcessor);
     }
 
     @Test
@@ -565,16 +565,16 @@ public class ConsumerBuilderImplTest {
         assertFalse(configurationData.isStartPaused());
         assertFalse(configurationData.isAutoScaledReceiverQueueSizeEnabled());
 
-        assertNull(configurationData.getMessageListener());
-        assertNull(configurationData.getConsumerEventListener());
-        assertNull(configurationData.getNegativeAckRedeliveryBackoff());
-        assertNull(configurationData.getAckTimeoutRedeliveryBackoff());
-        assertNull(configurationData.getMessageListener());
-        assertNull(configurationData.getMessageCrypto());
-        assertNull(configurationData.getCryptoKeyReader());
-        assertNull(configurationData.getBatchReceivePolicy());
-        assertNull(configurationData.getKeySharedPolicy());
-        assertNull(configurationData.getPayloadProcessor());
+        assertNotNull(configurationData.getMessageListener());
+        assertNotNull(configurationData.getConsumerEventListener());
+        assertNotNull(configurationData.getNegativeAckRedeliveryBackoff());
+        assertNotNull(configurationData.getAckTimeoutRedeliveryBackoff());
+        assertNotNull(configurationData.getMessageListener());
+        assertNotNull(configurationData.getMessageCrypto());
+        assertNotNull(configurationData.getCryptoKeyReader());
+        assertNotNull(configurationData.getBatchReceivePolicy());
+        assertNotNull(configurationData.getKeySharedPolicy());
+        assertNotNull(configurationData.getPayloadProcessor());
     }
 
     private ConsumerBuilderImpl<byte[]> createConsumerBuilder() {


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://docs.google.com/document/d/1d8Pw6ZbWk-_pCKdOmdvx9rnhPiyuxwq60_TrD68d7BA/edit#heading=h.trs9rsex3xom)*. 

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->
### Motivation
Currently `ConsumerBuilder::loadConf` resets non-serializable of `ConsumerConfigurationData` to `null`.
It would be useful that `ConsumerBuilder::loadConf` supports loading non-serializable fields.

An alternative is to not modify fields not present in the property map in `ConfigurationDataUtils::loadData` as proposed by https://github.com/apache/pulsar/pull/13298 . This PR is for discussion.

### Modifications
In `ConsumerBuilder::loadConf`, save values for each non-serializable property and apply it after calling `ConfigurationDataUtils::loadData`

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change added tests and can be verified as follows:

* Run `ConsumerBuilderImplTest::testLoadConf` and `ConsumerBuilderImplTest::testLoadConfNotModified`

### Does this pull request potentially affect one of the following parts:

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/cbornet/pulsar/pull/7

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
