### PR TITLE
[fix][broker] Fix deadlock in PendingAckHandleImpl

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/pendingack/impl/PendingAckHandleImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/pendingack/impl/PendingAckHandleImpl.java
@@ -938,23 +938,18 @@ public class PendingAckHandleImpl extends PendingAckHandleState implements Pendi
     }
 
     public void completeHandleFuture() {
-        synchronized (this.pendingAckHandleCompletableFuture) {
-            if (!this.pendingAckHandleCompletableFuture.isDone()) {
-                this.pendingAckHandleCompletableFuture.complete(PendingAckHandleImpl.this);
-            }
-            if (recoverTime.getRecoverStartTime() != 0L) {
-                recoverTime.setRecoverEndTime(System.currentTimeMillis());
-            }
+        if (!this.pendingAckHandleCompletableFuture.isDone()) {
+            this.pendingAckHandleCompletableFuture.complete(PendingAckHandleImpl.this);
         }
-
+        if (recoverTime.getRecoverStartTime() != 0L) {
+            recoverTime.setRecoverEndTime(System.currentTimeMillis());
+        }
     }
 
     public void exceptionHandleFuture(Throwable t) {
-        synchronized (this.pendingAckHandleCompletableFuture) {
-            if (!this.pendingAckHandleCompletableFuture.isDone()) {
-                this.pendingAckHandleCompletableFuture.completeExceptionally(t);
-                recoverTime.setRecoverEndTime(System.currentTimeMillis());
-            }
+        if (!this.pendingAckHandleCompletableFuture.isDone()) {
+            this.pendingAckHandleCompletableFuture.completeExceptionally(t);
+            recoverTime.setRecoverEndTime(System.currentTimeMillis());
         }
     }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/pendingack/impl/PendingAckHandleImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/pendingack/impl/PendingAckHandleImpl.java
@@ -938,17 +938,15 @@ public class PendingAckHandleImpl extends PendingAckHandleState implements Pendi
     }
 
     public void completeHandleFuture() {
-        if (!this.pendingAckHandleCompletableFuture.isDone()) {
-            this.pendingAckHandleCompletableFuture.complete(PendingAckHandleImpl.this);
-        }
-        if (recoverTime.getRecoverStartTime() != 0L) {
+        this.pendingAckHandleCompletableFuture.complete(PendingAckHandleImpl.this);
+        if (recoverTime.getRecoverStartTime() != 0L && recoverTime.getRecoverEndTime() == 0L) {
             recoverTime.setRecoverEndTime(System.currentTimeMillis());
         }
     }
 
     public void exceptionHandleFuture(Throwable t) {
-        if (!this.pendingAckHandleCompletableFuture.isDone()) {
-            this.pendingAckHandleCompletableFuture.completeExceptionally(t);
+        final boolean completedNow = this.pendingAckHandleCompletableFuture.completeExceptionally(t);
+        if (completedNow) {
             recoverTime.setRecoverEndTime(System.currentTimeMillis());
         }
     }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/pendingack/impl/PendingAckHandleImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/pendingack/impl/PendingAckHandleImpl.java
@@ -162,13 +162,13 @@ public class PendingAckHandleImpl extends PendingAckHandleState implements Pendi
                         completeHandleFuture();
                     }
                 }, internalPinnedExecutor)
-                .exceptionally(e -> {
+                .exceptionallyAsync(e -> {
                     Throwable t = FutureUtil.unwrapCompletionException(e);
                     changeToErrorState();
                     exceptionHandleFuture(t);
                     this.pendingAckStoreFuture.completeExceptionally(t);
                     return null;
-                });
+                }, internalPinnedExecutor);
     }
 
     private void initPendingAckStore() {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/pendingack/impl/PendingAckHandleImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/pendingack/impl/PendingAckHandleImpl.java
@@ -937,19 +937,24 @@ public class PendingAckHandleImpl extends PendingAckHandleState implements Pendi
         return transactionPendingAckStats;
     }
 
-    public synchronized void completeHandleFuture() {
-        if (!this.pendingAckHandleCompletableFuture.isDone()) {
-            this.pendingAckHandleCompletableFuture.complete(PendingAckHandleImpl.this);
+    public void completeHandleFuture() {
+        synchronized (this.pendingAckHandleCompletableFuture) {
+            if (!this.pendingAckHandleCompletableFuture.isDone()) {
+                this.pendingAckHandleCompletableFuture.complete(PendingAckHandleImpl.this);
+            }
+            if (recoverTime.getRecoverStartTime() != 0L) {
+                recoverTime.setRecoverEndTime(System.currentTimeMillis());
+            }
         }
-        if (recoverTime.getRecoverStartTime() != 0L) {
-            recoverTime.setRecoverEndTime(System.currentTimeMillis());
-        }
+
     }
 
-    public synchronized void exceptionHandleFuture(Throwable t) {
-        if (!this.pendingAckHandleCompletableFuture.isDone()) {
-            this.pendingAckHandleCompletableFuture.completeExceptionally(t);
-            recoverTime.setRecoverEndTime(System.currentTimeMillis());
+    public void exceptionHandleFuture(Throwable t) {
+        synchronized (this.pendingAckHandleCompletableFuture) {
+            if (!this.pendingAckHandleCompletableFuture.isDone()) {
+                this.pendingAckHandleCompletableFuture.completeExceptionally(t);
+                recoverTime.setRecoverEndTime(System.currentTimeMillis());
+            }
         }
     }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/pendingack/impl/PendingAckHandleImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/pendingack/impl/PendingAckHandleImpl.java
@@ -155,13 +155,13 @@ public class PendingAckHandleImpl extends PendingAckHandleState implements Pendi
                         .getBrokerService().getPulsar().getTransactionPendingAckStoreProvider();
 
         pendingAckStoreProvider.checkInitializedBefore(persistentSubscription)
-                .thenAccept(init -> {
+                .thenAcceptAsync(init -> {
                     if (init) {
                         initPendingAckStore();
                     } else {
                         completeHandleFuture();
                     }
-                })
+                }, internalPinnedExecutor)
                 .exceptionally(e -> {
                     Throwable t = FutureUtil.unwrapCompletionException(e);
                     changeToErrorState();


### PR DESCRIPTION
Fixes #18988

### Motivation

Based on stacktrace in the issue, in `PendingAckHandleImpl`, if the first time `pendingAckHandleCompletableFuture` is completed via the method `addConsumer` the `PendingAckHandleImpl` object is locked to the current thread because the method `completeHandleFuture` is synchronized. The `addConsumer` then locks the `PersistentSubscription`. In the reverse order the subscription closing procedure locks the `PersistentSubscription` object and then `PendingAckHandleImpl`. 
It's possible that if they run concurrently it ends up in a deadlock 

### Modifications

* Remove synchronized from `completeHandleFuture` methods. In this way the `PendingAckHandleImpl` object isn't locked in the stages chain.
* Moved the init callback to use the internal executor instead of the metadata store executor


I haven't added tests since I wasn't able to reproduce it programmatically.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->
