### PR TITLE
[fix][doc] miss stats-internal for non-partition topic and wrong API for paritioned topic stats-internal

### DIFF
--- a/site2/docs/admin-api-topics.md
+++ b/site2/docs/admin-api-topics.md
@@ -1782,7 +1782,6 @@ admin.topics().getPartitionedTopicList(namespace);
 
 ### Stats
 
-
 You can check the current statistics of a given partitioned topic and its connected producers and consumers in the following ways.
 
 ````mdx-code-block

--- a/site2/docs/admin-api-topics.md
+++ b/site2/docs/admin-api-topics.md
@@ -1921,7 +1921,7 @@ You can get the internal stats for the partitioned topic in the following ways.
 
 ```shell
 pulsar-admin topics partitioned-stats-internal \
-persistent://test-tenant/namespace/topic
+    persistent://test-tenant/namespace/topic
 ```
 
 </TabItem>

--- a/site2/docs/admin-api-topics.md
+++ b/site2/docs/admin-api-topics.md
@@ -1463,6 +1463,77 @@ The following is an example. For the description of topic stats, see [Pulsar sta
 }
 ```
 
+### Internal stats
+
+You can check the detailed statistics of a topic. The following is an example. For the description of each internal topic stats, see [Pulsar statistics](administration-stats.md#topic-internal-stats).
+
+```json
+{
+  "entriesAddedCounter": 20449518,
+  "numberOfEntries": 3233,
+  "totalSize": 331482,
+  "currentLedgerEntries": 3233,
+  "currentLedgerSize": 331482,
+  "lastLedgerCreatedTimestamp": "2016-06-29 03:00:23.825",
+  "lastLedgerCreationFailureTimestamp": null,
+  "waitingCursorsCount": 1,
+  "pendingAddEntriesCount": 0,
+  "lastConfirmedEntry": "324711539:3232",
+  "state": "LedgerOpened",
+  "ledgers": [
+    {
+      "ledgerId": 324711539,
+      "entries": 0,
+      "size": 0
+    }
+  ],
+  "cursors": {
+    "my-subscription": {
+      "markDeletePosition": "324711539:3133",
+      "readPosition": "324711539:3233",
+      "waitingReadOp": true,
+      "pendingReadOps": 0,
+      "messagesConsumedCounter": 20449501,
+      "cursorLedger": 324702104,
+      "cursorLedgerLastEntry": 21,
+      "individuallyDeletedMessages": "[(324711539:3134‥324711539:3136], (324711539:3137‥324711539:3140], ]",
+      "lastLedgerSwitchTimestamp": "2016-06-29 01:30:19.313",
+      "state": "Open"
+    }
+  }
+}
+```
+
+You can get the internal stats for the partitioned topic in the following ways.
+
+````mdx-code-block
+<Tabs groupId="api-choice"
+  defaultValue="pulsar-admin"
+  values={[{"label":"pulsar-admin","value":"pulsar-admin"},{"label":"REST API","value":"REST API"},{"label":"Java","value":"Java"}]}>
+<TabItem value="pulsar-admin">
+
+```shell
+pulsar-admin topics stats-internal \
+persistent://test-tenant/namespace/topic
+```
+
+</TabItem>
+<TabItem value="REST API">
+
+{@inject: endpoint|GET|/admin/v2/:schema/:tenant/:namespace/:topic/internalStats|operation/getInternalStats?version=@pulsar:version_number@}
+
+</TabItem>
+<TabItem value="Java">
+
+```java
+admin.topics().getInternalStats(topic);
+```
+
+</TabItem>
+
+</Tabs>
+````
+
 ## Manage partitioned topics
 You can use Pulsar [admin API](admin-api-overview.md) to create, update, delete and check the status of partitioned topics.
 
@@ -1802,7 +1873,7 @@ Note that in the subscription JSON object, `chuckedMessageRate` is deprecated. P
 
 ### Internal stats
 
-You can check the detailed statistics of a topic. The following is an example. For the description of each internal topic stats, see [Pulsar statistics](administration-stats.md#topic-internal-stats).
+You can check the detailed statistics of a partitioned topic. The following is an example. For the description of each internal topic stats, see [Pulsar statistics](administration-stats.md#topic-internal-stats).
 
 ```json
 {
@@ -1850,20 +1921,20 @@ You can get the internal stats for the partitioned topic in the following ways.
 <TabItem value="pulsar-admin">
 
 ```shell
-pulsar-admin topics stats-internal \
+pulsar-admin topics partitioned-stats-internal \
 persistent://test-tenant/namespace/topic
 ```
 
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v2/:schema/:tenant/:namespace/:topic/internalStats|operation/getInternalStats?version=@pulsar:version_number@}
+{@inject: endpoint|GET|/admin/v2/:schema/:tenant/:namespace/:topic/partitioned-internalStats|operation/getPartitionedInternalStats?version=@pulsar:version_number@}
 
 </TabItem>
 <TabItem value="Java">
 
 ```java
-admin.topics().getInternalStats(topic);
+admin.topics().getPartitionedInternalStats(topic);
 ```
 
 </TabItem>

