### PR TITLE
[fix][sec] Upgrade org.bouncycastle:bc-fips to 1.0.2.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -139,7 +139,7 @@ flexible messaging model and an intuitive client API.</description>
     <commons.collections4.version>4.4</commons.collections4.version>
     <log4j2.version>2.18.0</log4j2.version>
     <bouncycastle.version>1.69</bouncycastle.version>
-    <bouncycastlefips.version>1.0.2</bouncycastlefips.version>
+    <bouncycastlefips.version>1.0.2.1</bouncycastlefips.version>
     <jackson.version>2.13.4.20221013</jackson.version>
     <reflections.version>0.9.11</reflections.version>
     <swagger.version>1.6.2</swagger.version>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.bouncycastle:bc-fips 1.0.2
- [CVE-2020-15522](https://www.oscs1024.com/hd/CVE-2020-15522)


### What did I do？
Upgrade org.bouncycastle:bc-fips from 1.0.2 to 1.0.2.1 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### Documentation

- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS
Signed-off-by:pen4<948453219@qq.com>