### PR TITLE
Revert "Update .asf.yaml to avoid merge PRs without approvals to the active release branches (#19024)

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -52,6 +52,8 @@ github:
            - Pulsar CI checks completed
 
       required_pull_request_reviews:
+        dismiss_stale_reviews: false
+        require_code_owner_reviews: true
         required_approving_review_count: 1
 
       # squash or rebase must be allowed in the repo for this setting to be set to true.
@@ -75,21 +77,11 @@ github:
     branch-2.4: {}
     branch-2.5: {}
     branch-2.6: {}
-    branch-2.7:
-      required_pull_request_reviews:
-        required_approving_review_count: 1
-    branch-2.8:
-      required_pull_request_reviews:
-        required_approving_review_count: 1
-    branch-2.9:
-      required_pull_request_reviews:
-        required_approving_review_count: 1
-    branch-2.10:
-      required_pull_request_reviews:
-        required_approving_review_count: 1
-    branch-2.11:
-      required_pull_request_reviews:
-        required_approving_review_count: 1
+    branch-2.7: {}
+    branch-2.8: {}
+    branch-2.9: {}
+    branch-2.10: {}
+    branch-2.11: {}
 
 notifications:
   commits:      commits@pulsar.apache.org


### PR DESCRIPTION
### Motivation

See: https://github.com/apache/pulsar/pull/19024#issuecomment-1363480874

### Modifications

Revert #19024

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->
