### PR TITLE
[improve] Add PulsarExceptionBase class that supports slf4j like parameterized string formatting

### DIFF
--- a/pulsar-common/src/main/java/org/apache/pulsar/common/exception/PulsarExceptionBase.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/exception/PulsarExceptionBase.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.common.exception;
+
+import org.slf4j.helpers.MessageFormatter;
+
+public abstract class PulsarExceptionBase extends Exception {
+
+    protected static String format(String message, Object... os) {
+        Throwable throwableCandidate = MessageFormatter.getThrowableCandidate(os);
+        Object[] args = os;
+        if (throwableCandidate != null) {
+            args = MessageFormatter.trimmedCopy(os);
+        }
+        return MessageFormatter.arrayFormat(message, args, null).getMessage();
+    }
+
+    private static final long serialVersionUID = -2343132778619884518L;
+
+    protected PulsarExceptionBase() {
+        super();
+    }
+
+    protected PulsarExceptionBase(String message) {
+        super(message);
+    }
+
+    protected PulsarExceptionBase(String message, Object... os) {
+        this(format(message, os), MessageFormatter.getThrowableCandidate(os));
+    }
+
+    protected PulsarExceptionBase(Throwable cause) {
+        super(cause);
+    }
+
+    protected PulsarExceptionBase(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+}

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/exception/package-info.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/exception/package-info.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+/**
+ * Exception classes
+ */
+package org.apache.pulsar.common.exception;

--- a/pulsar-common/src/test/java/org/apache/pulsar/exception/PulsarExceptionSample.java
+++ b/pulsar-common/src/test/java/org/apache/pulsar/exception/PulsarExceptionSample.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.exception;
+
+import org.apache.pulsar.common.exception.PulsarExceptionBase;
+
+public class PulsarExceptionSample extends PulsarExceptionBase {
+
+    protected PulsarExceptionSample() {
+        super();
+    }
+
+    protected PulsarExceptionSample(String message) {
+        super(message);
+    }
+
+    protected PulsarExceptionSample(String message, Object... os) {
+        super(message, os);
+    }
+
+    protected PulsarExceptionSample(Throwable cause) {
+        super(cause);
+    }
+
+    protected PulsarExceptionSample(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/pulsar-common/src/test/java/org/apache/pulsar/exception/PulsarExceptionTest.java
+++ b/pulsar-common/src/test/java/org/apache/pulsar/exception/PulsarExceptionTest.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.exception;
+
+import org.testng.annotations.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class PulsarExceptionTest {
+
+    @Test
+    public void testPulsarExceptionWithParameters() {
+
+        String key = "123";
+        String value = "abc";
+
+        PulsarExceptionSample testException =
+                new PulsarExceptionSample("key={}, value={}", key, value);
+        assertThat(testException.getMessage()).isEqualTo("key=123, value=abc");
+    }
+
+    @Test
+    public void testPulsarExceptionSimple() {
+
+        PulsarExceptionSample testException =
+                new PulsarExceptionSample("Simple Message");
+        assertThat(testException.getMessage()).isEqualTo("Simple Message");
+    }
+
+    @Test
+    public void testPulsarExceptionCompound() {
+
+        int key = 123;
+        String value = "abc";
+
+        PulsarExceptionSample testException =
+                new PulsarExceptionSample("key={}, value={}", key, value, new Exception("inner exception"));
+
+        assertThat(testException.getMessage()).contains("key=123, value=abc");
+        assertThat(testException.getCause().getMessage()).isEqualTo("inner exception");
+    }
+}


### PR DESCRIPTION
### Motivation

We frequently have to pass strings to exceptions, similar to log4j , this allows us to use the same parameterized formatting in both.

### Modifications

<!-- Describe the modifications you've done. -->

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [X] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
