### PR TITLE
[fix][test] Fix flaky test PulsarMultiListenersWithoutInternalListenerNameTest.setup

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/PortForwarder.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/PortForwarder.java
@@ -67,6 +67,7 @@ public class PortForwarder implements AutoCloseable {
                     .handler(new LoggingHandler(PortForwarder.class, LogLevel.DEBUG))
                     .childHandler(new Initializer())
                     .childOption(ChannelOption.AUTO_READ, false)
+                    .option(ChannelOption.SO_REUSEADDR, true)
                     .bind(listenAddress).sync().channel();
 
             LOG.info("Started port forwarding service on {}, target: {}", listenAddress, targetAddress);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/PulsarMultiListenersWithInternalListenerNameTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/PulsarMultiListenersWithInternalListenerNameTest.java
@@ -82,16 +82,21 @@ public class PulsarMultiListenersWithInternalListenerNameTest extends MockedPuls
         this.eventExecutors = new NioEventLoopGroup();
         this.isTcpLookup = true;
         String host = InetAddress.getLocalHost().getHostAddress();
-        int brokerPort = getFreePort();
+        Pair<Integer, Integer> freePorts = getFreePorts();
+        int brokerPort = freePorts.getLeft();
         brokerAddress = InetSocketAddress.createUnresolved(host, brokerPort);
-        int brokerPortSsl = getFreePort();
+        int brokerPortSsl = freePorts.getRight();
         brokerSslAddress = InetSocketAddress.createUnresolved(host, brokerPortSsl);
         super.internalSetup();
     }
 
-    private static int getFreePort() {
-        try (ServerSocket serverSocket = new ServerSocket(0)) {
-            return serverSocket.getLocalPort();
+    private static Pair<Integer, Integer> getFreePorts() {
+        try (ServerSocket serverSocket = new ServerSocket(); ServerSocket serverSocket2 = new ServerSocket()) {
+            serverSocket.setReuseAddress(true);
+            serverSocket.bind(new InetSocketAddress(0));
+            serverSocket2.setReuseAddress(true);
+            serverSocket2.bind(new InetSocketAddress(0));
+            return Pair.of(serverSocket.getLocalPort(), serverSocket2.getLocalPort());
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }


### PR DESCRIPTION
Fixes #19005

### Motivation

See #19005

### Modifications

Change free port allocation so that both ports are detected at once. Use SO_REUSEADDR socket option for PortForwarder.


- [ ] `doc` <!-- Your PR contains doc changes -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->