### PR TITLE
[improve][misc] Upgrade Netty to 4.1.86.Final and Netty Tcnative to 2.0.54.Final

### DIFF
--- a/buildtools/pom.xml
+++ b/buildtools/pom.xml
@@ -47,7 +47,7 @@
     <maven-shade-plugin.version>3.4.0</maven-shade-plugin.version>
     <puppycrawl.checkstyle.version>8.37</puppycrawl.checkstyle.version>
     <maven-checkstyle-plugin.version>3.1.2</maven-checkstyle-plugin.version>
-    <netty.version>4.1.77.Final</netty.version>
+    <netty.version>4.1.86.Final</netty.version>
     <guice.version>4.2.3</guice.version>
     <guava.version>31.0.1-jre</guava.version>
     <ant.version>1.10.12</ant.version>

--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -314,9 +314,9 @@ The Apache Software License, Version 2.0
     - io.netty-netty-tcnative-boringssl-static-2.0.54.Final-osx-x86_64.jar
     - io.netty-netty-tcnative-boringssl-static-2.0.54.Final-windows-x86_64.jar
     - io.netty-netty-tcnative-classes-2.0.54.Final.jar
-    - io.netty.incubator-netty-incubator-transport-classes-io_uring-0.0.15.Final.jar
-    - io.netty.incubator-netty-incubator-transport-native-io_uring-0.0.15.Final-linux-x86_64.jar
-    - io.netty.incubator-netty-incubator-transport-native-io_uring-0.0.15.Final-linux-aarch_64.jar
+    - io.netty.incubator-netty-incubator-transport-classes-io_uring-0.0.16.Final.jar
+    - io.netty.incubator-netty-incubator-transport-native-io_uring-0.0.16.Final-linux-x86_64.jar
+    - io.netty.incubator-netty-incubator-transport-native-io_uring-0.0.16.Final-linux-aarch_64.jar
  * Prometheus client
     - io.prometheus.jmx-collector-0.16.1.jar
     - io.prometheus-simpleclient-0.16.0.jar

--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -286,34 +286,34 @@ The Apache Software License, Version 2.0
     - org.apache.commons-commons-lang3-3.11.jar
     - org.apache.commons-commons-text-1.10.0.jar
  * Netty
