### PR TITLE
[fix][ci] Regex syntax

### DIFF
--- a/.github/workflows/ci-semantic-pull-request.yml
+++ b/.github/workflows/ci-semantic-pull-request.yml
@@ -92,5 +92,5 @@ jobs:
           # ... where valid types and scopes can be found above; for example:
           #
           #     [fix][test] flaky test V1_ProxyAuthenticationTest.anonymousSocketTest
-          headerPattern: '^\[(\w*?)\](?:\[(.*?)\])?(:?\s*)(.*)$'
+          headerPattern: '^\[(\w*?)\](?:\[(.*?)\])?(?:\s*)(.*)$'
           headerPatternCorrespondence: type, scope, subject


### PR DESCRIPTION
### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: N/A

cc @nicoloboschi @lhotari I tested on the regex101.com the last time, but miss the group number.

Here's a false case: https://github.com/apache/pulsar/actions/runs/3547655293 and should be fixed with this patch.