### PR TITLE
[improve][pip-230] Throw exception when MessageIdImpl and BatchMessageIdImpl compare with each other

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MessageIdImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MessageIdImpl.java
@@ -204,11 +204,13 @@ public class MessageIdImpl implements MessageId {
     @Override
     public int compareTo(@Nonnull MessageId o) {
         if (o instanceof MessageIdImpl) {
+            if (o instanceof BatchMessageIdImpl) {
+                throw new UnsupportedOperationException(this.getClass().getName()
+                        + " can't compare with " + o.getClass().getName());
+            }
             MessageIdImpl other = (MessageIdImpl) o;
-            int batchIndex = (o instanceof BatchMessageIdImpl) ? ((BatchMessageIdImpl) o).getBatchIndex() : NO_BATCH;
             return messageIdCompare(
-                this.ledgerId, this.entryId, this.partitionIndex, NO_BATCH,
-                other.ledgerId, other.entryId, other.partitionIndex, batchIndex
+                this.ledgerId, this.entryId, this.partitionIndex, other.ledgerId, other.entryId, other.partitionIndex
             );
         } else if (o instanceof TopicMessageIdImpl) {
             return compareTo(((TopicMessageIdImpl) o).getInnerMessageId());
@@ -222,14 +224,13 @@ public class MessageIdImpl implements MessageId {
     }
 
     static int messageIdCompare(
-        long ledgerId1, long entryId1, int partitionIndex1, int batchIndex1,
-        long ledgerId2, long entryId2, int partitionIndex2, int batchIndex2
+            long ledgerId1, long entryId1, int partitionIndex1,
+            long ledgerId2, long entryId2, int partitionIndex2
     ) {
         return ComparisonChain.start()
-            .compare(ledgerId1, ledgerId2)
-            .compare(entryId1, entryId2)
-            .compare(partitionIndex1, partitionIndex2)
-            .compare(batchIndex1, batchIndex2)
-            .result();
+                .compare(ledgerId1, ledgerId2)
+                .compare(entryId1, entryId2)
+                .compare(partitionIndex1, partitionIndex2)
+                .result();
     }
 }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PersistentAcknowledgmentsGroupingTracker.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PersistentAcknowledgmentsGroupingTracker.java
@@ -666,13 +666,13 @@ class LastCumulativeAck {
         if (this.messageId instanceof BatchMessageIdImpl && (!(messageId instanceof BatchMessageIdImpl))) {
             final BatchMessageIdImpl lhs = (BatchMessageIdImpl) this.messageId;
             final MessageIdImpl rhs = (MessageIdImpl) messageId;
-            return MessageIdImpl.messageIdCompare(
+            return BatchMessageIdImpl.messageIdCompare(
                     lhs.getLedgerId(), lhs.getEntryId(), lhs.getPartitionIndex(), lhs.getBatchIndex(),
                     rhs.getLedgerId(), rhs.getEntryId(), rhs.getPartitionIndex(), Integer.MAX_VALUE);
         } else if (messageId instanceof BatchMessageIdImpl && (!(this.messageId instanceof BatchMessageIdImpl))){
             final MessageIdImpl lhs = this.messageId;
             final BatchMessageIdImpl rhs = (BatchMessageIdImpl) messageId;
-            return MessageIdImpl.messageIdCompare(
+            return BatchMessageIdImpl.messageIdCompare(
                     lhs.getLedgerId(), lhs.getEntryId(), lhs.getPartitionIndex(), Integer.MAX_VALUE,
                     rhs.getLedgerId(), rhs.getEntryId(), rhs.getPartitionIndex(), rhs.getBatchIndex());
         } else {

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/MessageIdCompareToTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/MessageIdCompareToTest.java
@@ -34,6 +34,14 @@ import org.testng.annotations.Test;
  */
 public class MessageIdCompareToTest  {
 
+    private static final String COMPARE_MESSAGE_ID_AND_BATCH_MESSAGE_ID_THROW_MESSAGE =
+            "org.apache.pulsar.client.impl.MessageIdImpl "
+                    + "can't compare with org.apache.pulsar.client.impl.BatchMessageIdImpl";
+
+    private static final String COMPARE_BATCH_MESSAGE_ID_AND_MESSAGE_ID_THROW_MESSAGE =
+            "org.apache.pulsar.client.impl.BatchMessageIdImpl "
+                    + "can't compare with org.apache.pulsar.client.impl.MessageIdImpl";
+
     @Test
     public void testEqual() {
         MessageIdImpl messageIdImpl1 = new MessageIdImpl(123L, 345L, 567);
@@ -111,82 +119,92 @@ public class MessageIdCompareToTest  {
     }
 
     @Test
-    public void testCompareDifferentType() {
+    public void testMessageIdImplCompareToBatchMessageIdImpl() {
         MessageIdImpl messageIdImpl = new MessageIdImpl(123L, 345L, 567);
-        BatchMessageIdImpl batchMessageId1 = new BatchMessageIdImpl(123L, 345L, 566, 789);
-        BatchMessageIdImpl batchMessageId2 = new BatchMessageIdImpl(123L, 345L, 567, 789);
-        BatchMessageIdImpl batchMessageId3 = new BatchMessageIdImpl(messageIdImpl);
-        assertTrue(messageIdImpl.compareTo(batchMessageId1) > 0, "Expected to be greater than");
-        assertTrue(messageIdImpl.compareTo(batchMessageId2) < 0, "Expected to be less than");
-        assertEquals(messageIdImpl.compareTo(batchMessageId3), 0, "Expected to be equal");
-        assertTrue(batchMessageId1.compareTo(messageIdImpl) < 0, "Expected to be less than");
-        assertTrue(batchMessageId2.compareTo(messageIdImpl) > 0, "Expected to be greater than");
-        assertEquals(batchMessageId3.compareTo(messageIdImpl), 0, "Expected to be equal");
-    }
+        BatchMessageIdImpl batchMessageId =
+                new BatchMessageIdImpl(123L, 345L, 566, 789);
+        try {
+            messageIdImpl.compareTo(batchMessageId);
+            fail();
+        } catch (Exception e) {
+            assertTrue(e instanceof UnsupportedOperationException);
+            assertEquals(e.getMessage(), COMPARE_MESSAGE_ID_AND_BATCH_MESSAGE_ID_THROW_MESSAGE);
+        }
 
-    @Test
-    public void compareToSymmetricTest() {
-        MessageIdImpl simpleMessageId = new MessageIdImpl(123L, 345L, 567);
-        // batchIndex is -1 if message is non-batched message and has the batchIndex for a batch message
-        BatchMessageIdImpl batchMessageId1 = new BatchMessageIdImpl(123L, 345L, 567, -1);
-        BatchMessageIdImpl batchMessageId2 = new BatchMessageIdImpl(123L, 345L, 567, 1);
-        BatchMessageIdImpl batchMessageId3 = new BatchMessageIdImpl(123L, 345L, 566, 1);
-        BatchMessageIdImpl batchMessageId4 = new BatchMessageIdImpl(123L, 345L, 566, -1);
+        try {
+            batchMessageId.compareTo(messageIdImpl);
+            fail();
+        } catch (Exception e) {
+            assertTrue(e instanceof UnsupportedOperationException);
+            assertEquals(e.getMessage(), COMPARE_BATCH_MESSAGE_ID_AND_MESSAGE_ID_THROW_MESSAGE);
+        }
 
-        assertEquals(simpleMessageId.compareTo(batchMessageId1), 0, "Expected to be equal");
-        assertEquals(batchMessageId1.compareTo(simpleMessageId), 0, "Expected to be equal");
-        assertTrue(batchMessageId2.compareTo(simpleMessageId) > 0, "Expected to be greater than");
-        assertTrue(simpleMessageId.compareTo(batchMessageId2) < 0, "Expected to be less than");
-        assertTrue(simpleMessageId.compareTo(batchMessageId3) > 0, "Expected to be greater than");
-        assertTrue(batchMessageId3.compareTo(simpleMessageId) < 0, "Expected to be less than");
-        assertTrue(simpleMessageId.compareTo(batchMessageId4) > 0, "Expected to be greater than");
-        assertTrue(batchMessageId4.compareTo(simpleMessageId) < 0, "Expected to be less than");
     }
 
     @Test
     public void testMessageIdImplCompareToTopicMessageId() {
         MessageIdImpl messageIdImpl = new MessageIdImpl(123L, 345L, 567);
-        TopicMessageIdImpl topicMessageId1 = new TopicMessageIdImpl(
+        TopicMessageIdImpl topicBatchMessageIdImpl = new TopicMessageIdImpl(
             "test-topic-partition-0",
             "test-topic",
             new BatchMessageIdImpl(123L, 345L, 566, 789));
         TopicMessageIdImpl topicMessageId2 = new TopicMessageIdImpl(
             "test-topic-partition-0",
             "test-topic",
-            new BatchMessageIdImpl(123L, 345L, 567, 789));
+            new MessageIdImpl(123L, 346L, 567));
         TopicMessageIdImpl topicMessageId3 = new TopicMessageIdImpl(
             "test-topic-partition-0",
             "test-topic",
-            new BatchMessageIdImpl(messageIdImpl));
-        assertTrue(messageIdImpl.compareTo(topicMessageId1) > 0, "Expected to be greater than");
+                messageIdImpl);
+        try {
+            messageIdImpl.compareTo(topicBatchMessageIdImpl);
+            fail();
+        } catch (Exception e) {
+            assertTrue(e instanceof UnsupportedOperationException);
+            assertEquals(e.getMessage(), COMPARE_MESSAGE_ID_AND_BATCH_MESSAGE_ID_THROW_MESSAGE);
+        }
+
+        try {
+            topicBatchMessageIdImpl.compareTo(messageIdImpl);
+            fail();
+        } catch (Exception e) {
+            assertTrue(e instanceof UnsupportedOperationException);
+            assertEquals(e.getMessage(), COMPARE_BATCH_MESSAGE_ID_AND_MESSAGE_ID_THROW_MESSAGE);
+        }
         assertTrue(messageIdImpl.compareTo(topicMessageId2) < 0, "Expected to be less than");
         assertEquals(messageIdImpl.compareTo(topicMessageId3), 0, "Expected to be equal");
-        assertTrue(topicMessageId1.compareTo(messageIdImpl) < 0, "Expected to be less than");
         assertTrue(topicMessageId2.compareTo(messageIdImpl) > 0, "Expected to be greater than");
         assertEquals(topicMessageId3.compareTo(messageIdImpl), 0, "Expected to be equal");
     }
 
     @Test
     public void testBatchMessageIdImplCompareToTopicMessageId() {
-        BatchMessageIdImpl messageIdImpl1 = new BatchMessageIdImpl(123L, 345L, 567, 789);
-        BatchMessageIdImpl messageIdImpl2 = new BatchMessageIdImpl(123L, 345L, 567, 0);
-        BatchMessageIdImpl messageIdImpl3 = new BatchMessageIdImpl(123L, 345L, 567, -1);
-        TopicMessageIdImpl topicMessageId1 = new TopicMessageIdImpl(
-            "test-topic-partition-0",
-            "test-topic",
-            new MessageIdImpl(123L, 345L, 566));
-        TopicMessageIdImpl topicMessageId2 = new TopicMessageIdImpl(
-            "test-topic-partition-0",
-            "test-topic",
-            new MessageIdImpl(123L, 345L, 567));
-        assertTrue(messageIdImpl1.compareTo(topicMessageId1) > 0, "Expected to be greater than");
-        assertTrue(messageIdImpl1.compareTo(topicMessageId2) > 0, "Expected to be greater than");
-        assertTrue(messageIdImpl2.compareTo(topicMessageId2) > 0, "Expected to be greater than");
-        assertEquals(messageIdImpl3.compareTo(topicMessageId2), 0, "Expected to be equal");
-        assertTrue(topicMessageId1.compareTo(messageIdImpl1) < 0, "Expected to be less than");
-        assertTrue(topicMessageId2.compareTo(messageIdImpl1) < 0, "Expected to be less than");
-        assertTrue(topicMessageId2.compareTo(messageIdImpl2) < 0, "Expected to be less than");
-        assertTrue(topicMessageId2.compareTo(messageIdImpl2) < 0, "Expected to be less than");
+        BatchMessageIdImpl messageIdImpl = new BatchMessageIdImpl(123L, 345L, 567, 789);
+        TopicMessageIdImpl topicBatchMessageId = new TopicMessageIdImpl(
+                "test-topic-partition-0",
+                "test-topic",
+                new BatchMessageIdImpl(123L, 345L, 566, 788));
+        TopicMessageIdImpl topicMessageId = new TopicMessageIdImpl(
+                "test-topic-partition-0",
+                "test-topic",
+                new MessageIdImpl(123L, 345L, 566));
+        assertTrue(messageIdImpl.compareTo(topicBatchMessageId) > 0, "Expected to be greater than");
+        assertTrue(topicBatchMessageId.compareTo(messageIdImpl) < 0, "Expected to be less than");
+        try {
+            messageIdImpl.compareTo(topicMessageId);
+            fail();
+        } catch (Exception e) {
+            assertTrue(e instanceof UnsupportedOperationException);
+            assertEquals(e.getMessage(), COMPARE_BATCH_MESSAGE_ID_AND_MESSAGE_ID_THROW_MESSAGE);
+        }
+
+        try {
+            topicMessageId.compareTo(messageIdImpl);
+            fail();
+        } catch (Exception e) {
+            assertTrue(e instanceof UnsupportedOperationException);
+            assertEquals(e.getMessage(), COMPARE_MESSAGE_ID_AND_BATCH_MESSAGE_ID_THROW_MESSAGE);
+        }
     }
 
     @Test


### PR DESCRIPTION
### Motivation
https://github.com/apache/pulsar/issues/18957

### Modifications
https://github.com/apache/pulsar/issues/18957

### Verifying this change
Add the different MessageId compareTo another MessageId test

### Does this pull request potentially affect one of the following parts:

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
