### PR TITLE
[fix][client] Fix too many redelivered messages when one message acked timeout in listener

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/ConsumerRedeliveryTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/ConsumerRedeliveryTest.java
@@ -40,7 +40,6 @@ import org.apache.pulsar.client.impl.ConsumerImpl;
 import org.apache.pulsar.client.impl.MessageIdImpl;
 import org.apache.pulsar.common.api.proto.CommandAck;
 import org.apache.pulsar.common.util.FutureUtil;
-import org.apache.pulsar.common.util.collections.GrowableArrayBlockingQueue;
 import org.awaitility.Awaitility;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/ConsumerRedeliveryTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/ConsumerRedeliveryTest.java
@@ -27,9 +27,12 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import lombok.Cleanup;
@@ -37,6 +40,8 @@ import org.apache.pulsar.client.impl.ConsumerImpl;
 import org.apache.pulsar.client.impl.MessageIdImpl;
 import org.apache.pulsar.common.api.proto.CommandAck;
 import org.apache.pulsar.common.util.FutureUtil;
+import org.apache.pulsar.common.util.collections.GrowableArrayBlockingQueue;
+import org.awaitility.Awaitility;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.annotations.AfterClass;
@@ -260,6 +265,62 @@ public class ConsumerRedeliveryTest extends ProducerConsumerBase {
         }, 5, 2000);
         assertEquals(consumer2.getTotalIncomingMessages(), queueSize);
         log.info("-- Exiting {} test --", methodName);
+    }
+
+    @Test(timeOut = 30000)
+    public void testMessageRedeliveryWhenTimeoutInListener() throws Exception {
+        final String subName = "sub_testMessageRedeliveryWhenTimeoutInListener";
+        final String topicName = "testMessageRedeliveryWhenTimeoutInListener" + UUID.randomUUID();
+
+        final int messages = 10;
+
+        @Cleanup
+        Producer<String> producer = pulsarClient.newProducer(Schema.STRING)
+                .topic(topicName)
+                .enableBatching(false)
+                .create();
+
+        final String redeliveryMsg = "Hello-0";
+        final AtomicInteger index = new AtomicInteger(0);
+        BlockingQueue<Message<byte[]>> receivedMsgs = new LinkedBlockingQueue<>();
+        MessageListener<byte[]> listener = (consumer, msg) -> {
+            try {
+                // the first msg will wait until timeout
+                if (index.getAndDecrement() == 0 && new String(msg.getData()).equals(redeliveryMsg)) {
+                    Thread.sleep(5000);
+                }
+                System.out.println(">>>>>>> " + new String(msg.getData()));
+                receivedMsgs.add(msg);
+                System.out.println("<<<<<<<" + receivedMsgs.size());
+                consumer.acknowledge(msg);
+            } catch (Exception e) {
+            }
+        };
+
+        @Cleanup
+        Consumer<byte[]> consumer = pulsarClient.newConsumer()
+                .topic(topicName)
+                .subscriptionName(subName)
+                .subscriptionType(SubscriptionType.Shared)
+                .ackTimeout(1, TimeUnit.SECONDS)
+                .acknowledgmentGroupTime(0, TimeUnit.SECONDS)
+                .messageListener(listener)
+                .subscribe();
+
+        for (int i = 0; i < messages; i++) {
+            producer.sendAsync("Hello-" + i);
+        }
+        producer.flush();
+
+        // assert only redelivery the "Hello-0" msg
+        Awaitility.await().untilAsserted(() -> assertEquals(receivedMsgs.size(), messages + 1));
+        List<Message<byte[]>> redeliveryMsgList = receivedMsgs.stream()
+                .filter(msg -> new String(msg.getData()).equals(redeliveryMsg))
+                .collect(Collectors.toList());
+        assertEquals(redeliveryMsgList.size(), 2);
+        for (int i = 0; i < redeliveryMsgList.size(); i++) {
+            assertEquals(i, redeliveryMsgList.get(i).getRedeliveryCount());
+        }
     }
 
     @Test(timeOut = 30000)

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/ConsumerRedeliveryTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/ConsumerRedeliveryTest.java
@@ -288,9 +288,7 @@ public class ConsumerRedeliveryTest extends ProducerConsumerBase {
                 if (index.getAndDecrement() == 0 && new String(msg.getData()).equals(redeliveryMsg)) {
                     Thread.sleep(5000);
                 }
-                System.out.println(">>>>>>> " + new String(msg.getData()));
                 receivedMsgs.add(msg);
-                System.out.println("<<<<<<<" + receivedMsgs.size());
                 consumer.acknowledge(msg);
             } catch (Exception e) {
             }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/ConsumerRedeliveryTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/ConsumerRedeliveryTest.java
