### PR TITLE
[improve][misc] Send GitHub discussion notifications to commits@

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -87,5 +87,5 @@ notifications:
   commits:      commits@pulsar.apache.org
   issues:       commits@pulsar.apache.org
   pullrequests: commits@pulsar.apache.org
-  discussions:  dev@pulsar.apache.org
+  discussions:  commits@pulsar.apache.org
   jira_options: link label


### PR DESCRIPTION
### Motivation

Mailing list thread: https://lists.apache.org/thread/ny8cz9fj4lwk752m4nylpzdg35lwfn6v

When we first introduced GitHub discussions, we had their notifications go to the dev@ list. That has produced many notifications, and can create duplicate notifications for anyone following the GitHub repo itself.

I propose that we move these notifications to the commits@ list, which is also where we send all other GitHub notifications.

Note that discussions are primarily intended for users to ask questions. Users are free to propose new features/designs, but those proposals should ultimately be directed to the dev list for relevant discussions.

### Documentation

- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
