### PR TITLE
[improve][client] Change default threads from 1 to available processors

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ClientConfigurationData.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ClientConfigurationData.java
@@ -110,13 +110,13 @@ public class ClientConfigurationData implements Serializable, Cloneable {
             name = "numIoThreads",
             value = "Number of IO threads."
     )
-    private int numIoThreads = 1;
+    private int numIoThreads = Runtime.getRuntime().availableProcessors();
 
     @ApiModelProperty(
             name = "numListenerThreads",
             value = "Number of consumer listener threads."
     )
-    private int numListenerThreads = 1;
+    private int numListenerThreads = Runtime.getRuntime().availableProcessors();
 
     @ApiModelProperty(
             name = "connectionsPerBroker",

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/conf/ConfigurationDataUtilsTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/conf/ConfigurationDataUtilsTest.java
@@ -152,7 +152,9 @@ public class ConfigurationDataUtilsTest {
         assertNotNull(pulsarClient, "Pulsar client built using config should not be null");
 
         assertEquals(pulsarClient.getConfiguration().getServiceUrl(), "pulsar://unknown:6650");
-        assertEquals(pulsarClient.getConfiguration().getNumListenerThreads(), 1, "builder default not set properly");
+        assertEquals(pulsarClient.getConfiguration().getNumListenerThreads(),
+                Runtime.getRuntime().availableProcessors(), "builder default not set properly");
+        assertEquals(pulsarClient.getConfiguration().getNumIoThreads(), Runtime.getRuntime().availableProcessors());
         assertEquals(pulsarClient.getConfiguration().getStatsIntervalSeconds(), 80,
                 "builder default should override if set explicitly");
     }


### PR DESCRIPTION
### Motivation

I noticed the Java Client (I haven't checked other clients) uses 1 IO thread and 1 listener thread by default. It will require users to update the thread configuration if they have multiple cores and desired high throughput.  Here is the example that we change to 16 IO threads in openmessaging benchmark 

https://github.com/openmessaging/benchmark/blob/master/driver-pulsar/pulsar.yaml#L22 

We can apply the configuration of the threads based on the CPU cores. So that for the most common cases, users don't need to touch the thread configuration.  

``` 
private int numIoThreads = Runtime.getRuntime().availableProcessors(); private int numListenerThreads = Runtime.getRuntime().availableProcessors(); 
```

discussion under the mailing list https://lists.apache.org/thread/5obfm17g58n3dnbzyxg57vokgmwyp6hx

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->