@@ -284,9 +284,9 @@ public class ConsumerRedeliveryTest extends ProducerConsumerBase {
         BlockingQueue<Message<byte[]>> receivedMsgs = new LinkedBlockingQueue<>();
         MessageListener<byte[]> listener = (consumer, msg) -> {
             try {
-                // the first msg will wait until timeout
+                // the first "Hello-0" will wait until timeout
                 if (index.getAndDecrement() == 0 && new String(msg.getData()).equals(redeliveryMsg)) {
-                    Thread.sleep(5000);
+                    Thread.sleep(3000);
                 }
                 receivedMsgs.add(msg);
                 consumer.acknowledge(msg);

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBase.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBase.java
@@ -215,6 +215,13 @@ public abstract class ConsumerBase<T> extends HandlerState implements Consumer<T
         }
     }
 
+    // if lister is not null, we will track unAcked msg in callMessageListener
+    protected void trackUnAckedMsgIfNoListener(MessageId messageId, int redeliveryCount) {
+        if (listener == null) {
+            unAckedMessageTracker.add(messageId, redeliveryCount);
+        }
+    }
+
     protected void reduceCurrentReceiverQueueSize() {
         if (!conf.isAutoScaledReceiverQueueSizeEnabled()) {
             return;

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
@@ -1628,8 +1628,8 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
                 //TODO: check parent consumer here
                 // we should no longer track this message, TopicsConsumer will take care from now onwards
                 unAckedMessageTracker.remove(id);
-            } else if (listener == null){
-                unAckedMessageTracker.add(id, redeliveryCount);
+            } else {
+                trackUnAckedMsgIfNoListener(messageId, redeliveryCount);
             }
         }
     }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
@@ -145,7 +145,6 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
     private final boolean hasParentConsumer;
     private final boolean parentConsumerHasListener;
 
-    private final UnAckedMessageTracker unAckedMessageTracker;
     private final AcknowledgmentsGroupingTracker acknowledgmentsGroupingTracker;
     private final NegativeAcksTracker negativeAcksTracker;
 
@@ -291,16 +290,6 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
         }
 
         duringSeek = new AtomicBoolean(false);
-
-        if (conf.getAckTimeoutMillis() != 0) {
-            if (conf.getAckTimeoutRedeliveryBackoff() != null) {
-                this.unAckedMessageTracker = new UnAckedMessageRedeliveryTracker(client, this, conf);
-            } else {
-                this.unAckedMessageTracker = new UnAckedMessageTracker(client, this, conf);
-            }
-        } else {
-            this.unAckedMessageTracker = UnAckedMessageTracker.UNACKED_MESSAGE_TRACKER_DISABLED;
-        }
 
         // Create msgCrypto if not created already
         if (conf.getCryptoKeyReader() != null) {
@@ -1639,7 +1628,7 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
                 //TODO: check parent consumer here
                 // we should no longer track this message, TopicsConsumer will take care from now onwards
                 unAckedMessageTracker.remove(id);
-            } else {
+            } else if (listener == null){
                 unAckedMessageTracker.add(id, redeliveryCount);
             }
         }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
@@ -1619,17 +1619,13 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
 
     protected void trackMessage(MessageId messageId, int redeliveryCount) {
         if (conf.getAckTimeoutMillis() > 0 && messageId instanceof MessageIdImpl) {
-            MessageIdImpl id = (MessageIdImpl) messageId;
-            if (id instanceof BatchMessageIdImpl) {
-                // do not add each item in batch message into tracker
-                id = new MessageIdImpl(id.getLedgerId(), id.getEntryId(), getPartitionIndex());
-            }
+            MessageId id = normalizeMessageId(messageId);
             if (hasParentConsumer) {
                 //TODO: check parent consumer here
                 // we should no longer track this message, TopicsConsumer will take care from now onwards
                 unAckedMessageTracker.remove(id);
             } else {
-                trackUnAckedMsgIfNoListener(messageId, redeliveryCount);
+                trackUnAckedMsgIfNoListener(id, redeliveryCount);
             }
         }
     }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiTopicsConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiTopicsConsumerImpl.java
