### PR TITLE
[improve][build] dockerfile add timeout and retries threshold

### DIFF
--- a/docker/pulsar/Dockerfile
+++ b/docker/pulsar/Dockerfile
@@ -53,10 +53,13 @@ FROM ubuntu:20.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 ARG UBUNTU_MIRROR=mirror://mirrors.ubuntu.com/mirrors.txt
+# adjust TIMEOUT and RETIES when receiving "503  Service Unavailable" while running apt-get update
+ARG TIMEOUT=30
+ARG RETIES=3
 
 # Install some utilities
 RUN sed -i "s|http://archive\.ubuntu\.com/ubuntu/|${UBUNTU_MIRROR:-mirror://mirrors.ubuntu.com/mirrors.txt}|g" /etc/apt/sources.list \
-     && echo 'Acquire::http::Timeout "30";\nAcquire::ftp::Timeout "30";\nAcquire::Retries "3";' > /etc/apt/apt.conf.d/99timeout_and_retries \
+     && echo "Acquire::http::Timeout \"${TIMEOUT:-30}\";\nAcquire::ftp::Timeout \"${TIMEOUT:-30}\";\nAcquire::Retries \"${RETIES:-30}\";" > /etc/apt/apt.conf.d/99timeout_and_retries \
      && apt-get update \
      && apt-get -y dist-upgrade \
      && apt-get -y install --no-install-recommends netcat dnsutils less procps iputils-ping \


### PR DESCRIPTION
### Motivation
When I tried to build docker image by running 
`mvn package -Pdocker,-main -am -pl docker/pulsar-all -DskipTests`
and it show error "503  Service Unavailable"
![apt-timeout](https://user-images.githubusercontent.com/84658856/201523265-e3c28233-dd40-45d9-94b7-0abe3f3c2251.png)
and get response time by ping the mirror url, it's much longer than default value 30.
![image](https://user-images.githubusercontent.com/84658856/201523396-7d932d3a-dfe6-4565-99b4-4a0bbc80cc9e.png)
I fixed this problem by modifying the timeout and retry threshold.
I think it's better to use variant representing timeout and retries threshold, and add some annotation to help the beginners to quickly solving environment problems.

### Modifications
make variants to represent timeout and retries threshold.
make minor annotations

### Verifying this change

- [ ] Make sure that the change passes the CI checks.
### Documentation
- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->
