### PR TITLE
[improve][sec] Remove snakeyaml dependency to suppress CVE-2022-1471

### DIFF
--- a/buildtools/pom.xml
+++ b/buildtools/pom.xml
@@ -51,7 +51,6 @@
     <guice.version>4.2.3</guice.version>
     <guava.version>31.0.1-jre</guava.version>
     <ant.version>1.10.12</ant.version>
-    <snakeyaml.version>1.32</snakeyaml.version>
     <mockito.version>3.12.4</mockito.version>
     <!-- required for running tests on JDK11+ -->
     <test.additional.args>
@@ -73,12 +72,6 @@
   </dependencyManagement>
 
   <dependencies>
-
-    <dependency>
-      <groupId>org.yaml</groupId>
-      <artifactId>snakeyaml</artifactId>
-      <version>${snakeyaml.version}</version>
-    </dependency>
     <dependency>
       <groupId>org.apache.ant</groupId>
       <artifactId>ant</artifactId>

--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -394,7 +394,6 @@ The Apache Software License, Version 2.0
     - org.eclipse.jetty.websocket-websocket-servlet-9.4.48.v20220622.jar
     - org.eclipse.jetty-jetty-alpn-conscrypt-server-9.4.48.v20220622.jar
     - org.eclipse.jetty-jetty-alpn-server-9.4.48.v20220622.jar
- * SnakeYaml -- org.yaml-snakeyaml-1.32.jar
  * RocksDB - org.rocksdb-rocksdbjni-6.29.4.1.jar
  * Google Error Prone Annotations - com.google.errorprone-error_prone_annotations-2.5.1.jar
  * Apache Thrift - org.apache.thrift-libthrift-0.14.2.jar

--- a/pom.xml
+++ b/pom.xml
@@ -228,7 +228,6 @@ flexible messaging model and an intuitive client API.</description>
     <apache-http-client.version>4.5.13</apache-http-client.version>
     <apache-httpcomponents.version>4.4.15</apache-httpcomponents.version>
     <jetcd.version>0.5.11</jetcd.version>
-    <snakeyaml.version>1.32</snakeyaml.version>
     <ant.version>1.10.12</ant.version>
     <seancfoley.ipaddress.version>5.3.3</seancfoley.ipaddress.version>
     <disruptor.version>3.4.3</disruptor.version>
@@ -1263,12 +1262,6 @@ flexible messaging model and an intuitive client API.</description>
         <groupId>com.google.j2objc</groupId>
         <artifactId>j2objc-annotations</artifactId>
         <version>${j2objc-annotations.version}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>org.yaml</groupId>
-        <artifactId>snakeyaml</artifactId>
-        <version>${snakeyaml.version}</version>
       </dependency>
 
       <dependency>

--- a/pulsar-client-admin-shaded/pom.xml
+++ b/pulsar-client-admin-shaded/pom.xml
@@ -145,7 +145,6 @@
                   <include>org.jvnet.mimepull:*</include>
                   <include>io.opencensus:*</include>
                   <include>org.objenesis:*</include>
-                  <include>org.yaml:snakeyaml</include>
                   <include>io.swagger:*</include>
                   <!-- Issue #6834, Since Netty ByteBuf shaded, we need also shade this module -->
                   <include>org.apache.pulsar:pulsar-client-messagecrypto-bc</include>

--- a/pulsar-client-all/pom.xml
+++ b/pulsar-client-all/pom.xml
@@ -185,7 +185,6 @@
                   <include>org.jvnet.mimepull:*</include>
                   <include>io.opencensus:*</include>
                   <include>org.objenesis:*</include>
-                  <include>org.yaml:snakeyaml</include>
                   <include>org.apache.avro:*</include>
                   <!-- Avro transitive dependencies-->
                   <include>com.thoughtworks.paranamer:paranamer</include>

--- a/pulsar-client-shaded/pom.xml
+++ b/pulsar-client-shaded/pom.xml
@@ -161,7 +161,6 @@
                   <include>org.apache.pulsar:pulsar-common</include>
                   <include>com.yahoo.datasketches:sketches-core</include>
                   <include>org.objenesis:*</include>
-                  <include>org.yaml:snakeyaml</include>
 
                   <include>org.apache.avro:*</include>
                   <!-- Avro transitive dependencies-->

--- a/pulsar-functions/localrun-shaded/pom.xml
+++ b/pulsar-functions/localrun-shaded/pom.xml
@@ -119,7 +119,6 @@
                                     <include>org.reactivestreams:reactive-streams</include>
                                     <include>org.apache.commons:*</include>
                                     <include>io.swagger:*</include>
-                                    <include>org.yaml:snakeyaml</include>
                                     <include>io.perfmark:*</include>
                                     <include>io.prometheus:*</include>
                                     <include>io.prometheus.jmx:*</include>

--- a/pulsar-sql/presto-distribution/LICENSE
+++ b/pulsar-sql/presto-distribution/LICENSE
@@ -398,8 +398,6 @@ The Apache Software License, Version 2.0
     - trino-record-decoder-363.jar
   * RocksDB JNI
     - rocksdbjni-6.29.4.1.jar
-  * SnakeYAML
-    - snakeyaml-1.32.jar
   * Bean Validation API
     - validation-api-2.0.1.Final.jar
   * Objectsize


### PR DESCRIPTION
### Motivation

- snakeyaml dependency seems to be completely unnecessary in Pulsar.
  - Jackson's YAML support is used for parsing YAML

- snakeyaml won't fix CVE-2022-1471
  - See https://bitbucket.org/snakeyaml/snakeyaml/issues/561/cve-2022-1471-vulnerability-in and https://bitbucket.org/snakeyaml/snakeyaml/wiki/CVE%20&%20NIST.md

### Modifications

Remove snakeyaml dependency.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/lhotari/pulsar/pull/112

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
