### PR TITLE
[improve][test] Print stacktrace when the test is skipped

### DIFF
--- a/buildtools/src/main/java/org/apache/pulsar/tests/PulsarTestListener.java
+++ b/buildtools/src/main/java/org/apache/pulsar/tests/PulsarTestListener.java
@@ -55,6 +55,10 @@ public class PulsarTestListener implements ITestListener {
     public void onTestSkipped(ITestResult result) {
         System.out.format("~~~~~~~~~ SKIPPED -- %s.%s(%s)-------\n", result.getTestClass(),
                 result.getMethod().getMethodName(), Arrays.toString(result.getParameters()));
+        if (result.getThrowable() != null) {
+            System.out.println("~~~~~~~~~ STACKTRACE ~~~~~~~~~");
+            result.getThrowable().printStackTrace();
+        }
     }
 
     @Override


### PR DESCRIPTION
### Motivation

When a test is skipped, we need to know why. See the following log, this log doesn't contain why skip:

```
2022-11-15T16:58:39,575 - INFO  - [metadata-store-72-1:ServerCnx@1144] - [/127.0.0.1:47616] Created subscription on topic persistent://prop/use/my-ns/__change_events / reader-244e8c3e2a
2022-11-15T16:58:39,576 - INFO  - [pulsar-io-67-4:ConsumerImpl@920] - [persistent://prop/use/my-ns/__change_events][reader-244e8c3e2a] Subscribed to topic on localhost/127.0.0.1:40931 -- consumer: 0
2022-11-15T16:58:39,595 - INFO  - [bookkeeper-ml-scheduler-OrderedScheduler-0-0:ManagedCursorImpl$30@3007] - [prop/use/my-ns/persistent/my-topic1] Updated cursor my-sub with ledger id 6 md-position=3:1 rd-position=3:10
~~~~~~~~~ SKIPPED -- [TestClass name=class org.apache.pulsar.websocket.proxy.v1.V1_ProxyAuthenticationTest].anonymousSocketTest([])-------
2022-11-15T16:58:48,913 - INFO  - [main:SimpleConsumerSocket@68] - Connection closed: 1006 - Disconnected
2022-11-15T16:58:48,914 - INFO  - [pulsar-websocket-web-110-5:AbstractWebSocketHandler@191] - [/127.0.0.1:40892] Closed WebSocket session on topic persistent://prop/use/my-ns/my-topic1. status: 1001 - reason: Shutdown
2022-11-15T16:58:48,916 - INFO  - [pulsar-io-67-2:ServerCnx@1839] - [/127.0.0.1:47612] Closing consumer: consumerId=0
2022-11-15T16:58:48,917 - INFO  - [pulsar-io-67-2:AbstractDispatcherSingleActiveConsumer@187] - Removing consumer Consumer{subscription=PersistentSubscription{topic=persistent://prop/use/my-ns/my-topic1, name=my-sub}, consumerId=0, consumerName=bd5bc, address=/127.0.0.1:47612}
2022-11-15T16:58:48,917 - INFO  - [pulsar-io-67-2:ServerCnx@1875] - [/127.0.0.1:47612] Closed consumer, consumerId=0
```

### Modifications

Print stacktrace when the test is skipped.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
