### PR TITLE
[improve][cli] Tools: Derive default value tls-insecure-cnx param based on trust-store input

### DIFF
--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/PulsarAdminTool.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/PulsarAdminTool.java
@@ -33,6 +33,7 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.function.Supplier;
 import lombok.Getter;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.pulsar.PulsarVersion;
 import org.apache.pulsar.admin.cli.extensions.CommandExecutionContext;
 import org.apache.pulsar.admin.cli.extensions.CustomCommandFactory;
@@ -122,8 +123,8 @@ public class PulsarAdminTool {
         String tlsKeyFilePath = properties.getProperty("tlsKeyFilePath");
         String tlsCertificateFilePath = properties.getProperty("tlsCertificateFilePath");
 
-        boolean tlsAllowInsecureConnection = Boolean.parseBoolean(properties
-                .getProperty("tlsAllowInsecureConnection", "false"));
+        boolean tlsAllowInsecureConnection = Boolean.parseBoolean(properties.getProperty("tlsAllowInsecureConnection",
+                Boolean.toString(StringUtils.isBlank(tlsTrustStorePath))));
 
         boolean tlsEnableHostnameVerification = Boolean.parseBoolean(properties
                 .getProperty("tlsEnableHostnameVerification", "false"));

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/PulsarAdminTool.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/PulsarAdminTool.java
@@ -123,12 +123,11 @@ public class PulsarAdminTool {
         String tlsKeyFilePath = properties.getProperty("tlsKeyFilePath");
         String tlsCertificateFilePath = properties.getProperty("tlsCertificateFilePath");
 
-        boolean tlsAllowInsecureConnection = Boolean.parseBoolean(properties.getProperty("tlsAllowInsecureConnection",
-                Boolean.toString(StringUtils.isBlank(tlsTrustStorePath))));
-
         boolean tlsEnableHostnameVerification = Boolean.parseBoolean(properties
                 .getProperty("tlsEnableHostnameVerification", "false"));
         final String tlsTrustCertsFilePath = properties.getProperty("tlsTrustCertsFilePath");
+        boolean tlsAllowInsecureConnection = Boolean.parseBoolean(properties.getProperty("tlsAllowInsecureConnection",
+                Boolean.toString(StringUtils.isBlank(tlsTrustCertsFilePath))));
 
         return PulsarAdmin.builder().allowTlsInsecureConnection(tlsAllowInsecureConnection)
                 .enableTlsHostnameVerification(tlsEnableHostnameVerification)

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/client/cli/PulsarClientTool.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/client/cli/PulsarClientTool.java
@@ -104,8 +104,6 @@ public class PulsarClientTool {
     public PulsarClientTool(Properties properties) {
         rootParams = new RootParams();
         initRootParamsFromProperties(properties);
-        this.tlsAllowInsecureConnection = Boolean
-                .parseBoolean(properties.getProperty("tlsAllowInsecureConnection", "false"));
         this.tlsEnableHostnameVerification = Boolean
                 .parseBoolean(properties.getProperty("tlsEnableHostnameVerification", "false"));
         this.useKeyStoreTls = Boolean
@@ -119,6 +117,8 @@ public class PulsarClientTool {
         this.tlsKeyStorePassword = properties.getProperty("tlsKeyStorePassword");
         this.tlsKeyFilePath = properties.getProperty("tlsKeyFilePath");
         this.tlsCertificateFilePath = properties.getProperty("tlsCertificateFilePath");
+        this.tlsAllowInsecureConnection = Boolean.parseBoolean(properties.getProperty("tlsAllowInsecureConnection",
+                Boolean.toString(StringUtils.isBlank(tlsTrustStorePath))));
 
         initJCommander();
     }

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/client/cli/PulsarClientTool.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/client/cli/PulsarClientTool.java
@@ -118,7 +118,7 @@ public class PulsarClientTool {
         this.tlsKeyFilePath = properties.getProperty("tlsKeyFilePath");
         this.tlsCertificateFilePath = properties.getProperty("tlsCertificateFilePath");
         this.tlsAllowInsecureConnection = Boolean.parseBoolean(properties.getProperty("tlsAllowInsecureConnection",
-                Boolean.toString(StringUtils.isBlank(tlsTrustStorePath))));
+                Boolean.toString(StringUtils.isBlank(rootParams.tlsTrustCertsFilePath))));
 
         initJCommander();
     }


### PR DESCRIPTION
### Motivation

Sometimes user wants to create tls connection with server without using trust-store cert and wants to create insecure connection. However, right now tools-CLI requires user to pass `tlsAllowInsecureConnection` explicitly along with empty truststore file path. So, tools should derive default value of `tlsAllowInsecureConnection` flag based on input value of truststore cert file path.

### Modifications

Derive default value of `tlsAllowInsecureConnection` flag based on configured trust-store path.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [x] The admin CLI options
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
