### PR TITLE
[fix][test] Fix PrometheusMetricsTest.testBrokerConnection

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/PrometheusMetricsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/PrometheusMetricsTest.java
@@ -1318,16 +1318,16 @@ public class PrometheusMetricsTest extends BrokerTestBase {
         String metricsStr = statsOut.toString();
         Multimap<String, Metric> metrics = parseMetrics(metricsStr);
         List<Metric> cm = (List<Metric>) metrics.get("pulsar_connection_created_total_count");
-        compareBrokerConnectionStateCount(cm, 1.0);
+        compareBrokerConnectionStateCount(cm, 2.0);
 
         cm = (List<Metric>) metrics.get("pulsar_connection_create_success_count");
-        compareBrokerConnectionStateCount(cm, 1.0);
+        compareBrokerConnectionStateCount(cm, 2.0);
 
         cm = (List<Metric>) metrics.get("pulsar_connection_closed_total_count");
         compareBrokerConnectionStateCount(cm, 0.0);
 
         cm = (List<Metric>) metrics.get("pulsar_active_connections");
-        compareBrokerConnectionStateCount(cm, 1.0);
+        compareBrokerConnectionStateCount(cm, 2.0);
 
         pulsarClient.close();
         statsOut = new ByteArrayOutputStream();
@@ -1365,13 +1365,13 @@ public class PrometheusMetricsTest extends BrokerTestBase {
         compareBrokerConnectionStateCount(cm, 1.0);
 
         cm = (List<Metric>) metrics.get("pulsar_connection_create_success_count");
-        compareBrokerConnectionStateCount(cm, 1.0);
+        compareBrokerConnectionStateCount(cm, 2.0);
 
         cm = (List<Metric>) metrics.get("pulsar_active_connections");
-        compareBrokerConnectionStateCount(cm, 0.0);
+        compareBrokerConnectionStateCount(cm, 1.0);
 
         cm = (List<Metric>) metrics.get("pulsar_connection_created_total_count");
-        compareBrokerConnectionStateCount(cm, 2.0);
+        compareBrokerConnectionStateCount(cm, 3.0);
     }
 
     private void compareBrokerConnectionStateCount(List<Metric> cm, double count) {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/PrometheusMetricsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/PrometheusMetricsTest.java
@@ -94,9 +94,6 @@ public class PrometheusMetricsTest extends BrokerTestBase {
     protected void setup() throws Exception {
         conf.setTopicLevelPoliciesEnabled(false);
         conf.setSystemTopicEnabled(false);
-        conf.setTransactionCoordinatorEnabled(true);
-        conf.setTransactionLogBatchedWriteEnabled(true);
-        conf.setTransactionPendingAckBatchedWriteEnabled(true);
         super.baseSetup();
         AuthenticationProviderToken.resetMetrics();
     }
@@ -782,6 +779,12 @@ public class PrometheusMetricsTest extends BrokerTestBase {
     // Running the test twice to make sure types are present when generated multiple times
     @Test(invocationCount = 2)
     public void testDuplicateMetricTypeDefinitions() throws Exception {
+        cleanup();
+        conf.setTransactionCoordinatorEnabled(true);
+        conf.setTransactionLogBatchedWriteEnabled(true);
+        conf.setTransactionPendingAckBatchedWriteEnabled(true);
+        setup();
+
         Set<String> allPrometheusSuffixString = allPrometheusSuffixEnums();
         Producer<byte[]> p1 = pulsarClient.newProducer().topic("persistent://my-property/use/my-ns/my-topic1").create();
         Producer<byte[]> p2 = pulsarClient.newProducer().topic("persistent://my-property/use/my-ns/my-topic2").create();
@@ -861,6 +864,10 @@ public class PrometheusMetricsTest extends BrokerTestBase {
 
         p1.close();
         p2.close();
+
+        conf.setTransactionCoordinatorEnabled(false);
+        conf.setTransactionLogBatchedWriteEnabled(false);
+        conf.setTransactionPendingAckBatchedWriteEnabled(false);
     }
 
     /***
@@ -1318,16 +1325,16 @@ public class PrometheusMetricsTest extends BrokerTestBase {
         String metricsStr = statsOut.toString();
         Multimap<String, Metric> metrics = parseMetrics(metricsStr);
         List<Metric> cm = (List<Metric>) metrics.get("pulsar_connection_created_total_count");
-        compareBrokerConnectionStateCount(cm, 2.0);
+        compareBrokerConnectionStateCount(cm, 1.0);
 
         cm = (List<Metric>) metrics.get("pulsar_connection_create_success_count");
-        compareBrokerConnectionStateCount(cm, 2.0);
+        compareBrokerConnectionStateCount(cm, 1.0);
 
         cm = (List<Metric>) metrics.get("pulsar_connection_closed_total_count");
         compareBrokerConnectionStateCount(cm, 0.0);
 
         cm = (List<Metric>) metrics.get("pulsar_active_connections");
-        compareBrokerConnectionStateCount(cm, 2.0);
+        compareBrokerConnectionStateCount(cm, 1.0);
 
         pulsarClient.close();
         statsOut = new ByteArrayOutputStream();
@@ -1365,13 +1372,13 @@ public class PrometheusMetricsTest extends BrokerTestBase {
         compareBrokerConnectionStateCount(cm, 1.0);
 
         cm = (List<Metric>) metrics.get("pulsar_connection_create_success_count");
-        compareBrokerConnectionStateCount(cm, 2.0);
-
-        cm = (List<Metric>) metrics.get("pulsar_active_connections");
         compareBrokerConnectionStateCount(cm, 1.0);
 
+        cm = (List<Metric>) metrics.get("pulsar_active_connections");
+        compareBrokerConnectionStateCount(cm, 0.0);
+
         cm = (List<Metric>) metrics.get("pulsar_connection_created_total_count");
-        compareBrokerConnectionStateCount(cm, 3.0);
+        compareBrokerConnectionStateCount(cm, 2.0);
     }
 
     private void compareBrokerConnectionStateCount(List<Metric> cm, double count) {


### PR DESCRIPTION
Fixes #18535

### Motivation

in #17905, we enable transaction coordinator in the broker, this will lead to opening a connection in broker, so connection_count should recalculate.

### Modifications

Enable transaction coordinator in broker only in `testDuplicateMetricTypeDefinitions`.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/coderzc/pulsar/pull/33
