### PR TITLE
[improve][test] Add subscribing regex topic test for `delete_when_subscriptions_caught_up`.

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/InactiveTopicDeleteTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/InactiveTopicDeleteTest.java
@@ -35,6 +35,8 @@ import org.apache.pulsar.broker.service.persistent.PersistentTopic;
 import org.apache.pulsar.client.api.Consumer;
 import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.Producer;
+import org.apache.pulsar.client.impl.ConsumerImpl;
+import org.apache.pulsar.client.impl.MultiTopicsConsumerImpl;
 import org.apache.pulsar.common.naming.NamespaceName;
 import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.naming.TopicVersion;
@@ -355,6 +357,8 @@ public class InactiveTopicDeleteTest extends BrokerTestBase {
         admin.topics().skipAllMessages(topic, "sub");
         Awaitility.await().untilAsserted(() -> {
             Assert.assertFalse(consumer.isConnected());
+            final List<ConsumerImpl> consumers = ((MultiTopicsConsumerImpl) consumer2).getConsumers();
+            consumers.forEach(c -> Assert.assertFalse(c.isConnected()));
             Assert.assertFalse(consumer2.isConnected());
             Assert.assertFalse(admin.topics().getList("prop/ns-abc").contains(topic));
             Assert.assertFalse(admin.topics().getList("prop/ns-abc").contains(topic2));

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/InactiveTopicDeleteTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/InactiveTopicDeleteTest.java
@@ -354,6 +354,8 @@ public class InactiveTopicDeleteTest extends BrokerTestBase {
 
         admin.topics().skipAllMessages(topic, "sub");
         Awaitility.await().untilAsserted(() -> {
+            Assert.assertFalse(consumer.isConnected());
+            Assert.assertFalse(consumer2.isConnected());
             Assert.assertFalse(admin.topics().getList("prop/ns-abc").contains(topic));
             Assert.assertFalse(admin.topics().getList("prop/ns-abc").contains(topic2));
         });

--- a/pulsar-client-admin-api/src/main/java/org/apache/pulsar/common/policies/data/InactiveTopicDeleteMode.java
+++ b/pulsar-client-admin-api/src/main/java/org/apache/pulsar/common/policies/data/InactiveTopicDeleteMode.java
@@ -29,7 +29,7 @@ public enum InactiveTopicDeleteMode {
     delete_when_no_subscriptions,
 
     /**
-     * The topic can be deleted when all subscriptions catchup and no active producers/consumers.
+     * The topic can be deleted when all subscriptions catchup and no active producers.
      */
     delete_when_subscriptions_caught_up
 }


### PR DESCRIPTION

### Motivation

Add subscribing regex topic test for https://github.com/apache/pulsar/pull/18283.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

