### PR TITLE
[fix][cli] pulsar-perf fails on jdk17

### DIFF
--- a/bin/pulsar-perf
+++ b/bin/pulsar-perf
@@ -134,6 +134,13 @@ PULSAR_CLASSPATH="$PULSAR_JAR:$PULSAR_CLASSPATH:$PULSAR_EXTRA_CLASSPATH"
 PULSAR_CLASSPATH="`dirname $PULSAR_LOG_CONF`:$PULSAR_CLASSPATH"
 OPTS="$OPTS -Dlog4j.configurationFile=`basename $PULSAR_LOG_CONF` -Djava.net.preferIPv4Stack=true"
 
+IS_JAVA_8=`$JAVA -version 2>&1 |grep version|grep '"1\.8'`
+# Start --add-opens options
+# '--add-opens' option is not supported in jdk8
+if [[ -z "$IS_JAVA_8" ]]; then
+  OPTS="$OPTS --add-opens java.base/sun.net=ALL-UNNAMED --add-opens java.base/java.lang=ALL-UNNAMED"
+fi
+
 OPTS="-cp $PULSAR_CLASSPATH $OPTS"
 OPTS="$OPTS $PULSAR_EXTRA_OPTS"
 


### PR DESCRIPTION
### Motivation

`pulsar-perf` fails with jdk17.


```
2022-12-06T09:43:53,357-0600 [pulsar-perf-producer-exec-1-1] WARN  io.netty.resolver.dns.DnsServerAddressStreamProviders - Can not find io.netty.resolver.dns.macos.MacOSDnsServerAddressStreamProvider in the classpath, fallback to system defaults. This may result in incorrect DNS resolutions on MacOS.
2022-12-06T09:43:53,369-0600 [pulsar-perf-producer-exec-1-1] WARN  org.apache.pulsar.common.util.netty.DnsResolverUtil - Cannot get DNS TTL settings from sun.net.InetAddressCachePolicy class
java.lang.IllegalAccessException: class org.apache.pulsar.common.util.netty.DnsResolverUtil cannot access class sun.net.InetAddressCachePolicy (in module java.base) because module java.base does not export sun.net to unnamed module @6456fb59
    at jdk.internal.reflect.Reflection.newIllegalAccessException(Reflection.java:392) ~[?:?]
    at java.lang.reflect.AccessibleObject.checkAccess(AccessibleObject.java:674) ~[?:?]
```
### Modifications

Add `--add-opens` like in the other cli tools.


### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->