--- a/site2/docs/admin-api-topics.md
+++ b/site2/docs/admin-api-topics.md
@@ -1514,7 +1514,7 @@ You can get the internal stats for the partitioned topic in the following ways.
 
 ```shell
 pulsar-admin topics stats-internal \
-persistent://test-tenant/namespace/topic
+    persistent://test-tenant/namespace/topic
 ```
 
 </TabItem>

--- a/site2/website/versioned_docs/version-2.10.x/admin-api-topics.md
+++ b/site2/website/versioned_docs/version-2.10.x/admin-api-topics.md
@@ -2271,7 +2271,7 @@ You can get the internal stats for the partitioned topic in the following ways.
 
 ```shell
 pulsar-admin topics partitioned-stats-internal \
-persistent://test-tenant/namespace/topic
+    persistent://test-tenant/namespace/topic
 ```
 
 </TabItem>

--- a/site2/website/versioned_docs/version-2.10.x/admin-api-topics.md
+++ b/site2/website/versioned_docs/version-2.10.x/admin-api-topics.md
@@ -1870,6 +1870,36 @@ You can check the detailed statistics of a topic. The following is an example. F
 }
 ```
 
+You can get the internal stats for the partitioned topic in the following ways.
+
+````mdx-code-block
+<Tabs groupId="api-choice"
+  defaultValue="pulsar-admin"
+  values={[{"label":"pulsar-admin","value":"pulsar-admin"},{"label":"REST API","value":"REST API"},{"label":"Java","value":"Java"}]}>
+<TabItem value="pulsar-admin">
+
+```shell
+$ pulsar-admin topics stats-internal \
+  persistent://test-tenant/namespace/topic
+```
+
+</TabItem>
+<TabItem value="REST API">
+
+{@inject: endpoint|GET|/admin/v2/:schema/:tenant/:namespace/:topic/internalStats|operation/getInternalStats?version=@pulsar:version_number@}
+
+</TabItem>
+<TabItem value="Java">
+
+```java
+admin.topics().getInternalStats(topic);
+```
+
+</TabItem>
+
+</Tabs>
+````
+
 ## Manage partitioned topics
 You can use Pulsar [admin API](admin-api-overview.md) to create, update, delete and check status of partitioned topics.
 
@@ -2270,8 +2300,8 @@ You can get the internal stats for the partitioned topic in the following ways.
 <TabItem value="pulsar-admin">
 
 ```shell
