### PR TITLE
[improve][cli] pulsar cli: use return code 1 for general error

### DIFF
--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/client/cli/PulsarClientTool.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/client/cli/PulsarClientTool.java
@@ -155,7 +155,7 @@ public class PulsarClientTool {
             } catch (IllegalArgumentException e) {
                 System.out.println("Incorrect proxyProtocol name '" + proxyProtocolString + "'");
                 e.printStackTrace();
-                System.exit(-1);
+                System.exit(1);
             }
         }
     }
@@ -190,7 +190,7 @@ public class PulsarClientTool {
         if (isNotBlank(rootParams.proxyServiceURL)) {
             if (rootParams.proxyProtocol == null) {
                 System.out.println("proxy-protocol must be provided with proxy-url");
-                System.exit(-1);
+                System.exit(1);
             }
             clientBuilder.proxyServiceUrl(rootParams.proxyServiceURL, rootParams.proxyProtocol);
         }
@@ -256,7 +256,7 @@ public class PulsarClientTool {
     public static void main(String[] args) throws Exception {
         if (args.length == 0) {
             System.out.println("Usage: pulsar-client CONF_FILE_PATH [options] [command] [command options]");
-            System.exit(-1);
+            System.exit(1);
         }
         String configFile = args[0];
         Properties properties = new Properties();

--- a/pulsar-io/docs/src/main/java/org/apache/pulsar/io/docs/ConnectorDocGenerator.java
+++ b/pulsar-io/docs/src/main/java/org/apache/pulsar/io/docs/ConnectorDocGenerator.java
@@ -164,7 +164,7 @@ public class ConnectorDocGenerator {
             }
         } catch (Exception e) {
             commander.usage();
-            Runtime.getRuntime().exit(-1);
+            Runtime.getRuntime().exit(1);
             return;
         }
 

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/PulsarZooKeeperClient.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/PulsarZooKeeperClient.java
@@ -139,7 +139,7 @@ public class PulsarZooKeeperClient extends ZooKeeper implements Watcher, AutoClo
                 }, connectRetryPolicy, rateLimiter, createClientStats);
             } catch (Exception e) {
                 log.error("Gave up reconnecting to ZooKeeper : ", e);
-                Runtime.getRuntime().exit(-1);
+                Runtime.getRuntime().exit(1);
             }
         }
 

--- a/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/ProxyServiceStarter.java
+++ b/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/ProxyServiceStarter.java
@@ -132,7 +132,7 @@ public class ProxyServiceStarter {
                 }
             } catch (Exception e) {
                 jcommander.usage();
-                System.exit(-1);
+                System.exit(1);
             }
 
             // load config file

