### PR TITLE
[branch-2.11][fix][cpp] Fix the standalone set up

### DIFF
--- a/pulsar-client-cpp/pulsar-test-service-start.sh
+++ b/pulsar-client-cpp/pulsar-test-service-start.sh
@@ -82,6 +82,7 @@ $PULSAR_DIR/bin/pulsar-admin clusters list | grep -q '^standalone$' ||
 $PULSAR_DIR/bin/pulsar-admin tenants update public -r "anonymous" -c "standalone"
 
 # Update "public/default" with no auth required
+$PULSAR_DIR/bin/pulsar-admin namespaces create public/default
 $PULSAR_DIR/bin/pulsar-admin namespaces grant-permission public/default \
                         --actions produce,consume \
                         --role "anonymous"


### PR DESCRIPTION
### Motivation

https://github.com/apache/pulsar/pull/15186 changed the behavior of how to create the default namespace. However, it brings a regression that even if the built-in admin didn't have the authentication configured while the standalone enabled the authentication, the namespace could still be created successfully. This PR also changed the deploy script to remove the creation of "public/default" namespace. Instead, it grants the permission to this namespace directly.

After https://github.com/apache/pulsar/pull/17864 and https://github.com/apache/pulsar/pull/18837, the namespace will be created by the built-in admin again. But the deploy script would fail.

### Modifications

Create the default namespace via `pulsar-admin` in the deploy script.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/BewareMyPower/pulsar/pull/13