### PR TITLE
[fix][sec] Upgrade org.bouncycastle:bc-fips to 1.0.2.3

### DIFF
--- a/bouncy-castle/bcfips/pom.xml
+++ b/bouncy-castle/bcfips/pom.xml
@@ -43,13 +43,13 @@
     <dependency>
       <groupId>org.bouncycastle</groupId>
       <artifactId>bc-fips</artifactId>
-      <version>${bouncycastlefips.version}</version>
+      <version>${bouncycastle.bc-fips.version}</version>
     </dependency>
 
     <dependency>
       <groupId>org.bouncycastle</groupId>
       <artifactId>bcpkix-fips</artifactId>
-      <version>${bouncycastlefips.version}</version>
+      <version>${bouncycastle.bcpkix-fips.version}</version>
     </dependency>
   </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -139,7 +139,8 @@ flexible messaging model and an intuitive client API.</description>
     <commons.collections4.version>4.4</commons.collections4.version>
     <log4j2.version>2.18.0</log4j2.version>
     <bouncycastle.version>1.69</bouncycastle.version>
-    <bouncycastlefips.version>1.0.2</bouncycastlefips.version>
+    <bouncycastle.bcpkix-fips.version>1.0.6</bouncycastle.bcpkix-fips.version>
+    <bouncycastle.bc-fips.version>1.0.2.3</bouncycastle.bc-fips.version>
     <jackson.version>2.13.4.20221013</jackson.version>
     <reflections.version>0.9.11</reflections.version>
     <swagger.version>1.6.2</swagger.version>

--- a/pulsar-broker-common/pom.xml
+++ b/pulsar-broker-common/pom.xml
@@ -73,7 +73,7 @@
     <dependency>
       <groupId>org.bouncycastle</groupId>
       <artifactId>bc-fips</artifactId>
-      <version>${bouncycastlefips.version}</version>
+      <version>${bouncycastle.bc-fips.version}</version>
       <scope>test</scope>
     </dependency>
 

--- a/pulsar-common/pom.xml
+++ b/pulsar-common/pom.xml
@@ -184,7 +184,7 @@
     <dependency>
       <groupId>org.bouncycastle</groupId>
       <artifactId>bc-fips</artifactId>
-      <version>${bouncycastlefips.version}</version>
+      <version>${bouncycastle.bc-fips.version}</version>
       <scope>test</scope>
     </dependency>
 

--- a/site2/docs/security-bouncy-castle.md
+++ b/site2/docs/security-bouncy-castle.md
@@ -101,17 +101,17 @@ Pulsar module `bouncy-castle-bcfips`, which is defined by `bouncy-castle/bcfips/
 Similar to `bouncy-castle-bc`, `bouncy-castle-bcfips` is also packaged as a `jar-in-jar` package for easy include/exclude.
 
 ```xml
-    <dependency>
-      <groupId>org.bouncycastle</groupId>
-      <artifactId>bc-fips</artifactId>
-      <version>${bouncycastlefips.version}</version>
-    </dependency>
+<dependency>
+  <groupId>org.bouncycastle</groupId>
+  <artifactId>bc-fips</artifactId>
+  <version>${bouncycastle.bc-fips.version}</version>
+</dependency>
 
-    <dependency>
-      <groupId>org.bouncycastle</groupId>
-      <artifactId>bcpkix-fips</artifactId>
-      <version>${bouncycastlefips.version}</version>
-    </dependency>
+<dependency>
+  <groupId>org.bouncycastle</groupId>
+  <artifactId>bcpkix-fips</artifactId>
+  <version>${bouncycastle.bcpkix-fips.version}</version>
+</dependency>
 ```
 
 ### Exclude BC-non-FIPS and include BC-FIPS


### PR DESCRIPTION
This supersedes #18558 and fixes CVE-2020-15522. Co-authored by @pen4.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [x] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: 