### PR TITLE
[fix][test] Fix `testMaxPendingChunkMessages`

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/MessageChunkingTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/MessageChunkingTest.java
@@ -19,8 +19,8 @@
 package org.apache.pulsar.client.impl;
 
 import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertNotEquals;
 import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 import io.netty.buffer.ByteBuf;
@@ -33,8 +33,6 @@ import java.util.List;
 import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -309,57 +307,53 @@ public class MessageChunkingTest extends ProducerConsumerBase {
         producer.close();
     }
 
-    @Test(enabled = false)
-    public void testMaxPendingChunkMessages() throws Exception {
+    private void sendSingleChunk(Producer<String> producer, String uuid, int chunkId, int totalChunks)
+            throws PulsarClientException {
+        TypedMessageBuilderImpl<String> msg = (TypedMessageBuilderImpl<String>) producer.newMessage()
+                .value(String.format("chunk-%s-%d|", uuid, chunkId));
+        MessageMetadata msgMetadata = msg.getMetadataBuilder();
+        msgMetadata.setUuid(uuid)
+                .setChunkId(chunkId)
+                .setNumChunksFromMsg(totalChunks)
+                .setTotalChunkMsgSize(100);
+        msg.send();
+    }
 
+    @Test
+    public void testMaxPendingChunkMessages() throws Exception {
         log.info("-- Starting {} test --", methodName);
-        this.conf.setMaxMessageSize(100);
-        final int totalMessages = 25;
         final String topicName = "persistent://my-property/my-ns/maxPending";
-        final int totalProducers = 25;
-        @Cleanup("shutdownNow")
-        ExecutorService executor = Executors.newFixedThreadPool(totalProducers);
 
         @Cleanup
-        ConsumerImpl<byte[]> consumer = (ConsumerImpl<byte[]>) pulsarClient.newConsumer().topic(topicName)
-                .subscriptionName("my-subscriber-name").acknowledgmentGroupTime(0, TimeUnit.SECONDS)
-                .maxPendingChunkedMessage(1).autoAckOldestChunkedMessageOnQueueFull(true)
-                .ackTimeout(5, TimeUnit.SECONDS).subscribe();
+        Consumer<String> consumer = pulsarClient.newConsumer(Schema.STRING)
+                .topic(topicName)
+                .subscriptionName("my-subscriber-name")
+                .maxPendingChunkedMessage(1)
+                .autoAckOldestChunkedMessageOnQueueFull(true)
+                .subscribe();
+        @Cleanup
+        Producer<String> producer = pulsarClient.newProducer(Schema.STRING)
+                .topic(topicName)
+                .chunkMaxMessageSize(100)
+                .enableChunking(true)
+                .enableBatching(false)
+                .create();
 
-        ProducerBuilder<byte[]> producerBuilder = pulsarClient.newProducer().topic(topicName);
+        sendSingleChunk(producer, "0", 0, 2);
+        sendSingleChunk(producer, "1", 0, 2);
+        sendSingleChunk(producer, "1", 1, 2);
 
-        Producer<byte[]>[] producers = new Producer[totalProducers];
-        int totalPublishedMessages = totalProducers;
-        List<CompletableFuture<MessageId>> futures = new ArrayList<>();
-        for (int i = 0; i < totalProducers; i++) {
-            producers[i] = producerBuilder.enableChunking(true).enableBatching(false).create();
-            int index = i;
-            executor.submit(() -> {
-                futures.add(producers[index].sendAsync(createMessagePayload(450).getBytes()));
-            });
-        }
+        // The chunked message of uuid 0 is discarded.
+        Message<String> receivedMsg = consumer.receive(5, TimeUnit.SECONDS);
+        assertEquals(receivedMsg.getValue(), "chunk-1-0|chunk-1-1|");
 
-        FutureUtil.waitForAll(futures).get();
+        consumer.acknowledge(receivedMsg);
+        consumer.redeliverUnacknowledgedMessages();
 
-        Message<byte[]> msg = null;
-        Set<String> messageSet = new HashSet<>();
-        for (int i = 0; i < totalMessages; i++) {
-            msg = consumer.receive(1, TimeUnit.SECONDS);
-            if (msg == null) {
-                break;
-            }
-            String receivedMessage = new String(msg.getData());
-            log.info("Received message: [{}]", receivedMessage);
-            messageSet.add(receivedMessage);
-            consumer.acknowledge(msg);
-        }
+        sendSingleChunk(producer, "0", 1, 2);
 
-        log.info("messageSet size: {}, totalPublishedMessages: {}", messageSet.size(), totalPublishedMessages);
-        assertNotEquals(messageSet.size(), totalPublishedMessages);
-
-        for (int i = 0; i < totalProducers; i++) {
-            producers[i].close();
-        }
+        // Ensure that the chunked message of uuid 0 is discarded.
+        assertNull(consumer.receive(5, TimeUnit.SECONDS));
     }
 
     /**


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://docs.google.com/document/d/1d8Pw6ZbWk-_pCKdOmdvx9rnhPiyuxwq60_TrD68d7BA/edit#heading=h.trs9rsex3xom)*. 

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->

Fixes #18570 


### Motivation

The `testMaxPendingChunkMessages` is flaky. This PR use another approach to test the maxPendingChunkMessages configuration.

#### Root cause of this flaky test
The original test is a probability test, and it can only succeed with a certain probability. It simulates 25 producers writing to a topic with large messages, each with 5 chunks concurrently. Only if one of these chunked messages appears interleaved will it cause message loss and make the test pass. The success of the test is asserted by the loss of at least one message. The result of the test on my local machine is that only 2 out of 25 messages are lost. So the probability of failure of this test is still relatively high.

Therefore, I choose another approach to rewrite the test and make it deterministic by sending each single chunk manually.

### Modifications

* Fix `testMaxPendingChunkMessages`


### Does this pull request potentially affect one of the following parts:

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
