### PR TITLE
[fix][broker] Fix estimateBacklogFromPosition if position is greater than the greatest ledgerId 

### DIFF
--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerTest.java
@@ -3837,4 +3837,15 @@ public class ManagedLedgerTest extends MockedBookKeeperTestCase {
         managedLedger.getEnsemblesAsync(lastLedger).join();
         Assert.assertFalse(managedLedger.ledgerCache.containsKey(lastLedger));
     }
+
+    @Test
+    public void testGetEstimatedBacklogSize() throws Exception {
+        ManagedLedgerImpl ledger = (ManagedLedgerImpl) factory.open("testGetEstimatedBacklogSize");
+        for (int i = 0; i < 10; i++) {
+            ledger.addEntry(new byte[1024]);
+        }
+        Assert.assertEquals(ledger.getEstimatedBacklogSize(new PositionImpl(-1, -1)), 10240);
+        Assert.assertEquals(ledger.getEstimatedBacklogSize(new PositionImpl(11, 2)), 0);
+        ledger.close();
+    }
 }

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerTest.java
@@ -3840,12 +3840,19 @@ public class ManagedLedgerTest extends MockedBookKeeperTestCase {
 
     @Test
     public void testGetEstimatedBacklogSize() throws Exception {
-        ManagedLedgerImpl ledger = (ManagedLedgerImpl) factory.open("testGetEstimatedBacklogSize");
+        ManagedLedgerConfig config = new ManagedLedgerConfig();
+        config.setMaxEntriesPerLedger(2);
+        config.setRetentionTime(-1, TimeUnit.SECONDS);
+        config.setRetentionSizeInMB(-1);
+        ManagedLedgerImpl ledger = (ManagedLedgerImpl) factory.open("testGetEstimatedBacklogSize", config);
+        List<Position> positions = new ArrayList<>(10);
         for (int i = 0; i < 10; i++) {
-            ledger.addEntry(new byte[1024]);
+            positions.add(ledger.addEntry(new byte[1]));
         }
-        Assert.assertEquals(ledger.getEstimatedBacklogSize(new PositionImpl(-1, -1)), 10240);
-        Assert.assertEquals(ledger.getEstimatedBacklogSize(new PositionImpl(11, 2)), 0);
+
+        Assert.assertEquals(ledger.getEstimatedBacklogSize(new PositionImpl(-1, -1)), 10);
+        Assert.assertEquals(ledger.getEstimatedBacklogSize(((PositionImpl) positions.get(1))), 8);
+        Assert.assertEquals(ledger.getEstimatedBacklogSize(((PositionImpl) positions.get(9)).getNext()), 0);
         ledger.close();
     }
 }


### PR DESCRIPTION
### Motivation

- Fix bug: If the input paramter `position` is greater than the greatest ledgerId in `ManagedLedgerImpl#ledgers`,  the `estimateBacklogFromPosition` should return 0,  instead of `getTotalSize()`
- Improve: Using `java.util.NavigableMap#tailMap(K)` to calculate the `size`, which will avoid traversal the whole `ManagedLedgerImpl#ledgers`


### Verifying this change

- [x] Make sure that the change passes the CI checks.
- Add ut `ManagedLedgerTest#testGetEstimatedBacklogSize` to test this change

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository:  https://github.com/AnonHxy/pulsar/pull/24
