### PR TITLE
[fix][cli] pulsar-perf java 17 compatibility

### DIFF
--- a/bin/pulsar-perf
+++ b/bin/pulsar-perf
@@ -144,6 +144,13 @@ PULSAR_LOG_LEVEL=${PULSAR_LOG_LEVEL:-"info"}
 PULSAR_LOG_ROOT_LEVEL=${PULSAR_LOG_ROOT_LEVEL:-"${PULSAR_LOG_LEVEL}"}
 PULSAR_LOG_IMMEDIATE_FLUSH="${PULSAR_LOG_IMMEDIATE_FLUSH:-"false"}"
 
+IS_JAVA_8=`$JAVA -version 2>&1 |grep version|grep '"1\.8'`
+# Start --add-opens options
+# '--add-opens' option is not supported in jdk8
+if [[ -z "$IS_JAVA_8" ]]; then
+  OPTS="$OPTS --add-opens java.base/sun.net=ALL-UNNAMED"
+fi
+
 #Configure log configuration system properties
 OPTS="$OPTS -Dpulsar.log.appender=$PULSAR_LOG_APPENDER"
 OPTS="$OPTS -Dpulsar.log.level=$PULSAR_LOG_LEVEL"


### PR DESCRIPTION
Allow pulsar-perf to use the java.base/sun.net module

<!--
### Contribution Checklist
  
  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://docs.google.com/document/d/1d8Pw6ZbWk-_pCKdOmdvx9rnhPiyuxwq60_TrD68d7BA/edit#heading=h.trs9rsex3xom)*. 

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->

### Motivation

Running the pulsar-perf command with java 17 currently logs DNS resolution exceptions.
```
2022-12-07T22:10:24,646-0600 [pulsar-perf-producer-exec-1-1] WARN  org.apache.pulsar.common.util.netty.DnsResolverUtil - Cannot get DNS TTL settings from sun.net.InetAddressCachePolicy class
java.lang.IllegalAccessException: class org.apache.pulsar.common.util.netty.DnsResolverUtil cannot access class sun.net.InetAddressCachePolicy (in module java.base) because module java.base does not export sun.net to unnamed module @6456fb59
	at jdk.internal.reflect.Reflection.newIllegalAccessException(Reflection.java:392) ~[?:?]
	at java.lang.reflect.AccessibleObject.checkAccess(AccessibleObject.java:674) ~[?:?]
	at java.lang.reflect.Method.invoke(Method.java:560) ~[?:?]
	at org.apache.pulsar.common.util.netty.DnsResolverUtil.<clinit>(DnsResolverUtil.java:46) ~[pulsar-common-2.11.0-SNAPSHOT.jar:2.11.0-SNAPSHOT]
	at org.apache.pulsar.client.impl.ConnectionPool.createAddressResolver(ConnectionPool.java:159) ~[pulsar-client-original-2.11.0-SNAPSHOT.jar:2.11.0-SNAPSHOT]
	at org.apache.pulsar.client.impl.ConnectionPool.lambda$new$1(ConnectionPool.java:126) ~[pulsar-client-original-2.11.0-SNAPSHOT.jar:2.11.0-SNAPSHOT]
	at java.util.Optional.orElseGet(Optional.java:364) ~[?:?]
	at org.apache.pulsar.client.impl.ConnectionPool.<init>(ConnectionPool.java:126) ~[pulsar-client-original-2.11.0-SNAPSHOT.jar:2.11.0-SNAPSHOT]
	at org.apache.pulsar.client.impl.ConnectionPool.<init>(ConnectionPool.java:95) ~[pulsar-client-original-2.11.0-SNAPSHOT.jar:2.11.0-SNAPSHOT]
	at org.apache.pulsar.client.impl.ConnectionPool.<init>(ConnectionPool.java:90) ~[pulsar-client-original-2.11.0-SNAPSHOT.jar:2.11.0-SNAPSHOT]
	at org.apache.pulsar.client.impl.PulsarClientImpl.<init>(PulsarClientImpl.java:197) ~[pulsar-client-original-2.11.0-SNAPSHOT.jar:2.11.0-SNAPSHOT]
	at org.apache.pulsar.client.impl.PulsarClientImpl.<init>(PulsarClientImpl.java:153) ~[pulsar-client-original-2.11.0-SNAPSHOT.jar:2.11.0-SNAPSHOT]
	at org.apache.pulsar.client.impl.ClientBuilderImpl.build(ClientBuilderImpl.java:63) ~[pulsar-client-original-2.11.0-SNAPSHOT.jar:2.11.0-SNAPSHOT]
	at org.apache.pulsar.testclient.PerformanceProducer.runProducer(PerformanceProducer.java:547) ~[pulsar-testclient.jar:2.11.0-SNAPSHOT]
	at org.apache.pulsar.testclient.PerformanceProducer.lambda$main$1(PerformanceProducer.java:394) ~[pulsar-testclient.jar:2.11.0-SNAPSHOT]
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:539) ~[?:?]
	at java.util.concurrent.FutureTask.run(FutureTask.java:264) ~[?:?]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136) ~[?:?]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635) ~[?:?]
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30) ~[netty-common-4.1.77.Final.jar:4.1.77.Final]
	at java.lang.Thread.run(Thread.java:833) ~[?:?]

```

### Modifications

This fixes the issue by updating the bash script to set Java module configuration similar to what is currently used in the `pulsar` and `pulsar-client` commands.  For example, see: https://github.com/apache/pulsar/pull/15540

### Verifying this change

- [ X ] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [X] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/pgier/pulsar/pull/5

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
