### PR TITLE
[fix][client] New API for closing the consumer after waiting for the job to complete

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/ConsumerWaitCloseTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/ConsumerWaitCloseTest.java
@@ -1,0 +1,625 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.client.impl;
+
+import static org.testng.Assert.assertEquals;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.apache.pulsar.client.api.BatchReceivePolicy;
+import org.apache.pulsar.client.api.CloseWaitForJobPolicy;
+import org.apache.pulsar.client.api.Consumer;
+import org.apache.pulsar.client.api.Message;
+import org.apache.pulsar.client.api.MessageId;
+import org.apache.pulsar.client.api.Messages;
+import org.apache.pulsar.client.api.Producer;
+import org.apache.pulsar.client.api.ProducerConsumerBase;
+import org.apache.pulsar.client.api.PulsarClientException;
+import org.apache.pulsar.client.api.Schema;
+import org.apache.pulsar.client.api.SubscriptionType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+@Test(groups = "broker-impl")
+public class ConsumerWaitCloseTest extends ProducerConsumerBase {
+    private static final long testTimeout = 90000; // 1.5 min
+    private static final Logger log = LoggerFactory.getLogger(ConsumerWaitCloseTest.class);
+
+
+    @BeforeClass(alwaysRun = true)
+    @Override
+    protected void setup() throws Exception {
+        super.internalSetup();
+        super.producerBaseSetup();
+    }
+
+    @AfterMethod(alwaysRun = true)
+    public void rest() throws Exception {
+        pulsar.getConfiguration().setForceDeleteTenantAllowed(true);
+        pulsar.getConfiguration().setForceDeleteNamespaceAllowed(true);
+
+        for (String tenant : admin.tenants().getTenants()) {
+            for (String namespace : admin.namespaces().getNamespaces(tenant)) {
+                deleteNamespaceWithRetry(namespace, true);
+            }
+            admin.tenants().deleteTenant(tenant, true);
+        }
+
+        for (String cluster : admin.clusters().getClusters()) {
+            admin.clusters().deleteCluster(cluster);
+        }
+
+        pulsar.getConfiguration().setForceDeleteTenantAllowed(false);
+        pulsar.getConfiguration().setForceDeleteNamespaceAllowed(false);
+
+        super.producerBaseSetup();
+    }
+
+    @AfterClass(alwaysRun = true)
+    @Override
+    protected void cleanup() throws Exception {
+    }
+
+    @Test(timeOut = testTimeout)
+    public void testWithoutWaitCloseConsumer() throws Exception {
+
+        log.info("-- Starting {} test --", methodName);
+        final String topic = buildOneTopic();
+        final int numMessages = 5;
+        AtomicInteger counter = new AtomicInteger(0);
+
+        Consumer<String> consumer = pulsarClient.newConsumer(Schema.STRING)
+                .topic(topic)
+                .subscriptionName("my-sub")
+                .subscribe();
+
+        producerTopic(topic, numMessages);
+
+        for (int i = 0; i < numMessages; i++) {
+            Message<String> msg = consumer.receive(1, TimeUnit.SECONDS);
+            log.info("consumer message:{}, messageId:{}", msg.getValue(), msg.getMessageId().toString());
+            int tempIdx = i;
+            new Thread(() -> {
+                try {
+                    if (tempIdx % 2 == 0) {
+                        TimeUnit.SECONDS.sleep(3);
+                    } else {
+                        TimeUnit.SECONDS.sleep(4);
+                    }
+                    consumer.acknowledge(msg);
+                    counter.incrementAndGet();
+                    log.info("ack, messageId:{}", msg.getMessageId().toString());
+                } catch (Exception ignored) {
+                }
+            }).start();
+        }
+        consumer.close();
+        assertEquals(counter.get(), 0);
+    }
+
+    @Test(timeOut = testTimeout)
+    public void testFailConfig() throws Exception {
+
+        log.info("-- Starting {} test --", methodName);
+        final String topic = buildOneTopic();
+        Exception exception = null;
+        try {
+            pulsarClient.newConsumer(Schema.STRING)
+                    .topic(topic)
+                    .subscriptionName("my-sub")
+                    .closeWaitForJob(CloseWaitForJobPolicy.builder()
+                            .closeWaitForJob(true)
+                            .timeout(1, null)
+                            .build())
+                    .subscribe();
+        }catch (IllegalArgumentException e){
+            exception = e;
+        }
+        assertEquals(exception.getMessage(),"Must set timeout unit for timeout.");
+
+
+    }
+
+    @Test(timeOut = testTimeout)
+    public void testWaitCloseConsumer() throws Exception {
+
+        log.info("-- Starting {} test --", methodName);
+        final String topic = buildOneTopic();
+        final int numMessages = 5;
+        AtomicInteger counter = new AtomicInteger(0);
+
+        Consumer<String> consumer = pulsarClient.newConsumer(Schema.STRING)
+                .topic(topic)
+                .subscriptionName("my-sub")
+                .closeWaitForJob(CloseWaitForJobPolicy.builder()
+                        .closeWaitForJob(true)
+                        .build())
+                .subscribe();
+
+        producerTopic(topic, numMessages);
+
+        for (int i = 0; i < numMessages; i++) {
+            Message<String> msg = consumer.receive(1, TimeUnit.SECONDS);
+            log.info("consumer message:{}, messageId:{}", msg.getValue(), msg.getMessageId().toString());
+            int tempIdx = i;
+            new Thread(() -> {
+                try {
+                    if (tempIdx % 2 == 0) {
+                        TimeUnit.SECONDS.sleep(1);
+                    } else {
+                        TimeUnit.SECONDS.sleep(2);
+                    }
+                    consumer.acknowledge(msg);
+                    counter.incrementAndGet();
+                    log.info("ack, messageId:{}", msg.getMessageId().toString());
+                } catch (Exception ignored) {
+                }
+            }).start();
+        }
+        consumer.close();
+
+        assertEquals(counter.get(), numMessages);
+    }
+
+
+    @Test(timeOut = testTimeout)
+    public void testWaitCloseConsumerAsync() throws PulsarClientException, InterruptedException, ExecutionException {
+        String topic = buildOneTopic();
+        String subscriptionName = "my-test-close-consumer";
+        final int numMessages = 5;
+        AtomicInteger counter = new AtomicInteger(0);
+
+        Consumer<String> consumer = pulsarClient.newConsumer(Schema.STRING)
+                .topic(topic)
+                .subscriptionName(subscriptionName)
+                .subscriptionType(SubscriptionType.Shared)
+                .ackTimeout(0, TimeUnit.SECONDS)
+                .closeWaitForJob(CloseWaitForJobPolicy.builder()
+                        .closeWaitForJob(true)
+                        .build())
+                .subscribe();
+
+        producerTopic(topic, numMessages);
+
+        for (int i = 0; i < numMessages; i++) {
+
+            Message<String> message = consumer.receiveAsync().get();
+            log.info("consumer message:{}, messageId:{}", message.getValue(), message.getMessageId().toString());
+            int tempIdx = i;
+            new Thread(() -> {
+                try {
+                    if (tempIdx % 2 == 0) {
+                        TimeUnit.SECONDS.sleep(1);
+                    } else {
+                        TimeUnit.SECONDS.sleep(2);
+                    }
+                    consumer.acknowledgeAsync(message);
+                    counter.incrementAndGet();
+                    log.info("ack, messageId:{}", message.getMessageId().toString());
+                } catch (Exception ignored) {
+                }
+            }).start();
+        }
+        consumer.close();
+
+        assertEquals(counter.get(), numMessages);
+    }
+
+    @Test(timeOut = testTimeout)
+    public void testCloseBatch() throws PulsarClientException {
+        String topic = buildOneTopic();
+        String subscriptionName = "my-test-close-consumer";
+        final int numMessages = 5;
+        AtomicInteger counter = new AtomicInteger(0);
+
+        Consumer<String> consumer = pulsarClient.newConsumer(Schema.STRING)
+                .topic(topic)
+                .subscriptionName(subscriptionName)
+                .subscriptionType(SubscriptionType.Shared)
+                .batchReceivePolicy(BatchReceivePolicy.builder()
+                        .maxNumMessages(numMessages)
+                        .build())
+                .closeWaitForJob(CloseWaitForJobPolicy.builder()
+                        .closeWaitForJob(true)
+                        .build())
+                .subscribe();
+
+        producerTopic(topic, numMessages);
+
+        Messages<String> messages = consumer.batchReceive();
+        new Thread(() -> {
+            try {
+                TimeUnit.SECONDS.sleep(2);
+                consumer.acknowledge(messages);
+                counter.incrementAndGet();
+                log.info("ack, messageId:{}", messages.size());
+            } catch (Exception ignored) {
+            }
+        }).start();
+        consumer.close();
+
+        assertEquals(counter.get(), 1);
+    }
+
+
+    @Test(timeOut = testTimeout)
+    public void testCloseBatchAsync() throws PulsarClientException, ExecutionException, InterruptedException {
+        String topic = buildOneTopic();
+        String subscriptionName = "my-test-close-consumer";
+        final int numMessages = 5;
+        AtomicInteger counter = new AtomicInteger(0);
+
+        Consumer<String> consumer = pulsarClient.newConsumer(Schema.STRING)
+                .topic(topic)
+                .subscriptionName(subscriptionName)
+                .subscriptionType(SubscriptionType.Shared)
+                .batchReceivePolicy(BatchReceivePolicy.builder()
+                        .maxNumMessages(numMessages)
+                        .build())
+                .closeWaitForJob(CloseWaitForJobPolicy.builder()
+                        .closeWaitForJob(true)
+                        .build())
+                .subscribe();
+
+        producerTopic(topic, numMessages);
+
+        Messages<String> messages = consumer.batchReceiveAsync().get();
+        new Thread(() -> {
+            try {
+                TimeUnit.SECONDS.sleep(2);
+                consumer.acknowledge(messages);
+                counter.incrementAndGet();
+                log.info("ack, messageId:{}", messages.size());
+            } catch (Exception ignored) {
+            }
+        }).start();
+        consumer.close();
+
+        assertEquals(counter.get(), 1);
+    }
+
+
+    @Test(timeOut = testTimeout)
+    public void testCloseMultiBatch() throws PulsarClientException {
+        List<String> listTopic = buildListTopic();
+        String subscriptionName = "my-test-close-consumer";
+        final int numMessages = 5;
+        AtomicInteger counter = new AtomicInteger(0);
+
+        Consumer<String> consumer = pulsarClient.newConsumer(Schema.STRING)
+                .topics(listTopic)
+                .subscriptionName(subscriptionName)
+                .subscriptionType(SubscriptionType.Shared)
+                .batchReceivePolicy(BatchReceivePolicy.builder()
+                        .maxNumMessages(10)
+                        .build())
+                .closeWaitForJob(CloseWaitForJobPolicy.builder()
+                        .closeWaitForJob(true)
+                        .build())
+                .subscribe();
+
+        for (String topic : listTopic) {
+            producerTopic(topic, numMessages);
+        }
+
+        Messages<String> messages = consumer.batchReceive();
+        log.info("batchReceive size={}", messages.size());
+        new Thread(() -> {
+            try {
+                TimeUnit.SECONDS.sleep(2);
+                consumer.acknowledge(messages);
+                counter.incrementAndGet();
+                log.info("ack, messageId:{}", messages.size());
+            } catch (Exception ignored) {
+            }
+        }).start();
+        consumer.close();
+
+        assertEquals(counter.get(), 1);
+    }
+
+    @Test(timeOut = testTimeout)
+    public void testCloseCumulative() throws PulsarClientException {
+        String topic = buildOneTopic();
+        String subscriptionName = "my-test-close-consumer-cumulative";
+        final int numMessages = 5;
+        AtomicInteger counter = new AtomicInteger(0);
+
+        Consumer<String> consumer = pulsarClient.newConsumer(Schema.STRING)
+                .topic(topic)
+                .subscriptionName(subscriptionName)
+                .subscriptionType(SubscriptionType.Exclusive)
+                .closeWaitForJob(CloseWaitForJobPolicy.builder()
+                        .closeWaitForJob(true)
+                        .build())
+                .subscribe();
+
+        producerTopic(topic, numMessages);
+
+        for (int i = 0; i < numMessages; i++) {
+            Message<String> message = consumer.receive();
+            log.info("consumer message:{}, messageId:{}", message.getValue(), message.getMessageId().toString());
+            if (i == numMessages - 1) {
+                new Thread(() -> {
+                    try {
+                        TimeUnit.SECONDS.sleep(3);
+                        consumer.acknowledgeCumulative(message);
+                        counter.incrementAndGet();
+                        log.info("ack, messageId:{}", message.getMessageId().toString());
+                    } catch (Exception ignored) {
+                    }
+                }).start();
+            }
+        }
+
+        consumer.close();
+
+        assertEquals(counter.get(), 1);
+    }
+
+    @Test(timeOut = testTimeout)
+    public void testCloseNegative() throws PulsarClientException {
+        String topic = buildOneTopic();
+        String subscriptionName = "my-test-close-consumer-cumulative";
+        final int numMessages = 5;
+        AtomicInteger counter = new AtomicInteger(0);
+
+        Consumer<String> consumer = pulsarClient.newConsumer(Schema.STRING)
+                .topic(topic)
+                .subscriptionName(subscriptionName)
+                .subscriptionType(SubscriptionType.Shared)
+                .ackTimeout(0, TimeUnit.SECONDS)
+                .closeWaitForJob(CloseWaitForJobPolicy.builder()
+                        .closeWaitForJob(true)
+                        .build())
+                .subscribe();
+        producerTopic(topic, numMessages);
+
+        for (int i = 0; i < numMessages; i++) {
+
+            Message<String> message = consumer.receive();
+            log.info("consumer message:{}, messageId:{}", message.getValue(), message.getMessageId().toString());
+            int tempIdx = i;
+            new Thread(() -> {
+                try {
+                    if (tempIdx % 2 == 0) {
+                        TimeUnit.SECONDS.sleep(1);
+                    } else {
+                        TimeUnit.SECONDS.sleep(2);
+                    }
+                    consumer.negativeAcknowledge(message);
+                    counter.incrementAndGet();
+                    log.info("negative, messageId:{}", message.getMessageId().toString());
+                } catch (Exception ignored) {
+                }
+            }).start();
+        }
+
+        consumer.close();
+
+        assertEquals(counter.get(), numMessages);
+    }
+
+    @Test()
+    public void testCloseMultiNegative() throws PulsarClientException {
+        List<String> listTopic = buildListTopic();
+        String subscriptionName = "my-test-close-consumer-cumulative";
+        final int numMessages = 5;
+        AtomicInteger counter = new AtomicInteger(0);
+
+        Consumer<String> consumer = pulsarClient.newConsumer(Schema.STRING)
+                .topics(listTopic)
+                .subscriptionName(subscriptionName)
+                .subscriptionType(SubscriptionType.Shared)
+                .closeWaitForJob(CloseWaitForJobPolicy.builder()
+                        .closeWaitForJob(true)
+                        .build())
+                .subscribe();
+
+        for (String topic : listTopic) {
+            producerTopic(topic, numMessages);
+        }
+
+        for (int i = 0; i < numMessages * 2; i++) {
+
+            Message<String> message = consumer.receive();
+            log.info("consumer message:{}, messageId:{}", message.getValue(), message.getMessageId().toString());
+            int tempIdx = i;
+            new Thread(() -> {
+                try {
+                    if (tempIdx % 2 == 0) {
+                        TimeUnit.SECONDS.sleep(1);
+                    } else {
+                        TimeUnit.SECONDS.sleep(2);
+                    }
+                    consumer.negativeAcknowledge(message);
+                    counter.incrementAndGet();
+                    log.info("negative, messageId:{}", message.getMessageId().toString());
+                } catch (Exception ignored) {
+                }
+            }).start();
+        }
+
+        consumer.close();
+
+        assertEquals(counter.get(), numMessages * 2);
+    }
+
+    @Test(timeOut = testTimeout)
+    public void testCloseMultiConsumer() throws PulsarClientException {
+        List<String> listTopic = buildListTopic();
+        String subscriptionName = "my-test-close-consumer";
+        final int numMessages = 5;
+        AtomicInteger counter = new AtomicInteger(0);
+        Consumer<String> consumer = pulsarClient.newConsumer(Schema.STRING)
+                .topics(listTopic)
+                .subscriptionName(subscriptionName)
+                .subscriptionType(SubscriptionType.Shared)
+                .ackTimeout(0, TimeUnit.SECONDS)
+                .closeWaitForJob(CloseWaitForJobPolicy.builder()
+                        .closeWaitForJob(true)
+                        .build())
+                .subscribe();
+
+        for (String topic : listTopic) {
+            producerTopic(topic, numMessages);
+        }
+
+        for (int i = 0; i < numMessages * 2; i++) {
+            Message<String> message = consumer.receive();
+            log.info("consumer message:{}, messageId:{}", message.getValue(), message.getMessageId().toString());
+            int finalI = i;
+            new Thread(() -> {
+                try {
+                    if (finalI % 2 == 0) {
+                        TimeUnit.SECONDS.sleep(1);
+                    } else {
+                        TimeUnit.SECONDS.sleep(2);
+                    }
+                    consumer.acknowledge(message);
+                    counter.incrementAndGet();
+                    log.info("ack, messageId:{}", message.getMessageId().toString());
+                } catch (Exception ignored) {
+                }
+            }).start();
+        }
+
+        consumer.close();
+
+        assertEquals(counter.get(), numMessages * 2);
+    }
+
+    @Test(timeOut = testTimeout)
+    public void testCloseGracefulMultiConsumerAsync()
+            throws PulsarClientException, InterruptedException, ExecutionException {
+        List<String> listTopic = buildListTopic();
+        String subscriptionName = "my-test-close-consumer";
+        final int numMessages = 5;
+        AtomicInteger counter = new AtomicInteger(0);
+
+        Consumer<String> consumer = pulsarClient.newConsumer(Schema.STRING)
+                .topics(listTopic)
+                .subscriptionName(subscriptionName)
+                .subscriptionType(SubscriptionType.Shared)
+                .closeWaitForJob(CloseWaitForJobPolicy.builder()
+                        .closeWaitForJob(true)
+                        .build())
+                .subscribe();
+
+        for (String topic : listTopic) {
+            producerTopic(topic, numMessages);
+        }
+
+        for (int i = 0; i < numMessages * 2; i++) {
+            Message<String> message = consumer.receiveAsync().get();
+            log.info("consumer message:{}, messageId:{}", message.getValue(), message.getMessageId().toString());
+            int tempIdx = i;
+            new Thread(() -> {
+                try {
+                    if (tempIdx % 2 == 0) {
+                        TimeUnit.SECONDS.sleep(1);
+                    } else {
+                        TimeUnit.SECONDS.sleep(2);
+                    }
+                    consumer.acknowledgeAsync(message);
+                    counter.incrementAndGet();
+                    log.info("ack, messageId:{}", message.getMessageId().toString());
+                } catch (Exception ignored) {
+                }
+            }).start();
+        }
+
+        consumer.close();
+
+        assertEquals(counter.get(), numMessages * 2);
+    }
+
+
+    @Test(timeOut = testTimeout)
+    public void testCloseTimeoutMultiConsumer() throws PulsarClientException {
+        List<String> listTopic = buildListTopic();
+        String subscriptionName = "my-test-close-consumer";
+        final int numMessages = 5;
+        AtomicInteger counter = new AtomicInteger(0);
+
+        Consumer<String> consumer = pulsarClient.newConsumer(Schema.STRING)
+                .topics(listTopic)
+                .subscriptionName(subscriptionName)
+                .subscriptionType(SubscriptionType.Shared)
+                .closeWaitForJob(CloseWaitForJobPolicy.builder()
+                        .closeWaitForJob(true)
+                        .timeout(5, TimeUnit.SECONDS)
+                        .build())
+                .subscribe();
+
+
+        for (int i = 0; i < numMessages * 2; i++) {
+            Message<String> message = consumer.receive(100, TimeUnit.MILLISECONDS);
+            if (message == null) {
+                continue;
+            }
+            log.info("consumer message:{}, messageId:{}", message.getValue(), message.getMessageId().toString());
+            int finalI = i;
+            new Thread(() -> {
+                try {
+                    if (finalI % 2 == 0) {
+                        TimeUnit.SECONDS.sleep(1);
+                    } else {
+                        TimeUnit.SECONDS.sleep(2);
+                    }
+                    consumer.acknowledge(message);
+                    counter.incrementAndGet();
+                    log.info("ack, messageId:{}", message.getMessageId().toString());
+                } catch (Exception ignored) {
+                }
+            }).start();
+        }
+
+        consumer.close();
+
+        assertEquals(counter.get(), 0);
+    }
+
+    private String buildOneTopic() {
+        return "persistent://public/default/topic1";
+    }
+
+    private List<String> buildListTopic() {
+        return Arrays.asList("persistent://public/default/topic1", "persistent://public/default/topic2");
+    }
+
+    private void producerTopic(String topic, int number) throws PulsarClientException {
+        Producer<String> producer = pulsarClient.newProducer(Schema.STRING)
+                .topic(topic)
+                .create();
+        for (int i = 0; i < number; i++) {
+            MessageId hello = producer.send("hello");
+            log.info("producer topic:{}, messageId:{}", topic, hello.toString());
+        }
+        producer.close();
+    }
+
+
+}

