### PR TITLE
[fix][client] Prevent DNS reverse lookup when physical address is an IP address

### DIFF
--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/http/AsyncHttpConnector.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/http/AsyncHttpConnector.java
@@ -210,7 +210,7 @@ public class AsyncHttpConnector implements Connector {
     private URI replaceWithNew(InetSocketAddress address, URI uri) {
         String originalUri = uri.toString();
         String newUri = (originalUri.split(":")[0] + "://")
-                + address.getHostName() + ":"
+                + address.getHostString() + ":"
                 + address.getPort()
                 + uri.getRawPath();
         if (uri.getRawQuery() != null) {

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConnectionPool.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConnectionPool.java
@@ -274,7 +274,7 @@ public class ConnectionPool implements AutoCloseable {
                 cnx.setTargetBroker(logicalAddress);
             }
 
-            cnx.setRemoteHostName(physicalAddress.getHostName());
+            cnx.setRemoteHostName(physicalAddress.getHostString());
 
             cnx.connectionFuture().thenRun(() -> {
                 if (log.isDebugEnabled()) {

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PulsarServiceNameResolver.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PulsarServiceNameResolver.java
@@ -61,7 +61,7 @@ public class PulsarServiceNameResolver implements ServiceNameResolver {
     @Override
     public URI resolveHostUri() {
         InetSocketAddress host = resolveHost();
-        String hostUrl = serviceUri.getServiceScheme() + "://" + host.getHostName() + ":" + host.getPort();
+        String hostUrl = serviceUri.getServiceScheme() + "://" + host.getHostString() + ":" + host.getPort();
         return URI.create(hostUrl);
     }
 


### PR DESCRIPTION
### Motivation

A call to java.net.InetSocketAddress#getHostName will trigger a reverse DNS lookup when the physical address is an IP address. This is not desired since the DNS resolver will be blocking execution.

### Modifications

Use java.net.InetSocketAddress#getHostString to use the address passed as input (host string or ip address).

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/lhotari/pulsar/pull/120

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->