### PR TITLE
[fix][test] Close KafkaProducer in integration tests to prevent thread leak

### DIFF
--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/sources/KafkaSourceTester.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/sources/KafkaSourceTester.java
@@ -118,29 +118,30 @@ public class KafkaSourceTester extends SourceTester<KafkaContainer> {
 
     @Override
     public Map<String, String> produceSourceMessages(int numMessages) throws Exception{
-        KafkaProducer<String, String> producer = new KafkaProducer<>(
+        try (KafkaProducer<String, String> producer = new KafkaProducer<>(
                 ImmutableMap.of(
                         ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaContainer.getBootstrapServers(),
                         ProducerConfig.CLIENT_ID_CONFIG, UUID.randomUUID().toString()
                 ),
                 new StringSerializer(),
                 new StringSerializer()
-        );
-        LinkedHashMap<String, String> kvs = new LinkedHashMap<>();
-        for (int i = 0; i < numMessages; i++) {
-            String key = "key-" + i;
-            String value = "value-" + i;
-            ProducerRecord<String, String> record = new ProducerRecord<>(
-                kafkaTopicName,
-                key,
-                value
-            );
-            kvs.put(key, value);
-            producer.send(record).get();
-        }
+        )) {
+            LinkedHashMap<String, String> kvs = new LinkedHashMap<>();
+            for (int i = 0; i < numMessages; i++) {
+                String key = "key-" + i;
+                String value = "value-" + i;
+                ProducerRecord<String, String> record = new ProducerRecord<>(
+                        kafkaTopicName,
+                        key,
+                        value
+                );
+                kvs.put(key, value);
+                producer.send(record).get();
+            }
 
-        log.info("Successfully produced {} messages to kafka topic {}", numMessages, kafkaTopicName);
-        return kvs;
+            log.info("Successfully produced {} messages to kafka topic {}", numMessages, kafkaTopicName);
+            return kvs;
+        }
     }
 
     @Override


### PR DESCRIPTION
Fixes #15853

### Motivation

There's a resource leak in KafkaSourceTester which will be fixed by this PR.

### Modifications

Use try-with-resource to close the KafkaProducer after use.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->