--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/CloseWaitForJobPolicy.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/CloseWaitForJobPolicy.java
@@ -55,11 +55,11 @@ public class CloseWaitForJobPolicy {
 
     @Override
     public String toString() {
-        return "CloseWaitForJobPolicy{" +
-                "closeWaitForJob=" + closeWaitForJob +
-                ", timeout=" + timeout +
-                ", timeoutUnit=" + timeoutUnit +
-                '}';
+        return "CloseWaitForJobPolicy{"
+                + "closeWaitForJob=" + closeWaitForJob
+                + ", timeout=" + timeout
+                + ", timeoutUnit=" + timeoutUnit
+                + '}';
     }
 
     /**

--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/CloseWaitForJobPolicy.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/CloseWaitForJobPolicy.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.client.api;
+
+import java.util.concurrent.TimeUnit;
+import org.apache.pulsar.common.classification.InterfaceAudience;
+import org.apache.pulsar.common.classification.InterfaceStability;
+
+/**
+ * Configuration for the close consumer policy.
+ *
+ * @see ConsumerBuilder#closeWaitForJob(CloseWaitForJobPolicy)
+ */
+@InterfaceAudience.Public
+@InterfaceStability.Stable
+public class CloseWaitForJobPolicy {
+
+    private boolean closeWaitForJob;
+    private int timeout;
+    private TimeUnit timeoutUnit;
+
+    private CloseWaitForJobPolicy(boolean closeWaitForJob, int timeout, TimeUnit timeoutUnit) {
+        this.closeWaitForJob = closeWaitForJob;
+        this.timeout = timeout;
+        this.timeoutUnit = timeoutUnit;
+    }
+
+    public boolean isCloseWaitForJob() {
+        return closeWaitForJob;
+    }
+
+    public int getTimeout() {
+        return timeout;
+    }
+
+    public TimeUnit getTimeoutUnit() {
+        return timeoutUnit;
+    }
+
+    @Override
+    public String toString() {
+        return "CloseWaitForJobPolicy{" +
+                "closeWaitForJob=" + closeWaitForJob +
+                ", timeout=" + timeout +
+                ", timeoutUnit=" + timeoutUnit +
+                '}';
+    }
+
+    /**
+     * Builder of CloseWaitForJobPolicy.
+     */
+    public static class Builder {
+
+        private boolean closeWaitForJob;
+        private int timeout;
+        private TimeUnit timeoutUnit;
+
+        public CloseWaitForJobPolicy.Builder closeWaitForJob(boolean closeWaitForJob) {
+            this.closeWaitForJob = closeWaitForJob;
+            return this;
+        }
+
+        public CloseWaitForJobPolicy.Builder timeout(int timeout, TimeUnit timeoutUnit) {
+            this.timeout = timeout;
+            this.timeoutUnit = timeoutUnit;
+            return this;
+        }
+
+        public CloseWaitForJobPolicy build() {
+            return new CloseWaitForJobPolicy(closeWaitForJob, timeout, timeoutUnit);
+        }
+    }
+
+    public static CloseWaitForJobPolicy.Builder builder() {
+        return new CloseWaitForJobPolicy.Builder();
+    }
+
+    public void verify() {
+        if (closeWaitForJob && timeout > 0 && timeoutUnit == null) {
+            throw new IllegalArgumentException("Must set timeout unit for timeout.");
+        }
+    }
+}

--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/ConsumerBuilder.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/ConsumerBuilder.java
@@ -867,4 +867,20 @@ public interface ConsumerBuilder<T> extends Cloneable {
      */
     ConsumerBuilder<T> topicConfiguration(Pattern topicsPattern,
                                           java.util.function.Consumer<TopicConsumerBuilder<T>> builderConsumer);
+
+    /**
+     * set close policy {@link CloseWaitForJobPolicy} for consumer.
+     * By default, this is off.
+     *
+     * <p>Example:
+     * <pre>
+     * pulsarClient.newConsumer(Schema.STRING)
+     *                 .closeWaitForJob(CloseWaitForJobPolicy.builder()
+     *                         .closeWaitForJob(true)
+     *                         .timeout(5, TimeUnit.SECONDS)
+     *                         .build())
+     *                 .subscribe();
+     * </pre>
+     */
+    ConsumerBuilder<T> closeWaitForJob(CloseWaitForJobPolicy closeWaitForJobPolicy);
 }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBuilderImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBuilderImpl.java
@@ -33,6 +33,7 @@ import lombok.Getter;
 import lombok.NonNull;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.pulsar.client.api.BatchReceivePolicy;
+import org.apache.pulsar.client.api.CloseWaitForJobPolicy;
 import org.apache.pulsar.client.api.Consumer;
 import org.apache.pulsar.client.api.ConsumerBuilder;
 import org.apache.pulsar.client.api.ConsumerCryptoFailureAction;
@@ -566,6 +567,14 @@ public class ConsumerBuilderImpl<T> implements ConsumerBuilder<T> {
     public ConsumerBuilder<T> topicConfiguration(Pattern topicsPattern,
                                                  java.util.function.Consumer<TopicConsumerBuilder<T>> builderConsumer) {
         builderConsumer.accept(topicConfiguration(topicsPattern));
+        return this;
+    }
+
+    @Override
+    public ConsumerBuilder<T> closeWaitForJob(CloseWaitForJobPolicy closeWaitForJobPolicy) {
+        checkArgument(closeWaitForJobPolicy != null, "closeWaitForJobPolicy must not be null.");
+        closeWaitForJobPolicy.verify();
+        conf.setCloseWaitForJobPolicy(closeWaitForJobPolicy);
         return this;
     }
 }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
@@ -35,6 +35,7 @@ import io.netty.util.Timeout;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedList;
@@ -533,6 +534,7 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
                 cancellationHandler.setCancelAction(() -> pendingBatchReceives.remove(opBatchReceive));
             }
         });
