### PR TITLE
[fix][txn] Fix replication of transactional messages

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/GeoPersistentReplicator.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/GeoPersistentReplicator.java
@@ -171,7 +171,7 @@ public class GeoPersistentReplicator extends PersistentReplicator {
                 } else {
                     msg.setSchemaInfoForReplicator(schemaFuture.get());
                     msg.getMessageBuilder().clearTxnidMostBits();
-                    msg.getMessageBuilder().clearTxnidMostBits();
+                    msg.getMessageBuilder().clearTxnidLeastBits();
                     producer.sendAsync(msg, ProducerSendCallback.create(this, entry, msg));
                     atLeastOneMessageSentForReplication = true;
                 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentReplicator.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentReplicator.java
@@ -68,7 +68,7 @@ import org.slf4j.LoggerFactory;
 public abstract class PersistentReplicator extends AbstractReplicator
         implements Replicator, ReadEntriesCallback, DeleteCallback {
 
-    private final PersistentTopic topic;
+    protected final PersistentTopic topic;
     protected final ManagedCursor cursor;
 
     protected Optional<DispatchRateLimiter> dispatchRateLimiter = Optional.empty();
@@ -249,7 +249,7 @@ public abstract class PersistentReplicator extends AbstractReplicator
                     log.debug("[{}] Schedule read of {} messages", replicatorId, messagesToRead);
                 }
                 cursor.asyncReadEntriesOrWait(messagesToRead, readMaxSizeBytes, this,
-                        null, PositionImpl.LATEST);
+                        null, topic.getMaxReadPosition());
             } else {
                 if (log.isDebugEnabled()) {
                     log.debug("[{}] Not scheduling read due to pending read. Messages To Read {}",

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatorTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatorTest.java
@@ -1383,19 +1383,37 @@ public class ReplicatorTest extends ReplicatorTestBase {
                 "testDoesNotReplicateSystemTopic").toString();
         String systemTopic = TopicName.get("persistent", NamespaceName.get(namespace),
                 SystemTopicNames.TRANSACTION_BUFFER_SNAPSHOT).toString();
+
+        @Cleanup
+        PulsarClient client2 = PulsarClient.builder().serviceUrl(pulsar2.getBrokerServiceUrl()).build();
+
+        @Cleanup
+        Consumer<byte[]> consumerFromR2 = client2.newConsumer()
+                .topic(topic.toString())
+                .subscriptionName("sub-rep")
+                .subscribe();
+
         admin1.topics().createNonPartitionedTopic(topic);
         // Replicator will not replicate System Topic other than topic policies
         initTransaction(2, admin1, pulsar1.getBrokerServiceUrl(), pulsar1);
         @Cleanup
         PulsarClient client = PulsarClient.builder().serviceUrl(pulsar1.getBrokerServiceUrl())
                 .enableTransaction(true).build();
-        TransactionImpl transaction = (TransactionImpl) client.newTransaction()
+        TransactionImpl abortTransaction = (TransactionImpl) client.newTransaction()
                 .withTransactionTimeout(60, TimeUnit.SECONDS).build().get();
+
         @Cleanup
         Producer<byte[]> producer = client.newProducer().topic(topic)
                 .sendTimeout(0, TimeUnit.SECONDS)
                 .enableBatching(false).create();
+        producer.newMessage(abortTransaction).value("aborted".getBytes(StandardCharsets.UTF_8)).send();
+        abortTransaction.abort().get();
+
+        TransactionImpl transaction = (TransactionImpl) client.newTransaction()
+                .withTransactionTimeout(60, TimeUnit.SECONDS).build().get();
+
         producer.newMessage(transaction).value("1".getBytes(StandardCharsets.UTF_8)).send();
+        Assert.assertNull(consumerFromR2.receive(5, TimeUnit.SECONDS));
         transaction.commit();
 
         Awaitility.await().untilAsserted(() -> {
@@ -1403,6 +1421,8 @@ public class ReplicatorTest extends ReplicatorTestBase {
             Assert.assertEquals(admin2.topics().getStats(systemTopic).getReplication().size(), 0);
             Assert.assertEquals(admin3.topics().getStats(systemTopic).getReplication().size(), 0);
         });
+        Assert.assertEquals(consumerFromR2.receive(5, TimeUnit.SECONDS).getValue(),
+                "1".getBytes(StandardCharsets.UTF_8));
         cleanup();
         setup();
     }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatorTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatorTest.java
@@ -1408,12 +1408,13 @@ public class ReplicatorTest extends ReplicatorTestBase {
                 .enableBatching(false).create();
         producer.newMessage(abortTransaction).value("aborted".getBytes(StandardCharsets.UTF_8)).send();
         abortTransaction.abort().get();
+        assertNull(consumerFromR2.receive(5, TimeUnit.SECONDS));
 
         TransactionImpl transaction = (TransactionImpl) client.newTransaction()
                 .withTransactionTimeout(60, TimeUnit.SECONDS).build().get();
 
         producer.newMessage(transaction).value("1".getBytes(StandardCharsets.UTF_8)).send();
-        Assert.assertNull(consumerFromR2.receive(5, TimeUnit.SECONDS));
+        assertNull(consumerFromR2.receive(5, TimeUnit.SECONDS));
         transaction.commit();
 
         Awaitility.await().untilAsserted(() -> {


### PR DESCRIPTION

Fixes #18888

### Motivation

Transaction markers and non committed messages should not being replicated by the geo-replicator.
Those messages must appear as normal messages in the destination clusters.


### Modifications

* Skip txn marker in the replicator
* Skip messages of aborted txn in the replicator
* In the replicator read entries from the maxReadPosition of the topic instead of Latest in order to not read non committed messages
* Remove txn metadata from the message metadata 

Notes: I haven't modified the shadow topic replicator because I'm not sure if that feature is completed or not and in any case it's better to fix it in another pull

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository
https://github.com/nicoloboschi/pulsar/pull/39