-pulsar-admin topics partitioned-stats-internal \
-    persistent://test-tenant/namespace/topic
+$ pulsar-admin topics partitioned-stats-internal \
+  persistent://test-tenant/namespace/topic
 ```
 
 </TabItem>

--- a/site2/website/versioned_docs/version-2.10.x/admin-api-topics.md
+++ b/site2/website/versioned_docs/version-2.10.x/admin-api-topics.md
@@ -1829,6 +1829,47 @@ admin.topics().getStats(topic, false /* is precise backlog */);
 </Tabs>
 ````
 
+### Internal stats
+
+You can check the detailed statistics of a topic. The following is an example. For the description of each internal topic stats, see [Pulsar statistics](administration-stats.md#topic-internal-stats).
+
+```json
+{
+  "entriesAddedCounter": 20449518,
+  "numberOfEntries": 3233,
+  "totalSize": 331482,
+  "currentLedgerEntries": 3233,
+  "currentLedgerSize": 331482,
+  "lastLedgerCreatedTimestamp": "2016-06-29 03:00:23.825",
+  "lastLedgerCreationFailureTimestamp": null,
+  "waitingCursorsCount": 1,
+  "pendingAddEntriesCount": 0,
+  "lastConfirmedEntry": "324711539:3232",
+  "state": "LedgerOpened",
+  "ledgers": [
+    {
+      "ledgerId": 324711539,
+      "entries": 0,
+      "size": 0
+    }
+  ],
+  "cursors": {
+    "my-subscription": {
+      "markDeletePosition": "324711539:3133",
+      "readPosition": "324711539:3233",
+      "waitingReadOp": true,
+      "pendingReadOps": 0,
+      "messagesConsumedCounter": 20449501,
+      "cursorLedger": 324702104,
+      "cursorLedgerLastEntry": 21,
+      "individuallyDeletedMessages": "[(324711539:3134‥324711539:3136], (324711539:3137‥324711539:3140], ]",
+      "lastLedgerSwitchTimestamp": "2016-06-29 01:30:19.313",
+      "state": "Open"
+    }
+  }
+}
+```
+
 ## Manage partitioned topics
 You can use Pulsar [admin API](admin-api-overview.md) to create, update, delete and check status of partitioned topics.
 
@@ -2179,7 +2220,7 @@ admin.topics().getPartitionedStats(topic, true /* per partition */, false /* is 
 
 ### Internal stats
 
-You can check the detailed statistics of a topic. The following is an example. For description of each stats, refer to [get internal stats](#get-internal-stats).
+You can check the detailed statistics of a partitioned topic. The following is an example. For description of each stats, refer to [get internal stats](#get-internal-stats).
 
 ```json
 
@@ -2229,24 +2270,20 @@ You can get the internal stats for the partitioned topic in the following ways.
 <TabItem value="pulsar-admin">
 
 ```shell
-
-$ pulsar-admin topics stats-internal \
-  persistent://test-tenant/namespace/topic
-
+pulsar-admin topics partitioned-stats-internal \
+persistent://test-tenant/namespace/topic
 ```
 
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v2/:schema/:tenant/:namespace/:topic/internalStats|operation/getInternalStats?version=@pulsar:version_number@}
+{@inject: endpoint|GET|/admin/v2/:schema/:tenant/:namespace/:topic/partitioned-internalStats|operation/getPartitionedInternalStats?version=@pulsar:version_number@}
 
 </TabItem>
 <TabItem value="Java">
 
 ```java
-
-admin.topics().getInternalStats(topic);
-
+admin.topics().getPartitionedInternalStats(topic);
 ```
 
 </TabItem>

--- a/site2/website/versioned_docs/version-2.8.x/admin-api-topics.md
+++ b/site2/website/versioned_docs/version-2.8.x/admin-api-topics.md
@@ -2018,7 +2018,7 @@ You can get the internal stats for the partitioned topic in the following ways.
 
 ```shell
 pulsar-admin topics partitioned-stats-internal \
-persistent://test-tenant/namespace/topic
+    persistent://test-tenant/namespace/topic
 ```
 
 </TabItem>

--- a/site2/website/versioned_docs/version-2.8.x/admin-api-topics.md
+++ b/site2/website/versioned_docs/version-2.8.x/admin-api-topics.md
@@ -1596,8 +1596,8 @@ You can get the internal stats for the partitioned topic in the following ways.
 <TabItem value="pulsar-admin">
 
 ```shell
-pulsar-admin topics stats-internal \
-persistent://test-tenant/namespace/topic
+$ pulsar-admin topics stats-internal \
+  persistent://test-tenant/namespace/topic
 ```
 
 </TabItem>
