### PR TITLE
[fix][io] Only bundle kafka schema registry client

### DIFF
--- a/pulsar-io/kafka/pom.xml
+++ b/pulsar-io/kafka/pom.xml
@@ -85,16 +85,6 @@
       <groupId>io.confluent</groupId>
       <artifactId>kafka-schema-registry-client</artifactId>
       <version>${kafka.confluent.schemaregistryclient.version}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>log4j</groupId>
-          <artifactId>log4j</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.slf4j</groupId>
-          <artifactId>slf4j-log4j12</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
 
     <dependency>

--- a/pulsar-io/kafka/pom.xml
+++ b/pulsar-io/kafka/pom.xml
@@ -83,7 +83,7 @@
 
     <dependency>
       <groupId>io.confluent</groupId>
-      <artifactId>kafka-schema-registry</artifactId>
+      <artifactId>kafka-schema-registry-client</artifactId>
       <version>${kafka.confluent.schemaregistryclient.version}</version>
       <exclusions>
         <exclusion>


### PR DESCRIPTION
Fixes #18920 

### Motivation

Only kafka-schema-registry-client has ASL license and the connector actually needs only it (and serializers, ASL too)

### Modifications

* import `kafka-schema-registry-client ` instead of `kafka-schema-registry`  

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->
