### PR TITLE
[improve][broker] The interval of scheduled task should be greater than 0

### DIFF
--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -554,6 +554,7 @@ public class ServiceConfiguration implements PulsarConfiguration {
 
     @FieldContext(
         category = CATEGORY_POLICIES,
+        minValue = 1,
         doc = "How often to check for topics that have reached the quota."
             + " It only takes effects when `backlogQuotaCheckEnabled` is true"
     )
@@ -616,6 +617,7 @@ public class ServiceConfiguration implements PulsarConfiguration {
     private boolean brokerDeleteInactivePartitionedTopicMetadataEnabled = false;
     @FieldContext(
         category = CATEGORY_POLICIES,
+        minValue = 1,
         dynamic = true,
         doc = "How often to check for inactive topics"
     )
@@ -665,6 +667,7 @@ public class ServiceConfiguration implements PulsarConfiguration {
 
     @FieldContext(
         category = CATEGORY_POLICIES,
+        minValue = 1,
         doc = "How frequently to proactively check and purge expired messages"
     )
     private int messageExpiryCheckIntervalInMinutes = 5;
@@ -768,6 +771,7 @@ public class ServiceConfiguration implements PulsarConfiguration {
 
     @FieldContext(
         category = CATEGORY_POLICIES,
+        minValue = 1,
         doc = "Time of inactivity after which the broker will discard the deduplication information"
             + " relative to a disconnected producer. Default is 6 hours.")
     private int brokerDeduplicationProducerInactivityTimeoutMinutes = 360;
@@ -2705,6 +2709,7 @@ public class ServiceConfiguration implements PulsarConfiguration {
     private boolean exposePublisherStats = true;
     @FieldContext(
         category = CATEGORY_METRICS,
+        minValue = 1,
         doc = "Stats update frequency in seconds"
     )
     private int statsUpdateFrequencyInSecs = 60;


### PR DESCRIPTION
### Motivation
Some scheduled tasks will be started when the broker starting, including:
```java
        // start other housekeeping functions
        this.startStatsUpdater(
                serviceConfig.getStatsUpdateInitialDelayInSecs(),
                serviceConfig.getStatsUpdateFrequencyInSecs());
        this.startInactivityMonitor();
        this.startMessageExpiryMonitor();
        this.startCompactionMonitor();
        this.startConsumedLedgersMonitor();
        this.startBacklogQuotaChecker();
        this.startCheckReplicationPolicies();
        this.startDeduplicationSnapshotMonitor();
```
But the interval of these scheduled tasks should be greater than 0, otherwise an exception will be reported during startup, as below:
```
ERROR org.apache.pulsar.broker.PulsarService - Failed to start Pulsar service: null
java.lang.IllegalArgumentException: null
        at java.util.concurrent.ScheduledThreadPoolExecutor.scheduleAtFixedRate(ScheduledThreadPoolExecutor.java:623) ~[?:?]
        at java.util.concurrent.Executors$DelegatedScheduledExecutorService.scheduleAtFixedRate(Executors.java:819) ~[?:?]
        at org.apache.pulsar.broker.service.BrokerService.startInactivityMonitor(BrokerService.java:568) ~[pulsar-broker.jar:2.11.0-SNAPSHOT]
        at org.apache.pulsar.broker.service.BrokerService.start(BrokerService.java:534) ~[pulsar-broker.jar:2.11.0-SNAPSHOT]
        at org.apache.pulsar.broker.PulsarService.start(PulsarService.java:784) ~[pulsar-broker.jar:2.11.0-SNAPSHOT]
        at org.apache.pulsar.PulsarStandalone.start(PulsarStandalone.java:348) ~[pulsar-broker.jar:2.11.0-SNAPSHOT]
        at org.apache.pulsar.PulsarStandaloneStarter.main(PulsarStandaloneStarter.java:141) ~[pulsar-broker.jar:2.11.0-SNAPSHOT]
```
Therefore, it is necessary to judge whether the interval is greater than 0 and give clear information, as below:
```
java.lang.IllegalArgumentException: brokerDeleteInactiveTopicsFrequencySeconds value -1 doesn't fit in given range (1, 9223372036854775807)
	at org.apache.pulsar.common.configuration.PulsarConfigurationLoader.isComplete(PulsarConfigurationLoader.java:153)
```
### Modifications
- check interval > 0 and give clear information

### Documentation
- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository
PR in forked repository: 