### PR TITLE
[improve][fn] 18532: Function JavaInstanceStarter support reading configs from file

### DIFF
--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/InstanceConfig.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/InstanceConfig.java
@@ -48,6 +48,7 @@ public class InstanceConfig {
     private boolean exposePulsarAdminClientEnabled = false;
     private int metricsPort;
     private List<String> additionalJavaRuntimeArguments = Collections.emptyList();
+    private String configFile;
 
     /**
      * Get the string representation of {@link #getInstanceId()}.

--- a/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/JavaInstanceConfiguration.java
+++ b/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/JavaInstanceConfiguration.java
@@ -1,0 +1,221 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.functions.runtime;
+
+import java.util.Properties;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+import org.apache.pulsar.common.configuration.Category;
+import org.apache.pulsar.common.configuration.FieldContext;
+import org.apache.pulsar.common.configuration.PulsarConfiguration;
+import org.apache.pulsar.common.nar.NarClassLoader;
+
+// TODO do we have to set the default Configuration ?
+
+@Getter
+@Setter
+@ToString
+public class JavaInstanceConfiguration implements PulsarConfiguration {
+    @Category
+    private static final String CATEGORY_FUNCTIONS = "Functions";
+
+    @FieldContext(
+            category = CATEGORY_FUNCTIONS,
+            doc = "Function details json"
+    )
+    private String functionDetailsJsonString;
+
+    @FieldContext(
+            category = CATEGORY_FUNCTIONS,
+            doc = "Path to user function jar"
+    )
+    private String jarFile;
+
+    @FieldContext(
+            category = CATEGORY_FUNCTIONS,
+            doc = "Path to the transform function jar"
+    )
+    private String transformFunctionJarFile;
+
+    @FieldContext(
+            category = CATEGORY_FUNCTIONS,
+            doc = "instanceId used to uniquely identify a function instance"
+    )
+    private Integer instanceId;
+
+
+    @FieldContext(
+            category = CATEGORY_FUNCTIONS,
+            doc = "functionId used to uniquely identify a function"
+    )
+    private String functionId;
+
+
+    @FieldContext(
+            category = CATEGORY_FUNCTIONS,
+            doc = "The version of the function"
+    )
+    private String functionVersion;
+
+    @FieldContext(
+            category = CATEGORY_FUNCTIONS,
+            doc = "serviceUrl of the target Pulsar cluster"
+    )
+    private String pulsarServiceUrl;
+
+    @FieldContext(
+            category = CATEGORY_FUNCTIONS,
+            doc = "functionId of the transform function"
+    )
+    private String transformFunctionId;
+
+    @FieldContext(
+            category = CATEGORY_FUNCTIONS,
+            doc = "Client auth plugin full classname"
+    )
+    private String clientAuthenticationPlugin;
+
+    @FieldContext(
+            category = CATEGORY_FUNCTIONS,
+            doc = "Client auth parameters"
+    )
+    private String clientAuthenticationParameters;
+
+    @FieldContext(
+            category = CATEGORY_FUNCTIONS,
+            doc = "Use tls connection"
+    )
+    private String useTls = Boolean.FALSE.toString();
+
+    @FieldContext(
+            category = CATEGORY_FUNCTIONS,
+            doc = "Allow insecure tls connection"
+    )
+    private String tlsAllowInsecureConnection = Boolean.TRUE.toString();
+
+    @FieldContext(
+            category = CATEGORY_FUNCTIONS,
+            doc = "Enable hostname verification"
+    )
+    private String tlsHostNameVerificationEnabled = Boolean.FALSE.toString();
+
+    @FieldContext(
+            category = CATEGORY_FUNCTIONS,
+            doc = "tls trust cert file path"
+    )
+    private String tlsTrustCertFilePath;
+
+    @FieldContext(
+            category = CATEGORY_FUNCTIONS,
+            doc = "State storage service implementation classname"
+    )
+    private String stateStorageImplClass;
+
+    @FieldContext(
+            category = CATEGORY_FUNCTIONS,
+            doc = "State storage service url"
+    )
+    private String stateStorageServiceUrl;
+
+    @FieldContext(
+            category = CATEGORY_FUNCTIONS,
+            doc = "Port to listen on"
+    )
+    private Integer port;
+
+    @FieldContext(
+            category = CATEGORY_FUNCTIONS,
+            doc = "Port metrics will be exposed on"
+    )
+    private Integer metricsPort;
+
+    @FieldContext(
+            category = CATEGORY_FUNCTIONS,
+            doc = "Maximum number of tuples to buffer"
+    )
+    private Integer maxBufferedTuples;
+
+    @FieldContext(
+            category = CATEGORY_FUNCTIONS,
+            doc = "Expected interval in seconds between health checks"
+    )
+    private Integer expectedHealthCheckInterval;
+
+    @FieldContext(
+            category = CATEGORY_FUNCTIONS,
+            doc = "The classname of the secrets provider"
+    )
+    private String secretsProviderClassName;
+
+    @FieldContext(
+            category = CATEGORY_FUNCTIONS,
+            doc = "The config that needs to be passed to secrets provider"
+    )
+    private String secretsProviderConfig;
+
+    @FieldContext(
+            category = CATEGORY_FUNCTIONS,
+            doc = "The name of the cluster this instance is running on"
+    )
+    private String clusterName;
+
+    @FieldContext(
+            category = CATEGORY_FUNCTIONS,
+            doc = "The directory where extraction of nar packages happen"
+    )
+    private String narExtractionDirectory = NarClassLoader.DEFAULT_NAR_EXTRACTION_DIR;
+
+    @FieldContext(
+            category = CATEGORY_FUNCTIONS,
+            doc = "Max pending async requests per instance"
+    )
+    private Integer maxPendingAsyncRequests = 1000;
+
+    @FieldContext(
+            category = CATEGORY_FUNCTIONS,
+            doc = "Pulsar Web Service Url"
+    )
+    private String webServiceUrl;
+
+    @FieldContext(
+            category = CATEGORY_FUNCTIONS,
+            doc = "Whether the pulsar admin client exposed to function context, default is disabled"
+    )
+    private Boolean exposePulsarAdminClientEnabled = false;
+
+
+    @ToString.Exclude
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private Properties properties = new Properties();
+
+    public Object getProperty(String key) {
+        return properties.get(key);
+    }
+
+    @Override
+    public Properties getProperties() {
+        return properties;
+    }
+
+    @Override
+    public void setProperties(Properties properties) {
+        this.properties = properties;
+    }
+}

--- a/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/JavaInstanceStarter.java
+++ b/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/JavaInstanceStarter.java
@@ -156,7 +156,7 @@ public class JavaInstanceStarter implements AutoCloseable {
     public Integer maxPendingAsyncRequests = 1000;
 
     @Parameter(names = "--web_serviceurl", description = "Pulsar Web Service Url")
-    public String webServiceUrl;
+    public String webServiceUrl  = null;
 
     @Parameter(names = "--expose_pulsaradmin", description = "Whether the pulsar admin client "
             + "exposed to function context, default is disabled. Providing this flag set value to true")
@@ -571,13 +571,9 @@ public class JavaInstanceStarter implements AutoCloseable {
     /**
      * If a config field is not provided in JCommander, then it will be initialized to null.
      *
-     * <p>Then we reads from file. If file is not valid or non-exist or empty (cannot load the file), just skip the file
-     * as if no file are provided. When reading configs from file, first check if the config field is null, only
-     * set the config field from file if the config field is null (which indicates command line didn't provide this
-     * config field). This way we can ensure the command line has a higher priority than the file config.
-     *
-     * <p> If a config field is not provided by command nor by file (also indicated by a null value),
-     * then we will throw an exception if the config field is required, or set it with the default value.
+     * <p>File config and Command line config should be exclusive. When --config_file is used,
+     * users should not provide any other command line arguments. This design is to avoid possible confusion and
+     * allow users to easy reason where a configuration value comes from.
      * @param args
      * @throws IOException
      */
@@ -589,10 +585,8 @@ public class JavaInstanceStarter implements AutoCloseable {
         if (configFile != null) {
             checkNoOtherConfigs(args);
             useConfigFromFileAndProvideDefaultValue();
-            validateRequiredConfigs();
-        } else {
-            validateRequiredConfigs();
         }
+        validateRequiredConfigs();
     }
 
     protected static Set<String> requireConfigFieldsNames = new HashSet<>(){{

--- a/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/JavaInstanceStarter.java
+++ b/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/JavaInstanceStarter.java
@@ -18,11 +18,17 @@
  */
 package org.apache.pulsar.functions.runtime;
 
+
+import static java.util.Objects.requireNonNull;
 import static org.apache.pulsar.functions.utils.FunctionCommon.getSinkType;
 import static org.apache.pulsar.functions.utils.FunctionCommon.getSourceType;
 import com.beust.jcommander.JCommander;
 import com.beust.jcommander.Parameter;
+import com.beust.jcommander.ParameterException;
+import com.beust.jcommander.Parameterized;
+import com.beust.jcommander.Strings;
 import com.beust.jcommander.converters.StringConverter;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
 import com.google.protobuf.Empty;
@@ -31,14 +37,21 @@ import io.grpc.Server;
 import io.grpc.ServerBuilder;
 import io.grpc.stub.StreamObserver;
 import io.prometheus.client.exporter.HTTPServer;
+import java.io.FileNotFoundException;
+import java.io.IOException;
 import java.lang.reflect.Type;
 import java.net.InetSocketAddress;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import javax.validation.ValidationException;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.pulsar.common.configuration.PulsarConfigurationLoader;
 import org.apache.pulsar.common.functions.WindowConfig;
 import org.apache.pulsar.common.nar.NarClassLoader;
 import org.apache.pulsar.common.util.Reflections;
@@ -57,39 +70,39 @@ import org.apache.pulsar.functions.utils.FunctionCommon;
 
 @Slf4j
 public class JavaInstanceStarter implements AutoCloseable {
-    @Parameter(names = "--function_details", description = "Function details json\n", required = true)
+    @Parameter(names = "--function_details", description = "Function details json\n")
     public String functionDetailsJsonString;
     @Parameter(
             names = "--jar",
-            description = "Path to Jar\n",
+            description = "Path to user function jar\n",
             listConverter = StringConverter.class)
     public String jarFile;
 
     @Parameter(
             names = "--transform_function_jar",
-            description = "Path to Transform Function Jar\n",
+            description = "Path to the transform function jar\n",
             listConverter = StringConverter.class)
     public String transformFunctionJarFile;
 
-    @Parameter(names = "--instance_id", description = "Instance Id\n", required = true)
-    public int instanceId;
+    @Parameter(names = "--instance_id", description = "instanceId used to uniquely identify a function instance\n")
+    public Integer instanceId;
 
-    @Parameter(names = "--function_id", description = "Function Id\n", required = true)
+    @Parameter(names = "--function_id", description = "functionId used to uniquely identify a function\n")
     public String functionId;
 
-    @Parameter(names = "--function_version", description = "Function Version\n", required = true)
+    @Parameter(names = "--function_version", description = "The version of the function\n")
     public String functionVersion;
 
-    @Parameter(names = "--pulsar_serviceurl", description = "Pulsar Service Url\n", required = true)
+    @Parameter(names = "--pulsar_serviceurl", description = "serviceUrl of the target Pulsar cluster\n")
     public String pulsarServiceUrl;
 
-    @Parameter(names = "--transform_function_id", description = "Transform Function Id\n")
+    @Parameter(names = "--transform_function_id", description = "functionId of the transform function\n")
     public String transformFunctionId;
 
-    @Parameter(names = "--client_auth_plugin", description = "Client auth plugin name\n")
+    @Parameter(names = "--client_auth_plugin", description = "Client auth plugin full classname\n")
     public String clientAuthenticationPlugin;
 
-    @Parameter(names = "--client_auth_params", description = "Client auth param\n")
+    @Parameter(names = "--client_auth_params", description = "Client auth parameters\n")
     public String clientAuthenticationParameters;
 
     @Parameter(names = "--use_tls", description = "Use tls connection\n")
@@ -104,51 +117,55 @@ public class JavaInstanceStarter implements AutoCloseable {
     @Parameter(names = "--tls_trust_cert_path", description = "tls trust cert file path")
     public String tlsTrustCertFilePath;
 
-    @Parameter(names = "--state_storage_impl_class", description = "State Storage Service "
-            + "Implementation class\n", required = false)
+    @Parameter(names = "--state_storage_impl_class", description = "State storage service"
+            + "implementation classname\n")
     public String stateStorageImplClass;
 
-    @Parameter(names = "--state_storage_serviceurl", description = "State Storage Service Url\n", required = false)
+    @Parameter(names = "--state_storage_serviceurl", description = "State storage service url\n")
     public String stateStorageServiceUrl;
 
-    @Parameter(names = "--port", description = "Port to listen on\n", required = true)
-    public int port;
+    @Parameter(names = "--port", description = "Port to listen on\n")
+    public Integer port;
 
-    @Parameter(names = "--metrics_port", description = "Port metrics will be exposed on\n", required = true)
-    public int metricsPort;
+    @Parameter(names = "--metrics_port", description = "Port metrics will be exposed on\n")
+    public Integer metricsPort;
 
-    @Parameter(names = "--max_buffered_tuples", description = "Maximum number of tuples to buffer\n", required = true)
-    public int maxBufferedTuples;
+    @Parameter(names = "--max_buffered_tuples", description = "Maximum number of tuples to buffer\n")
+    public Integer maxBufferedTuples;
 
     @Parameter(names = "--expected_healthcheck_interval", description = "Expected interval in "
-            + "seconds between healtchecks", required = true)
-    public int expectedHealthCheckInterval;
+            + "seconds between health checks")
+    public Integer expectedHealthCheckInterval;
 
-    @Parameter(names = "--secrets_provider", description = "The classname of the secrets provider", required = false)
+    @Parameter(names = "--secrets_provider", description = "The classname of the secrets provider")
     public String secretsProviderClassName;
 
     @Parameter(names = "--secrets_provider_config", description = "The config that needs to be "
-            + "passed to secrets provider", required = false)
+            + "passed to secrets provider")
     public String secretsProviderConfig;
 
     @Parameter(names = "--cluster_name", description = "The name of the cluster this "
-            + "instance is running on", required = true)
+            + "instance is running on")
     public String clusterName;
 
     @Parameter(names = "--nar_extraction_directory", description = "The directory where "
-            + "extraction of nar packages happen", required = false)
+            + "extraction of nar packages happen")
     public String narExtractionDirectory = NarClassLoader.DEFAULT_NAR_EXTRACTION_DIR;
 
-    @Parameter(names = "--pending_async_requests", description = "Max pending async requests per instance",
-            required = false)
-    public int maxPendingAsyncRequests = 1000;
+    @Parameter(names = "--pending_async_requests", description = "Max pending async requests per instance")
+    public Integer maxPendingAsyncRequests = 1000;
 
-    @Parameter(names = "--web_serviceurl", description = "Pulsar Web Service Url", required = false)
-    public String webServiceUrl = null;
+    @Parameter(names = "--web_serviceurl", description = "Pulsar Web Service Url")
+    public String webServiceUrl;
 
     @Parameter(names = "--expose_pulsaradmin", description = "Whether the pulsar admin client "
-            + "exposed to function context, default is disabled.", required = false)
+            + "exposed to function context, default is disabled. Providing this flag set value to true")
+
     public Boolean exposePulsarAdminClientEnabled = false;
