### PR TITLE
[fix][test] Flaky-test: ShadowTopicTest.testShadowTopicConsuming

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/ShadowTopicTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/ShadowTopicTest.java
@@ -130,9 +130,7 @@ public class ShadowTopicTest extends BrokerTestBase {
                     (PersistentTopic) pulsar.getBrokerService().getTopicIfExists(sourceTopic).get().get();
             ShadowReplicator
                     replicator = (ShadowReplicator) sourcePersistentTopic.getShadowReplicators().get(shadowTopic);
-            if (replicator == null) {
-                return;
-            }
+            Assert.assertNotNull(replicator);
             Assert.assertEquals(String.valueOf(replicator.getState()), "Started");
         });
     }


### PR DESCRIPTION


<!-- Either this PR fixes an issue, -->

Fixes #18705

### Motivation

awaitUntilShadowReplicatorReady check is returned when ShadowReplicator is null

so the replicator is not ready when producer send message.

and the consumer wont get any message.

### Modifications

<!-- Describe the modifications you've done. -->

### Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->


