### PR TITLE
[fix][doc] Add client config override

### DIFF
--- a/site2/docs/reference-configuration.md
+++ b/site2/docs/reference-configuration.md
@@ -5,3 +5,19 @@ sidebar_label: "Pulsar Configuration"
 ---
 
 For a complete list of Pulsar configuration, visit the [Pulsar Reference](http://pulsar.apache.org/reference/#/) website.
+
+***
+
+### Override client configurations
+
+If you want to override the configurations of clients internal to brokers, websockets, and proxies, you can use the following prefix.
+
+|Prefix|Description|
+|---|---|
+|brokerClient_| Configure **all** the Pulsar Clients and Pulsar Admin Clients of brokers, websockets, and proxies. These configurations are applied after hard-coded configurations and before the client configurations named in the [Pulsar Reference](http://pulsar.apache.org/reference/#/) website.|
+|bookkeeper_| Configure the broker's BookKeeper clients used by managed ledgers and the BookkeeperPackagesStorage bookkeeper client. Takes precedence over most other configuration values.|
+
+:::note
+* This feature only applies to Pulsar 2.10.1 and later versions.
+* When running the function worker within the broker, you have to configure those clients by using the `functions_worker.yml` file. These prefixed configurations do not apply to any of those clients.
+:::


### PR DESCRIPTION
Fixes https://github.com/apache/pulsar/issues/18490

### Modifications

<!-- Describe the modifications you've done. -->

Add back the configuration override information introduced in https://github.com/apache/pulsar/pull/15818 but missed on the new [Pulsar config](https://pulsar.apache.org/reference/#/next/config/) site.

<img width="1424" alt="image" src="https://user-images.githubusercontent.com/60642177/202111557-eda5c4b8-654f-431d-a482-6a86088f8fd7.png">

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [x] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->