+        verifyCloseConsumerWithMessages(result);
         return result;
     }
 
@@ -767,6 +769,8 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
 
         // Ensure the message is not redelivered for ack-timeout, since we did receive an "ack"
         unAckedMessageTracker.remove(message.getMessageId());
+
+        doCloseConsumerNotify(Arrays.asList(message.getMessageId()), AckType.Individual);
     }
 
     @Override
@@ -1029,6 +1033,8 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
             failPendingReceive().whenComplete((r, t) -> closeFuture.complete(null));
             return closeFuture;
         }
+
+        doCloseConsumerWait();
 
         stats.getStatTimeout().ifPresent(Timeout::cancel);
 

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ConsumerConfigurationData.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ConsumerConfigurationData.java
@@ -364,7 +364,7 @@ public class ConsumerConfigurationData<T> implements Serializable, Cloneable {
             name = "closeWaitForJobPolicy",
             value = "close policy for consumers."
     )
-    private CloseWaitForJobPolicy closeWaitForJobPolicy;
+    private transient CloseWaitForJobPolicy closeWaitForJobPolicy;
 
     @JsonIgnore
     private BatchReceivePolicy batchReceivePolicy;

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ConsumerConfigurationData.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ConsumerConfigurationData.java
@@ -36,6 +36,7 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import org.apache.pulsar.client.api.BatchReceivePolicy;
+import org.apache.pulsar.client.api.CloseWaitForJobPolicy;
 import org.apache.pulsar.client.api.ConsumerCryptoFailureAction;
 import org.apache.pulsar.client.api.ConsumerEventListener;
 import org.apache.pulsar.client.api.CryptoKeyReader;
