### PR TITLE
[fix][doc] Avoid refer to deprecated classes

### DIFF
--- a/site2/docs/cookbooks-compaction.md
+++ b/site2/docs/cookbooks-compaction.md
@@ -110,11 +110,11 @@ PulsarClient client = PulsarClient.builder()
         .build();
 
 Producer<byte[]> compactedTopicProducer = client.newProducer()
-        .newMessage()
         .topic("some-compacted-topic")
         .create();
 
-compactedTopicProducer.key("some-key")
+compactedTopicProducer.newMessage()
+        .key("some-key")
         .value(someByteArray)
         .send();
 ```

--- a/site2/docs/cookbooks-compaction.md
+++ b/site2/docs/cookbooks-compaction.md
@@ -92,20 +92,16 @@ Consumer<byte[]> compactedTopicConsumer = client.newConsumer()
 As mentioned above, topic compaction in Pulsar works on a *per-key basis*. That means that messages that you produce on compacted topics need to have keys (the content of the key will depend on your use case). Messages that don't have keys will be ignored by the compaction process. Here's an example Pulsar message with a key:
 
 ```java
-import org.apache.pulsar.client.api.Message;
-import org.apache.pulsar.client.api.MessageBuilder;
+import org.apache.pulsar.client.api.TypedMessageBuilder;
 
-Message<byte[]> msg = MessageBuilder.create()
-        .setContent(someByteArray)
-        .setKey("some-key")
-        .build();
+TypedMessageBuilder<byte[]> msg = producer.newMessage()
+        .key("some-key")
+        .value(someByteArray);
 ```
 
 The example below shows a message with a key being produced on a compacted Pulsar topic:
 
 ```java
-import org.apache.pulsar.client.api.Message;
-import org.apache.pulsar.client.api.MessageBuilder;
 import org.apache.pulsar.client.api.Producer;
 import org.apache.pulsar.client.api.PulsarClient;
 
@@ -114,14 +110,11 @@ PulsarClient client = PulsarClient.builder()
         .build();
 
 Producer<byte[]> compactedTopicProducer = client.newProducer()
+        .newMessage()
         .topic("some-compacted-topic")
         .create();
 
-Message<byte[]> msg = MessageBuilder.create()
-        .setContent(someByteArray)
-        .setKey("some-key")
-        .build();
-
-compactedTopicProducer.send(msg);
+compactedTopicProducer.key("some-key")
+        .value(someByteArray)
+        .send();
 ```
-

--- a/site2/website/versioned_docs/version-2.10.x/cookbooks-compaction.md
+++ b/site2/website/versioned_docs/version-2.10.x/cookbooks-compaction.md
@@ -127,11 +127,11 @@ PulsarClient client = PulsarClient.builder()
         .build();
 
 Producer<byte[]> compactedTopicProducer = client.newProducer()
-        .newMessage()
         .topic("some-compacted-topic")
         .create();
 
-compactedTopicProducer.key("some-key")
+compactedTopicProducer.newMessage()
+        .key("some-key")
         .value(someByteArray)
         .send();
 ```

--- a/site2/website/versioned_docs/version-2.10.x/cookbooks-compaction.md
+++ b/site2/website/versioned_docs/version-2.10.x/cookbooks-compaction.md
@@ -109,23 +109,16 @@ Consumer<byte[]> compactedTopicConsumer = client.newConsumer()
 As mentioned above, topic compaction in Pulsar works on a *per-key basis*. That means that messages that you produce on compacted topics need to have keys (the content of the key will depend on your use case). Messages that don't have keys will be ignored by the compaction process. Here's an example Pulsar message with a key:
 
 ```java
+import org.apache.pulsar.client.api.TypedMessageBuilder;
 
-import org.apache.pulsar.client.api.Message;
-import org.apache.pulsar.client.api.MessageBuilder;
-
-Message<byte[]> msg = MessageBuilder.create()
-        .setContent(someByteArray)
-        .setKey("some-key")
-        .build();
-
+TypedMessageBuilder<byte[]> msg = producer.newMessage()
+        .key("some-key")
+        .value(someByteArray);
 ```
 
 The example below shows a message with a key being produced on a compacted Pulsar topic:
 
 ```java
-
-import org.apache.pulsar.client.api.Message;
-import org.apache.pulsar.client.api.MessageBuilder;
 import org.apache.pulsar.client.api.Producer;
 import org.apache.pulsar.client.api.PulsarClient;
 
@@ -134,15 +127,11 @@ PulsarClient client = PulsarClient.builder()
         .build();
 
 Producer<byte[]> compactedTopicProducer = client.newProducer()
+        .newMessage()
         .topic("some-compacted-topic")
         .create();
 
-Message<byte[]> msg = MessageBuilder.create()
-        .setContent(someByteArray)
-        .setKey("some-key")
-        .build();
-
-compactedTopicProducer.send(msg);
-
+compactedTopicProducer.key("some-key")
+        .value(someByteArray)
+        .send();
 ```
-

--- a/site2/website/versioned_docs/version-2.8.x/cookbooks-compaction.md
+++ b/site2/website/versioned_docs/version-2.8.x/cookbooks-compaction.md
@@ -127,11 +127,11 @@ PulsarClient client = PulsarClient.builder()
         .build();
 
 Producer<byte[]> compactedTopicProducer = client.newProducer()
-        .newMessage()
         .topic("some-compacted-topic")
         .create();
 
