### PR TITLE
[fix][broker] Fix the wrong behaviour when set `overrideBrokerNicSpeedGbps`

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/LinuxBrokerHostUsageImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/LinuxBrokerHostUsageImpl.java
@@ -27,6 +27,7 @@ import static org.apache.pulsar.broker.loadbalance.LinuxInfoUtils.getTotalNicLim
 import static org.apache.pulsar.broker.loadbalance.LinuxInfoUtils.getTotalNicUsage;
 import static org.apache.pulsar.broker.loadbalance.LinuxInfoUtils.isCGroupEnabled;
 import static org.apache.pulsar.common.util.Runnables.catchingAndLoggingThrowables;
+import com.google.common.annotations.VisibleForTesting;
 import com.sun.management.OperatingSystemMXBean;
 import java.lang.management.ManagementFactory;
 import java.util.List;
@@ -121,10 +122,12 @@ public class LinuxBrokerHostUsageImpl implements BrokerHostUsage {
         this.usage = usage;
     }
 
-    private double getTotalNicLimitWithConfiguration(List<String> nics) {
+    @VisibleForTesting
+    public double getTotalNicLimitWithConfiguration(List<String> nics) {
         // Use the override value as configured. Return the total max speed across all available NICs, converted
         // from Gbps into Kbps
         return overrideBrokerNicSpeedGbps.map(BitRateUnit.Gigabit::toKilobit)
+                .map(speed -> speed * nics.size())
                 .orElseGet(() -> getTotalNicLimit(nics, BitRateUnit.Kilobit));
     }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/LinuxBrokerHostUsageImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/LinuxBrokerHostUsageImpl.java
@@ -123,7 +123,7 @@ public class LinuxBrokerHostUsageImpl implements BrokerHostUsage {
     }
 
     @VisibleForTesting
-    public double getTotalNicLimitWithConfiguration(List<String> nics) {
+    double getTotalNicLimitWithConfiguration(List<String> nics) {
         // Use the override value as configured. Return the total max speed across all available NICs, converted
         // from Gbps into Kbps
         return overrideBrokerNicSpeedGbps.map(BitRateUnit.Gigabit::toKilobit)

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/LinuxBrokerHostUsageImplTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/LinuxBrokerHostUsageImplTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pulsar.broker.loadbalance;
 
+import lombok.Cleanup;
 import org.apache.pulsar.broker.loadbalance.impl.LinuxBrokerHostUsageImpl;
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -31,6 +32,7 @@ public class LinuxBrokerHostUsageImplTest {
 
     @Test
     public void checkOverrideBrokerNicSpeedGbps() {
+        @Cleanup("shutdown")
         ScheduledExecutorService executorService = Executors.newSingleThreadScheduledExecutor();
         LinuxBrokerHostUsageImpl linuxBrokerHostUsage =
                 new LinuxBrokerHostUsageImpl(1, Optional.of(3.0), executorService);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/LinuxBrokerHostUsageImplTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/LinuxBrokerHostUsageImplTest.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.loadbalance;
+
+import org.apache.pulsar.broker.loadbalance.impl.LinuxBrokerHostUsageImpl;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+
+public class LinuxBrokerHostUsageImplTest {
+
+    @Test
+    public void checkOverrideBrokerNicSpeedGbps() {
+        ScheduledExecutorService executorService = Executors.newSingleThreadScheduledExecutor();
+        LinuxBrokerHostUsageImpl linuxBrokerHostUsage =
+                new LinuxBrokerHostUsageImpl(1, Optional.of(3.0), executorService);
+        List<String> nics = new ArrayList<>();
+        nics.add("1");
+        nics.add("2");
+        nics.add("3");
+        double totalLimit = linuxBrokerHostUsage.getTotalNicLimitWithConfiguration(nics);
+        Assert.assertEquals(totalLimit, 3.0 * 1000 * 1000 * 3);
+    }
+}

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/impl/LinuxBrokerHostUsageImplTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/impl/LinuxBrokerHostUsageImplTest.java
@@ -16,10 +16,9 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.pulsar.broker.loadbalance;
+package org.apache.pulsar.broker.loadbalance.impl;
 
 import lombok.Cleanup;
-import org.apache.pulsar.broker.loadbalance.impl.LinuxBrokerHostUsageImpl;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 import java.util.ArrayList;


### PR DESCRIPTION
### Motivation

This break was introduced by #14648 and affected unreleased 2.11.

### Modifications

- Multiply `overrideBrokerNicSpeedGbps` with the NIC number.

### Verifying this change

- [x] Make sure that the change passes the CI checks.


- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
