### PR TITLE
[fix][test] Fix ConcurrentModificationException in testConcurrentWriteBrokerData

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/BrokerServiceLookupTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/BrokerServiceLookupTest.java
@@ -217,10 +217,10 @@ public class BrokerServiceLookupTest extends ProducerConsumerBase {
         @Cleanup("shutdownNow")
         ExecutorService executor = Executors.newFixedThreadPool(10);
         List<Future<?>> list = new ArrayList<>();
+        LocalBrokerData data = loadManager.getLoadManager().updateLocalBrokerData();
+        data.cleanDeltas();
+        data.getBundles().clear();
         for (int i = 0; i < 1000; i++) {
-            LocalBrokerData data = loadManager.getLoadManager().updateLocalBrokerData();
-            data.cleanDeltas();
-            data.getBundles().clear();
             list.add(executor.submit(() -> {
                 try {
                     assertNotNull(loadManager.generateLoadReport());


### PR DESCRIPTION
Fixes https://github.com/apache/pulsar/issues/18417


### Motivation

Fixes https://github.com/apache/pulsar/issues/18417

### Modifications

Change `bundles`, `lastBundleGains` and `lastBundleLosses`  from `HashSet` to `ConcurrentHashSet`, and remove the setter methods

### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/AnonHxy/pulsar/pull/16
