### PR TITLE
[improve][cli] pulsar-perf: check for invalid CLI options

### DIFF
--- a/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceConsumer.java
+++ b/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceConsumer.java
@@ -222,6 +222,15 @@ public class PerformanceConsumer {
             arguments.authPluginClassName = arguments.deprecatedAuthPluginClassName;
         }
 
+        for (String arg : arguments.topic) {
+            if (arg.startsWith("-")) {
+                System.out.printf("invalid option: '%s'\nTo use a topic with the name '%s', "
+                        + "please use a fully qualified topic name\n", arg, arg);
+                jc.usage();
+                PerfClientUtils.exit(-1);
+            }
+        }
+
         if (arguments.topic != null && arguments.topic.size() != arguments.numTopics) {
             // keep compatibility with the previous version
             if (arguments.topic.size() == 1) {

--- a/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceProducer.java
+++ b/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceProducer.java
@@ -292,6 +292,15 @@ public class PerformanceProducer {
             arguments.authPluginClassName = arguments.deprecatedAuthPluginClassName;
         }
 
+        for (String arg : arguments.topics) {
+            if (arg.startsWith("-")) {
+                System.out.printf("invalid option: '%s'\nTo use a topic with the name '%s', "
+                        + "please use a fully qualified topic name\n", arg, arg);
+                jc.usage();
+                PerfClientUtils.exit(-1);
+            }
+        }
+
         if (arguments.topics != null && arguments.topics.size() != arguments.numTopics) {
             // keep compatibility with the previous version
             if (arguments.topics.size() == 1) {

--- a/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceReader.java
+++ b/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceReader.java
@@ -122,6 +122,15 @@ public class PerformanceReader {
             PerfClientUtils.exit(-1);
         }
 
+        for (String arg : arguments.topic) {
+            if (arg.startsWith("-")) {
+                System.out.printf("invalid option: '%s'\nTo use a topic with the name '%s', "
+                        + "please use a fully qualified topic name\n", arg, arg);
+                jc.usage();
+                PerfClientUtils.exit(-1);
+            }
+        }
+
         if (arguments.topic != null && arguments.topic.size() != arguments.numTopics) {
             // keep compatibility with the previous version
             if (arguments.topic.size() == 1) {


### PR DESCRIPTION
Fixes #18866

### Motivation

pulsar-perf incorrectly interprets bad options (e.g. --foo) as topic names.  This results in an unclear error message if, for example, there is a typo in one of the options.

### Modifications

I looked through the code for the JCommander library to see if there is a built-in argument validation for things like this, however, JCommander is kind of limited in this respect.  If you accept any non-option arguments, then it's up to you to validate those, so I had to add arg/topic validation to the pulsar-perf code.

Check the non-option arguments for values starting with a '-'.  If found, print an error message that there was an un-recognized option.

Old error message
```
> bin/pulsar-perf produce --foo mytopic
The size of topics list should be equal to --num-topic
Usage: pulsar-perf produce [options] persistent://prop/ns/my-topic
  Options:
    -am, --access-mode
      Producer access mode
  ...
```
New error message
```
> bin/pulsar-perf produce --foo mytopic
invalid option: '--foo'
To use a topic with the name '--foo', please use a fully qualified topic name
Usage: pulsar-perf produce [options] persistent://prop/ns/my-topic
  Options:
    -am, --access-mode
      Producer access mode
  ...
```
### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [X] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/pgier/pulsar/pull/6

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