@@ -358,6 +359,12 @@ public class ConsumerConfigurationData<T> implements Serializable, Cloneable {
     private transient DeadLetterPolicy deadLetterPolicy;
 
     private boolean retryEnable = false;
+
+    @ApiModelProperty(
+            name = "closeWaitForJobPolicy",
+            value = "close policy for consumers."
+    )
+    private CloseWaitForJobPolicy closeWaitForJobPolicy;
 
     @JsonIgnore
     private BatchReceivePolicy batchReceivePolicy;


### PR DESCRIPTION
* This fixes #8308
* This fixes #18799

### Motivation

Wait for the consumer's job to finish before closing the consumer.

### Modifications

```java
        Consumer<String> consumer = pulsarClient.newConsumer(Schema.STRING)
                .topics(listTopic)
                .subscriptionName(subscriptionName)
                .subscriptionType(SubscriptionType.Shared)
                .closeWaitForJob(CloseWaitForJobPolicy.builder()
                        .closeWaitForJob(true)
                        .timeout(5, TimeUnit.SECONDS)
                        .build())
                .subscribe();
```

New wait notification mechanism when closing consumer.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.



This change is already covered by existing tests, such as:
https://github.com/crossoverJie/pulsar/blob/fcc050abc60aead29a80c133648c5df2feaa7f34/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/ConsumerWaitCloseTest.java#L46


### Does this pull request potentially affect one of the following parts:

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->
https://github.com/crossoverJie/pulsar/pull/4
<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