-    - io.netty-netty-buffer-4.1.77.Final.jar
-    - io.netty-netty-codec-4.1.77.Final.jar
-    - io.netty-netty-codec-dns-4.1.77.Final.jar
-    - io.netty-netty-codec-http-4.1.77.Final.jar
-    - io.netty-netty-codec-http2-4.1.77.Final.jar
-    - io.netty-netty-codec-socks-4.1.77.Final.jar
-    - io.netty-netty-codec-haproxy-4.1.77.Final.jar
-    - io.netty-netty-common-4.1.77.Final.jar
-    - io.netty-netty-handler-4.1.77.Final.jar
-    - io.netty-netty-handler-proxy-4.1.77.Final.jar
-    - io.netty-netty-resolver-4.1.77.Final.jar
-    - io.netty-netty-resolver-dns-4.1.77.Final.jar
-    - io.netty-netty-resolver-dns-classes-macos-4.1.77.Final.jar
-    - io.netty-netty-resolver-dns-native-macos-4.1.77.Final-osx-aarch_64.jar
-    - io.netty-netty-resolver-dns-native-macos-4.1.77.Final-osx-x86_64.jar
-    - io.netty-netty-transport-4.1.77.Final.jar
-    - io.netty-netty-transport-classes-epoll-4.1.77.Final.jar
-    - io.netty-netty-transport-native-epoll-4.1.77.Final-linux-x86_64.jar
-    - io.netty-netty-transport-native-epoll-4.1.77.Final.jar
-    - io.netty-netty-transport-native-unix-common-4.1.77.Final.jar
-    - io.netty-netty-transport-native-unix-common-4.1.77.Final-linux-x86_64.jar
-    - io.netty-netty-tcnative-boringssl-static-2.0.52.Final.jar
-    - io.netty-netty-tcnative-boringssl-static-2.0.52.Final-linux-aarch_64.jar
-    - io.netty-netty-tcnative-boringssl-static-2.0.52.Final-linux-x86_64.jar
-    - io.netty-netty-tcnative-boringssl-static-2.0.52.Final-osx-aarch_64.jar
-    - io.netty-netty-tcnative-boringssl-static-2.0.52.Final-osx-x86_64.jar
-    - io.netty-netty-tcnative-boringssl-static-2.0.52.Final-windows-x86_64.jar
-    - io.netty-netty-tcnative-classes-2.0.52.Final.jar
+    - io.netty-netty-buffer-4.1.86.Final.jar
+    - io.netty-netty-codec-4.1.86.Final.jar
+    - io.netty-netty-codec-dns-4.1.86.Final.jar
+    - io.netty-netty-codec-http-4.1.86.Final.jar
+    - io.netty-netty-codec-http2-4.1.86.Final.jar
+    - io.netty-netty-codec-socks-4.1.86.Final.jar
+    - io.netty-netty-codec-haproxy-4.1.86.Final.jar
+    - io.netty-netty-common-4.1.86.Final.jar
+    - io.netty-netty-handler-4.1.86.Final.jar
+    - io.netty-netty-handler-proxy-4.1.86.Final.jar
+    - io.netty-netty-resolver-4.1.86.Final.jar
+    - io.netty-netty-resolver-dns-4.1.86.Final.jar
+    - io.netty-netty-resolver-dns-classes-macos-4.1.86.Final.jar
+    - io.netty-netty-resolver-dns-native-macos-4.1.86.Final-osx-aarch_64.jar
+    - io.netty-netty-resolver-dns-native-macos-4.1.86.Final-osx-x86_64.jar
+    - io.netty-netty-transport-4.1.86.Final.jar
+    - io.netty-netty-transport-classes-epoll-4.1.86.Final.jar
+    - io.netty-netty-transport-native-epoll-4.1.86.Final-linux-x86_64.jar
+    - io.netty-netty-transport-native-epoll-4.1.86.Final.jar
+    - io.netty-netty-transport-native-unix-common-4.1.86.Final.jar
+    - io.netty-netty-transport-native-unix-common-4.1.86.Final-linux-x86_64.jar
+    - io.netty-netty-tcnative-boringssl-static-2.0.54.Final.jar
+    - io.netty-netty-tcnative-boringssl-static-2.0.54.Final-linux-aarch_64.jar
+    - io.netty-netty-tcnative-boringssl-static-2.0.54.Final-linux-x86_64.jar
+    - io.netty-netty-tcnative-boringssl-static-2.0.54.Final-osx-aarch_64.jar
+    - io.netty-netty-tcnative-boringssl-static-2.0.54.Final-osx-x86_64.jar
+    - io.netty-netty-tcnative-boringssl-static-2.0.54.Final-windows-x86_64.jar
+    - io.netty-netty-tcnative-classes-2.0.54.Final.jar
     - io.netty.incubator-netty-incubator-transport-classes-io_uring-0.0.15.Final.jar
     - io.netty.incubator-netty-incubator-transport-native-io_uring-0.0.15.Final-linux-x86_64.jar
     - io.netty.incubator-netty-incubator-transport-native-io_uring-0.0.15.Final-linux-aarch_64.jar

--- a/pom.xml
+++ b/pom.xml
@@ -127,7 +127,7 @@ flexible messaging model and an intuitive client API.</description>
     <dropwizardmetrics.version>4.1.12.1</dropwizardmetrics.version> <!-- ZooKeeper server -->
     <curator.version>5.1.0</curator.version>
     <netty.version>4.1.86.Final</netty.version>
-    <netty-iouring.version>0.0.15.Final</netty-iouring.version>
+    <netty-iouring.version>0.0.16.Final</netty-iouring.version>
     <jetty.version>9.4.48.v20220622</jetty.version>
     <conscrypt.version>2.5.2</conscrypt.version>
     <jersey.version>2.34</jersey.version>

--- a/pom.xml
+++ b/pom.xml
@@ -126,7 +126,7 @@ flexible messaging model and an intuitive client API.</description>
     <snappy.version>1.1.8.4</snappy.version> <!-- ZooKeeper server -->
     <dropwizardmetrics.version>4.1.12.1</dropwizardmetrics.version> <!-- ZooKeeper server -->
     <curator.version>5.1.0</curator.version>
