### PR TITLE
[improvement] Avoid leaks  when use computeIfAbsent in ConcurrentLongHashMap and ConcurrentOpenHashMap

### DIFF
--- a/pulsar-common/src/main/java/org/apache/pulsar/common/util/collections/ConcurrentLongHashMap.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/util/collections/ConcurrentLongHashMap.java
@@ -361,6 +361,9 @@ public class ConcurrentLongHashMap<V> {
         }
 
         V put(long key, V value, int keyHash, boolean onlyIfAbsent, LongFunction<V> valueProvider) {
+            if (value == null) {
+                requireNonNull(valueProvider.apply(key));
+            }
             int bucket = keyHash;
 
             long stamp = writeLock();

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/util/collections/ConcurrentOpenHashMap.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/util/collections/ConcurrentOpenHashMap.java
@@ -377,6 +377,9 @@ public class ConcurrentOpenHashMap<K, V> {
         }
 
         V put(K key, V value, int keyHash, boolean onlyIfAbsent, Function<K, V> valueProvider) {
+            if (value == null) {
+                requireNonNull(valueProvider.apply(key));
+            }
             long stamp = writeLock();
             int bucket = signSafeMod(keyHash, capacity);
 

--- a/pulsar-common/src/test/java/org/apache/pulsar/common/util/collections/ConcurrentLongHashMapTest.java
+++ b/pulsar-common/src/test/java/org/apache/pulsar/common/util/collections/ConcurrentLongHashMapTest.java
@@ -529,6 +529,38 @@ public class ConcurrentLongHashMapTest {
         assertEquals(map.get(2).intValue(), 2);
     }
 
+    @Test
+    public void testPutWhenNull() {
+        ConcurrentLongHashMap<Integer> map = ConcurrentLongHashMap.<Integer>newBuilder()
+                .expectedItems(5)
+                .concurrencyLevel(1)
+                .autoShrink(true)
+                .build();
+        try {
+            map.put(0, null);
+            fail("should have thrown exception");
+        } catch (NullPointerException e) {
+            // ok
+        }
+    }
+
+    @Test
+    public void testComputeIfAbsentWhenNull() {
+        ConcurrentLongHashMap<Integer> map = ConcurrentLongHashMap.<Integer>newBuilder()
+                .expectedItems(5)
+                .concurrencyLevel(1)
+                .autoShrink(true)
+                .build();
+
+        LongFunction<Integer> nullProvider = key -> null;
+        try {
+            map.computeIfAbsent(0, nullProvider);
+            fail("should have thrown exception");
+        } catch (NullPointerException e) {
+            // ok
+        }
+    }
+
     static final int Iterations = 1;
     static final int ReadIterations = 10000;
     static final int N = 100_000;

--- a/pulsar-common/src/test/java/org/apache/pulsar/common/util/collections/ConcurrentOpenHashMapTest.java
+++ b/pulsar-common/src/test/java/org/apache/pulsar/common/util/collections/ConcurrentOpenHashMapTest.java
@@ -464,6 +464,37 @@ public class ConcurrentOpenHashMapTest {
     }
 
     @Test
+    public void testPutWhenNull() {
+        ConcurrentOpenHashMap<Integer, Integer> map = ConcurrentOpenHashMap.<Integer, Integer>newBuilder()
+                .expectedItems(16)
+                .concurrencyLevel(1)
+                .build();
+        try {
+            map.put(0, null);
+            fail("should have thrown exception");
+        } catch (NullPointerException e) {
+            // ok
+        }
+    }
+
+    @Test
+    public void testComputeIfAbsentWhenNull() {
+        ConcurrentOpenHashMap<Integer, Integer> map = ConcurrentOpenHashMap.<Integer, Integer>newBuilder()
+                .expectedItems(16)
+                .concurrencyLevel(1)
+                .autoShrink(true)
+                .build();
+
+        Function<Integer, Integer>  nullProvider = key -> null;
+        try {
+            map.computeIfAbsent(0, nullProvider);
+            fail("should have thrown exception");
+        } catch (NullPointerException e) {
+            // ok
+        }
+    }
+
+    @Test
     public void testEqualsKeys() {
         class T {
             int value;


### PR DESCRIPTION
The PR was introduced in bookkeeper's PR：https://github.com/apache/bookkeeper/pull/3706


- [ ] `doc` <!-- Your PR contains doc changes -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->