### PR TITLE
[fix][ci] Disable branch-2.9 force push

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -79,7 +79,7 @@ github:
     branch-2.6: {}
     branch-2.7: {}
     branch-2.8: {}
-#    branch-2.9: {}
+    branch-2.9: {}
     branch-2.10: {}
     branch-2.11: {}
 


### PR DESCRIPTION
reason: https://lists.apache.org/thread/jcrq9q0k6kh9rvb71dwb9s3mvo5c5dk5

branch-2.9 has reset to commit `5ed247de3a5e0ff67f181b4805fd6140d8174994`, so close force-push

- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->