### PR TITLE
[improve][cli] Pulsar shell: allow cloning an existing config

### DIFF
--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/shell/ConfigShell.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/shell/ConfigShell.java
@@ -112,6 +112,7 @@ public class ConfigShell implements ShellCommandsProvider {
 
         commands.put("list", new CmdConfigList());
         commands.put("create", new CmdConfigCreate());
+        commands.put("clone", new CmdConfigClone());
         commands.put("update", new CmdConfigUpdate());
         commands.put("delete", new CmdConfigDelete());
         commands.put("use", new CmdConfigUse());
@@ -256,6 +257,9 @@ public class ConfigShell implements ShellCommandsProvider {
     @Parameters(commandDescription = "Create a new configuration.")
     private class CmdConfigCreate extends CmdConfigPut {
 
+        @Parameter(description = "Configuration name", required = true)
+        protected String name;
+
         @Override
         @SneakyThrows
         boolean verifyCondition() {
@@ -266,10 +270,19 @@ public class ConfigShell implements ShellCommandsProvider {
             }
             return true;
         }
+
+        @Override
+        String name() {
+            return name;
+        }
     }
 
     @Parameters(commandDescription = "Update an existing configuration.")
     private class CmdConfigUpdate extends CmdConfigPut {
+
+        @Parameter(description = "Configuration name", required = true)
+        @JCommanderCompleter.ParameterCompleter(type = JCommanderCompleter.ParameterCompleter.Type.CONFIGS)
+        protected String name;
 
         @Override
         @SneakyThrows
@@ -285,13 +298,14 @@ public class ConfigShell implements ShellCommandsProvider {
             }
             return true;
         }
+
+        @Override
+        String name() {
+            return name;
+        }
     }
 
     private abstract class CmdConfigPut implements RunnableWithResult {
-
-        @Parameter(description = "Configuration name", required = true)
-        @JCommanderCompleter.ParameterCompleter(type = JCommanderCompleter.ParameterCompleter.Type.CONFIGS)
-        protected String name;
 
         @Parameter(names = {"--url"}, description = "URL of the config")
         protected String url;
@@ -309,6 +323,7 @@ public class ConfigShell implements ShellCommandsProvider {
             if (!verifyCondition()) {
                 return false;
             }
+            final String name = name();
             final String value;
             if (inlineValue != null) {
                 if (inlineValue.startsWith("base64:")) {
@@ -346,9 +361,39 @@ public class ConfigShell implements ShellCommandsProvider {
             return true;
         }
 
-
+        abstract String name();
 
         abstract boolean verifyCondition();
+    }
+
+
+    private class CmdConfigClone implements RunnableWithResult {
+
+        @Parameter(description = "Configuration to clone", required = true)
+        @JCommanderCompleter.ParameterCompleter(type = JCommanderCompleter.ParameterCompleter.Type.CONFIGS)
+        protected String cloneFrom;
+
+        @Parameter(names = {"--name"}, description = "Name of the new config", required = true)
+        protected String newName;
+
+        @Override
+        @SneakyThrows
+        public boolean run() {
+            if (DEFAULT_CONFIG.equals(newName) || configStore.getConfig(newName) != null) {
+                print("'" + newName + "' already exists.");
+                return false;
+            }
+            final ConfigStore.ConfigEntry config = configStore.getConfig(cloneFrom);
+            if (config == null) {
+                print("Config '" + config + "' does not exist.");
+                return false;
+            }
+
+            final ConfigStore.ConfigEntry entry = new ConfigStore.ConfigEntry(newName, config.getValue());
+            configStore.putConfig(entry);
+            reloadIfCurrent(entry);
+            return true;
+        }
     }
 
     private void reloadIfCurrent(ConfigStore.ConfigEntry entry) throws Exception {
@@ -382,7 +427,7 @@ public class ConfigShell implements ShellCommandsProvider {
             }
 
             if (propertyValue == null) {
-                print("-v parameter is required. you can pass an empty value to empty the property. (-v= )");
+                print("-v parameter is required. You can pass an empty value to empty the property. (-v= )");
                 return false;
             }
 

--- a/pulsar-client-tools/src/test/java/org/apache/pulsar/shell/ConfigShellTest.java
+++ b/pulsar-client-tools/src/test/java/org/apache/pulsar/shell/ConfigShellTest.java
@@ -143,6 +143,16 @@ public class ConfigShellTest {
                 "--file", newClientConf.toFile().getAbsolutePath()}));
         assertTrue(output.isEmpty());
         verify(pulsarShell, times(2)).reload(any());
+
+        assertTrue(runCommand(new String[]{"clone", "myclient",
+                "--name", "myclient-copied"}));
+        assertTrue(output.isEmpty());
+        verify(pulsarShell, times(2)).reload(any());
+
+        assertTrue(runCommand(new String[]{"view", "myclient-copied"}));
+        assertEquals(output.get(0), "webServiceUrl=http://localhost:8081/\nbrokerServiceUrl" +
+                "=pulsar://localhost:6651/\n");
+        output.clear();
     }
 
     @Test


### PR DESCRIPTION
Fixes #18175

### Motivation
To simplify adding a new config, it might be useful to clone an existing one and then update the needed fields with `set-property` cmd

### Modifications

* Added `config clone <copyfrom> --name <newconfig>` command
* Also fixed autocomplete in config create to not autocomplete with existing names

### Documentation

https://github.com/apache/pulsar-site/pull/303

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->
