### PR TITLE
Revert "[improve][broker] Unreasonable AuthenticationException refere…

### DIFF
--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authentication/AuthenticationService.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authentication/AuthenticationService.java
@@ -87,6 +87,7 @@ public class AuthenticationService implements Closeable {
 
     public String authenticateHttpRequest(HttpServletRequest request, AuthenticationDataSource authData)
             throws AuthenticationException {
+        AuthenticationException authenticationException = null;
         String authMethodName = request.getHeader(AuthenticationFilter.PULSAR_AUTH_METHOD_NAME);
 
         if (authMethodName != null) {
@@ -107,6 +108,8 @@ public class AuthenticationService implements Closeable {
                     LOG.debug("Authentication failed for provider " + providerToUse.getAuthMethodName() + " : "
                             + e.getMessage(), e);
                 }
+                // Store the exception so we can throw it later instead of a generic one
+                authenticationException = e;
                 throw e;
             }
         } else {
@@ -130,7 +133,11 @@ public class AuthenticationService implements Closeable {
                 return anonymousUserRole;
             }
             // If at least a provider was configured, then the authentication needs to be provider
-            throw new AuthenticationException("Authentication required");
+            if (authenticationException != null) {
+                throw authenticationException;
+            } else {
+                throw new AuthenticationException("Authentication required");
+            }
         } else {
             // No authentication required
             return "<none>";


### PR DESCRIPTION
…nce (#18502)"

This reverts commit e5e5852ee3ed5ae661104784c82a1b8f0cda321d.

### Motivation

I do not think sufficient justification was provided in #18502. The code is verbose, but it is intentionally verbose in order to maintain a potentially helpful stack trace. Given that the exception could have happened in any number of authentication providers, it seems helpful to store and throw a meaningful stack trace. I propose that we revert the commit.

### Documentation
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
