### PR TITLE
[fix][test] flaky test ManagedLedgerBkTest.asyncMarkDeleteAndClose

### DIFF
--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerBkTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerBkTest.java
@@ -334,8 +334,8 @@ public class ManagedLedgerBkTest extends BookKeeperClusterTestCase {
 
         counter.await();
 
-        cursor.close();
-        ledger.close();
+        // cleanup.
+        closeManagedLedgerWithRetry(ledger);
 
         // Add information to determine the problem.
         if (gotException.get() != null){

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/test/BookKeeperClusterTestCase.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/test/BookKeeperClusterTestCase.java
@@ -58,6 +58,7 @@ import org.apache.bookkeeper.conf.ServerConfiguration;
 import org.apache.bookkeeper.conf.TestBKConfiguration;
 import org.apache.bookkeeper.meta.zk.ZKMetadataDriverBase;
 import org.apache.bookkeeper.metastore.InMemoryMetaStore;
+import org.apache.bookkeeper.mledger.ManagedLedger;
 import org.apache.bookkeeper.net.BookieId;
 import org.apache.bookkeeper.net.BookieSocketAddress;
 import org.apache.bookkeeper.proto.BookieServer;
@@ -848,4 +849,14 @@ public abstract class BookKeeperClusterTestCase {
         return servers.get(index).getStatsProvider();
     }
 
+    public static void closeManagedLedgerWithRetry(ManagedLedger closeable){
+        Awaitility.await().until(() -> {
+            try {
+                closeable.close();
+                return true;
+            } catch (Exception ex){
+                return false;
+            }
+        });
+    }
 }


### PR DESCRIPTION
Fixes #16729

### Motivation

same as #18310

`ManagedCursorImpl` has a known problem: when the `cursor.close` and the `cursor.switchLedger` are concurrent executing, a bad version exception is thrown. see: 

https://github.com/apache/pulsar/blob/0c3c175eb132d4ef0fb3a12842127dcb4fa1933d/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java#L2595-L2619

### Modifications

- `managedLedger.close` triggers the `cursor.close`, so remove code `cursor.close`
- if `managedLedger.close` fail, just retry, it will be ok

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: 

- https://github.com/poorbarcode/pulsar/pull/38