### PR TITLE
[fix][offload] Fix numerical overflow bug while reading data from tiered storage

### DIFF
--- a/tiered-storage/jcloud/src/main/java/org/apache/bookkeeper/mledger/offload/jcloud/impl/BlobStoreBackedInputStreamImpl.java
+++ b/tiered-storage/jcloud/src/main/java/org/apache/bookkeeper/mledger/offload/jcloud/impl/BlobStoreBackedInputStreamImpl.java
@@ -182,6 +182,7 @@ public class BlobStoreBackedInputStreamImpl extends BackedInputStream {
 
     @Override
     public int available() throws IOException {
-        return (int) (objectLen - cursor) + buffer.readableBytes();
+        long available = objectLen - cursor + buffer.readableBytes();
+        return available > Integer.MAX_VALUE ? Integer.MAX_VALUE : (int) available;
     }
 }


### PR DESCRIPTION
Fixes #18580

### Motivation

Fix numerical overflow bug while reading data from tiered storage.

### Modifications

Fix the `BlobStoreBackedInputStreamImpl.available`.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change is hard to add test case because it might cause OOM.

### Does this pull request potentially affect one of the following parts:

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/dragonls/pulsar/pull/5