--- a/pulsar-testclient/src/main/java/org/apache/pulsar/proxy/socket/client/PerformanceClient.java
+++ b/pulsar-testclient/src/main/java/org/apache/pulsar/proxy/socket/client/PerformanceClient.java
@@ -146,12 +146,12 @@ public class PerformanceClient {
         } catch (ParameterException e) {
             System.out.println(e.getMessage());
             jc.usage();
-            PerfClientUtils.exit(-1);
+            PerfClientUtils.exit(1);
         }
 
         if (arguments.help) {
             jc.usage();
-            PerfClientUtils.exit(-1);
+            PerfClientUtils.exit(1);
         }
 
         if (isBlank(arguments.authPluginClassName) && !isBlank(arguments.deprecatedAuthPluginClassName)) {
@@ -161,7 +161,7 @@ public class PerformanceClient {
         if (arguments.topics.size() != 1) {
             System.err.println("Only one topic name is allowed");
             jc.usage();
-            PerfClientUtils.exit(-1);
+            PerfClientUtils.exit(1);
         }
 
         if (arguments.confFile != null) {

--- a/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/BrokerMonitor.java
+++ b/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/BrokerMonitor.java
@@ -479,7 +479,7 @@ public class BrokerMonitor {
         } catch (ParameterException e) {
             System.out.println(e.getMessage());
             jc.usage();
-            PerfClientUtils.exit(-1);
+            PerfClientUtils.exit(1);
         }
         final ZooKeeper zkClient = new ZooKeeper(arguments.connectString, ZOOKEEPER_TIMEOUT_MILLIS, null);
         final BrokerMonitor monitor = new BrokerMonitor(zkClient);

--- a/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/CmdGenerateDocumentation.java
+++ b/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/CmdGenerateDocumentation.java
@@ -53,12 +53,12 @@ public class CmdGenerateDocumentation {
         } catch (ParameterException e) {
             System.out.println(e.getMessage());
             jc.usage();
-            PerfClientUtils.exit(-1);
+            PerfClientUtils.exit(1);
         }
 
         if (arguments.help) {
             jc.usage();
-            PerfClientUtils.exit(-1);
+            PerfClientUtils.exit(1);
         }
 
         Map<String, Class<?>> cmdClassMap = new LinkedHashMap<>();

--- a/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/LoadSimulationClient.java
+++ b/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/LoadSimulationClient.java
@@ -343,7 +343,7 @@ public class LoadSimulationClient {
         } catch (ParameterException e) {
             System.out.println(e.getMessage());
             jc.usage();
-            PerfClientUtils.exit(-1);
+            PerfClientUtils.exit(1);
         }
         PerfClientUtils.printJVMInformation(log);
         (new LoadSimulationClient(mainArguments)).run();

--- a/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/LoadSimulationController.java
+++ b/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/LoadSimulationController.java
@@ -723,7 +723,7 @@ public class LoadSimulationController {
         } catch (Exception ex) {
             System.out.println(ex.getMessage());
             jc.usage();
-            PerfClientUtils.exit(-1);
+            PerfClientUtils.exit(1);
         }
         (new LoadSimulationController(arguments)).run();
     }

--- a/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/ManagedLedgerWriter.java
+++ b/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/ManagedLedgerWriter.java
@@ -149,12 +149,12 @@ public class ManagedLedgerWriter {
         } catch (ParameterException e) {
             System.out.println(e.getMessage());
             jc.usage();
-            PerfClientUtils.exit(-1);
+            PerfClientUtils.exit(1);
         }
 
         if (arguments.help) {
             jc.usage();
-            PerfClientUtils.exit(-1);
+            PerfClientUtils.exit(1);
         }
 
         if (arguments.metadataStoreUrl == null && arguments.zookeeperServers == null) {
@@ -280,7 +280,7 @@ public class ManagedLedgerWriter {
                         @Override
                         public void addFailed(ManagedLedgerException exception, Object ctx) {
                             log.warn("Write error on message", exception);
-                            PerfClientUtils.exit(-1);
+                            PerfClientUtils.exit(1);
                         }
                     };
 

--- a/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceBaseArguments.java
+++ b/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceBaseArguments.java
@@ -157,7 +157,7 @@ public abstract class PerformanceBaseArguments {
             } catch (IllegalArgumentException e) {
                 System.out.println("Incorrect proxyProtocol name '" + proxyProtocolString + "'");
                 e.printStackTrace();
-                exit(-1);
+                exit(1);
             }
 
         }

--- a/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceConsumer.java
+++ b/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceConsumer.java
@@ -211,12 +211,12 @@ public class PerformanceConsumer {
         } catch (ParameterException e) {
             System.out.println(e.getMessage());
             jc.usage();
-            PerfClientUtils.exit(-1);
+            PerfClientUtils.exit(1);
         }
 
         if (arguments.help) {
             jc.usage();
-            PerfClientUtils.exit(-1);
+            PerfClientUtils.exit(1);
         }
 
         if (isBlank(arguments.authPluginClassName) && !isBlank(arguments.deprecatedAuthPluginClassName)) {
@@ -228,7 +228,7 @@ public class PerformanceConsumer {
                 System.out.printf("invalid option: '%s'\nTo use a topic with the name '%s', "
                         + "please use a fully qualified topic name\n", arg, arg);
                 jc.usage();
-                PerfClientUtils.exit(-1);
+                PerfClientUtils.exit(1);
             }
         }
 
@@ -244,14 +244,14 @@ public class PerformanceConsumer {
             } else {
                 System.out.println("The size of topics list should be equal to --num-topics");
                 jc.usage();
-                PerfClientUtils.exit(-1);
+                PerfClientUtils.exit(1);
             }
         }
 
         if (arguments.subscriptionType == SubscriptionType.Exclusive && arguments.numConsumers > 1) {
             System.out.println("Only one consumer is allowed when subscriptionType is Exclusive");
             jc.usage();
-            PerfClientUtils.exit(-1);
+            PerfClientUtils.exit(1);
         }
 
         if (arguments.subscriptions != null && arguments.subscriptions.size() != arguments.numSubscriptions) {
@@ -268,7 +268,7 @@ public class PerformanceConsumer {
             } else {
                 System.out.println("The size of subscriptions list should be equal to --num-subscriptions");
                 jc.usage();
-                PerfClientUtils.exit(-1);
+                PerfClientUtils.exit(1);
             }
         }
         arguments.fillArgumentsFromProperties();

--- a/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceProducer.java
+++ b/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceProducer.java
@@ -280,12 +280,12 @@ public class PerformanceProducer {
         } catch (ParameterException e) {
             System.out.println(e.getMessage());
             jc.usage();
-            PerfClientUtils.exit(-1);
+            PerfClientUtils.exit(1);
         }
 
         if (arguments.help) {
             jc.usage();
-            PerfClientUtils.exit(-1);
+            PerfClientUtils.exit(1);
         }
 
         if (isBlank(arguments.authPluginClassName) && !isBlank(arguments.deprecatedAuthPluginClassName)) {
@@ -297,7 +297,7 @@ public class PerformanceProducer {
                 System.out.printf("invalid option: '%s'\nTo use a topic with the name '%s', "
                         + "please use a fully qualified topic name\n", arg, arg);
                 jc.usage();
-                PerfClientUtils.exit(-1);
+                PerfClientUtils.exit(1);
             }
         }
 
@@ -313,7 +313,7 @@ public class PerformanceProducer {
             } else {
                 System.out.println("The size of topics list should be equal to --num-topic");
                 jc.usage();
-                PerfClientUtils.exit(-1);
+                PerfClientUtils.exit(1);
             }
         }
 
