### PR TITLE
[improve][io] reduce dependencies of pulsar-io-common module

### DIFF
--- a/pulsar-functions/instance/pom.xml
+++ b/pulsar-functions/instance/pom.xml
@@ -67,12 +67,6 @@
 
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>pulsar-io-common</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-
-    <dependency>
-      <groupId>${project.groupId}</groupId>
       <artifactId>pulsar-functions-api</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/pulsar-io/common/pom.xml
+++ b/pulsar-io/common/pom.xml
@@ -33,15 +33,11 @@
     <artifactId>pulsar-io-common</artifactId>
     <name>Pulsar IO :: IO Common</name>
 
+    <!-- This module is supposed to be used by Pulsar IO connectors and to only include strictly needed dependencies-->
     <dependencies>
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>pulsar-io-core</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>${project.groupId}</groupId>
-            <artifactId>pulsar-common</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>

--- a/pulsar-io/common/src/main/java/org/apache/pulsar/io/common/IOConfigUtils.java
+++ b/pulsar-io/common/src/main/java/org/apache/pulsar/io/common/IOConfigUtils.java
@@ -24,19 +24,23 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Field;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang.StringUtils;
-import org.apache.pulsar.common.util.Reflections;
 import org.apache.pulsar.io.core.SinkContext;
 import org.apache.pulsar.io.core.SourceContext;
 import org.apache.pulsar.io.core.annotations.FieldDoc;
 
 @Slf4j
 public class IOConfigUtils {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
     public static <T> T loadWithSecrets(Map<String, Object> map, Class<T> clazz, SourceContext sourceContext) {
         return loadWithSecrets(map, clazz, secretName -> sourceContext.getSecret(secretName));
     }
@@ -47,9 +51,7 @@ public class IOConfigUtils {
 
     public static Map<String, Object> loadConfigFromJsonString(String config) throws JsonProcessingException {
         if (!isBlank(config)) {
-            ObjectMapper mapper = new ObjectMapper();
-            return mapper.readValue(config, new TypeReference<Map<String, Object>>() {
-            });
+            return MAPPER.readValue(config, new TypeReference<>() {});
         } else {
             return Collections.emptyMap();
         }
@@ -59,7 +61,7 @@ public class IOConfigUtils {
                                          Function<String, String> secretsGetter) {
         Map<String, Object> configs = new HashMap<>(map);
 
-        for (Field field : Reflections.getAllFields(clazz)) {
+        for (Field field : getAllFields(clazz)) {
             field.setAccessible(true);
             for (Annotation annotation : field.getAnnotations()) {
                 if (annotation.annotationType().equals(FieldDoc.class)) {
@@ -81,7 +83,7 @@ public class IOConfigUtils {
                             throw new IllegalArgumentException(field.getName() + " cannot be null");
                         }
                         String value = fieldDoc.defaultValue();
-                        if (!StringUtils.isEmpty(value)) {
+                        if (value != null && !value.isEmpty()) {
                             return value;
                         }
                         return null;
@@ -89,6 +91,15 @@ public class IOConfigUtils {
                 }
             }
         }
-        return new ObjectMapper().convertValue(configs, clazz);
+        return MAPPER.convertValue(configs, clazz);
+    }
+
+    private static List<Field> getAllFields(Class<?> type) {
+        List<Field> fields = new LinkedList<>();
+        fields.addAll(Arrays.asList(type.getDeclaredFields()));
+        if (type.getSuperclass() != null) {
+            fields.addAll(getAllFields(type.getSuperclass()));
+        }
+        return fields;
     }
 }

--- a/pulsar-io/common/src/main/java/org/apache/pulsar/io/common/IOConfigUtils.java
+++ b/pulsar-io/common/src/main/java/org/apache/pulsar/io/common/IOConfigUtils.java
@@ -18,7 +18,6 @@
  */
 package org.apache.pulsar.io.common;
 
-import static org.apache.commons.lang.StringUtils.isBlank;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -50,11 +49,10 @@ public class IOConfigUtils {
     }
 
     public static Map<String, Object> loadConfigFromJsonString(String config) throws JsonProcessingException {
-        if (!isBlank(config)) {
-            return MAPPER.readValue(config, new TypeReference<>() {});
-        } else {
+        if (config == null || config.isEmpty()) {
             return Collections.emptyMap();
         }
+        return MAPPER.readValue(config, new TypeReference<>() {});
     }
 
     private static <T> T loadWithSecrets(Map<String, Object> map, Class<T> clazz,

--- a/pulsar-io/nsq/pom.xml
+++ b/pulsar-io/nsq/pom.xml
@@ -59,6 +59,11 @@
       <version>${project.version}</version>
     </dependency>
 
+    <dependency>
+      <groupId>com.fasterxml.jackson.dataformat</groupId>
+      <artifactId>jackson-dataformat-yaml</artifactId>
+    </dependency>
+
   </dependencies>
 
   <build>


### PR DESCRIPTION
### Motivation

`pulsar-io-common` is a module published as convenience for java connectors to help with loading configuration. 
When a connectors declares it, it brings also `pulsar-common` which contains a lot of other transitive dependencies. (for example, Netty)

We can remove all the non necessary dependencies since it's trivial to replace their usage in the `pulsar-io-common` module. 

### Modifications

* Removed `pulsar-common` and `commons-lang` dependecies and replaced with vanilla methods 100% compatible
* Improve usage of the underlyng ObjectMapper used for read the config

### Verifying this change

- [x] Make sure that the change passes the CI checks.
### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository
