### PR TITLE
[improve][io] Parameterize hadoop version for hdfs2 and hdfs3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -183,6 +183,8 @@ flexible messaging model and an intuitive client API.</description>
     <debezium.mysql.version>8.0.30</debezium.mysql.version>
     <jsonwebtoken.version>0.11.1</jsonwebtoken.version>
     <opencensus.version>0.28.0</opencensus.version>
+    <hadoop2.version>2.10.2</hadoop2.version>
+    <hadoop3.version>3.3.4</hadoop3.version>
     <hbase.version>2.4.9</hbase.version>
     <guava.version>31.0.1-jre</guava.version>
     <jcip.version>1.0</jcip.version>

--- a/pulsar-io/hdfs2/pom.xml
+++ b/pulsar-io/hdfs2/pom.xml
@@ -53,7 +53,7 @@
   	<dependency>
   		<groupId>org.apache.hadoop</groupId>
   		<artifactId>hadoop-client</artifactId>
-  		<version>2.10.2</version>
+  		<version>${hadoop2.version}</version>
         <exclusions>
             <exclusion>
                 <groupId>log4j</groupId>

--- a/pulsar-io/hdfs3/pom.xml
+++ b/pulsar-io/hdfs3/pom.xml
@@ -53,7 +53,7 @@
   	<dependency>
   		<groupId>org.apache.hadoop</groupId>
   		<artifactId>hadoop-client</artifactId>
-  		<version>3.3.3</version>
+  		<version>${hadoop3.version}</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>


### PR DESCRIPTION
### Motivation

Currently, Hadoop versions for pulsar-io-hdfs2 and hdfs3 is hard-coded in their pom.xml, but it's not so convenient for users who want to build Pulsar against specific version of Hadoop.

### Modifications

This PR defines those versions as Maven properties just like other Pulsar IO modules so that users can easily override them with Maven's `-D` option at compile time.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

https://github.com/sekikn/incubator-pulsar/actions/runs/3779316356
There are some failures but all of them seem to be unrelated with this change.

This change is already covered by existing tests, such as unit tests for pulsar-io-hdfs2 and pulsar-io-hdfs3.

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [x] Dependencies (add or upgrade a dependency): This PR also upgrades Hadoop version from 3.3.3 to 3.3.4.
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/sekikn/incubator-pulsar/pull/2