### PR TITLE
[improve][client] Fast fail when msg size larger than maxBatchSize

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiTest.java
@@ -3234,6 +3234,7 @@ public class AdminApiTest extends MockedPulsarServiceBaseTest {
                 .subscribe();
         @Cleanup
         Producer<byte[]> producer = pulsarClient.newProducer()
+                .batchingMaxBytes(1024 * 1024)
                 .topic(topic)
                 .create();
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/MessagePublishBufferThrottleTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/MessagePublishBufferThrottleTest.java
@@ -109,6 +109,7 @@ public class MessagePublishBufferThrottleTest extends BrokerTestBase {
         final String topic = "persistent://prop/ns-abc/testBlockByPublishRateLimiting";
         Producer<byte[]> producer = pulsarClient.newProducer()
                 .topic(topic)
+                .batchingMaxBytes(1024 * 1024)
                 .producerName("producer-name")
                 .create();
         Topic topicRef = pulsar.getBrokerService().getTopicReference(topic).get();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/MessagePublishBufferThrottleTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/MessagePublishBufferThrottleTest.java
@@ -77,6 +77,7 @@ public class MessagePublishBufferThrottleTest extends BrokerTestBase {
         final String topic = "persistent://prop/ns-abc/testMessagePublishBufferThrottleEnable";
         Producer<byte[]> producer = pulsarClient.newProducer()
                 .topic(topic)
+                .batchingMaxBytes(1024 * 1024)
                 .producerName("producer-name")
                 .create();
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/ProducerMaxBytesTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/ProducerMaxBytesTest.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.client.impl;
+
+import lombok.Cleanup;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.apache.pulsar.client.api.ProducerConsumerBase;
+import org.apache.pulsar.client.api.PulsarClient;
+import org.apache.pulsar.client.api.PulsarClientException;
+import org.junit.Assert;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.TimeUnit;
+
+@Test(groups = "broker-impl")
+public class ProducerMaxBytesTest extends ProducerConsumerBase {
+
+    @Override
+    @BeforeMethod
+    protected void setup() throws Exception {
+        super.internalSetup();
+        super.producerBaseSetup();
+    }
+
+    @Override
+    @AfterMethod(alwaysRun = true)
+    protected void cleanup() throws Exception {
+        super.internalCleanup();
+    }
+
+    @Test(timeOut = 10_000)
+    public void testProduceMaxThanBatchSize() throws Exception {
+        final String topic = "testProduceMaxThanBatchSize";
+        final int maxBatchSize = 1024;
+        final int messageSize = maxBatchSize + 1;
+        final String message = RandomStringUtils.randomAlphabetic(messageSize);
+
+        @Cleanup
+        PulsarClient client = PulsarClient.builder()
+                .serviceUrl(brokerUrl.toString())
+                .statsInterval(0, TimeUnit.SECONDS)
+                .build();
+
+        @Cleanup
+        ProducerImpl<byte[]> producer = (ProducerImpl<byte[]>) client.newProducer()
+                .topic(topic)
+                .enableBatching(true)
+                .batchingMaxBytes(maxBatchSize)
+                .create();
+
+        try {
+            producer.send(message.getBytes(StandardCharsets.UTF_8));
+            throw new IllegalStateException("Should have failed to send message");
+        } catch (PulsarClientException.InvalidMessageException ex) {
+            Assert.assertNotNull(ex);
+        }
+    }
+
+}

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/ProducerSemaphoreTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/ProducerSemaphoreTest.java
@@ -271,7 +271,7 @@ public class ProducerSemaphoreTest extends ProducerConsumerBase {
             batchMessageContainerField.setAccessible(true);
             BatchMessageContainerImpl batchMessageContainer = (BatchMessageContainerImpl) batchMessageContainerField.get(spyProducer);
             batchMessageContainer.setProducer(spyProducer);
-            spyProducer.send("semaphore-test".getBytes(StandardCharsets.UTF_8));
+            spyProducer.send("semaphore".getBytes(StandardCharsets.UTF_8));
 
             throw new IllegalStateException("can not reach here");
         } catch (PulsarClientException.TimeoutException ex) {


### PR DESCRIPTION
### Motivation

Fast fail when msg size larger than maxBatchSize

### Verifying this change

Add unit tests to cover this change

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/Shoothzj/pulsar/pull/2
