### PR TITLE
[fix][build] fix permission denied error while running `install-pulsar-client.sh`

### DIFF
--- a/docker/pulsar/Dockerfile
+++ b/docker/pulsar/Dockerfile
@@ -98,6 +98,7 @@ ARG PULSAR_CLIENT_PYTHON_VERSION
 ENV PULSAR_CLIENT_PYTHON_VERSION ${PULSAR_CLIENT_PYTHON_VERSION}
 
 # This script is intentionally run as the root user to make the dependencies available for all UIDs.
+RUN chmod +x /pulsar/bin/install-pulsar-client.sh
 RUN /pulsar/bin/install-pulsar-client.sh
 
 # The UID must be non-zero. Otherwise, it is arbitrary. No logic should rely on its specific value.


### PR DESCRIPTION
Fixes #18443

### Motivation
I tried to build docker image on my win10, and I use wsl2 for my docker, all my softwares versions are listed on #18443. I have encountered "permission denied" error while running `install-pulsar-client.sh`, seems it happens on some linux kernel. I searched this error on stackoverflow and I got this, https://stackoverflow.com/questions/69323982/permission-denied-in-docker-entrypoint. So I add `RUN chmod +x /pulsar/bin/install-pulsar-client.sh`, and it works fine for me.

Adding this may happen many beginner reduce this kind of problems.

### Modifications

Add `chmod +x` command to dockerfile

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->