### PR TITLE
[fix][client] Messages with inconsistent consumer epochs are not filtered when using batch receive and trigger timeout

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/MultiTopicsConsumerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/MultiTopicsConsumerTest.java
@@ -37,6 +37,7 @@ import org.apache.pulsar.client.admin.PulsarAdminException;
 import org.apache.pulsar.client.impl.ClientBuilderImpl;
 import org.apache.pulsar.client.impl.PulsarClientImpl;
 import org.apache.pulsar.client.impl.conf.ClientConfigurationData;
+import org.awaitility.Awaitility;
 import org.mockito.AdditionalAnswers;
 import org.mockito.Mockito;
 import org.slf4j.Logger;
@@ -191,5 +192,43 @@ public class MultiTopicsConsumerTest extends ProducerConsumerBase {
             Assert.assertEquals(message.getValue().longValue(), receivedSequenceCounter.getAndIncrement());
         }
         Assert.assertEquals(numPartitions * numMessages, receivedCount);
+    }
+
+    @Test
+    public void testBatchReceiveAckTimeout()
+            throws PulsarAdminException, PulsarClientException {
+        String topicName = newTopicName();
+        int numPartitions = 2;
+        int numMessages = 100000;
+        admin.topics().createPartitionedTopic(topicName, numPartitions);
+
+        @Cleanup
+        Producer<Long> producer = pulsarClient.newProducer(Schema.INT64)
+                .topic(topicName)
+                .enableBatching(false)
+                .blockIfQueueFull(true)
+                .create();
+
+        @Cleanup
+        Consumer<Long> consumer = pulsarClient
+                .newConsumer(Schema.INT64)
+                .topic(topicName)
+                .receiverQueueSize(numMessages)
+                .batchReceivePolicy(
+                        BatchReceivePolicy.builder().maxNumMessages(1).timeout(2, TimeUnit.SECONDS).build()
+                ).ackTimeout(1000, TimeUnit.MILLISECONDS)
+                .subscriptionName(methodName)
+                .subscribe();
+
+        producer.newMessage()
+                .value(1l)
+                .send();
+
+        // first batch receive
+        Assert.assertEquals(consumer.batchReceive().size(), 1);
+        // Not ack, trigger redelivery this message.
+        Awaitility.await().untilAsserted(() -> {
+            Assert.assertEquals(consumer.batchReceive().size(), 1);
+        });
     }
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/MessageRedeliveryTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/MessageRedeliveryTest.java
@@ -429,12 +429,14 @@ public class MessageRedeliveryTest extends ProducerConsumerBase {
         final String subName = "my-sub";
         admin.topics().createPartitionedTopic(topic, 5);
         final int messageNumber = 50;
+        @Cleanup
         Consumer<String> consumer = pulsarClient.newConsumer(Schema.STRING)
                 .topic(topic)
                 .subscriptionName(subName)
                 .subscriptionType(SubscriptionType.Failover)
                 .subscribe();
 
+        @Cleanup
         Producer<String> producer = pulsarClient.newProducer(Schema.STRING)
                 .topic(topic)
                 .enableBatching(enableBatch)

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/MessageRedeliveryTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/MessageRedeliveryTest.java
@@ -22,7 +22,6 @@ import static org.testng.Assert.assertNotEquals;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNull;
-import java.lang.reflect.Field;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executors;
@@ -33,17 +32,17 @@ import java.util.concurrent.atomic.AtomicInteger;
 import lombok.Cleanup;
 import org.apache.bookkeeper.mledger.impl.ManagedCursorImpl;
 import org.apache.bookkeeper.mledger.impl.ManagedLedgerImpl;
-import org.apache.pulsar.broker.service.persistent.PersistentDispatcherSingleActiveConsumer;
 import org.apache.pulsar.broker.service.persistent.PersistentTopic;
 import org.apache.pulsar.client.admin.PulsarAdminException;
+import org.apache.pulsar.client.api.BatchReceivePolicy;
 import org.apache.pulsar.client.api.Consumer;
 import org.apache.pulsar.client.api.Message;
+import org.apache.pulsar.client.api.Messages;
 import org.apache.pulsar.client.api.Producer;
 import org.apache.pulsar.client.api.ProducerConsumerBase;
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.client.api.SubscriptionType;
-import org.apache.pulsar.common.naming.TopicName;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.annotations.AfterMethod;
@@ -226,6 +225,7 @@ public class MessageRedeliveryTest extends ProducerConsumerBase {
         final String topic = "testDoNotRedeliveryMarkDeleteMessages";
         final String subName = "my-sub";
 
+        @Cleanup
         Consumer<byte[]> consumer = pulsarClient.newConsumer()
                 .topic(topic)
                 .subscriptionName(subName)
@@ -233,6 +233,7 @@ public class MessageRedeliveryTest extends ProducerConsumerBase {
                 .ackTimeout(1, TimeUnit.SECONDS)
                 .subscribe();
 
+        @Cleanup
         Producer<byte[]> producer = pulsarClient.newProducer()
                 .topic(topic)
                 .enableBatching(false)
@@ -261,12 +262,14 @@ public class MessageRedeliveryTest extends ProducerConsumerBase {
     public void testRedeliveryAddEpoch(boolean enableBatch) throws Exception{
         final String topic = "testRedeliveryAddEpoch";
         final String subName = "my-sub";
-        ConsumerBase<String> consumer = ((ConsumerBase<String>) pulsarClient.newConsumer(Schema.STRING)
+        @Cleanup
+        ConsumerImpl<String> consumer = ((ConsumerImpl<String>) pulsarClient.newConsumer(Schema.STRING)
                 .topic(topic)
                 .subscriptionName(subName)
                 .subscriptionType(SubscriptionType.Failover)
                 .subscribe());
 
+        @Cleanup
         Producer<String> producer = pulsarClient.newProducer(Schema.STRING)
                 .topic(topic)
                 .enableBatching(enableBatch)
@@ -275,14 +278,9 @@ public class MessageRedeliveryTest extends ProducerConsumerBase {
         String test1 = "Pulsar1";
         String test2 = "Pulsar2";
         String test3 = "Pulsar3";
-        producer.send(test1);
-
-        PersistentTopic persistentTopic = (PersistentTopic) pulsar.getBrokerService().getTopics()
-                .get(TopicName.get("persistent://public/default/" + topic).toString()).get().get();
-        PersistentDispatcherSingleActiveConsumer persistentDispatcherSingleActiveConsumer =
-                (PersistentDispatcherSingleActiveConsumer) persistentTopic.getSubscription(subName).getDispatcher();
 
         consumer.setConsumerEpoch(1);
+        producer.send(test1);
         Message<String> message = consumer.receive(3, TimeUnit.SECONDS);
         assertNull(message);
         consumer.redeliverUnacknowledgedMessages();
@@ -309,18 +307,113 @@ public class MessageRedeliveryTest extends ProducerConsumerBase {
         message = consumer.receive(3, TimeUnit.SECONDS);
         assertNull(message);
 
-        Field field = consumer.getClass().getDeclaredField("connectionHandler");
-        field.setAccessible(true);
-        ConnectionHandler connectionHandler = (ConnectionHandler) field.get(consumer);
-
-        field = connectionHandler.getClass().getDeclaredField("CLIENT_CNX_UPDATER");
-        field.setAccessible(true);
+        ConnectionHandler connectionHandler = consumer.getConnectionHandler();
 
         connectionHandler.cnx().channel().close();
 
-        ((ConsumerImpl<String>) consumer).grabCnx();
+        consumer.grabCnx();
         message = consumer.receive(3, TimeUnit.SECONDS);
         assertNotNull(message);
+        assertEquals(message.getValue(), test3);
+    }
+
+    @Test(dataProvider = "enableBatch")
+    public void testRedeliveryAddEpochAndPermits(boolean enableBatch) throws Exception {
+        final String topic = "testRedeliveryAddEpochAndPermits";
+        final String subName = "my-sub";
+        // set receive queue size is 4, and first send 4 messages,
+        // then call redeliver messages, assert receive msg num.
+        int receiveQueueSize = 4;
+
+        @Cleanup
+        ConsumerImpl<String> consumer = ((ConsumerImpl<String>) pulsarClient.newConsumer(Schema.STRING)
+                .topic(topic)
+                .receiverQueueSize(receiveQueueSize)
+                .autoScaledReceiverQueueSizeEnabled(false)
+                .subscriptionName(subName)
+                .subscriptionType(SubscriptionType.Failover)
+                .subscribe());
+
+        @Cleanup
+        Producer<String> producer = pulsarClient.newProducer(Schema.STRING)
+                .topic(topic)
+                .enableBatching(enableBatch)
+                .create();
+
+        consumer.setConsumerEpoch(1);
+        for (int i = 0; i < receiveQueueSize; i++) {
+            producer.send("pulsar" + i);
+        }
+        assertNull(consumer.receive(1, TimeUnit.SECONDS));
+
+        consumer.redeliverUnacknowledgedMessages();
+        for (int i = 0; i < receiveQueueSize; i++) {
+            Message<String> msg = consumer.receive();
+            assertEquals("pulsar" + i, msg.getValue());
+        }
+    }
+
+    @Test(dataProvider = "enableBatch")
+    public void testBatchReceiveRedeliveryAddEpoch(boolean enableBatch) throws Exception{
+        final String topic = "testBatchReceiveRedeliveryAddEpoch";
+        final String subName = "my-sub";
+
+        @Cleanup
+        ConsumerImpl<String> consumer = ((ConsumerImpl<String>) pulsarClient.newConsumer(Schema.STRING)
+                .topic(topic)
+                .subscriptionName(subName)
+                .batchReceivePolicy(BatchReceivePolicy.builder().timeout(1000, TimeUnit.MILLISECONDS).build())
+                .subscriptionType(SubscriptionType.Failover)
+                .subscribe());
+
+        @Cleanup
+        Producer<String> producer = pulsarClient.newProducer(Schema.STRING)
+                .topic(topic)
+                .enableBatching(enableBatch)
+                .create();
+
+        String test1 = "Pulsar1";
+        String test2 = "Pulsar2";
+        String test3 = "Pulsar3";
+
+        consumer.setConsumerEpoch(1);
+        producer.send(test1);
+
+        Messages<String> messages;
+        Message<String> message;
+
+        messages = consumer.batchReceive();
+        assertEquals(messages.size(), 0);
+        consumer.redeliverUnacknowledgedMessages();
+        messages = consumer.batchReceive();
+        assertEquals(messages.size(), 1);
+        message = messages.iterator().next();
+        consumer.acknowledgeCumulativeAsync(message).get();
+        assertEquals(message.getValue(), test1);
+
+        consumer.setConsumerEpoch(3);
+        producer.send(test2);
+        messages = consumer.batchReceive();
+        assertEquals(messages.size(), 0);
+        consumer.redeliverUnacknowledgedMessages();
+        messages = consumer.batchReceive();
+        assertEquals(messages.size(), 1);
+        message = messages.iterator().next();
+        assertEquals(message.getValue(), test2);
+        consumer.acknowledgeCumulativeAsync(message).get();
+
+        consumer.setConsumerEpoch(6);
+        producer.send(test3);
+        messages = consumer.batchReceive();
+        assertEquals(messages.size(), 0);
+
+        ConnectionHandler connectionHandler = consumer.getConnectionHandler();
+        connectionHandler.cnx().channel().close();
+
+        consumer.grabCnx();
+        messages = consumer.batchReceive();
+        assertEquals(messages.size(), 1);
+        message = messages.iterator().next();
         assertEquals(message.getValue(), test3);
     }
 
@@ -381,5 +474,67 @@ public class MessageRedeliveryTest extends ProducerConsumerBase {
         // can't receive message again
         message = consumer.receive(5, TimeUnit.SECONDS);
         assertNull(message);
+    }
+
+    @Test(dataProvider = "enableBatch", invocationCount = 10)
+    public void testMultiConsumerBatchRedeliveryAddEpoch(boolean enableBatch) throws Exception{
+
+        final String topic = "testMultiConsumerBatchRedeliveryAddEpoch";
+        final String subName = "my-sub";
+        admin.topics().createPartitionedTopic(topic, 5);
+        final int messageNumber = 50;
+
+        @Cleanup
+        Consumer<String> consumer = pulsarClient.newConsumer(Schema.STRING)
+                .topic(topic)
+                .batchReceivePolicy(BatchReceivePolicy.builder().timeout(2, TimeUnit.SECONDS).build())
+                .subscriptionName(subName)
+                .subscriptionType(SubscriptionType.Failover)
+                .subscribe();
+
+        @Cleanup
+        Producer<String> producer = pulsarClient.newProducer(Schema.STRING)
+                .topic(topic)
+                .enableBatching(enableBatch)
+                .create();
+
+        for (int i = 0; i < messageNumber; i++) {
+            producer.send("" + i);
+        }
+
+        int receiveNum = 0;
+        while (receiveNum < messageNumber) {
+            receiveNum += consumer.batchReceive().size();
+        }
+
+        // redeliverUnacknowledgedMessages once
+        consumer.redeliverUnacknowledgedMessages();
+
+        receiveNum = 0;
+        while (receiveNum < messageNumber) {
+            Messages<String> messages = consumer.batchReceive();
+            receiveNum += messages.size();
+            for (Message<String> message : messages) {
+                assertEquals((((MessageImpl)((TopicMessageImpl) message).getMessage())).getConsumerEpoch(), 1);
+            }
+        }
+
+        // can't receive message again
+        assertEquals(consumer.batchReceive().size(), 0);
+
+        // redeliverUnacknowledgedMessages twice
+        consumer.redeliverUnacknowledgedMessages();
+
+        receiveNum = 0;
+        while (receiveNum < messageNumber) {
+            Messages<String> messages = consumer.batchReceive();
+            receiveNum += messages.size();
+            for (Message<String> message : messages) {
+                assertEquals((((MessageImpl)((TopicMessageImpl) message).getMessage())).getConsumerEpoch(), 2);
+            }
+        }
+
+        // can't receive message again
+        assertEquals(consumer.batchReceive().size(), 0);
     }
 }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBase.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBase.java
@@ -850,8 +850,7 @@ public abstract class ConsumerBase<T> extends HandlerState implements Consumer<T
         // synchronize redeliverUnacknowledgedMessages().
         incomingQueueLock.lock();
         try {
-            if (isValidConsumerEpoch((MessageImpl<T>) message) && canEnqueueMessage(message)
-                    && incomingMessages.offer(message)) {
+            if (canEnqueueMessage(message) && incomingMessages.offer(message)) {
                 // After we have enqueued the messages on `incomingMessages` queue, we cannot touch the message
                 // instance anymore, since for pooled messages, this instance was possibly already been released
                 // and recycled.

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBase.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBase.java
@@ -945,10 +945,6 @@ public abstract class ConsumerBase<T> extends HandlerState implements Consumer<T
             Message<T> msg = incomingMessages.poll();
             if (msg != null) {
                 messageProcessed(msg);
-                if (!isValidConsumerEpoch((MessageImpl<T>) msg)) {
-                    msgPeeked = incomingMessages.peek();
-                    continue;
-                }
                 Message<T> interceptMsg = beforeConsume(msg);
                 messages.add(interceptMsg);
             }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
@@ -1886,7 +1886,8 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
 
             // clear local message
             int currentSize;
-            synchronized (incomingQueueLock) {
+            incomingQueueLock.lock();
+            try {
                 // we should increase epoch every time, because MultiTopicsConsumerImpl also increase it,
                 // we need to keep both epochs the same
                 if (conf.getSubscriptionType() == SubscriptionType.Failover
@@ -1898,6 +1899,8 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
                 currentSize = incomingMessages.size();
                 clearIncomingMessages();
                 unAckedMessageTracker.clear();
+            } finally {
+                incomingQueueLock.unlock();
             }
 
             // is channel is connected, we should send redeliver command to broker

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
@@ -460,10 +460,6 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
         }
     }
 
-    boolean isValidConsumerEpoch(Message<T> message) {
-        return isValidConsumerEpoch((MessageImpl<T>) message);
-    }
-
     @Override
     protected CompletableFuture<Message<T>> internalReceiveAsync() {
         CompletableFutureCancellationHandler cancellationHandler = new CompletableFutureCancellationHandler();
@@ -1920,13 +1916,6 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
                         + "so don't need to send redeliver command to broker", this);
             }
         }
-    }
-
-    public int clearIncomingMessagesAndGetMessageNumber() {
-        int messagesNumber = incomingMessages.size();
-        clearIncomingMessages();
-        unAckedMessageTracker.clear();
-        return messagesNumber;
     }
 
     @Override

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiTopicsConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiTopicsConsumerImpl.java
@@ -341,14 +341,6 @@ public class MultiTopicsConsumerImpl<T> extends ConsumerBase<T> {
         }
     }
 
-    // If message consumer epoch is smaller than consumer epoch present that
-    // it has been sent to the client before the user calls redeliverUnacknowledgedMessages, this message is invalid.
-    // so we should release this message and receive again
-    private boolean isValidConsumerEpoch(Message<T> message) {
-        return isValidConsumerEpoch(((MessageImpl<T>) (((TopicMessageImpl<T>) message))
-                .getMessage()));
-    }
-
     @Override
     public int minReceiverQueueSize() {
         int size = Math.min(INITIAL_RECEIVER_QUEUE_SIZE, maxReceiverQueueSize);
@@ -371,11 +363,6 @@ public class MultiTopicsConsumerImpl<T> extends ConsumerBase<T> {
             message = incomingMessages.take();
             decreaseIncomingMessageSize(message);
             checkState(message instanceof TopicMessageImpl);
-            if (!isValidConsumerEpoch(message)) {
-                resumeReceivingFromPausedConsumersIfNeeded();
-                message.release();
-                return internalReceive();
-            }
             unAckedMessageTracker.add(message.getMessageId(), message.getRedeliveryCount());
             resumeReceivingFromPausedConsumersIfNeeded();
             return message;
@@ -387,8 +374,6 @@ public class MultiTopicsConsumerImpl<T> extends ConsumerBase<T> {
     @Override
     protected Message<T> internalReceive(long timeout, TimeUnit unit) throws PulsarClientException {
         Message<T> message;
-
-        long callTime = System.nanoTime();
         try {
             if (incomingMessages.isEmpty()) {
                 expectMoreIncomingMessages();
@@ -397,16 +382,6 @@ public class MultiTopicsConsumerImpl<T> extends ConsumerBase<T> {
             if (message != null) {
                 decreaseIncomingMessageSize(message);
                 checkArgument(message instanceof TopicMessageImpl);
-                if (!isValidConsumerEpoch(message)) {
-                    long executionTime = System.nanoTime() - callTime;
-                    long timeoutInNanos = unit.toNanos(timeout);
-                    if (executionTime >= timeoutInNanos) {
-                        return null;
-                    } else {
-                        resumeReceivingFromPausedConsumersIfNeeded();
-                        return internalReceive(timeoutInNanos - executionTime, TimeUnit.NANOSECONDS);
-                    }
-                }
                 unAckedMessageTracker.add(message.getMessageId(), message.getRedeliveryCount());
             }
             resumeReceivingFromPausedConsumersIfNeeded();
@@ -437,22 +412,7 @@ public class MultiTopicsConsumerImpl<T> extends ConsumerBase<T> {
         CompletableFuture<Messages<T>> result = cancellationHandler.createFuture();
         internalPinnedExecutor.execute(() -> {
             if (hasEnoughMessagesForBatchReceive()) {
-                MessagesImpl<T> messages = getNewMessagesImpl();
-                Message<T> msgPeeked = incomingMessages.peek();
-                while (msgPeeked != null && messages.canAdd(msgPeeked)) {
-                    Message<T> msg = incomingMessages.poll();
-                    if (msg != null) {
-                        decreaseIncomingMessageSize(msg);
-                        if (!isValidConsumerEpoch(msg)) {
-                            msgPeeked = incomingMessages.peek();
-                            continue;
-                        }
-                        Message<T> interceptMsg = beforeConsume(msg);
-                        messages.add(interceptMsg);
-                    }
-                    msgPeeked = incomingMessages.peek();
-                }
-                result.complete(messages);
+                notifyPendingBatchReceivedCallBack(result);
             } else {
                 expectMoreIncomingMessages();
                 OpBatchReceive<T> opBatchReceive = OpBatchReceive.of(result);
@@ -705,14 +665,16 @@ public class MultiTopicsConsumerImpl<T> extends ConsumerBase<T> {
     @Override
     public void redeliverUnacknowledgedMessages() {
         internalPinnedExecutor.execute(() -> {
-            CONSUMER_EPOCH.incrementAndGet(this);
-            consumers.values().stream().forEach(consumer -> {
-                consumer.redeliverUnacknowledgedMessages();
-                consumer.unAckedChunkedMessageIdSequenceMap.clear();
-            });
-            clearIncomingMessages();
-            unAckedMessageTracker.clear();
-            resumeReceivingFromPausedConsumersIfNeeded();
+            synchronized (incomingQueueLock) {
+                CONSUMER_EPOCH.incrementAndGet(this);
+                consumers.values().stream().forEach(consumer -> {
+                    consumer.redeliverUnacknowledgedMessages();
+                    consumer.unAckedChunkedMessageIdSequenceMap.clear();
+                });
+                clearIncomingMessages();
+                unAckedMessageTracker.clear();
+                resumeReceivingFromPausedConsumersIfNeeded();
+            }
         });
     }
 
@@ -747,7 +709,7 @@ public class MultiTopicsConsumerImpl<T> extends ConsumerBase<T> {
 
     @Override
     protected void completeOpBatchReceive(OpBatchReceive<T> op) {
-        notifyPendingBatchReceivedCallBack(op);
+        notifyPendingBatchReceivedCallBack(op.future);
         resumeReceivingFromPausedConsumersIfNeeded();
     }
 

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiTopicsConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiTopicsConsumerImpl.java
@@ -665,7 +665,8 @@ public class MultiTopicsConsumerImpl<T> extends ConsumerBase<T> {
     @Override
     public void redeliverUnacknowledgedMessages() {
         internalPinnedExecutor.execute(() -> {
-            synchronized (incomingQueueLock) {
+            incomingQueueLock.lock();
+            try {
                 CONSUMER_EPOCH.incrementAndGet(this);
                 consumers.values().stream().forEach(consumer -> {
                     consumer.redeliverUnacknowledgedMessages();
@@ -674,6 +675,8 @@ public class MultiTopicsConsumerImpl<T> extends ConsumerBase<T> {
                 clearIncomingMessages();
                 unAckedMessageTracker.clear();
                 resumeReceivingFromPausedConsumersIfNeeded();
+            } finally {
+                incomingQueueLock.unlock();
             }
         });
     }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/util/NoOpLock.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/util/NoOpLock.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/util/NoOpLock.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/util/NoOpLock.java
@@ -1,0 +1,55 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.client.util;
+
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.Condition;
+import java.util.concurrent.locks.Lock;
+
+public class NoOpLock implements Lock {
+    public static final NoOpLock INSTANCE = new NoOpLock();
+
+    public void lock() {
+    }
+
+    public void lockInterruptibly() throws InterruptedException {
+        if (Thread.interrupted()) {
+            throw new InterruptedException();
+        }
+    }
+
+    public boolean tryLock() {
+        return true;
+    }
+
+    public boolean tryLock(long l, TimeUnit tu) throws InterruptedException {
+        if (Thread.interrupted()) {
+            throw new InterruptedException();
+        } else {
+            return true;
+        }
+    }
+
+    public void unlock() {
+    }
+
+    public Condition newCondition() {
+        throw new UnsupportedOperationException();
+    }
+}


### PR DESCRIPTION
### Motivation

The original patch is https://github.com/apache/pulsar/pull/17318. Revert by https://github.com/apache/pulsar/pull/18475

Messages with inconsistent consumer epochs are not filtered when using batch receive and trigger timeout.

### Modifications

- Add consumer epoch on `notifyPendingBatchReceivedCallBack`.
- Reuse `notifyPendingBatchReceivedCallBack` logic.

### Verifying this change
- `testBatchReceiveRedeliveryAddEpoch` unit test covers the scene.

### Documentation
- [x] `doc-not-needed` 

