### PR TITLE
[cleanup][io] Remove useless kafka server dep in debezium sources

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -178,8 +178,6 @@ flexible messaging model and an intuitive client API.</description>
     <opensearch.version>1.2.4</opensearch.version>
     <elasticsearch-java.version>8.5.2</elasticsearch-java.version>
     <trino.version>363</trino.version>
-    <scala.binary.version>2.13</scala.binary.version>
-    <scala-library.version>2.13.10</scala-library.version>
     <debezium.version>1.9.7.Final</debezium.version>
     <debezium.postgresql.version>42.5.0</debezium.postgresql.version>
     <debezium.mysql.version>8.0.30</debezium.mysql.version>
@@ -1339,19 +1337,6 @@ flexible messaging model and an intuitive client API.</description>
         <artifactId>RoaringBitmap</artifactId>
         <version>${roaringbitmap.version}</version>
       </dependency>
-
-      <dependency>
-        <groupId>org.scala-lang</groupId>
-        <artifactId>scala-library</artifactId>
-        <version>${scala-library.version}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>org.scala-lang</groupId>
-        <artifactId>scala-reflect</artifactId>
-        <version>${scala-library.version}</version>
-      </dependency>
-
     </dependencies>
   </dependencyManagement>
 

--- a/pulsar-io/debezium/core/pom.xml
+++ b/pulsar-io/debezium/core/pom.xml
@@ -64,12 +64,6 @@
 
     <dependency>
       <groupId>org.apache.kafka</groupId>
-      <artifactId>kafka_${scala.binary.version}</artifactId>
-      <version>${kafka-client.version}</version>
-    </dependency>
-
-    <dependency>
-      <groupId>org.apache.kafka</groupId>
       <artifactId>connect-runtime</artifactId>
       <version>${kafka-client.version}</version>
       <exclusions>


### PR DESCRIPTION
### Motivation

Pulsar IO debezium sources depends on kafka (the whole server) but it only actually needs kafka-connect framework. 

### Modifications

* Removed kafka dependency from `debezium-core` and all the related dependencies (scala) 

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

Fork pull: https://github.com/nicoloboschi/pulsar/pull/42