### PR TITLE
[improve][io] Upgrade Kafka client, connect runtime to 2.8.2 and Confluent version to 6.2.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -188,8 +188,6 @@ flexible messaging model and an intuitive client API.</description>
     <jcip.version>1.0</jcip.version>
     <prometheus-jmx.version>0.16.1</prometheus-jmx.version>
     <confluent.version>6.2.8</confluent.version>
-    <kafka.confluent.schemaregistryclient.version>${confluent.version}</kafka.confluent.schemaregistryclient.version>
-    <kafka.confluent.avroserializer.version>${confluent.version}</kafka.confluent.avroserializer.version>
     <aircompressor.version>0.20</aircompressor.version>
     <asynchttpclient.version>2.12.1</asynchttpclient.version>
     <jcommander.version>1.82</jcommander.version>

--- a/pom.xml
+++ b/pom.xml
@@ -160,7 +160,7 @@ flexible messaging model and an intuitive client API.</description>
     <hbc-core.version>2.2.0</hbc-core.version>
     <cassandra.version>3.11.2</cassandra.version>
     <aerospike-client.version>4.4.20</aerospike-client.version>
-    <kafka-client.version>2.7.2</kafka-client.version>
+    <kafka-client.version>2.8.2</kafka-client.version>
     <rabbitmq-client.version>5.5.3</rabbitmq-client.version>
     <aws-sdk.version>1.12.262</aws-sdk.version>
     <avro.version>1.10.2</avro.version>
@@ -187,9 +187,9 @@ flexible messaging model and an intuitive client API.</description>
     <guava.version>31.0.1-jre</guava.version>
     <jcip.version>1.0</jcip.version>
     <prometheus-jmx.version>0.16.1</prometheus-jmx.version>
-    <confluent.version>7.0.1</confluent.version>
-    <kafka.confluent.schemaregistryclient.version>5.3.0</kafka.confluent.schemaregistryclient.version>
-    <kafka.confluent.avroserializer.version>5.3.0</kafka.confluent.avroserializer.version>
+    <confluent.version>6.2.8</confluent.version>
+    <kafka.confluent.schemaregistryclient.version>${confluent.version}</kafka.confluent.schemaregistryclient.version>
+    <kafka.confluent.avroserializer.version>${confluent.version}</kafka.confluent.avroserializer.version>
     <aircompressor.version>0.20</aircompressor.version>
     <asynchttpclient.version>2.12.1</asynchttpclient.version>
     <jcommander.version>1.82</jcommander.version>

--- a/pulsar-io/kafka/pom.xml
+++ b/pulsar-io/kafka/pom.xml
@@ -84,13 +84,13 @@
     <dependency>
       <groupId>io.confluent</groupId>
       <artifactId>kafka-schema-registry-client</artifactId>
-      <version>${kafka.confluent.schemaregistryclient.version}</version>
+      <version>${confluent.version}</version>
     </dependency>
 
     <dependency>
       <groupId>io.confluent</groupId>
       <artifactId>kafka-avro-serializer</artifactId>
-      <version>${kafka.confluent.avroserializer.version}</version>
+      <version>${confluent.version}</version>
     </dependency>
 
     <dependency>

--- a/tests/integration/pom.xml
+++ b/tests/integration/pom.xml
@@ -280,7 +280,7 @@
             <artifactId>maven-surefire-plugin</artifactId>
             <configuration>
               <argLine>${testJacocoAgentArgument} -XX:+ExitOnOutOfMemoryError -Xmx1G -XX:MaxDirectMemorySize=1G
-              -Dio.netty.leakDetectionLevel=advanced
+              -Dio.netty.leakDetectionLevel=advanced -Dconfluent.version=${confluent.version}
               ${test.additional.args}
               </argLine>
               <skipTests>false</skipTests>

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/sinks/KafkaSinkTester.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/sinks/KafkaSinkTester.java
@@ -35,12 +35,14 @@ import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.pulsar.tests.integration.topologies.PulsarCluster;
 import org.testcontainers.containers.Container.ExecResult;
 import org.testcontainers.containers.KafkaContainer;
+import org.testcontainers.utility.DockerImageName;
 
 /**
  * A tester for testing kafka sink.
  */
 @Slf4j
 public class KafkaSinkTester extends SinkTester<KafkaContainer> {
+    public static final String CONFLUENT_PLATFORM_VERSION = System.getProperty("confluent.version", "6.2.8");
 
     private final String kafkaTopicName;
     private KafkaConsumer<String, String> kafkaConsumer;
@@ -63,7 +65,7 @@ public class KafkaSinkTester extends SinkTester<KafkaContainer> {
     @SuppressWarnings("deprecation")
     @Override
     protected KafkaContainer createSinkService(PulsarCluster cluster) {
-        return new KafkaContainer()
+        return new KafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:" + CONFLUENT_PLATFORM_VERSION))
                 .withEmbeddedZookeeper()
                 .withNetworkAliases(containerName)
                 .withCreateContainerCmdModifier(createContainerCmd -> createContainerCmd

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/sources/AvroKafkaSourceTest.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/sources/AvroKafkaSourceTest.java
@@ -71,6 +71,7 @@ import static org.testng.Assert.*;
  */
 @Slf4j
 public class AvroKafkaSourceTest extends PulsarFunctionsTestBase {
+    public static final String CONFLUENT_PLATFORM_VERSION = System.getProperty("confluent.version", "6.2.8");
 
     private static final String SOURCE_TYPE = "kafka";
 
@@ -139,7 +140,8 @@ public class AvroKafkaSourceTest extends PulsarFunctionsTestBase {
     }
 
     protected EnhancedKafkaContainer createKafkaContainer(PulsarCluster cluster) {
-        return (EnhancedKafkaContainer) new EnhancedKafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:6.0.1"))
+        return (EnhancedKafkaContainer) new EnhancedKafkaContainer(
+                DockerImageName.parse("confluentinc/cp-kafka:" + CONFLUENT_PLATFORM_VERSION))
                 .withEmbeddedZookeeper()
                 .withCreateContainerCmdModifier(createContainerCmd -> createContainerCmd
                         .withName(kafkaContainerName)
@@ -480,7 +482,6 @@ public class AvroKafkaSourceTest extends PulsarFunctionsTestBase {
     }
 
     public class SchemaRegistryContainer extends GenericContainer<SchemaRegistryContainer> {
-        public static final String CONFLUENT_PLATFORM_VERSION = "6.0.1";
         private static final int SCHEMA_REGISTRY_INTERNAL_PORT = 8081;
 
         public SchemaRegistryContainer(String boostrapServers) throws Exception {


### PR DESCRIPTION
### Motivation

There are multiple Confluent platform versions in use at the moment. 
There's now references to both version 7.0.1 and version 5.3.0 (from July 2019) and this doesn't make much sense.

The Confluent platform version should be compatible with the Kafka client and Kafka connect runtime versions.

Confluent 6.2.x is compatible with Kafka client 2.8.2 . ([release notes of Confluent 6.2.8](https://docs.confluent.io/platform/6.2.8/release-notes/index.html))

### Modifications

- Upgrade Kafka client and Kafka connect runtime to 2.8.2
- Upgrade Confluent version to 6.2.8

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/lhotari/pulsar/pull/117

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->