### PR TITLE
[cleanup][doc] Remove wrong expressions

### DIFF
--- a/site2/docs/io-debezium-source.md
+++ b/site2/docs/io-debezium-source.md
@@ -185,7 +185,7 @@ This example shows how to change the data of a MySQL table using the Pulsar Debe
        - One topic (`offset.storage.topic`) for storing the offset metadata messages. The connector saves the last successfully-committed offsets on this topic.
        - One per-table topic. The connector writes change events for all operations that occur in a table to a single Pulsar topic that is specific to that table.
 
-     If the automatic topic creation is disabled on your broker, you need to manually create the above 4 types of topics and the destination topic.
+     If the automatic topic creation is disabled on your broker, you need to manually create the above 4 types of topics.
 
      :::
 
@@ -327,7 +327,7 @@ This example shows how to change the data of a PostgreSQL table using the Pulsar
        - One topic (`offset.storage.topic`) for storing the offset metadata messages. The connector saves the last successfully-committed offsets on this topic.
        - One per-table topic. The connector writes change events for all operations that occur in a table to a single Pulsar topic that is specific to that table.
 
-     If the automatic topic creation is disabled on your broker, you need to manually create the above 4 types of topics and the destination topic.
+     If the automatic topic creation is disabled on your broker, you need to manually create the above 4 types of topics.
 
      :::
 
@@ -487,7 +487,7 @@ This example shows how to change the data of a MongoDB table using the Pulsar De
        - One topic (`offset.storage.topic`) for storing the offset metadata messages. The connector saves the last successfully-committed offsets on this topic.
        - One per-table topic. The connector writes change events for all operations that occur in a table to a single Pulsar topic that is specific to that table.
 
-     If the automatic topic creation is disabled on your broker, you need to manually create the above 4 types of topics and the destination topic.
+     If the automatic topic creation is disabled on your broker, you need to manually create the above 4 types of topics.
 
      :::
 


### PR DESCRIPTION
This is a follow-up to #18769. Sorry, I miss these lines in the first place.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [x] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
