### PR TITLE
[fix][build] Fix license issue in 2.11

### DIFF
--- a/pulsar-sql/presto-distribution/LICENSE
+++ b/pulsar-sql/presto-distribution/LICENSE
@@ -222,6 +222,7 @@ The Apache Software License, Version 2.0
     - jackson-module-jsonSchema-2.13.4.jar
  * Guava
     - guava-31.0.1-jre.jar
+    - listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.jar
     - failureaccess-1.0.1.jar
  * Google Guice
     - guice-5.1.0.jar
@@ -252,7 +253,6 @@ The Apache Software License, Version 2.0
     - netty-tcnative-classes-2.0.54.Final.jar
     - netty-transport-4.1.86.Final.jar
     - netty-transport-classes-epoll-4.1.86.Final.jar
-    - netty-transport-native-epoll-4.1.86.Final.jar
     - netty-transport-native-epoll-4.1.86.Final-linux-x86_64.jar
     - netty-transport-native-unix-common-4.1.86.Final.jar
     - netty-transport-native-unix-common-4.1.86.Final-linux-x86_64.jar
@@ -272,7 +272,8 @@ The Apache Software License, Version 2.0
 
  * Joda Time
     - joda-time-2.10.5.jar
-  * Jetty
+    - failsafe-2.4.4.jar
+ * Jetty
     - http2-client-9.4.48.v20220622.jar
     - http2-common-9.4.48.v20220622.jar
     - http2-hpack-9.4.48.v20220622.jar
@@ -542,7 +543,10 @@ CDDL-1.1 -- licenses/LICENSE-CDDL-1.1.txt
     - jersey-client-2.34.jar
     - jersey-container-servlet-2.34.jar
     - jersey-container-servlet-core-2.34.jar
+    - jersey-entity-filtering-2.34.jar
     - jersey-hk2-2.34.jar
+    - jersey-media-json-jackson-2.34.jar
+    - jersey-media-multipart-2.34.jar
     - jersey-server-2.34.jar
     - jersey-common-2.34.jar
  * JAXB


### PR DESCRIPTION
### Motivation

Branch 2.11 doesn't bring the correct LICENSE file for Pulsar SQL. 

>➜  pulsar2 git:(v2.11.0-candidate-3) ./src/check-binary-license.sh distribution/server/target/apache-pulsar-2.11.0-bin.tar.gz
failsafe-2.4.4.jar unaccounted for in lib/presto/LICENSE
jersey-entity-filtering-2.34.jar unaccounted for in lib/presto/LICENSE
jersey-media-json-jackson-2.34.jar unaccounted for in lib/presto/LICENSE
jersey-media-multipart-2.34.jar unaccounted for in lib/presto/LICENSE
listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.jar unaccounted for in lib/presto/LICENSE
netty-transport-native-epoll-4.1.86.Final.jar mentioned in lib/presto/LICENSE, but not bundled
It looks like there are issues with the LICENSE/NOTICE.

### Modifications

* Fix the Pulsar SQL License file

### Verifying this change
Run ./src/check-binary-license.sh 

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->