@@ -379,7 +379,7 @@ public class PerformanceProducer {
                             log.error("Topic {} already exists but it has a wrong number of partitions: {}, "
                                             + "expecting {}",
                                     topic, partitionedTopicMetadata.partitions, arguments.partitions);
-                            PerfClientUtils.exit(-1);
+                            PerfClientUtils.exit(1);
                         }
                     }
                 }
@@ -692,7 +692,7 @@ public class PerformanceProducer {
                         log.warn("Write message error with exception", ex);
                         messagesFailed.increment();
                         if (arguments.exitOnFailure) {
-                            PerfClientUtils.exit(-1);
+                            PerfClientUtils.exit(1);
                         }
                         return null;
                     });
@@ -753,7 +753,7 @@ public class PerformanceProducer {
             if (null != client) {
                 try {
                     client.close();
-                    PerfClientUtils.exit(-1);
+                    PerfClientUtils.exit(1);
                 } catch (PulsarClientException e) {
                     log.error("Failed to close test client", e);
                 }

--- a/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceReader.java
+++ b/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceReader.java
@@ -114,12 +114,12 @@ public class PerformanceReader {
         } catch (ParameterException e) {
             System.out.println(e.getMessage());
             jc.usage();
-            PerfClientUtils.exit(-1);
+            PerfClientUtils.exit(1);
         }
 
         if (arguments.help) {
             jc.usage();
-            PerfClientUtils.exit(-1);
+            PerfClientUtils.exit(1);
         }
 
         for (String arg : arguments.topic) {
@@ -127,7 +127,7 @@ public class PerformanceReader {
                 System.out.printf("invalid option: '%s'\nTo use a topic with the name '%s', "
                         + "please use a fully qualified topic name\n", arg, arg);
                 jc.usage();
-                PerfClientUtils.exit(-1);
+                PerfClientUtils.exit(1);
             }
         }
 
@@ -143,7 +143,7 @@ public class PerformanceReader {
             } else {
                 System.out.println("The size of topics list should be equal to --num-topics");
                 jc.usage();
-                PerfClientUtils.exit(-1);
+                PerfClientUtils.exit(1);
             }
         }
         arguments.fillArgumentsFromProperties();

--- a/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceTransaction.java
+++ b/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceTransaction.java
@@ -195,12 +195,12 @@ public class PerformanceTransaction {
         } catch (ParameterException e) {
             System.out.println(e.getMessage());
             jc.usage();
-            PerfClientUtils.exit(-1);
+            PerfClientUtils.exit(1);
         }
 
         if (arguments.help) {
             jc.usage();
-            PerfClientUtils.exit(-1);
+            PerfClientUtils.exit(1);
         }
         arguments.fillArgumentsFromProperties();
 
@@ -235,7 +235,7 @@ public class PerformanceTransaction {
                             log.error(
                                     "Topic {} already exists but it has a wrong number of partitions: {}, expecting {}",
                                     topic, partitionedTopicMetadata.partitions, arguments.partitions);
-                            PerfClientUtils.exit(-1);
+                            PerfClientUtils.exit(1);
                         }
                     }
                 }
