### PR TITLE
[fix][doc] Rename LedgerInfo to avoid swagger docs conflict

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
@@ -4254,7 +4254,8 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
         FutureUtil.waitForAll(ledgerMetadataFutures.values()).thenAccept(__ -> {
             stats.ledgers = new ArrayList();
             ledgersInfos.forEach(li -> {
-                ManagedLedgerInternalStats.LedgerInfo info = new ManagedLedgerInternalStats.LedgerInfo();
+                ManagedLedgerInternalStats.InternalLedgerInfo info =
+                        new ManagedLedgerInternalStats.InternalLedgerInfo();
                 info.ledgerId = li.getLedgerId();
                 info.entries = li.getEntries();
                 info.size = li.getSize();

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -134,7 +134,7 @@ import org.apache.pulsar.common.policies.data.BacklogQuota.BacklogQuotaType;
 import org.apache.pulsar.common.policies.data.ClusterData.ClusterUrl;
 import org.apache.pulsar.common.policies.data.InactiveTopicDeleteMode;
 import org.apache.pulsar.common.policies.data.ManagedLedgerInternalStats.CursorStats;
-import org.apache.pulsar.common.policies.data.ManagedLedgerInternalStats.LedgerInfo;
+import org.apache.pulsar.common.policies.data.ManagedLedgerInternalStats.InternalLedgerInfo;
 import org.apache.pulsar.common.policies.data.PersistentTopicInternalStats;
 import org.apache.pulsar.common.policies.data.Policies;
 import org.apache.pulsar.common.policies.data.RetentionPolicies;
@@ -2204,7 +2204,7 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
                         statFuture.completeExceptionally(e);
                     } else {
                         ml.getLedgersInfo().forEach((id, li) -> {
-                            LedgerInfo info = new LedgerInfo();
+                            InternalLedgerInfo info = new InternalLedgerInfo();
                             info.ledgerId = li.getLedgerId();
                             info.entries = li.getEntries();
                             info.size = li.getSize();
@@ -2232,7 +2232,7 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
         );
 
         // Add ledger info for compacted topic ledger if exist.
-        LedgerInfo info = new LedgerInfo();
+        InternalLedgerInfo info = new InternalLedgerInfo();
         info.ledgerId = -1;
         info.entries = -1;
         info.size = -1;
@@ -2316,7 +2316,7 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
                             }
                             if (metadataFuture != null) {
                                 metadataFuture.thenAccept(metadata -> {
-                                    LedgerInfo schemaLedgerInfo = new LedgerInfo();
+                                    InternalLedgerInfo schemaLedgerInfo = new InternalLedgerInfo();
                                     schemaLedgerInfo.ledgerId = metadata.getLedgerId();
                                     schemaLedgerInfo.entries = metadata.getLastEntryId() + 1;
                                     schemaLedgerInfo.size = metadata.getLength();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiSchemaTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiSchemaTest.java
@@ -45,6 +45,7 @@ import org.apache.pulsar.client.api.schema.SchemaDefinition;
 import org.apache.pulsar.client.impl.schema.SchemaInfoImpl;
 import org.apache.pulsar.client.impl.schema.StringSchema;
 import org.apache.pulsar.common.policies.data.ClusterData;
+import org.apache.pulsar.common.policies.data.ManagedLedgerInternalStats;
 import org.apache.pulsar.common.policies.data.PersistentTopicInternalStats;
 import org.apache.pulsar.common.policies.data.SchemaAutoUpdateCompatibilityStrategy;
 import org.apache.pulsar.common.policies.data.SchemaCompatibilityStrategy;
@@ -384,9 +385,9 @@ public class AdminApiSchemaTest extends MockedPulsarServiceBaseTest {
             }
         })).when(mockBookKeeper).getLedgerMetadata(anyLong());
         PersistentTopicInternalStats persistentTopicInternalStats = admin.topics().getInternalStats(topicName);
-        List<PersistentTopicInternalStats.LedgerInfo> list = persistentTopicInternalStats.schemaLedgers;
+        List<ManagedLedgerInternalStats.InternalLedgerInfo> list = persistentTopicInternalStats.schemaLedgers;
         assertEquals(list.size(), 1);
-        PersistentTopicInternalStats.LedgerInfo ledgerInfo = list.get(0);
+        ManagedLedgerInternalStats.InternalLedgerInfo ledgerInfo = list.get(0);
         assertEquals(ledgerInfo.ledgerId, ledgerId);
         assertEquals(ledgerInfo.entries, entryId + 1);
         assertEquals(ledgerInfo.size, length);

--- a/pulsar-client-admin-api/src/main/java/org/apache/pulsar/common/policies/data/ManagedLedgerInternalStats.java
+++ b/pulsar-client-admin-api/src/main/java/org/apache/pulsar/common/policies/data/ManagedLedgerInternalStats.java
@@ -62,7 +62,7 @@ public class ManagedLedgerInternalStats {
     public String state;
 
     /** The ordered list of all ledgers for this topic holding messages. */
-    public List<LedgerInfo> ledgers;
+    public List<InternalLedgerInfo> ledgers;
 
     /** The list of all cursors on this topic. Each subscription in the topic stats has a cursor. */
     public Map<String, CursorStats> cursors;
@@ -70,7 +70,7 @@ public class ManagedLedgerInternalStats {
     /**
      * Ledger information.
      */
-    public static class LedgerInfo {
+    public static class InternalLedgerInfo {
         public long ledgerId;
         public long entries;
         public long size;

--- a/pulsar-client-admin-api/src/main/java/org/apache/pulsar/common/policies/data/PersistentTopicInternalStats.java
+++ b/pulsar-client-admin-api/src/main/java/org/apache/pulsar/common/policies/data/PersistentTopicInternalStats.java
@@ -23,10 +23,10 @@ import java.util.List;
 /**
  * Persistent topic internal statistics.
  */
-public class PersistentTopicInternalStats extends ManagedLedgerInternalStats{
+public class PersistentTopicInternalStats extends ManagedLedgerInternalStats {
 
-    public List<LedgerInfo> schemaLedgers;
+    public List<InternalLedgerInfo> schemaLedgers;
 
-    // LedgerInfo for compacted topic if exist.
-    public LedgerInfo compactedLedger;
+    // LedgerInfo for compacted topic if existed.
+    public InternalLedgerInfo compactedLedger;
 }

--- a/pulsar-client-tools-test/src/test/java/org/apache/pulsar/admin/cli/PulsarAdminToolTest.java
+++ b/pulsar-client-tools-test/src/test/java/org/apache/pulsar/admin/cli/PulsarAdminToolTest.java
@@ -97,7 +97,7 @@ import org.apache.pulsar.common.policies.data.DispatchRate;
 import org.apache.pulsar.common.policies.data.FailureDomain;
 import org.apache.pulsar.common.policies.data.InactiveTopicDeleteMode;
 import org.apache.pulsar.common.policies.data.InactiveTopicPolicies;
-import org.apache.pulsar.common.policies.data.ManagedLedgerInternalStats.LedgerInfo;
+import org.apache.pulsar.common.policies.data.ManagedLedgerInternalStats.InternalLedgerInfo;
 import org.apache.pulsar.common.policies.data.OffloadPoliciesImpl;
 import org.apache.pulsar.common.policies.data.OffloadedReadPriority;
 import org.apache.pulsar.common.policies.data.PersistencePolicies;
@@ -1981,8 +1981,8 @@ public class PulsarAdminToolTest {
 
     }
 
-    private static LedgerInfo newLedger(long id, long entries, long size) {
-        LedgerInfo l = new LedgerInfo();
+    private static InternalLedgerInfo newLedger(long id, long entries, long size) {
+        InternalLedgerInfo l = new InternalLedgerInfo();
         l.ledgerId = id;
         l.entries = entries;
         l.size = size;

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdTopics.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdTopics.java
@@ -67,6 +67,7 @@ import org.apache.pulsar.common.policies.data.DelayedDeliveryPolicies;
 import org.apache.pulsar.common.policies.data.DispatchRate;
 import org.apache.pulsar.common.policies.data.InactiveTopicDeleteMode;
 import org.apache.pulsar.common.policies.data.InactiveTopicPolicies;
+import org.apache.pulsar.common.policies.data.ManagedLedgerInternalStats;
 import org.apache.pulsar.common.policies.data.OffloadPoliciesImpl;
 import org.apache.pulsar.common.policies.data.OffloadedReadPriority;
 import org.apache.pulsar.common.policies.data.PersistencePolicies;
@@ -1428,13 +1429,13 @@ public class CmdTopics extends CmdBase {
         }
     }
 
-    static MessageId findFirstLedgerWithinThreshold(List<PersistentTopicInternalStats.LedgerInfo> ledgers,
+    static MessageId findFirstLedgerWithinThreshold(List<ManagedLedgerInternalStats.InternalLedgerInfo> ledgers,
                                                     long sizeThreshold) {
         long suffixSize = 0L;
 
         ledgers = Lists.reverse(ledgers);
         long previousLedger = ledgers.get(0).ledgerId;
-        for (PersistentTopicInternalStats.LedgerInfo l : ledgers) {
+        for (ManagedLedgerInternalStats.InternalLedgerInfo l : ledgers) {
             suffixSize += l.size;
             if (suffixSize > sizeThreshold) {
                 return new MessageIdImpl(previousLedger, 0L, -1);
@@ -1464,7 +1465,7 @@ public class CmdTopics extends CmdBase {
                 throw new PulsarAdminException("Topic doesn't have any data");
             }
 
-            LinkedList<PersistentTopicInternalStats.LedgerInfo> ledgers = new LinkedList(stats.ledgers);
+            LinkedList<ManagedLedgerInternalStats.InternalLedgerInfo> ledgers = new LinkedList(stats.ledgers);
             ledgers.get(ledgers.size() - 1).size = stats.currentLedgerSize; // doesn't get filled in now it seems
             MessageId messageId = findFirstLedgerWithinThreshold(ledgers, sizeThreshold);
 

--- a/pulsar-client-tools/src/test/java/org/apache/pulsar/admin/cli/TestCmdTopics.java
+++ b/pulsar-client-tools/src/test/java/org/apache/pulsar/admin/cli/TestCmdTopics.java
@@ -43,7 +43,7 @@ import org.apache.pulsar.client.admin.Schemas;
 import org.apache.pulsar.client.admin.Topics;
 import org.apache.pulsar.client.impl.MessageIdImpl;
 import org.apache.pulsar.common.naming.TopicDomain;
-import org.apache.pulsar.common.policies.data.ManagedLedgerInternalStats.LedgerInfo;
+import org.apache.pulsar.common.policies.data.ManagedLedgerInternalStats.InternalLedgerInfo;
 import org.mockito.Mockito;
 import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
@@ -78,8 +78,8 @@ public class TestCmdTopics {
         //NOTHING FOR NOW
     }
 
-    private static LedgerInfo newLedger(long id, long entries, long size) {
-        LedgerInfo l = new LedgerInfo();
+    private static InternalLedgerInfo newLedger(long id, long entries, long size) {
+        InternalLedgerInfo l = new InternalLedgerInfo();
         l.ledgerId = id;
         l.entries = entries;
         l.size = size;
@@ -88,7 +88,7 @@ public class TestCmdTopics {
 
     @Test
     public void testFindFirstLedgerWithinThreshold() throws Exception {
-        List<LedgerInfo> ledgers = new ArrayList<>();
+        List<InternalLedgerInfo> ledgers = new ArrayList<>();
         ledgers.add(newLedger(0, 10, 1000));
         ledgers.add(newLedger(1, 10, 2000));
         ledgers.add(newLedger(2, 10, 3000));

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/functions/UpdateOptionsImpl.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/functions/UpdateOptionsImpl.java
@@ -26,9 +26,11 @@ import lombok.NoArgsConstructor;
 /**
  * Options while updating the sink.
  */
+@ApiModel(
+        value = "UpdateOptions",
+        description = "Options while updating the sink")
 @Data
 @NoArgsConstructor
-@ApiModel(value = "UpdateOptions", description = "Options while updating the sink")
 public class UpdateOptionsImpl implements UpdateOptions {
     @ApiModelProperty(
             value = "Whether or not to update the auth data",

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/TenantInfoImpl.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/TenantInfoImpl.java
@@ -29,10 +29,12 @@ import lombok.NoArgsConstructor;
 /**
  * Information of admin roles and allowed clusters for tenant.
  */
+@ApiModel(
+        value = "TenantInfo",
+        description = "Information of adminRoles and allowedClusters for tenant")
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
-@ApiModel(value = "TenantInfo", description = "Information of adminRoles and allowedClusters for tenant")
 public class TenantInfoImpl implements TenantInfo {
     /**
      * List of role enabled as admin for this tenant.

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/admin/AdminTest.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/admin/AdminTest.java
@@ -19,7 +19,6 @@
 package org.apache.pulsar.tests.integration.admin;
 
 import static org.testng.Assert.assertNotNull;
-
 import java.util.function.Supplier;
 import lombok.Cleanup;
 import lombok.extern.slf4j.Slf4j;
@@ -28,6 +27,7 @@ import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.client.api.Producer;
 import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.client.api.Schema;
+import org.apache.pulsar.common.policies.data.ManagedLedgerInternalStats;
 import org.apache.pulsar.common.policies.data.PersistentTopicInternalStats;
 import org.apache.pulsar.tests.integration.messaging.MessagingBase;
 import org.testng.Assert;
@@ -68,7 +68,7 @@ public class AdminTest extends MessagingBase {
         log.info("Successfully to publish 10 messages to {}", topicName);
         PersistentTopicInternalStats stats = admin.topics().getInternalStats(topicName);
         Assert.assertTrue(stats.ledgers.size() > 0);
-        for (PersistentTopicInternalStats.LedgerInfo ledger : stats.ledgers) {
+        for (ManagedLedgerInternalStats.InternalLedgerInfo ledger : stats.ledgers) {
             Assert.assertFalse(ledger.underReplicated);
         }
     }

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/offload/TestBaseOffload.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/offload/TestBaseOffload.java
@@ -21,7 +21,6 @@ package org.apache.pulsar.tests.integration.offload;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
-
 import lombok.extern.slf4j.Slf4j;
 import org.apache.bookkeeper.client.BKException;
 import org.apache.bookkeeper.client.BookKeeper;
@@ -32,7 +31,7 @@ import org.apache.pulsar.client.api.Consumer;
 import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.Producer;
 import org.apache.pulsar.client.api.PulsarClient;
-import org.apache.pulsar.common.policies.data.PersistentTopicInternalStats;
+import org.apache.pulsar.common.policies.data.ManagedLedgerInternalStats;
 import org.apache.pulsar.tests.integration.suites.PulsarTieredStorageTestSuite;
 import org.awaitility.Awaitility;
 import org.testng.Assert;
@@ -214,7 +213,7 @@ public abstract class TestBaseOffload extends PulsarTieredStorageTestSuite {
         }
     }
 
-    private boolean ledgerOffloaded(List<PersistentTopicInternalStats.LedgerInfo> ledgers, long ledgerId) {
+    private boolean ledgerOffloaded(List<ManagedLedgerInternalStats.InternalLedgerInfo> ledgers, long ledgerId) {
         return ledgers.stream().filter(l -> l.ledgerId == ledgerId)
                 .map(l -> l.offloaded).findFirst().get();
     }
@@ -236,7 +235,7 @@ public abstract class TestBaseOffload extends PulsarTieredStorageTestSuite {
                     ? topic + "-partition-" + partitionNum
                     : topic;
 
-            List<PersistentTopicInternalStats.LedgerInfo> ledgers = admin.topics()
+            List<ManagedLedgerInternalStats.InternalLedgerInfo> ledgers = admin.topics()
                     .getInternalStats(topicToCheck).ledgers;
             long currentLedger = ledgers.get(ledgers.size() - 1).ledgerId;
 


### PR DESCRIPTION
See https://github.com/apache/pulsar-site/commit/619e9ec67f9eae97f58743429b92b11c40d0b2c1.

These two classes conflict in name:

* `org.apache.pulsar.common.policies.data.ManagedLedgerInternalStats.LedgerInfo`
* `org.apache.bookkeeper.mledger.ManagedLedgerInfo.LedgerInfo`

Since the latter one is a public interface while the former one is for internal usage, I tend to rename the former one to deduplicate.

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [x] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
