### PR TITLE
[fix][doc] Ammend PIP proposal around discussions 

### DIFF
--- a/wiki/proposals/PIP.md
+++ b/wiki/proposals/PIP.md
@@ -79,7 +79,10 @@ The process works in the following way:
 1. The author(s) of the proposal will create a GitHub issue ticket choosing the
    template for PIP proposals.
 2. The author(s) will send a note to the dev@pulsar.apache.org mailing list
-   to start the discussion, using subject prefix `[PIP] xxx`.
+   to start the discussion, using subject prefix `[PIP] xxx`. The discussion
+   need to happen in the mailing list. Please avoid discussing it using
+   GitHub comments in the PIP GitHub issue, as it creates two tracks 
+   of feedback.
 3. Based on the discussion and feedback, some changes might be applied by
    authors to the text of the proposal.
 4. Once some consensus is reached, there will be a vote to formally approve


### PR DESCRIPTION


<!--
### Contribution Checklist
  
  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://docs.google.com/document/d/1d8Pw6ZbWk-_pCKdOmdvx9rnhPiyuxwq60_TrD68d7BA/edit#heading=h.trs9rsex3xom)*. 

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->

### Motivation

Sometimes PIP discussion happens concurrently in the mailing list DISCUSS thread and the PIP GitHub issue using comments. This creates confusion. 

### Modifications

Modified the PIP process file to explicitly state PIP discussion should be in the mailing list and not in the GitHub issue. This was after a [discussion](https://lists.apache.org/thread/61byrwwqq96f7f55ft1xdjc78g7mntx0) on the mailing list.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*
### Does this pull request potentially affect one of the following parts:

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [x] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->
