### PR TITLE
[fix][broker]Fix failover/exclusive consumer cumulate ack not remove msg from UnAckedMessageTracker

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/NegativeAcksTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/NegativeAcksTest.java
@@ -496,16 +496,22 @@ public class NegativeAcksTest extends ProducerConsumerBase {
         admin.topics().deletePartitionedTopic("persistent://public/default/" + topic);
     }
 
-    @Test
-    public void testFailOverConsumerCumulativeAck() throws Exception {
+    @DataProvider(name = "subscriptionType")
+    public static Object[][] subscriptionType() {
+        return new Object[][] {{SubscriptionType.Failover}, {SubscriptionType.Exclusive}};
+    }
+
+    @Test(dataProvider = "subscriptionType")
+    public void testFailOverConsumerCumulativeAck(SubscriptionType type) throws Exception {
         log.info("-- Starting {} test --", methodName);
+        final String topicName = BrokerTestUtil.newUniqueName("persistent://my-property/my-ns/testFailOverConsumerCumulativeAck");
         Producer<byte[]> producer = pulsarClient.newProducer()
-                .topic("persistent://my-property/my-ns/testFailOverConsumerCumulativeAck")
+                .topic(topicName)
                 .create();
         ConsumerImpl<byte[]> consumer = (ConsumerImpl<byte[]>) pulsarClient.newConsumer()
-                .topic("persistent://my-property/my-ns/testFailOverConsumerCumulativeAck")
+                .topic(topicName)
                 .subscriptionName("sub")
-                .subscriptionType(SubscriptionType.Failover)
+                .subscriptionType(type)
                 .ackTimeout(5, TimeUnit.SECONDS)
                 .acknowledgmentGroupTime(100, TimeUnit.MILLISECONDS)
                 .subscriptionInitialPosition(SubscriptionInitialPosition.Latest)

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/NegativeAcksTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/NegativeAcksTest.java
@@ -517,7 +517,7 @@ public class NegativeAcksTest extends ProducerConsumerBase {
                 .subscriptionInitialPosition(SubscriptionInitialPosition.Latest)
                 .subscribe();
         final MessageId msgId = producer.send("1".getBytes());
-        log.info("msgId : {}", msgId);
+        log.info("produce msgId : {}", msgId);
         final Message<byte[]> message = consumer.receive();
         CountDownLatch latch = new CountDownLatch(1);
         consumer.acknowledgeCumulativeAsync(message).whenComplete((r, e) -> latch.countDown());

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/NegativeAcksTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/NegativeAcksTest.java
@@ -478,8 +478,7 @@ public class NegativeAcksTest extends ProducerConsumerBase {
         Thread.sleep(1000L);
         internalPinnedExecutor.submit(() -> consumer.redeliverUnacknowledgedMessages()).get();
         // Make sure the message redelivery is completed. The incoming queue will be cleaned up during the redelivery.
-        internalPinnedExecutor.submit(() -> {
-        }).get();
+        internalPinnedExecutor.submit(() -> {}).get();
 
         Set<Integer> receivedMsgs = new HashSet<>();
         for (; ; ) {

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiTopicsConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiTopicsConsumerImpl.java
@@ -462,7 +462,7 @@ public class MultiTopicsConsumerImpl<T> extends ConsumerBase<T> {
             if (individualConsumer != null) {
                 MessageId innerId = topicMessageId.getInnerMessageId();
                 return individualConsumer.acknowledgeCumulativeAsync(innerId)
-                        .thenAccept(__ -> unAckedMessageTracker.remove(topicMessageId));
+                        .thenAccept(__ -> unAckedMessageTracker.removeMessagesTill(topicMessageId));
             } else {
                 return FutureUtil.failedFuture(new PulsarClientException.NotConnectedException());
             }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiTopicsConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiTopicsConsumerImpl.java
@@ -462,7 +462,7 @@ public class MultiTopicsConsumerImpl<T> extends ConsumerBase<T> {
             if (individualConsumer != null) {
                 MessageId innerId = topicMessageId.getInnerMessageId();
                 return individualConsumer.acknowledgeCumulativeAsync(innerId)
-                        .thenAccept(__ -> unAckedMessageTracker.removeMessagesTill(topicMessageId));
+                        .thenAccept(__ -> unAckedMessageTracker.remove(topicMessageId));
             } else {
                 return FutureUtil.failedFuture(new PulsarClientException.NotConnectedException());
             }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiTopicsConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiTopicsConsumerImpl.java
@@ -461,7 +461,8 @@ public class MultiTopicsConsumerImpl<T> extends ConsumerBase<T> {
             Consumer individualConsumer = consumers.get(topicMessageId.getTopicPartitionName());
             if (individualConsumer != null) {
                 MessageId innerId = topicMessageId.getInnerMessageId();
-                return individualConsumer.acknowledgeCumulativeAsync(innerId);
+                return individualConsumer.acknowledgeCumulativeAsync(innerId)
+                        .thenAccept(__ -> unAckedMessageTracker.remove(topicMessageId));
             } else {
                 return FutureUtil.failedFuture(new PulsarClientException.NotConnectedException());
             }


### PR DESCRIPTION
### Motivation

If the consumer subscription type is `Failover`, or `Exclusive`, when do cumulate ack, the msg is not removed from UnAckedMessageTracker, causing the msg to be triggered redeliver by ack timeout.
,
### Modifications

Remove the msg from UnAckedMessageTracker when complete `acknowledgeCumulativeAsync`

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

