### PR TITLE
[fix][doc] Workaround Docusaurus links issue

### DIFF
--- a/site2/docs/client-libraries.md
+++ b/site2/docs/client-libraries.md
@@ -4,16 +4,20 @@ title: Pulsar client libraries
 sidebar_label: "Overview"
 ---
 
+````mdx-code-block
+import useBaseUrl from '@docusaurus/useBaseUrl';
+````
+
 Pulsar supports the following language-specific client libraries:
 
-| Language  | Documentation                                                          | Release note                                                                      | Code repo                                                             |
-| --------- |------------------------------------------------------------------------| --------------------------------------------------------------------------------- | --------------------------------------------------------------------- |
-| Java      | [User doc](client-libraries-java.md)   <br/> [API doc](/api/client/)   | [Bundled](/release-notes/)                                                        | [Bundled](https://github.com/apache/pulsar/tree/master/pulsar-client) |
-| C++       | [User doc](client-libraries-cpp.md)    <br/> [API doc](/api/cpp/3.0.0) | [Bundled](/release-notes/)                                                        | [Standalone](https://github.com/apache/pulsar/pulsar-client-cpp)      |
-| Python    | [User doc](client-libraries-python.md) <br/> [API doc](@pulsar:apidoc:python@)       | [Bundled](/release-notes/)                                                        | [Standalone](https://github.com/apache/pulsar-client-python)          |
-| Go client | [User doc](client-libraries-go.md)                                     | [Standalone](https://github.com/apache/pulsar-client-go/releases)                 | [Standalone](https://github.com/apache/pulsar-client-go)              |
-| Node.js   | [User doc](client-libraries-node.md)                                   | [Standalone](https://github.com/apache/pulsar-client-node/releases)               | [Standalone](https://github.com/apache/pulsar-client-node)            |
-| C#        | [User doc](client-libraries-dotnet.md)                                 | [Standalone](https://github.com/apache/pulsar-dotpulsar/blob/master/CHANGELOG.md) | [Standalone](https://github.com/apache/pulsar-dotpulsar)              |
+| Language  | Documentation                                                                                                      | Release note                                                                      | Code repo                                                             |
+| --------- |--------------------------------------------------------------------------------------------------------------------| --------------------------------------------------------------------------------- | --------------------------------------------------------------------- |
+| Java      | [User doc](client-libraries-java.md)   <br/> [API doc](/api/client/)                                               | [Bundled](/release-notes/)                                                        | [Bundled](https://github.com/apache/pulsar/tree/master/pulsar-client) |
+| C++       | [User doc](client-libraries-cpp.md)    <br/> <a href={useBaseUrl('/api/cpp/3.0.0/')} target={"_blank"}>API doc</a> | [Bundled](/release-notes/)                                                        | [Standalone](https://github.com/apache/pulsar/pulsar-client-cpp)      |
+| Python    | [User doc](client-libraries-python.md) <br/> [API doc](@pulsar:apidoc:python@)                                     | [Bundled](/release-notes/)                                                        | [Standalone](https://github.com/apache/pulsar-client-python)          |
+| Go client | [User doc](client-libraries-go.md)                                                                                 | [Standalone](https://github.com/apache/pulsar-client-go/releases)                 | [Standalone](https://github.com/apache/pulsar-client-go)              |
+| Node.js   | [User doc](client-libraries-node.md)                                                                               | [Standalone](https://github.com/apache/pulsar-client-node/releases)               | [Standalone](https://github.com/apache/pulsar-client-node)            |
+| C#        | [User doc](client-libraries-dotnet.md)                                                                             | [Standalone](https://github.com/apache/pulsar-dotpulsar/blob/master/CHANGELOG.md) | [Standalone](https://github.com/apache/pulsar-dotpulsar)              |
 
 Pulsar supports the following language-agnostic client libraries:
 

--- a/site2/docs/client-libraries.md
+++ b/site2/docs/client-libraries.md
@@ -4,10 +4,6 @@ title: Pulsar client libraries
 sidebar_label: "Overview"
 ---
 
-````mdx-code-block
-import useBaseUrl from '@docusaurus/useBaseUrl';
-````
-
 Pulsar supports the following language-specific client libraries:
 
 | Language  | Documentation                                                                     | Release note                                                                      | Code repo                                                             |

--- a/site2/docs/client-libraries.md
+++ b/site2/docs/client-libraries.md
@@ -10,14 +10,14 @@ import useBaseUrl from '@docusaurus/useBaseUrl';
 
 Pulsar supports the following language-specific client libraries:
 
-| Language  | Documentation                                                                                                      | Release note                                                                      | Code repo                                                             |
-| --------- |--------------------------------------------------------------------------------------------------------------------| --------------------------------------------------------------------------------- | --------------------------------------------------------------------- |
-| Java      | [User doc](client-libraries-java.md)   <br/> [API doc](/api/client/)                                               | [Bundled](/release-notes/)                                                        | [Bundled](https://github.com/apache/pulsar/tree/master/pulsar-client) |
-| C++       | [User doc](client-libraries-cpp.md)    <br/> <a href={useBaseUrl('/api/cpp/3.0.0/')} target={"_blank"}>API doc</a> | [Bundled](/release-notes/)                                                        | [Standalone](https://github.com/apache/pulsar/pulsar-client-cpp)      |
-| Python    | [User doc](client-libraries-python.md) <br/> [API doc](@pulsar:apidoc:python@)                                     | [Bundled](/release-notes/)                                                        | [Standalone](https://github.com/apache/pulsar-client-python)          |
-| Go client | [User doc](client-libraries-go.md)                                                                                 | [Standalone](https://github.com/apache/pulsar-client-go/releases)                 | [Standalone](https://github.com/apache/pulsar-client-go)              |
-| Node.js   | [User doc](client-libraries-node.md)                                                                               | [Standalone](https://github.com/apache/pulsar-client-node/releases)               | [Standalone](https://github.com/apache/pulsar-client-node)            |
-| C#        | [User doc](client-libraries-dotnet.md)                                                                             | [Standalone](https://github.com/apache/pulsar-dotpulsar/blob/master/CHANGELOG.md) | [Standalone](https://github.com/apache/pulsar-dotpulsar)              |
+| Language  | Documentation                                                                     | Release note                                                                      | Code repo                                                             |
+| --------- |-----------------------------------------------------------------------------------| --------------------------------------------------------------------------------- | --------------------------------------------------------------------- |
+| Java      | [User doc](client-libraries-java.md)   <br/> [API doc](/api/client/)              | [Bundled](/release-notes/)                                                        | [Bundled](https://github.com/apache/pulsar/tree/master/pulsar-client) |
+| C++       | [User doc](client-libraries-cpp.md)    <br/> [API doc](pathname:///api/cpp/3.0.0) | [Bundled](/release-notes/)                                                        | [Standalone](https://github.com/apache/pulsar/pulsar-client-cpp)      |
+| Python    | [User doc](client-libraries-python.md) <br/> [API doc](@pulsar:apidoc:python@)    | [Bundled](/release-notes/)                                                        | [Standalone](https://github.com/apache/pulsar-client-python)          |
+| Go client | [User doc](client-libraries-go.md)                                                | [Standalone](https://github.com/apache/pulsar-client-go/releases)                 | [Standalone](https://github.com/apache/pulsar-client-go)              |
+| Node.js   | [User doc](client-libraries-node.md)                                              | [Standalone](https://github.com/apache/pulsar-client-node/releases)               | [Standalone](https://github.com/apache/pulsar-client-node)            |
+| C#        | [User doc](client-libraries-dotnet.md)                                            | [Standalone](https://github.com/apache/pulsar-dotpulsar/blob/master/CHANGELOG.md) | [Standalone](https://github.com/apache/pulsar-dotpulsar)              |
 
 Pulsar supports the following language-agnostic client libraries:
 


### PR DESCRIPTION
This is the counterpart of https://github.com/apache/pulsar-site/pull/293.

It's a bit clumsy to update multiple occurrences for the same purpose :/

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [x] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
