### PR TITLE
[fix][sec] Upgrade woodstox to 5.4.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -249,6 +249,7 @@ flexible messaging model and an intuitive client API.</description>
     <awaitility.version>4.2.0</awaitility.version>
     <reload4j.version>1.2.22</reload4j.version>
     <jettison.version>1.5.1</jettison.version>
+    <woodstox.version>5.4.0</woodstox.version>
     <wiremock.version>2.33.2</wiremock.version>
 
     <!-- Plugin dependencies -->
@@ -829,6 +830,12 @@ flexible messaging model and an intuitive client API.</description>
         <groupId>org.codehaus.jettison</groupId>
         <artifactId>jettison</artifactId>
         <version>${jettison.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>com.fasterxml.woodstox</groupId>
+        <artifactId>woodstox-core</artifactId>
+        <version>${woodstox.version}</version>
       </dependency>
 
 


### PR DESCRIPTION
### Motivation

Woodstox 5.3.0 is vulnerable to [CVE-2022-40152](http://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2022-40152)

Woodstox core is used in the file system offloader

### Modifications

* Upgrade from 5.3.0 to 5.4.0

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->
