### PR TITLE
[fix][broker] Avoid OOM not trigger PulsarByteBufAllocator outOfMemoryListener when use ByteBufAllocator.DEFAULT.heapBuffer in PrometheusMetricsGeneratorUtils

### DIFF
--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/stats/prometheus/PrometheusMetricsGeneratorUtils.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/stats/prometheus/PrometheusMetricsGeneratorUtils.java
@@ -19,7 +19,6 @@
 package org.apache.pulsar.broker.stats.prometheus;
 
 import io.netty.buffer.ByteBuf;
-import io.netty.buffer.ByteBufAllocator;
 import io.prometheus.client.Collector;
 import io.prometheus.client.CollectorRegistry;
 import java.io.IOException;
@@ -27,6 +26,7 @@ import java.io.OutputStream;
 import java.util.Enumeration;
 import java.util.List;
 import org.apache.commons.collections4.CollectionUtils;
+import org.apache.pulsar.common.allocator.PulsarByteBufAllocator;
 import org.apache.pulsar.common.util.SimpleTextOutputStream;
 
 /**
@@ -38,7 +38,7 @@ public class PrometheusMetricsGeneratorUtils {
     public static void generate(String cluster, OutputStream out,
                                 List<PrometheusRawMetricsProvider> metricsProviders)
             throws IOException {
-        ByteBuf buf = ByteBufAllocator.DEFAULT.heapBuffer();
+        ByteBuf buf = PulsarByteBufAllocator.DEFAULT.heapBuffer();
         try {
             SimpleTextOutputStream stream = new SimpleTextOutputStream(buf);
             generateSystemMetrics(stream, cluster);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/PrometheusMetricsGenerator.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/PrometheusMetricsGenerator.java
@@ -22,7 +22,6 @@ import static org.apache.pulsar.broker.stats.prometheus.PrometheusMetricsGenerat
 import static org.apache.pulsar.broker.stats.prometheus.PrometheusMetricsGeneratorUtils.getTypeStr;
 import static org.apache.pulsar.common.stats.JvmMetrics.getJvmDirectMemoryUsed;
 import io.netty.buffer.ByteBuf;
-import io.netty.buffer.ByteBufAllocator;
 import io.netty.buffer.UnpooledByteBufAllocator;
 import io.prometheus.client.Collector;
 import io.prometheus.client.CollectorRegistry;
@@ -51,6 +50,7 @@ import org.apache.pulsar.broker.stats.WindowWrap;
 import org.apache.pulsar.broker.stats.metrics.ManagedCursorMetrics;
 import org.apache.pulsar.broker.stats.metrics.ManagedLedgerCacheMetrics;
 import org.apache.pulsar.broker.stats.metrics.ManagedLedgerMetrics;
+import org.apache.pulsar.common.allocator.PulsarByteBufAllocator;
 import org.apache.pulsar.common.stats.Metrics;
 import org.apache.pulsar.common.util.DirectMemoryUtils;
 import org.apache.pulsar.common.util.SimpleTextOutputStream;
@@ -138,7 +138,7 @@ public class PrometheusMetricsGenerator {
                 } catch (IOException e) {
                     log.error("Generate metrics failed", e);
                     //return empty buffer if exception happens
-                    return ByteBufAllocator.DEFAULT.heapBuffer(0);
+                    return PulsarByteBufAllocator.DEFAULT.heapBuffer(0);
                 }
             });
 

--- a/pulsar-common/src/main/java/org/apache/pulsar/client/impl/schema/SchemaUtils.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/client/impl/schema/SchemaUtils.java
@@ -31,7 +31,6 @@ import com.google.gson.JsonPrimitive;
 import com.google.gson.JsonSerializationContext;
 import com.google.gson.JsonSerializer;
 import io.netty.buffer.ByteBuf;
-import io.netty.buffer.ByteBufAllocator;
 import io.netty.buffer.ByteBufUtil;
 import java.io.IOException;
 import java.lang.reflect.Type;
@@ -44,6 +43,7 @@ import java.util.Map;
 import java.util.SortedMap;
 import java.util.TreeMap;
 import org.apache.pulsar.client.internal.DefaultImplementation;
+import org.apache.pulsar.common.allocator.PulsarByteBufAllocator;
 import org.apache.pulsar.common.schema.KeyValue;
 import org.apache.pulsar.common.schema.SchemaInfo;
 import org.apache.pulsar.common.schema.SchemaInfoWithVersion;
@@ -367,7 +367,7 @@ public final class SchemaUtils {
         int dataLength = 4 + keyBytes.length + 4 + valueBytes.length;
         byte[] schema = new byte[dataLength];
         //record the key value schema respective length
-        ByteBuf byteBuf = ByteBufAllocator.DEFAULT.heapBuffer(dataLength);
+        ByteBuf byteBuf = PulsarByteBufAllocator.DEFAULT.heapBuffer(dataLength);
         byteBuf.writeInt(keyBytes.length).writeBytes(keyBytes).writeInt(valueBytes.length).writeBytes(valueBytes);
         byteBuf.readBytes(schema);
         return schema;


### PR DESCRIPTION
### Motivation

To avoid OOM exception not trigger `PulsarByteBufAllocator outOfMemoryListener`, we should use `PulsarByteBufAllocator.DEFAULT` to replace `ByteBufAllocator.DEFAULT` to allocate memory;


In our case, broker.conf set  as `skipBrokerShutdownOnOOM=false`
 and the prometheus-stats-39-1 throw OOM exception, but not trigger broker shutdown. 


```
 [prometheus-stats-39-1] ERROR org.apache.bookkeeper.common.util.SafeRunnable - Unexpected throwable caught
java.lang.Error: java.lang.reflect.InvocationTargetException
Caused by: java.lang.OutOfMemoryError: Java heap space
        at jdk.internal.misc.Unsafe.allocateUninitializedArray(Unsafe.java:1269) ~[?:?]
        at jdk.internal.reflect.GeneratedMethodAccessor18.invoke(Unknown Source) ~[?:?]
        at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:?]
        at java.lang.reflect.Method.invoke(Method.java:566) ~[?:?]
        at io.netty.util.internal.PlatformDependent0.allocateUninitializedArray(PlatformDependent0.java:575) 
        at io.netty.util.internal.PlatformDependent.allocateUninitializedArray(PlatformDependent.java:287) 
        at io.netty.buffer.PoolArena$HeapArena.newByteArray(PoolArena.java:567) 
        at io.netty.buffer.PoolArena$HeapArena.newUnpooledChunk(PoolArena.java:583) 
        at io.netty.buffer.PoolArena.allocateHuge(PoolArena.java:214) 
        at io.netty.buffer.PoolArena.allocate(PoolArena.java:141) 
        at io.netty.buffer.PoolArena.reallocate(PoolArena.java:287) 
        at io.netty.buffer.PooledByteBuf.capacity(PooledByteBuf.java:122) 
        at io.netty.buffer.AbstractByteBuf.ensureWritable0(AbstractByteBuf.java:305) 
        at io.netty.buffer.AbstractByteBuf.writeByte(AbstractByteBuf.java:984) 
        at org.apache.pulsar.common.util.SimpleTextOutputStream.write(SimpleTextOutputStream.java:57) 
        at org.apache.pulsar.broker.stats.prometheus.TopicStats.appendRequiredLabels(TopicStats.java:453) 
        at org.apache.pulsar.broker.stats.prometheus.TopicStats.metric(TopicStats.java:385) 
        at org.apache.pulsar.broker.stats.prometheus.TopicStats.printTopicStats(TopicStats.java:128) 
        at org.apache.pulsar.broker.stats.prometheus.NamespaceStatsAggregator.lambda$generate$0(NamespaceStatsAggregator.java:84) 
        at org.apache.pulsar.broker.stats.prometheus.NamespaceStatsAggregator$$Lambda$1115/0x00000008009d5840.accept(Unknown Source) ~[?:?]
        at org.apache.pulsar.common.util.collections.ConcurrentOpenHashMap$Section.forEach(ConcurrentOpenHashMap.java:544) 
        at org.apache.pulsar.common.util.collections.ConcurrentOpenHashMap.forEach(ConcurrentOpenHashMap.java:272) 
        at org.apache.pulsar.broker.stats.prometheus.NamespaceStatsAggregator.lambda$generate$1(NamespaceStatsAggregator.java:75) 
        at org.apache.pulsar.broker.stats.prometheus.NamespaceStatsAggregator$$Lambda$1114/0x00000008009d4840.accept(Unknown Source) ~[?:?]
        at org.apache.pulsar.common.util.collections.ConcurrentOpenHashMap$Section.forEach(ConcurrentOpenHashMap.java:544) 
        at org.apache.pulsar.common.util.collections.ConcurrentOpenHashMap.forEach(ConcurrentOpenHashMap.java:272) 
        at org.apache.pulsar.broker.stats.prometheus.NamespaceStatsAggregator.lambda$generate$2(NamespaceStatsAggregator.java:74) 
        at org.apache.pulsar.broker.stats.prometheus.NamespaceStatsAggregator$$Lambda$1113/0x00000008009d3440.accept(Unknown Source) ~[?:?]
        at org.apache.pulsar.common.util.collections.ConcurrentOpenHashMap$Section.forEach(ConcurrentOpenHashMap.java:544) 
        at org.apache.pulsar.common.util.collections.ConcurrentOpenHashMap.forEach(ConcurrentOpenHashMap.java:272) 
        at org.apache.pulsar.broker.stats.prometheus.NamespaceStatsAggregator.generate(NamespaceStatsAggregator.java:70) 
        at org.apache.pulsar.broker.stats.prometheus.PrometheusMetricsGenerator.generate(PrometheusMetricsGenerator.java:110) 
```

### Modifications

1. Use `PulsarByteBufAllocator.DEFAULT` replace `ByteBufAllocator.DEFAULT` in `PrometheusMetricsGenerator/PrometheusMetricsGeneratorUtils/SchemaUtils`.



### Documentation
- [X] `doc-not-needed` <!-- Your PR changes do not impact docs -->
