### PR TITLE
[improve][monitor] Rename "GC Pauses" to "GC Time" in Pulsar JVM dashboards

### DIFF
--- a/grafana/dashboards/jvm.json
+++ b/grafana/dashboards/jvm.json
@@ -374,7 +374,7 @@
           "thresholds": [],
           "timeFrom": null,
           "timeShift": null,
-          "title": "GC Pauses",
+          "title": "GC Time",
           "tooltip": {
             "shared": true,
             "sort": 0,
@@ -779,7 +779,7 @@
           "thresholds": [],
           "timeFrom": null,
           "timeShift": null,
-          "title": "GC Pauses",
+          "title": "GC Time",
           "tooltip": {
             "shared": true,
             "sort": 0,
@@ -1184,7 +1184,7 @@
           "thresholds": [],
           "timeFrom": null,
           "timeShift": null,
-          "title": "GC Pauses",
+          "title": "GC Time",
           "tooltip": {
             "shared": true,
             "sort": 0,
@@ -1589,7 +1589,7 @@
           "thresholds": [],
           "timeFrom": null,
           "timeShift": null,
-          "title": "GC Pauses",
+          "title": "GC Time",
           "tooltip": {
             "shared": true,
             "sort": 0,
@@ -1994,7 +1994,7 @@
           "thresholds": [],
           "timeFrom": null,
           "timeShift": null,
-          "title": "GC Pauses",
+          "title": "GC Time",
           "tooltip": {
             "shared": true,
             "sort": 0,
@@ -2399,7 +2399,7 @@
           "thresholds": [],
           "timeFrom": null,
           "timeShift": null,
-          "title": "GC Pauses",
+          "title": "GC Time",
           "tooltip": {
             "shared": true,
             "sort": 0,


### PR DESCRIPTION
### Motivation

- source metric is not about GC pauses.
- the source metric is "jvm_gc_collection_seconds_sum" which is not the same as "GC pause"
- The metric is defined in Prometheus Java client
  - "Time spent in a given JVM garbage collector in seconds."
  - source code is https://github.com/prometheus/client_java/blob/e68daf23336eb5de7856df406eb1d497f51ad3be/simpleclient_hotspot/src/main/java/io/prometheus/client/hotspot/GarbageCollectorExports.java#L53
    - calls GarbageCollectorMXBean.getCollectionTime() - Javadoc https://docs.oracle.com/en/java/javase/11/docs/api/java.management/java/lang/management/GarbageCollectorMXBean.html#getCollectionTime() "Returns the approximate accumulated collection elapsed time in milliseconds."
     - Stackoverflow Q&A: https://stackoverflow.com/a/44686539

### Modifications

Replace "GC Pauses" with "GC Time" in Grafana JVM dashboards.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->