-compactedTopicProducer.key("some-key")
+compactedTopicProducer.newMessage()
+        .key("some-key")
         .value(someByteArray)
         .send();
 ```

--- a/site2/website/versioned_docs/version-2.8.x/cookbooks-compaction.md
+++ b/site2/website/versioned_docs/version-2.8.x/cookbooks-compaction.md
@@ -109,23 +109,16 @@ Consumer<byte[]> compactedTopicConsumer = client.newConsumer()
 As mentioned above, topic compaction in Pulsar works on a *per-key basis*. That means that messages that you produce on compacted topics need to have keys (the content of the key will depend on your use case). Messages that don't have keys will be ignored by the compaction process. Here's an example Pulsar message with a key:
 
 ```java
+import org.apache.pulsar.client.api.TypedMessageBuilder;
 
-import org.apache.pulsar.client.api.Message;
-import org.apache.pulsar.client.api.MessageBuilder;
-
-Message<byte[]> msg = MessageBuilder.create()
-        .setContent(someByteArray)
-        .setKey("some-key")
-        .build();
-
+TypedMessageBuilder<byte[]> msg = producer.newMessage()
+        .key("some-key")
+        .value(someByteArray);
 ```
 
 The example below shows a message with a key being produced on a compacted Pulsar topic:
 
 ```java
-
-import org.apache.pulsar.client.api.Message;
-import org.apache.pulsar.client.api.MessageBuilder;
 import org.apache.pulsar.client.api.Producer;
 import org.apache.pulsar.client.api.PulsarClient;
 
@@ -134,15 +127,11 @@ PulsarClient client = PulsarClient.builder()
         .build();
 
 Producer<byte[]> compactedTopicProducer = client.newProducer()
+        .newMessage()
         .topic("some-compacted-topic")
         .create();
 
-Message<byte[]> msg = MessageBuilder.create()
-        .setContent(someByteArray)
-        .setKey("some-key")
-        .build();
-
-compactedTopicProducer.send(msg);
-
+compactedTopicProducer.key("some-key")
+        .value(someByteArray)
+        .send();
 ```
-

--- a/site2/website/versioned_docs/version-2.9.x/cookbooks-compaction.md
+++ b/site2/website/versioned_docs/version-2.9.x/cookbooks-compaction.md
@@ -126,11 +126,11 @@ PulsarClient client = PulsarClient.builder()
         .serviceUrl("pulsar://localhost:6650")
         .build();
 
-        Producer<byte[]> compactedTopicProducer = client.newProducer()
+Producer<byte[]> compactedTopicProducer = client.newProducer()
         .topic("some-compacted-topic")
         .create();
 
-        compactedTopicProducer.newMessage()
+compactedTopicProducer.newMessage()
         .key("some-key")
         .value(someByteArray)
         .send();

--- a/site2/website/versioned_docs/version-2.9.x/cookbooks-compaction.md
+++ b/site2/website/versioned_docs/version-2.9.x/cookbooks-compaction.md
@@ -109,23 +109,16 @@ Consumer<byte[]> compactedTopicConsumer = client.newConsumer()
 As mentioned above, topic compaction in Pulsar works on a *per-key basis*. That means that messages that you produce on compacted topics need to have keys (the content of the key will depend on your use case). Messages that don't have keys will be ignored by the compaction process. Here's an example Pulsar message with a key:
 
 ```java
+import org.apache.pulsar.client.api.TypedMessageBuilder;
 
-import org.apache.pulsar.client.api.Message;
-import org.apache.pulsar.client.api.MessageBuilder;
-
-Message<byte[]> msg = MessageBuilder.create()
-        .setContent(someByteArray)
-        .setKey("some-key")
-        .build();
-
+TypedMessageBuilder<byte[]> msg = producer.newMessage()
+        .key("some-key")
+        .value(someByteArray);
 ```
 
 The example below shows a message with a key being produced on a compacted Pulsar topic:
 
 ```java
-
-import org.apache.pulsar.client.api.Message;
-import org.apache.pulsar.client.api.MessageBuilder;
 import org.apache.pulsar.client.api.Producer;
 import org.apache.pulsar.client.api.PulsarClient;
 
@@ -133,16 +126,13 @@ PulsarClient client = PulsarClient.builder()
         .serviceUrl("pulsar://localhost:6650")
         .build();
 
-Producer<byte[]> compactedTopicProducer = client.newProducer()
+        Producer<byte[]> compactedTopicProducer = client.newProducer()
+        .newMessage()
         .topic("some-compacted-topic")
         .create();
 
-Message<byte[]> msg = MessageBuilder.create()
-        .setContent(someByteArray)
-        .setKey("some-key")
-        .build();
-
-compactedTopicProducer.send(msg);
-
+        compactedTopicProducer.key("some-key")
+        .value(someByteArray)
+        .send();
 ```
 

--- a/site2/website/versioned_docs/version-2.9.x/cookbooks-compaction.md
+++ b/site2/website/versioned_docs/version-2.9.x/cookbooks-compaction.md
@@ -127,12 +127,11 @@ PulsarClient client = PulsarClient.builder()
         .build();
 
         Producer<byte[]> compactedTopicProducer = client.newProducer()
-        .newMessage()
         .topic("some-compacted-topic")
         .create();
 
-        compactedTopicProducer.key("some-key")
+        compactedTopicProducer.newMessage()
+        .key("some-key")
         .value(someByteArray)
         .send();
 ```
-


### PR DESCRIPTION
This closes #8917.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [x] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
