### PR TITLE
[fix][client] add support to TableView to read encrypted messages

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/TableViewTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/TableViewTest.java
@@ -378,4 +378,5 @@ public class TableViewTest extends MockedPulsarServiceBaseTest {
             assertEquals(tv.size(), count);
         });
         assertEquals(tv.keySet(), keys);
+    }
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/TableViewTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/TableViewTest.java
@@ -59,6 +59,8 @@ import org.testng.annotations.Test;
 @Test(groups = "broker-impl")
 public class TableViewTest extends MockedPulsarServiceBaseTest {
 
+    private static final String ECDSA_PUBLIC_KEY = "src/test/resources/certificate/public-key.client-ecdsa.pem";
+
     @BeforeClass
     @Override
     protected void setup() throws Exception {
@@ -86,6 +88,10 @@ public class TableViewTest extends MockedPulsarServiceBaseTest {
     }
 
     private Set<String> publishMessages(String topic, int count, boolean enableBatch) throws Exception {
+        return publishMessages(topic, count, enableBatch, false);
+    }
+
+    private Set<String> publishMessages(String topic, int count, boolean enableBatch, boolean enableEncryption) throws Exception {
         Set<String> keys = new HashSet<>();
         ProducerBuilder<byte[]> builder = pulsarClient.newProducer();
         builder.messageRoutingMode(MessageRoutingMode.SinglePartition);
@@ -98,6 +104,10 @@ public class TableViewTest extends MockedPulsarServiceBaseTest {
             builder.batchingMaxMessages(count);
         } else {
             builder.enableBatching(false);
+        }
+        if (enableEncryption) {
+            builder.addEncryptionKey("client-ecdsa.pem")
+                .defaultCryptoKeyReader("file:./" + ECDSA_PUBLIC_KEY);
         }
         try (Producer<byte[]> producer = builder.create()) {
             CompletableFuture<?> lastFuture = null;

--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/TableViewBuilder.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/TableViewBuilder.java
@@ -108,4 +108,25 @@ public interface TableViewBuilder<T> {
      * @return the {@link TableViewBuilder} builder instance
      */
     TableViewBuilder<T> cryptoKeyReader(CryptoKeyReader cryptoKeyReader);
+
+    /**
+     * Set the default implementation of {@link CryptoKeyReader}.
+     *
+     * <p>Configure the key reader to be used to decrypt message payloads.
+     *
+     * @param privateKey the private key that is always used to decrypt message payloads.
+     * @return the {@link TableViewBuilder} builder instance
+     */
+    TableViewBuilder<T> defaultCryptoKeyReader(String privateKey);
+
+    /**
+     * Set the default implementation of {@link CryptoKeyReader}.
+     *
+     * <p>Configure the key reader to be used to decrypt message payloads.
+     *
+     * @param privateKeys the map of private key names and their URIs
+     *                    used to decrypt message payloads.
+     * @return the {@link TableViewBuilder} builder instance
+     */
+    TableViewBuilder<T> defaultCryptoKeyReader(Map<String, String> privateKeys);
 }

--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/TableViewBuilder.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/TableViewBuilder.java
@@ -129,4 +129,12 @@ public interface TableViewBuilder<T> {
      * @return the {@link TableViewBuilder} builder instance
      */
     TableViewBuilder<T> defaultCryptoKeyReader(Map<String, String> privateKeys);
+
+    /**
+     * Set the {@link ConsumerCryptoFailureAction} to specify.
+     *
+     * @param action the action to take when the decoding fails
+     * @return the {@link TableViewBuilder} builder instance
+     */
+    TableViewBuilder<T> cryptoFailureAction(ConsumerCryptoFailureAction action);
 }

--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/TableViewBuilder.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/TableViewBuilder.java
@@ -100,4 +100,12 @@ public interface TableViewBuilder<T> {
      * @return the {@link TableViewBuilder} builder instance
      */
     TableViewBuilder<T> subscriptionName(String subscriptionName);
+
+    /**
+     * Set the {@link CryptoKeyReader} to decrypt the message payloads.
+     *
+     * @param cryptoKeyReader CryptoKeyReader object
+     * @return the {@link TableViewBuilder} builder instance
+     */
+    TableViewBuilder<T> cryptoKeyReader(CryptoKeyReader cryptoKeyReader);
 }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/TableViewBuilderImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/TableViewBuilderImpl.java
@@ -23,6 +23,7 @@ import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.pulsar.client.api.CryptoKeyReader;
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.client.api.TableView;
@@ -80,6 +81,12 @@ public class TableViewBuilderImpl<T> implements TableViewBuilder<T> {
     public TableViewBuilder<T> subscriptionName(String subscriptionName) {
         checkArgument(StringUtils.isNotBlank(subscriptionName), "subscription name cannot be blank");
         conf.setSubscriptionName(StringUtils.trim(subscriptionName));
+        return this;
+    }
+
+    @Override
+    public TableViewBuilder<T> cryptoKeyReader(CryptoKeyReader cryptoKeyReader) {
+        conf.setCryptoKeyReader(cryptoKeyReader);
         return this;
     }
 }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/TableViewBuilderImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/TableViewBuilderImpl.java
@@ -24,6 +24,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import lombok.NonNull;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.pulsar.client.api.ConsumerCryptoFailureAction;
 import org.apache.pulsar.client.api.CryptoKeyReader;
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.api.Schema;
@@ -101,5 +102,11 @@ public class TableViewBuilderImpl<T> implements TableViewBuilder<T> {
     public TableViewBuilder<T> defaultCryptoKeyReader(@NonNull Map<String, String> privateKeys) {
         checkArgument(!privateKeys.isEmpty(), "privateKeys cannot be empty");
         return cryptoKeyReader(DefaultCryptoKeyReader.builder().privateKeys(privateKeys).build());
+    }
+
+    @Override
+    public TableViewBuilder<T> cryptoFailureAction(ConsumerCryptoFailureAction action) {
+        conf.setCryptoFailureAction(action);
+        return this;
     }
 }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/TableViewBuilderImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/TableViewBuilderImpl.java
@@ -22,6 +22,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
+import lombok.NonNull;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.pulsar.client.api.CryptoKeyReader;
 import org.apache.pulsar.client.api.PulsarClientException;
@@ -88,5 +89,17 @@ public class TableViewBuilderImpl<T> implements TableViewBuilder<T> {
     public TableViewBuilder<T> cryptoKeyReader(CryptoKeyReader cryptoKeyReader) {
         conf.setCryptoKeyReader(cryptoKeyReader);
         return this;
+    }
+
+    @Override
+    public TableViewBuilder<T> defaultCryptoKeyReader(String privateKey) {
+        checkArgument(StringUtils.isNotBlank(privateKey), "privateKey cannot be blank");
+        return cryptoKeyReader(DefaultCryptoKeyReader.builder().defaultPrivateKey(privateKey).build());
+    }
+
+    @Override
+    public TableViewBuilder<T> defaultCryptoKeyReader(@NonNull Map<String, String> privateKeys) {
+        checkArgument(!privateKeys.isEmpty(), "privateKeys cannot be empty");
+        return cryptoKeyReader(DefaultCryptoKeyReader.builder().privateKeys(privateKeys).build());
     }
 }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/TableViewConfigurationData.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/TableViewConfigurationData.java
@@ -19,6 +19,9 @@
 package org.apache.pulsar.client.impl;
 
 import java.io.Serializable;
+
+import org.apache.pulsar.client.api.CryptoKeyReader;
+
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
@@ -31,6 +34,7 @@ public class TableViewConfigurationData implements Serializable, Cloneable {
     private String subscriptionName = null;
     private long autoUpdatePartitionsSeconds = 60;
 
+    private CryptoKeyReader cryptoKeyReader = null;
     @Override
     public TableViewConfigurationData clone() {
         try {

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/TableViewConfigurationData.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/TableViewConfigurationData.java
@@ -19,12 +19,10 @@
 package org.apache.pulsar.client.impl;
 
 import java.io.Serializable;
-
-import org.apache.pulsar.client.api.ConsumerCryptoFailureAction;
-import org.apache.pulsar.client.api.CryptoKeyReader;
-
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.apache.pulsar.client.api.ConsumerCryptoFailureAction;
+import org.apache.pulsar.client.api.CryptoKeyReader;
 
 @Data
 @NoArgsConstructor

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/TableViewConfigurationData.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/TableViewConfigurationData.java
@@ -20,6 +20,7 @@ package org.apache.pulsar.client.impl;
 
 import java.io.Serializable;
 
+import org.apache.pulsar.client.api.ConsumerCryptoFailureAction;
 import org.apache.pulsar.client.api.CryptoKeyReader;
 
 import lombok.Data;
@@ -35,6 +36,8 @@ public class TableViewConfigurationData implements Serializable, Cloneable {
     private long autoUpdatePartitionsSeconds = 60;
 
     private CryptoKeyReader cryptoKeyReader = null;
+    private ConsumerCryptoFailureAction cryptoFailureAction = ConsumerCryptoFailureAction.FAIL;
+
     @Override
     public TableViewConfigurationData clone() {
         try {

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/TableViewImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/TableViewImpl.java
@@ -80,6 +80,8 @@ public class TableViewImpl<T> implements TableView<T> {
             readerBuilder.cryptoKeyReader(cryptoKeyReader);
         }
 
+        readerBuilder.cryptoFailureAction(conf.getCryptoFailureAction());
+
         this.reader = readerBuilder.createAsync();
     }
 

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/TableViewImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/TableViewImpl.java
@@ -32,7 +32,6 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.BiConsumer;
 import lombok.extern.slf4j.Slf4j;
-
 import org.apache.pulsar.client.api.CryptoKeyReader;
 import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.MessageId;

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/TableViewImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/TableViewImpl.java
@@ -32,6 +32,8 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.BiConsumer;
 import lombok.extern.slf4j.Slf4j;
+
+import org.apache.pulsar.client.api.CryptoKeyReader;
 import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.client.api.PulsarClientException;
@@ -72,6 +74,12 @@ public class TableViewImpl<T> implements TableView<T> {
         if (isPersistentTopic) {
             readerBuilder.readCompacted(true);
         }
+
+        CryptoKeyReader cryptoKeyReader = conf.getCryptoKeyReader();
+        if (cryptoKeyReader != null) {
+            readerBuilder.cryptoKeyReader(cryptoKeyReader);
+        }
+
         this.reader = readerBuilder.createAsync();
     }
 

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/TableViewBuilderImplTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/TableViewBuilderImplTest.java
@@ -1,0 +1,135 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.client.impl;
+
+import org.apache.pulsar.client.api.ConsumerCryptoFailureAction;
+import org.apache.pulsar.client.api.CryptoKeyReader;
+import org.apache.pulsar.client.api.PulsarClientException;
+import org.apache.pulsar.client.api.Reader;
+import org.apache.pulsar.client.api.Schema;
+import org.apache.pulsar.client.api.TableView;
+import org.apache.pulsar.client.impl.conf.ReaderConfigurationData;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertNotNull;
+
+/**
+ * Unit tests of {@link TablewViewBuilderImpl}.
+ */
+public class TableViewBuilderImplTest {
+
+    private static final String TOPIC_NAME = "testTopicName";
+    private PulsarClientImpl client;
+    private TableViewBuilderImpl tableViewBuilderImpl;
+
+    @BeforeClass(alwaysRun = true)
+    public void setup() {
+        Reader reader = mock(Reader.class);
+        when(reader.readNextAsync()).thenReturn(CompletableFuture.allOf());
+        client = mock(PulsarClientImpl.class);
+        when(client.newReader(any(Schema.class)))
+            .thenReturn(new ReaderBuilderImpl(client, Schema.BYTES));
+        when(client.createReaderAsync(any(ReaderConfigurationData.class), any(Schema.class)))
+            .thenReturn(CompletableFuture.completedFuture(reader));
+        tableViewBuilderImpl = new TableViewBuilderImpl(client, Schema.BYTES);
+    }
+
+    @Test
+    public void testTableViewBuilderImpl() throws PulsarClientException {
+        TableView tableView = tableViewBuilderImpl.topic(TOPIC_NAME)
+            .autoUpdatePartitionsInterval(5, TimeUnit.SECONDS)
+            .subscriptionName("testSubscriptionName")
+            .cryptoKeyReader(mock(CryptoKeyReader.class))
+            .cryptoFailureAction(ConsumerCryptoFailureAction.DISCARD)
+            .create();
+
+        assertNotNull(tableView);
+    }
+
+    @Test
+    public void testTableViewBuilderImplWhenOnlyTopicNameIsSet() throws PulsarClientException {
+        TableView tableView = tableViewBuilderImpl.topic(TOPIC_NAME)
+            .create();
+
+        assertNotNull(tableView);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testTableViewBuilderImplWhenTopicIsNullString() throws PulsarClientException {
+        tableViewBuilderImpl.topic(null).create();
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testTableViewBuilderImplWhenTopicIsEmptyString() throws PulsarClientException {
+        tableViewBuilderImpl.topic("").create();
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testTableViewBuilderImplWhenAutoUpdatePartitionsIntervalIsSmallerThanOneSecond() throws PulsarClientException {
+        tableViewBuilderImpl.topic(TOPIC_NAME).autoUpdatePartitionsInterval(100, TimeUnit.MILLISECONDS).create();
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testTableViewBuilderImplWhenSubscriptionNameIsNullString() throws PulsarClientException {
+        tableViewBuilderImpl.topic(TOPIC_NAME).subscriptionName(null).create();
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testTableViewBuilderImplWhenSubscriptionNameIsEmptyString() throws PulsarClientException {
+        tableViewBuilderImpl.topic(TOPIC_NAME).subscriptionName("").create();
+    }
+
+    @Test
+    public void testTableViewBuilderImplWithCryptoKeyReader() throws PulsarClientException {
+        TableView tableView = tableViewBuilderImpl.topic(TOPIC_NAME)
+            .cryptoKeyReader(mock(CryptoKeyReader.class))
+            .create();
+
+        assertNotNull(tableView);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testTableViewImplWhenDefaultCryptoKeyReaderIsNullString() throws PulsarClientException {
+        tableViewBuilderImpl.topic(TOPIC_NAME).defaultCryptoKeyReader((String) null).create();
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testTableViewImplWhenDefaultCryptoKeyReaderIsEmptyString() throws PulsarClientException {
+        tableViewBuilderImpl.topic(TOPIC_NAME).defaultCryptoKeyReader("").create();
+    }
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void testTableViewImplWhenDefaultCryptoKeyReaderIsNullMap() throws PulsarClientException {
+        tableViewBuilderImpl.topic(TOPIC_NAME).defaultCryptoKeyReader((Map<String, String>) null).create();
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testTableViewImplWhenDefaultCryptoKeyReaderIsEmptyMap() throws PulsarClientException {
+        tableViewBuilderImpl.topic(TOPIC_NAME).defaultCryptoKeyReader(new HashMap<String, String>()).create();
+    }
+}

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/TableViewImplTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/TableViewImplTest.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.client.impl;
+
+import org.apache.pulsar.client.api.CryptoKeyReader;
+import org.apache.pulsar.client.api.Schema;
+import org.apache.pulsar.client.api.TableView;
+import org.apache.pulsar.client.impl.TableViewConfigurationData;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertNotNull;
+
+public class TableViewImplTest {
+
+    private PulsarClientImpl client;
+    private TableViewConfigurationData data;
+
+    @BeforeClass(alwaysRun = true)
+    public void setup() {
+        client = mock(PulsarClientImpl.class);
+        when(client.newReader(any(Schema.class)))
+            .thenReturn(new ReaderBuilderImpl(client, Schema.BYTES));
+
+        data = new TableViewConfigurationData();
+        data.setTopicName("testTopicName");
+    }
+
+    @Test
+    public void testTableViewImpl() {
+        data.setCryptoKeyReader(mock(CryptoKeyReader.class));
+        TableView tableView = new TableViewImpl(client, Schema.BYTES, data);
+
+        assertNotNull(tableView);
+    }
+}


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://docs.google.com/document/d/1d8Pw6ZbWk-_pCKdOmdvx9rnhPiyuxwq60_TrD68d7BA/edit#heading=h.trs9rsex3xom)*. 

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->

<!-- Either this PR fixes an issue, -->

Fixes #19007


### Motivation

This PR adds support for a `TableView` to read encrypted messages from a topic.

### Modifications

Analogous to `ReaderBuilder`, I've added methods to `TableViewBuilder` that allow to specify a `CryptoKeyReader` and a `ConsumerCryptoFailureAction`. The respective values are stored in `TableViewConfigurationData` and forwarded to the `ReaderBuilder` instance inside `TableViewImpl` when the `Reader` is constructed.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change added tests and can be verified as follows:
  - Added unit tests for `TableViewImpl` and `TableViewBuilderImpl`
  - Extended integration test verifying that encrypted messages can be read inside a `TableView`

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [x] The public API


### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

[PR in forked repository](https://github.com/rbarbey/pulsar/pull/1)

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
