### PR TITLE
[improve][client] Check topic pattern when creating consumer

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/PatternTopicsConsumerImplTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/PatternTopicsConsumerImplTest.java
@@ -132,6 +132,31 @@ public class PatternTopicsConsumerImplTest extends ProducerConsumerBase {
         } catch (IllegalArgumentException e) {
             // expected
         }
+
+        // test failing builder with empty pattern should fail
+        try {
+            pattern = Pattern.compile("");
+            pulsarClient.newConsumer()
+                    .topicsPattern(pattern)
+                    .subscriptionName(subscriptionName)
+                    .subscriptionType(SubscriptionType.Shared)
+                    .ackTimeout(ackTimeOutMillis, TimeUnit.MILLISECONDS)
+                    .subscribe();
+            fail("subscribe4 with empty pattern should fail.");
+        } catch (IllegalArgumentException e) {
+            assertEquals(e.getMessage(), "Pattern has already been set or is empty.");
+        }
+        try {
+            pulsarClient.newConsumer()
+                    .topicsPattern("")
+                    .subscriptionName(subscriptionName)
+                    .subscriptionType(SubscriptionType.Shared)
+                    .ackTimeout(ackTimeOutMillis, TimeUnit.MILLISECONDS)
+                    .subscribe();
+            fail("subscribe5 with empty pattern should fail.");
+        } catch (IllegalArgumentException e) {
+            assertEquals(e.getMessage(), "topicsPattern should not be null or empty");
+        }
     }
 
     // verify consumer create success, and works well.

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBuilderImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBuilderImpl.java
@@ -199,13 +199,15 @@ public class ConsumerBuilderImpl<T> implements ConsumerBuilder<T> {
 
     @Override
     public ConsumerBuilder<T> topicsPattern(Pattern topicsPattern) {
-        checkArgument(conf.getTopicsPattern() == null, "Pattern has already been set.");
+        checkArgument(conf.getTopicsPattern() == null && !topicsPattern.pattern().isEmpty(),
+                "Pattern has already been set or is empty.");
         conf.setTopicsPattern(topicsPattern);
         return this;
     }
 
     @Override
     public ConsumerBuilder<T> topicsPattern(String topicsPattern) {
+        checkArgument(StringUtils.isNotEmpty(topicsPattern), "topicsPattern should not be null or empty");
         return topicsPattern(Pattern.compile(topicsPattern));
     }
 


### PR DESCRIPTION
### Motivation
Check `topicsPattern` is not null or empty when invoking `ConsumerBuilder.topicsPattern`. 
```java
ConsumerBuilder<T> topicsPattern(String topicsPattern);
ConsumerBuilder<T> topicsPattern(Pattern topicsPattern);
```
**case 1:** String topicsPattern is `null`
```
java.lang.NullPointerException: Cannot invoke "String.isEmpty()" because "this.pattern" is null
```
**case 2:** String topicsPattern is `empty` or Pattern topicsPattern  regex is `empty`
```
java.lang.IllegalArgumentException: Invalid short topic name '', it should be in the format of <tenant>/<namespace>/<topic> or <topic>
```


### Modifications
Check `topicsPattern` is not null or empty when invoking `ConsumerBuilder.topicsPattern`. 

### Documentation
- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository
PR in forked repository: 