@@ -301,9 +301,7 @@ public class MultiTopicsConsumerImpl<T> extends ConsumerBase<T> {
         // if asyncReceive is waiting : return message to callback without adding to incomingMessages queue
         CompletableFuture<Message<T>> receivedFuture = nextPendingReceive();
         if (receivedFuture != null) {
-            if (listener == null) {
-                unAckedMessageTracker.add(topicMessage.getMessageId(), topicMessage.getRedeliveryCount());
-            }
+            unAckedMessageTracker.add(topicMessage.getMessageId(), topicMessage.getRedeliveryCount());
             completePendingReceive(receivedFuture, topicMessage);
         } else if (enqueueMessageAndCheckBatchReceive(topicMessage) && hasPendingBatchReceive()) {
             notifyPendingBatchReceivedCallBack();
@@ -314,9 +312,7 @@ public class MultiTopicsConsumerImpl<T> extends ConsumerBase<T> {
 
     @Override
     protected synchronized void messageProcessed(Message<?> msg) {
-        if (listener == null) {
-            unAckedMessageTracker.add(msg.getMessageId(), msg.getRedeliveryCount());
-        }
+        unAckedMessageTracker.add(msg.getMessageId(), msg.getRedeliveryCount());
         decreaseIncomingMessageSize(msg);
     }
 
@@ -357,9 +353,7 @@ public class MultiTopicsConsumerImpl<T> extends ConsumerBase<T> {
             message = incomingMessages.take();
             decreaseIncomingMessageSize(message);
             checkState(message instanceof TopicMessageImpl);
-            if (listener == null) {
-                unAckedMessageTracker.add(message.getMessageId(), message.getRedeliveryCount());
-            }
+            unAckedMessageTracker.add(message.getMessageId(), message.getRedeliveryCount());
             resumeReceivingFromPausedConsumersIfNeeded();
             return message;
         } catch (Exception e) {
@@ -379,9 +373,7 @@ public class MultiTopicsConsumerImpl<T> extends ConsumerBase<T> {
             if (message != null) {
                 decreaseIncomingMessageSize(message);
                 checkArgument(message instanceof TopicMessageImpl);
-                if (listener == null) {
-                    unAckedMessageTracker.add(message.getMessageId(), message.getRedeliveryCount());
-                }
+                trackUnAckedMsgIfNoListener(message.getMessageId(), message.getRedeliveryCount());
             }
             resumeReceivingFromPausedConsumersIfNeeded();
             return message;
@@ -439,9 +431,7 @@ public class MultiTopicsConsumerImpl<T> extends ConsumerBase<T> {
             } else {
                 decreaseIncomingMessageSize(message);
                 checkState(message instanceof TopicMessageImpl);
-                if (listener == null) {
-                    unAckedMessageTracker.add(message.getMessageId(), message.getRedeliveryCount());
-                }
+                unAckedMessageTracker.add(message.getMessageId(), message.getRedeliveryCount());
                 resumeReceivingFromPausedConsumersIfNeeded();
                 result.complete(message);
             }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ZeroQueueConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ZeroQueueConsumerImpl.java
@@ -174,7 +174,7 @@ public class ZeroQueueConsumerImpl<T> extends ConsumerImpl<T> {
                 }
                 waitingOnListenerForZeroQueueSize = true;
                 trackMessage(message);
-                unAckedMessageTracker.add(message.getMessageId(), message.getRedeliveryCount());
+                unAckedMessageTracker.add(normalizeMessageId(message.getMessageId()), message.getRedeliveryCount());
                 listener.received(ZeroQueueConsumerImpl.this, beforeConsume(message));
             } catch (Throwable t) {
                 log.error("[{}][{}] Message listener error in processing unqueued message: {}", topic, subscription,

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ZeroQueueConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ZeroQueueConsumerImpl.java
@@ -174,6 +174,7 @@ public class ZeroQueueConsumerImpl<T> extends ConsumerImpl<T> {
                 }
                 waitingOnListenerForZeroQueueSize = true;
                 trackMessage(message);
+                unAckedMessageTracker.add(message.getMessageId(), message.getRedeliveryCount());
                 listener.received(ZeroQueueConsumerImpl.this, beforeConsume(message));
             } catch (Throwable t) {
                 log.error("[{}][{}] Message listener error in processing unqueued message: {}", topic, subscription,


### PR DESCRIPTION
Fixes https://github.com/apache/pulsar/issues/18910


### Motivation
The root cause is that:
1. When msg0 is processing in the pulsar-external-listener thread,  the `MultiTopicsConsumerImpl` will also poll other messages like msg1, msg2 from the `ConsumerBase#incomingMessages`(Line383). Then msg1, msg2 will be added to the `unAckedMessageTracker`(Line387). Note that msg1, msg2 timeout task starts at this point.
https://github.com/apache/pulsar/blob/01e7eacd34f01a88d201c70329ecacfa581db1a8/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiTopicsConsumerImpl.java#L377-L390
2. All the polled messages will be submitted to the pulsar-external-listener thread pool to process the messages.  As we know, if there was no available threads,  the tasks will be waited in the blocking queue of the thread pool.
3. The default thread num of pulsar-external-listener thread pool is 1.  So if msg0 processed too long time, other messages waiting in the blocking queue will also have to wait for a long time and be timeout.


To fix this issue we shouldn't add the messages to `unAckedMessageTracker` when poll them from the `ConsumerBase#incomingMessages`, instead we should add them just before call `MessageListener#received` if we have set MessageListener in the consumer

### Modifications

- Add messages to `unAckedMessageTracker` just before call `MessageListener#received` if we have set MessageListener in the consumer
- Move `unAckedMessageTracker` to `ConsumerBase`

### Verifying this change

- [x] Make sure that the change passes the CI checks.


### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->

### Matching PR in forked repository

PR in forked repository: https://github.com/AnonHxy/pulsar/pull/23