@@ -2017,8 +2017,8 @@ You can get the internal stats for the partitioned topic in the following ways.
 <TabItem value="pulsar-admin">
 
 ```shell
-pulsar-admin topics partitioned-stats-internal \
-    persistent://test-tenant/namespace/topic
+$ pulsar-admin topics partitioned-stats-internal \
+  persistent://test-tenant/namespace/topic
 ```
 
 </TabItem>

--- a/site2/website/versioned_docs/version-2.8.x/admin-api-topics.md
+++ b/site2/website/versioned_docs/version-2.8.x/admin-api-topics.md
@@ -1546,6 +1546,77 @@ admin.topics().getStats(topic, false /* is precise backlog */);
 </Tabs>
 ````
 
+### Internal stats
+
+You can check the detailed statistics of a topic. The following is an example. For the description of each internal topic stats, see [Pulsar statistics](administration-stats.md#topic-internal-stats).
+
+```json
+{
+  "entriesAddedCounter": 20449518,
+  "numberOfEntries": 3233,
+  "totalSize": 331482,
+  "currentLedgerEntries": 3233,
+  "currentLedgerSize": 331482,
+  "lastLedgerCreatedTimestamp": "2016-06-29 03:00:23.825",
+  "lastLedgerCreationFailureTimestamp": null,
+  "waitingCursorsCount": 1,
+  "pendingAddEntriesCount": 0,
+  "lastConfirmedEntry": "324711539:3232",
+  "state": "LedgerOpened",
+  "ledgers": [
+    {
+      "ledgerId": 324711539,
+      "entries": 0,
+      "size": 0
+    }
+  ],
+  "cursors": {
+    "my-subscription": {
+      "markDeletePosition": "324711539:3133",
+      "readPosition": "324711539:3233",
+      "waitingReadOp": true,
+      "pendingReadOps": 0,
+      "messagesConsumedCounter": 20449501,
+      "cursorLedger": 324702104,
+      "cursorLedgerLastEntry": 21,
+      "individuallyDeletedMessages": "[(324711539:3134‥324711539:3136], (324711539:3137‥324711539:3140], ]",
+      "lastLedgerSwitchTimestamp": "2016-06-29 01:30:19.313",
+      "state": "Open"
+    }
+  }
+}
+```
+
+You can get the internal stats for the partitioned topic in the following ways.
+
+````mdx-code-block
+<Tabs groupId="api-choice"
+  defaultValue="pulsar-admin"
+  values={[{"label":"pulsar-admin","value":"pulsar-admin"},{"label":"REST API","value":"REST API"},{"label":"Java","value":"Java"}]}>
+<TabItem value="pulsar-admin">
+
+```shell
+pulsar-admin topics stats-internal \
+persistent://test-tenant/namespace/topic
+```
+
+</TabItem>
+<TabItem value="REST API">
+
+{@inject: endpoint|GET|/admin/v2/:schema/:tenant/:namespace/:topic/internalStats|operation/getInternalStats?version=@pulsar:version_number@}
+
+</TabItem>
+<TabItem value="Java">
+
+```java
+admin.topics().getInternalStats(topic);
+```
+
+</TabItem>
+
+</Tabs>
+````
+
 ## Manage partitioned topics
 You can use Pulsar [admin API](admin-api-overview.md) to create, update, delete and check status of partitioned topics.
 
@@ -1896,7 +1967,7 @@ admin.topics().getPartitionedStats(topic, true /* per partition */, false /* is 
 
 ### Internal stats
 
-You can check the detailed statistics of a topic. The following is an example. For description of each stats, refer to [get internal stats](#get-internal-stats).
+You can check the detailed statistics of a partitioned topic. The following is an example. For description of each stats, refer to [get internal stats](#get-internal-stats).
 
 ```json
 
@@ -1946,23 +2017,21 @@ You can get the internal stats for the partitioned topic in the following ways.
 <TabItem value="pulsar-admin">
 
 ```shell
-
-$ pulsar-admin topics stats-internal \
-  persistent://test-tenant/namespace/topic
-
+pulsar-admin topics partitioned-stats-internal \
+persistent://test-tenant/namespace/topic
 ```
 
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v2/:schema/:tenant/:namespace/:topic/internalStats|operation/getInternalStats?version=@pulsar:version_number@}
+{@inject: endpoint|GET|/admin/v2/:schema/:tenant/:namespace/:topic/partitioned-internalStats|operation/getPartitionedInternalStats?version=@pulsar:version_number@}
 
 </TabItem>
 <TabItem value="Java">
 
 ```java
 
-admin.topics().getInternalStats(topic);
+admin.topics().getPartitionedInternalStats(topic);
 
 ```
 

--- a/site2/website/versioned_docs/version-2.9.x/admin-api-topics.md
+++ b/site2/website/versioned_docs/version-2.9.x/admin-api-topics.md
@@ -1775,6 +1775,77 @@ admin.topics().getStats(topic, false /* is precise backlog */);
 </Tabs>
 ````
 
+### Internal stats
+
+You can check the detailed statistics of a topic. The following is an example. For the description of each internal topic stats, see [Pulsar statistics](administration-stats.md#topic-internal-stats).
+
+```json
+{
+  "entriesAddedCounter": 20449518,
+  "numberOfEntries": 3233,
+  "totalSize": 331482,
+  "currentLedgerEntries": 3233,
+  "currentLedgerSize": 331482,
+  "lastLedgerCreatedTimestamp": "2016-06-29 03:00:23.825",
+  "lastLedgerCreationFailureTimestamp": null,
+  "waitingCursorsCount": 1,
+  "pendingAddEntriesCount": 0,
+  "lastConfirmedEntry": "324711539:3232",
+  "state": "LedgerOpened",
+  "ledgers": [
+    {
+      "ledgerId": 324711539,
+      "entries": 0,
+      "size": 0
+    }
+  ],
+  "cursors": {
+    "my-subscription": {
+      "markDeletePosition": "324711539:3133",
+      "readPosition": "324711539:3233",
+      "waitingReadOp": true,
+      "pendingReadOps": 0,
+      "messagesConsumedCounter": 20449501,
+      "cursorLedger": 324702104,
+      "cursorLedgerLastEntry": 21,
+      "individuallyDeletedMessages": "[(324711539:3134‥324711539:3136], (324711539:3137‥324711539:3140], ]",
+      "lastLedgerSwitchTimestamp": "2016-06-29 01:30:19.313",
+      "state": "Open"
+    }
+  }
+}
+```
+
+You can get the internal stats for the partitioned topic in the following ways.
+
+````mdx-code-block
+<Tabs groupId="api-choice"
+  defaultValue="pulsar-admin"
+  values={[{"label":"pulsar-admin","value":"pulsar-admin"},{"label":"REST API","value":"REST API"},{"label":"Java","value":"Java"}]}>
+<TabItem value="pulsar-admin">
+
+```shell
+pulsar-admin topics stats-internal \
+persistent://test-tenant/namespace/topic
+```
+
+</TabItem>
+<TabItem value="REST API">
+
+{@inject: endpoint|GET|/admin/v2/:schema/:tenant/:namespace/:topic/internalStats|operation/getInternalStats?version=@pulsar:version_number@}
+
+</TabItem>
+<TabItem value="Java">
+
+```java
+admin.topics().getInternalStats(topic);
+```
+
+</TabItem>
+
+</Tabs>
+````
+
 ## Manage partitioned topics
 You can use Pulsar [admin API](admin-api-overview.md) to create, update, delete and check status of partitioned topics.
 
@@ -2125,7 +2196,7 @@ admin.topics().getPartitionedStats(topic, true /* per partition */, false /* is 
 
 ### Internal stats
 
-You can check the detailed statistics of a topic. The following is an example. For description of each stats, refer to [get internal stats](#get-internal-stats).
+You can check the detailed statistics of a partitioned topic. The following is an example. For description of each stats, refer to [get internal stats](#get-internal-stats).
 
 ```json
 
@@ -2175,24 +2246,20 @@ You can get the internal stats for the partitioned topic in the following ways.
 <TabItem value="pulsar-admin">
 
 ```shell
-
-$ pulsar-admin topics stats-internal \
-  persistent://test-tenant/namespace/topic
-
+pulsar-admin topics partitioned-stats-internal \
+persistent://test-tenant/namespace/topic
 ```
 
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v2/:schema/:tenant/:namespace/:topic/internalStats|operation/getInternalStats?version=@pulsar:version_number@}
+{@inject: endpoint|GET|/admin/v2/:schema/:tenant/:namespace/:topic/partitioned-internalStats|operation/getPartitionedInternalStats?version=@pulsar:version_number@}
 
 </TabItem>
 <TabItem value="Java">
 
 ```java
-
-admin.topics().getInternalStats(topic);
-
+admin.topics().getPartitionedInternalStats(topic);
 ```
 
 </TabItem>

--- a/site2/website/versioned_docs/version-2.9.x/admin-api-topics.md
+++ b/site2/website/versioned_docs/version-2.9.x/admin-api-topics.md
@@ -2247,7 +2247,7 @@ You can get the internal stats for the partitioned topic in the following ways.
 
 ```shell
 pulsar-admin topics partitioned-stats-internal \
-persistent://test-tenant/namespace/topic
+    persistent://test-tenant/namespace/topic
 ```
 
 </TabItem>

--- a/site2/website/versioned_docs/version-2.9.x/admin-api-topics.md
+++ b/site2/website/versioned_docs/version-2.9.x/admin-api-topics.md
@@ -1825,8 +1825,8 @@ You can get the internal stats for the partitioned topic in the following ways.
 <TabItem value="pulsar-admin">
 
 ```shell
-pulsar-admin topics stats-internal \
-persistent://test-tenant/namespace/topic
+$ pulsar-admin topics stats-internal \
+  persistent://test-tenant/namespace/topic
 ```
 
 </TabItem>
@@ -2246,8 +2246,8 @@ You can get the internal stats for the partitioned topic in the following ways.
 <TabItem value="pulsar-admin">
 
 ```shell
-pulsar-admin topics partitioned-stats-internal \
-    persistent://test-tenant/namespace/topic
+$ pulsar-admin topics partitioned-stats-internal \
+  persistent://test-tenant/namespace/topic
 ```
 
 </TabItem>


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://docs.google.com/document/d/1d8Pw6ZbWk-_pCKdOmdvx9rnhPiyuxwq60_TrD68d7BA/edit#heading=h.trs9rsex3xom)*. 

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->

<!-- Either this PR fixes an issue, -->

Fixes #xyz

<!-- or this PR is one task of an issue -->

Master Issue: #xyz

<!-- If the PR belongs to a PIP, please add the PIP link here -->

PIP: #xyz 

<!-- Details of when a PIP is required and how the PIP process work, please see: https://github.com/apache/pulsar/blob/master/wiki/proposals/PIP.md -->

### Motivation

<!-- Explain here the context, and why you're making that change. What is the problem you're trying to solve. -->

https://pulsar.apache.org/docs/2.10.x/admin-api-topics/#manage-non-partitioned-topics missed the `stats-internal` API introduction.

https://pulsar.apache.org/docs/2.10.x/admin-api-topics/#internal-stats used the wrong `stats-internal` API, the current API is for the non-partition topic rather than for the partitioned topic. 

### Modifications

<!-- Describe the modifications you've done. -->

Fix the above issues in this document. 

PR preview build:

<img width="800" alt="截屏2022-12-23 下午7 32 48" src="https://user-images.githubusercontent.com/10498732/209329535-4ed98fea-8db1-4c12-bcef-89c8cc9df5c2.png">

<img width="800" alt="截屏2022-12-23 下午7 33 49" src="https://user-images.githubusercontent.com/10498732/209329557-c1b7f105-2efb-4eb4-9557-cad213815959.png">

<img width="800" alt="截屏2022-12-23 下午7 33 57" src="https://user-images.githubusercontent.com/10498732/209329567-69f73a9b-6b5c-4ff2-bd5b-8af8d2bc8124.png">


### Verifying this change

- [x] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [x] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
