### PR TITLE
[improve][broker] Make Consumer#equals more effective

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Consumer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Consumer.java
@@ -908,7 +908,7 @@ public class Consumer {
     public boolean equals(Object obj) {
         if (obj instanceof Consumer) {
             Consumer other = (Consumer) obj;
-            return Objects.equals(cnx.clientAddress(), other.cnx.clientAddress()) && consumerId == other.consumerId;
+            return consumerId == other.consumerId && Objects.equals(cnx.clientAddress(), other.cnx.clientAddress());
         }
         return false;
     }


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://docs.google.com/document/d/1d8Pw6ZbWk-_pCKdOmdvx9rnhPiyuxwq60_TrD68d7BA/edit#heading=h.trs9rsex3xom)*. 

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->

### Motivation

It's from a production case in my org, one of our consumer application constantly create consumer instance after increase topic partition due to old pulsar-client bug. The application got OOM eventually and broker publish latency goes more than 30s, so many publish requests timeout, broker latency go back normal after application restart.

It could be reproduce below:
```shell
pulsar-admin namespaces create -b 128 public/perf
pa namespaces set-max-consumers-per-topic -c 0 public/perf
pa namespaces set-max-consumers-per-subscription -c 0 public/perf
pulsar-perf produce -r 1000 persistent://public/perf/perf
pulsar-perf consume -st Shared -n 100000 persistent://public/perf/perf
```
After stop consume program, `pulsar-io` thread will be block for a while, publish latency will be very high (35s+ in my case).

It's a cpu profile during consumer stops:
![image](https://user-images.githubusercontent.com/5058708/204340904-e48be20d-bb61-4318-a876-176d312ccb3e.png)
![image](https://user-images.githubusercontent.com/5058708/204339193-0de6e4ea-6b2a-4317-81bf-e5bc1c7b4366.png)

- [profile.100kconsume1k.stoping.122601.html.zip](https://github.com/apache/pulsar/files/10106134/profile.100kconsume1k.stoping.122601.html.zip)

The time complexity of `CopyOnWriteList.remove` is O(n), so `Consumer#equals` method is a hot method.
https://github.com/apache/pulsar/blob/master/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumers.java#L192

### Modifications

Flip `&&` expression

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->

### Matching PR in forked repository

PR in forked repository: https://github.com/Shawyeok/pulsar/pull/5

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
