### PR TITLE
[fix][misc] Fix NoClassDefFoundError: io/netty/incubator/channel/uring/IOUringEventLoopGroup

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -647,6 +647,11 @@ flexible messaging model and an intuitive client API.</description>
 
       <dependency>
         <groupId>io.netty.incubator</groupId>
+        <artifactId>netty-incubator-transport-classes-io_uring</artifactId>
+        <version>${netty-iouring.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.netty.incubator</groupId>
         <artifactId>netty-incubator-transport-native-io_uring</artifactId>
         <version>${netty-iouring.version}</version>
       </dependency>

--- a/pulsar-common/pom.xml
+++ b/pulsar-common/pom.xml
@@ -133,6 +133,11 @@
 
     <dependency>
       <groupId>io.netty.incubator</groupId>
+      <artifactId>netty-incubator-transport-classes-io_uring</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.netty.incubator</groupId>
       <artifactId>netty-incubator-transport-native-io_uring</artifactId>
       <classifier>linux-x86_64</classifier>
     </dependency>


### PR DESCRIPTION
Fixes #18530

### Motivation
There's need to add the classes dependency for io-uring in order to always have them in the classpath, even if you're compiling in a platform where native implementation of netty io-uring is not available. 

### Modifications

* Added the `netty-incubator-transport-classes-io_uring` dependency to pulsar-common

### Verifying this change
Build `pulsar-common` and `distribution` (to generate the classpath.txt) and test the cli tools

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->