-    <netty.version>4.1.77.Final</netty.version>
+    <netty.version>4.1.86.Final</netty.version>
     <netty-iouring.version>0.0.15.Final</netty-iouring.version>
     <jetty.version>9.4.48.v20220622</jetty.version>
     <conscrypt.version>2.5.2</conscrypt.version>

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
@@ -2867,8 +2867,6 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
                 && !autoReadDisabledRateLimiting && !autoReadDisabledPublishBufferLimiting) {
             // Resume reading from socket if pending-request is not reached to threshold
             ctx.channel().config().setAutoRead(true);
-            // triggers channel read
-            ctx.read();
             throttledConnections.dec();
         }
     }

--- a/pulsar-sql/presto-distribution/LICENSE
+++ b/pulsar-sql/presto-distribution/LICENSE
@@ -231,34 +231,34 @@ The Apache Software License, Version 2.0
     - commons-compress-1.21.jar
     - commons-lang3-3.11.jar
  * Netty
-    - netty-buffer-4.1.77.Final.jar
-    - netty-codec-4.1.77.Final.jar
-    - netty-codec-dns-4.1.77.Final.jar
-    - netty-codec-http-4.1.77.Final.jar
-    - netty-codec-haproxy-4.1.77.Final.jar
-    - netty-codec-socks-4.1.77.Final.jar
-    - netty-handler-proxy-4.1.77.Final.jar
-    - netty-common-4.1.77.Final.jar
-    - netty-handler-4.1.77.Final.jar
+    - netty-buffer-4.1.86.Final.jar
+    - netty-codec-4.1.86.Final.jar
+    - netty-codec-dns-4.1.86.Final.jar
+    - netty-codec-http-4.1.86.Final.jar
+    - netty-codec-haproxy-4.1.86.Final.jar
+    - netty-codec-socks-4.1.86.Final.jar
+    - netty-handler-proxy-4.1.86.Final.jar
+    - netty-common-4.1.86.Final.jar
+    - netty-handler-4.1.86.Final.jar
     - netty-reactive-streams-2.0.6.jar
-    - netty-resolver-4.1.77.Final.jar
-    - netty-resolver-dns-4.1.77.Final.jar
-    - netty-resolver-dns-classes-macos-4.1.77.Final.jar
-    - netty-resolver-dns-native-macos-4.1.77.Final-osx-aarch_64.jar
-    - netty-resolver-dns-native-macos-4.1.77.Final-osx-x86_64.jar
-    - netty-tcnative-boringssl-static-2.0.52.Final.jar
-    - netty-tcnative-boringssl-static-2.0.52.Final-linux-aarch_64.jar
-    - netty-tcnative-boringssl-static-2.0.52.Final-linux-x86_64.jar
-    - netty-tcnative-boringssl-static-2.0.52.Final-osx-aarch_64.jar
-    - netty-tcnative-boringssl-static-2.0.52.Final-osx-x86_64.jar
-    - netty-tcnative-boringssl-static-2.0.52.Final-windows-x86_64.jar
-    - netty-tcnative-classes-2.0.52.Final.jar
-    - netty-transport-4.1.77.Final.jar
-    - netty-transport-classes-epoll-4.1.77.Final.jar
-    - netty-transport-native-epoll-4.1.77.Final-linux-x86_64.jar
-    - netty-transport-native-unix-common-4.1.77.Final.jar
-    - netty-transport-native-unix-common-4.1.77.Final-linux-x86_64.jar
-    - netty-codec-http2-4.1.77.Final.jar
+    - netty-resolver-4.1.86.Final.jar
+    - netty-resolver-dns-4.1.86.Final.jar
+    - netty-resolver-dns-classes-macos-4.1.86.Final.jar
+    - netty-resolver-dns-native-macos-4.1.86.Final-osx-aarch_64.jar
+    - netty-resolver-dns-native-macos-4.1.86.Final-osx-x86_64.jar
+    - netty-tcnative-boringssl-static-2.0.54.Final.jar
+    - netty-tcnative-boringssl-static-2.0.54.Final-linux-aarch_64.jar
+    - netty-tcnative-boringssl-static-2.0.54.Final-linux-x86_64.jar
+    - netty-tcnative-boringssl-static-2.0.54.Final-osx-aarch_64.jar
+    - netty-tcnative-boringssl-static-2.0.54.Final-osx-x86_64.jar
+    - netty-tcnative-boringssl-static-2.0.54.Final-windows-x86_64.jar
+    - netty-tcnative-classes-2.0.54.Final.jar
+    - netty-transport-4.1.86.Final.jar
+    - netty-transport-classes-epoll-4.1.86.Final.jar
+    - netty-transport-native-epoll-4.1.86.Final-linux-x86_64.jar
+    - netty-transport-native-unix-common-4.1.86.Final.jar
+    - netty-transport-native-unix-common-4.1.86.Final-linux-x86_64.jar
+    - netty-codec-http2-4.1.86.Final.jar
     - netty-incubator-transport-classes-io_uring-0.0.15.Final.jar
     - netty-incubator-transport-native-io_uring-0.0.15.Final-linux-x86_64.jar
     - netty-incubator-transport-native-io_uring-0.0.15.Final-linux-aarch_64.jar

