### PR TITLE
[improve][broker] Add logs for why namespace bundle been split

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/BundleSplitterTask.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/BundleSplitterTask.java
@@ -102,6 +102,12 @@ public class BundleSplitterTask implements BundleSplitStrategy {
                                 .getBundleCount(NamespaceName.get(namespace));
                         if ((bundleCount + namespaceBundleCount.getOrDefault(namespace, 0))
                                 < maxBundleCount) {
+                            log.info("The bundle {} is considered to be unload. Topics: {}/{}, Sessions: ({}+{})/{}, "
+                                            + "Message Rate: {}/{} (msgs/s), Message Throughput: {}/{} (MB/s)",
+                                    bundle, stats.topics, maxBundleTopics, stats.producerCount, stats.consumerCount,
+                                    maxBundleSessions, totalMessageRate, maxBundleMsgRate,
+                                    totalMessageThroughput / LoadManagerShared.MIBI,
+                                    maxBundleBandwidth / LoadManagerShared.MIBI);
                             bundleCache.add(bundle);
                             int bundleNum = namespaceBundleCount.getOrDefault(namespace, 0);
                             namespaceBundleCount.put(namespace, bundleNum + 1);


### PR DESCRIPTION
### Motivation

Add logs for why the namespace bundle been split.
With the details logs. Users can tune the load manager options to improve the bundle split.

```
18:28:07.197 [pulsar-modular-load-manager-31-1] INFO  org.apache.pulsar.broker.loadbalance.BundleSplitStrategy - The bundle public/default/0x50000000_0x60000000 is considered to be unload. Topics: 10/1000, Sessions: (10+0)/1000, Message Rate: 49976.285872448774/30000 (msgs/s), Message Throughput: 0.5233347144619912/100 (MB/s)
18:28:07.218 [pulsar-modular-load-manager-31-1] INFO  org.apache.pulsar.broker.loadbalance.BundleSplitStrategy - The bundle public/default/0xd0000000_0xe0000000 is considered to be unload. Topics: 9/1000, Sessions: (8+3)/1000, Message Rate: 39837.6273878898/30000 (msgs/s), Message Throughput: 0.41714825665545885/100 (MB/s)
18:28:16.290 [pulsar-modular-load-manager-31-1] INFO  org.apache.pulsar.broker.loadbalance.BundleSplitStrategy - The bundle public/default/0xb0000000_0xc0000000 is considered to be unload. Topics: 10/1000, Sessions: (10+0)/1000, Message Rate: 49572.71491202636/30000 (msgs/s), Message Throughput: 0.5195150078973758/100 (MB/s)
18:28:16.332 [pulsar-modular-load-manager-31-1] INFO  org.apache.pulsar.broker.loadbalance.BundleSplitStrategy - The bundle public/default/0xa0000000_0xb0000000 is considered to be unload. Topics: 8/1000, Sessions: (8+0)/1000, Message Rate: 39809.21623701227/30000 (msgs/s), Message Throughput: 0.4172123698464636/100 (MB/s)
18:28:16.393 [pulsar-modular-load-manager-31-1] INFO  org.apache.pulsar.broker.loadbalance.BundleSplitStrategy - The bundle public/default/0x20000000_0x30000000 is considered to be unload. Topics: 10/1000, Sessions: (10+0)/1000, Message Rate: 50415.7972425106/30000 (msgs/s), Message Throughput: 0.5283939562704797/100 (MB/s)
18:28:21.406 [pulsar-modular-load-manager-31-1] INFO  org.apache.pulsar.broker.loadbalance.BundleSplitStrategy - The bundle public/default/0x20000000_0x30000000 is considered to be unload. Topics: 10/1000, Sessions: (10+0)/1000, Message Rate: 50415.7972425106/30000 (msgs/s), Message Throughput: 0.5283939562704797/100 (MB/s)
18:28:59.112 [pulsar-modular-load-manager-31-1] INFO  org.apache.pulsar.broker.loadbalance.BundleSplitStrategy - The bundle public/default/0x20000000_0x30000000 is considered to be unload. Topics: 10/1000, Sessions: (10+0)/1000, Message Rate: 50415.7972425106/30000 (msgs/s), Message Throughput: 0.5283939562704797/100 (MB/s)
18:29:06.666 [pulsar-modular-load-manager-31-1] INFO  org.apache.pulsar.broker.loadbalance.BundleSplitStrategy - The bundle public/default/0xb8000000_0xc0000000 is considered to be unload. Topics: 7/1000, Sessions: (7+0)/1000, Message Rate: 39170.64232204444/30000 (msgs/s), Message Throughput: 0.4131560949721377/100 (MB/s)
18:29:06.676 [pulsar-modular-load-manager-31-1] INFO  org.apache.pulsar.broker.loadbalance.BundleSplitStrategy - The bundle public/default/0x50000000_0x58000000 is considered to be unload. Topics: 6/1000, Sessions: (6+0)/1000, Message Rate: 33308.84162853347/30000 (msgs/s), Message Throughput: 0.35130126128578953/100 (MB/s)
18:29:06.685 [pulsar-modular-load-manager-31-1] INFO  org.apache.pulsar.broker.loadbalance.BundleSplitStrategy - The bundle public/default/0xf0000000_0xffffffff is considered to be unload. Topics: 6/1000, Sessions: (6+0)/1000, Message Rate: 31255.591676699634/30000 (msgs/s), Message Throughput: 0.329708951203032/100 (MB/s)
18:29:06.690 [pulsar-modular-load-manager-31-1] INFO  org.apache.pulsar.broker.loadbalance.BundleSplitStrategy - The bundle public/default/0x20000000_0x30000000 is considered to be unload. Topics: 10/1000, Sessions: (10+0)/1000, Message Rate: 50415.7972425106/30000 (msgs/s), Message Throughput: 0.5283939562704797/100 (MB/s)
18:29:12.510 [pulsar-modular-load-manager-31-1] INFO  org.apache.pulsar.broker.loadbalance.BundleSplitStrategy - The bundle public/default/0xc0000000_0xd0000000 is considered to be unload. Topics: 11/1000, Sessions: (74+0)/1000, Message Rate: 30204.324830724177/30000 (msgs/s), Message Throughput: 2.059469199580096/100 (MB/s)
18:29:12.510 [pulsar-modular-load-manager-31-1] INFO  org.apache.pulsar.broker.loadbalance.BundleSplitStrategy - The bundle public/default/0x20000000_0x30000000 is considered to be unload. Topics: 10/1000, Sessions: (10+0)/1000, Message Rate: 50415.7972425106/30000 (msgs/s), Message Throughput: 0.5283939562704797/100 (MB/s)
18:29:14.040 [pulsar-modular-load-manager-31-1] INFO  org.apache.pulsar.broker.loadbalance.BundleSplitStrategy - The bundle public/default/0x20000000_0x30000000 is considered to be unload. Topics: 10/1000, Sessions: (10+0)/1000, Message Rate: 50415.7972425106/30000 (msgs/s), Message Throughput: 0.5283939562704797/100 (MB/s)
18:29:15.494 [pulsar-modular-load-manager-31-1] INFO  org.apache.pulsar.broker.loadbalance.BundleSplitStrategy - The bundle public/default/0x80000000_0x90000000 is considered to be unload. Topics: 6/1000, Sessions: (6+0)/1000, Message Rate: 32364.419750693123/30000 (msgs/s), Message Throughput: 0.3413933785702919/100 (MB/s)
18:29:15.518 [pulsar-modular-load-manager-31-1] INFO  org.apache.pulsar.broker.loadbalance.BundleSplitStrategy - The bundle public/default/0x20000000_0x28000000 is considered to be unload. Topics: 6/1000, Sessions: (6+0)/1000, Message Rate: 33342.31966631791/30000 (msgs/s), Message Throughput: 0.3516866646614494/100 (MB/s)
18:30:08.348 [pulsar-modular-load-manager-31-1] INFO  org.apache.pulsar.broker.loadbalance.BundleSplitStrategy - The bundle public/default/0xc8000000_0xd0000000 is considered to be unload. Topics: 7/1000, Sessions: (7+0)/1000, Message Rate: 35024.66246401582/30000 (msgs/s), Message Throughput: 0.3693784850036239/100 (MB/s)
```

It's better to cherry-pick to release branches. Currently, it's super inefficient to troubleshoot issues like why the bundle has been split.

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->
