### PR TITLE
[fix][test] Fix flaky test AdditionalServletsTest.testEmptyStringAsExtractionDirectory

### DIFF
--- a/pulsar-broker-common/src/test/java/org/apache/pulsar/broker/web/plugin/servlet/AdditionalServletsTest.java
+++ b/pulsar-broker-common/src/test/java/org/apache/pulsar/broker/web/plugin/servlet/AdditionalServletsTest.java
@@ -52,10 +52,8 @@ public class AdditionalServletsTest {
         AdditionalServletWithClassLoader as1 = mock(AdditionalServletWithClassLoader.class);
         AdditionalServletWithClassLoader as2 = mock(AdditionalServletWithClassLoader.class);
 
-        String originalTmpDirectory = System.getProperty("java.io.tmpdir");
         try (MockedStatic<AdditionalServletUtils> utils = mockStatic(AdditionalServletUtils.class)) {
-            String tmpDirectory = "/my/tmp/directory";
-            System.setProperty("java.io.tmpdir", tmpDirectory);
+            String tmpDirectory =  System.getProperty("java.io.tmpdir");
             utils.when(() -> AdditionalServletUtils.searchForServlets(
                     "/additionalServletDirectory", tmpDirectory)).thenReturn(definitions);
             utils.when(() -> AdditionalServletUtils.load(asm1, tmpDirectory)).thenReturn(as1);
@@ -65,8 +63,6 @@ public class AdditionalServletsTest {
 
             Assert.assertEquals(servlets.getServlets().get("AS1"), as1);
             Assert.assertEquals(servlets.getServlets().get("AS2"), as2);
-        } finally {
-            System.setProperty("java.io.tmpdir", originalTmpDirectory);
         }
     }
 


### PR DESCRIPTION
<!-- Either this PR fixes an issue, -->

Fixes #18587

### Motivation

AdditionalServletsTest.testEmptyStringAsExtractionDirectory is flaky because it depends on NarClassLoader#DEFAULT_NAR_EXTRACTION_DIR being initialized after the test is begun. 

### Modifications

Remove the override of the tmp directory from the test.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

  - *This change only modifies test code*

### Does this pull request potentially affect one of the following parts:

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [X] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/andrasbeni/pulsar/pull/8

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
