### PR TITLE
[improve][doc] Specially handle Python and C++ API documents

### DIFF
--- a/site2/docs/client-libraries-cpp.md
+++ b/site2/docs/client-libraries-cpp.md
@@ -11,7 +11,7 @@ import TabItem from '@theme/TabItem';
 
 You can use a Pulsar C++ client to create producers, consumers, and readers. For complete examples, refer to [C++ client examples](https://github.com/apache/pulsar-client-cpp/tree/main/examples).
 
-All the methods in producer, consumer, and reader of a C++ client are thread-safe. You can read the [API docs](/api/cpp) for the C++ client.
+All the methods in producer, consumer, and reader of a C++ client are thread-safe. You can read the [API docs](@pulsar:apidoc:cpp@) for the C++ client.
 
 ## Installation
 

--- a/site2/docs/client-libraries-python.md
+++ b/site2/docs/client-libraries-python.md
@@ -11,7 +11,7 @@ import TabItem from '@theme/TabItem';
 
 You can use a Pulsar Python client to create producers, consumers, and readers.
 
-All the methods in producer, consumer, and reader of a Python client are thread-safe. You can read the [API docs](/api/python) for the Python client.
+All the methods in producer, consumer, and reader of a Python client are thread-safe. You can read the [API docs](@pulsar:apidoc:python@) for the Python client.
 
 ## Installation
 
@@ -65,7 +65,7 @@ pulsar+ssl://pulsar.us-west.example.com:6651
 
 ## API Reference
 
-The complete Python API reference is available at [api/python](/api/python).
+The complete Python API reference is available at [api/python](@pulsar:apidoc:python@).
 
 ## Examples
 

--- a/site2/docs/client-libraries.md
+++ b/site2/docs/client-libraries.md
@@ -6,14 +6,14 @@ sidebar_label: "Overview"
 
 Pulsar supports the following language-specific client libraries:
 
-| Language  | Documentation                                                        | Release note                                                                      | Code repo                                                             |
-| --------- | -------------------------------------------------------------------- | --------------------------------------------------------------------------------- | --------------------------------------------------------------------- |
-| Java      | [User doc](client-libraries-java.md)   <br/> [API doc](/api/client/) | [Bundled](/release-notes/)                                                        | [Bundled](https://github.com/apache/pulsar/tree/master/pulsar-client) |
-| C++       | [User doc](client-libraries-cpp.md)    <br/> [API doc](/api/cpp/)    | [Bundled](/release-notes/)                                                        | [Standalone](https://github.com/apache/pulsar/pulsar-client-cpp)      |
-| Python    | [User doc](client-libraries-python.md) <br/> [API doc](/api/python/) | [Bundled](/release-notes/)                                                        | [Standalone](https://github.com/apache/pulsar-client-python)          |
-| Go client | [User doc](client-libraries-go.md)                                   | [Standalone](https://github.com/apache/pulsar-client-go/releases)                 | [Standalone](https://github.com/apache/pulsar-client-go)              |
-| Node.js   | [User doc](client-libraries-node.md)                                 | [Standalone](https://github.com/apache/pulsar-client-node/releases)               | [Standalone](https://github.com/apache/pulsar-client-node)            |
-| C#        | [User doc](client-libraries-dotnet.md)                               | [Standalone](https://github.com/apache/pulsar-dotpulsar/blob/master/CHANGELOG.md) | [Standalone](https://github.com/apache/pulsar-dotpulsar)              |
+| Language  | Documentation                                                          | Release note                                                                      | Code repo                                                             |
+| --------- |------------------------------------------------------------------------| --------------------------------------------------------------------------------- | --------------------------------------------------------------------- |
+| Java      | [User doc](client-libraries-java.md)   <br/> [API doc](/api/client/)   | [Bundled](/release-notes/)                                                        | [Bundled](https://github.com/apache/pulsar/tree/master/pulsar-client) |
+| C++       | [User doc](client-libraries-cpp.md)    <br/> [API doc](/api/cpp/3.0.0) | [Bundled](/release-notes/)                                                        | [Standalone](https://github.com/apache/pulsar/pulsar-client-cpp)      |
+| Python    | [User doc](client-libraries-python.md) <br/> [API doc](@pulsar:apidoc:python@)       | [Bundled](/release-notes/)                                                        | [Standalone](https://github.com/apache/pulsar-client-python)          |
+| Go client | [User doc](client-libraries-go.md)                                     | [Standalone](https://github.com/apache/pulsar-client-go/releases)                 | [Standalone](https://github.com/apache/pulsar-client-go)              |
+| Node.js   | [User doc](client-libraries-node.md)                                   | [Standalone](https://github.com/apache/pulsar-client-node/releases)               | [Standalone](https://github.com/apache/pulsar-client-node)            |
+| C#        | [User doc](client-libraries-dotnet.md)                                 | [Standalone](https://github.com/apache/pulsar-dotpulsar/blob/master/CHANGELOG.md) | [Standalone](https://github.com/apache/pulsar-dotpulsar)              |
 
 Pulsar supports the following language-agnostic client libraries:
 

--- a/site2/website/versioned_docs/version-2.10.x/client-libraries-cpp.md
+++ b/site2/website/versioned_docs/version-2.10.x/client-libraries-cpp.md
@@ -12,7 +12,7 @@ import TabItem from '@theme/TabItem';
 
 You can use a Pulsar C++ client to create producers, consumers, and readers.
 
-All the methods in producer, consumer, and reader of a C++ client are thread-safe. You can read the [API docs](/api/cpp) for the C++ client.
+All the methods in producer, consumer, and reader of a C++ client are thread-safe. You can read the [API docs](@pulsar:apidoc:cpp@) for the C++ client.
 
 ## Installation
 

--- a/site2/website/versioned_docs/version-2.10.x/client-libraries-python.md
+++ b/site2/website/versioned_docs/version-2.10.x/client-libraries-python.md
@@ -11,11 +11,11 @@ import TabItem from '@theme/TabItem';
 ````
 
 
-Pulsar Python client library is a wrapper over the existing [C++ client library](client-libraries-cpp.md) and exposes all of the [same features](/api/cpp). You can find the code in the [Python directory](https://github.com/apache/pulsar-client-python) of the C++ client code.
+Pulsar Python client library is a wrapper over the existing [C++ client library](client-libraries-cpp.md) and exposes all of the [same features](@pulsar:apidoc:cpp@). You can find the code in the [Python directory](https://github.com/apache/pulsar-client-python) of the C++ client code.
 
 All the methods in producer, consumer, and reader of a Python client are thread-safe.
 
-[pdoc](https://github.com/BurntSushi/pdoc)-generated API docs for the Python client are available [here](/api/python).
+[pdoc](https://github.com/BurntSushi/pdoc)-generated API docs for the Python client are available [here](@pulsar:apidoc:python@).
 
 ## Install
 
@@ -70,7 +70,7 @@ $ sudo python setup.py install
 
 ## API Reference
 
-The complete Python API reference is available at [api/python](/api/python).
+The complete Python API reference is available at [(@pulsar:apidoc:python@)](@pulsar:apidoc:python@).
 
 ## Examples
 

--- a/site2/website/versioned_docs/version-2.10.x/client-libraries.md
+++ b/site2/website/versioned_docs/version-2.10.x/client-libraries.md
@@ -7,15 +7,15 @@ original_id: client-libraries
 
 Pulsar supports the following client libraries:
 
-|Language|Documentation|Release note|Code repo
-|---|---|---|---
-Java |- [User doc](client-libraries-java.md) <br /><br />- [API doc](/api/client/)|[Here](/release-notes/)|[Here](https://github.com/apache/pulsar/tree/master/pulsar-client) 
-C++ | - [User doc](client-libraries-cpp.md) <br /><br />- [API doc](/api/cpp/)|[Here](/release-notes/)|[Here](https://github.com/apache/pulsar-client-cpp) 
-Python | - [User doc](client-libraries-python.md) <br /><br />- [API doc](/api/python/)|[Here](/release-notes/)|[Here](https://github.com/apache/pulsar-client-python) 
-WebSocket| [User doc](client-libraries-websocket.md) | [Here](/release-notes/)|[Here](https://github.com/apache/pulsar/tree/master/pulsar-websocket) 
-Go client|[User doc](client-libraries-go.md)|[Here](https://github.com/apache/pulsar-client-go/blob/master/CHANGELOG) |[Here](https://github.com/apache/pulsar-client-go) 
-Node.js|[User doc](client-libraries-node.md)|[Here](https://github.com/apache/pulsar-client-node/releases) |[Here](https://github.com/apache/pulsar-client-node) 
-C# |[User doc](client-libraries-dotnet.md)| [Here](https://github.com/apache/pulsar-dotpulsar/blob/master/CHANGELOG)|[Here](https://github.com/apache/pulsar-dotpulsar) 
+| Language  | Documentation                                                                            | Release note                                                             | Code repo                                                             |
+|-----------|------------------------------------------------------------------------------------------|--------------------------------------------------------------------------|-----------------------------------------------------------------------|
+| Java      | - [User doc](client-libraries-java.md) <br /><br />- [API doc](/api/client/)             | [Here](/release-notes/)                                                  | [Here](https://github.com/apache/pulsar/tree/master/pulsar-client)    |
+| C++       | - [User doc](client-libraries-cpp.md) <br /><br />- [API doc](@pulsar:apidoc:cpp@)       | [Here](/release-notes/)                                                  | [Here](https://github.com/apache/pulsar-client-cpp)                   |
+| Python    | - [User doc](client-libraries-python.md) <br /><br />- [API doc](@pulsar:apidoc:python@) | [Here](/release-notes/)                                                  | [Here](https://github.com/apache/pulsar-client-python)                |
+| WebSocket | [User doc](client-libraries-websocket.md)                                                | [Here](/release-notes/)                                                  | [Here](https://github.com/apache/pulsar/tree/master/pulsar-websocket) |
+| Go client | [User doc](client-libraries-go.md)                                                       | [Here](https://github.com/apache/pulsar-client-go/blob/master/CHANGELOG) | [Here](https://github.com/apache/pulsar-client-go)                    |
+| Node.js   | [User doc](client-libraries-node.md)                                                     | [Here](https://github.com/apache/pulsar-client-node/releases)            | [Here](https://github.com/apache/pulsar-client-node)                  |
+| C#        | [User doc](client-libraries-dotnet.md)                                                   | [Here](https://github.com/apache/pulsar-dotpulsar/blob/master/CHANGELOG) | [Here](https://github.com/apache/pulsar-dotpulsar)                    |
 
 :::note
 

--- a/site2/website/versioned_docs/version-2.2.0/client-libraries-python.md
+++ b/site2/website/versioned_docs/version-2.2.0/client-libraries-python.md
@@ -5,7 +5,7 @@ sidebar_label: "Python"
 original_id: client-libraries-python
 ---
 
-The Pulsar Python client library is a wrapper over the existing [C++ client library](client-libraries-cpp.md) and exposes all of the [same features](/api/cpp). You can find the code in the [`python` GitHub Repository](https://github.com/apache/pulsar-client-python) of the C++ client code.
+The Pulsar Python client library is a wrapper over the existing [C++ client library](client-libraries-cpp.md) and exposes all of the [same features](@pulsar:apidoc:cpp@). You can find the code in the [`python` GitHub Repository](https://github.com/apache/pulsar-client-python) of the C++ client code.
 
 ## Installation
 
@@ -44,7 +44,7 @@ $ sudo python setup.py install
 
 ## API Reference
 
-The complete Python API reference is available at [api/python](/api/python).
+The complete Python API reference is available at [api/python](@pulsar:apidoc:python@).
 
 ## Examples
 

--- a/site2/website/versioned_docs/version-2.2.0/client-libraries.md
+++ b/site2/website/versioned_docs/version-2.2.0/client-libraries.md
@@ -32,13 +32,13 @@ For a tutorial on using the Pulsar Go client, see [The Pulsar Go client](client-
 
 For a tutorial on using the Pulsar Python client, see [The Pulsar Python client](client-libraries-python.md).
 
-There are also [pdoc](https://github.com/BurntSushi/pdoc)-generated API docs for the Python client [here](/api/python).
+There are also [pdoc](https://github.com/BurntSushi/pdoc)-generated API docs for the Python client [here](@pulsar:apidoc:python@).
 
 ## C++ client
 
 For a tutorial on using the Pulsar C++ clent, see [The Pulsar C++ client](client-libraries-cpp.md).
 
-There are also [Doxygen](http://www.stack.nl/~dimitri/doxygen/)-generated API docs for the C++ client [here](/api/cpp).
+There are also [Doxygen](http://www.stack.nl/~dimitri/doxygen/)-generated API docs for the C++ client [here](@pulsar:apidoc:cpp@).
 
 ## Feature Matrix
 

--- a/site2/website/versioned_docs/version-2.2.0/functions-api.md
+++ b/site2/website/versioned_docs/version-2.2.0/functions-api.md
@@ -600,7 +600,7 @@ There is one example Python native function in this {@inject: github:folder:/pul
 
 ### Python SDK functions
 
-To get started developing Pulsar Functions using the Python SDK, you'll need to install the [`pulsar-client`](/api/python) library using the instructions [above](#getting-started).
+To get started developing Pulsar Functions using the Python SDK, you'll need to install the [`pulsar-client`](@pulsar:apidoc:python@) library using the instructions [above](#getting-started).
 
 #### Python SDK examples
 

--- a/site2/website/versioned_docs/version-2.2.1/client-libraries-cpp.md
+++ b/site2/website/versioned_docs/version-2.2.1/client-libraries-cpp.md
@@ -12,7 +12,7 @@ All the methods in producer, consumer, and reader of a C++ client are thread-saf
 
 Pulsar C++ client is supported on **Linux** ,**MacOS** and **Windows** platforms.
 
-[Doxygen](http://www.doxygen.nl/)-generated API docs for the C++ client are available [here](/api/cpp).
+[Doxygen](http://www.doxygen.nl/)-generated API docs for the C++ client are available [here](@pulsar:apidoc:cpp@).
 
 
 ## Linux

--- a/site2/website/versioned_docs/version-2.2.1/client-libraries-python.md
+++ b/site2/website/versioned_docs/version-2.2.1/client-libraries-python.md
@@ -10,11 +10,11 @@ import TabItem from '@theme/TabItem';
 ````
 
 
-Pulsar Python client library is a wrapper over the existing [C++ client library](client-libraries-cpp.md) and exposes all of the [same features](/api/cpp). You can find the code in the [Python directory](https://github.com/apache/pulsar-client-python) of the C++ client code.
+Pulsar Python client library is a wrapper over the existing [C++ client library](client-libraries-cpp.md) and exposes all of the [same features](@pulsar:apidoc:cpp@). You can find the code in the [Python directory](https://github.com/apache/pulsar-client-python) of the C++ client code.
 
 All the methods in producer, consumer, and reader of a Python client are thread-safe.
 
-[pdoc](https://github.com/BurntSushi/pdoc)-generated API docs for the Python client are available [here](/api/python).
+[pdoc](https://github.com/BurntSushi/pdoc)-generated API docs for the Python client are available [here](@pulsar:apidoc:python@).
 
 ## Install
 
@@ -70,7 +70,7 @@ $ sudo python setup.py install
 
 ## API Reference
 
-The complete Python API reference is available at [api/python](/api/python).
+The complete Python API reference is available at [api/python](@pulsar:apidoc:python@).
 
 ## Examples
 

--- a/site2/website/versioned_docs/version-2.2.1/client-libraries.md
+++ b/site2/website/versioned_docs/version-2.2.1/client-libraries.md
@@ -9,8 +9,8 @@ Pulsar supports the following client libraries:
 |Language|Documentation|Release note|Code repo
 |---|---|---|---
 Java |- [User doc](client-libraries-java.md) <br /><br />- [API doc](https://pulsar.apache.org/api/client/)|[Here](https://pulsar.apache.org/release-notes/)|[Here](https://github.com/apache/pulsar/tree/master/pulsar-client) 
-C++ | - [User doc](client-libraries-cpp.md) <br /><br />- [API doc](https://pulsar.apache.org/api/cpp/)|[Here](https://pulsar.apache.org/release-notes/)|[Here](https://github.com/apache/pulsar-client-cpp) 
-Python | - [User doc](client-libraries-python.md) <br /><br />- [API doc](https://pulsar.apache.org/api/python/)|[Here](https://pulsar.apache.org/release-notes/)|[Here](https://github.com/apache/pulsar-client-python) 
+C++ | - [User doc](client-libraries-cpp.md) <br /><br />- [API doc](@pulsar:apidoc:cpp@)|[Here](https://pulsar.apache.org/release-notes/)|[Here](https://github.com/apache/pulsar-client-cpp) 
+Python | - [User doc](client-libraries-python.md) <br /><br />- [API doc](@pulsar:apidoc:python@)|[Here](https://pulsar.apache.org/release-notes/)|[Here](https://github.com/apache/pulsar-client-python) 
 WebSocket| [User doc](client-libraries-websocket.md) | [Here](https://pulsar.apache.org/release-notes/)|[Here](https://github.com/apache/pulsar/tree/master/pulsar-websocket) 
 Go client|[User doc](client-libraries-go.md)|[Here](https://github.com/apache/pulsar-client-go/blob/master/CHANGELOG) |[Here](https://github.com/apache/pulsar-client-go) 
 Node.js|[User doc](client-libraries-node.md)|[Here](https://github.com/apache/pulsar-client-node/releases) |[Here](https://github.com/apache/pulsar-client-node) 

--- a/site2/website/versioned_docs/version-2.3.0/client-libraries-python.md
+++ b/site2/website/versioned_docs/version-2.3.0/client-libraries-python.md
@@ -5,7 +5,7 @@ sidebar_label: "Python"
 original_id: client-libraries-python
 ---
 
-The Pulsar Python client library is a wrapper over the existing [C++ client library](client-libraries-cpp.md) and exposes all of the [same features](/api/cpp). You can find the code in the [`python` GitHub Repository](https://github.com/apache/pulsar-client-python) of the C++ client code.
+The Pulsar Python client library is a wrapper over the existing [C++ client library](client-libraries-cpp.md) and exposes all of the [same features](@pulsar:apidoc:cpp@). You can find the code in the [`python` GitHub Repository](https://github.com/apache/pulsar-client-python) of the C++ client code.
 
 ## Installation
 
@@ -44,7 +44,7 @@ $ sudo python setup.py install
 
 ## API Reference
 
-The complete Python API reference is available at [api/python](/api/python).
+The complete Python API reference is available at [api/python](@pulsar:apidoc:python@).
 
 ## Examples
 

--- a/site2/website/versioned_docs/version-2.3.0/client-libraries.md
+++ b/site2/website/versioned_docs/version-2.3.0/client-libraries.md
@@ -9,8 +9,8 @@ Pulsar supports the following client libraries:
 |Language|Documentation|Release note|Code repo
 |---|---|---|---
 Java |- [User doc](client-libraries-java.md) <br /><br />- [API doc](https://pulsar.apache.org/api/client/)|[Here](https://pulsar.apache.org/release-notes/)|[Here](https://github.com/apache/pulsar/tree/master/pulsar-client) 
-C++ | - [User doc](client-libraries-cpp.md) <br /><br />- [API doc](https://pulsar.apache.org/api/cpp/)|[Here](https://pulsar.apache.org/release-notes/)|[Here](https://github.com/apache/pulsar-client-cpp) 
-Python | - [User doc](client-libraries-python.md) <br /><br />- [API doc](https://pulsar.apache.org/api/python/)|[Here](https://pulsar.apache.org/release-notes/)|[Here](https://github.com/apache/pulsar-client-python) 
+C++ | - [User doc](client-libraries-cpp.md) <br /><br />- [API doc](@pulsar:apidoc:cpp@)|[Here](https://pulsar.apache.org/release-notes/)|[Here](https://github.com/apache/pulsar-client-cpp) 
+Python | - [User doc](client-libraries-python.md) <br /><br />- [API doc](@pulsar:apidoc:python@)|[Here](https://pulsar.apache.org/release-notes/)|[Here](https://github.com/apache/pulsar-client-python) 
 WebSocket| [User doc](client-libraries-websocket.md) | [Here](https://pulsar.apache.org/release-notes/)|[Here](https://github.com/apache/pulsar/tree/master/pulsar-websocket) 
 Go client|[User doc](client-libraries-go.md)|[Here](https://github.com/apache/pulsar-client-go/blob/master/CHANGELOG) |[Here](https://github.com/apache/pulsar-client-go) 
 Node.js|[User doc](client-libraries-node.md)|[Here](https://github.com/apache/pulsar-client-node/releases) |[Here](https://github.com/apache/pulsar-client-node) 

--- a/site2/website/versioned_docs/version-2.3.1/client-libraries-python.md
+++ b/site2/website/versioned_docs/version-2.3.1/client-libraries-python.md
@@ -5,7 +5,7 @@ sidebar_label: "Python"
 original_id: client-libraries-python
 ---
 
-The Pulsar Python client library is a wrapper over the existing [C++ client library](client-libraries-cpp.md) and exposes all of the [same features](/api/cpp). You can find the code in the [`python` GitHub Repository](https://github.com/apache/pulsar-client-python) of the C++ client code.
+The Pulsar Python client library is a wrapper over the existing [C++ client library](client-libraries-cpp.md) and exposes all of the [same features](@pulsar:apidoc:cpp@). You can find the code in the [`python` GitHub Repository](https://github.com/apache/pulsar-client-python) of the C++ client code.
 
 ## Installation
 
@@ -44,7 +44,7 @@ $ sudo python setup.py install
 
 ## API Reference
 
-The complete Python API reference is available at [api/python](/api/python).
+The complete Python API reference is available at [api/python](@pulsar:apidoc:python@).
 
 ## Examples
 

--- a/site2/website/versioned_docs/version-2.3.1/client-libraries.md
+++ b/site2/website/versioned_docs/version-2.3.1/client-libraries.md
@@ -9,8 +9,8 @@ Pulsar supports the following client libraries:
 |Language|Documentation|Release note|Code repo
 |---|---|---|---
 Java |- [User doc](client-libraries-java.md) <br /><br />- [API doc](https://pulsar.apache.org/api/client/)|[Here](https://pulsar.apache.org/release-notes/)|[Here](https://github.com/apache/pulsar/tree/master/pulsar-client) 
-C++ | - [User doc](client-libraries-cpp.md) <br /><br />- [API doc](https://pulsar.apache.org/api/cpp/)|[Here](https://pulsar.apache.org/release-notes/)|[Here](https://github.com/apache/pulsar-client-cpp) 
-Python | - [User doc](client-libraries-python.md) <br /><br />- [API doc](https://pulsar.apache.org/api/python/)|[Here](https://pulsar.apache.org/release-notes/)|[Here](https://github.com/apache/pulsar-client-python) 
+C++ | - [User doc](client-libraries-cpp.md) <br /><br />- [API doc](@pulsar:apidoc:cpp@)|[Here](https://pulsar.apache.org/release-notes/)|[Here](https://github.com/apache/pulsar-client-cpp) 
+Python | - [User doc](client-libraries-python.md) <br /><br />- [API doc](@pulsar:apidoc:python@)|[Here](https://pulsar.apache.org/release-notes/)|[Here](https://github.com/apache/pulsar-client-python) 
 WebSocket| [User doc](client-libraries-websocket.md) | [Here](https://pulsar.apache.org/release-notes/)|[Here](https://github.com/apache/pulsar/tree/master/pulsar-websocket) 
 Go client|[User doc](client-libraries-go.md)|[Here](https://github.com/apache/pulsar-client-go/blob/master/CHANGELOG) |[Here](https://github.com/apache/pulsar-client-go) 
 Node.js|[User doc](client-libraries-node.md)|[Here](https://github.com/apache/pulsar-client-node/releases) |[Here](https://github.com/apache/pulsar-client-node) 

--- a/site2/website/versioned_docs/version-2.3.2/client-libraries-cpp.md
+++ b/site2/website/versioned_docs/version-2.3.2/client-libraries-cpp.md
@@ -12,7 +12,7 @@ All the methods in producer, consumer, and reader of a C++ client are thread-saf
 
 Pulsar C++ client is supported on **Linux** ,**MacOS** and **Windows** platforms.
 
-[Doxygen](http://www.doxygen.nl/)-generated API docs for the C++ client are available [here](/api/cpp).
+[Doxygen](http://www.doxygen.nl/)-generated API docs for the C++ client are available [here](@pulsar:apidoc:cpp@).
 
 
 ## Linux

--- a/site2/website/versioned_docs/version-2.3.2/client-libraries-python.md
+++ b/site2/website/versioned_docs/version-2.3.2/client-libraries-python.md
@@ -10,11 +10,11 @@ import TabItem from '@theme/TabItem';
 ````
 
 
-Pulsar Python client library is a wrapper over the existing [C++ client library](client-libraries-cpp.md) and exposes all of the [same features](/api/cpp). You can find the code in the [Python directory](https://github.com/apache/pulsar-client-python) of the C++ client code.
+Pulsar Python client library is a wrapper over the existing [C++ client library](client-libraries-cpp.md) and exposes all of the [same features](@pulsar:apidoc:cpp@). You can find the code in the [Python directory](https://github.com/apache/pulsar-client-python) of the C++ client code.
 
 All the methods in producer, consumer, and reader of a Python client are thread-safe.
 
-[pdoc](https://github.com/BurntSushi/pdoc)-generated API docs for the Python client are available [here](/api/python).
+[pdoc](https://github.com/BurntSushi/pdoc)-generated API docs for the Python client are available [here](@pulsar:apidoc:python@).
 
 ## Install
 
@@ -70,7 +70,7 @@ $ sudo python setup.py install
 
 ## API Reference
 
-The complete Python API reference is available at [api/python](/api/python).
+The complete Python API reference is available at [api/python](@pulsar:apidoc:python@).
 
 ## Examples
 

--- a/site2/website/versioned_docs/version-2.3.2/client-libraries.md
+++ b/site2/website/versioned_docs/version-2.3.2/client-libraries.md
@@ -33,13 +33,13 @@ For a tutorial on using the Pulsar Go client, see [Pulsar Go client](client-libr
 
 For a tutorial on using the Pulsar Python client, see [Pulsar Python client](client-libraries-python.md).
 
-There are also [pdoc](https://github.com/BurntSushi/pdoc)-generated API docs for the Python client [here](/api/python).
+There are also [pdoc](https://github.com/BurntSushi/pdoc)-generated API docs for the Python client [here](@pulsar:apidoc:python@).
 
 ## C++ client
 
 For a tutorial on using the Pulsar C++ clent, see [Pulsar C++ client](client-libraries-cpp.md).
 
-There are also [Doxygen](http://www.stack.nl/~dimitri/doxygen/)-generated API docs for the C++ client [here](/api/cpp).
+There are also [Doxygen](http://www.stack.nl/~dimitri/doxygen/)-generated API docs for the C++ client [here](@pulsar:apidoc:cpp@).
 
 ## Feature Matrix
 Pulsar client feature matrix for different languages is listed on [Client Features Matrix](https://github.com/apache/pulsar/wiki/Client-Features-Matrix) page.

--- a/site2/website/versioned_docs/version-2.4.0/client-libraries-cpp.md
+++ b/site2/website/versioned_docs/version-2.4.0/client-libraries-cpp.md
@@ -12,7 +12,7 @@ All the methods in producer, consumer, and reader of a C++ client are thread-saf
 
 Pulsar C++ client is supported on **Linux** ,**MacOS** and **Windows** platforms.
 
-[Doxygen](http://www.doxygen.nl/)-generated API docs for the C++ client are available [here](/api/cpp).
+[Doxygen](http://www.doxygen.nl/)-generated API docs for the C++ client are available [here](@pulsar:apidoc:cpp@).
 
 
 ## Linux

--- a/site2/website/versioned_docs/version-2.4.0/client-libraries-python.md
+++ b/site2/website/versioned_docs/version-2.4.0/client-libraries-python.md
@@ -5,7 +5,7 @@ sidebar_label: "Python"
 original_id: client-libraries-python
 ---
 
-The Pulsar Python client library is a wrapper over the existing [C++ client library](client-libraries-cpp.md) and exposes all of the [same features](/api/cpp). You can find the code in the [`python` GitHub Repository](https://github.com/apache/pulsar-client-python) of the C++ client code.
+The Pulsar Python client library is a wrapper over the existing [C++ client library](client-libraries-cpp.md) and exposes all of the [same features](@pulsar:apidoc:cpp@). You can find the code in the [`python` GitHub Repository](https://github.com/apache/pulsar-client-python) of the C++ client code.
 
 ## Installation
 
@@ -44,7 +44,7 @@ $ sudo python setup.py install
 
 ## API Reference
 
-The complete Python API reference is available at [api/python](/api/python).
+The complete Python API reference is available at [api/python](@pulsar:apidoc:python@).
 
 ## Examples
 

--- a/site2/website/versioned_docs/version-2.4.0/client-libraries.md
+++ b/site2/website/versioned_docs/version-2.4.0/client-libraries.md
@@ -9,8 +9,8 @@ Pulsar supports the following client libraries:
 |Language|Documentation|Release note|Code repo
 |---|---|---|---
 Java |- [User doc](client-libraries-java.md) <br /><br />- [API doc](https://pulsar.apache.org/api/client/)|[Here](https://pulsar.apache.org/release-notes/)|[Here](https://github.com/apache/pulsar/tree/master/pulsar-client) 
-C++ | - [User doc](client-libraries-cpp.md) <br /><br />- [API doc](https://pulsar.apache.org/api/cpp/)|[Here](https://pulsar.apache.org/release-notes/)|[Here](https://github.com/apache/pulsar-client-cpp) 
-Python | - [User doc](client-libraries-python.md) <br /><br />- [API doc](https://pulsar.apache.org/api/python/)|[Here](https://pulsar.apache.org/release-notes/)|[Here](https://github.com/apache/pulsar-client-python) 
+C++ | - [User doc](client-libraries-cpp.md) <br /><br />- [API doc](@pulsar:apidoc:cpp@)|[Here](https://pulsar.apache.org/release-notes/)|[Here](https://github.com/apache/pulsar-client-cpp) 
+Python | - [User doc](client-libraries-python.md) <br /><br />- [API doc](@pulsar:apidoc:python@)|[Here](https://pulsar.apache.org/release-notes/)|[Here](https://github.com/apache/pulsar-client-python) 
 WebSocket| [User doc](client-libraries-websocket.md) | [Here](https://pulsar.apache.org/release-notes/)|[Here](https://github.com/apache/pulsar/tree/master/pulsar-websocket) 
 Go client|[User doc](client-libraries-go.md)|[Here](https://github.com/apache/pulsar-client-go/blob/master/CHANGELOG) |[Here](https://github.com/apache/pulsar-client-go) 
 Node.js|[User doc](client-libraries-node.md)|[Here](https://github.com/apache/pulsar-client-node/releases) |[Here](https://github.com/apache/pulsar-client-node) 

--- a/site2/website/versioned_docs/version-2.4.0/functions-api.md
+++ b/site2/website/versioned_docs/version-2.4.0/functions-api.md
@@ -607,7 +607,7 @@ There is one example Python native function in this {@inject: github:folder:/pul
 
 ### Python SDK functions
 
-To get started developing Pulsar Functions using the Python SDK, you'll need to install the [`pulsar-client`](/api/python) library using the instructions [above](#getting-started).
+To get started developing Pulsar Functions using the Python SDK, you'll need to install the [`pulsar-client`](@pulsar:apidoc:python@) library using the instructions [above](#getting-started).
 
 #### Python SDK examples
 

--- a/site2/website/versioned_docs/version-2.4.1/client-libraries-cpp.md
+++ b/site2/website/versioned_docs/version-2.4.1/client-libraries-cpp.md
@@ -12,7 +12,7 @@ All the methods in producer, consumer, and reader of a C++ client are thread-saf
 
 Pulsar C++ client is supported on **Linux** ,**MacOS** and **Windows** platforms.
 
-[Doxygen](http://www.doxygen.nl/)-generated API docs for the C++ client are available [here](/api/cpp).
+[Doxygen](http://www.doxygen.nl/)-generated API docs for the C++ client are available [here](@pulsar:apidoc:cpp@).
 
 
 ## Linux

--- a/site2/website/versioned_docs/version-2.4.1/client-libraries-python.md
+++ b/site2/website/versioned_docs/version-2.4.1/client-libraries-python.md
@@ -5,7 +5,7 @@ sidebar_label: "Python"
 original_id: client-libraries-python
 ---
 
-The Pulsar Python client library is a wrapper over the existing [C++ client library](client-libraries-cpp.md) and exposes all of the [same features](/api/cpp). You can find the code in the [`python` GitHub Repository](https://github.com/apache/pulsar-client-python) of the C++ client code.
+The Pulsar Python client library is a wrapper over the existing [C++ client library](client-libraries-cpp.md) and exposes all of the [same features](@pulsar:apidoc:cpp@). You can find the code in the [`python` GitHub Repository](https://github.com/apache/pulsar-client-python) of the C++ client code.
 
 ## Installation
 
@@ -44,7 +44,7 @@ $ sudo python setup.py install
 
 ## API Reference
 
-The complete Python API reference is available at [api/python](/api/python).
+The complete Python API reference is available at [api/python](@pulsar:apidoc:python@).
 
 ## Examples
 

--- a/site2/website/versioned_docs/version-2.4.1/client-libraries.md
+++ b/site2/website/versioned_docs/version-2.4.1/client-libraries.md
@@ -9,8 +9,8 @@ Pulsar supports the following client libraries:
 |Language|Documentation|Release note|Code repo
 |---|---|---|---
 Java |- [User doc](client-libraries-java.md) <br /><br />- [API doc](https://pulsar.apache.org/api/client/)|[Here](https://pulsar.apache.org/release-notes/)|[Here](https://github.com/apache/pulsar/tree/master/pulsar-client) 
-C++ | - [User doc](client-libraries-cpp.md) <br /><br />- [API doc](https://pulsar.apache.org/api/cpp/)|[Here](https://pulsar.apache.org/release-notes/)|[Here](https://github.com/apache/pulsar-client-cpp) 
-Python | - [User doc](client-libraries-python.md) <br /><br />- [API doc](https://pulsar.apache.org/api/python/)|[Here](https://pulsar.apache.org/release-notes/)|[Here](https://github.com/apache/pulsar-client-python) 
+C++ | - [User doc](client-libraries-cpp.md) <br /><br />- [API doc](@pulsar:apidoc:cpp@)|[Here](https://pulsar.apache.org/release-notes/)|[Here](https://github.com/apache/pulsar-client-cpp) 
+Python | - [User doc](client-libraries-python.md) <br /><br />- [API doc](@pulsar:apidoc:python@)|[Here](https://pulsar.apache.org/release-notes/)|[Here](https://github.com/apache/pulsar-client-python) 
 WebSocket| [User doc](client-libraries-websocket.md) | [Here](https://pulsar.apache.org/release-notes/)|[Here](https://github.com/apache/pulsar/tree/master/pulsar-websocket) 
 Go client|[User doc](client-libraries-go.md)|[Here](https://github.com/apache/pulsar-client-go/blob/master/CHANGELOG) |[Here](https://github.com/apache/pulsar-client-go) 
 Node.js|[User doc](client-libraries-node.md)|[Here](https://github.com/apache/pulsar-client-node/releases) |[Here](https://github.com/apache/pulsar-client-node) 

--- a/site2/website/versioned_docs/version-2.4.2/client-libraries-cpp.md
+++ b/site2/website/versioned_docs/version-2.4.2/client-libraries-cpp.md
@@ -12,7 +12,7 @@ All the methods in producer, consumer, and reader of a C++ client are thread-saf
 
 Pulsar C++ client is supported on **Linux** ,**MacOS** and **Windows** platforms.
 
-[Doxygen](http://www.doxygen.nl/)-generated API docs for the C++ client are available [here](/api/cpp).
+[Doxygen](http://www.doxygen.nl/)-generated API docs for the C++ client are available [here](@pulsar:apidoc:cpp@).
 
 
 ## Linux

--- a/site2/website/versioned_docs/version-2.4.2/client-libraries-python.md
+++ b/site2/website/versioned_docs/version-2.4.2/client-libraries-python.md
@@ -5,7 +5,7 @@ sidebar_label: "Python"
 original_id: client-libraries-python
 ---
 
-The Pulsar Python client library is a wrapper over the existing [C++ client library](client-libraries-cpp.md) and exposes all of the [same features](/api/cpp). You can find the code in the [`python` GitHub Repository](https://github.com/apache/pulsar-client-python) of the C++ client code.
+The Pulsar Python client library is a wrapper over the existing [C++ client library](client-libraries-cpp.md) and exposes all of the [same features](@pulsar:apidoc:cpp@). You can find the code in the [`python` GitHub Repository](https://github.com/apache/pulsar-client-python) of the C++ client code.
 
 ## Installation
 
@@ -44,7 +44,7 @@ $ sudo python setup.py install
 
 ## API Reference
 
-The complete Python API reference is available at [api/python](/api/python).
+The complete Python API reference is available at [api/python](@pulsar:apidoc:python@).
 
 ## Examples
 

--- a/site2/website/versioned_docs/version-2.4.2/client-libraries.md
+++ b/site2/website/versioned_docs/version-2.4.2/client-libraries.md
@@ -9,8 +9,8 @@ Pulsar supports the following client libraries:
 |Language|Documentation|Release note|Code repo
 |---|---|---|---
 Java |- [User doc](client-libraries-java.md) <br /><br />- [API doc](https://pulsar.apache.org/api/client/)|[Here](https://pulsar.apache.org/release-notes/)|[Here](https://github.com/apache/pulsar/tree/master/pulsar-client) 
-C++ | - [User doc](client-libraries-cpp.md) <br /><br />- [API doc](https://pulsar.apache.org/api/cpp/)|[Here](https://pulsar.apache.org/release-notes/)|[Here](https://github.com/apache/pulsar-client-cpp) 
-Python | - [User doc](client-libraries-python.md) <br /><br />- [API doc](https://pulsar.apache.org/api/python/)|[Here](https://pulsar.apache.org/release-notes/)|[Here](https://github.com/apache/pulsar-client-python) 
+C++ | - [User doc](client-libraries-cpp.md) <br /><br />- [API doc](@pulsar:apidoc:cpp@)|[Here](https://pulsar.apache.org/release-notes/)|[Here](https://github.com/apache/pulsar-client-cpp) 
+Python | - [User doc](client-libraries-python.md) <br /><br />- [API doc](@pulsar:apidoc:python@)|[Here](https://pulsar.apache.org/release-notes/)|[Here](https://github.com/apache/pulsar-client-python) 
 WebSocket| [User doc](client-libraries-websocket.md) | [Here](https://pulsar.apache.org/release-notes/)|[Here](https://github.com/apache/pulsar/tree/master/pulsar-websocket) 
 Go client|[User doc](client-libraries-go.md)|[Here](https://github.com/apache/pulsar-client-go/blob/master/CHANGELOG) |[Here](https://github.com/apache/pulsar-client-go) 
 Node.js|[User doc](client-libraries-node.md)|[Here](https://github.com/apache/pulsar-client-node/releases) |[Here](https://github.com/apache/pulsar-client-node) 

--- a/site2/website/versioned_docs/version-2.5.0/client-libraries-python.md
+++ b/site2/website/versioned_docs/version-2.5.0/client-libraries-python.md
@@ -5,7 +5,7 @@ sidebar_label: "Python"
 original_id: client-libraries-python
 ---
 
-The Pulsar Python client library is a wrapper over the existing [C++ client library](client-libraries-cpp.md) and exposes all of the [same features](/api/cpp). You can find the code in the [`python` GitHub Repository](https://github.com/apache/pulsar-client-python) of the C++ client code.
+The Pulsar Python client library is a wrapper over the existing [C++ client library](client-libraries-cpp.md) and exposes all of the [same features](@pulsar:apidoc:cpp@). You can find the code in the [`python` GitHub Repository](https://github.com/apache/pulsar-client-python) of the C++ client code.
 
 ## Installation
 
@@ -44,7 +44,7 @@ $ sudo python setup.py install
 
 ## API Reference
 
-The complete Python API reference is available at [api/python](/api/python).
+The complete Python API reference is available at [api/python](@pulsar:apidoc:python@).
 
 ## Examples
 

--- a/site2/website/versioned_docs/version-2.5.0/client-libraries.md
+++ b/site2/website/versioned_docs/version-2.5.0/client-libraries.md
@@ -33,13 +33,13 @@ For a tutorial on using the Pulsar Go client, see [Pulsar Go client](client-libr
 
 For a tutorial on using the Pulsar Python client, see [Pulsar Python client](client-libraries-python.md).
 
-There are also [pdoc](https://github.com/BurntSushi/pdoc)-generated API docs for the Python client [here](/api/python).
+There are also [pdoc](https://github.com/BurntSushi/pdoc)-generated API docs for the Python client [here](@pulsar:apidoc:python@).
 
 ## C++ client
 
 For a tutorial on using the Pulsar C++ clent, see [Pulsar C++ client](client-libraries-cpp.md).
 
-There are also [Doxygen](http://www.doxygen.nl/)-generated API docs for the C++ client [here](/api/cpp).
+There are also [Doxygen](http://www.doxygen.nl/)-generated API docs for the C++ client [here](@pulsar:apidoc:cpp@).
 
 ## Feature Matrix
 Pulsar client feature matrix for different languages is listed on [Client Features Matrix](https://github.com/apache/pulsar/wiki/Client-Features-Matrix) page.

--- a/site2/website/versioned_docs/version-2.5.1/client-libraries-cpp.md
+++ b/site2/website/versioned_docs/version-2.5.1/client-libraries-cpp.md
@@ -13,7 +13,7 @@ All the methods in producer, consumer, and reader of a C++ client are thread-saf
 
 Pulsar C++ client is supported on **Linux** and **MacOS** platforms.
 
-[Doxygen](http://www.doxygen.nl/)-generated API docs for the C++ client are available [here](/api/cpp).
+[Doxygen](http://www.doxygen.nl/)-generated API docs for the C++ client are available [here](@pulsar:apidoc:cpp@).
 
 ## Linux
 

--- a/site2/website/versioned_docs/version-2.5.1/client-libraries-python.md
+++ b/site2/website/versioned_docs/version-2.5.1/client-libraries-python.md
@@ -5,11 +5,11 @@ sidebar_label: "Python"
 original_id: client-libraries-python
 ---
 
-Pulsar Python client library is a wrapper over the existing [C++ client library](client-libraries-cpp.md) and exposes all of the [same features](/api/cpp). You can find the code in the [`python` GitHub Repository](https://github.com/apache/pulsar-client-python) of the C++ client code.
+Pulsar Python client library is a wrapper over the existing [C++ client library](client-libraries-cpp.md) and exposes all of the [same features](@pulsar:apidoc:cpp@). You can find the code in the [`python` GitHub Repository](https://github.com/apache/pulsar-client-python) of the C++ client code.
 
 All the methods in producer, consumer, and reader of a Python client are thread-safe.
 
-[pdoc](https://github.com/BurntSushi/pdoc)-generated API docs for the Python client are available [here](/api/python).
+[pdoc](https://github.com/BurntSushi/pdoc)-generated API docs for the Python client are available [here](@pulsar:apidoc:python@).
 
 ## Install
 
@@ -48,7 +48,7 @@ $ sudo python setup.py install
 
 ## API Reference
 
-The complete Python API reference is available at [api/python](/api/python).
+The complete Python API reference is available at [api/python](@pulsar:apidoc:python@).
 
 ## Examples
 

--- a/site2/website/versioned_docs/version-2.5.2/client-libraries-cpp.md
+++ b/site2/website/versioned_docs/version-2.5.2/client-libraries-cpp.md
@@ -13,7 +13,7 @@ All the methods in producer, consumer, and reader of a C++ client are thread-saf
 
 Pulsar C++ client is supported on **Linux** and **MacOS** platforms.
 
-[Doxygen](http://www.doxygen.nl/)-generated API docs for the C++ client are available [here](/api/cpp).
+[Doxygen](http://www.doxygen.nl/)-generated API docs for the C++ client are available [here](@pulsar:apidoc:cpp@).
 
 ## Linux
 

--- a/site2/website/versioned_docs/version-2.5.2/client-libraries-python.md
+++ b/site2/website/versioned_docs/version-2.5.2/client-libraries-python.md
@@ -5,11 +5,11 @@ sidebar_label: "Python"
 original_id: client-libraries-python
 ---
 
-Pulsar Python client library is a wrapper over the existing [C++ client library](client-libraries-cpp.md) and exposes all of the [same features](/api/cpp). You can find the code in the [`python` GitHub Repository](https://github.com/apache/pulsar-client-python) of the C++ client code.
+Pulsar Python client library is a wrapper over the existing [C++ client library](client-libraries-cpp.md) and exposes all of the [same features](@pulsar:apidoc:cpp@). You can find the code in the [`python` GitHub Repository](https://github.com/apache/pulsar-client-python) of the C++ client code.
 
 All the methods in producer, consumer, and reader of a Python client are thread-safe.
 
-[pdoc](https://github.com/BurntSushi/pdoc)-generated API docs for the Python client are available [here](/api/python).
+[pdoc](https://github.com/BurntSushi/pdoc)-generated API docs for the Python client are available [here](@pulsar:apidoc:python@).
 
 ## Install
 
@@ -48,7 +48,7 @@ $ sudo python setup.py install
 
 ## API Reference
 
-The complete Python API reference is available at [api/python](/api/python).
+The complete Python API reference is available at [api/python](@pulsar:apidoc:python@).
 
 ## Examples
 

--- a/site2/website/versioned_docs/version-2.6.0/client-libraries-cpp.md
+++ b/site2/website/versioned_docs/version-2.6.0/client-libraries-cpp.md
@@ -13,7 +13,7 @@ All the methods in producer, consumer, and reader of a C++ client are thread-saf
 
 Pulsar C++ client is supported on **Linux** and **MacOS** platforms.
 
-[Doxygen](http://www.doxygen.nl/)-generated API docs for the C++ client are available [here](/api/cpp).
+[Doxygen](http://www.doxygen.nl/)-generated API docs for the C++ client are available [here](@pulsar:apidoc:cpp@).
 
 ## Linux
 

--- a/site2/website/versioned_docs/version-2.6.0/client-libraries-python.md
+++ b/site2/website/versioned_docs/version-2.6.0/client-libraries-python.md
@@ -5,11 +5,11 @@ sidebar_label: "Python"
 original_id: client-libraries-python
 ---
 
-Pulsar Python client library is a wrapper over the existing [C++ client library](client-libraries-cpp.md) and exposes all of the [same features](/api/cpp). You can find the code in the [`python` GitHub Repository](https://github.com/apache/pulsar-client-python) of the C++ client code.
+Pulsar Python client library is a wrapper over the existing [C++ client library](client-libraries-cpp.md) and exposes all of the [same features](@pulsar:apidoc:cpp@). You can find the code in the [`python` GitHub Repository](https://github.com/apache/pulsar-client-python) of the C++ client code.
 
 All the methods in producer, consumer, and reader of a Python client are thread-safe.
 
-[pdoc](https://github.com/BurntSushi/pdoc)-generated API docs for the Python client are available [here](/api/python).
+[pdoc](https://github.com/BurntSushi/pdoc)-generated API docs for the Python client are available [here](@pulsar:apidoc:python@).
 
 ## Install
 
@@ -48,7 +48,7 @@ $ sudo python setup.py install
 
 ## API Reference
 
-The complete Python API reference is available at [api/python](/api/python).
+The complete Python API reference is available at [api/python](@pulsar:apidoc:python@).
 
 ## Examples
 

--- a/site2/website/versioned_docs/version-2.6.1/client-libraries-cpp.md
+++ b/site2/website/versioned_docs/version-2.6.1/client-libraries-cpp.md
@@ -13,7 +13,7 @@ All the methods in producer, consumer, and reader of a C++ client are thread-saf
 
 Pulsar C++ client is supported on **Linux** and **MacOS** platforms.
 
-[Doxygen](http://www.doxygen.nl/)-generated API docs for the C++ client are available [here](/api/cpp).
+[Doxygen](http://www.doxygen.nl/)-generated API docs for the C++ client are available [here](@pulsar:apidoc:cpp@).
 
 ## Linux
 

--- a/site2/website/versioned_docs/version-2.6.1/client-libraries-python.md
+++ b/site2/website/versioned_docs/version-2.6.1/client-libraries-python.md
@@ -5,11 +5,11 @@ sidebar_label: "Python"
 original_id: client-libraries-python
 ---
 
-Pulsar Python client library is a wrapper over the existing [C++ client library](client-libraries-cpp.md) and exposes all of the [same features](/api/cpp). You can find the code in the [`python` GitHub Repository](https://github.com/apache/pulsar-client-python) of the C++ client code.
+Pulsar Python client library is a wrapper over the existing [C++ client library](client-libraries-cpp.md) and exposes all of the [same features](@pulsar:apidoc:cpp@). You can find the code in the [`python` GitHub Repository](https://github.com/apache/pulsar-client-python) of the C++ client code.
 
 All the methods in producer, consumer, and reader of a Python client are thread-safe.
 
-[pdoc](https://github.com/BurntSushi/pdoc)-generated API docs for the Python client are available [here](/api/python).
+[pdoc](https://github.com/BurntSushi/pdoc)-generated API docs for the Python client are available [here](@pulsar:apidoc:python@).
 
 ## Install
 
@@ -48,7 +48,7 @@ $ sudo python setup.py install
 
 ## API Reference
 
-The complete Python API reference is available at [api/python](/api/python).
+The complete Python API reference is available at [api/python](@pulsar:apidoc:python@).
 
 ## Examples
 

--- a/site2/website/versioned_docs/version-2.6.2/client-libraries-cpp.md
+++ b/site2/website/versioned_docs/version-2.6.2/client-libraries-cpp.md
@@ -13,7 +13,7 @@ All the methods in producer, consumer, and reader of a C++ client are thread-saf
 
 Pulsar C++ client is supported on **Linux** and **MacOS** platforms.
 
-[Doxygen](http://www.doxygen.nl/)-generated API docs for the C++ client are available [here](/api/cpp).
+[Doxygen](http://www.doxygen.nl/)-generated API docs for the C++ client are available [here](@pulsar:apidoc:cpp@).
 
 ## Linux
 

--- a/site2/website/versioned_docs/version-2.6.2/client-libraries-python.md
+++ b/site2/website/versioned_docs/version-2.6.2/client-libraries-python.md
@@ -5,11 +5,11 @@ sidebar_label: "Python"
 original_id: client-libraries-python
 ---
 
-Pulsar Python client library is a wrapper over the existing [C++ client library](client-libraries-cpp.md) and exposes all of the [same features](/api/cpp). You can find the code in the [`python` GitHub Repository](https://github.com/apache/pulsar-client-python) of the C++ client code.
+Pulsar Python client library is a wrapper over the existing [C++ client library](client-libraries-cpp.md) and exposes all of the [same features](@pulsar:apidoc:cpp@). You can find the code in the [`python` GitHub Repository](https://github.com/apache/pulsar-client-python) of the C++ client code.
 
 All the methods in producer, consumer, and reader of a Python client are thread-safe.
 
-[pdoc](https://github.com/BurntSushi/pdoc)-generated API docs for the Python client are available [here](/api/python).
+[pdoc](https://github.com/BurntSushi/pdoc)-generated API docs for the Python client are available [here](@pulsar:apidoc:python@).
 
 ## Install
 
@@ -48,7 +48,7 @@ $ sudo python setup.py install
 
 ## API Reference
 
-The complete Python API reference is available at [api/python](/api/python).
+The complete Python API reference is available at [api/python](@pulsar:apidoc:python@).
 
 ## Examples
 

--- a/site2/website/versioned_docs/version-2.6.3/client-libraries-cpp.md
+++ b/site2/website/versioned_docs/version-2.6.3/client-libraries-cpp.md
@@ -13,7 +13,7 @@ All the methods in producer, consumer, and reader of a C++ client are thread-saf
 
 Pulsar C++ client is supported on **Linux** and **MacOS** platforms.
 
-[Doxygen](http://www.doxygen.nl/)-generated API docs for the C++ client are available [here](/api/cpp).
+[Doxygen](http://www.doxygen.nl/)-generated API docs for the C++ client are available [here](@pulsar:apidoc:cpp@).
 
 ## Linux
 

--- a/site2/website/versioned_docs/version-2.6.3/client-libraries-python.md
+++ b/site2/website/versioned_docs/version-2.6.3/client-libraries-python.md
@@ -5,11 +5,11 @@ sidebar_label: "Python"
 original_id: client-libraries-python
 ---
 
-Pulsar Python client library is a wrapper over the existing [C++ client library](client-libraries-cpp.md) and exposes all of the [same features](/api/cpp). You can find the code in the [`python` GitHub Repository](https://github.com/apache/pulsar-client-python) of the C++ client code.
+Pulsar Python client library is a wrapper over the existing [C++ client library](client-libraries-cpp.md) and exposes all of the [same features](@pulsar:apidoc:cpp@). You can find the code in the [`python` GitHub Repository](https://github.com/apache/pulsar-client-python) of the C++ client code.
 
 All the methods in producer, consumer, and reader of a Python client are thread-safe.
 
-[pdoc](https://github.com/BurntSushi/pdoc)-generated API docs for the Python client are available [here](/api/python).
+[pdoc](https://github.com/BurntSushi/pdoc)-generated API docs for the Python client are available [here](@pulsar:apidoc:python@).
 
 ## Install
 
@@ -48,7 +48,7 @@ $ sudo python setup.py install
 
 ## API Reference
 
-The complete Python API reference is available at [api/python](/api/python).
+The complete Python API reference is available at [api/python](@pulsar:apidoc:python@).
 
 ## Examples
 

--- a/site2/website/versioned_docs/version-2.6.4/client-libraries-cpp.md
+++ b/site2/website/versioned_docs/version-2.6.4/client-libraries-cpp.md
@@ -13,7 +13,7 @@ All the methods in producer, consumer, and reader of a C++ client are thread-saf
 
 Pulsar C++ client is supported on **Linux** and **MacOS** platforms.
 
-[Doxygen](http://www.doxygen.nl/)-generated API docs for the C++ client are available [here](/api/cpp).
+[Doxygen](http://www.doxygen.nl/)-generated API docs for the C++ client are available [here](@pulsar:apidoc:cpp@).
 
 ## Linux
 

--- a/site2/website/versioned_docs/version-2.6.4/client-libraries-python.md
+++ b/site2/website/versioned_docs/version-2.6.4/client-libraries-python.md
@@ -5,11 +5,11 @@ sidebar_label: "Python"
 original_id: client-libraries-python
 ---
 
-Pulsar Python client library is a wrapper over the existing [C++ client library](client-libraries-cpp.md) and exposes all of the [same features](/api/cpp). You can find the code in the [`python` GitHub Repository](https://github.com/apache/pulsar-client-python) of the C++ client code.
+Pulsar Python client library is a wrapper over the existing [C++ client library](client-libraries-cpp.md) and exposes all of the [same features](@pulsar:apidoc:cpp@). You can find the code in the [`python` GitHub Repository](https://github.com/apache/pulsar-client-python) of the C++ client code.
 
 All the methods in producer, consumer, and reader of a Python client are thread-safe.
 
-[pdoc](https://github.com/BurntSushi/pdoc)-generated API docs for the Python client are available [here](/api/python).
+[pdoc](https://github.com/BurntSushi/pdoc)-generated API docs for the Python client are available [here](@pulsar:apidoc:python@).
 
 ## Install
 
@@ -48,7 +48,7 @@ $ sudo python setup.py install
 
 ## API Reference
 
-The complete Python API reference is available at [api/python](/api/python).
+The complete Python API reference is available at [api/python](@pulsar:apidoc:python@).
 
 ## Examples
 

--- a/site2/website/versioned_docs/version-2.7.0/client-libraries-cpp.md
+++ b/site2/website/versioned_docs/version-2.7.0/client-libraries-cpp.md
@@ -13,7 +13,7 @@ All the methods in producer, consumer, and reader of a C++ client are thread-saf
 
 Pulsar C++ client is supported on **Linux** and **MacOS** platforms.
 
-[Doxygen](http://www.doxygen.nl/)-generated API docs for the C++ client are available [here](/api/cpp).
+[Doxygen](http://www.doxygen.nl/)-generated API docs for the C++ client are available [here](@pulsar:apidoc:cpp@).
 
 ## Linux
 

--- a/site2/website/versioned_docs/version-2.7.0/client-libraries-python.md
+++ b/site2/website/versioned_docs/version-2.7.0/client-libraries-python.md
@@ -5,11 +5,11 @@ sidebar_label: "Python"
 original_id: client-libraries-python
 ---
 
-Pulsar Python client library is a wrapper over the existing [C++ client library](client-libraries-cpp.md) and exposes all of the [same features](/api/cpp). You can find the code in the [`python` GitHub Repository](https://github.com/apache/pulsar-client-python) of the C++ client code.
+Pulsar Python client library is a wrapper over the existing [C++ client library](client-libraries-cpp.md) and exposes all of the [same features](@pulsar:apidoc:cpp@). You can find the code in the [`python` GitHub Repository](https://github.com/apache/pulsar-client-python) of the C++ client code.
 
 All the methods in producer, consumer, and reader of a Python client are thread-safe.
 
-[pdoc](https://github.com/BurntSushi/pdoc)-generated API docs for the Python client are available [here](/api/python).
+[pdoc](https://github.com/BurntSushi/pdoc)-generated API docs for the Python client are available [here](@pulsar:apidoc:python@).
 
 ## Install
 
@@ -48,7 +48,7 @@ $ sudo python setup.py install
 
 ## API Reference
 
-The complete Python API reference is available at [api/python](/api/python).
+The complete Python API reference is available at [api/python](@pulsar:apidoc:python@).
 
 ## Examples
 

--- a/site2/website/versioned_docs/version-2.7.1/client-libraries-cpp.md
+++ b/site2/website/versioned_docs/version-2.7.1/client-libraries-cpp.md
@@ -13,7 +13,7 @@ All the methods in producer, consumer, and reader of a C++ client are thread-saf
 
 Pulsar C++ client is supported on **Linux** and **MacOS** platforms.
 
-[Doxygen](http://www.doxygen.nl/)-generated API docs for the C++ client are available [here](/api/cpp).
+[Doxygen](http://www.doxygen.nl/)-generated API docs for the C++ client are available [here](@pulsar:apidoc:cpp@).
 
 ## Linux
 

--- a/site2/website/versioned_docs/version-2.7.1/client-libraries-python.md
+++ b/site2/website/versioned_docs/version-2.7.1/client-libraries-python.md
@@ -5,11 +5,11 @@ sidebar_label: "Python"
 original_id: client-libraries-python
 ---
 
-Pulsar Python client library is a wrapper over the existing [C++ client library](client-libraries-cpp.md) and exposes all of the [same features](/api/cpp). You can find the code in the [`python` GitHub Repository](https://github.com/apache/pulsar-client-python) of the C++ client code.
+Pulsar Python client library is a wrapper over the existing [C++ client library](client-libraries-cpp.md) and exposes all of the [same features](@pulsar:apidoc:cpp@). You can find the code in the [`python` GitHub Repository](https://github.com/apache/pulsar-client-python) of the C++ client code.
 
 All the methods in producer, consumer, and reader of a Python client are thread-safe.
 
-[pdoc](https://github.com/BurntSushi/pdoc)-generated API docs for the Python client are available [here](/api/python).
+[pdoc](https://github.com/BurntSushi/pdoc)-generated API docs for the Python client are available [here](@pulsar:apidoc:python@).
 
 ## Install
 
@@ -48,7 +48,7 @@ $ sudo python setup.py install
 
 ## API Reference
 
-The complete Python API reference is available at [api/python](/api/python).
+The complete Python API reference is available at [api/python](@pulsar:apidoc:python@).
 
 ## Examples
 

--- a/site2/website/versioned_docs/version-2.7.2/client-libraries-cpp.md
+++ b/site2/website/versioned_docs/version-2.7.2/client-libraries-cpp.md
@@ -13,7 +13,7 @@ All the methods in producer, consumer, and reader of a C++ client are thread-saf
 
 Pulsar C++ client is supported on **Linux** and **MacOS** platforms.
 
-[Doxygen](http://www.doxygen.nl/)-generated API docs for the C++ client are available [here](/api/cpp).
+[Doxygen](http://www.doxygen.nl/)-generated API docs for the C++ client are available [here](@pulsar:apidoc:cpp@).
 
 ## Linux
 

--- a/site2/website/versioned_docs/version-2.7.2/client-libraries-python.md
+++ b/site2/website/versioned_docs/version-2.7.2/client-libraries-python.md
@@ -5,11 +5,11 @@ sidebar_label: "Python"
 original_id: client-libraries-python
 ---
 
-Pulsar Python client library is a wrapper over the existing [C++ client library](client-libraries-cpp.md) and exposes all of the [same features](/api/cpp). You can find the code in the [`python` GitHub Repository](https://github.com/apache/pulsar-client-python) of the C++ client code.
+Pulsar Python client library is a wrapper over the existing [C++ client library](client-libraries-cpp.md) and exposes all of the [same features](@pulsar:apidoc:cpp@). You can find the code in the [`python` GitHub Repository](https://github.com/apache/pulsar-client-python) of the C++ client code.
 
 All the methods in producer, consumer, and reader of a Python client are thread-safe.
 
-[pdoc](https://github.com/BurntSushi/pdoc)-generated API docs for the Python client are available [here](/api/python).
+[pdoc](https://github.com/BurntSushi/pdoc)-generated API docs for the Python client are available [here](@pulsar:apidoc:python@).
 
 ## Install
 
@@ -48,7 +48,7 @@ $ sudo python setup.py install
 
 ## API Reference
 
-The complete Python API reference is available at [api/python](/api/python).
+The complete Python API reference is available at [api/python](@pulsar:apidoc:python@).
 
 ## Examples
 

--- a/site2/website/versioned_docs/version-2.7.3/client-libraries-cpp.md
+++ b/site2/website/versioned_docs/version-2.7.3/client-libraries-cpp.md
@@ -13,7 +13,7 @@ All the methods in producer, consumer, and reader of a C++ client are thread-saf
 
 Pulsar C++ client is supported on **Linux** and **MacOS** platforms.
 
-[Doxygen](http://www.doxygen.nl/)-generated API docs for the C++ client are available [here](/api/cpp).
+[Doxygen](http://www.doxygen.nl/)-generated API docs for the C++ client are available [here](@pulsar:apidoc:cpp@).
 
 ## Linux
 

--- a/site2/website/versioned_docs/version-2.7.3/client-libraries-python.md
+++ b/site2/website/versioned_docs/version-2.7.3/client-libraries-python.md
@@ -5,11 +5,11 @@ sidebar_label: "Python"
 original_id: client-libraries-python
 ---
 
-Pulsar Python client library is a wrapper over the existing [C++ client library](client-libraries-cpp.md) and exposes all of the [same features](/api/cpp). You can find the code in the [`python` GitHub Repository](https://github.com/apache/pulsar-client-python) of the C++ client code.
+Pulsar Python client library is a wrapper over the existing [C++ client library](client-libraries-cpp.md) and exposes all of the [same features](@pulsar:apidoc:cpp@). You can find the code in the [`python` GitHub Repository](https://github.com/apache/pulsar-client-python) of the C++ client code.
 
 All the methods in producer, consumer, and reader of a Python client are thread-safe.
 
-[pdoc](https://github.com/BurntSushi/pdoc)-generated API docs for the Python client are available [here](/api/python).
+[pdoc](https://github.com/BurntSushi/pdoc)-generated API docs for the Python client are available [here](@pulsar:apidoc:python@).
 
 ## Install
 
@@ -48,7 +48,7 @@ $ sudo python setup.py install
 
 ## API Reference
 
-The complete Python API reference is available at [api/python](/api/python).
+The complete Python API reference is available at [api/python](@pulsar:apidoc:python@).
 
 ## Examples
 

--- a/site2/website/versioned_docs/version-2.7.4/client-libraries-cpp.md
+++ b/site2/website/versioned_docs/version-2.7.4/client-libraries-cpp.md
@@ -13,7 +13,7 @@ All the methods in producer, consumer, and reader of a C++ client are thread-saf
 
 Pulsar C++ client is supported on **Linux** and **MacOS** platforms.
 
-[Doxygen](http://www.doxygen.nl/)-generated API docs for the C++ client are available [here](/api/cpp).
+[Doxygen](http://www.doxygen.nl/)-generated API docs for the C++ client are available [here](@pulsar:apidoc:cpp@).
 
 ## Linux
 

--- a/site2/website/versioned_docs/version-2.7.4/client-libraries-python.md
+++ b/site2/website/versioned_docs/version-2.7.4/client-libraries-python.md
@@ -5,11 +5,11 @@ sidebar_label: "Python"
 original_id: client-libraries-python
 ---
 
-Pulsar Python client library is a wrapper over the existing [C++ client library](client-libraries-cpp.md) and exposes all of the [same features](/api/cpp). You can find the code in the [`python` GitHub Repository](https://github.com/apache/pulsar-client-python) of the C++ client code.
+Pulsar Python client library is a wrapper over the existing [C++ client library](client-libraries-cpp.md) and exposes all of the [same features](@pulsar:apidoc:cpp@). You can find the code in the [`python` GitHub Repository](https://github.com/apache/pulsar-client-python) of the C++ client code.
 
 All the methods in producer, consumer, and reader of a Python client are thread-safe.
 
-[pdoc](https://github.com/BurntSushi/pdoc)-generated API docs for the Python client are available [here](/api/python).
+[pdoc](https://github.com/BurntSushi/pdoc)-generated API docs for the Python client are available [here](@pulsar:apidoc:python@).
 
 ## Install
 
@@ -48,7 +48,7 @@ $ sudo python setup.py install
 
 ## API Reference
 
-The complete Python API reference is available at [api/python](/api/python).
+The complete Python API reference is available at [api/python](@pulsar:apidoc:python@).
 
 ## Examples
 

--- a/site2/website/versioned_docs/version-2.7.5/client-libraries-cpp.md
+++ b/site2/website/versioned_docs/version-2.7.5/client-libraries-cpp.md
@@ -12,7 +12,7 @@ import TabItem from '@theme/TabItem';
 
 You can use a Pulsar C++ client to create producers, consumers, and readers.
 
-All the methods in producer, consumer, and reader of a C++ client are thread-safe. You can read the [API docs](/api/cpp) for the C++ client.
+All the methods in producer, consumer, and reader of a C++ client are thread-safe. You can read the [API docs](@pulsar:apidoc:cpp@) for the C++ client.
 
 ## Installation
 

--- a/site2/website/versioned_docs/version-2.7.5/client-libraries-python.md
+++ b/site2/website/versioned_docs/version-2.7.5/client-libraries-python.md
@@ -5,11 +5,11 @@ sidebar_label: "Python"
 original_id: client-libraries-python
 ---
 
-Pulsar Python client library is a wrapper over the existing [C++ client library](client-libraries-cpp.md) and exposes all of the [same features](/api/cpp). You can find the code in the [`python` GitHub Repository](https://github.com/apache/pulsar-client-python) of the C++ client code.
+Pulsar Python client library is a wrapper over the existing [C++ client library](client-libraries-cpp.md) and exposes all of the [same features](@pulsar:apidoc:cpp@). You can find the code in the [`python` GitHub Repository](https://github.com/apache/pulsar-client-python) of the C++ client code.
 
 All the methods in producer, consumer, and reader of a Python client are thread-safe.
 
-[pdoc](https://github.com/BurntSushi/pdoc)-generated API docs for the Python client are available [here](/api/python).
+[pdoc](https://github.com/BurntSushi/pdoc)-generated API docs for the Python client are available [here](@pulsar:apidoc:python@).
 
 ## Install
 
@@ -48,7 +48,7 @@ $ sudo python setup.py install
 
 ## API Reference
 
-The complete Python API reference is available at [api/python](/api/python).
+The complete Python API reference is available at [api/python](@pulsar:apidoc:python@).
 
 ## Examples
 

--- a/site2/website/versioned_docs/version-2.8.x/client-libraries-cpp.md
+++ b/site2/website/versioned_docs/version-2.8.x/client-libraries-cpp.md
@@ -12,7 +12,7 @@ import TabItem from '@theme/TabItem';
 
 You can use a Pulsar C++ client to create producers, consumers, and readers.
 
-All the methods in producer, consumer, and reader of a C++ client are thread-safe. You can read the [API docs](/api/cpp) for the C++ client.
+All the methods in producer, consumer, and reader of a C++ client are thread-safe. You can read the [API docs](@pulsar:apidoc:cpp@) for the C++ client.
 
 ## Installation
 

--- a/site2/website/versioned_docs/version-2.8.x/client-libraries-python.md
+++ b/site2/website/versioned_docs/version-2.8.x/client-libraries-python.md
@@ -5,11 +5,11 @@ sidebar_label: "Python"
 original_id: client-libraries-python
 ---
 
-Pulsar Python client library is a wrapper over the existing [C++ client library](client-libraries-cpp.md) and exposes all of the [same features](/api/cpp). You can find the code in the [`python` GitHub Repository](https://github.com/apache/pulsar-client-python) of the C++ client code.
+Pulsar Python client library is a wrapper over the existing [C++ client library](client-libraries-cpp.md) and exposes all of the [same features](@pulsar:apidoc:cpp@). You can find the code in the [`python` GitHub Repository](https://github.com/apache/pulsar-client-python) of the C++ client code.
 
 All the methods in producer, consumer, and reader of a Python client are thread-safe.
 
-[pdoc](https://github.com/BurntSushi/pdoc)-generated API docs for the Python client are available [here](/api/python).
+[pdoc](https://github.com/BurntSushi/pdoc)-generated API docs for the Python client are available [here](@pulsar:apidoc:python@).
 
 ## Install
 
@@ -65,7 +65,7 @@ $ sudo python setup.py install
 
 ## API Reference
 
-The complete Python API reference is available at [api/python](/api/python).
+The complete Python API reference is available at [api/python](@pulsar:apidoc:python@).
 
 ## Examples
 

--- a/site2/website/versioned_docs/version-2.9.x/client-libraries-cpp.md
+++ b/site2/website/versioned_docs/version-2.9.x/client-libraries-cpp.md
@@ -12,7 +12,7 @@ import TabItem from '@theme/TabItem';
 
 You can use a Pulsar C++ client to create producers, consumers, and readers.
 
-All the methods in producer, consumer, and reader of a C++ client are thread-safe. You can read the [API docs](/api/cpp) for the C++ client.
+All the methods in producer, consumer, and reader of a C++ client are thread-safe. You can read the [API docs](@pulsar:apidoc:cpp@) for the C++ client.
 
 ## Installation
 

--- a/site2/website/versioned_docs/version-2.9.x/client-libraries-python.md
+++ b/site2/website/versioned_docs/version-2.9.x/client-libraries-python.md
@@ -5,11 +5,11 @@ sidebar_label: "Python"
 original_id: client-libraries-python
 ---
 
-Pulsar Python client library is a wrapper over the existing [C++ client library](client-libraries-cpp.md) and exposes all of the [same features](/api/cpp). You can find the code in the [Python directory](https://github.com/apache/pulsar-client-python) of the C++ client code.
+Pulsar Python client library is a wrapper over the existing [C++ client library](client-libraries-cpp.md) and exposes all of the [same features](@pulsar:apidoc:cpp@). You can find the code in the [Python directory](https://github.com/apache/pulsar-client-python) of the C++ client code.
 
 All the methods in producer, consumer, and reader of a Python client are thread-safe.
 
-[pdoc](https://github.com/BurntSushi/pdoc)-generated API docs for the Python client are available [here](/api/python).
+[pdoc](https://github.com/BurntSushi/pdoc)-generated API docs for the Python client are available [here](@pulsar:apidoc:python@).
 
 ## Install
 
@@ -64,7 +64,7 @@ $ sudo python setup.py install
 
 ## API Reference
 
-The complete Python API reference is available at [api/python](/api/python).
+The complete Python API reference is available at [api/python](@pulsar:apidoc:python@).
 
 ## Examples
 


### PR DESCRIPTION
This is the counterpart of https://github.com/apache/pulsar-site/pull/291.

Now they have their own repository and release cycle, it's impossible to infer the proper version from the current Pulsar version. We should instead hardcode the corresponding versions for new versions.
### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [x] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
