### PR TITLE
[fix][broker] forbid uploading BYTES schema with admin API

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/SchemasResourceBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/SchemasResourceBase.java
@@ -115,8 +115,8 @@ public class SchemasResourceBase extends AdminResource {
 
     public CompletableFuture<SchemaVersion> postSchemaAsync(PostSchemaPayload payload, boolean authoritative) {
         if (SchemaType.BYTES.name().equals(payload.getType())) {
-            throw new RestException(Response.Status.NOT_ACCEPTABLE,
-                    "Do not upload a BYTES schema, because it's the default schema type");
+            return CompletableFuture.failedFuture(new RestException(Response.Status.NOT_ACCEPTABLE,
+                    "Do not upload a BYTES schema, because it's the default schema type"));
         }
         return validateOwnershipAndOperationAsync(authoritative, TopicOperation.PRODUCE)
                 .thenCompose(__ -> getSchemaCompatibilityStrategyAsyncWithoutAuth())

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/SchemasResourceBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/SchemasResourceBase.java
@@ -114,6 +114,10 @@ public class SchemasResourceBase extends AdminResource {
     }
 
     public CompletableFuture<SchemaVersion> postSchemaAsync(PostSchemaPayload payload, boolean authoritative) {
+        if (SchemaType.BYTES.name().equals(payload.getType())) {
+            throw new RestException(Response.Status.NOT_ACCEPTABLE,
+                    "Do not upload a BYTES schema, because it's the default schema type");
+        }
         return validateOwnershipAndOperationAsync(authoritative, TopicOperation.PRODUCE)
                 .thenCompose(__ -> getSchemaCompatibilityStrategyAsyncWithoutAuth())
                 .thenCompose(schemaCompatibilityStrategy -> {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiSchemaTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiSchemaTest.java
@@ -190,6 +190,7 @@ public class AdminApiSchemaTest extends MockedPulsarServiceBaseTest {
         // forbid admin api creating BYTES schema to be consistent with client side
         try {
             testSchemaInfoApi(Schema.BYTES, "schematest/test/test-BYTES");
+            fail("should fail");
         } catch (Exception e) {
             assertTrue(e.getMessage().contains("Do not upload a BYTES schema"));
         }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiSchemaTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiSchemaTest.java
@@ -185,6 +185,16 @@ public class AdminApiSchemaTest extends MockedPulsarServiceBaseTest {
 
     }
 
+    @Test
+    public void testCreateBytesSchema() {
+        // forbid admin api creating BYTES schema to be consistent with client side
+        try {
+            testSchemaInfoApi(Schema.BYTES, "schematest/test/test-BYTES");
+        } catch (Exception e) {
+            assertTrue(e.getMessage().contains("Do not upload a BYTES schema"));
+        }
+    }
+
     @Test(dataProvider = "version")
     public void testPostSchemaCompatibilityStrategy(ApiVersion version) throws PulsarAdminException {
         String namespace = format("%s%s%s", "schematest", (ApiVersion.V1.equals(version) ? "/" + cluster + "/" : "/"),

--- a/pulsar-broker/src/test/java/org/apache/pulsar/schema/SchemaTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/schema/SchemaTest.java
@@ -469,6 +469,11 @@ public class SchemaTest extends MockedPulsarServiceBaseTest {
     }
 
     @Test
+    public void testUseAutoConsumeWithBytesSchemaTopic() throws Exception {
+        testUseAutoConsumeWithSchemalessTopic(SchemaType.BYTES);
+    }
+
+    @Test
     public void testUseAutoConsumeWithNoneSchemaTopic() throws Exception {
         testUseAutoConsumeWithSchemalessTopic(SchemaType.NONE);
     }
@@ -491,13 +496,17 @@ public class SchemaTest extends MockedPulsarServiceBaseTest {
         admin.topics().createPartitionedTopic(topic, 2);
 
         // set schema
-        SchemaInfo schemaInfo = SchemaInfoImpl
-                .builder()
-                .schema(new byte[0])
-                .name("dummySchema")
-                .type(schema)
-                .build();
-        admin.schemas().createSchema(topic, schemaInfo);
+        if (!schema.equals(SchemaType.BYTES)) {
+            // don't upload bytes schema with admin API
+            // because null schema means the BYTES schema
+            SchemaInfo schemaInfo = SchemaInfoImpl
+                    .builder()
+                    .schema(new byte[0])
+                    .name("dummySchema")
+                    .type(schema)
+                    .build();
+            admin.schemas().createSchema(topic, schemaInfo);
+        }
 
         Producer<byte[]> producer = pulsarClient
                 .newProducer()
@@ -522,7 +531,8 @@ public class SchemaTest extends MockedPulsarServiceBaseTest {
         Message<GenericRecord> message2 = consumer2.receive();
         if (schema == SchemaType.BYTES) {
             assertEquals(schema, message.getReaderSchema().get().getSchemaInfo().getType());
-            assertEquals(schema, message2.getReaderSchema().get().getSchemaInfo().getType());
+            // default schema of AUTO_CONSUME is BYTES
+            assertTrue(message2.getReaderSchema().get().toString().contains("BYTES"));
         } else if (schema == SchemaType.NONE) {
             // schema NONE is always reported as BYTES
             assertEquals(SchemaType.BYTES, message.getReaderSchema().get().getSchemaInfo().getType());

--- a/pulsar-broker/src/test/java/org/apache/pulsar/schema/SchemaTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/schema/SchemaTest.java
@@ -469,11 +469,6 @@ public class SchemaTest extends MockedPulsarServiceBaseTest {
     }
 
     @Test
-    public void testUseAutoConsumeWithBytesSchemaTopic() throws Exception {
-        testUseAutoConsumeWithSchemalessTopic(SchemaType.BYTES);
-    }
-
-    @Test
     public void testUseAutoConsumeWithNoneSchemaTopic() throws Exception {
         testUseAutoConsumeWithSchemalessTopic(SchemaType.NONE);
     }


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://docs.google.com/document/d/1d8Pw6ZbWk-_pCKdOmdvx9rnhPiyuxwq60_TrD68d7BA/edit#heading=h.trs9rsex3xom)*. 

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->

<!-- Either this PR fixes an issue, -->

Fixes [#18825](https://github.com/apache/pulsar/issues/18825)

### Motivation

Admin API can upload `BYTES` schema and store a `NONE` schema in the schema registry, which is inconsistent with the client side. After discussion, we decided to forbid users from uploading `BYTES` schema.

Mail list: https://lists.apache.org/thread/672zmptfblwjmrf9z8336mk12r7csngf

### Modifications

Add a check to reject `BYTES` schema upload.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [x] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/labuladong/pulsar/pull/17

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
