### PR TITLE
[fix][build] Include Pulsar shell in the released artifacts

### DIFF
--- a/src/stage-release.sh
+++ b/src/stage-release.sh
@@ -35,6 +35,8 @@ popd
 cp $PULSAR_PATH/target/apache-pulsar-$VERSION-src.tar.gz $DEST_PATH
 cp $PULSAR_PATH/distribution/server/target/apache-pulsar-$VERSION-bin.tar.gz $DEST_PATH
 cp $PULSAR_PATH/distribution/offloaders/target/apache-pulsar-offloaders-$VERSION-bin.tar.gz $DEST_PATH
+cp $PULSAR_PATH/distribution/shell/target/apache-pulsar-shell-$VERSION-shell.tar.gz $DEST_PATH
+cp $PULSAR_PATH/distribution/shell/target/apache-pulsar-shell-$VERSION-shell.zip $DEST_PATH
 
 cp -r $PULSAR_PATH/distribution/io/target/apache-pulsar-io-connectors-$VERSION-bin $DEST_PATH/connectors
 


### PR DESCRIPTION
### Motivation

The current release process doesn't stage the pulsar shell artifacts. Pulsar shell is going to be released in 2.11.0 

### Modifications

* Add the .tar.gz and .zip pulsar shell artifacts to the stage-artifacts procedure

- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->


note: we should update the release process in the pulsar-site repository.