### PR TITLE
[improve][doc] Add "force" option to delete namespace

### DIFF
--- a/site2/docs/reference-pulsar-admin.md
+++ b/site2/docs/reference-pulsar-admin.md
@@ -1055,6 +1055,12 @@ Usage
 pulsar-admin namespaces delete tenant/namespace
 ```
 
+Options
+
+|Flag|Description|Default|
+|---|---|---|
+|`-f`, `--force`|Delete namespace forcefully by force deleting all topics under it|false|
+
 ### `set-deduplication`
 Enable or disable message deduplication on a namespace
 


### PR DESCRIPTION
Missed option deleting a namespace

### Motivation

Missed option in the documentation

### Modifications

Add option:

```
./bin/pulsar-admin namespaces delete                                                                                                                                            130 ↵
Main parameters are required ("tenant/namespace")

Deletes a namespace.
Usage: delete [options] tenant/namespace
  Options:
    -f, --force
      Delete namespace forcefully by force deleting all topics under it
      Default: false
```

### Verifying this change

- [ X ] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] Anything that affects deployment

### Documentation


- [ X ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->


