### PR TITLE
[fix][ci] Fix running OWASP for PRs that change dependencies

### DIFF
--- a/.github/workflows/pulsar-ci.yaml
+++ b/.github/workflows/pulsar-ci.yaml
@@ -45,6 +45,8 @@ jobs:
     outputs:
       docs_only: ${{ steps.check_changes.outputs.docs_only }}
       changed_tests: ${{ steps.changes.outputs.tests_files }}
+      need_owasp: ${{ steps.changes.outputs.need_owasp }}
+      
     steps:
       - name: checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
### Motivation

- The GitHub Actions workflow "Pulsar CI" is supposed to run OWASP dependency check when pom.xml files are modified. This doesn't currently work. This seems to be a problem in the original change #17568.

### Modifications

- Fix the problem that causes "OWASP dependency check" job to always get skipped.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/lhotari/pulsar/pull/111 (added some additional changes that contain pom.xml changes)