### PR TITLE
[fix][broker] Fix unexpected behaviour by invoke `PulsarConfigurationLoader#convertFrom`

### DIFF
--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/common/configuration/PulsarConfigurationLoader.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/common/configuration/PulsarConfigurationLoader.java
@@ -187,7 +187,8 @@ public class PulsarConfigurationLoader {
                 try {
                     confField.setAccessible(true);
                     Field convertedConfField = ServiceConfiguration.class.getDeclaredField(confField.getName());
-                    if (!Modifier.isStatic(convertedConfField.getModifiers())) {
+                    if (!Modifier.isStatic(convertedConfField.getModifiers())
+                            && convertedConfField.getDeclaredAnnotation(FieldContext.class) != null) {
                         convertedConfField.setAccessible(true);
                         convertedConfField.set(convertedConf, confField.get(conf));
                     }

--- a/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyConfigurationTest.java
+++ b/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyConfigurationTest.java
@@ -110,4 +110,26 @@ public class ProxyConfigurationTest {
         assertEquals(serviceConfig.getMetadataStoreSessionTimeoutMillis(), 100);
         assertEquals(serviceConfig.getMetadataStoreCacheExpirySeconds(), 300);
     }
+
+
+    @Test
+    public void testConvert() throws IOException {
+        File testConfigFile = new File("tmp." + System.currentTimeMillis() + ".properties");
+        if (testConfigFile.exists()) {
+            testConfigFile.delete();
+        }
+        try (PrintWriter printWriter = new PrintWriter(new OutputStreamWriter(new FileOutputStream(testConfigFile)))) {
+            printWriter.println("proxyAdditionalServlets=a,b,c");
+        }
+        testConfigFile.deleteOnExit();
+        try(InputStream stream = new FileInputStream(testConfigFile)) {
+            ProxyConfiguration proxyConfig = PulsarConfigurationLoader.create(stream, ProxyConfiguration.class);
+            assertEquals(proxyConfig.getProperties().getProperty("proxyAdditionalServlets"), "a,b,c");
+            assertEquals(proxyConfig.getProxyAdditionalServlets().size(), 3);
+            PulsarConfigurationLoader.convertFrom(proxyConfig);
+            assertEquals(proxyConfig.getProperties().getProperty("proxyAdditionalServlets"), "a,b,c");
+            assertEquals(proxyConfig.getProxyAdditionalServlets().size(), 3);
+        }
+    }
+
 }


### PR DESCRIPTION
### Motivation

This regression is introduced by #16234. 

I found it by setting `proxyAdditionalServlets ` on the proxy, I expected it could load the additional servlet, but it didn’t work well. the `proxyConfig.getProperties().getProperty("proxyAdditionalServlets")`  method returns `null` after invoking `PulsarConfigurationLoader#convertFrom`.

After investigating, The root cause is we use the same properties object when we invoke `convertFrom ` method. And then, it set the unknown field to the new config without any type check.


### Modifications

- Don't use the same properties object when converting.

### Verifying this change

- [x] Make sure that the change passes the CI checks.


- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
