### PR TITLE
[fix][cli] Pulsar shell: allows absolute config file

### DIFF
--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/shell/ConfigShell.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/shell/ConfigShell.java
@@ -25,6 +25,7 @@ import com.beust.jcommander.ParameterException;
 import com.beust.jcommander.Parameters;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
+import com.google.common.annotations.VisibleForTesting;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
@@ -54,10 +55,15 @@ public class ConfigShell implements ShellCommandsProvider {
     private static final String LOCAL_FILES_BASE_DIR = System.getProperty("pulsar.shell.working.dir");
 
     static File resolveLocalFile(String input) {
-        if (LOCAL_FILES_BASE_DIR != null) {
-            return new File(LOCAL_FILES_BASE_DIR, input);
+        return resolveLocalFile(input, LOCAL_FILES_BASE_DIR);
+    }
+
+    static File resolveLocalFile(String input, String baseDir) {
+        final File file = new File(input);
+        if (!file.isAbsolute() && baseDir != null) {
+            return new File(baseDir, input);
         }
-        return new File(input);
+        return file;
     }
 
 

--- a/pulsar-client-tools/src/test/java/org/apache/pulsar/shell/ConfigShellTest.java
+++ b/pulsar-client-tools/src/test/java/org/apache/pulsar/shell/ConfigShellTest.java
@@ -30,6 +30,7 @@ import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 import com.beust.jcommander.internal.Console;
+import java.io.File;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -226,5 +227,23 @@ public class ConfigShellTest {
             configShell.setupState(null);
             setConsole();
         }
+    }
+
+    @Test
+    public void testResolveLocalFile() throws Exception {
+        assertEquals(ConfigShell.resolveLocalFile("myfile").getAbsolutePath(),
+                new File("myfile").getAbsolutePath());
+        assertEquals(ConfigShell.resolveLocalFile("mydir/myfile.txt").getAbsolutePath(),
+                new File("mydir/myfile.txt").getAbsolutePath());
+        assertEquals(ConfigShell.resolveLocalFile("myfile", "current").getAbsolutePath(),
+                new File("current/myfile").getAbsolutePath());
+        assertEquals(ConfigShell.resolveLocalFile("mydir/myfile.txt", "current").getAbsolutePath(),
+                new File("current/mydir/myfile.txt").getAbsolutePath());
+
+        assertEquals(ConfigShell.resolveLocalFile("/tmp/absolute.txt").getAbsolutePath(),
+                new File("/tmp/absolute.txt").getAbsolutePath());
+
+        assertEquals(ConfigShell.resolveLocalFile("/tmp/absolute.txt", "current").getAbsolutePath(),
+                new File("/tmp/absolute.txt").getAbsolutePath());
     }
 }


### PR DESCRIPTION
### Motivation

When creating a config with the `--file` option, absolute paths are not allowed. 

### Modifications

* Do not prepend the current dir if the passed file is absolute
### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->
