### PR TITLE
[fix][test] Fix `testLargeMessage` doesn't respect the parameter `clientSizeMaxMessageSize`

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/MessageChunkingTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/MessageChunkingTest.java
@@ -116,10 +116,10 @@ public class MessageChunkingTest extends ProducerConsumerBase {
     public void testLargeMessage(boolean ackReceiptEnabled, boolean clientSizeMaxMessageSize) throws Exception {
 
         log.info("-- Starting {} test --", methodName);
-        clientSizeMaxMessageSize = false;
-        this.conf.setMaxMessageSize(50);
         if (clientSizeMaxMessageSize) {
-            this.conf.setMaxMessageSize(5);
+            this.conf.setMaxMessageSize(35);
+        } else {
+            this.conf.setMaxMessageSize(50);
         }
         final int totalMessages = 5;
         final String topicName = "persistent://my-property/my-ns/my-topic1";
@@ -130,7 +130,7 @@ public class MessageChunkingTest extends ProducerConsumerBase {
 
         ProducerBuilder<byte[]> producerBuilder = pulsarClient.newProducer().topic(topicName);
         if (clientSizeMaxMessageSize) {
-            producerBuilder.chunkMaxMessageSize(5);
+            producerBuilder.chunkMaxMessageSize(35);
         }
 
         Producer<byte[]> producer = producerBuilder.compressionType(CompressionType.LZ4).enableChunking(true)


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://docs.google.com/document/d/1d8Pw6ZbWk-_pCKdOmdvx9rnhPiyuxwq60_TrD68d7BA/edit#heading=h.trs9rsex3xom)*. 

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->

### Motivation

https://github.com/apache/pulsar/pull/14382 introduced the client-side maxMessageSize for the message chunking. But the parameter `clientSizeMaxMessageSize` in `testLargeMessage` is not respected in that PR. This PR fixes this issue.

### Modifications

* Respect the `clientSizeMaxMessageSize`. The `clientSizeMaxMessageSize` should not be too small because https://github.com/apache/pulsar/pull/14007 has included the metadata when calculating the chunk size.

### Verifying this change

This change is already covered by existing tests, such as *testLargeMessage*.


### Does this pull request potentially affect one of the following parts:

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/RobertIndie/pulsar/pull/8

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
