### PR TITLE
[improve][build] Add lombok plugin to solve Javadoc issue.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -284,6 +284,7 @@ flexible messaging model and an intuitive client API.</description>
     <dependency-check-maven.version>7.1.0</dependency-check-maven.version>
     <roaringbitmap.version>0.9.15</roaringbitmap.version>
     <extra-enforcer-rules.version>1.6.1</extra-enforcer-rules.version>
+    <lombok.plugin.version>1.18.20.0</lombok.plugin.version>
 
     <!-- Used to configure rename.netty.native. Libs -->
     <rename.netty.native.libs>rename-netty-native-libs.sh</rename.netty.native.libs>
@@ -1818,7 +1819,21 @@ flexible messaging model and an intuitive client API.</description>
           <configuration>
             <doclint>none</doclint>
             <notimestamp>true</notimestamp>
+            <sourcepath>${project.build.directory}/generated-sources/delombok</sourcepath>
           </configuration>
+        </plugin>
+        <plugin>
+          <groupId>org.projectlombok</groupId>
+          <artifactId>lombok-maven-plugin</artifactId>
+          <version>${lombok.plugin.version}</version>
+          <executions>
+            <execution>
+              <phase>generate-sources</phase>
+              <goals>
+                <goal>delombok</goal>
+              </goals>
+            </execution>
+          </executions>
         </plugin>
         <plugin>
           <artifactId>maven-antrun-plugin</artifactId>


### PR DESCRIPTION

### Motivation

When releasing branch-2.11, there is a issue when generating Javadoc :
```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-javadoc-plugin:3.0.1:javadoc (default-cli) on project pulsar-functions-api: An error has occurred in Javadoc report generation: 
[ERROR] Exit code: 1 - Loading source files for package org.apache.pulsar.functions.api...
[ERROR] Loading source files for package org.apache.pulsar.functions.api.utils...
[ERROR] Loading source files for package org.apache.pulsar.functions.api.state...
[ERROR] Constructing Javadoc information...
[ERROR] /Users/tboy/tboy/workspace_3/pulsar/pulsar-functions/api-java/src/main/java/org/apache/pulsar/functions/api/Context.java:173: error: cannot find symbol
[ERROR]     <X> FunctionRecord.FunctionRecordBuilder<X> newOutputRecordBuilder(Schema<X> schema);
[ERROR]                       ^
[ERROR]   symbol:   class FunctionRecordBuilder
[ERROR]   location: class FunctionRecord
[ERROR] /Users/tboy/tboy/workspace_3/pulsar/pulsar-functions/api-java/src/main/java/org/apache/pulsar/functions/api/utils/FunctionRecord.java:52: error: cannot find symbol
[ERROR]     public static <T> FunctionRecord.FunctionRecordBuilder<T> from(Context context, Schema<T> schema) {
[ERROR]                                     ^
[ERROR]   symbol:   class FunctionRecordBuilder
[ERROR]   location: class FunctionRecord
[ERROR] 2 errors
[ERROR] 
[ERROR] Command line was: /Library/Java/JavaVirtualMachines/jdk-17.0.3.1.jdk/Contents/Home/bin/javadoc @options @packages
[ERROR] 
[ERROR] Refer to the generated Javadoc files in '/Users/tboy/tboy/workspace_3/pulsar/pulsar-functions/api-java/target/site/apidocs' dir.
```

We can use `mvn javadoc:javadoc` to reproduce in the master branch.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->


