### PR TITLE
[fix][sql] Fix message without schema issue.

### DIFF
--- a/pulsar-sql/presto-pulsar/src/main/java/org/apache/pulsar/sql/presto/PulsarRecordCursor.java
+++ b/pulsar-sql/presto-pulsar/src/main/java/org/apache/pulsar/sql/presto/PulsarRecordCursor.java
@@ -655,7 +655,7 @@ public class PulsarRecordCursor implements RecordCursor {
             return schemaInfo;
         }
         try {
-            if (this.currentMessage.getSchemaVersion() == null) {
+            if (this.currentMessage.getSchemaVersion() == null || this.currentMessage.getSchemaVersion().length == 0) {
                 schemaInfo = pulsarSplit.getSchemaInfo();
             } else {
                 schemaInfo =  schemaInfoProvider.getSchemaByVersion(this.currentMessage.getSchemaVersion()).get();


### PR DESCRIPTION
### Motivation

Fix message without schema cause BufferUnderflowException. This issue is the same with #15622,  #14626

```
2022-11-22T19:10:31.948653279-05:00 com.google.common.util.concurrent.UncheckedExecutionException: java.nio.BufferUnderflowException
2022-11-22T19:10:31.948663818-05:00 	at com.google.common.cache.LocalCache$Segment.get(LocalCache.java:2055)
2022-11-22T19:10:31.948667961-05:00 	at com.google.common.cache.LocalCache.get(LocalCache.java:3966)
2022-11-22T19:10:31.948671522-05:00 	at com.google.common.cache.LocalCache.getOrLoad(LocalCache.java:3989)
2022-11-22T19:10:31.948674754-05:00 	at com.google.common.cache.LocalCache$LocalLoadingCache.get(LocalCache.java:4950)
2022-11-22T19:10:31.948678018-05:00 	at org.apache.pulsar.sql.presto.PulsarSqlSchemaInfoProvider.getSchemaByVersion(PulsarSqlSchemaInfoProvider.java:72)
2022-11-22T19:10:31.948682457-05:00 	at org.apache.pulsar.sql.presto.PulsarRecordCursor.getSchemaInfo(PulsarRecordCursor.java:661)
2022-11-22T19:10:31.948685508-05:00 	at org.apache.pulsar.sql.presto.PulsarRecordCursor.advanceNextPosition(PulsarRecordCursor.java:529)
2022-11-22T19:10:31.948688772-05:00 	at io.prestosql.spi.connector.RecordPageSource.getNextPage(RecordPageSource.java:90)
2022-11-22T19:10:31.948702066-05:00 	at io.prestosql.operator.TableScanOperator.getOutput(TableScanOperator.java:302)
2022-11-22T19:10:31.948705627-05:00 	at io.prestosql.operator.Driver.processInternal(Driver.java:379)
2022-11-22T19:10:31.948708545-05:00 	at io.prestosql.operator.Driver.lambda$processFor$8(Driver.java:283)
2022-11-22T19:10:31.948711749-05:00 	at io.prestosql.operator.Driver.tryWithLock(Driver.java:675)
2022-11-22T19:10:31.948714673-05:00 	at io.prestosql.operator.Driver.processFor(Driver.java:276)
2022-11-22T19:10:31.948717762-05:00 	at io.prestosql.execution.SqlTaskExecution$DriverSplitRunner.processFor(SqlTaskExecution.java:1075)
2022-11-22T19:10:31.948721008-05:00 	at io.prestosql.execution.executor.PrioritizedSplitRunner.process(PrioritizedSplitRunner.java:163)
2022-11-22T19:10:31.948723797-05:00 	at io.prestosql.execution.executor.TaskExecutor$TaskRunner.run(TaskExecutor.java:484)
2022-11-22T19:10:31.948726867-05:00 	at io.prestosql.$gen.Presto_332____20221122_212951_2.run(Unknown Source)
2022-11-22T19:10:31.948729829-05:00 	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
2022-11-22T19:10:31.948732538-05:00 	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
2022-11-22T19:10:31.948735400-05:00 	at java.base/java.lang.Thread.run(Thread.java:829)
2022-11-22T19:10:31.948739325-05:00 Caused by: java.nio.BufferUnderflowException
2022-11-22T19:10:31.948758426-05:00 	at java.base/java.nio.Buffer.nextGetIndex(Buffer.java:651)
2022-11-22T19:10:31.948761757-05:00 	at java.base/java.nio.HeapByteBuffer.getLong(HeapByteBuffer.java:454)
2022-11-22T19:10:31.948764646-05:00 	at org.apache.pulsar.sql.presto.PulsarSqlSchemaInfoProvider.loadSchema(PulsarSqlSchemaInfoProvider.java:101)
2022-11-22T19:10:31.948767641-05:00 	at org.apache.pulsar.sql.presto.PulsarSqlSchemaInfoProvider.access$000(PulsarSqlSchemaInfoProvider.java:45)
2022-11-22T19:10:31.948771209-05:00 	at org.apache.pulsar.sql.presto.PulsarSqlSchemaInfoProvider$1.load(PulsarSqlSchemaInfoProvider.java:57)
2022-11-22T19:10:31.948773964-05:00 	at org.apache.pulsar.sql.presto.PulsarSqlSchemaInfoProvider$1.load(PulsarSqlSchemaInfoProvider.java:54)
2022-11-22T19:10:31.948776775-05:00 	at com.google.common.cache.LocalCache$LoadingValueReference.loadFuture(LocalCache.java:3533)
2022-11-22T19:10:31.948779600-05:00 	at com.google.common.cache.LocalCache$Segment.loadSync(LocalCache.java:2282)
2022-11-22T19:10:31.948782541-05:00 	at com.google.common.cache.LocalCache$Segment.lockedGetOrLoad(LocalCache.java:2159)
2022-11-22T19:10:31.948785602-05:00 	at com.google.common.cache.LocalCache$Segment.get(LocalCache.java:2049)
2022-11-22T19:10:31.948788514-05:00 	... 19 more
```


### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->


