### PR TITLE
[fix][broker] DnsResolverUtil.TTL should be greater than zero

### DIFF
--- a/pulsar-common/src/main/java/org/apache/pulsar/common/util/netty/DnsResolverUtil.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/util/netty/DnsResolverUtil.java
@@ -51,7 +51,7 @@ public class DnsResolverUtil {
             log.warn("Cannot get DNS TTL settings from sun.net.InetAddressCachePolicy class", e);
         }
         TTL = ttl <= 0 ? DEFAULT_TTL : ttl;
-        NEGATIVE_TTL = negativeTtl < 0 ? DEFAULT_TTL : negativeTtl;
+        NEGATIVE_TTL = negativeTtl < 0 ? DEFAULT_NEGATIVE_TTL : negativeTtl;
     }
 
     private DnsResolverUtil() {

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/util/netty/DnsResolverUtil.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/util/netty/DnsResolverUtil.java
@@ -44,21 +44,14 @@ public class DnsResolverUtil {
             Class<?> inetAddressCachePolicyClass = Class.forName("sun.net.InetAddressCachePolicy");
             Method getTTLMethod = inetAddressCachePolicyClass.getMethod("get");
             ttl = (Integer) getTTLMethod.invoke(null);
-            if (ttl <= 0) {
-                ttl = DEFAULT_TTL;
-            }
             Method getNegativeTTLMethod = inetAddressCachePolicyClass.getMethod("getNegative");
             negativeTtl = (Integer) getNegativeTTLMethod.invoke(null);
         } catch (NoSuchMethodException | ClassNotFoundException | InvocationTargetException
                  | IllegalAccessException e) {
             log.warn("Cannot get DNS TTL settings from sun.net.InetAddressCachePolicy class", e);
         }
-        TTL = ttl;
-        NEGATIVE_TTL = useDefaultTTLWhenSetToForever(negativeTtl, DEFAULT_NEGATIVE_TTL);
-    }
-
-    private static int useDefaultTTLWhenSetToForever(int ttl, int defaultTtl) {
-        return ttl < 0 ? defaultTtl : ttl;
+        TTL = ttl <= 0 ? DEFAULT_TTL : ttl;
+        NEGATIVE_TTL = negativeTtl < 0 ? DEFAULT_TTL : negativeTtl;
     }
 
     private DnsResolverUtil() {

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/util/netty/DnsResolverUtil.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/util/netty/DnsResolverUtil.java
@@ -44,13 +44,16 @@ public class DnsResolverUtil {
             Class<?> inetAddressCachePolicyClass = Class.forName("sun.net.InetAddressCachePolicy");
             Method getTTLMethod = inetAddressCachePolicyClass.getMethod("get");
             ttl = (Integer) getTTLMethod.invoke(null);
+            if (ttl <= 0) {
+                ttl = DEFAULT_TTL;
+            }
             Method getNegativeTTLMethod = inetAddressCachePolicyClass.getMethod("getNegative");
             negativeTtl = (Integer) getNegativeTTLMethod.invoke(null);
         } catch (NoSuchMethodException | ClassNotFoundException | InvocationTargetException
                  | IllegalAccessException e) {
             log.warn("Cannot get DNS TTL settings from sun.net.InetAddressCachePolicy class", e);
         }
-        TTL = useDefaultTTLWhenSetToForever(ttl, DEFAULT_TTL);
+        TTL = ttl;
         NEGATIVE_TTL = useDefaultTTLWhenSetToForever(negativeTtl, DEFAULT_NEGATIVE_TTL);
     }
 

--- a/pulsar-common/src/test/java/org/apache/pulsar/common/util/netty/DnsResolverTest.java
+++ b/pulsar-common/src/test/java/org/apache/pulsar/common/util/netty/DnsResolverTest.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.common.util.netty;
+
+import io.netty.channel.EventLoop;
+import io.netty.resolver.dns.DnsNameResolverBuilder;
+import org.mockito.Mockito;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class DnsResolverTest {
+
+    @Test
+    public void testMaxTtl() {
+        EventLoop eventLoop = Mockito.mock(EventLoop.class);
+        DnsNameResolverBuilder dnsNameResolverBuilder = new DnsNameResolverBuilder(eventLoop);
+        DnsResolverUtil.applyJdkDnsCacheSettings(dnsNameResolverBuilder);
+        // If the maxTtl is <=0, it will throw IllegalArgumentException.
+        try {
+            dnsNameResolverBuilder.build();
+        } catch (Exception ex) {
+            Assert.assertFalse(ex instanceof IllegalArgumentException);
+        }
+    }
+}


### PR DESCRIPTION
### Motivation

When the user set DNS cache maxTTl to 0, it will throw below exception :
```
Caused by: java.lang.IllegalArgumentException: maxTtl : 0 (expected: > 0)
	at io.netty.util.internal.ObjectUtil.checkPositive(ObjectUtil.java:100)
	at io.netty.resolver.dns.DefaultDnsCnameCache.<init>(DefaultDnsCnameCache.java:60)
	at io.netty.resolver.dns.DnsNameResolverBuilder.newCnameCache(DnsNameResolverBuilder.java:451)
	at io.netty.resolver.dns.DnsNameResolverBuilder.build(DnsNameResolverBuilder.java:485)
	at io.netty.resolver.dns.DnsAddressResolverGroup.newNameResolver(DnsAddressResolverGroup.java:114)
	at io.netty.resolver.dns.DnsAddressResolverGroup.newResolver(DnsAddressResolverGroup.java:92)
	at io.netty.resolver.dns.DnsAddressResolverGroup.newResolver(DnsAddressResolverGroup.java:77)
	at io.netty.resolver.AddressResolverGroup.getResolver(AddressResolverGroup.java:70)
```

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->


