### PR TITLE
[improve] Bump bookkeeper version to 4.15.3

### DIFF
--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -338,31 +338,31 @@ The Apache Software License, Version 2.0
     - org.apache.logging.log4j-log4j-web-2.18.0.jar
  * Java Native Access JNA -- net.java.dev.jna-jna-5.12.1.jar
  * BookKeeper
-    - org.apache.bookkeeper-bookkeeper-common-4.15.1.jar
-    - org.apache.bookkeeper-bookkeeper-common-allocator-4.15.1.jar
-    - org.apache.bookkeeper-bookkeeper-proto-4.15.1.jar
-    - org.apache.bookkeeper-bookkeeper-server-4.15.1.jar
-    - org.apache.bookkeeper-bookkeeper-tools-framework-4.15.1.jar
-    - org.apache.bookkeeper-circe-checksum-4.15.1.jar
-    - org.apache.bookkeeper-cpu-affinity-4.15.1.jar
-    - org.apache.bookkeeper-statelib-4.15.1.jar
-    - org.apache.bookkeeper-stream-storage-api-4.15.1.jar
-    - org.apache.bookkeeper-stream-storage-common-4.15.1.jar
-    - org.apache.bookkeeper-stream-storage-java-client-4.15.1.jar
-    - org.apache.bookkeeper-stream-storage-java-client-base-4.15.1.jar
-    - org.apache.bookkeeper-stream-storage-proto-4.15.1.jar
-    - org.apache.bookkeeper-stream-storage-server-4.15.1.jar
-    - org.apache.bookkeeper-stream-storage-service-api-4.15.1.jar
-    - org.apache.bookkeeper-stream-storage-service-impl-4.15.1.jar
-    - org.apache.bookkeeper.http-http-server-4.15.1.jar
-    - org.apache.bookkeeper.http-vertx-http-server-4.15.1.jar
-    - org.apache.bookkeeper.stats-bookkeeper-stats-api-4.15.1.jar
-    - org.apache.bookkeeper.stats-prometheus-metrics-provider-4.15.1.jar
-    - org.apache.distributedlog-distributedlog-common-4.15.1.jar
-    - org.apache.distributedlog-distributedlog-core-4.15.1-tests.jar
-    - org.apache.distributedlog-distributedlog-core-4.15.1.jar
-    - org.apache.distributedlog-distributedlog-protocol-4.15.1.jar
-    - org.apache.bookkeeper.stats-codahale-metrics-provider-4.15.1.jar
+    - org.apache.bookkeeper-bookkeeper-common-4.15.3.jar
+    - org.apache.bookkeeper-bookkeeper-common-allocator-4.15.3.jar
+    - org.apache.bookkeeper-bookkeeper-proto-4.15.3.jar
+    - org.apache.bookkeeper-bookkeeper-server-4.15.3.jar
+    - org.apache.bookkeeper-bookkeeper-tools-framework-4.15.3.jar
+    - org.apache.bookkeeper-circe-checksum-4.15.3.jar
+    - org.apache.bookkeeper-cpu-affinity-4.15.3.jar
+    - org.apache.bookkeeper-statelib-4.15.3.jar
+    - org.apache.bookkeeper-stream-storage-api-4.15.3.jar
+    - org.apache.bookkeeper-stream-storage-common-4.15.3.jar
+    - org.apache.bookkeeper-stream-storage-java-client-4.15.3.jar
+    - org.apache.bookkeeper-stream-storage-java-client-base-4.15.3.jar
+    - org.apache.bookkeeper-stream-storage-proto-4.15.3.jar
+    - org.apache.bookkeeper-stream-storage-server-4.15.3.jar
+    - org.apache.bookkeeper-stream-storage-service-api-4.15.3.jar
+    - org.apache.bookkeeper-stream-storage-service-impl-4.15.3.jar
+    - org.apache.bookkeeper.http-http-server-4.15.3.jar
+    - org.apache.bookkeeper.http-vertx-http-server-4.15.3.jar
+    - org.apache.bookkeeper.stats-bookkeeper-stats-api-4.15.3.jar
+    - org.apache.bookkeeper.stats-prometheus-metrics-provider-4.15.3.jar
+    - org.apache.distributedlog-distributedlog-common-4.15.3.jar
+    - org.apache.distributedlog-distributedlog-core-4.15.3-tests.jar
+    - org.apache.distributedlog-distributedlog-core-4.15.3.jar
+    - org.apache.distributedlog-distributedlog-protocol-4.15.3.jar
+    - org.apache.bookkeeper.stats-codahale-metrics-provider-4.15.3.jar
   * Apache HTTP Client
     - org.apache.httpcomponents-httpclient-4.5.13.jar
     - org.apache.httpcomponents-httpcore-4.4.15.jar

--- a/pom.xml
+++ b/pom.xml
@@ -118,7 +118,7 @@ flexible messaging model and an intuitive client API.</description>
     <!-- apache commons -->
     <commons-compress.version>1.21</commons-compress.version>
 
-    <bookkeeper.version>4.15.1</bookkeeper.version>
+    <bookkeeper.version>4.15.3</bookkeeper.version>
     <zookeeper.version>3.8.0</zookeeper.version>
     <commons-cli.version>1.5.0</commons-cli.version>
     <commons-text.version>1.10.0</commons-text.version>

--- a/pulsar-sql/presto-distribution/LICENSE
+++ b/pulsar-sql/presto-distribution/LICENSE
@@ -421,18 +421,18 @@ The Apache Software License, Version 2.0
     - async-http-client-2.12.1.jar
     - async-http-client-netty-utils-2.12.1.jar
   * Apache Bookkeeper
-    - bookkeeper-common-4.15.1.jar
-    - bookkeeper-common-allocator-4.15.1.jar
-    - bookkeeper-proto-4.15.1.jar
-    - bookkeeper-server-4.15.1.jar
-    - bookkeeper-stats-api-4.15.1.jar
-    - bookkeeper-tools-framework-4.15.1.jar
-    - circe-checksum-4.15.1.jar
-    - codahale-metrics-provider-4.15.1.jar
-    - cpu-affinity-4.15.1.jar
-    - http-server-4.15.1.jar
-    - prometheus-metrics-provider-4.15.1.jar
-    - codahale-metrics-provider-4.15.1.jar
+    - bookkeeper-common-4.15.3.jar
+    - bookkeeper-common-allocator-4.15.3.jar
+    - bookkeeper-proto-4.15.3.jar
+    - bookkeeper-server-4.15.3.jar
+    - bookkeeper-stats-api-4.15.3.jar
+    - bookkeeper-tools-framework-4.15.3.jar
+    - circe-checksum-4.15.3.jar
+    - codahale-metrics-provider-4.15.3.jar
+    - cpu-affinity-4.15.3.jar
+    - http-server-4.15.3.jar
+    - prometheus-metrics-provider-4.15.3.jar
+    - codahale-metrics-provider-4.15.3.jar
   * Apache Commons
     - commons-cli-1.5.0.jar
     - commons-codec-1.15.jar


### PR DESCRIPTION
BookKeeper released 4.15.3 and it has some improvements and bug fixes.

See more details on this:
https://github.com/apache/bookkeeper/releases/tag/release-4.15.3

### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Documentation

- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
