### PR TITLE
[improve][doc] Update PR template and PIP for metrics changes

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -24,6 +24,8 @@ Master Issue: #xyz
 
 PIP: #xyz 
 
+<!-- Details of when a PIP is required and how the PIP process work, please see: https://github.com/apache/pulsar/blob/master/wiki/proposals/PIP.md -->
+
 ### Motivation
 
 <!-- Explain here the context, and why you're making that change. What is the problem you're trying to solve. -->
@@ -68,8 +70,6 @@ This change added tests and can be verified as follows:
 - [ ] The admin CLI options
 - [ ] The metrics
 - [ ] Anything that affects deployment
-
-<!-- NOTE: A PIP is required if the PR will change any parts of the above. See https://github.com/apache/pulsar/blob/master/wiki/proposals/PIP.md -->
 
 ### Documentation
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -20,6 +20,10 @@ Fixes #xyz
 
 Master Issue: #xyz
 
+<!-- If the PR belongs to a PIP, please add the PIP link here -->
+
+PIP: #xyz 
+
 ### Motivation
 
 <!-- Explain here the context, and why you're making that change. What is the problem you're trying to solve. -->
@@ -50,6 +54,8 @@ This change added tests and can be verified as follows:
 
 ### Does this pull request potentially affect one of the following parts:
 
+<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->
+
 *If the box was checked, please highlight the changes*
 
 - [ ] Dependencies (add or upgrade a dependency)
@@ -60,7 +66,10 @@ This change added tests and can be verified as follows:
 - [ ] The binary protocol
 - [ ] The REST endpoints
 - [ ] The admin CLI options
+- [ ] The metrics
 - [ ] Anything that affects deployment
+
+<!-- NOTE: A PIP is required if the PR will change any parts of the above. See https://github.com/apache/pulsar/blob/master/wiki/proposals/PIP.md -->
 
 ### Documentation
 

--- a/wiki/proposals/PIP.md
+++ b/wiki/proposals/PIP.md
@@ -41,6 +41,7 @@ It is not a goal for PIP to add undue process or slow-down the development.
 * Any change to the semantic of existing functionality, even when current
   behavior is incorrect.
 * Any large code change that will touch multiple components
+* Any changes to the metrics (metrics endpoint, topic stats, topics internal stats, broker stats, etc.)
 
 ## When is a PIP *not* required?
 


### PR DESCRIPTION
### Motivation

Update PR template and PIP for metrics changes according to the [discussion](https://lists.apache.org/thread/bmwtk6zcyt4ft4t95jmz1bnsxbysjw8m) under the mailing list

### Modifications

- Add PIP link option to PR template
- Add metrics change to the checklist of the PR template
- Update PIP.md for requiring PIP for metrics changes

### Does this pull request potentially affect one of the following parts:

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [x] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->
