### PR TITLE
[improve] [broker] filter system topics while shedding

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/NamespaceService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/NamespaceService.java
@@ -23,6 +23,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import static java.lang.String.format;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
+import static org.apache.pulsar.common.naming.NamespaceName.SYSTEM_NAMESPACE;
 import com.google.common.collect.Lists;
 import com.google.common.hash.Hashing;
 import io.prometheus.client.Counter;
@@ -1400,7 +1401,8 @@ public class NamespaceService implements AutoCloseable {
     }
 
     public static boolean isSystemServiceNamespace(String namespace) {
-        return HEARTBEAT_NAMESPACE_PATTERN.matcher(namespace).matches()
+        return SYSTEM_NAMESPACE.toString().equals(namespace)
+                || HEARTBEAT_NAMESPACE_PATTERN.matcher(namespace).matches()
                 || HEARTBEAT_NAMESPACE_PATTERN_V2.matcher(namespace).matches()
                 || SLA_NAMESPACE_PATTERN.matcher(namespace).matches();
     }


### PR DESCRIPTION
<!-- Either this PR fixes an issue, -->
Fixes #18935

### Motivation

Topics/Bundles will be unload while doing shedding, and there are some special topics that should not be unloaded for some reason. For example, if `transaction_coordinator_assign` is unloaded, the corresponding TC need to be recovered, which is time consuming. 
So, we have better avoid unload these topics. And i found that such features have been implemented in the latest branch except branch-2.9. 

### Modifications

fitler system topics while shedding in branch-2.9.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is already covered by existing tests, such as *(please describe tests)*.


### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/thetumbled/pulsar/pull/9

