### PR TITLE
[fix][proxy] Cleanup default collector registry when closing the ProxyServiceStarter

### DIFF
--- a/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/ProxyServiceStarter.java
+++ b/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/ProxyServiceStarter.java
@@ -240,6 +240,7 @@ public class ProxyServiceStarter {
             if (server != null) {
                 server.stop();
             }
+            CollectorRegistry.defaultRegistry.clear();
         } catch (Exception e) {
             log.warn("server couldn't stop gracefully {}", e.getMessage(), e);
         } finally {

--- a/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyServiceStarterTest.java
+++ b/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyServiceStarterTest.java
@@ -21,7 +21,6 @@ package org.apache.pulsar.proxy.server;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 
-import io.prometheus.client.CollectorRegistry;
 import java.net.URI;
 import java.nio.ByteBuffer;
 import java.util.Base64;
@@ -72,7 +71,6 @@ public class ProxyServiceStarterTest extends MockedPulsarServiceBaseTest {
     protected void cleanup() throws Exception {
         internalCleanup();
         serviceStarter.close();
-        CollectorRegistry.defaultRegistry.clear();
     }
 
     private String computeWsBasePath() {

--- a/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyServiceStarterTest.java
+++ b/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyServiceStarterTest.java
@@ -20,7 +20,6 @@ package org.apache.pulsar.proxy.server;
 
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
-
 import java.net.URI;
 import java.nio.ByteBuffer;
 import java.util.Base64;

--- a/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyServiceStarterTest.java
+++ b/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyServiceStarterTest.java
@@ -20,6 +20,8 @@ package org.apache.pulsar.proxy.server;
 
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
+
+import io.prometheus.client.CollectorRegistry;
 import java.net.URI;
 import java.nio.ByteBuffer;
 import java.util.Base64;
@@ -70,6 +72,7 @@ public class ProxyServiceStarterTest extends MockedPulsarServiceBaseTest {
     protected void cleanup() throws Exception {
         internalCleanup();
         serviceStarter.close();
+        CollectorRegistry.defaultRegistry.clear();
     }
 
     private String computeWsBasePath() {


### PR DESCRIPTION
Fixes: #19011 

### Motivation

Related issue https://github.com/apache/pulsar/issues/19011.

Most of the tests are all based on the class `TestRetrySupport`, which supports resetting the broken test environments, the `ProxyServiceStarter` will register metrics in the default collector registry if we restart the `ProxyServiceStarter`, it will throw the exception like this.

```
java.lang.IllegalArgumentException: Failed to register Collector of type Gauge: jvm_memory_direct_bytes_used is already in use by another Collector of type Gauge
```

### Modifications

Clean up the default collector registry when closing the `ProxyServiceStarter`.

### Verifying this change

This change is already covered by existing tests.

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/gaoran10/pulsar/pull/20