### PR TITLE
[fix][broker] Revert #14829 Filter the virtual NIC with relative path

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/LinuxInfoUtils.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/LinuxInfoUtils.java
@@ -149,7 +149,7 @@ public class LinuxInfoUtils {
      */
     private static boolean isPhysicalNic(Path nicPath) {
         try {
-            if (nicPath.toRealPath().toString().contains("/virtual/")) {
+            if (nicPath.toString().contains("/virtual/")) {
                 return false;
             }
             // Check the type to make sure it's ethernet (type "1")

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/LinuxBrokerHostUsageImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/LinuxBrokerHostUsageImpl.java
@@ -125,7 +125,6 @@ public class LinuxBrokerHostUsageImpl implements BrokerHostUsage {
         // Use the override value as configured. Return the total max speed across all available NICs, converted
         // from Gbps into Kbps
         return overrideBrokerNicSpeedGbps.map(BitRateUnit.Gigabit::toKilobit)
-                .map(speed -> speed * nics.size())
                 .orElseGet(() -> getTotalNicLimit(nics, BitRateUnit.Kilobit));
     }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/LinuxBrokerHostUsageImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/LinuxBrokerHostUsageImpl.java
@@ -125,6 +125,7 @@ public class LinuxBrokerHostUsageImpl implements BrokerHostUsage {
         // Use the override value as configured. Return the total max speed across all available NICs, converted
         // from Gbps into Kbps
         return overrideBrokerNicSpeedGbps.map(BitRateUnit.Gigabit::toKilobit)
+                .map(speed -> speed * nics.size())
                 .orElseGet(() -> getTotalNicLimit(nics, BitRateUnit.Kilobit));
     }
 


### PR DESCRIPTION
### Motivation

As https://github.com/apache/pulsar/issues/14820#issuecomment-1340677223 mentioned, we need to revert this change to fix regression.

For the original issue, the workaround fix is he can divide the target by two. for the fixing, I would like to start a discussion, and I suggest introducing the new config to fix this problem.

### Modifications

- Revert 14829

### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Documentation

I'm not sure if we need to notice this problem.

- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
