### PR TITLE
[fix][branch-2.10]The pulsarMessageOverhead in 2.10 is different

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/PrometheusMetricsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/PrometheusMetricsTest.java
@@ -365,7 +365,7 @@ public class PrometheusMetricsTest extends BrokerTestBase {
                 .subscribe();
 
         final int messages = 5;
-        final int pulsarMessageOverhead = 31; // Number of extra bytes pulsar adds to each message
+        final int pulsarMessageOverhead = 42; // Number of extra bytes pulsar adds to each message
         final int messageSizeBytes = "my-message-n".getBytes().length + pulsarMessageOverhead;
 
         for (int i = 0; i < messages; i++) {


### PR DESCRIPTION
### Motivation & Modifications
Fix test testPerTopicStatsReconnect.
The `headersAndPayload` - `msg.bytes` = 42 in 2.10.
1. This is not contained in branch 2.10, which makes the payload of this test message add 8 bytes.
if n=1, batchedMessageMetadataAndPayload size = 10 in master but 12 in breach master. 
https://github.com/apache/pulsar/blob/463f590c8215bdee836ecfe44b83abbbd6ce6fbb/pulsar-client/src/main/java/org/apache/pulsar/client/impl/BatchMessageContainerImpl.java#L146-L151
https://github.com/apache/pulsar/blob/463f590c8215bdee836ecfe44b83abbbd6ce6fbb/pulsar-common/src/main/java/org/apache/pulsar/common/protocol/Commands.java#L1776-L1785
2. This code is deleted from the master, which adds 3 bytes.
```java
        if (!msgMetadata.hasPublishTime()) {
            msgMetadata.setPublishTime(client.getClientClock().millis());

            checkArgument(!msgMetadata.hasProducerName());

            msgMetadata.setProducerName(producerName);

            if (conf.getCompressionType() != CompressionType.NONE) {
                msgMetadata
                        .setCompression(CompressionCodecProvider.convertToWireProtocol(conf.getCompressionType()));
            }
            msgMetadata.setUncompressedSize(uncompressedSize);
        }
```

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->


