### PR TITLE
[improve][build] Remove versions that are handled by netty-bom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -126,7 +126,6 @@ flexible messaging model and an intuitive client API.</description>
     <dropwizardmetrics.version>4.1.12.1</dropwizardmetrics.version> <!-- ZooKeeper server -->
     <curator.version>5.1.0</curator.version>
     <netty.version>4.1.77.Final</netty.version>
-    <netty-tc-native.version>2.0.52.Final</netty-tc-native.version>
     <netty-iouring.version>0.0.15.Final</netty-iouring.version>
     <jetty.version>9.4.48.v20220622</jetty.version>
     <conscrypt.version>2.5.2</conscrypt.version>
@@ -631,18 +630,6 @@ flexible messaging model and an intuitive client API.</description>
         <version>${netty.version}</version>
         <type>pom</type>
         <scope>import</scope>
-      </dependency>
-
-      <dependency>
-        <groupId>io.netty</groupId>
-        <artifactId>netty-tcnative-boringssl-static</artifactId>
-        <version>${netty-tc-native.version}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>io.netty</groupId>
-        <artifactId>netty-codec-haproxy</artifactId>
-        <version>${netty.version}</version>
       </dependency>
 
       <dependency>

--- a/pulsar-io/kafka-connect-adaptor/pom.xml
+++ b/pulsar-io/kafka-connect-adaptor/pom.xml
@@ -97,7 +97,6 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-buffer</artifactId>
-      <version>${netty.version}</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
### Motivation

[netty-bom](https://search.maven.org/artifact/io.netty/netty-bom) includes the correct Netty tcnative version which is compatible with a particular Netty version. Because of this reason, it's an unnecessary overhead to duplicate the information in Pulsar pom.xml .

### Modifications

- remove `netty-tc-native.version` from Pulsar's `pom.xml`
- remove unnecessary dependency management dependencies that are included in netty-bom
- remove unnecessary definition of version for a netty dependency

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/lhotari/pulsar/pull/107