### PR TITLE
[fix][txn] Use correct tcId variable to prevent data race

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
@@ -2304,7 +2304,7 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
                     if (log.isDebugEnabled()) {
                         log.debug("Send response {} for new txn request {}", tcId.getId(), requestId);
                     }
-                    commandSender.sendNewTxnResponse(requestId, txnID, command.getTcId());
+                    commandSender.sendNewTxnResponse(requestId, txnID, tcId.getId());
                 } else {
                     if (ex instanceof CoordinatorException.ReachMaxActiveTxnException) {
                         // if new txn throw ReachMaxActiveTxnException, don't return any response to client,


### PR DESCRIPTION
### Motivation

The `command` generated protobuf object is not meant to be shared across threads. Instead, we need to copy relevant values into other variables. In the `handleNewTxn` we did not follow this paradigm in the "happy path".

### Modifications

* Replace `command` with `tcId` since the latter is a final variable meant to be published to another thread.

### Verifying this change

This is a trivial change that is already covered by tests.

### Documentation

- [x] `doc-not-needed` 

This is an internal change.

### Matching PR in forked repository

PR in forked repository: https://github.com/michaeljmarshall/pulsar/pull/8
