### PR TITLE
[fix][monitor] Fix reporting pulsar_subscription_blocked_on_unacked_messages metric

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/NamespaceStatsAggregator.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/NamespaceStatsAggregator.java
@@ -128,6 +128,7 @@ public class NamespaceStatsAggregator {
         subsStats.lastConsumedTimestamp = subscriptionStats.lastConsumedTimestamp;
         subsStats.lastMarkDeleteAdvancedTimestamp = subscriptionStats.lastMarkDeleteAdvancedTimestamp;
         subsStats.consumersCount = subscriptionStats.consumers.size();
+        subsStats.blockedSubscriptionOnUnackedMsgs = subscriptionStats.blockedSubscriptionOnUnackedMsgs;
         subscriptionStats.consumers.forEach(cStats -> {
             stats.consumersCount++;
             subsStats.unackedMessages += cStats.unackedMessages;
@@ -135,9 +136,6 @@ public class NamespaceStatsAggregator {
             subsStats.msgRateOut += cStats.msgRateOut;
             subsStats.messageAckRate += cStats.messageAckRate;
             subsStats.msgThroughputOut += cStats.msgThroughputOut;
-            if (!subsStats.blockedSubscriptionOnUnackedMsgs && cStats.blockedConsumerOnUnackedMsgs) {
-                subsStats.blockedSubscriptionOnUnackedMsgs = true;
-            }
         });
         stats.rateOut += subsStats.msgRateOut;
         stats.throughputOut += subsStats.msgThroughputOut;

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/prometheus/NamespaceStatsAggregatorTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/prometheus/NamespaceStatsAggregatorTest.java
@@ -1,0 +1,163 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.stats.prometheus;
+
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.when;
+import java.util.List;
+import org.apache.bookkeeper.mledger.ManagedLedger;
+import org.apache.bookkeeper.mledger.impl.ManagedLedgerMBeanImpl;
+import org.apache.bookkeeper.mledger.util.StatsBuckets;
+import org.apache.pulsar.broker.PulsarService;
+import org.apache.pulsar.broker.PulsarServiceMockSupport;
+import org.apache.pulsar.broker.ServiceConfiguration;
+import org.apache.pulsar.broker.service.BrokerService;
+import org.apache.pulsar.broker.service.Consumer;
+import org.apache.pulsar.broker.service.Replicator;
+import org.apache.pulsar.broker.service.Subscription;
+import org.apache.pulsar.broker.service.Topic;
+import org.apache.pulsar.broker.service.persistent.PersistentTopic;
+import org.apache.pulsar.common.policies.data.BacklogQuota;
+import org.apache.pulsar.common.policies.data.stats.ConsumerStatsImpl;
+import org.apache.pulsar.common.policies.data.stats.SubscriptionStatsImpl;
+import org.apache.pulsar.common.policies.data.stats.TopicStatsImpl;
+import org.apache.pulsar.common.util.collections.ConcurrentOpenHashMap;
+import org.apache.pulsar.metadata.impl.ZKMetadataStore;
+import org.mockito.Mockito;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+@Test(groups = "broker")
+public class NamespaceStatsAggregatorTest {
+    protected PulsarService pulsar;
+    private BrokerService broker;
+    private ConcurrentOpenHashMap<String, ConcurrentOpenHashMap<String, ConcurrentOpenHashMap<String, Topic>>>
+            multiLayerTopicsMap;
+
+    @BeforeMethod(alwaysRun = true)
+    public void setup() throws Exception {
+        multiLayerTopicsMap = ConcurrentOpenHashMap.<String,
+                        ConcurrentOpenHashMap<String, ConcurrentOpenHashMap<String, Topic>>>newBuilder()
+                .build();
+        pulsar = Mockito.mock(PulsarService.class);
+        broker = Mockito.mock(BrokerService.class);
+        doReturn(multiLayerTopicsMap).when(broker).getMultiLayerTopicMap();
+        Mockito.when(pulsar.getLocalMetadataStore()).thenReturn(Mockito.mock(ZKMetadataStore.class));
+        ServiceConfiguration mockConfig = Mockito.mock(ServiceConfiguration.class);
+        PulsarServiceMockSupport.mockPulsarServiceProps(pulsar, () -> {
+            doReturn(mockConfig).when(pulsar).getConfiguration();
+            doReturn(broker).when(pulsar).getBrokerService();
+        });
+    }
+
+    @Test
+    public void testGenerateSubscriptionsStats() {
+        // given
+        final String namespace = "tenant/cluster/ns";
+
+        // prepare multi-layer topic map
+        ConcurrentOpenHashMap bundlesMap = ConcurrentOpenHashMap.newBuilder().build();
+        ConcurrentOpenHashMap topicsMap = ConcurrentOpenHashMap.newBuilder().build();
+        ConcurrentOpenHashMap subscriptionsMaps = ConcurrentOpenHashMap.newBuilder().build();
+        bundlesMap.put("my-bundle", topicsMap);
+        multiLayerTopicsMap.put(namespace, bundlesMap);
+
+        // Prepare managed ledger
+        ManagedLedger ml = Mockito.mock(ManagedLedger.class);
+        ManagedLedgerMBeanImpl mlBeanStats = Mockito.mock(ManagedLedgerMBeanImpl.class);
+        StatsBuckets statsBuckets = new StatsBuckets(ManagedLedgerMBeanImpl.ENTRY_LATENCY_BUCKETS_USEC);
+        when(mlBeanStats.getInternalAddEntryLatencyBuckets()).thenReturn(statsBuckets);
+        when(mlBeanStats.getInternalLedgerAddEntryLatencyBuckets()).thenReturn(statsBuckets);
+        when(mlBeanStats.getInternalEntrySizeBuckets()).thenReturn(
+                new StatsBuckets(ManagedLedgerMBeanImpl.ENTRY_SIZE_BUCKETS_BYTES));
+        when(ml.getStats()).thenReturn(mlBeanStats);
+
+        // Prepare topic and subscription
+        PersistentTopic topic = Mockito.mock(PersistentTopic.class);
+        Subscription subscription = Mockito.mock(Subscription.class);
+        Consumer consumer = Mockito.mock(Consumer.class);
+        ConsumerStatsImpl consumerStats = new ConsumerStatsImpl();
+        when(consumer.getStats()).thenReturn(consumerStats);
+        when(subscription.getConsumers()).thenReturn(List.of(consumer));
+        subscriptionsMaps.put("my-subscription", subscription);
+        SubscriptionStatsImpl subStats = new SubscriptionStatsImpl();
+        TopicStatsImpl topicStats = new TopicStatsImpl();
+        topicStats.subscriptions.put("my-subscription", subStats);
+        when(topic.getStats(false, false, false)).thenReturn(topicStats);
+        when(topic.getBrokerService()).thenReturn(broker);
+        when(topic.getSubscriptions()).thenReturn(subscriptionsMaps);
+        when(topic.getReplicators()).thenReturn(ConcurrentOpenHashMap.<String,Replicator>newBuilder().build());
+        when(topic.getManagedLedger()).thenReturn(ml);
+        when(topic.getBacklogQuota(Mockito.any())).thenReturn(Mockito.mock(BacklogQuota.class));
+        topicsMap.put("my-topic", topic);
+        PrometheusMetricStreams metricStreams = Mockito.spy(new PrometheusMetricStreams());
+
+        // Populate subscriptions stats
+        subStats.blockedSubscriptionOnUnackedMsgs = true;
+        consumerStats.blockedConsumerOnUnackedMsgs = false; // should not affect blockedSubscriptionOnUnackedMsgs
+        consumerStats.unackedMessages = 1;
+        consumerStats.msgRateRedeliver = 0.7;
+        subStats.consumers.add(0, consumerStats);
+
+        // when
+        NamespaceStatsAggregator.generate(pulsar, true, true,
+                true, true, metricStreams);
+
+        // then
+        verifySubscriptionMetric(metricStreams, "pulsar_subscription_blocked_on_unacked_messages", 1);
+        verifyConsumerMetric(metricStreams, "pulsar_consumer_blocked_on_unacked_messages", 0);
+
+        verifySubscriptionMetric(metricStreams, "pulsar_subscription_msg_rate_redeliver", 0.7);
+        verifySubscriptionMetric(metricStreams, "pulsar_subscription_unacked_messages", 1L);
+    }
+
+    private void verifySubscriptionMetric(PrometheusMetricStreams metricStreams, String metricName, Number value) {
+        Mockito.verify(metricStreams).writeSample(metricName,
+                value,
+                "cluster",
+                null,
+                "namespace",
+                "tenant/cluster/ns",
+                "topic",
+                "my-topic",
+                "partition",
+                "-1",
+                "subscription",
+                "my-subscription");
+    }
+
+    private void verifyConsumerMetric(PrometheusMetricStreams metricStreams, String metricName, Number value) {
+        Mockito.verify(metricStreams).writeSample(metricName,
+                value,
+                "cluster",
+                null,
+                "namespace",
+                "tenant/cluster/ns",
+                "topic",
+                "my-topic",
+                "partition",
+                "-1",
+                "subscription",
+                "my-subscription",
+                "consumer_name",
+                null,
+                "consumer_id",
+                "0");
+    }
+}


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://docs.google.com/document/d/1d8Pw6ZbWk-_pCKdOmdvx9rnhPiyuxwq60_TrD68d7BA/edit#heading=h.trs9rsex3xom)*. 

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->

### Motivation

The pulsar_subscription_blocked_on_unacked_messages metric was not scrapped by Prometheus although the dispatcher can be blocked on number of unacked messages:
```
Dispatcher read is blocked due to unackMessages 200010 reached to max 200000
```

### Modifications

When Prometheus scrapes stats topics, the previous logic was relying on the consumer flag to update the subscription  although the subscription configs and logic is independent of the attached consumer. The related config for subscription is `maxUnackedMessagesPerSubscription` and for consumers is `maxUnackedMessagesPerConsumer`

This change just copied over the value from the `SubscriptionStats` to the `AggregatedSubscriptionStats`

### Verifying this change

- [X] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

I couldn't add unit tests for `NamespaceStatsAggregator` in a short time but tested the changes locally with Pulsar standalone + Prometheous:

![image](https://user-images.githubusercontent.com/13960949/203879386-34ef03f5-c4f2-4a9d-9120-e4718f11c42f.png)


### Does this pull request potentially affect one of the following parts:

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/aymkhalil/pulsar/pull/3

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
