### PR TITLE
[improve][build] `install-pulsar-client.sh` add pip3 install timeout threshold

### DIFF
--- a/docker/pulsar/scripts/install-pulsar-client.sh
+++ b/docker/pulsar/scripts/install-pulsar-client.sh
@@ -22,6 +22,8 @@ set -x
 
 # TODO: remove these lines once grpcio doesn't need to compile from source on ARM64 platform
 ARCH=$(uname -m | sed -r 's/aarch64/arm64/g' |  awk '!/arm64/{$0="amd64"}1')
+# modify the timeout threshold by the response from ping host
+pip3 install --default-timeout=200 future
 if [ "${ARCH}" == "arm64" ]; then
   apt update
   apt -y install build-essential python3-dev


### PR DESCRIPTION
### Motivation
When I tried to build docker image by running
`mvn package -Pdocker,-main -am -pl docker/pulsar-all -DskipTests`, after executing 
`RUN /pulsar/bin/install-pulsar-client.sh`, it shows urllib3.exceptions.ReadTimeoutError: HTTPSConnectionPool(host='files.pythonhosted.org', port=443): Read timed out.
![py timeout](https://user-images.githubusercontent.com/84658856/201524050-ebd00305-3b01-4438-97d9-8cd0449c5cf2.png)
and I get the response time from ping files.pythonhosted.org, the delay is not stable, sometimes 600ms, sometimes 64ms.
When I failed this shell script by timeout, I changed the default timeout by adding `pip3 install --default-timeout=500 future`.
So It's better to add a timeout threshold and annotations for pip3 install, it's friendly to beginners.


### Modifications
Change default timeout for pip3 install 
Add annotations

### Verifying this change

- [ ] Make sure that the change passes the CI checks.
- [ ] 
### Documentation
- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->
