### PR TITLE
[fix][test] ZKSessionTest.testReacquireLocksAfterSessionLost fail easily

### DIFF
--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/api/MetadataStoreConfig.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/api/MetadataStoreConfig.java
@@ -86,4 +86,11 @@ public class MetadataStoreConfig {
      * separate clusters.
      */
     private MetadataEventSynchronizer synchronizer;
+
+    /**
+     * if enable sessionWatcherCheckConnection logic.
+     * set false for some unit test.
+     */
+    @Builder.Default
+    private final boolean sessionWatcherCheckConnectionStatus = true;
 }

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/PulsarZooKeeperClient.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/PulsarZooKeeperClient.java
@@ -126,7 +126,7 @@ public class PulsarZooKeeperClient extends ZooKeeper implements Watcher, AutoClo
                         }
                         waitForConnection();
                         zk.set(newZk);
-                        log.info("ZooKeeper session {} is created to {}.",
+                        log.info("ZooKeeper session 0x{} is created to {}.",
                                 Long.toHexString(newZk.getSessionId()), connectString);
                         return newZk;
                     }
@@ -352,7 +352,7 @@ public class PulsarZooKeeperClient extends ZooKeeper implements Watcher, AutoClo
             return;
         }
 
-        log.info("ZooKeeper session {} is expired from {}.",
+        log.info("ZooKeeper session 0x{} is expired from {}.",
                 Long.toHexString(getSessionId()), connectString);
         try {
             connectExecutor.execute(clientCreator);

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/ZKMetadataStore.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/ZKMetadataStore.java
@@ -99,7 +99,8 @@ public class ZKMetadataStore extends AbstractBatchedMetadataStore
                     .watchers(Collections.singleton(this::processSessionWatcher))
                     .build();
             if (enableSessionWatcher) {
-                sessionWatcher = new ZKSessionWatcher(zkc, this::receivedSessionEvent);
+                sessionWatcher = new ZKSessionWatcher(zkc, this::receivedSessionEvent,
+                        metadataStoreConfig.isSessionWatcherCheckConnectionStatus());
             } else {
                 sessionWatcher = null;
             }


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://docs.google.com/document/d/1d8Pw6ZbWk-_pCKdOmdvx9rnhPiyuxwq60_TrD68d7BA/edit#heading=h.trs9rsex3xom)*. 

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->

<!-- Either this PR fixes an issue, -->

Fixes #18641


### Motivation
ZKSessionTest.testReacquireLocksAfterSessionLost fail easily in local environment.

there are two ways to trigger session event submit in sessionWatcher

1. zk client watch callback
2. schedule task call zk.exist("/");

the second one is checked every sessionTimeoutMs / 15 if we set sessionTimeoutMs to 2000. it is very easily to trigger [ConnectionLost,Reconnected] session event.

add option to disable session watcher check to avoid unit test fail.

### Does this pull request potentially affect one of the following parts:

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
