### PR TITLE
[improve][client] Avoid `SingleThreadExecutor` submit tasks recursively

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/util/ExecutorProvider.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/util/ExecutorProvider.java
@@ -24,7 +24,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import lombok.Getter;
@@ -76,7 +75,7 @@ public class ExecutorProvider {
     }
 
     protected ExecutorService createExecutor(ExtendedThreadFactory threadFactory) {
-       return Executors.newSingleThreadExecutor(threadFactory);
+       return new ReentrantSingleThreadEventExecutor(threadFactory);
     }
 
     public ExecutorService getExecutor() {

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/util/ReentrantSingleThreadEventExecutor.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/util/ReentrantSingleThreadEventExecutor.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.client.util;
+
+import io.netty.util.concurrent.DefaultEventExecutor;
+import io.netty.util.concurrent.DefaultThreadFactory;
+import io.netty.util.concurrent.EventExecutorGroup;
+import io.netty.util.concurrent.RejectedExecutionHandlers;
+import io.netty.util.concurrent.SingleThreadEventExecutor;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ThreadFactory;
+
+public class ReentrantSingleThreadEventExecutor extends SingleThreadEventExecutor {
+    private static final int MAX_PENDING_TASKS = Integer.MAX_VALUE;
+
+    public ReentrantSingleThreadEventExecutor() {
+        this((EventExecutorGroup) null);
+    }
+
+    public ReentrantSingleThreadEventExecutor(ThreadFactory threadFactory) {
+        this((EventExecutorGroup) null, (ThreadFactory) threadFactory);
+    }
+
+    public ReentrantSingleThreadEventExecutor(Executor executor) {
+        this((EventExecutorGroup) null, (Executor) executor);
+    }
+
+    public ReentrantSingleThreadEventExecutor(EventExecutorGroup parent) {
+        this(parent, (ThreadFactory) (new DefaultThreadFactory(DefaultEventExecutor.class)));
+    }
+
+    public ReentrantSingleThreadEventExecutor(EventExecutorGroup parent, ThreadFactory threadFactory) {
+        super(parent, threadFactory, true, MAX_PENDING_TASKS, RejectedExecutionHandlers.reject());
+    }
+
+    public ReentrantSingleThreadEventExecutor(EventExecutorGroup parent, Executor executor) {
+        super(parent, executor, true, MAX_PENDING_TASKS, RejectedExecutionHandlers.reject());
+    }
+
+    @Override
+    protected void run() {
+        do {
+            Runnable task = this.takeTask();
+            if (task != null) {
+                runTask(task);
+                this.updateLastExecutionTime();
+            }
+        } while(!this.confirmShutdown());
+
+    }
+
+    @Override
+    public void execute(Runnable task) {
+        if (inEventLoop()) {
+            task.run();
+        } else {
+            super.execute(task);
+        }
+    }
+}


### PR DESCRIPTION
### Motivation

In the client, we use a lot of `SingleThreadExecutor` such as `internalPinnedExecutor`, In order to avoid `SingleThreadExecutor` submit tasks recursively leading to deadlock and unnecessary submission, I use ReentrantSingleThreadEventExecutor to improve it.

```java
internalPinnedExecutor.execute(() -> {
// ....
internalPinnedExecutor.submit(() -> {
}).get();
// ....
});
```

### Modifications

Use `ReentrantSingleThreadEventExecutor` instead of the normal `SingleThreadExecutor`.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/coderzc/pulsar/pull/31
