### PR TITLE
[improve][admin]internalGetMessageById shouldn't be allowed on partitioned topic

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
@@ -2766,19 +2766,19 @@ public class PersistentTopicsBase extends AdminResource {
             future = CompletableFuture.completedFuture(null);
         }
         return future.thenCompose(__ -> {
-            if (!topicName.isPartitioned()) {
+            if (topicName.isPartitioned()) {
+                return CompletableFuture.completedFuture(null);
+            } else {
                 return getPartitionedTopicMetadataAsync(topicName, authoritative, false)
-                        .thenCompose(topicMetadata -> {
+                        .thenAccept(topicMetadata -> {
                             if (topicMetadata.partitions > 0) {
                                 log.warn("[{}] Not supported getMessageById operation on partitioned-topic {}",
                                         clientAppId(), topicName);
                                 throw new RestException(Status.METHOD_NOT_ALLOWED,
                                         "GetMessageById is not allowed on partitioned-topic");
                             }
-                            return CompletableFuture.completedFuture(null);
                         });
-            } else {
-                return CompletableFuture.completedFuture(null);
+
             }
         })
         .thenCompose(ignore -> validateTopicOwnershipAsync(topicName, authoritative))

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
@@ -2763,7 +2763,7 @@ public class PersistentTopicsBase extends AdminResource {
         // will redirect if the topic not owned by current broker
         getPartitionedTopicMetadataAsync(topicName, authoritative, false)
                 .thenAccept(partitionMetadata -> {
-                    if (!topicName.isPartitioned() && partitionMetadata.partitions > 0) {
+                    if (partitionMetadata.partitions > 0) {
                         log.warn("[{}] Not supported getMessageById operation on partitioned-topic {}",
                                 clientAppId(), topicName);
                         asyncResponse.resume(new RestException(Status.METHOD_NOT_ALLOWED,


### PR DESCRIPTION
### Motivation
Now, if a topic without partition index provided when querying `internalGetMessageById`,  error `Topic not found` will be thrown out. It will confuse users. 

We'd better forbidden `internalGetMessageById` on partitioned-topic.

### Modifications

If a partitioned-topic is provided, `Status.METHOD_NOT_ALLOWED` will be thrown out
                  

### Verifying this change

- [x] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [x] The REST endpoints
- [x] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository
https://github.com/gaozhangmin/pulsar/pull/5
