### PR TITLE
[improve][misc] Update caffeine from 2.9.1 to 3.1.2

### DIFF
--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -254,7 +254,7 @@ The Apache Software License, Version 2.0
      - com.fasterxml.jackson.jaxrs-jackson-jaxrs-json-provider-2.13.4.jar
      - com.fasterxml.jackson.module-jackson-module-jaxb-annotations-2.13.4.jar
      - com.fasterxml.jackson.module-jackson-module-jsonSchema-2.13.4.jar
- * Caffeine -- com.github.ben-manes.caffeine-caffeine-2.9.1.jar
+ * Caffeine -- com.github.ben-manes.caffeine-caffeine-3.1.2.jar
  * Conscrypt -- org.conscrypt-conscrypt-openjdk-uber-2.5.2.jar
  * Proto Google Common Protos -- com.google.api.grpc-proto-google-common-protos-2.0.1.jar
  * Bitbucket -- org.bitbucket.b_c-jose4j-0.7.6.jar

--- a/pom.xml
+++ b/pom.xml
@@ -200,7 +200,7 @@ flexible messaging model and an intuitive client API.</description>
     <javax.ws.rs-api.version>2.1</javax.ws.rs-api.version>
     <hdrHistogram.version>2.1.9</hdrHistogram.version>
     <javax.servlet-api>3.1.0</javax.servlet-api>
-    <caffeine.version>2.9.1</caffeine.version>
+    <caffeine.version>3.1.2</caffeine.version>
     <java-semver.version>0.9.0</java-semver.version>
     <jline.version>2.14.6</jline.version>
     <jline3.version>3.21.0</jline3.version>

--- a/pulsar-sql/presto-distribution/LICENSE
+++ b/pulsar-sql/presto-distribution/LICENSE
@@ -366,7 +366,7 @@ The Apache Software License, Version 2.0
     - avro-1.10.2.jar
     - avro-protobuf-1.10.2.jar
   * Caffeine
-    - caffeine-2.9.1.jar
+    - caffeine-3.1.2.jar
   * Javax
     - javax.inject-1.jar
     - javax.servlet-api-3.1.0.jar


### PR DESCRIPTION
### Motivation

Now we only use caffeine in broker module. *caffeine* has a jdk11+ version, which is more proper for jdk11+ project to integrated with.(Spring3.0 uses caffeine 3.X too.) So I think it's worth for us to update caffeine to 3.x

### Modifications

Update caffeine from 2.9.1 to 3.1.2

- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

https://github.com/apache/pulsar/pull/18647