### PR TITLE
[fix][client] Fix unable to send cumulative acknowledgment for last messageId of a batch when enable batch index acknowledgment

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PersistentAcknowledgmentsGroupingTracker.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PersistentAcknowledgmentsGroupingTracker.java
@@ -622,7 +622,18 @@ class LastCumulativeAck {
     private boolean flushRequired = false;
 
     public synchronized void update(final MessageIdImpl messageId, final BitSetRecyclable bitSetRecyclable) {
-        if (messageId.compareTo(this.messageId) > 0) {
+        MessageIdImpl newMessageId = messageId;
+        MessageIdImpl lastMessageId = this.messageId;
+        if (newMessageId instanceof BatchMessageIdImpl && !(lastMessageId instanceof BatchMessageIdImpl)) {
+            lastMessageId =
+                    new BatchMessageIdImpl(lastMessageId.ledgerId, lastMessageId.entryId, lastMessageId.partitionIndex,
+                            Integer.MAX_VALUE);
+        } else if (!(newMessageId instanceof BatchMessageIdImpl) && (lastMessageId instanceof BatchMessageIdImpl)) {
+            newMessageId =
+                    new BatchMessageIdImpl(newMessageId.ledgerId, newMessageId.entryId, newMessageId.partitionIndex,
+                            Integer.MAX_VALUE);
+        }
+        if (newMessageId.compareTo(lastMessageId) > 0) {
             if (this.bitSetRecyclable != null && this.bitSetRecyclable != bitSetRecyclable) {
                 this.bitSetRecyclable.recycle();
             }


### PR DESCRIPTION
### Motivation
When enable batch index acknowledgment, we are unable to send a cumulative acknowledgment for the last messageId of a batch, the root cause is the last messageId of a batch doesn't carry with batch index but due to the wrong comparison in `org.apache.pulsar.client.impl.LastCumulativeAck#update` make the last messageId can't be sent.

https://github.com/apache/pulsar/blob/545f33fa35309510585e28283ba485a60deddf15/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PersistentAcknowledgmentsGroupingTracker.java#L228-L229

https://github.com/apache/pulsar/blob/545f33fa35309510585e28283ba485a60deddf15/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PersistentAcknowledgmentsGroupingTracker.java#L624-L632

```java
    public synchronized void update(final MessageIdImpl messageId, final BitSetRecyclable bitSetRecyclable) {
        if (messageId.compareTo(this.messageId) > 0) {
        // messageId(3,0,-1) < this.messageId(3,0,-1,8) so the following logic cannot be executed
            if (this.bitSetRecyclable != null && this.bitSetRecyclable != bitSetRecyclable) {
                this.bitSetRecyclable.recycle();
            }
            set(messageId, bitSetRecyclable);
            flushRequired = true;
        }
    }
```
https://github.com/apache/pulsar/blob/82237d3684fe506bcb6426b3b23f413422e6e4fb/pulsar-client/src/main/java/org/apache/pulsar/client/impl/BatchMessageIdImpl.java#L71-L84

### Modifications

Fix the wrong comparison in `org.apache.pulsar.client.impl.LastCumulativeAck#update`, change it to 
`(x,y,z) >= (x,y,z,w)`.

I'm not sure whether modifying `MessageImpl.compareTo` and `BatchMessageIdImpl.compareTo` can lead to other problems, so just modify `org.apache.pulsar.client.impl.LastCumulativeAck#update` 

### Verifying this change

- [x] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*testAcknowledgeCumulative*

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/coderzc/pulsar/pull/32
