### PR TITLE
[improve][broker] Reduce object creation in TopicResources.handleNotification

### DIFF
--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/resources/TopicResources.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/resources/TopicResources.java
@@ -19,7 +19,6 @@
 package org.apache.pulsar.broker.resources;
 
 import static org.apache.pulsar.common.util.Codec.decode;
-import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -128,7 +127,8 @@ public class TopicResources {
 
     void handleNotification(Notification notification) {
         if (notification.getPath().startsWith(MANAGED_LEDGER_PATH)
-                && EnumSet.of(NotificationType.Created, NotificationType.Deleted).contains(notification.getType())) {
+                && (notification.getType() == NotificationType.Created
+                || notification.getType() == NotificationType.Deleted)) {
             for (Map.Entry<BiConsumer<String, NotificationType>, Pattern> entry :
                     new HashMap<>(topicListeners).entrySet()) {
                 Matcher matcher = entry.getValue().matcher(notification.getPath());

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/resources/TopicResources.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/resources/TopicResources.java
@@ -19,7 +19,6 @@
 package org.apache.pulsar.broker.resources;
 
 import static org.apache.pulsar.common.util.Codec.decode;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -130,7 +129,7 @@ public class TopicResources {
                 && (notification.getType() == NotificationType.Created
                 || notification.getType() == NotificationType.Deleted)) {
             for (Map.Entry<BiConsumer<String, NotificationType>, Pattern> entry :
-                    new HashMap<>(topicListeners).entrySet()) {
+                    topicListeners.entrySet()) {
                 Matcher matcher = entry.getValue().matcher(notification.getPath());
                 if (matcher.matches()) {
                     TopicName topicName = TopicName.get(

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/resources/TopicResources.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/resources/TopicResources.java
@@ -125,6 +125,9 @@ public class TopicResources {
     }
 
     void handleNotification(Notification notification) {
+        if (topicListeners.isEmpty()) {
+            return;
+        }
         if (notification.getPath().startsWith(MANAGED_LEDGER_PATH)
                 && (notification.getType() == NotificationType.Created
                 || notification.getType() == NotificationType.Deleted)) {


### PR DESCRIPTION
### Motivation

Follow "zero garbage" style on hot code paths.

* In this case, the usage of EnumSet isn't justified since there's only 2 enums to check
* topicListeners is a ConcurrentHashMap, no need for a copy
* skip checks when topicListeners is empty

### Modifications

* optimize TopicResources.handleNotification method.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->