### PR TITLE
[fix][broker] change name limitTime to limitTimeInSec

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/AdminResource.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/AdminResource.java
@@ -394,7 +394,7 @@ public abstract class AdminResource extends PulsarWebResource {
         }
         // time based quota is in second
         if (retention.getRetentionTimeInMinutes() > 0
-                && quota.getLimitTime() >= retention.getRetentionTimeInMinutes() * 60) {
+                && quota.getLimitTimeInSec() >= retention.getRetentionTimeInMinutes() * 60) {
             return false;
         }
         return true;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BacklogQuotaManager.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BacklogQuotaManager.java
@@ -197,7 +197,7 @@ public class BacklogQuotaManager {
         if (preciseTimeBasedBacklogQuotaCheck) {
             // Set the reduction factor to 90%. The aim is to drop down the backlog to 90% of the quota limit.
             double reductionFactor = 0.9;
-            int target = (int) (reductionFactor * quota.getLimitTime());
+            int target = (int) (reductionFactor * quota.getLimitTimeInSec());
             if (log.isDebugEnabled()) {
                 log.debug("[{}] target backlog expire time is [{}]", persistentTopic.getName(), target);
             }
@@ -226,7 +226,7 @@ public class BacklogQuotaManager {
                     }
                     // Timestamp only > 0 if ledger has been closed
                     if (ledgerInfo.getTimestamp() > 0
-                            && currentMillis - ledgerInfo.getTimestamp() > quota.getLimitTime() * 1000) {
+                            && currentMillis - ledgerInfo.getTimestamp() > quota.getLimitTimeInSec() * 1000) {
                         // skip whole ledger for the slowest cursor
                         PositionImpl nextPosition =
                                 PositionImpl.get(mLedger.getNextValidLedger(ledgerInfo.getLedgerId()), -1);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -2724,7 +2724,7 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
      */
     public CompletableFuture<Boolean> checkTimeBacklogExceeded() {
         TopicName topicName = TopicName.get(getName());
-        int backlogQuotaLimitInSecond = getBacklogQuota(BacklogQuotaType.message_age).getLimitTime();
+        int backlogQuotaLimitInSecond = getBacklogQuota(BacklogQuotaType.message_age).getLimitTimeInSec();
 
         // If backlog quota by time is not set and we have no durable cursor.
         if (backlogQuotaLimitInSecond <= 0
@@ -2780,7 +2780,7 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
 
     private CompletableFuture<Boolean> slowestReaderTimeBasedBacklogQuotaCheck(PositionImpl slowestPosition)
             throws ExecutionException, InterruptedException {
-        int backlogQuotaLimitInSecond = getBacklogQuota(BacklogQuotaType.message_age).getLimitTime();
+        int backlogQuotaLimitInSecond = getBacklogQuota(BacklogQuotaType.message_age).getLimitTimeInSec();
         Long ledgerId = slowestPosition.getLedgerId();
         if (((ManagedLedgerImpl) ledger).getLedgersInfo().lastKey().equals(ledgerId)) {
             return CompletableFuture.completedFuture(false);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/NamespaceStatsAggregator.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/NamespaceStatsAggregator.java
@@ -162,7 +162,7 @@ public class NamespaceStatsAggregator {
             stats.backlogQuotaLimit = topic
                     .getBacklogQuota(BacklogQuota.BacklogQuotaType.destination_storage).getLimitSize();
             stats.backlogQuotaLimitTime = topic
-                    .getBacklogQuota(BacklogQuota.BacklogQuotaType.message_age).getLimitTime();
+                    .getBacklogQuota(BacklogQuota.BacklogQuotaType.message_age).getLimitTimeInSec();
 
             stats.managedLedgerStats.storageWriteLatencyBuckets
                     .addAll(mlStats.getInternalAddEntryLatencyBuckets());

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatorTopicPoliciesTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatorTopicPoliciesTest.java
@@ -83,7 +83,7 @@ public class ReplicatorTopicPoliciesTest extends ReplicatorTestBase {
         // set BacklogQuota
         BacklogQuotaImpl backlogQuota = new BacklogQuotaImpl();
         backlogQuota.setLimitSize(1);
-        backlogQuota.setLimitTime(2);
+        backlogQuota.setLimitTimeInSec(2);
         // local
         admin1.topicPolicies().setBacklogQuota(topic, backlogQuota);
         Awaitility.await().untilAsserted(() ->

--- a/pulsar-client-admin-api/src/main/java/org/apache/pulsar/common/policies/data/BacklogQuota.java
+++ b/pulsar-client-admin-api/src/main/java/org/apache/pulsar/common/policies/data/BacklogQuota.java
@@ -49,7 +49,7 @@ public interface BacklogQuota {
      *
      * @return quota limit in second
      */
-    int getLimitTime();
+    int getLimitTimeInSec();
 
     RetentionPolicy getPolicy();
 

--- a/pulsar-client-admin-api/src/main/java/org/apache/pulsar/common/policies/data/impl/BacklogQuotaImpl.java
+++ b/pulsar-client-admin-api/src/main/java/org/apache/pulsar/common/policies/data/impl/BacklogQuotaImpl.java
@@ -45,12 +45,12 @@ public class BacklogQuotaImpl implements BacklogQuota {
     /**
      * backlog quota by time in second.
      */
-    private int limitTime;
+    private int limitTimeInSec;
     private RetentionPolicy policy;
 
-    public BacklogQuotaImpl(long limitSize, int limitTime, RetentionPolicy policy) {
+    public BacklogQuotaImpl(long limitSize, int limitTimeInSec, RetentionPolicy policy) {
         this.limitSize = limitSize;
-        this.limitTime = limitTime;
+        this.limitTimeInSec = limitTimeInSec;
         this.policy = policy;
     }
 
@@ -80,12 +80,12 @@ public class BacklogQuotaImpl implements BacklogQuota {
         this.limit = limitSize;
     }
 
-    public int getLimitTime() {
-        return limitTime;
+    public int getLimitTimeInSec() {
+        return limitTimeInSec;
     }
 
-    public void setLimitTime(int limitTime) {
-        this.limitTime = limitTime;
+    public void setLimitTimeInSec(int limitTimeInSec) {
+        this.limitTimeInSec = limitTimeInSec;
     }
 
     public RetentionPolicy getPolicy() {

--- a/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/BacklogQuotaCompatibilityTest.java
+++ b/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/BacklogQuotaCompatibilityTest.java
@@ -47,7 +47,7 @@ public class BacklogQuotaCompatibilityTest {
         Policies writePolicy = new Policies();
         BacklogQuotaImpl writeBacklogQuota = new BacklogQuotaImpl();
         writeBacklogQuota.setLimit(1024);
-        writeBacklogQuota.setLimitTime(60);
+        writeBacklogQuota.setLimitTimeInSec(60);
         writeBacklogQuota.setPolicy(testPolicy);
         HashMap<BacklogQuota.BacklogQuotaType, BacklogQuota> quotaHashMap = new HashMap<>();
         quotaHashMap.put(BacklogQuota.BacklogQuotaType.destination_storage, writeBacklogQuota);
@@ -56,7 +56,7 @@ public class BacklogQuotaCompatibilityTest {
         Policies policies = simpleType.deserialize("/path", serialize, null);
         BacklogQuota readBacklogQuota = policies.backlog_quota_map.get(BacklogQuota.BacklogQuotaType.destination_storage);
         Assert.assertEquals(readBacklogQuota.getLimitSize(), 1024);
-        Assert.assertEquals(readBacklogQuota.getLimitTime(), 60);
+        Assert.assertEquals(readBacklogQuota.getLimitTimeInSec(), 60);
         Assert.assertEquals(readBacklogQuota.getPolicy(), testPolicy);
     }
 
@@ -65,7 +65,7 @@ public class BacklogQuotaCompatibilityTest {
         Policies writePolicy = new Policies();
         BacklogQuotaImpl writeBacklogQuota = new BacklogQuotaImpl();
         writeBacklogQuota.setLimitSize(1024);
-        writeBacklogQuota.setLimitTime(60);
+        writeBacklogQuota.setLimitTimeInSec(60);
         writeBacklogQuota.setPolicy(testPolicy);
         HashMap<BacklogQuota.BacklogQuotaType, BacklogQuota> quotaHashMap = new HashMap<>();
         quotaHashMap.put(BacklogQuota.BacklogQuotaType.destination_storage, writeBacklogQuota);
@@ -74,7 +74,7 @@ public class BacklogQuotaCompatibilityTest {
         Policies policies = simpleType.deserialize("/path", serialize, null);
         BacklogQuota readBacklogQuota = policies.backlog_quota_map.get(BacklogQuota.BacklogQuotaType.destination_storage);
         Assert.assertEquals(readBacklogQuota.getLimit(), 1024);
-        Assert.assertEquals(readBacklogQuota.getLimitTime(), 60);
+        Assert.assertEquals(readBacklogQuota.getLimitTimeInSec(), 60);
         Assert.assertEquals(readBacklogQuota.getPolicy(), testPolicy);
     }
 
@@ -103,7 +103,7 @@ public class BacklogQuotaCompatibilityTest {
         Policies policies = simpleType.deserialize(null, oldPolicyStr.getBytes(), null);
         assertEquals(policies.backlog_quota_map.get(BacklogQuota.BacklogQuotaType.destination_storage).getLimitSize(),
                 1001);
-        assertEquals(policies.backlog_quota_map.get(BacklogQuota.BacklogQuotaType.destination_storage).getLimitTime(),
+        assertEquals(policies.backlog_quota_map.get(BacklogQuota.BacklogQuotaType.destination_storage).getLimitTimeInSec(),
                 0);
         assertEquals(policies.backlog_quota_map.get(BacklogQuota.BacklogQuotaType.destination_storage).getPolicy(),
                 BacklogQuota.RetentionPolicy.consumer_backlog_eviction);
@@ -125,7 +125,7 @@ public class BacklogQuotaCompatibilityTest {
         Policies policies = simpleType.deserialize(null, oldPolicyStr.getBytes(), null);
         assertEquals(policies.backlog_quota_map.get(BacklogQuota.BacklogQuotaType.destination_storage).getLimitSize(),
                 0);
-        assertEquals(policies.backlog_quota_map.get(BacklogQuota.BacklogQuotaType.destination_storage).getLimitTime(),
+        assertEquals(policies.backlog_quota_map.get(BacklogQuota.BacklogQuotaType.destination_storage).getLimitTimeInSec(),
                 0);
     }
 


### PR DESCRIPTION
### Motivation

limitTime It's a confusing name, without the time unit, it is easy to cause bugs,
so we should deprecate the old name limitTime and introduce a new one limitTimeInSec

### Modifications
change name limitTime to limitTimeInSec

### Verifying this change
- [ ] Make sure that the change passes the CI checks.
This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation
Check the box below or label this PR directly.

Need to update docs?

- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository
PR in forked repository: https://github.com/StevenLuMT/pulsar/pull/1