### PR TITLE
[branch-2.8]Fix non-durable cursor leak problem

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
@@ -953,6 +953,7 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
             return;
         } else if (!cursor.isDurable()) {
             cursors.removeCursor(consumerName);
+            cursor.setInactive();
             callback.deleteCursorComplete(ctx);
             return;
         }
@@ -963,6 +964,7 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
             @Override
             public void operationComplete(Void result, Stat stat) {
                 cursor.asyncDeleteCursorLedger();
+                cursor.setInactive();
                 cursors.removeCursor(consumerName);
 
                 // Redo invalidation of entries in cache


### PR DESCRIPTION
### Motivation
There exists potential non-durable cursor leak problem, if `deleteCursor` called but without deactive this cursor.

Master branch has fix this issue by #17273


### Modifications

Deactive cursor  in deleteCursor



### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository  
https://github.com/gaozhangmin/pulsar/pull/2