### PR TITLE
[fix][admin][doc] Fix set-persistent admin doc

### DIFF
--- a/site2/docs/admin-api-namespaces.md
+++ b/site2/docs/admin-api-namespaces.md
@@ -385,13 +385,13 @@ admin.namespaces().removeBacklogQuota(namespace, backlogQuotaType)
 
 Persistence policies allow users to configure persistency-level for all topic messages under a given namespace.
 
-  -   Bookkeeper-ack-quorum: Number of acks (guaranteed copies) to wait for each entry, default: 0
+  -   Bookkeeper-ack-quorum: Number of acks (guaranteed copies) to wait for each entry, default: 2
 
-  -   Bookkeeper-ensemble: Number of bookies to use for a topic, default: 0
+  -   Bookkeeper-ensemble: Number of bookies to use for a topic, default: 2
 
-  -   Bookkeeper-write-quorum: How many writes to make of each entry, default: 0
+  -   Bookkeeper-write-quorum: How many writes to make of each entry, default: 2
 
-  -   Ml-mark-delete-max-rate: Throttling rate of mark-delete operation (0 means no throttle), default: 0.0
+  -   Ml-mark-delete-max-rate: Throttling rate of mark-delete operation (0 means no throttle), default: 0
 
 ````mdx-code-block
 <Tabs groupId="api-choice"

--- a/site2/docs/reference-pulsar-admin.md
+++ b/site2/docs/reference-pulsar-admin.md
@@ -1297,10 +1297,10 @@ Options
 
 |Flag|Description|Default|
 |----|---|---|
-|`-a`, `--bookkeeper-ack-quorum`|The number of acks (guaranteed copies) to wait for each entry|0|
-|`-e`, `--bookkeeper-ensemble`|The number of bookies to use for a topic|0|
-|`-w`, `--bookkeeper-write-quorum`|How many writes to make of each entry|0|
-|`-r`, `--ml-mark-delete-max-rate`|Throttling rate of mark-delete operation (0 means no throttle)||
+|`-a`, `--bookkeeper-ack-quorum`|The number of acks (guaranteed copies) to wait for each entry|2|
+|`-e`, `--bookkeeper-ensemble`|The number of bookies to use for a topic|2|
+|`-w`, `--bookkeeper-write-quorum`|How many writes to make of each entry|2|
+|`-r`, `--ml-mark-delete-max-rate`|Throttling rate of mark-delete operation (0 means no throttle)|0|
 
 
 ### `get-message-ttl`
@@ -2707,10 +2707,10 @@ Options
 
 |Flag|Description|Default|
 |----|---|---|
-|`-e`, `--bookkeeper-ensemble`|Number of bookies to use for a topic|0|
-|`-w`, `--bookkeeper-write-quorum`|How many writes to make of each entry|0|
-|`-a`, `--bookkeeper-ack-quorum`|Number of acks (guaranteed copies) to wait for each entry|0|
-|`-r`, `--ml-mark-delete-max-rate`|Throttling rate of mark-delete operation (0 means no throttle)||
+|`-e`, `--bookkeeper-ensemble`|Number of bookies to use for a topic|2|
+|`-w`, `--bookkeeper-write-quorum`|How many writes to make of each entry|2|
+|`-a`, `--bookkeeper-ack-quorum`|Number of acks (guaranteed copies) to wait for each entry|2|
+|`-r`, `--ml-mark-delete-max-rate`|Throttling rate of mark-delete operation (0 means no throttle)|0|
 
 ### `remove-persistence`
 Remove the persistence policy for a topic.


### PR DESCRIPTION
### Motivation

fix the default value of namespace/topic set-persistent command. see: https://github.com/apache/pulsar/blob/master/pulsar-client-admin-api/src/main/java/org/apache/pulsar/common/policies/data/PersistencePolicies.java#L34

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [x] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: 
