### PR TITLE
[improve][broker] First judge whether config is null when standalone start

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/PulsarStandalone.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/PulsarStandalone.java
@@ -269,6 +269,11 @@ public class PulsarStandalone implements AutoCloseable {
     private boolean usingNewDefaultsPIP117;
 
     public void start() throws Exception {
+        if (config == null) {
+            log.error("Failed to load configuration");
+            System.exit(1);
+        }
+
         String forceUseZookeeperEnv = System.getenv(PULSAR_STANDALONE_USE_ZOOKEEPER);
 
         // Allow forcing to use ZK mode via an env variable. eg:
@@ -282,11 +287,6 @@ public class PulsarStandalone implements AutoCloseable {
         } else {
             // There's no existing ZK data directory, or we're already using RocksDB for metadata
             usingNewDefaultsPIP117 = true;
-        }
-
-        if (config == null) {
-            log.error("Failed to load configuration");
-            System.exit(1);
         }
 
         log.debug("--- setup PulsarStandaloneStarter ---");


### PR DESCRIPTION
### Modifications
First judge whether config is null when standalone start.

### Documentation
- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository
PR in forked repository: 