### PR TITLE
[improve][io] Add zstd support to hdfs2 and hdfs3

### DIFF
--- a/pulsar-io/hdfs2/src/main/java/org/apache/pulsar/io/hdfs2/Compression.java
+++ b/pulsar-io/hdfs2/src/main/java/org/apache/pulsar/io/hdfs2/Compression.java
@@ -22,5 +22,5 @@ package org.apache.pulsar.io.hdfs2;
  * An enumeration of compression codecs available for HDFS.
  */
 public enum Compression {
-    BZIP2, DEFLATE, GZIP, LZ4, SNAPPY
+    BZIP2, DEFLATE, GZIP, LZ4, SNAPPY, ZSTANDARD
 }

--- a/pulsar-io/hdfs2/src/test/java/org/apache/pulsar/io/hdfs2/sink/seq/HdfsSequentialSinkTests.java
+++ b/pulsar-io/hdfs2/src/test/java/org/apache/pulsar/io/hdfs2/sink/seq/HdfsSequentialSinkTests.java
@@ -22,6 +22,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.testng.Assert.assertNotNull;
 import org.apache.pulsar.io.hdfs2.sink.AbstractHdfsSinkTest;
+import org.testng.SkipException;
 import org.testng.annotations.Test;
 
 public class HdfsSequentialSinkTests extends AbstractHdfsSinkTest<Long, String> {
@@ -86,6 +87,20 @@ public class HdfsSequentialSinkTests extends AbstractHdfsSinkTest<Long, String> 
     public final void deflateCompressionTest() throws Exception {
         map.put("filenamePrefix", "deflateCompressionTest-seq");
         map.put("compression", "DEFLATE");
+        map.remove("fileExtension");
+        sink.open(map, mockSinkContext);
+        send(5000);
+        sink.close();
+        verify(mockRecord, times(5000)).ack();
+    }
+
+    @Test
+    public final void zStandardCompressionTest() throws Exception {
+        if (System.getenv("LD_LIBRARY_PATH") == null) {
+            throw new SkipException("Skip zStandardCompressionTest since LD_LIBRARY_PATH is not set");
+        }
+        map.put("filenamePrefix", "zStandardCompressionTest-seq");
+        map.put("compression", "ZSTANDARD");
         map.remove("fileExtension");
         sink.open(map, mockSinkContext);
         send(5000);

--- a/pulsar-io/hdfs2/src/test/java/org/apache/pulsar/io/hdfs2/sink/seq/HdfsTextSinkTests.java
+++ b/pulsar-io/hdfs2/src/test/java/org/apache/pulsar/io/hdfs2/sink/seq/HdfsTextSinkTests.java
@@ -22,6 +22,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.testng.Assert.assertNotNull;
 import org.apache.pulsar.io.hdfs2.sink.AbstractHdfsSinkTest;
+import org.testng.SkipException;
 import org.testng.annotations.Test;
 
 public class HdfsTextSinkTests extends AbstractHdfsSinkTest<String, String> {
@@ -94,6 +95,22 @@ public class HdfsTextSinkTests extends AbstractHdfsSinkTest<String, String> {
     public final void deflateCompressionTest() throws Exception {
         map.put("filenamePrefix", "deflateCompressionTestText-seq");
         map.put("compression", "DEFLATE");
+        map.remove("fileExtension");
+        sink.open(map, mockSinkContext);
+
+        assertNotNull(mockRecord);
+        send(5000);
+        sink.close();
+        verify(mockRecord, times(5000)).ack();
+    }
+
+    @Test
+    public final void zStandardCompressionTest() throws Exception {
+        if (System.getenv("LD_LIBRARY_PATH") == null) {
+            throw new SkipException("Skip zStandardCompressionTest since LD_LIBRARY_PATH is not set");
+        }
+        map.put("filenamePrefix", "zStandardCompressionTestText-seq");
+        map.put("compression", "ZSTANDARD");
         map.remove("fileExtension");
         sink.open(map, mockSinkContext);
 

--- a/pulsar-io/hdfs2/src/test/java/org/apache/pulsar/io/hdfs2/sink/text/HdfsStringSinkTests.java
+++ b/pulsar-io/hdfs2/src/test/java/org/apache/pulsar/io/hdfs2/sink/text/HdfsStringSinkTests.java
@@ -21,6 +21,7 @@ package org.apache.pulsar.io.hdfs2.sink.text;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import org.apache.pulsar.io.hdfs2.sink.AbstractHdfsSinkTest;
+import org.testng.SkipException;
 import org.testng.annotations.Test;
 
 public class HdfsStringSinkTests extends AbstractHdfsSinkTest<String, String> {
@@ -93,6 +94,21 @@ public class HdfsStringSinkTests extends AbstractHdfsSinkTest<String, String> {
         map.put("filenamePrefix", "deflateCompressionTest");
         map.put("compression", "DEFLATE");
         map.put("fileExtension", ".deflate");
+        map.put("separator", '\n');
+        sink.open(map, mockSinkContext);
+        send(50000);
+        sink.close();
+        verify(mockRecord, times(50000)).ack();
+    }
+
+    @Test
+    public final void zStandardCompressionTest() throws Exception {
+        if (System.getenv("LD_LIBRARY_PATH") == null) {
+            throw new SkipException("Skip zStandardCompressionTest since LD_LIBRARY_PATH is not set");
+        }
+        map.put("filenamePrefix", "zStandardCompressionTest");
+        map.put("compression", "ZSTANDARD");
+        map.put("fileExtension", ".zstandard");
         map.put("separator", '\n');
         sink.open(map, mockSinkContext);
         send(50000);

--- a/pulsar-io/hdfs3/src/main/java/org/apache/pulsar/io/hdfs3/Compression.java
+++ b/pulsar-io/hdfs3/src/main/java/org/apache/pulsar/io/hdfs3/Compression.java
@@ -22,5 +22,5 @@ package org.apache.pulsar.io.hdfs3;
  * An enumeration of compression codecs available for HDFS.
  */
 public enum Compression {
-    BZIP2, DEFLATE, GZIP, LZ4, SNAPPY
+    BZIP2, DEFLATE, GZIP, LZ4, SNAPPY, ZSTANDARD
 }

--- a/pulsar-io/hdfs3/src/test/java/org/apache/pulsar/io/hdfs3/sink/seq/HdfsSequentialSinkTests.java
+++ b/pulsar-io/hdfs3/src/test/java/org/apache/pulsar/io/hdfs3/sink/seq/HdfsSequentialSinkTests.java
@@ -22,6 +22,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.testng.Assert.assertNotNull;
 import org.apache.pulsar.io.hdfs3.sink.AbstractHdfsSinkTest;
+import org.testng.SkipException;
 import org.testng.annotations.Test;
 
 public class HdfsSequentialSinkTests extends AbstractHdfsSinkTest<Long, String> {
@@ -86,6 +87,20 @@ public class HdfsSequentialSinkTests extends AbstractHdfsSinkTest<Long, String> 
     public final void deflateCompressionTest() throws Exception {
         map.put("filenamePrefix", "deflateCompressionTest-seq");
         map.put("compression", "DEFLATE");
+        map.remove("fileExtension");
+        sink.open(map, mockSinkContext);
+        send(5000);
+        sink.close();
+        verify(mockRecord, times(5000)).ack();
+    }
+
+    @Test
+    public final void zStandardCompressionTest() throws Exception {
+        if (System.getenv("LD_LIBRARY_PATH") == null) {
+            throw new SkipException("Skip zStandardCompressionTest since LD_LIBRARY_PATH is not set");
+        }
+        map.put("filenamePrefix", "zStandardCompressionTest-seq");
+        map.put("compression", "ZSTANDARD");
         map.remove("fileExtension");
         sink.open(map, mockSinkContext);
         send(5000);

--- a/pulsar-io/hdfs3/src/test/java/org/apache/pulsar/io/hdfs3/sink/seq/HdfsTextSinkTests.java
+++ b/pulsar-io/hdfs3/src/test/java/org/apache/pulsar/io/hdfs3/sink/seq/HdfsTextSinkTests.java
@@ -22,6 +22,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.testng.Assert.assertNotNull;
 import org.apache.pulsar.io.hdfs3.sink.AbstractHdfsSinkTest;
+import org.testng.SkipException;
 import org.testng.annotations.Test;
 
 public class HdfsTextSinkTests extends AbstractHdfsSinkTest<String, String> {
@@ -94,6 +95,22 @@ public class HdfsTextSinkTests extends AbstractHdfsSinkTest<String, String> {
     public final void deflateCompressionTest() throws Exception {
         map.put("filenamePrefix", "deflateCompressionTestText-seq");
         map.put("compression", "DEFLATE");
+        map.remove("fileExtension");
+        sink.open(map, mockSinkContext);
+
+        assertNotNull(mockRecord);
+        send(5000);
+        sink.close();
+        verify(mockRecord, times(5000)).ack();
+    }
+
+    @Test
+    public final void zStandardCompressionTest() throws Exception {
+        if (System.getenv("LD_LIBRARY_PATH") == null) {
+            throw new SkipException("Skip zStandardCompressionTest since LD_LIBRARY_PATH is not set");
+        }
+        map.put("filenamePrefix", "zStandardCompressionTestText-seq");
+        map.put("compression", "ZSTANDARD");
         map.remove("fileExtension");
         sink.open(map, mockSinkContext);
 

--- a/pulsar-io/hdfs3/src/test/java/org/apache/pulsar/io/hdfs3/sink/text/HdfsStringSinkTests.java
+++ b/pulsar-io/hdfs3/src/test/java/org/apache/pulsar/io/hdfs3/sink/text/HdfsStringSinkTests.java
@@ -21,6 +21,7 @@ package org.apache.pulsar.io.hdfs3.sink.text;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import org.apache.pulsar.io.hdfs3.sink.AbstractHdfsSinkTest;
+import org.testng.SkipException;
 import org.testng.annotations.Test;
 
 public class HdfsStringSinkTests extends AbstractHdfsSinkTest<String, String> {
@@ -93,6 +94,21 @@ public class HdfsStringSinkTests extends AbstractHdfsSinkTest<String, String> {
         map.put("filenamePrefix", "deflateCompressionTest");
         map.put("compression", "DEFLATE");
         map.put("fileExtension", ".deflate");
+        map.put("separator", '\n');
+        sink.open(map, mockSinkContext);
+        send(50000);
+        sink.close();
+        verify(mockRecord, times(50000)).ack();
+    }
+
+    @Test
+    public final void zStandardCompressionTest() throws Exception {
+        if (System.getenv("LD_LIBRARY_PATH") == null) {
+            throw new SkipException("Skip zStandardCompressionTest since LD_LIBRARY_PATH is not set");
+        }
+        map.put("filenamePrefix", "zStandardCompressionTest");
+        map.put("compression", "ZSTANDARD");
+        map.put("fileExtension", ".zstandard");
         map.put("separator", '\n');
         sink.open(map, mockSinkContext);
         send(50000);

--- a/site2/docs/io-hdfs2-sink.md
+++ b/site2/docs/io-hdfs2-sink.md
@@ -17,7 +17,7 @@ The configuration of the HDFS2 sink connector has the following properties.
 | `hdfsConfigResources` | String|true| None | A file or a comma-separated list containing the Hadoop file system configuration.<br /><br />**Example**<br />'core-site.xml'<br />'hdfs-site.xml' |
 | `directory` | String | true | None|The HDFS directory where files read from or written to. |
 | `encoding` | String |false |None |The character encoding for the files.<br /><br />**Example**<br />UTF-8<br />ASCII |
-| `compression` | Compression |false |None |The compression code used to compress or de-compress the files on HDFS. <br /><br />Below are the available options:<br /><li>BZIP2<br /></li><li>DEFLATE<br /></li><li>GZIP<br /></li><li>LZ4<br /></li><li>SNAPPY</li>|
+| `compression` | Compression |false |None |The compression code used to compress or de-compress the files on HDFS. <br /><br />Below are the available options:<br /><li>BZIP2<br /></li><li>DEFLATE<br /></li><li>GZIP<br /></li><li>LZ4<br /></li><li>SNAPPY<br /></li><li>ZSTANDARD</li>|
 | `kerberosUserPrincipal` |String| false| None|The principal account of Kerberos user used for authentication. |
 | `keytab` | String|false|None| The full pathname of the Kerberos keytab file used for authentication. |
 | `filenamePrefix` |String| true, if `compression` is set to `None`. | None |The prefix of the files created inside the HDFS directory.<br /><br />**Example**<br /> The value of topicA result in files named topicA-. |

--- a/site2/docs/io-hdfs3-sink.md
+++ b/site2/docs/io-hdfs3-sink.md
@@ -17,7 +17,7 @@ The configuration of the HDFS3 sink connector has the following properties.
 | `hdfsConfigResources` | String|true| None | A file or a comma-separated list containing the Hadoop file system configuration.<br /><br />**Example**<br />'core-site.xml'<br />'hdfs-site.xml' |
 | `directory` | String | true | None|The HDFS directory where files read from or written to. |
 | `encoding` | String |false |None |The character encoding for the files.<br /><br />**Example**<br />UTF-8<br />ASCII |
-| `compression` | Compression |false |None |The compression code used to compress or de-compress the files on HDFS. <br /><br />Below are the available options:<br /><li>BZIP2<br /></li><li>DEFLATE<br /></li><li>GZIP<br /></li><li>LZ4<br /></li><li>SNAPPY</li>|
+| `compression` | Compression |false |None |The compression code used to compress or de-compress the files on HDFS. <br /><br />Below are the available options:<br /><li>BZIP2<br /></li><li>DEFLATE<br /></li><li>GZIP<br /></li><li>LZ4<br /></li><li>SNAPPY<br /></li><li>ZSTANDARD</li>|
 | `kerberosUserPrincipal` |String| false| None|The principal account of Kerberos user used for authentication. |
 | `keytab` | String|false|None| The full pathname of the Kerberos keytab file used for authentication. |
 | `filenamePrefix` |String| false |None |The prefix of the files created inside the HDFS directory.<br /><br />**Example**<br /> The value of topicA result in files named topicA-. |


### PR DESCRIPTION
### Motivation

<!-- Explain here the context, and why you're making that change. What is the problem you're trying to solve. -->

Recent versions of Hadoop support zstd compression, but it's not enabled in the hdfs2 and hdfs3 pulsar-io, so I'd like to activate it.

### Modifications

<!-- Describe the modifications you've done. -->

Added an enum definition and some unit tests.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

I ran the CI on my own GitHub account and it was successful except for the unit tests for broker group 2. I think that failure is irrelevant to this fix.
https://github.com/sekikn/incubator-pulsar/actions/runs/3774398563

This change added tests and can be verified as follows:

```
$ LD_LIBRARY_PATH=$HADOOP_HOME/lib/native ./mvnw test -f pulsar-io/hdfs2/pom.xml
$ LD_LIBRARY_PATH=$HADOOP_HOME/lib/native ./mvnw test -f pulsar-io/hdfs3/pom.xml
```

Zstd compression depends on Hadoop's native libraries, so LD_LIBRARY_PATH should be set for running them. If not, the newly added tests are simply skipped.

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [x] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

![io-hdfs-zstd](https://user-images.githubusercontent.com/898388/209455195-8bdbf10c-578d-42db-927f-f7e4396caa01.png)

### Matching PR in forked repository

PR in forked repository: https://github.com/sekikn/incubator-pulsar/pull/1

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
