### PR TITLE
[fix][sec]: upgrade org.testng:testng to 7.7.0

### DIFF
--- a/buildtools/pom.xml
+++ b/buildtools/pom.xml
@@ -41,7 +41,7 @@
     <surefire.version>3.0.0-M3</surefire.version>
     <log4j2.version>2.18.0</log4j2.version>
     <slf4j.version>1.7.32</slf4j.version>
-    <testng.version>7.6.1</testng.version>
+    <testng.version>7.7.0</testng.version>
     <commons-lang3.version>3.11</commons-lang3.version>
     <license-maven-plugin.version>4.1</license-maven-plugin.version>
     <maven-shade-plugin.version>3.4.0</maven-shade-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -241,7 +241,7 @@ flexible messaging model and an intuitive client API.</description>
     <!-- Set docker-java.version to the version of docker-java used in Testcontainers -->
     <docker-java.version>3.2.13</docker-java.version>
     <kerby.version>1.1.1</kerby.version>
-    <testng.version>7.6.1</testng.version>
+    <testng.version>7.7.0</testng.version>
     <mockito.version>3.12.4</mockito.version>
     <javassist.version>3.25.0-GA</javassist.version>
     <skyscreamer.version>1.5.0</skyscreamer.version>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.testng:testng 7.6.1
- [CVE-2022-4065](https://www.oscs1024.com/hd/CVE-2022-4065)


### What did I do？
Upgrade org.testng:testng from 7.6.1 to  for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS
Signed-off-by:pen4<948453219@qq.com>