### PR TITLE
[fix][build] Include pulsar-common dependency 

### DIFF
--- a/pulsar-client-tools-test/pom.xml
+++ b/pulsar-client-tools-test/pom.xml
@@ -62,6 +62,12 @@
       <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>pulsar-common</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
     <!-- add the dependency in order to let maven build the module before this module -->
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/pulsar-functions/runtime/pom.xml
+++ b/pulsar-functions/runtime/pom.xml
@@ -70,7 +70,11 @@
       <artifactId>pulsar-broker-common</artifactId>
       <version>${project.version}</version>
     </dependency>
-
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>pulsar-common</artifactId>
+      <version>${project.version}</version>
+    </dependency>
   </dependencies>
 
   <build>


### PR DESCRIPTION


### Motivation
`pulsar-client-tools-test`  and `pulsar-functions-instance`  depend on `pulsar-common` module
like 
`org.apache.pulsar.common.sasl.SaslConstants`  `org.apache.pulsar.common.policies.data.OffloadPoliciesImpl` 

### Modifications

include `pulsar-common` module in pom.



### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

https://github.com/gaozhangmin/pulsar/pull/3
