### PR TITLE
Support reading config options from file in Function Python Runner

### DIFF
--- a/docker/pulsar/Dockerfile
+++ b/docker/pulsar/Dockerfile
@@ -79,7 +79,7 @@ RUN apt-get -y --purge autoremove \
      && apt-get clean \
      && rm -rf /var/lib/apt/lists/*
 
-RUN pip3 install pyyaml==5.4.1
+RUN pip3 install pyyaml==5.4.1 watchdog==2.1.9
 
 # Pulsar currently writes to the below directories, assuming the default configuration.
 # Note that number 4 is the reason that pulsar components need write access to the /pulsar directory.

--- a/pulsar-functions/instance/src/main/python/python_instance.py
+++ b/pulsar-functions/instance/src/main/python/python_instance.py
@@ -458,6 +458,7 @@ class PythonInstance(object):
   def config_observer_on_modified(self, event):
     # TODO: This function is used for runtime parameters handling logic
     #  when listening to changes in the configuration file (self.config_file)
+    Log.debug("Configuration file %s modified detected" % self.config_file)
     pass
 
   def setup_config_observer(self):
@@ -472,7 +473,7 @@ class PythonInstance(object):
       while True:
         pass
     except Exception as e:
-      Log.error("Uncaught exception in Python instance (config observer): %s" % e);
+      Log.error("Uncaught exception in Python instance (config observer): %s" % e)
       observer.stop()
       observer.join()
 

--- a/pulsar-functions/instance/src/main/python/python_instance_main.py
+++ b/pulsar-functions/instance/src/main/python/python_instance_main.py
@@ -68,34 +68,37 @@ def merge_arguments(args, config_file):
   config = util.read_config(config_file)
   if not config:
     return
-  if not args.client_auth_plugin and config.get("client_auth_plugin", None):
-    args.client_auth_plugin = config.get("client_auth_plugin")
-  if not args.client_auth_params and config.get("client_auth_params", None):
-    args.client_auth_params = config.get("client_auth_params")
-  if not args.use_tls and config.get("use_tls", None):
-    args.use_tls = config.get("use_tls")
-  if not args.tls_allow_insecure_connection and config.get("tls_allow_insecure_connection", None):
-    args.tls_allow_insecure_connection = config.get("tls_allow_insecure_connection")
-  if not args.hostname_verification_enabled and config.get("hostname_verification_enabled", None):
-    args.hostname_verification_enabled = config.get("hostname_verification_enabled")
-  if not args.tls_trust_cert_path and config.get("tls_trust_cert_path", None):
-    args.tls_trust_cert_path = config.get("tls_trust_cert_path")
-  if not args.logging_level and config.get("logging_level", None):
-    args.logging_level = config.get("logging_level")
-  if not args.secrets_provider and config.get("secrets_provider", None):
-    args.secrets_provider = config.get("secrets_provider")
-  if not args.secrets_provider_config and config.get("secrets_provider_config", None):
-    args.secrets_provider_config = config.get("secrets_provider_config")
-  if not args.install_usercode_dependencies and config.get("install_usercode_dependencies", None):
-    args.install_usercode_dependencies = config.get("install_usercode_dependencies")
-  if not args.dependency_repository and config.get("dependency_repository", None):
-    args.dependency_repository = config.get("dependency_repository")
-  if not args.extra_dependency_repository and config.get("extra_dependency_repository", None):
-    args.extra_dependency_repository = config.get("extra_dependency_repository")
-  if not args.state_storage_serviceurl and config.get("state_storage_serviceurl", None):
-    args.state_storage_serviceurl = config.get("state_storage_serviceurl")
-  if not args.enable_live_update and config.get("enable_live_update", None):
-    args.enable_live_update = config.get("enable_live_update")
+  default_config = config["DEFAULT"]
+  if not default_config:
+    return
+  if not args.client_auth_plugin and default_config.get("client_auth_plugin", None):
+    args.client_auth_plugin = default_config.get("client_auth_plugin")
+  if not args.client_auth_params and default_config.get("client_auth_params", None):
+    args.client_auth_params = default_config.get("client_auth_params")
+  if not args.use_tls and default_config.get("use_tls", None):
+    args.use_tls = default_config.get("use_tls")
+  if not args.tls_allow_insecure_connection and default_config.get("tls_allow_insecure_connection", None):
+    args.tls_allow_insecure_connection = default_config.get("tls_allow_insecure_connection")
+  if not args.hostname_verification_enabled and default_config.get("hostname_verification_enabled", None):
+    args.hostname_verification_enabled = default_config.get("hostname_verification_enabled")
+  if not args.tls_trust_cert_path and default_config.get("tls_trust_cert_path", None):
+    args.tls_trust_cert_path = default_config.get("tls_trust_cert_path")
+  if not args.logging_level and default_config.get("logging_level", None):
+    args.logging_level = default_config.get("logging_level")
+  if not args.secrets_provider and default_config.get("secrets_provider", None):
+    args.secrets_provider = default_config.get("secrets_provider")
+  if not args.secrets_provider_config and default_config.get("secrets_provider_config", None):
+    args.secrets_provider_config = default_config.get("secrets_provider_config")
+  if not args.install_usercode_dependencies and default_config.get("install_usercode_dependencies", None):
+    args.install_usercode_dependencies = default_config.get("install_usercode_dependencies")
+  if not args.dependency_repository and default_config.get("dependency_repository", None):
+    args.dependency_repository = default_config.get("dependency_repository")
+  if not args.extra_dependency_repository and default_config.get("extra_dependency_repository", None):
+    args.extra_dependency_repository = default_config.get("extra_dependency_repository")
+  if not args.state_storage_serviceurl and default_config.get("state_storage_serviceurl", None):
+    args.state_storage_serviceurl = default_config.get("state_storage_serviceurl")
+  if not args.enable_live_update and default_config.get("enable_live_update", None):
+    args.enable_live_update = default_config.get("enable_live_update")
 
 def main():
   # Setup signal handlers

--- a/pulsar-functions/instance/src/main/python/util.py
+++ b/pulsar-functions/instance/src/main/python/util.py
@@ -25,6 +25,7 @@ import os
 import inspect
 import sys
 import importlib
+import configparser
 from threading import Timer
 from pulsar.functions import serde
 
@@ -79,6 +80,23 @@ def getFullyQualifiedInstanceId(tenant, namespace, name, instance_id):
 
 def get_properties(fullyQualifiedName, instanceId):
     return {"application": "pulsar-function", "id": str(fullyQualifiedName), "instance_id": str(instanceId)}
+
+def read_config(config_file):
+    """
+    The content of the configuration file is styled as follows:
+
+    [DEFAULT]
+    parameter1 = value1
+    parameter2 = value2
+    parameter3 = value3
+    ...
+    """
+    if config_file == "":
+        return None
+
+    cfg = configparser.ConfigParser()
+    cfg.read(config_file)
+    return cfg.get("DEFAULT", None)
 
 class FixedTimer():
 

--- a/pulsar-functions/instance/src/main/python/util.py
+++ b/pulsar-functions/instance/src/main/python/util.py
@@ -96,7 +96,7 @@ def read_config(config_file):
 
     cfg = configparser.ConfigParser()
     cfg.read(config_file)
-    return cfg.get("DEFAULT", None)
+    return cfg
 
 class FixedTimer():
 


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://docs.google.com/document/d/1d8Pw6ZbWk-_pCKdOmdvx9rnhPiyuxwq60_TrD68d7BA/edit#heading=h.trs9rsex3xom)*. 

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->

<!-- Either this PR fixes an issue, -->

Fixes #18533

<!-- or this PR is one task of an issue -->

Master Issue: #18533

### Motivation

The Pulsar functions have the ability to provide the number of instances of the called function (see, for example, ["Get num instances"](https://pulsar.apache.org/docs/2.10.x/window-functions-context/#get-num-instances) ), but the data that this function currently relies on needs to be passed in via command line arguments and cannot be easily changed dynamically. Therefore we need to provide a more dynamic way of accessing data (mainly FunctionDetails) for functions, and this way can also serve to pass the function's other parameters.

This mechanism is aimed at allowing the function to dynamically fetch the required parameters and data without having to restart the function in order to load the latest parameters or data.

A more appropriate approach is to provide the function with a local config file where the data and parameters are stored. The provider of the data and parameters (usually the initiator of the function, e.g. function-worker) writes the contents of the parameters and the data (FunctionDetails) to a fixed local config file, and passes the path of this config file to the function.

```
exec --config-file /path/to/config-file
```

The function determines the value of `--config-file` and determines if the target config file exists, and parses its contents if it does.

The rules for applying parameters or data to the function are as follows.

- Parameters or data passed in on the command line have a lower priority than the corresponding parameters or data in the configuration file
- For mandatory parameters or data, if they are not passed in, an exception is thrown.
- For optional parameters or data, if not passed in, the default value is used

### Modifications

1. add two arguments
    - `enable_live_update`, default is False, which means that python-function will listen for changes to the configuration file and update the configuration of the running function instance when it has listened for an event
    - `config_file`, default is None, which means you need to get the configuration content from `config_file`
2. the priority of command line arguments is higher than the priority of configuration file arguments during initialization
3. if `args.config_file` and `args.enable_live_update` are enabled, add a new thread and use the [`watchdog`](https://github.com/gorakhargosh/watchdog) library to listen to `args.config_file` and update the relevant configuration after listening to the `on_modified` event

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
