### PR TITLE
[fix][broker] Fix possible race condition in completing topic list watcher

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/TopicListService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/TopicListService.java
@@ -197,7 +197,11 @@ public class TopicListService {
                     if (exception != null) {
                         watcherFuture.completeExceptionally(exception);
                     } else {
-                        watcherFuture.complete(watcher);
+                        if (!watcherFuture.complete(watcher)) {
+                            log.warn("[{}] Watcher future was already completed. Deregistering watcherId={}.",
+                                    connection.getRemoteAddress(), watcherId);
+                            topicResources.deregisterPersistentTopicListener(watcher);
+                        }
                     }
                 });
     }


### PR DESCRIPTION
### Motivation

While reading code in TopicListService, I noticed a race condition that could happen in the case where the connection is closing and there's a TopicListWatcher that is in being initialized. 

### Modifications

Add check to see if the watcherFuture can be completed. If not, deregister the watcher.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->