### PR TITLE
[fix][broker] Ignore the exception of creating namespace

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/PulsarStandalone.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/PulsarStandalone.java
@@ -396,7 +396,7 @@ public class PulsarStandalone implements AutoCloseable {
             try {
                 broker.getAdminClient().namespaces().createNamespace(ns.toString());
             } catch (Exception e) {
-                log.warn(e.getMessage());
+                log.warn("Failed to create the default namespace {}: {}", ns, e.getMessage());
             }
         }
     }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/PulsarStandalone.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/PulsarStandalone.java
@@ -393,7 +393,11 @@ public class PulsarStandalone implements AutoCloseable {
         }
 
         if (!nsr.namespaceExists(ns)) {
-            broker.getAdminClient().namespaces().createNamespace(ns.toString());
+            try {
+                broker.getAdminClient().namespaces().createNamespace(ns.toString());
+            } catch (Exception e) {
+                log.warn(e.getMessage());
+            }
         }
     }
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/PulsarStandaloneTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/PulsarStandaloneTest.java
@@ -21,6 +21,7 @@ package org.apache.pulsar;
 import static org.apache.commons.io.FileUtils.cleanDirectory;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -33,6 +34,7 @@ import org.apache.bookkeeper.conf.ServerConfiguration;
 import org.apache.bookkeeper.util.IOUtils;
 import org.apache.pulsar.client.admin.Namespaces;
 import org.apache.pulsar.client.admin.PulsarAdmin;
+import org.apache.pulsar.client.admin.PulsarAdminException;
 import org.apache.pulsar.common.naming.NamespaceName;
 import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.broker.ServiceConfiguration;
@@ -61,7 +63,7 @@ public class PulsarStandaloneTest {
         doNothing().when(tr).createTenant(eq(tenant), any());
 
         NamespaceResources nsr = mock(NamespaceResources.class);
-        when(nsr.namespaceExists(ns)).thenReturn(false).thenReturn(true);
+        when(nsr.namespaceExists(ns)).thenReturn(false).thenReturn(true).thenReturn(false);
         doNothing().when(nsr).createPolicies(eq(ns), any());
 
         PulsarResources resources = mock(PulsarResources.class);
@@ -95,6 +97,9 @@ public class PulsarStandaloneTest {
         verify(tr, times(1)).createTenant(eq(tenant), any());
         verify(admin, times(1)).namespaces();
         verify(admin.namespaces(), times(1)).createNamespace(eq(ns.toString()));
+
+        doThrow(new PulsarAdminException("No permission")).when(namespaces).createNamespace(any());
+        standalone.createNameSpace(cluster, tenant, ns);
     }
 
     @Test(groups = "broker")

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/standalone/SmokeTest.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/standalone/SmokeTest.java
@@ -39,7 +39,7 @@ public class SmokeTest extends PulsarStandaloneTestSuite {
         @Cleanup
         PulsarAdmin admin = PulsarAdmin.builder().serviceHttpUrl(getHttpServiceUrl()).build();
 
-        String topic = "test-get-bundle-range-topic";
+        String topic = "test-get-topic-bundle-range";
         admin.topics().createNonPartitionedTopic(topic);
         assertEquals(admin.lookups().getBundleRange(topic), "0xc0000000_0xffffffff");
     }

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/standalone/SmokeTest.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/standalone/SmokeTest.java
@@ -18,7 +18,12 @@
  */
 package org.apache.pulsar.tests.integration.standalone;
 
+import static org.testng.Assert.assertEquals;
 import java.util.function.Supplier;
+import lombok.Cleanup;
+import org.apache.pulsar.client.admin.PulsarAdmin;
+import org.apache.pulsar.client.admin.PulsarAdminException;
+import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.tests.integration.suites.PulsarStandaloneTestSuite;
 import org.testng.annotations.Test;
 
@@ -29,4 +34,13 @@ public class SmokeTest extends PulsarStandaloneTestSuite {
         super.testPublishAndConsume(serviceUrl.get(), isPersistent);
     }
 
+    @Test
+    public void testGetBundleRange() throws PulsarClientException, PulsarAdminException {
+        @Cleanup
+        PulsarAdmin admin = PulsarAdmin.builder().serviceHttpUrl(getHttpServiceUrl()).build();
+
+        String topic = "test-get-bundle-range-topic";
+        admin.topics().createNonPartitionedTopic(topic);
+        assertEquals(admin.lookups().getBundleRange(topic), "0xc0000000_0xffffffff");
+    }
 }

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/topologies/PulsarStandaloneTestBase.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/topologies/PulsarStandaloneTestBase.java
@@ -121,4 +121,7 @@ public abstract class PulsarStandaloneTestBase extends PulsarTestBase {
         }
     }
 
+    protected String getHttpServiceUrl() {
+        return container.getHttpServiceUrl();
+    }
 }


### PR DESCRIPTION
### Motivation

In the standalone model, when the `admin` client hasn't permission to create the namespace, the Pulsar will exit.

We should keep the same logic with branch-2.10.

https://github.com/apache/pulsar/blob/branch-2.10/pulsar-broker/src/main/java/org/apache/pulsar/PulsarStandalone.java#L409-L414

### Modifications

Add `try...catch` to pack.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
