### PR TITLE
[feat][broker] Expose pulsar out bytes and message metrics per topic

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/TopicStats.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/TopicStats.java
@@ -357,6 +357,10 @@ class TopicStats {
                 splitTopicAndPartitionIndexLabel);
         writeMetric(stream, "pulsar_in_messages_total", stats.msgInCounter, cluster, namespace, topic,
                 splitTopicAndPartitionIndexLabel);
+        writeMetric(stream, "pulsar_out_bytes_total", stats.bytesOutCounter, cluster, namespace, topic,
+                splitTopicAndPartitionIndexLabel);
+        writeMetric(stream, "pulsar_out_messages_total", stats.msgOutCounter, cluster, namespace, topic,
+                splitTopicAndPartitionIndexLabel);
 
         // Compaction
         boolean hasCompaction = compactorMXBean.flatMap(mxBean -> mxBean.getCompactionRecordForTopic(topic))

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/PrometheusMetricsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/PrometheusMetricsTest.java
@@ -268,12 +268,17 @@ public class PrometheusMetricsTest extends BrokerTestBase {
                 .subscriptionName("test")
                 .subscribe();
 
-        Consumer<byte[]> c2 = pulsarClient.newConsumer()
+        Consumer<byte[]> c2a = pulsarClient.newConsumer()
                 .topic("persistent://my-property/use/my-ns/my-topic2")
-                .subscriptionName("test")
+                .subscriptionName("test2a")
                 .subscribe();
 
-        final int messages = 10;
+        Consumer<byte[]> c2b = pulsarClient.newConsumer()
+                .topic("persistent://my-property/use/my-ns/my-topic2")
+                .subscriptionName("test2b")
+                .subscribe();
+
+        final int messages = 5;
 
         for (int i = 0; i < messages; i++) {
             String message = "my-message-" + i;
@@ -283,7 +288,8 @@ public class PrometheusMetricsTest extends BrokerTestBase {
 
         for (int i = 0; i < messages; i++) {
             c1.acknowledge(c1.receive());
-            c2.acknowledge(c2.receive());
+            c2a.acknowledge(c2a.receive());
+            c2b.acknowledge(c2b.receive());
         }
 
         ByteArrayOutputStream statsOut = new ByteArrayOutputStream();
@@ -329,27 +335,46 @@ public class PrometheusMetricsTest extends BrokerTestBase {
         assertEquals(cm.get(1).tags.get("namespace"), "my-property/use/my-ns");
 
         cm = (List<Metric>) metrics.get("pulsar_out_bytes_total");
-        assertEquals(cm.size(), 2);
+        assertEquals(cm.size(), 5);
         assertEquals(cm.get(0).tags.get("topic"), "persistent://my-property/use/my-ns/my-topic2");
         assertEquals(cm.get(0).tags.get("namespace"), "my-property/use/my-ns");
-        assertEquals(cm.get(0).tags.get("subscription"), "test");
-        assertEquals(cm.get(1).tags.get("topic"), "persistent://my-property/use/my-ns/my-topic1");
+        assertEquals(cm.get(0).tags.get("subscription"), "test2b");
+        assertEquals(cm.get(1).tags.get("topic"), "persistent://my-property/use/my-ns/my-topic2");
         assertEquals(cm.get(1).tags.get("namespace"), "my-property/use/my-ns");
-        assertEquals(cm.get(1).tags.get("subscription"), "test");
+        assertEquals(cm.get(1).tags.get("subscription"), "test2a");
+        assertEquals(cm.get(2).tags.get("topic"), "persistent://my-property/use/my-ns/my-topic2");
+        assertEquals(cm.get(2).tags.get("namespace"), "my-property/use/my-ns");
+        assertNull(cm.get(2).tags.get("subscription"));
+        assertEquals(cm.get(3).tags.get("topic"), "persistent://my-property/use/my-ns/my-topic1");
+        assertEquals(cm.get(3).tags.get("namespace"), "my-property/use/my-ns");
+        assertEquals(cm.get(3).tags.get("subscription"), "test");
+        assertEquals(cm.get(4).tags.get("topic"), "persistent://my-property/use/my-ns/my-topic1");
+        assertEquals(cm.get(4).tags.get("namespace"), "my-property/use/my-ns");
 
         cm = (List<Metric>) metrics.get("pulsar_out_messages_total");
-        assertEquals(cm.size(), 2);
+        assertEquals(cm.size(), 5);
+        assertEquals(cm.get(0).value, 5);
         assertEquals(cm.get(0).tags.get("topic"), "persistent://my-property/use/my-ns/my-topic2");
         assertEquals(cm.get(0).tags.get("namespace"), "my-property/use/my-ns");
-        assertEquals(cm.get(0).tags.get("subscription"), "test");
-        assertEquals(cm.get(1).tags.get("topic"), "persistent://my-property/use/my-ns/my-topic1");
+        assertEquals(cm.get(0).tags.get("subscription"), "test2b");
+        assertEquals(cm.get(1).value, 5);
+        assertEquals(cm.get(1).tags.get("topic"), "persistent://my-property/use/my-ns/my-topic2");
         assertEquals(cm.get(1).tags.get("namespace"), "my-property/use/my-ns");
-        assertEquals(cm.get(1).tags.get("subscription"), "test");
+        assertEquals(cm.get(1).tags.get("subscription"), "test2a");
+        assertEquals(cm.get(2).tags.get("topic"), "persistent://my-property/use/my-ns/my-topic2");
+        assertEquals(cm.get(2).tags.get("namespace"), "my-property/use/my-ns");
+        assertNull(cm.get(2).tags.get("subscription"));
+        assertEquals(cm.get(3).tags.get("topic"), "persistent://my-property/use/my-ns/my-topic1");
+        assertEquals(cm.get(3).tags.get("namespace"), "my-property/use/my-ns");
+        assertEquals(cm.get(3).tags.get("subscription"), "test");
+        assertEquals(cm.get(4).tags.get("topic"), "persistent://my-property/use/my-ns/my-topic1");
+        assertEquals(cm.get(4).tags.get("namespace"), "my-property/use/my-ns");
 
         p1.close();
         p2.close();
         c1.close();
-        c2.close();
+        c2a.close();
+        c2b.close();
     }
 
     @Test


### PR DESCRIPTION
Add prometheus metrics which expose the per topic messages out and bytes out total on a per topic basis.  Currently, only the subscription level stats are enabled.

### Motivation

There are currently two metrics `pulsar_out_bytes_total` and `pulsar_out_messages_total`.  The metrics represent the pulsar stats on a per subscription basis.  It would be convenient to be able to see the summary of these values per topic similar to the stats exposed by pulsar-admin.

### Modifications

Added the two metrics and updated the test to verify that the output is correct.

### Verifying this change

- [X] Make sure that the change passes the CI checks.

This change is already covered by existing tests, such as *(please describe tests)*.  I made an enhancement to the existing Promtheus metrics test.

### Does this pull request potentially affect one of the following parts:

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [X] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/pgier/pulsar/pull/1

