### PR TITLE
[improve][doc] Clarify maven running environments under windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,8 +137,10 @@ components in the Pulsar ecosystem, including connectors, adapters, and other la
 - Maven 3.6.1+
 - zip
 
-> Note: this project includes a [Maven Wrapper](https://maven.apache.org/wrapper/) that can be used instead of a system installed Maven.
-> Use it by replacing `mvn` by `./mvnw` on Linux and `mvnw.cmd` on Windows in the commands below.
+> Notes:
+> * This project includes a [Maven Wrapper](https://maven.apache.org/wrapper/) that can be used instead of a system installed Maven.
+> Use it by replacing `mvn` by `./mvnw` on Linux and `mvnw.cmd` on Windows in the commands below.    
+> * It's better to use CMD rather than Powershell on Windows, since maven will activate windows profile and run `rename-netty-native-libs.cmd`.
 
 ### Build
 Compile and install:

--- a/README.md
+++ b/README.md
@@ -138,9 +138,11 @@ components in the Pulsar ecosystem, including connectors, adapters, and other la
 - zip
 
 > **Note**:
-> * This project includes a [Maven Wrapper](https://maven.apache.org/wrapper/) that can be used instead of a system installed Maven.
+>
+> This project includes a [Maven Wrapper](https://maven.apache.org/wrapper/) that can be used instead of a system-installed Maven.
 > Use it by replacing `mvn` by `./mvnw` on Linux and `mvnw.cmd` on Windows in the commands below.    
-> * It's better to use CMD rather than Powershell on Windows, since maven will activate windows profile and run `rename-netty-native-libs.cmd`.
+>
+> It's better to use CMD rather than Powershell on Windows. Because maven will activate the `windows` profile which runs `rename-netty-native-libs.cmd`.
 
 ### Build
 Compile and install:

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ components in the Pulsar ecosystem, including connectors, adapters, and other la
 - Maven 3.6.1+
 - zip
 
-> Notes:
+> **Note**:
 > * This project includes a [Maven Wrapper](https://maven.apache.org/wrapper/) that can be used instead of a system installed Maven.
 > Use it by replacing `mvn` by `./mvnw` on Linux and `mvnw.cmd` on Windows in the commands below.    
 > * It's better to use CMD rather than Powershell on Windows, since maven will activate windows profile and run `rename-netty-native-libs.cmd`.


### PR DESCRIPTION
### Motivation
I tried to build my Pulsar environment by following README.md, but failed. Because I used Powershell to run maven command line on Windows, maven recognized windows and used `rename-netty-native-libs.cmd `, powershell can't run cmd. Even I annotate the windows profile, let maven run `rename-netty-native-libs.sh ` on powershell,  but there is lacking many Linux commands on Powershell, such as `mktemp`.
So I think it is better to clarify the command line running environment in windows to reduce misunderstandings.

### Modifications
Clarify the maven running environments under windows.
Other minor fixes, e.g. first word capitalization this -> This
- [x] `doc` <!-- Your PR contains doc changes -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->