### PR TITLE
[fix] Change link to Slack workspace auto-invite

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,7 +240,7 @@ Read https://pulsar.apache.org/contribute/setup-ide for setting up IntelliJ IDEA
 
 Pulsar slack channel at https://apache-pulsar.slack.com/
 
-You can self-register at https://apache-pulsar.herokuapp.com/
+You can self-register at https://communityinviter.com/apps/apache-pulsar/apache-pulsar
 
 ##### Report a security vulnerability
 


### PR DESCRIPTION
### Motivation

The Heroku app that was being used to automate the Slack invite of new users has stopped working since Heroku has terminated the free tier. 

I've added a new Slack app that does the email invite.

- [X] `doc` <!-- Your PR contains doc changes -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->