### PR TITLE
Update .asf.yaml to avoid merge PRs without approvals to the active release branches

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -52,8 +52,6 @@ github:
            - Pulsar CI checks completed
 
       required_pull_request_reviews:
-        dismiss_stale_reviews: false
-        require_code_owner_reviews: true
         required_approving_review_count: 1
 
       # squash or rebase must be allowed in the repo for this setting to be set to true.
@@ -79,28 +77,18 @@ github:
     branch-2.6: {}
     branch-2.7:
       required_pull_request_reviews:
-        dismiss_stale_reviews: false
-        require_code_owner_reviews: true
         required_approving_review_count: 1
     branch-2.8:
       required_pull_request_reviews:
-        dismiss_stale_reviews: false
-        require_code_owner_reviews: true
         required_approving_review_count: 1
     branch-2.9:
       required_pull_request_reviews:
-        dismiss_stale_reviews: false
-        require_code_owner_reviews: true
         required_approving_review_count: 1
     branch-2.10:
       required_pull_request_reviews:
-        dismiss_stale_reviews: false
-        require_code_owner_reviews: true
         required_approving_review_count: 1
     branch-2.11:
       required_pull_request_reviews:
-        dismiss_stale_reviews: false
-        require_code_owner_reviews: true
         required_approving_review_count: 1
 
 notifications:

--- a/.asf.yaml
+++ b/.asf.yaml
@@ -77,11 +77,31 @@ github:
     branch-2.4: {}
     branch-2.5: {}
     branch-2.6: {}
-    branch-2.7: {}
-    branch-2.8: {}
-    branch-2.9: {}
-    branch-2.10: {}
-    branch-2.11: {}
+    branch-2.7:
+      required_pull_request_reviews:
+        dismiss_stale_reviews: false
+        require_code_owner_reviews: true
+        required_approving_review_count: 1
+    branch-2.8:
+      required_pull_request_reviews:
+        dismiss_stale_reviews: false
+        require_code_owner_reviews: true
+        required_approving_review_count: 1
+    branch-2.9:
+      required_pull_request_reviews:
+        dismiss_stale_reviews: false
+        require_code_owner_reviews: true
+        required_approving_review_count: 1
+    branch-2.10:
+      required_pull_request_reviews:
+        dismiss_stale_reviews: false
+        require_code_owner_reviews: true
+        required_approving_review_count: 1
+    branch-2.11:
+      required_pull_request_reviews:
+        dismiss_stale_reviews: false
+        require_code_owner_reviews: true
+        required_approving_review_count: 1
 
 notifications:
   commits:      commits@pulsar.apache.org


### PR DESCRIPTION
### Motivation

We create PRs for the release branches once conflicts are not easy to handle when cherry-picking PRs.
Using a PR to resolve the conflicts and get more eyes on the changes to the release branches to reduce the risks that are introduced to the release branches.

But the approvals are not enforced for the release branches when merging PRs so that the committer can merge the PR without any approvals to the release branch.

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->