### PR TITLE
[improve][broker] Fast return if validalbe when getNextConsumerFromSameOrLowerLevel

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractDispatcherMultipleConsumers.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractDispatcherMultipleConsumers.java
@@ -189,10 +189,14 @@ public abstract class AbstractDispatcherMultipleConsumers extends AbstractBaseDi
      * @return
      */
     private int getNextConsumerFromSameOrLowerLevel(int currentRoundRobinIndex) {
+        Consumer currentRRConsumer = consumerList.get(currentRoundRobinIndex);
+        if (isConsumerAvailable(currentRRConsumer)) {
+            return currentRoundRobinIndex;
+        }
 
-        int targetPriority = consumerList.get(currentRoundRobinIndex).getPriorityLevel();
-        // use to do round-robin if can't find consumer from currentRR to last-consumer in list
-        int scanIndex = currentRoundRobinIndex;
+        // scan the consumerList, if consumer in currentRoundRobinIndex is unavailable
+        int targetPriority = currentRRConsumer.getPriorityLevel();
+        int scanIndex = currentRoundRobinIndex + 1;
         int endPriorityLevelIndex = currentRoundRobinIndex;
         do {
             Consumer scanConsumer = scanIndex < consumerList.size() ? consumerList.get(scanIndex)


### PR DESCRIPTION
### Motivation

For most case, consumer in `currentRoundRobinIndex` should be available,  so we could avoid some checks in first scan actions  by checking `currentRRConsumer` available first,  also this will make the code more clear

### Modifications

Fast return if validalbe when getNextConsumerFromSameOrLowerLevel

### Verifying this change

- [x] Make sure that the change passes the CI checks.


### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/AnonHxy/pulsar/pull/22