@@ -292,7 +292,7 @@ public class PerformanceTransaction {
                     } catch (Exception e) {
                         log.error("Failed to build Producer/Consumer with exception : ", e);
                         executorService.shutdownNow();
-                        PerfClientUtils.exit(-1);
+                        PerfClientUtils.exit(1);
                     }
                     //The while loop has no break, and finally ends the execution through the shutdownNow of
                     //the executorService
@@ -330,7 +330,7 @@ public class PerformanceTransaction {
                                         } catch (PulsarClientException e) {
                                             log.error("Receive message failed", e);
                                             executorService.shutdownNow();
-                                            PerfClientUtils.exit(-1);
+                                            PerfClientUtils.exit(1);
                                         }
                                         long receiveTime = System.nanoTime();
                                         if (!arguments.isDisableTransaction) {

--- a/pulsar-testclient/src/test/java/org/apache/pulsar/testclient/PerformanceBaseArgumentsTest.java
+++ b/pulsar-testclient/src/test/java/org/apache/pulsar/testclient/PerformanceBaseArgumentsTest.java
@@ -144,10 +144,7 @@ public class PerformanceBaseArgumentsTest {
             args.confFile = "./src/test/resources/performance_client3.conf";
             PerfClientUtils.setExitProcedure(code -> {
                 calledVar2.set(true);
-                Assert.assertNotNull(code);
-                if (code != -1) {
-                    fail("Incorrect exit code");
-                }
+                Assert.assertEquals(code, 1, "Incorrect exit code");
             });
 
             args.confFile = "./src/test/resources/performance_client3.conf";


### PR DESCRIPTION
Return code -1 is generally considered to be an invalid code. https://tldp.org/LDP/abs/html/exitcodes.html
Replace return code -1 with 1 which is commonly used as a general error.

Fixes #18945

### Motivation

There are a lot of cases in the pulsar cli tools where a `-1` is returned as the return code when there is an error executing the command.  This is generally considered an invalid return code and the code should be an integer between 0 and 255, with `1` commonly used as a general error code when specific error codes are not defined.  Because `-1` is invalid, running a pulsar command which fails will actually return a `255` because `255` is used to indicate that the return code is out of range.

### Modifications

Updated the CLI commands to return `1` instead of `-1` when there is an error.

### Verifying this change

- [X] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] Anything that affects deployment

I'm not sure if there are other applications which depend on the current specific return codes, but it's doubtful that there are many cases.  Normally, scripts just check for a non-zero return code and don't look specifically for a 255.  If there are a significant number of users that depend directly on the 255 return code, then we might have to make this change more gradually.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [X] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/pgier/pulsar/pull/7

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
