### PR TITLE
[fix][client] For exclusive subscriptions, if two consumers are created repeatedly, the second consumer will block

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiTopicsConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiTopicsConsumerImpl.java
@@ -1117,7 +1117,7 @@ public class MultiTopicsConsumerImpl<T> extends ConsumerBase<T> {
         log.warn("[{}] Failed to subscribe for topic [{}] in topics consumer {}", topic, topicName, error.getMessage());
         client.externalExecutorProvider().getExecutor().execute(() -> {
             AtomicInteger toCloseNum = new AtomicInteger(0);
-            consumers.values().stream().filter(consumer1 -> {
+            List<ConsumerImpl> filterConsumers = consumers.values().stream().filter(consumer1 -> {
                 String consumerTopicName = consumer1.getTopic();
                 if (TopicName.get(consumerTopicName).getPartitionedTopicName()
                         .equals(TopicName.get(topicName).getPartitionedTopicName())) {
@@ -1126,7 +1126,14 @@ public class MultiTopicsConsumerImpl<T> extends ConsumerBase<T> {
                 } else {
                     return false;
                 }
-            }).collect(Collectors.toList()).forEach(consumer2 -> {
+            }).collect(Collectors.toList());
+
+            if (filterConsumers.isEmpty()) {
+                subscribeFuture.completeExceptionally(error);
+                return;
+            }
+
+            filterConsumers.forEach(consumer2 -> {
                 consumer2.closeAsync().whenComplete((r, ex) -> {
                     consumer2.subscribeFuture().completeExceptionally(error);
                     allTopicPartitionsNumber.decrementAndGet();


### PR DESCRIPTION
### Motivation

For exclusive subscriptions, if two consumers are created repeatedly, the second consumer will block.

**Steps to reproduce:**
Start the following program twice. When starting the second time, the subscribe method will block and will not throw an exception: ConsumerBusyException: Exclusive consumer is already connected

```
 String topic = "test1";
        List<Integer> partitions = new ArrayList<>();
        for (int i = 0; i < 120; i++) {
            partitions.add(i);
        }
        List<String> realTopics = partitions.stream()
                .map(idx -> topic + "-partition-" + idx)
                .collect(Collectors.toList());
        Map<String, Object> consumerParams = Collections.emptyMap();

        System.out.println("begin subscribe " + LocalTime.now());
        Consumer<byte[]>  consumer;
        try {
            consumer = client.newConsumer()
                    .loadConf(consumerParams)
                    .topics(realTopics)
                    .subscriptionName(testName)
                    .subscriptionType(SubscriptionType.Exclusive)
                    .subscriptionInitialPosition(SubscriptionInitialPosition.Latest)
                    .subscribe();
        } catch (Exception ex) {
            System.out.println("after subscribe " + LocalTime.now() );
        }
```

The reasons are as follows:
When the 1121 line of code is executed, the consumers list may be empty, which will cause the subscribeFuture to fail to complete, and eventually cause the subscribe method to block forever and not throw an exception:
https://github.com/apache/pulsar/blob/355ba6002fc33b2716f59ca5d3a4fac667ecf3e1/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiTopicsConsumerImpl.java#L1121-L1144


### Modifications
Make subscribeFuture complete when the filtered consumer collection is empty：

```
            List<ConsumerImpl> filterConsumers = consumers.values().stream().filter(consumer1 -> {
                String consumerTopicName = consumer1.getTopic();
                if (TopicName.get(consumerTopicName).getPartitionedTopicName()
                        .equals(TopicName.get(topicName).getPartitionedTopicName())) {
                    toCloseNum.incrementAndGet();
                    return true;
                } else {
                    return false;
                }
            }).collect(Collectors.toList());

            if (filterConsumers.isEmpty()) {
                subscribeFuture.completeExceptionally(error);
                return;
            }
```


### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
