### PR TITLE
[fix][broker] Use correct file path for tls trust certificates

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
@@ -1513,7 +1513,7 @@ public class PulsarService implements AutoCloseable, ShutdownService {
                         conf.setTlsTrustCertsFilePath(
                                 isNotBlank(this.getConfiguration().getBrokerClientTrustCertsFilePath())
                                         ? this.getConfiguration().getBrokerClientTrustCertsFilePath()
-                                        : this.getConfiguration().getTlsCertificateFilePath());
+                                        : this.getConfiguration().getTlsTrustCertsFilePath());
                         conf.setTlsKeyFilePath(this.getConfiguration().getBrokerClientKeyFilePath());
                         conf.setTlsCertificateFilePath(this.getConfiguration().getBrokerClientCertificateFilePath());
                     }


### PR DESCRIPTION
### Motivation

This is a trivial cleanup, though it might technically break some deployments. Given that the `getBrokerClientTrustCertsFilePath` takes precedence over the `getTlsCertificateFilePath`, it is unlikely to have been used with any frequency. However, it is better to correctly update the trust certs file path. The consequence of this breaking change will be immediately obvious to any impacted users, as their pulsar clients will not trust certificates that they may have trusted before.

This is not a security vulnerability.

### Modifications

* Replace `getTlsCertificateFilePath` with `getTlsTrustCertsFilePath` when calling `setTlsTrustCertsFilePath` on the pulsar client in the pulsar broker.

### Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] Anything that affects deployment

### Documentation

- [x] `doc-not-needed`
