### PR TITLE
[cherry-pick][branch-2.9] Fix NPE when get OffloadThreshold on namespace. 

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/NamespacesBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/NamespacesBase.java
@@ -2337,7 +2337,8 @@ public abstract class NamespacesBase extends AdminResource {
     protected long internalGetOffloadThreshold() {
         validateNamespacePolicyOperation(namespaceName, PolicyName.OFFLOAD, PolicyOperation.READ);
         Policies policies = getNamespacePolicies(namespaceName);
-        if (policies.offload_policies == null) {
+        if (policies.offload_policies == null
+                || policies.offload_policies.getManagedLedgerOffloadThresholdInBytes() == null) {
             return policies.offload_threshold;
         } else {
             return policies.offload_policies.getManagedLedgerOffloadThresholdInBytes();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/NamespacesTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/NamespacesTest.java
@@ -48,6 +48,7 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
 import javax.ws.rs.BadRequestException;
 import javax.ws.rs.ClientErrorException;
 import javax.ws.rs.WebApplicationException;
@@ -1331,6 +1332,9 @@ public class NamespacesTest extends MockedPulsarServiceBaseTest {
         // create the namespace
         admin.namespaces().createNamespace(namespace, Sets.newHashSet(testLocalCluster));
         admin.topics().createNonPartitionedTopic(topicName.toString());
+
+        admin.namespaces().setOffloadDeleteLag(namespace, 10000, TimeUnit.SECONDS);
+        assertEquals(-1, admin.namespaces().getOffloadThreshold(namespace));
 
         // assert we get the default which indicates it will fall back to default
         assertEquals(-1, admin.namespaces().getOffloadThreshold(namespace));


### PR DESCRIPTION
Fixes #18023

### Motivation

If the namespace policy inits without setting `managedLedgerOffloadThresholdInBytes`(like : if user `setOffloadDeletionLag ` first and then `getOffloadThreshold `), it will cause NPE when get `OffloadThreshold`.


### Documentation

- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->

### Matching PR in forked repository

PR in forked repository: https://github.com/Technoboy-/pulsar/pull/12
