### PR TITLE
[fix][broker] Throw AlreadyClosedException while request to a closed metadata store

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
@@ -545,7 +545,14 @@ public class PulsarService implements AutoCloseable, ShutdownService {
             offloadersCache.close();
 
             if (coordinationService != null) {
-                coordinationService.close();
+                try {
+                    coordinationService.close();
+                } catch (Exception e) {
+                    Throwable cause = FutureUtil.unwrapCompletionException(e);
+                    if (!(cause instanceof MetadataStoreException.AlreadyClosedException)) {
+                        throw e;
+                    }
+                }
             }
 
             closeLocalMetadataStore();

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/api/MetadataStoreException.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/api/MetadataStoreException.java
@@ -137,6 +137,10 @@ public class MetadataStoreException extends IOException {
      * The store was already closed.
      */
     public static class AlreadyClosedException extends MetadataStoreException {
+
+        public AlreadyClosedException() {
+            super("The metadata store is closed");
+        }
         public AlreadyClosedException(Throwable t) {
             super(t);
         }

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/coordination/impl/LockManagerImpl.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/coordination/impl/LockManagerImpl.java
@@ -31,7 +31,6 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.bookkeeper.common.concurrent.FutureUtils;
 import org.apache.bookkeeper.common.util.SafeRunnable;
 import org.apache.pulsar.common.util.FutureUtil;
 import org.apache.pulsar.metadata.api.MetadataCache;
@@ -178,10 +177,8 @@ class LockManagerImpl<T> implements LockManager<T> {
             this.state = State.Closed;
         }
 
-        return FutureUtils.collect(
-                locks.values().stream()
-                        .map(ResourceLock::release)
-                        .collect(Collectors.toList()))
-                .thenApply(x -> null);
+        return FutureUtil.waitForAll(locks.values().stream()
+                .map(ResourceLock::release)
+                .collect(Collectors.toList()));
     }
 }

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/EtcdMetadataStore.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/EtcdMetadataStore.java
@@ -159,22 +159,24 @@ public class EtcdMetadataStore extends AbstractBatchedMetadataStore {
 
     @Override
     public void close() throws Exception {
-        super.close();
+        if (isClosed.compareAndSet(false, true)) {
+            super.close();
 
-        if (sessionWatcher != null) {
-            sessionWatcher.close();
+            if (sessionWatcher != null) {
+                sessionWatcher.close();
+            }
+
+            if (leaseClient != null) {
+                leaseClient.close();
+            }
+
+            if (leaseId != 0) {
+                client.getLeaseClient().revoke(leaseId);
+            }
+
+            kv.close();
+            client.close();
         }
-
-        if (leaseClient != null) {
-            leaseClient.close();
-        }
-
-        if (leaseId != 0) {
-            client.getLeaseClient().revoke(leaseId);
-        }
-
-        kv.close();
-        client.close();
     }
 
     private static final GetOption EXISTS_GET_OPTION = GetOption.newBuilder().withCountOnly(true).build();

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/LocalMemoryMetadataStore.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/LocalMemoryMetadataStore.java
@@ -229,4 +229,11 @@ public class LocalMemoryMetadataStore extends AbstractMetadataStore implements M
     public Optional<MetadataEventSynchronizer> getMetadataEventSynchronizer() {
         return Optional.ofNullable(synchronizer);
     }
+
+    @Override
+    public void close() throws Exception {
+        if (isClosed.compareAndSet(false, true)) {
+            super.close();
+        }
+    }
 }

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/RocksdbMetadataStore.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/RocksdbMetadataStore.java
@@ -85,17 +85,10 @@ public class RocksdbMetadataStore extends AbstractMetadataStore {
 
     private final TransactionDB db;
     private final ReentrantReadWriteLock dbStateLock;
-    private volatile State state;
-
     private final WriteOptions writeOptions;
     private final ReadOptions optionCache;
     private final ReadOptions optionDontCache;
     private MetadataEventSynchronizer synchronizer;
-
-    enum State {
-        RUNNING, CLOSED
-    }
-
     private int referenceCount = 1;
 
     private static final Map<String, RocksdbMetadataStore> instancesCache = new ConcurrentHashMap<>();
@@ -246,7 +239,6 @@ public class RocksdbMetadataStore extends AbstractMetadataStore {
             close();
             throw new MetadataStoreException("Error init metastore state", exception);
         }
-        state = State.RUNNING;
         dbStateLock = new ReentrantReadWriteLock();
         log.info("new RocksdbMetadataStore,url={},instanceId={}", metadataStoreConfig, instanceId);
     }
@@ -357,24 +349,20 @@ public class RocksdbMetadataStore extends AbstractMetadataStore {
         }
 
         instancesCache.remove(this.metadataUrl, this);
-
-        if (state == State.CLOSED) {
-            //already closed.
-            return;
-        }
-        try {
-            dbStateLock.writeLock().lock();
-            state = State.CLOSED;
-            log.info("close.instanceId={}", instanceId);
-            db.close();
-            writeOptions.close();
-            optionCache.close();
-            optionDontCache.close();
-            super.close();
-        } catch (Throwable throwable) {
-            throw MetadataStoreException.wrap(throwable);
-        } finally {
-            dbStateLock.writeLock().unlock();
+        if (isClosed.compareAndExchange(false, true)) {
+            try {
+                dbStateLock.writeLock().lock();
+                log.info("close.instanceId={}", instanceId);
+                db.close();
+                writeOptions.close();
+                optionCache.close();
+                optionDontCache.close();
+                super.close();
+            } catch (Throwable throwable) {
+                throw MetadataStoreException.wrap(throwable);
+            } finally {
+                dbStateLock.writeLock().unlock();
+            }
         }
     }
 
@@ -385,9 +373,6 @@ public class RocksdbMetadataStore extends AbstractMetadataStore {
         }
         try {
             dbStateLock.readLock().lock();
-            if (state == State.CLOSED) {
-                throw new MetadataStoreException.AlreadyClosedException("");
-            }
             byte[] value = db.get(optionCache, toBytes(path));
             if (value == null) {
                 return CompletableFuture.completedFuture(Optional.empty());
@@ -420,9 +405,6 @@ public class RocksdbMetadataStore extends AbstractMetadataStore {
         }
         try {
             dbStateLock.readLock().lock();
-            if (state == State.CLOSED) {
-                throw new MetadataStoreException.AlreadyClosedException("");
-            }
             try (RocksIterator iterator = db.newIterator(optionDontCache)) {
                 Set<String> result = new HashSet<>();
                 String firstKey = path.equals("/") ? path : path + "/";
@@ -465,9 +447,6 @@ public class RocksdbMetadataStore extends AbstractMetadataStore {
         }
         try {
             dbStateLock.readLock().lock();
-            if (state == State.CLOSED) {
-                throw new MetadataStoreException.AlreadyClosedException("");
-            }
             byte[] value = db.get(optionDontCache, toBytes(path));
             if (log.isDebugEnabled()) {
                 if (value != null) {
@@ -490,9 +469,6 @@ public class RocksdbMetadataStore extends AbstractMetadataStore {
         }
         try {
             dbStateLock.readLock().lock();
-            if (state == State.CLOSED) {
-                throw new MetadataStoreException.AlreadyClosedException("");
-            }
             try (Transaction transaction = db.beginTransaction(writeOptions)) {
                 byte[] pathBytes = toBytes(path);
                 byte[] oldValueData = transaction.getForUpdate(optionDontCache, pathBytes, true);
@@ -529,9 +505,6 @@ public class RocksdbMetadataStore extends AbstractMetadataStore {
         }
         try {
             dbStateLock.readLock().lock();
-            if (state == State.CLOSED) {
-                throw new MetadataStoreException.AlreadyClosedException("");
-            }
             try (Transaction transaction = db.beginTransaction(writeOptions)) {
                 byte[] pathBytes = toBytes(path);
                 byte[] oldValueData = transaction.getForUpdate(optionDontCache, pathBytes, true);

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/RocksdbMetadataStore.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/RocksdbMetadataStore.java
@@ -349,7 +349,7 @@ public class RocksdbMetadataStore extends AbstractMetadataStore {
         }
 
         instancesCache.remove(this.metadataUrl, this);
-        if (isClosed.compareAndExchange(false, true)) {
+        if (isClosed.compareAndSet(false, true)) {
             try {
                 dbStateLock.writeLock().lock();
                 log.info("close.instanceId={}", instanceId);

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/ZKMetadataStore.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/ZKMetadataStore.java
@@ -424,13 +424,15 @@ public class ZKMetadataStore extends AbstractBatchedMetadataStore
 
     @Override
     public void close() throws Exception {
-        if (isZkManaged) {
-            zkc.close();
+        if (isClosed.compareAndSet(false, true)) {
+            if (isZkManaged) {
+                zkc.close();
+            }
+            if (sessionWatcher != null) {
+                sessionWatcher.close();
+            }
+            super.close();
         }
-        if (sessionWatcher != null) {
-            sessionWatcher.close();
-        }
-        super.close();
     }
 
     private Stat getStat(String path, org.apache.zookeeper.data.Stat zkStat) {

--- a/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/MetadataStoreTest.java
+++ b/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/MetadataStoreTest.java
@@ -18,10 +18,6 @@
  */
 package org.apache.pulsar.metadata;
 
-import static org.mockito.ArgumentMatchers.anySetOf;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
@@ -36,7 +32,6 @@ import java.util.Set;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.LinkedBlockingDeque;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;


### PR DESCRIPTION
### Motivation

After the metadata store is closed, the metadata store will fail all the pending requests, but the new request will be blocked forever for the batched-supported metadata store.

The root cause is we are using a separate thread to flush the requests to the metadata services. The thread will be shutdown after the metadata store has been closed. But the new requests can still add to the pending requests and will never be complete.

So this PR is to prevent the new request to a closed metadata store. The caller will get `AlreadyClosedException` if the requested metadata store is closed 

It will also fix some flaky tests that stuck at the broker shutdown. Here is an example

```
2022-12-20T11:45:12.6521329Z "main" #1 prio=5 os_prio=0 cpu=134299.52ms elapsed=3504.19s tid=0x00007fa37c02ab80 nid=0xb20 waiting on condition  [0x00007fa383aed000]
2022-12-20T11:45:12.6521804Z    java.lang.Thread.State: WAITING (parking)
2022-12-20T11:45:12.6522810Z 	at jdk.internal.misc.Unsafe.park(java.base@17.0.5/Native Method)
2022-12-20T11:45:12.6523655Z 	- parking to wait for  <0x0000100010a0a8d8> (a java.util.concurrent.CompletableFuture$Signaller)
2022-12-20T11:45:12.6525332Z 	at java.util.concurrent.locks.LockSupport.park(java.base@17.0.5/LockSupport.java:211)
2022-12-20T11:45:12.6525816Z 	at java.util.concurrent.CompletableFuture$Signaller.block(java.base@17.0.5/CompletableFuture.java:1864)
2022-12-20T11:45:12.6526317Z 	at java.util.concurrent.ForkJoinPool.unmanagedBlock(java.base@17.0.5/ForkJoinPool.java:3463)
2022-12-20T11:45:12.6526984Z 	at java.util.concurrent.ForkJoinPool.managedBlock(java.base@17.0.5/ForkJoinPool.java:3434)
2022-12-20T11:45:12.6527493Z 	at java.util.concurrent.CompletableFuture.waitingGet(java.base@17.0.5/CompletableFuture.java:1898)
2022-12-20T11:45:12.6527987Z 	at java.util.concurrent.CompletableFuture.join(java.base@17.0.5/CompletableFuture.java:2117)
2022-12-20T11:45:12.6528626Z 	at org.apache.pulsar.metadata.coordination.impl.LockManagerImpl.close(LockManagerImpl.java:163)
2022-12-20T11:45:12.6529250Z 	at org.apache.pulsar.broker.loadbalance.impl.ModularLoadManagerImpl.stop(ModularLoadManagerImpl.java:982)
2022-12-20T11:45:12.6529917Z 	at org.apache.pulsar.broker.loadbalance.impl.ModularLoadManagerWrapper.stop(ModularLoadManagerWrapper.java:118)
2022-12-20T11:45:12.6530566Z 	at org.apache.pulsar.functions.worker.PulsarFunctionTlsTest.tearDown(PulsarFunctionTlsTest.java:194)
2022-12-20T11:45:12.6531116Z 	at jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(java.base@17.0.5/Native Method)
2022-12-20T11:45:12.6531636Z 	at jdk.internal.reflect.NativeMethodAccessorImpl.invoke(java.base@17.0.5/NativeMethodAccessorImpl.java:77)
2022-12-20T11:45:12.6532225Z 	at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(java.base@17.0.5/DelegatingMethodAccessorImpl.java:43)
2022-12-20T11:45:12.6532707Z 	at java.lang.reflect.Method.invoke(java.base@17.0.5/Method.java:568)
2022-12-20T11:45:12.6533198Z 	at org.testng.internal.invokers.MethodInvocationHelper.invokeMethod(MethodInvocationHelper.java:139)
2022-12-20T11:45:12.6534052Z 	at org.testng.internal.invokers.MethodInvocationHelper.invokeMethodConsideringTimeout(MethodInvocationHelper.java:69)
2022-12-20T11:45:12.6535785Z 	at org.testng.internal.invokers.ConfigInvoker.invokeConfigurationMethod(ConfigInvoker.java:361)
2022-12-20T11:45:12.6551326Z 	at org.testng.internal.invokers.ConfigInvoker.invokeConfigurations(ConfigInvoker.java:296)
2022-12-20T11:45:12.6552044Z 	at org.testng.internal.invokers.TestInvoker.runConfigMethods(TestInvoker.java:823)
2022-12-20T11:45:12.6553196Z 	at org.testng.internal.invokers.TestInvoker.runAfterConfigurations(TestInvoker.java:792)
2022-12-20T11:45:12.6554483Z 	at org.testng.internal.invokers.TestInvoker.invokeMethod(TestInvoker.java:768)
2022-12-20T11:45:12.6556779Z 	at org.testng.internal.invokers.TestInvoker.invokeTestMethod(TestInvoker.java:221)
2022-12-20T11:45:12.6557545Z 	at org.testng.internal.invokers.MethodRunner.runInSequence(MethodRunner.java:50)
2022-12-20T11:45:12.6559390Z 	at org.testng.internal.invokers.TestInvoker$MethodInvocationAgent.invoke(TestInvoker.java:969)
2022-12-20T11:45:12.6561582Z 	at org.testng.internal.invokers.TestInvoker.invokeTestMethods(TestInvoker.java:194)
2022-12-20T11:45:12.6563985Z 	at org.testng.internal.invokers.TestMethodWorker.invokeTestMethods(TestMethodWorker.java:148)
2022-12-20T11:45:12.6575879Z 	at org.testng.internal.invokers.TestMethodWorker.run(TestMethodWorker.java:128)
2022-12-20T11:45:12.6580949Z 	at org.testng.TestRunner$$Lambda$245/0x0000000800dc1238.accept(Unknown Source)
2022-12-20T11:45:12.6583537Z 	at java.util.ArrayList.forEach(java.base@17.0.5/ArrayList.java:1511)
2022-12-20T11:45:12.6587266Z 	at org.testng.TestRunner.privateRun(TestRunner.java:829)
2022-12-20T11:45:12.6592843Z 	at org.testng.TestRunner.run(TestRunner.java:602)
2022-12-20T11:45:12.6595493Z 	at org.testng.SuiteRunner.runTest(SuiteRunner.java:437)
2022-12-20T11:45:12.6600393Z 	at org.testng.SuiteRunner.runSequentially(SuiteRunner.java:431)
2022-12-20T11:45:12.6602541Z 	at org.testng.SuiteRunner.privateRun(SuiteRunner.java:391)
2022-12-20T11:45:12.6602915Z 	at org.testng.SuiteRunner.run(SuiteRunner.java:330)
2022-12-20T11:45:12.6603303Z 	at org.testng.SuiteRunnerWorker.runSuite(SuiteRunnerWorker.java:52)
2022-12-20T11:45:12.6603715Z 	at org.testng.SuiteRunnerWorker.run(SuiteRunnerWorker.java:95)
2022-12-20T11:45:12.6604088Z 	at org.testng.TestNG.runSuitesSequentially(TestNG.java:1256)
2022-12-20T11:45:12.6604477Z 	at org.testng.TestNG.runSuitesLocally(TestNG.java:1176)
2022-12-20T11:45:12.6604818Z 	at org.testng.TestNG.runSuites(TestNG.java:1099)
2022-12-20T11:45:12.6605333Z 	at org.testng.TestNG.run(TestNG.java:1067)
2022-12-20T11:45:12.6605934Z 	at org.apache.maven.surefire.testng.TestNGExecutor.run(TestNGExecutor.java:135)
2022-12-20T11:45:12.6606730Z 	at org.apache.maven.surefire.testng.TestNGDirectoryTestSuite.executeSingleClass(TestNGDirectoryTestSuite.java:112)
2022-12-20T11:45:12.6607859Z 	at org.apache.maven.surefire.testng.TestNGDirectoryTestSuite.executeLazy(TestNGDirectoryTestSuite.java:123)
2022-12-20T11:45:12.6608512Z 	at org.apache.maven.surefire.testng.TestNGDirectoryTestSuite.execute(TestNGDirectoryTestSuite.java:90)
2022-12-20T11:45:12.6609083Z 	at org.apache.maven.surefire.testng.TestNGProvider.invoke(TestNGProvider.java:146)
2022-12-20T11:45:12.6609829Z 	at org.apache.maven.surefire.booter.ForkedBooter.invokeProviderInSameClassLoader(ForkedBooter.java:384)
2022-12-20T11:45:12.6610433Z 	at org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:345)
2022-12-20T11:45:12.6610950Z 	at org.apache.maven.surefire.booter.ForkedBooter.execute(ForkedBooter.java:126)
2022-12-20T11:45:12.6611422Z 	at org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:418)
```

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/codelipenghui/incubator-pulsar/pull/20