### PR TITLE
[fix][offload] Fix memory leak while Offloading ledgers

### DIFF
--- a/tiered-storage/jcloud/src/main/java/org/apache/bookkeeper/mledger/offload/jcloud/impl/BlockAwareSegmentInputStreamImpl.java
+++ b/tiered-storage/jcloud/src/main/java/org/apache/bookkeeper/mledger/offload/jcloud/impl/BlockAwareSegmentInputStreamImpl.java
@@ -278,7 +278,7 @@ public class BlockAwareSegmentInputStreamImpl extends BlockAwareSegmentInputStre
         // And through debug, writeBlobStore.uploadMultipartPart in the offload method also will trigger
         // the close method.
         // So we add the close variable to avoid release paddingBuf twice.
-        if (!close.compareAndSet(false, true)) {
+        if (close.compareAndSet(false, true)) {
             super.close();
             dataBlockHeaderStream.close();
             if (!entriesByteBuf.isEmpty()) {

--- a/tiered-storage/jcloud/src/test/java/org/apache/bookkeeper/mledger/offload/jcloud/impl/BlockAwareSegmentInputStreamTest.java
+++ b/tiered-storage/jcloud/src/test/java/org/apache/bookkeeper/mledger/offload/jcloud/impl/BlockAwareSegmentInputStreamTest.java
@@ -30,6 +30,7 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.lang.reflect.Field;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.Iterator;
@@ -797,5 +798,19 @@ public class BlockAwareSegmentInputStreamTest {
         assertEquals(inputStream.getEndEntryId(), expectedEntryCount - 1);
 
         inputStream.close();
+    }
+
+    @Test
+    public void testCloseReleaseResources() throws Exception {
+        ReadHandle readHandle = new MockReadHandle(1, 10, 10);
+
+        BlockAwareSegmentInputStreamImpl inputStream = new BlockAwareSegmentInputStreamImpl(readHandle, 0, 1024);
+        inputStream.read();
+        Field field = BlockAwareSegmentInputStreamImpl.class.getDeclaredField("paddingBuf");
+        field.setAccessible(true);
+        ByteBuf paddingBuf = (ByteBuf) field.get(inputStream);
+        assertEquals(1, paddingBuf.refCnt());
+        inputStream.close();
+        assertEquals(0, paddingBuf.refCnt());
     }
 }


### PR DESCRIPTION

### Motivation

- BlockAwareSegmentInputStreamImpl never releases the BookKeeper entries in the close method
- This leads to OutOfDirectMemory errors on brokers that run frequently  Offloading activity

### Modifications

Fix the "if" condition.

### Verifying this change

This change added tests
### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->
