### PR TITLE
[improve][client] Add unified newTableView method in PulsarClient

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/TableViewTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/TableViewTest.java
@@ -162,6 +162,24 @@ public class TableViewTest extends MockedPulsarServiceBaseTest {
         }
     }
 
+    @Test
+    public void testNewTableView() throws Exception {
+        String topic = "persistent://public/default/new-tableview-test";
+        admin.topics().createPartitionedTopic(topic, 2);
+        Set<String> keys = this.publishMessages(topic, 10, false);
+        @Cleanup
+        TableView<byte[]> tv = pulsarClient.newTableView()
+                .topic(topic)
+                .autoUpdatePartitionsInterval(60, TimeUnit.SECONDS)
+                .create();
+        tv.forEachAndListen((k, v) -> log.info("{} -> {}", k, new String(v)));
+        Awaitility.await().untilAsserted(() -> {
+            log.info("Current tv size: {}", tv.size());
+            assertEquals(tv.size(), 10);
+        });
+        assertEquals(tv.keySet(), keys);
+    }
+
     @Test(timeOut = 30 * 1000, dataProvider = "topicDomain")
     public void testTableViewUpdatePartitions(String topicDomain) throws Exception {
         String topic = topicDomain + "://public/default/tableview-test-update-partitions";
@@ -231,7 +249,7 @@ public class TableViewTest extends MockedPulsarServiceBaseTest {
         tv.close();
 
         @Cleanup
-        TableView<String> tv1 = pulsarClient.newTableViewBuilder(Schema.STRING)
+        TableView<String> tv1 = pulsarClient.newTableView(Schema.STRING)
                 .topic(topic)
                 .autoUpdatePartitionsInterval(5, TimeUnit.SECONDS)
                 .create();

--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/PulsarClient.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/PulsarClient.java
@@ -230,6 +230,50 @@ public interface PulsarClient extends Closeable {
      *
      * <p>Example:
      * <pre>{@code
+     *  TableView<byte[]> tableView = client.newTableViewBuilder(Schema.BYTES)
+     *            .topic("my-topic")
+     *            .autoUpdatePartitionsInterval(5, TimeUnit.SECONDS)
+     *            .create();
+     *
+     *  tableView.forEach((k, v) -> System.out.println(k + ":" + v));
+     * }</pre>
+     *
+     * @param schema provide a way to convert between serialized data and domain objects
+     * @return a {@link TableViewBuilder} object to configure and construct the {@link TableView} instance
+     * @deprecated Use {@link PulsarClient#newTableView(Schema)} to build and configure a {@link TableViewBuilder}
+     * instance
+     */
+    @Deprecated
+    <T> TableViewBuilder<T> newTableViewBuilder(Schema<T> schema);
+
+    /**
+     * Create a table view builder for subscribing on a specific topic.
+     *
+     * <p>The TableView provides a key-value map view of a compacted topic. Messages without keys will
+     * be ignored.
+     *
+     * <p>Example:
+     * <pre>{@code
+     *  TableView<byte[]> tableView = client.newTableView()
+     *            .topic("my-topic")
+     *            .autoUpdatePartitionsInterval(5, TimeUnit.SECONDS)
+     *            .create();
+     *
+     *  tableView.forEach((k, v) -> System.out.println(k + ":" + v));
+     * }</pre>
+     *
+     * @return a {@link TableViewBuilder} object to configure and construct the {@link TableView} instance
+     */
+    TableViewBuilder<byte[]> newTableView();
+
+    /**
+     * Create a table view builder with a specific schema for subscribing on a specific topic.
+     *
+     * <p>The TableView provides a key-value map view of a compacted topic. Messages without keys will
+     * be ignored.
+     *
+     * <p>Example:
+     * <pre>{@code
      *  TableView<byte[]> tableView = client.newTableView(Schema.BYTES)
      *            .topic("my-topic")
      *            .autoUpdatePartitionsInterval(5, TimeUnit.SECONDS)
@@ -241,7 +285,7 @@ public interface PulsarClient extends Closeable {
      * @param schema provide a way to convert between serialized data and domain objects
      * @return a {@link TableViewBuilder} object to configure and construct the {@link TableView} instance
      */
-    <T> TableViewBuilder<T> newTableViewBuilder(Schema<T> schema);
+    <T> TableViewBuilder<T> newTableView(Schema<T> schema);
 
     /**
      * Update the service URL this client is using.

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PulsarClientImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PulsarClientImpl.java
@@ -305,8 +305,22 @@ public class PulsarClientImpl implements PulsarClient {
         return new ReaderBuilderImpl<>(this, schema);
     }
 
+    /**
+     * @deprecated use {@link #newTableView(Schema)} instead.
+     */
     @Override
+    @Deprecated
     public <T> TableViewBuilder<T> newTableViewBuilder(Schema<T> schema) {
+        return new TableViewBuilderImpl<>(this, schema);
+    }
+
+    @Override
+    public TableViewBuilder<byte[]> newTableView() {
+        return new TableViewBuilderImpl<>(this, Schema.BYTES);
+    }
+
+    @Override
+    public <T> TableViewBuilder<T> newTableView(Schema<T> schema) {
         return new TableViewBuilderImpl<>(this, schema);
     }
 


### PR DESCRIPTION
Currently, we can use PulsarClient to create `Producer`, `Consumer`, `Reader` and `TableView`, releated method as below:
```
ProducerBuilder<byte[]> newProducer();
<T> ProducerBuilder<T> newProducer(Schema<T> schema);
ConsumerBuilder<byte[]> newConsumer();
<T> ConsumerBuilder<T> newConsumer(Schema<T> schema);
ReaderBuilder<byte[]> newReader();
<T> ReaderBuilder<T> newReader(Schema<T> schema);
<T> TableViewBuilder<T> newTableViewBuilder(Schema<T> schema);
```
However, it is obvious that the method of creating `TableView` is not consistent with other methods, and no method with default scheme is provided.

### Motivation
Add unified `newTableView(Schema)` method and replace `newTableViewBuilder(Schema)`(attach `@Deprecated` annotation to it) in PulsarClient, which could consistent with `newProducer(Schema)`, `newConsumer(Schema)`, `newReader(Schema)`.
In addition, we will provide `newTableView()` method which  has default schema.

### Modifications
1. Add `newTableView(Schema)` method and replace `newTableViewBuilder(Schema)`(attach `@Deprecated` annotation to it)  in PulsarClient
2. Add `newTableView()` method and Scheme default is `Schema.BYTES` in PulsarClient

### Documentation
- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository
PR in forked repository: 
