### PR TITLE
[improve][client] allow customize subscription name for TableView

### DIFF
--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/TableViewBuilder.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/TableViewBuilder.java
@@ -91,4 +91,13 @@ public interface TableViewBuilder<T> {
      * @return the {@link TableViewBuilder} builder instance
      */
     TableViewBuilder<T> autoUpdatePartitionsInterval(int interval, TimeUnit unit);
+
+
+    /**
+     * Set the subscription name of the {@link TableView}.
+     *
+     * @param subscriptionName the name of the subscription to the topic
+     * @return the {@link TableViewBuilder} builder instance
+     */
+    TableViewBuilder<T> subscriptionName(String subscriptionName);
 }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/TableViewBuilderImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/TableViewBuilderImpl.java
@@ -75,4 +75,11 @@ public class TableViewBuilderImpl<T> implements TableViewBuilder<T> {
        conf.setAutoUpdatePartitionsSeconds(unit.toSeconds(interval));
        return this;
     }
+
+    @Override
+    public TableViewBuilder<T> subscriptionName(String subscriptionName) {
+        checkArgument(StringUtils.isNotBlank(subscriptionName), "subscription name cannot be blank");
+        conf.setSubscriptionName(StringUtils.trim(subscriptionName));
+        return this;
+    }
 }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/TableViewConfigurationData.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/TableViewConfigurationData.java
@@ -28,6 +28,7 @@ public class TableViewConfigurationData implements Serializable, Cloneable {
     private static final long serialVersionUID = 1L;
 
     private String topicName = null;
+    private String subscriptionName = null;
     private long autoUpdatePartitionsSeconds = 60;
 
     @Override
@@ -36,6 +37,7 @@ public class TableViewConfigurationData implements Serializable, Cloneable {
             TableViewConfigurationData clone = (TableViewConfigurationData) super.clone();
             clone.setTopicName(topicName);
             clone.setAutoUpdatePartitionsSeconds(autoUpdatePartitionsSeconds);
+            clone.setSubscriptionName(subscriptionName);
             return clone;
         } catch (CloneNotSupportedException e) {
             throw new AssertionError();

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/TableViewImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/TableViewImpl.java
@@ -67,7 +67,8 @@ public class TableViewImpl<T> implements TableView<T> {
                 .startMessageId(MessageId.earliest)
                 .autoUpdatePartitions(true)
                 .autoUpdatePartitionsInterval((int) conf.getAutoUpdatePartitionsSeconds(), TimeUnit.SECONDS)
-                .poolMessages(true);
+                .poolMessages(true)
+                .subscriptionName(conf.getSubscriptionName());
         if (isPersistentTopic) {
             readerBuilder.readCompacted(true);
         }

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/TableViewConfigurationDataTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/TableViewConfigurationDataTest.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.client.impl;
+
+import static org.testng.Assert.assertEquals;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.pulsar.client.impl.conf.ConfigurationDataUtils;
+import org.testng.annotations.Test;
+
+/**
+ * Unit test of {@link TableViewConfigurationData}.
+ */
+public class TableViewConfigurationDataTest {
+    @Test
+    public void testLoadConfigFromMap() {
+        Map<String, Object> configMap = new HashMap<>();
+        configMap.put("topicName", "persistent://public/default/test");
+        configMap.put("subscriptionName", "test-sub");
+        configMap.put("autoUpdatePartitionsSeconds", "60");
+        TableViewConfigurationData config = new TableViewConfigurationData();
+        config = ConfigurationDataUtils.loadData(
+                configMap, config, TableViewConfigurationData.class);
+
+        assertEquals(configMap.get("topicName"), config.getTopicName());
+        assertEquals(configMap.get("subscriptionName"), config.getSubscriptionName());
+        assertEquals(configMap.get("autoUpdatePartitionsSeconds"), String.valueOf(config.getAutoUpdatePartitionsSeconds()));
+    }
+}

--- a/site2/docs/client-libraries-java.md
+++ b/site2/docs/client-libraries-java.md
@@ -1129,6 +1129,7 @@ You can use the available parameters in the `loadConf` configuration or related 
 |---|---|---|---|---
 | `topic` | string | yes | The topic name of the TableView. | N/A
 | `autoUpdatePartitionInterval` | int | no | The interval to check for newly added partitions. | 60 (seconds)
+| `subscriptionName` | string | no | The subscription name of the TableView. | null
 
 ### Register listeners
  


### PR DESCRIPTION
### Motivation

TableView does not allow the user to customize the subscription name and is not friendly when clusters have strict permission setups (like the need to create the subscription name manually).

### Modifications

- pass `subscriptionName` to the internal Reader

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [x] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [x] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
