### PR TITLE
[improve][broker] Making defaultNumberOfNamespaceBundles of ServiceConfiguration dynamic

### DIFF
--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -774,6 +774,7 @@ public class ServiceConfiguration implements PulsarConfiguration {
 
     @FieldContext(
         category = CATEGORY_POLICIES,
+        dynamic = true,
         doc = "When a namespace is created without specifying the number of bundle, this"
             + " value will be used as the default")
     private int defaultNumberOfNamespaceBundles = 4;


### PR DESCRIPTION
### Motivation

 Making defaultNumberOfNamespaceBundles of `ServiceConfiguration` dynamic.   

The scenario is that we may create  a lot of topics with different namespaces in the future, but finding that the `defaultNumberOfNamespaceBundles` is not suitable, so it's better we could change the `defaultNumberOfNamespaceBundles` dynamic

### Modifications

 Make defaultNumberOfNamespaceBundles of `ServiceConfiguration` dynamic. 

### Verifying this change

- [x] Make sure that the change passes the CI checks.


### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/AnonHxy/pulsar/pull/19
