### PR TITLE
[improve][cli] handle help flag properly

### DIFF
--- a/pulsar-client-tools-test/src/test/java/org/apache/pulsar/admin/cli/PulsarAdminToolTest.java
+++ b/pulsar-client-tools-test/src/test/java/org/apache/pulsar/admin/cli/PulsarAdminToolTest.java
@@ -28,8 +28,10 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
+import com.beust.jcommander.JCommander;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
@@ -2422,6 +2424,43 @@ public class PulsarAdminToolTest {
         assertTrue(logs.contains("-bf=false")); // boolean flag, not passed = false
         assertTrue(logs.contains("main=null"));
 
+    }
+
+    @Test
+    public void testHelpFlag() {
+        PulsarAdmin admin = Mockito.mock(PulsarAdmin.class);
+
+        {
+            CmdSchemas cmdSchemas = new CmdSchemas(() -> admin);
+            cmdSchemas.run(split("-h"));
+            assertTrue(cmdSchemas.isHelp());
+        }
+
+        {
+            CmdSchemas cmdSchemas = new CmdSchemas(() -> admin);
+            cmdSchemas.run(split("--help"));
+            assertTrue(cmdSchemas.isHelp());
+        }
+
+        {
+            CmdSchemas cmdSchemas = new CmdSchemas(() -> admin);
+            cmdSchemas.run(split("delete --help"));
+            assertFalse(cmdSchemas.isHelp());
+            JCommander commander = cmdSchemas.getJcommander();
+            JCommander subCommander = commander.getCommands().get("delete");
+            CliCommand subcommand = (CliCommand) subCommander.getObjects().get(0);
+            assertTrue(subcommand.isHelp());
+        }
+
+        {
+            CmdSchemas cmdSchemas = new CmdSchemas(() -> admin);
+            cmdSchemas.run(split("delete -h"));
+            assertFalse(cmdSchemas.isHelp());
+            JCommander commander = cmdSchemas.getJcommander();
+            JCommander subCommander = commander.getCommands().get("delete");
+            CliCommand subcommand = (CliCommand) subCommander.getObjects().get(0);
+            assertTrue(subcommand.isHelp());
+        }
     }
 
     private static String runCustomCommand(String[] args) throws Exception {

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CliCommand.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CliCommand.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pulsar.admin.cli;
 
+import com.beust.jcommander.Parameter;
 import com.beust.jcommander.ParameterException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
@@ -37,6 +38,13 @@ import org.apache.pulsar.common.policies.data.AuthAction;
 import org.apache.pulsar.common.util.ObjectMapperFactory;
 
 public abstract class CliCommand {
+
+    @Parameter(names = { "--help", "-h" }, help = true, hidden = true)
+    private boolean help = false;
+
+    public boolean isHelp() {
+        return help;
+    }
 
     static String[] validatePropertyCluster(List<String> params) {
         return splitParameter(params, 2);

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdBase.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdBase.java
@@ -76,40 +76,40 @@ public abstract class CmdBase {
         }
 
         String cmd = jcommander.getParsedCommand();
-        if (cmd == null || help) {
+        if (cmd == null) {
             jcommander.usage();
+            return help;
+        }
+
+        JCommander obj = jcommander.getCommands().get(cmd);
+        CliCommand cmdObj = (CliCommand) obj.getObjects().get(0);
+
+        if (cmdObj.isHelp()) {
+            obj.setProgramName(jcommander.getProgramName() + " " + cmd);
+            obj.usage();
+            return true;
+        }
+
+        try {
+            cmdObj.run();
+            return true;
+        } catch (ParameterException e) {
+            System.err.println(e.getMessage());
+            System.err.println();
             return false;
-        } else {
-            JCommander obj = jcommander.getCommands().get(cmd);
-            CliCommand cmdObj = (CliCommand) obj.getObjects().get(0);
-
-            if (cmdObj.isHelp()) {
-                obj.setProgramName(jcommander.getProgramName() + " " + cmd);
-                obj.usage();
-                return true;
-            }
-
-            try {
-                cmdObj.run();
-                return true;
-            } catch (ParameterException e) {
-                System.err.println(e.getMessage());
-                System.err.println();
-                return false;
-            } catch (ConnectException e) {
-                System.err.println(e.getMessage());
-                System.err.println();
-                System.err.println("Error connecting to: " + getAdmin().getServiceUrl());
-                return false;
-            } catch (PulsarAdminException e) {
-                System.err.println(e.getHttpError());
-                System.err.println();
-                System.err.println("Reason: " + e.getMessage());
-                return false;
-            } catch (Exception e) {
-                e.printStackTrace();
-                return false;
-            }
+        } catch (ConnectException e) {
+            System.err.println(e.getMessage());
+            System.err.println();
+            System.err.println("Error connecting to: " + getAdmin().getServiceUrl());
+            return false;
+        } catch (PulsarAdminException e) {
+            System.err.println(e.getHttpError());
+            System.err.println();
+            System.err.println("Reason: " + e.getMessage());
+            return false;
+        } catch (Exception e) {
+            e.printStackTrace();
+            return false;
         }
     }
 

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdBase.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdBase.java
@@ -40,6 +40,10 @@ public abstract class CmdBase {
     @Parameter(names = { "--help", "-h" }, help = true, hidden = true)
     private boolean help = false;
 
+    public boolean isHelp() {
+        return help;
+    }
+
     public CmdBase(String cmdName, Supplier<PulsarAdmin> adminSupplier) {
         this.adminSupplier = adminSupplier;
         jcommander = new JCommander(this);

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdBase.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdBase.java
@@ -69,7 +69,8 @@ public abstract class CmdBase {
         try {
             jcommander.parse(args);
         } catch (Exception e) {
-            e.printStackTrace();
+            System.err.println(e.getMessage());
+            System.err.println();
             tryShowCommandUsage();
             return false;
         }


### PR DESCRIPTION
### Motivation

#### Currently

```bash
$ ./bin/pulsar-admin schemas -h


Expected a command, got -h

Invalid command, please use `pulsar-admin --help` to check out how to use
2022-12-09T16:18:27,751+0800 [main] WARN  org.apache.pulsar.common.util.ShutdownUtil - Triggering immediate shutdown of current process with status 1
java.lang.Exception: Stacktrace for immediate shutdown
	at org.apache.pulsar.common.util.ShutdownUtil.triggerImmediateForcefulShutdown(ShutdownUtil.java:52) ~[pulsar-common.jar:2.11.0-SNAPSHOT]
	at org.apache.pulsar.admin.cli.PulsarAdminTool.exit(PulsarAdminTool.java:309) ~[pulsar-client-tools.jar:2.11.0-SNAPSHOT]
	at org.apache.pulsar.admin.cli.PulsarAdminTool.main(PulsarAdminTool.java:300) ~[pulsar-client-tools.jar:2.11.0-SNAPSHOT]
```

```bash
$ ./bin/pulsar-admin schemas delete -h


null

Reason: java.util.concurrent.CompletionException: org.apache.pulsar.client.admin.internal.http.AsyncHttpConnector$RetryException: Could not complete the operation. Number of retries has been exhausted. Failed reason: Connection refused: localhost/127.0.0.1:8080
2022-12-09T16:18:32,984+0800 [main] WARN  org.apache.pulsar.common.util.ShutdownUtil - Triggering immediate shutdown of current process with status 1
java.lang.Exception: Stacktrace for immediate shutdown
	at org.apache.pulsar.common.util.ShutdownUtil.triggerImmediateForcefulShutdown(ShutdownUtil.java:52) ~[pulsar-common.jar:2.11.0-SNAPSHOT]
	at org.apache.pulsar.admin.cli.PulsarAdminTool.exit(PulsarAdminTool.java:309) ~[pulsar-client-tools.jar:2.11.0-SNAPSHOT]
	at org.apache.pulsar.admin.cli.PulsarAdminTool.main(PulsarAdminTool.java:300) ~[pulsar-client-tools.jar:2.11.0-SNAPSHOT]
```

#### With this patch

```bash
$ ./bin/pulsar-admin schemas -h       


Usage: pulsar-admin schemas [options] [command] [command options]
  Commands:
    get      Get the schema for a topic
      Usage: get [options] persistent://tenant/namespace/topic
        Options:
          -a, --all-version
            all version
            Default: false
          -v, --version
            version

    delete      Delete the latest schema for a topic
      Usage: delete [options] persistent://tenant/namespace/topic
        Options:
          -f, --force
            whether to delete schema completely. If true, delete all resources 
            (including metastore and ledger), otherwise only do a mark 
            deletion and not remove any resources indeed
            Default: false

    upload      Update the schema for a topic
      Usage: upload [options] persistent://tenant/namespace/topic
        Options:
        * -f, --filename
            filename

    extract      Provide the schema via a topic
      Usage: extract [options] persistent://tenant/namespace/topic
        Options:
          -a, --always-allow-null
            set schema whether always allow null or not
            Default: true
        * -c, --classname
            class name of pojo
          -n, --dry-run
            dost not apply to schema registry, just prints the post schema 
            payload 
            Default: false
        * -j, --jar
            jar filepath
        * -t, --type
            type avro or json
```

```bash
$ ./bin/pulsar-admin schemas delete -h


Usage: pulsar-admin schemas delete [options] 
      persistent://tenant/namespace/topic 
  Options:
    -f, --force
      whether to delete schema completely. If true, delete all resources 
      (including metastore and ledger), otherwise only do a mark deletion and 
      not remove any resources indeed
      Default: false
```

### Does this pull request potentially affect one of the following parts:

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [x] The admin CLI options
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: 