### PR TITLE
[improve][test] Remove conscrypt exception stacktrace in Apple silicon

### DIFF
--- a/pulsar-common/src/main/java/org/apache/pulsar/common/util/SecurityUtility.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/util/SecurityUtility.java
@@ -124,7 +124,12 @@ public class SecurityUtility {
             conscryptClazz = Class.forName("org.conscrypt.Conscrypt");
             conscryptClazz.getMethod("checkAvailability").invoke(null);
         } catch (Throwable e) {
-            log.warn("Conscrypt isn't available. Using JDK default security provider.", e);
+            if (e.getCause().getClass().getName().equals("java.lang.UnsatisfiedLinkError")) {
+                log.warn("Conscrypt isn't available for {} {}. Using JDK default security provider.",
+                        System.getProperty("os.name"), System.getProperty("os.arch"));
+            } else {
+                log.warn("Conscrypt isn't available. Using JDK default security provider.", e);
+            }
             return null;
         }
 
@@ -448,7 +453,7 @@ public class SecurityUtility {
         return certificates;
     }
 
-    public static X509Certificate[] loadCertificatesFromPemStream(InputStream inStream) throws KeyManagementException  {
+    public static X509Certificate[] loadCertificatesFromPemStream(InputStream inStream) throws KeyManagementException {
         if (inStream == null) {
             return null;
         }
@@ -546,7 +551,7 @@ public class SecurityUtility {
     }
 
     private static void setupClientAuthentication(SslContextBuilder builder,
-        boolean requireTrustedClientCertOnConnect) {
+                                                  boolean requireTrustedClientCertOnConnect) {
         if (requireTrustedClientCertOnConnect) {
             builder.clientAuth(ClientAuth.REQUIRE);
         } else {

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/util/SecurityUtility.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/util/SecurityUtility.java
@@ -124,7 +124,7 @@ public class SecurityUtility {
             conscryptClazz = Class.forName("org.conscrypt.Conscrypt");
             conscryptClazz.getMethod("checkAvailability").invoke(null);
         } catch (Throwable e) {
-            if (e.getCause().getClass().getName().equals("java.lang.UnsatisfiedLinkError")) {
+            if (e.getCause() != null && e.getCause().getClass().getName().equals("java.lang.UnsatisfiedLinkError")) {
                 log.warn("Conscrypt isn't available for {} {}. Using JDK default security provider.",
                         System.getProperty("os.name"), System.getProperty("os.arch"));
             } else {

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/util/SecurityUtility.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/util/SecurityUtility.java
@@ -91,8 +91,8 @@ public class SecurityUtility {
 
     /**
      * Get Bouncy Castle provider, and call Security.addProvider(provider) if success.
-     *  1. try get from classpath.
-     *  2. try get from Nar.
+     * 1. try get from classpath.
+     * 2. try get from Nar.
      */
     public static Provider getProvider() {
         boolean isProviderInstalled =
@@ -219,7 +219,8 @@ public class SecurityUtility {
     }
 
     public static SSLContext createSslContext(boolean allowInsecureConnection, String trustCertsFilePath,
-            String certFilePath, String keyFilePath, String providerName) throws GeneralSecurityException {
+                                              String certFilePath, String keyFilePath, String providerName)
+            throws GeneralSecurityException {
         X509Certificate[] trustCertificates = loadCertificatesFromPemFile(trustCertsFilePath);
         X509Certificate[] certificates = loadCertificatesFromPemFile(certFilePath);
         PrivateKey privateKey = loadPrivateKeyFromPemFile(keyFilePath);
@@ -228,6 +229,7 @@ public class SecurityUtility {
 
     /**
      * Creates {@link SslContext} with capability to do auto-cert refresh.
+     *
      * @param allowInsecureConnection
      * @param trustCertsFilePath
      * @param certFilePath
@@ -521,7 +523,7 @@ public class SecurityUtility {
     }
 
     private static void setupTrustCerts(SslContextBuilder builder, boolean allowInsecureConnection,
-            InputStream trustCertsStream) throws IOException, FileNotFoundException {
+                                        InputStream trustCertsStream) throws IOException, FileNotFoundException {
         if (allowInsecureConnection) {
             builder.trustManager(InsecureTrustManagerFactory.INSTANCE);
         } else {
@@ -534,7 +536,7 @@ public class SecurityUtility {
     }
 
     private static void setupKeyManager(SslContextBuilder builder, PrivateKey privateKey,
-            X509Certificate[] certificates) {
+                                        X509Certificate[] certificates) {
         builder.keyManager(privateKey, (X509Certificate[]) certificates);
     }
 

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/util/SecurityUtility.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/util/SecurityUtility.java
@@ -124,7 +124,7 @@ public class SecurityUtility {
             conscryptClazz = Class.forName("org.conscrypt.Conscrypt");
             conscryptClazz.getMethod("checkAvailability").invoke(null);
         } catch (Throwable e) {
-            if (e.getCause() != null && e.getCause().getClass().getName().equals("java.lang.UnsatisfiedLinkError")) {
+            if (e.getCause() instanceof UnsatisfiedLinkError) {
                 log.warn("Conscrypt isn't available for {} {}. Using JDK default security provider.",
                         System.getProperty("os.name"), System.getProperty("os.arch"));
             } else {

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/util/SecurityUtility.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/util/SecurityUtility.java
@@ -91,8 +91,8 @@ public class SecurityUtility {
 
     /**
      * Get Bouncy Castle provider, and call Security.addProvider(provider) if success.
-     * 1. try get from classpath.
-     * 2. try get from Nar.
+     *  1. try get from classpath.
+     *  2. try get from Nar.
      */
     public static Provider getProvider() {
         boolean isProviderInstalled =
@@ -219,8 +219,7 @@ public class SecurityUtility {
     }
 
     public static SSLContext createSslContext(boolean allowInsecureConnection, String trustCertsFilePath,
-                                              String certFilePath, String keyFilePath, String providerName)
-            throws GeneralSecurityException {
+            String certFilePath, String keyFilePath, String providerName) throws GeneralSecurityException {
         X509Certificate[] trustCertificates = loadCertificatesFromPemFile(trustCertsFilePath);
         X509Certificate[] certificates = loadCertificatesFromPemFile(certFilePath);
         PrivateKey privateKey = loadPrivateKeyFromPemFile(keyFilePath);
@@ -229,7 +228,6 @@ public class SecurityUtility {
 
     /**
      * Creates {@link SslContext} with capability to do auto-cert refresh.
-     *
      * @param allowInsecureConnection
      * @param trustCertsFilePath
      * @param certFilePath
@@ -455,7 +453,7 @@ public class SecurityUtility {
         return certificates;
     }
 
-    public static X509Certificate[] loadCertificatesFromPemStream(InputStream inStream) throws KeyManagementException {
+    public static X509Certificate[] loadCertificatesFromPemStream(InputStream inStream) throws KeyManagementException  {
         if (inStream == null) {
             return null;
         }
@@ -523,7 +521,7 @@ public class SecurityUtility {
     }
 
     private static void setupTrustCerts(SslContextBuilder builder, boolean allowInsecureConnection,
-                                        InputStream trustCertsStream) throws IOException, FileNotFoundException {
+            InputStream trustCertsStream) throws IOException, FileNotFoundException {
         if (allowInsecureConnection) {
             builder.trustManager(InsecureTrustManagerFactory.INSTANCE);
         } else {
@@ -536,7 +534,7 @@ public class SecurityUtility {
     }
 
     private static void setupKeyManager(SslContextBuilder builder, PrivateKey privateKey,
-                                        X509Certificate[] certificates) {
+            X509Certificate[] certificates) {
         builder.keyManager(privateKey, (X509Certificate[]) certificates);
     }
 
@@ -553,7 +551,7 @@ public class SecurityUtility {
     }
 
     private static void setupClientAuthentication(SslContextBuilder builder,
-                                                  boolean requireTrustedClientCertOnConnect) {
+        boolean requireTrustedClientCertOnConnect) {
         if (requireTrustedClientCertOnConnect) {
             builder.clientAuth(ClientAuth.REQUIRE);
         } else {


### PR DESCRIPTION

### Motivation

When running tests in Macos Apple silicon, there will be a long stacktrace like this

```
Caused by: java.lang.UnsatisfiedLinkError: no conscrypt_openjdk_jni-osx-aarch_64 in java.library.path: /Users/yaalsn/Library/Java/Extensions:/Library/Java/Extensions:/Network/Library/Java/Extensions:/System/Library/Java/Extensions:/usr/lib/java:.
	at java.lang.ClassLoader.loadLibrary(ClassLoader.java:2429) ~[?:?]
	at java.lang.Runtime.loadLibrary0(Runtime.java:818) ~[?:?]
	at java.lang.System.loadLibrary(System.java:1989) ~[?:?]
	at org.conscrypt.NativeLibraryUtil.loadLibrary(NativeLibraryUtil.java:54) ~[conscrypt-openjdk-uber-2.5.2.jar:2.5.2]
	at jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[?:?]
	at jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77) ~[?:?]
	at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:?]
	at java.lang.reflect.Method.invoke(Method.java:568) ~[?:?]
	at org.conscrypt.NativeLibraryLoader$1.run(NativeLibraryLoader.java:297) ~[conscrypt-openjdk-uber-2.5.2.jar:2.5.2]
	at org.conscrypt.NativeLibraryLoader$1.run(NativeLibraryLoader.java:289) ~[conscrypt-openjdk-uber-2.5.2.jar:2.5.2]
	at java.security.AccessController.doPrivileged(AccessController.java:318) ~[?:?]
	at org.conscrypt.NativeLibraryLoader.loadLibraryFromHelperClassloader(NativeLibraryLoader.java:289) ~[conscrypt-openjdk-uber-2.5.2.jar:2.5.2]
	at org.conscrypt.NativeLibraryLoader.loadLibrary(NativeLibraryLoader.java:262) ~[conscrypt-openjdk-uber-2.5.2.jar:2.5.2]
	at org.conscrypt.NativeLibraryLoader.load(NativeLibraryLoader.java:162) ~[conscrypt-openjdk-uber-2.5.2.jar:2.5.2]
	at org.conscrypt.NativeLibraryLoader.loadFirstAvailable(NativeLibraryLoader.java:106) ~[conscrypt-openjdk-uber-2.5.2.jar:2.5.2]
	at org.conscrypt.NativeCryptoJni.init(NativeCryptoJni.java:50) ~[conscrypt-openjdk-uber-2.5.2.jar:2.5.2]
	at org.conscrypt.NativeCrypto.<clinit>(NativeCrypto.java:64) ~[conscrypt-openjdk-uber-2.5.2.jar:2.5.2]
	at org.conscrypt.Conscrypt.checkAvailability(Conscrypt.java:119) ~[conscrypt-openjdk-uber-2.5.2.jar:2.5.2]
	... 41 more

...
```

There's no  osx aarch_64 conscrypt, so we can filter this stacktrace by catching `java.lang.UnsatisfiedLinkError`.


### Verifying this change

- [x] Make sure that the change passes the CI checks.


### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/yaalsn/pulsar/pull/16