### PR TITLE
[do not merge] [branch-2.9] just reproduce issue: ledgers lost

### DIFF
--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/LedgerLostTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/LedgerLostTest.java
@@ -1,0 +1,139 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.bookkeeper.mledger.impl;
+
+import io.netty.buffer.ByteBuf;
+import java.nio.charset.Charset;
+import java.util.Iterator;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.bookkeeper.mledger.AsyncCallbacks;
+import org.apache.bookkeeper.mledger.ManagedCursor;
+import org.apache.bookkeeper.mledger.ManagedLedger;
+import org.apache.bookkeeper.mledger.ManagedLedgerConfig;
+import org.apache.bookkeeper.mledger.ManagedLedgerException;
+import org.apache.bookkeeper.mledger.Position;
+import org.apache.bookkeeper.test.MockedBookKeeperTestCase;
+import org.apache.pulsar.common.api.proto.CommandSubscribe;
+import org.awaitility.Awaitility;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+@Slf4j
+public class LedgerLostTest extends MockedBookKeeperTestCase {
+
+    private void triggerLedgerRollover(ManagedLedger ledger, int maxEntriesPerLedger) {
+        new Thread(() -> {
+            int writeLedgerCount = 2;
+            for (int i = 0; i < writeLedgerCount; i++) {
+                for (int j = 0; j < maxEntriesPerLedger; j++) {
+                    byte[] data = String.format("%s_%s", i, j).getBytes(Charset.defaultCharset());
+                    Object ctx = "";
+                    ledger.asyncAddEntry(data, new AsyncCallbacks.AddEntryCallback() {
+                        @Override
+                        public void addComplete(Position position, ByteBuf entryData, Object ctx) {
+
+                        }
+
+                        @Override
+                        public void addFailed(ManagedLedgerException exception, Object ctx) {
+
+                        }
+                    }, ctx);
+                }
+            }
+        }).start();
+    }
+
+    private CompletableFuture<ManagedCursorImpl> openCursor(ManagedLedger ledger, String cursorName,
+                                                            CompletableFuture<ManagedCursorImpl> cursorFuture){
+        ledger.asyncOpenCursor(cursorName, CommandSubscribe.InitialPosition.Earliest,
+                new AsyncCallbacks.OpenCursorCallback(){
+                    @Override
+                    public void openCursorComplete(ManagedCursor cursor, Object ctx) {
+                        cursorFuture.complete((ManagedCursorImpl) cursor);
+                    }
+
+                    @Override
+                    public void openCursorFailed(ManagedLedgerException exception, Object ctx) {
+                        cursorFuture.completeExceptionally(exception);
+                    }
+                }, cursorName);
+        return cursorFuture;
+    }
+
+    private int calculateCursorCount(ManagedLedgerImpl ledger){
+        Iterator iterator = ledger.getCursors().iterator();
+        int count = 0;
+        while (iterator.hasNext()){
+            iterator.next();
+            count++;
+        }
+        return count;
+    }
+
+    @Test
+    public void testConcurrentCloseLedgerAndSwitchLedger() throws Exception {
+        String managedLedgerName = "lg_" + UUID.randomUUID().toString().replaceAll("-", "_");
+        String cursorName1 = "cs_01";
+        String cursorName2 = "cs_02";
+        int maxEntriesPerLedger = 5;
+        ManagedLedgerConfig config = new ManagedLedgerConfig();
+        config.setThrottleMarkDelete(1);
+        config.setMaximumRolloverTime(Integer.MAX_VALUE, TimeUnit.SECONDS);
+        config.setMaxEntriesPerLedger(5);
+
+        // call "switch ledger" and "managedLedger.close" concurrently.
+        ManagedLedgerImpl.PROCESS_COODINATOR.set(100);
+        final ManagedLedgerImpl managedLedger1 = (ManagedLedgerImpl) factory.open(managedLedgerName, config);
+        ManagedLedgerImpl.PROCESS_COODINATOR.set(0);
+        triggerLedgerRollover(managedLedger1, maxEntriesPerLedger);
+        managedLedger1.close();
+
+        // 1. close managedLedger1.
+        // 2. create new ManagedLedger: managedLedger2.
+        //   2-1: create cursor1 of managedLedger2.
+        // 3. close managedLedger1 twice, make managedLedger2 remove from cache of managedLedgerFactory.
+        // 4. create new ManagedLedger: managedLedger3.
+        //   4-2: create cursor2 of managedLedger3.
+        // Then two ManagedLedger appear at the same time and have different numbers of cursors.
+        int expectCursorNumInManagedLedger2 = 1;
+        int expectCursorNumInManagedLedger3 = 2;
+        Awaitility.await().untilAsserted(() ->
+                Assert.assertTrue(managedLedger1.getState() != ManagedLedgerImpl.State.Closed));
+        final ManagedLedgerImpl managedLedger2 = (ManagedLedgerImpl) factory.open(managedLedgerName, config);
+        Awaitility.await().until(() -> {
+            CompletableFuture<ManagedLedgerImpl> managedLedgerFuture = factory.ledgers.get(managedLedgerName);
+            return managedLedgerFuture.join() == managedLedger2;
+        });
+        managedLedger1.close();
+        managedLedger2.openCursor(cursorName1, CommandSubscribe.InitialPosition.Earliest);
+        Assert.assertEquals(managedLedger1.getState(), ManagedLedgerImpl.State.Closed);
+        Assert.assertTrue(factory.ledgers.isEmpty());
+        final ManagedLedgerImpl managedLedger3 = (ManagedLedgerImpl) factory.open(managedLedgerName, config);
+        managedLedger3.openCursor(cursorName2, CommandSubscribe.InitialPosition.Earliest);
+        Assert.assertTrue(managedLedger2.getState() != ManagedLedgerImpl.State.Closed);
+        Assert.assertTrue(managedLedger3.getState() != ManagedLedgerImpl.State.Closed);
+        Assert.assertEquals(calculateCursorCount(managedLedger2), expectCursorNumInManagedLedger2);
+        Assert.assertEquals(calculateCursorCount(managedLedger3), expectCursorNumInManagedLedger3);
+        System.out.println(1);
+    }
+}

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/test/MockedBookKeeperTestCase.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/test/MockedBookKeeperTestCase.java
@@ -112,7 +112,7 @@ public abstract class MockedBookKeeperTestCase {
 
     @BeforeClass(alwaysRun = true)
     public final void setUpClass() {
-        executor = OrderedScheduler.newSchedulerBuilder().numThreads(2).name("test").build();
+        executor = OrderedScheduler.newSchedulerBuilder().numThreads(20).name("test").build();
         cachedExecutor = Executors.newCachedThreadPool();
     }
 


### PR DESCRIPTION
### Motivation

In PR #17526, we know that a `topic` can be closed multiple times and that it is possible to have two same-named objects of class `Persistenttopic` in the same `broker` instance.

We know that closing the `topic` triggers the closure of the `ManagedLedger`. The `topic` object can be closed multiple times which means the `ManagedLedger` can be closed multiple times. This PR is used to prove: If a `ManagedLedger` is closed more than once, and switched `ledgerHandle` operation of `ManagedLedger` and method closed executed concurrently, there will be two of the same-named `Managedledger` in the same broker, possibly with different numbers of cursors.

If both Managedledgers are available and there are different numbers of cursors, this can cause the operation `trimLedgers` to delete too many ledgers from the meta of `ManagedLedger`.

Here is the process: 

| `managedLedger_1.close`| `switch ledgerHandle(managedLedger_1)` | `create managedLedger_2` | `create managedLedger_3` |
| --- | --- | --- | --- |
| | close current `LedgerHandle` |
| | async create new `LedgerHandle` |
| do close | |
| set the state to `Closed` | |
| remove `managedLedger_1` from `ManagedFactory.ledgers` | |
| | set current ledger to the new `LedgerHandle` |
| | set the state to `LedgerOpened` |
| do close the second time | |
| | | create `managedLedger_2`|
| | | put `managedLedger_2` to `ManagedFactory.ledgers` |
| remove `managedLedger_2` from `ManagedFactory.ledgers` | |
| | | create `cursor_1` into `managedLedger_2` |
| | | | create `managedLedger_3`|
| | | | put `managedLedger_3` to `ManagedFactory.ledgers` |
| | | | recover `cursor_1` from meta |
| | | | create `cursor_2` into `managedLedger_3` |
| | | has one cursor `cursor_1` | has two cursor: `cursor_1`, `cursor_2` |
----

### How to reproduce

Run the test `LedgerLostTest.testConcurrentCloseLedgerAndSwitchLedger`

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: 
- 1