--- a/pulsar-sql/presto-distribution/LICENSE
+++ b/pulsar-sql/presto-distribution/LICENSE
@@ -259,9 +259,9 @@ The Apache Software License, Version 2.0
     - netty-transport-native-unix-common-4.1.86.Final.jar
     - netty-transport-native-unix-common-4.1.86.Final-linux-x86_64.jar
     - netty-codec-http2-4.1.86.Final.jar
-    - netty-incubator-transport-classes-io_uring-0.0.15.Final.jar
-    - netty-incubator-transport-native-io_uring-0.0.15.Final-linux-x86_64.jar
-    - netty-incubator-transport-native-io_uring-0.0.15.Final-linux-aarch_64.jar
+    - netty-incubator-transport-classes-io_uring-0.0.16.Final.jar
+    - netty-incubator-transport-native-io_uring-0.0.16.Final-linux-x86_64.jar
+    - netty-incubator-transport-native-io_uring-0.0.16.Final-linux-aarch_64.jar
  * GRPC
     - grpc-api-1.45.1.jar
     - grpc-context-1.45.1.jar

--- a/src/owasp-dependency-check-false-positives.xml
+++ b/src/owasp-dependency-check-false-positives.xml
@@ -56,7 +56,7 @@
   </suppress>
   <suppress>
     <notes><![CDATA[
-   file name: netty-tcnative-boringssl-static-2.0.52.Final-osx-aarch_64.jar
+   file name: netty-tcnative-boringssl-static-2.0.54.Final-osx-aarch_64.jar
    ]]></notes>
     <packageUrl regex="true">^pkg:maven/io\.netty/netty\-tcnative\-boringssl\-static@.*$</packageUrl>
     <cpe>cpe:/a:chromium_project:chromium</cpe>


### PR DESCRIPTION
### Motivation

- Netty 4.1.85 includes an important fix to FlowControlHandler that [is used in Pulsar](https://github.com/apache/pulsar/blob/82237d3684fe506bcb6426b3b23f413422e6e4fb/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/PulsarChannelInitializer.java), see release notes https://netty.io/news/2022/11/09/4-1-85-Final.html
- Netty 4.1.86 includes a fix for the regression in 4.1.85 in HashedWheelTimer, see release notes https://netty.io/news/2022/12/12/4-1-86-Final.html . It also includes a fix for a security vulnerability, [CVE-2022-41881](https://github.com/netty/netty/security/advisories/GHSA-fx2c-96vj-985v)

### Modifications

- Upgrade Netty to 4.1.86.Final
- Update Netty Tcnative to 2.0.54.Final (referenced in netty-bom)
- Upgrade netty-iouring.version to 0.0.16.Final which is compatible with 4.1.85.Final/4.1.86.Final
- Remove extra `ctx.read()` which is no more required when autoread is switched on.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/lhotari/pulsar/pull/103

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