+
+    @Parameter(names = "--config_file", description = "The config file for instance to use, default "
+            + "use coomand line args")
+    public String configFile;
 
     private Server server;
     private RuntimeSpawner runtimeSpawner;
@@ -164,9 +181,7 @@ public class JavaInstanceStarter implements AutoCloseable {
             throws Exception {
         Thread.currentThread().setContextClassLoader(functionInstanceClassLoader);
 
-        JCommander jcommander = new JCommander(this);
-        // parse args by JCommander
-        jcommander.parse(args);
+        setConfigs(args);
 
         InstanceConfig instanceConfig = new InstanceConfig();
         instanceConfig.setFunctionId(functionId);
@@ -190,6 +205,7 @@ public class JavaInstanceStarter implements AutoCloseable {
         instanceConfig.setFunctionDetails(functionDetails);
         instanceConfig.setPort(port);
         instanceConfig.setMetricsPort(metricsPort);
+        instanceConfig.setConfigFile(configFile);
 
         Map<String, String> secretsProviderConfigMap = null;
         if (!StringUtils.isEmpty(secretsProviderConfig)) {
@@ -472,6 +488,168 @@ public class JavaInstanceStarter implements AutoCloseable {
             responseObserver.onCompleted();
 
             lastHealthCheckTs = System.currentTimeMillis();
+        }
+    }
+
+    @VisibleForTesting
+    protected void useConfigFromFileAndProvideDefaultValue() throws IOException {
+        if (configFile == null) {
+            // skip the file if not provided
+            throw new ValidationException("Error: config file cannot be null");
+        }
+
+        JavaInstanceConfiguration instanceConfiguration;
+        try {
+            instanceConfiguration = PulsarConfigurationLoader.create(
+                    configFile, JavaInstanceConfiguration.class);
+        }  catch (FileNotFoundException e) {
+            log.warn("The file {} is not found, using command line args only", configFile);
+            throw e;
+        }
+
+        requireNonNull(instanceConfiguration);
+        // optional String configs
+        jarFile = instanceConfiguration.getJarFile();
+        transformFunctionJarFile = instanceConfiguration.getTransformFunctionJarFile();
+        transformFunctionId = instanceConfiguration.getTransformFunctionId();
+        clientAuthenticationPlugin = instanceConfiguration.getClientAuthenticationPlugin();
+        clientAuthenticationParameters = instanceConfiguration.getClientAuthenticationParameters();
+        tlsTrustCertFilePath = instanceConfiguration.getTlsTrustCertFilePath();
+        stateStorageImplClass = instanceConfiguration.getStateStorageImplClass();
+        stateStorageServiceUrl = instanceConfiguration.getStateStorageServiceUrl();
+        secretsProviderClassName = instanceConfiguration.getSecretsProviderClassName();
+        secretsProviderConfig = instanceConfiguration.getSecretsProviderConfig();
+        narExtractionDirectory = instanceConfiguration.getNarExtractionDirectory();
+        webServiceUrl = instanceConfiguration.getWebServiceUrl();
+
+        // optional Integer configs
+        maxPendingAsyncRequests = instanceConfiguration.getMaxPendingAsyncRequests();
+
+        // optional Boolean configs
+        useTls = instanceConfiguration.getUseTls();
+        tlsAllowInsecureConnection = instanceConfiguration.getTlsAllowInsecureConnection();
+        tlsHostNameVerificationEnabled = instanceConfiguration.getTlsHostNameVerificationEnabled();
+
+        // special arity=0 Boolean config
+        exposePulsarAdminClientEnabled = instanceConfiguration.getExposePulsarAdminClientEnabled();
+
+        // required String configs
+        functionDetailsJsonString = instanceConfiguration.getFunctionDetailsJsonString();
+        functionId = instanceConfiguration.getFunctionId();
+        functionVersion = instanceConfiguration.getFunctionVersion();
+        pulsarServiceUrl = instanceConfiguration.getPulsarServiceUrl();
+        clusterName = instanceConfiguration.getClusterName();
+        // required Integer configs
+        instanceId = instanceConfiguration.getInstanceId();
+        port = instanceConfiguration.getPort();
+        metricsPort = instanceConfiguration.getMetricsPort();
+        maxBufferedTuples = instanceConfiguration.getMaxBufferedTuples();
+        expectedHealthCheckInterval = instanceConfiguration.getExpectedHealthCheckInterval();
+    }
+
+    private void validateRequiredConfigs() {
+        try {
+            // String configs
+            requireNonNull(functionDetailsJsonString);
+            requireNonNull(functionId);
+            requireNonNull(functionVersion);
+            requireNonNull(pulsarServiceUrl);
+            requireNonNull(clusterName);
+            // Integer configs
+            requireNonNull(instanceId);
+            requireNonNull(port);
+            requireNonNull(metricsPort);
+            requireNonNull(maxBufferedTuples);
+            requireNonNull(expectedHealthCheckInterval);
+        } catch (NullPointerException e) {
+            throw new ParameterException(String.format("The following option is required: [%s]",
+                    Strings.join(",", requiredConfigFieldNames().toArray())),
+                    e);
+        }
+    }
+
+    /**
+     * If a config field is not provided in JCommander, then it will be initialized to null.
+     *
+     * <p>Then we reads from file. If file is not valid or non-exist or empty (cannot load the file), just skip the file
+     * as if no file are provided. When reading configs from file, first check if the config field is null, only
+     * set the config field from file if the config field is null (which indicates command line didn't provide this
+     * config field). This way we can ensure the command line has a higher priority than the file config.
+     *
+     * <p> If a config field is not provided by command nor by file (also indicated by a null value),
+     * then we will throw an exception if the config field is required, or set it with the default value.
+     * @param args
+     * @throws IOException
+     */
+    @VisibleForTesting
+    protected void setConfigs(String[] args) throws IOException{
+        JCommander jcommander = new JCommander(this);
+        // parse args by JCommander
+        jcommander.parse(args);
+        if (configFile != null) {
+            checkNoOtherConfigs(args);
+            useConfigFromFileAndProvideDefaultValue();
+            validateRequiredConfigs();
+        } else {
+            validateRequiredConfigs();
+        }
+    }
+
+    protected static Set<String> requireConfigFieldsNames = new HashSet<>(){{
+        // String
+        add("functionDetailsJsonString");
+        add("functionId");
+        add("functionVersion");
+        add("pulsarServiceUrl");
+        add("clusterName");
+        add("instanceId");
+        add("port");
+        add("metricsPort");
+        add("maxBufferedTuples");
+        add("expectedHealthCheckInterval");
+    }};
+
+    @VisibleForTesting
+    protected Set<String> requiredConfigFieldNames() {
+        return requireConfigFieldsNames;
+    }
+
+    @VisibleForTesting
+    protected Set<String> optionalConfigFieldNames() {
+        JCommander jc = new JCommander(this);
+        return jc.getFields()
+                .keySet()
+                .stream()
+                .map(Parameterized::getName)
+                .filter(name -> !requireConfigFieldsNames.contains(name))
+                .collect(Collectors.toSet());
+    }
+
+    @VisibleForTesting
+    protected Set<String> requiredConfigLongestArgNames() {
+        JCommander jc = new JCommander(this);
+        return jc.getFields()
+                .entrySet()
+                .stream()
+                .filter(entry -> requireConfigFieldsNames.contains(entry.getKey().getName()))
+                .map(entry -> entry.getValue().getLongestName())
+                .collect(Collectors.toSet());
+    }
+
+    @VisibleForTesting
+    protected Set<String> optionalConfigLongestArgNames() {
+        JCommander jc = new JCommander(this);
+        return jc.getFields()
+                .entrySet()
+                .stream()
+                .filter(entry -> !requireConfigFieldsNames.contains(entry.getKey().getName()))
+                .map(entry -> entry.getValue().getLongestName())
+                .collect(Collectors.toSet());
+    }
+
+    private void checkNoOtherConfigs(String[] args) {
+        if (args.length != 2) {
+            throw new ValidationException("When using file config， configs should not be specified with command line");
         }
     }
 }

--- a/pulsar-functions/runtime/src/test/java/org/apache/pulsar/functions/runtime/JavaInstanceStarterTest.java
+++ b/pulsar-functions/runtime/src/test/java/org/apache/pulsar/functions/runtime/JavaInstanceStarterTest.java
@@ -1,0 +1,467 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.functions.runtime;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+
+import com.beust.jcommander.ParameterException;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.pulsar.common.nar.NarClassLoader;
+import org.assertj.core.util.Sets;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import javax.validation.ValidationException;
+
+import static org.apache.commons.lang3.RandomStringUtils.randomAlphabetic;
+
+@Slf4j
+public class JavaInstanceStarterTest {
+    
+    private static String STRING_INVALID_VALUE = "invalidString";
+    
+    private static String INTEGER_INVALID_VALUE = "-1";
+
+
+    @Test
+    public void fileConfigShouldConflictWithRequiredCommandlineConfig() throws IOException {
+        JavaInstanceStarter javaInstanceStarter = new JavaInstanceStarter();
+        String[] args = new CommandLineArgsBuilder()
+            .withJCommanderConfigs(requiredJCommanderConfigs())
+            .useFile()
+            .build();
+
+        Assert.assertThrows(ValidationException.class, () -> javaInstanceStarter.setConfigs(args));
+    }
+
+    @Test
+    public void fileConfigShouldConfigWithAnyCommandLineConfig() throws IOException {
+        JavaInstanceStarter javaInstanceStarter = new JavaInstanceStarter();
+        String[] args = new CommandLineArgsBuilder()
+            .withJCommanderConfigs("--use_tls", Boolean.TRUE.toString())
+            .useFile()
+            .build();
+
+        Assert.assertThrows(ValidationException.class, () -> javaInstanceStarter.setConfigs(args));
+    }
+
+    @Test
+    public void useBooleanStringShouldSetArityOneBooleanField() throws IOException {
+        JavaInstanceStarter javaInstanceStarter = new JavaInstanceStarter();
+        String[] args = new CommandLineArgsBuilder()
+                .withJCommanderConfigs(requiredJCommanderConfigs())
+                .withJCommanderConfigs("--use_tls", Boolean.TRUE.toString())
+                .build();
+        javaInstanceStarter.setConfigs(args);
+        assertRequiredFieldsAreSet(javaInstanceStarter);
+        Assert.assertEquals(javaInstanceStarter.useTls, Boolean.TRUE.toString());
+    }
+
+    @Test
+    public void useFlagShouldSetArityZeroBooleanField() throws IOException {
+        JavaInstanceStarter javaInstanceStarter = new JavaInstanceStarter();
+        String[] args = new CommandLineArgsBuilder()
+                .withJCommanderConfigs(requiredJCommanderConfigs())
+                .arityZeroBooleanInJCommander()
+                .build();
+        javaInstanceStarter.setConfigs(args);
+        assertRequiredFieldsAreSet(javaInstanceStarter);
+        Assert.assertEquals(javaInstanceStarter.exposePulsarAdminClientEnabled, Boolean.TRUE);
+    }
+
+    @Test
+    public void missingRequiredCommandLineArgsShouldFail() throws IOException {
+        JavaInstanceStarter javaInstanceStarter = new JavaInstanceStarter();
+        String[] args = new CommandLineArgsBuilder()
+            .withJCommanderConfigs(optionalJCommanderConfigs())
+            .build();
+
+        Assert.assertThrows(ParameterException.class, () -> javaInstanceStarter.setConfigs(args));
+    }
+
+    @Test
+    public void shouldSetDefaultCommandLineArgs() throws IOException {
+        JavaInstanceStarter javaInstanceStarter = new JavaInstanceStarter();
+        String[] args = new CommandLineArgsBuilder()
+            .withJCommanderConfigs(requiredJCommanderConfigs())
+            .build();
+        javaInstanceStarter.setConfigs(args);
+        assertOptionalFieldHasDefaultValue(javaInstanceStarter);
+    }
+
+    @Test
+    public void allOptionsCanBeSet() throws IOException {
+        JavaInstanceStarter javaInstanceStarter = new JavaInstanceStarter();
+        String[] args = new CommandLineArgsBuilder()
+            .withJCommanderConfigs(requiredJCommanderConfigs())
+            .withJCommanderConfigs(optionalJCommanderConfigs())
+            .arityZeroBooleanInJCommander()
+            .build();
+        javaInstanceStarter.setConfigs(args);
+        assertRequiredFieldsAreSet(javaInstanceStarter);
+        assertOptionalFieldsAreSet(javaInstanceStarter);
+    }
+
+    @Test
+    public void fileConfigShouldCheckRequiredFields() throws IOException {
+        JavaInstanceStarter javaInstanceStarter = new JavaInstanceStarter();
+        String[] args = new CommandLineArgsBuilder()
+            .useFile()
+            .build();
+        Assert.assertThrows(ParameterException.class, () -> javaInstanceStarter.setConfigs(args));
+    }
+
+    @Test
+    public void fileConfigShouldProvideSameDefaultValue() throws IOException {
+        JavaInstanceStarter javaInstanceStarter = new JavaInstanceStarter();
+        String[] args = new CommandLineArgsBuilder()
+            .useFile()
+            .withFileConfigs(requiredFileConfigs())
+            .build();
+        javaInstanceStarter.setConfigs(args);
+        assertRequiredFieldsAreSet(javaInstanceStarter);
+        assertOptionalFieldHasDefaultValue(javaInstanceStarter);
+    }
+
+    @Test
+    public void invalidFileLocationShouldThrowException() throws IOException{
+        JavaInstanceStarter javaInstanceStarter = new JavaInstanceStarter();
+        String[] args = new CommandLineArgsBuilder()
+            .withJCommanderConfigs("--config_file", "invalid_file")
+            .build();
+        Assert.assertThrows(FileNotFoundException.class, () -> javaInstanceStarter.setConfigs(args));
+    }
+
+    @Test
+    public void invalidFileConfigShouldBeIgnored() {
+
+    }
+
+    @Test
+    public void allOptionsInFileConfigCanBeSet() throws IOException{
+        JavaInstanceStarter javaInstanceStarter = new JavaInstanceStarter();
+        String[] args = new CommandLineArgsBuilder()
+            .withFileConfigs(requiredFileConfigs())
+            .withFileConfigs(optionalFileConfigs())
+            .build();
+        javaInstanceStarter.setConfigs(args);
+        assertRequiredFieldsAreSet(javaInstanceStarter);
+        assertOptionalFieldsAreSet(javaInstanceStarter);
+    }
+
+    private void assertRequiredFieldsAreSet(JavaInstanceStarter javaInstanceStarter) {
+        // Required String
+        Assert.assertEquals(javaInstanceStarter.functionDetailsJsonString, STRING_INVALID_VALUE);
+        Assert.assertEquals(javaInstanceStarter.functionId, STRING_INVALID_VALUE);
+        Assert.assertEquals(javaInstanceStarter.functionVersion, STRING_INVALID_VALUE);
+        Assert.assertEquals(javaInstanceStarter.pulsarServiceUrl, STRING_INVALID_VALUE);
+        Assert.assertEquals(javaInstanceStarter.clusterName, STRING_INVALID_VALUE);
+        // Required Integer
+        Assert.assertEquals(javaInstanceStarter.instanceId, Integer.valueOf(INTEGER_INVALID_VALUE));
+        Assert.assertEquals(javaInstanceStarter.port, Integer.valueOf(INTEGER_INVALID_VALUE));
+        Assert.assertEquals(javaInstanceStarter.metricsPort, Integer.valueOf(INTEGER_INVALID_VALUE));
+        Assert.assertEquals(javaInstanceStarter.maxBufferedTuples, Integer.valueOf(INTEGER_INVALID_VALUE));
+        Assert.assertEquals(javaInstanceStarter.expectedHealthCheckInterval, Integer.valueOf(INTEGER_INVALID_VALUE));
+
+    }
+
+    private void assertOptionalFieldsAreSet(JavaInstanceStarter javaInstanceStarter) {
+        // Optional String
+        Assert.assertEquals(javaInstanceStarter.jarFile, STRING_INVALID_VALUE);
+        Assert.assertEquals(javaInstanceStarter.transformFunctionJarFile, STRING_INVALID_VALUE);
+        Assert.assertEquals(javaInstanceStarter.transformFunctionId, STRING_INVALID_VALUE);
+        Assert.assertEquals(javaInstanceStarter.clientAuthenticationPlugin, STRING_INVALID_VALUE);
+        Assert.assertEquals(javaInstanceStarter.clientAuthenticationParameters, STRING_INVALID_VALUE);
+        Assert.assertEquals(javaInstanceStarter.tlsTrustCertFilePath, STRING_INVALID_VALUE);
+        Assert.assertEquals(javaInstanceStarter.stateStorageImplClass, STRING_INVALID_VALUE);
+        Assert.assertEquals(javaInstanceStarter.stateStorageServiceUrl, STRING_INVALID_VALUE);
+        Assert.assertEquals(javaInstanceStarter.secretsProviderClassName, STRING_INVALID_VALUE);
+        Assert.assertEquals(javaInstanceStarter.secretsProviderConfig, STRING_INVALID_VALUE);
+        Assert.assertEquals(javaInstanceStarter.narExtractionDirectory, STRING_INVALID_VALUE);
+        Assert.assertEquals(javaInstanceStarter.webServiceUrl, STRING_INVALID_VALUE);
+        // Optional Integer
+        Assert.assertEquals(javaInstanceStarter.maxPendingAsyncRequests, Integer.valueOf(INTEGER_INVALID_VALUE));
+
+        // Optional Boolean
+        Assert.assertEquals(javaInstanceStarter.useTls, Boolean.TRUE.toString());
+        Assert.assertEquals(javaInstanceStarter.tlsAllowInsecureConnection, Boolean.FALSE.toString());
+        Assert.assertEquals(javaInstanceStarter.tlsHostNameVerificationEnabled, Boolean.TRUE.toString());
+        Assert.assertEquals(javaInstanceStarter.exposePulsarAdminClientEnabled, Boolean.TRUE);
+    }
+
+    private void assertOptionalFieldHasDefaultValue(JavaInstanceStarter javaInstanceStarter) {
+        // Optional String
+        Assert.assertNull(javaInstanceStarter.jarFile);
+        Assert.assertNull(javaInstanceStarter.transformFunctionJarFile);
+        Assert.assertNull(javaInstanceStarter.transformFunctionId);
+        Assert.assertNull(javaInstanceStarter.clientAuthenticationPlugin);
+        Assert.assertNull(javaInstanceStarter.clientAuthenticationParameters);
+        Assert.assertNull(javaInstanceStarter.tlsTrustCertFilePath);
+        Assert.assertNull(javaInstanceStarter.stateStorageImplClass);
+        Assert.assertNull(javaInstanceStarter.stateStorageServiceUrl);
+        Assert.assertNull(javaInstanceStarter.secretsProviderClassName);
+        Assert.assertNull(javaInstanceStarter.secretsProviderConfig);
+        Assert.assertEquals(javaInstanceStarter.narExtractionDirectory, NarClassLoader.DEFAULT_NAR_EXTRACTION_DIR);
+        Assert.assertNull(javaInstanceStarter.webServiceUrl);
+        // Optional Integer
+        Assert.assertEquals(javaInstanceStarter.maxPendingAsyncRequests, Integer.valueOf(1000));
+        // Optional Boolean
+        Assert.assertEquals(javaInstanceStarter.useTls, Boolean.FALSE.toString());
+        Assert.assertEquals(javaInstanceStarter.tlsAllowInsecureConnection, Boolean.TRUE.toString());
+        Assert.assertEquals(javaInstanceStarter.tlsHostNameVerificationEnabled, Boolean.FALSE.toString());
+        Assert.assertEquals(javaInstanceStarter.exposePulsarAdminClientEnabled, Boolean.FALSE);
+    }
+
+    private Map<String, String> requiredJCommanderConfigs() {
+        return new HashMap<>(){{
+            // String
+            put("--function_details", STRING_INVALID_VALUE);
+            put("--function_id", STRING_INVALID_VALUE);
+            put("--function_version", STRING_INVALID_VALUE);
+            put("--pulsar_serviceurl", STRING_INVALID_VALUE);
+            put("--cluster_name", STRING_INVALID_VALUE);
+            // Integer
+            put("--instance_id", INTEGER_INVALID_VALUE);
+            put("--port", INTEGER_INVALID_VALUE);
+            put("--metrics_port", INTEGER_INVALID_VALUE);
+            put("--max_buffered_tuples", INTEGER_INVALID_VALUE);
+            put("--expected_healthcheck_interval", INTEGER_INVALID_VALUE);
+        }};
+    }
+
+    private Map<String, String> requiredFileConfigs() {
+        return new HashMap<>(){{
+            // String
+            put("functionDetailsJsonString", STRING_INVALID_VALUE);
+            put("functionId", STRING_INVALID_VALUE);
+            put("functionVersion", STRING_INVALID_VALUE);
+            put("pulsarServiceUrl", STRING_INVALID_VALUE);
+            put("clusterName", STRING_INVALID_VALUE);
+            // Integer
+            put("instanceId", INTEGER_INVALID_VALUE);
+            put("port", INTEGER_INVALID_VALUE);
+            put("metricsPort", INTEGER_INVALID_VALUE);
+            put("maxBufferedTuples", INTEGER_INVALID_VALUE);
+            put("expectedHealthCheckInterval", INTEGER_INVALID_VALUE);
+        }};
+    }
+
+    private Map<String, String> optionalJCommanderConfigs() {
+        return new HashMap<>(){{
+            // String
+            put("--jar", STRING_INVALID_VALUE);
+            put("--transform_function_jar", STRING_INVALID_VALUE);
+            put("--transform_function_id", STRING_INVALID_VALUE);
+            put("--client_auth_plugin", STRING_INVALID_VALUE);
+            put("--client_auth_params", STRING_INVALID_VALUE);
+            put("--tls_trust_cert_path", STRING_INVALID_VALUE);
+            put("--state_storage_impl_class", STRING_INVALID_VALUE);
+            put("--state_storage_serviceurl", STRING_INVALID_VALUE);
+            put("--secrets_provider", STRING_INVALID_VALUE);
+            put("--secrets_provider_config", STRING_INVALID_VALUE);
+            put("--nar_extraction_directory", STRING_INVALID_VALUE);
+            put("--web_serviceurl", STRING_INVALID_VALUE);
+            // Integer
+            put("--pending_async_requests", INTEGER_INVALID_VALUE);
+            // Boolean
+            put("--use_tls", Boolean.TRUE.toString());
+            put("--tls_allow_insecure", Boolean.FALSE.toString());
+            put("--hostname_verification_enabled", Boolean.TRUE.toString());
+        }};
+    }
+
+    private Map<String, String> optionalFileConfigs() {
+        return new HashMap<>(){{
+            // String
+            put("jarFile", STRING_INVALID_VALUE);
+            put("transformFunctionJarFile", STRING_INVALID_VALUE);
+            put("transformFunctionId", STRING_INVALID_VALUE);
+            put("clientAuthenticationPlugin", STRING_INVALID_VALUE);
+            put("clientAuthenticationParameters", STRING_INVALID_VALUE);
+            put("tlsTrustCertFilePath", STRING_INVALID_VALUE);
+            put("stateStorageImplClass", STRING_INVALID_VALUE);
+            put("stateStorageServiceUrl", STRING_INVALID_VALUE);
+            put("secretsProviderClassName", STRING_INVALID_VALUE);
+            put("secretsProviderConfig", STRING_INVALID_VALUE);
+            put("narExtractionDirectory", STRING_INVALID_VALUE);
+            put("webServiceUrl", STRING_INVALID_VALUE);
+            // Integer
+            put("maxPendingAsyncRequests", INTEGER_INVALID_VALUE);
+            // Boolean, value different from the default value
+            put("useTls", Boolean.TRUE.toString());
+            put("tlsAllowInsecureConnection", Boolean.FALSE.toString());
+            put("tlsHostNameVerificationEnabled", Boolean.TRUE.toString());
+            put("exposePulsarAdminClientEnabled", Boolean.TRUE.toString());
+        }};
+    }
+
+    @Test
+    public void testRequiredConfigFieldNames() {
+        JavaInstanceStarter jc = new JavaInstanceStarter();
+        assertSetContainsSame(jc.requiredConfigFieldNames(), requiredFileConfigs().keySet());
+    }
+
+    @Test
+    public void testOptionalConfigFieldNames() {
+        JavaInstanceStarter jc = new JavaInstanceStarter();
+        Set<String> expected = Sets.newHashSet();
+        expected.add("configFile");
+        expected.addAll(optionalFileConfigs().keySet());
+        assertSetContainsSame(jc.optionalConfigFieldNames(), expected);
+    }
+
+    @Test
+    public void testRequiredConfigLongestArgNames() {
+        JavaInstanceStarter jc = new JavaInstanceStarter();
+        assertSetContainsSame(jc.requiredConfigLongestArgNames(), requiredJCommanderConfigs().keySet());
+    }
+
+    @Test
+    public void testOptionalConfigLongestArgName() {
+        JavaInstanceStarter jc = new JavaInstanceStarter();
+        Set<String> expected = Sets.newHashSet();
+        expected.add("--config_file");
+        expected.add("--expose_pulsaradmin");
+        expected.addAll(optionalJCommanderConfigs().keySet());
+        assertSetContainsSame(jc.optionalConfigLongestArgNames(), expected);
+    }
+
+    private void assertSetContainsSame(Set<String> actual, Set<String> expected) {
+        Assert.assertTrue(actual.containsAll(expected));
+        Assert.assertTrue(expected.containsAll(actual));
+    }
+
+    private static String writeConfigsToFile(String name, Map<String, String> configs) throws IOException {
+        File runnerConfFile = File.createTempFile(name, ".conf");
+        runnerConfFile.deleteOnExit();
+        try (FileWriter fileWriter = new FileWriter(runnerConfFile, Charset.defaultCharset())) {
+            for (Map.Entry<String, String> entry : configs.entrySet()) {
+                fileWriter.write(entry.getKey() + "=" + entry.getValue() + System.getProperty("line.separator"));
+            }
+        }
+        return Paths.get(runnerConfFile.toString()).toAbsolutePath().toString();
+    }
+
+    private Map<String, String> setRandomValueForConfigs(Map<String, String> configs) {
+        configs.replaceAll((k, v) -> {
+            if (Objects.equals(v, INTEGER_INVALID_VALUE)) {
+                return String.valueOf(1);
+            } else if (Objects.equals(v, STRING_INVALID_VALUE)) {
+                return "valueFromFile";
+            } else {
+                return "true";
+            }
+        });
+        return configs;
+    }
+
+    public static class CommandLineArgsBuilder {
+        private Map<String, String> jCommanderConfigs;
+
+        private Map<String, String> fileConfigs;
+
+        private Boolean useFile = false;
+
+        private Boolean arityZeroBooleanInJCommander = false;
+
+        private CommandLineArgsBuilder(){
+            this.jCommanderConfigs = new HashMap<>();
+            this.fileConfigs = new HashMap<>();
+        };
+
+        public CommandLineArgsBuilder newBuilder() {
+            return new CommandLineArgsBuilder();
+        }
+
+
+        public CommandLineArgsBuilder withJCommanderConfigs(Map<String, String> jCommanderConfigs) {
+            this.jCommanderConfigs.putAll(jCommanderConfigs);
+            return this;
+        }
+
+        public CommandLineArgsBuilder withJCommanderConfigs(String key, String value) {
+            this.jCommanderConfigs.put(key, value);
+            return this;
+        }
+
+        public CommandLineArgsBuilder exceptJCommanderConfigWithKey(String key) {
+            this.jCommanderConfigs.remove(key);
+            return this;
+        }
+
+        public CommandLineArgsBuilder withFileConfigs(Map<String, String> jCommanderConfigs) {
+            this.useFile = true;
+            this.fileConfigs.putAll(jCommanderConfigs);
+            return this;
+        }
+
+        public CommandLineArgsBuilder withFileConfigs(String key, String value) {
+            this.useFile = true;
+            this.fileConfigs.put(key, value);
+            return this;
+        }
+
+        public CommandLineArgsBuilder exceptFileConfigWithKey(String key) {
+            this.fileConfigs.remove(key);
+            return this;
+        }
+
+        public CommandLineArgsBuilder useFile() {
+            this.useFile = true;
+            return this;
+        }
+
+        public CommandLineArgsBuilder arityZeroBooleanInJCommander() {
+            this.arityZeroBooleanInJCommander = true;
+            return this;
+        }
+
+        public String[] build() throws IOException {
+            List<String> result = new ArrayList<>();
+            for (Map.Entry<String, String> entry : jCommanderConfigs.entrySet()) {
+                result.add(entry.getKey());
+                result.add(entry.getValue());
+            }
+
+            if (arityZeroBooleanInJCommander) {
+                result.add("--expose_pulsaradmin");
+            }
+
+            if (useFile) {
+                String fileName = randomAlphabetic(7);
+                String completeFileName = writeConfigsToFile(fileName, fileConfigs);
+                result.add("--config_file");
+                result.add(completeFileName);
+            }
+            return result.toArray(new String[0]);
+        }
+    }
+}


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://docs.google.com/document/d/1d8Pw6ZbWk-_pCKdOmdvx9rnhPiyuxwq60_TrD68d7BA/edit#heading=h.trs9rsex3xom)*. 

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->

<!-- Either this PR fixes an issue, -->

Fixes #18532 

<!-- or this PR is one task of an issue -->

Master Issue: #18532 

### Motivation

PIP-225: https://github.com/apache/pulsar/issues/18744

Reading config options from command line is not  very flexible in a cloud-native environment. For example, in distroless containers where there is no shell access, it's hard to determine a config value from env vars.

Using file to read the configs allow a more flexible configuration pattern.

### Modifications
1. Added `JavaInstanceConfiguration extends PulsarConfiguration` to support reading configs from file.
2. Declare all JCommander fields as non-required
3. Add custom required field validation and default value  logic.
4. Added test case to make sure the command line args is not broken.


### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*


This change added tests and can be verified as follows:

- Added JavaInstanceStarterTest to make sure using command line args does not break.

### Does this pull request potentially affect one of the following parts:

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [X] The public API
- [ ] The schema
- [X] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [X] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [X] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
