### PR TITLE
[fix][cli] Pulsar shell: do not exit on user interrupt during commands

### DIFF
--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/shell/PulsarShell.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/shell/PulsarShell.java
@@ -22,7 +22,6 @@ import com.beust.jcommander.JCommander;
 import com.beust.jcommander.Parameter;
 import java.io.BufferedReader;
 import java.io.File;
-import java.io.IOError;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.StringReader;


### PR DESCRIPTION
### Motivation

In Pulsar shell if there's a command that is running (e.g client consume) and the user send a SIGINT (ctrl+c) the shell should not exit but it should only stop the current command.

### Modifications

* Added native signals to JLine terminal to explictly handle SIGINT and SIGQUIT

Note that ctrl+d (SIGTERM) will let the shell to exit in any case. this is done on purpose 

### Verifying this change

Run `client consume` without any message in the topic and hit ctrl+c.
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->
