### PR TITLE
[fix][io] Include Alluxio in the distribution

### DIFF
--- a/distribution/io/src/assemble/io.xml
+++ b/distribution/io/src/assemble/io.xml
@@ -80,5 +80,6 @@
     <file><source>${basedir}/../../pulsar-io/flume/target/pulsar-io-flume-${project.version}.nar</source></file>
     <file><source>${basedir}/../../pulsar-io/solr/target/pulsar-io-solr-${project.version}.nar</source></file>
     <file><source>${basedir}/../../pulsar-io/dynamodb/target/pulsar-io-dynamodb-${project.version}.nar</source></file>
+    <file><source>${basedir}/../../pulsar-io/alluxio/target/pulsar-io-alluxio-${project.version}.nar</source></file>
   </files>
 </assembly>

--- a/pulsar-io/alluxio/pom.xml
+++ b/pulsar-io/alluxio/pom.xml
@@ -29,7 +29,7 @@
     </parent>
 
     <properties>
-        <alluxio.version>2.5.0</alluxio.version>
+        <alluxio.version>2.7.3</alluxio.version>
         <metrics.version>4.1.11</metrics.version>
         <grpc.version>1.37.0</grpc.version>
     </properties>
@@ -43,7 +43,6 @@
             <groupId>${project.groupId}</groupId>
             <artifactId>pulsar-io-core</artifactId>
             <version>${project.version}</version>
-            <scope>provided</scope>
         </dependency>
 
         <dependency>

--- a/pulsar-io/alluxio/src/main/java/org/apache/pulsar/io/alluxio/AlluxioAbstractConfig.java
+++ b/pulsar-io/alluxio/src/main/java/org/apache/pulsar/io/alluxio/AlluxioAbstractConfig.java
@@ -18,7 +18,8 @@
  */
 package org.apache.pulsar.io.alluxio;
 
-import com.google.common.base.Preconditions;
+import static com.google.common.base.Preconditions.checkNotNull;
+import java.io.Serializable;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -26,8 +27,6 @@ import lombok.Setter;
 import lombok.ToString;
 import lombok.experimental.Accessors;
 import org.apache.pulsar.io.core.annotations.FieldDoc;
-
-import java.io.Serializable;
 
 /**
  * Configuration object for all Alluxio Sink components.
@@ -69,8 +68,8 @@ public class AlluxioAbstractConfig implements Serializable {
     private String securityLoginUser;
 
     public void validate() {
-        Preconditions.checkNotNull(alluxioMasterHost, "alluxioMasterHost property not set.");
-        Preconditions.checkNotNull(alluxioMasterPort, "alluxioMasterPort property not set.");
-        Preconditions.checkNotNull(alluxioDir, "alluxioDir property not set.");
+        checkNotNull(alluxioMasterHost, "alluxioMasterHost property not set.");
+        checkNotNull(alluxioMasterPort, "alluxioMasterPort property not set.");
+        checkNotNull(alluxioDir, "alluxioDir property not set.");
     }
 }

--- a/pulsar-io/alluxio/src/main/java/org/apache/pulsar/io/alluxio/package-info.java
+++ b/pulsar-io/alluxio/src/main/java/org/apache/pulsar/io/alluxio/package-info.java
@@ -1,0 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.io.alluxio;

--- a/pulsar-io/alluxio/src/main/java/org/apache/pulsar/io/alluxio/sink/AlluxioSink.java
+++ b/pulsar-io/alluxio/src/main/java/org/apache/pulsar/io/alluxio/sink/AlluxioSink.java
@@ -32,6 +32,14 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.Lists;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectOutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.client.api.schema.GenericObject;
@@ -44,15 +52,6 @@ import org.apache.pulsar.io.core.Sink;
 import org.apache.pulsar.io.core.SinkContext;
 import org.apache.pulsar.io.core.annotations.Connector;
 import org.apache.pulsar.io.core.annotations.IOType;
-
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.io.ObjectOutputStream;
-import java.nio.charset.StandardCharsets;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
-import java.util.UUID;
 
 /**
  * Alluxio sink that treats incoming messages on the input topic as Strings
@@ -127,6 +126,7 @@ public class AlluxioSink implements Sink<GenericObject> {
         rotationInterval =  alluxioSinkConfig.getRotationInterval();
     }
 
+    @SuppressWarnings("checkstyle:fallthrough")
     @Override
     public void write(Record<GenericObject> record) {
         long now = System.currentTimeMillis();
@@ -293,7 +293,8 @@ public class AlluxioSink implements Sink<GenericObject> {
                 KeyValueSchema<GenericObject, GenericObject> keyValueSchema = (KeyValueSchema) record.getSchema();
                 valueSchema = keyValueSchema.getValueSchema();
                 org.apache.pulsar.common.schema.KeyValue<GenericObject, GenericObject> keyValue =
-                        (org.apache.pulsar.common.schema.KeyValue<GenericObject, GenericObject>) record.getValue().getNativeObject();
+                        (org.apache.pulsar.common.schema.KeyValue<GenericObject, GenericObject>)
+                                record.getValue().getNativeObject();
                 recordValue = keyValue.getValue();
             } else {
                 valueSchema = record.getSchema();
@@ -315,8 +316,8 @@ public class AlluxioSink implements Sink<GenericObject> {
             return new KeyValue<>(null, value);
         } else {
             return new KeyValue<>(null, new String(record.getMessage()
-                            .orElseThrow(() -> new IllegalArgumentException("Record does not carry message information"))
-                            .getData(), StandardCharsets.UTF_8));
+                    .orElseThrow(() -> new IllegalArgumentException("Record does not carry message information"))
+                    .getData(), StandardCharsets.UTF_8));
         }
     }
 

--- a/pulsar-io/alluxio/src/main/java/org/apache/pulsar/io/alluxio/sink/AlluxioSinkConfig.java
+++ b/pulsar-io/alluxio/src/main/java/org/apache/pulsar/io/alluxio/sink/AlluxioSinkConfig.java
@@ -18,9 +18,13 @@
  */
 package org.apache.pulsar.io.alluxio.sink;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
-import com.google.common.base.Preconditions;
+import java.io.File;
+import java.io.IOException;
+import java.io.Serializable;
+import java.util.Map;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -29,11 +33,6 @@ import lombok.ToString;
 import lombok.experimental.Accessors;
 import org.apache.pulsar.io.alluxio.AlluxioAbstractConfig;
 import org.apache.pulsar.io.core.annotations.FieldDoc;
-
-import java.io.File;
-import java.io.IOException;
-import java.io.Serializable;
-import java.util.Map;
 
 @Data
 @Setter
@@ -86,9 +85,10 @@ public class AlluxioSinkConfig extends AlluxioAbstractConfig implements Serializ
     private String writeType = "MUST_CACHE";
 
     @FieldDoc(
-            required = false,
-            defaultValue = "false",
-            help = "Sets whether the Sink has to take into account the Schema or if it should simply copy the raw message to Alluxio"
+        required = false,
+        defaultValue = "false",
+        help = "Sets whether the Sink has to take into account the Schema or if it should simply copy the raw message"
+            + " to Alluxio"
     )
     private boolean schemaEnable = false;
 
@@ -105,8 +105,8 @@ public class AlluxioSinkConfig extends AlluxioAbstractConfig implements Serializ
     @Override
     public void validate() {
         super.validate();
-        Preconditions.checkArgument(rotationRecords > 0, "rotationRecords must be a positive long.");
-        Preconditions.checkArgument(rotationInterval == -1 || rotationInterval > 0,
+        checkArgument(rotationRecords > 0, "rotationRecords must be a positive long.");
+        checkArgument(rotationInterval == -1 || rotationInterval > 0,
             "rotationInterval must be either -1 or a positive long.");
     }
 }

--- a/pulsar-io/alluxio/src/main/java/org/apache/pulsar/io/alluxio/sink/package-info.java
+++ b/pulsar-io/alluxio/src/main/java/org/apache/pulsar/io/alluxio/sink/package-info.java
@@ -1,0 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.io.alluxio.sink;

--- a/pulsar-io/docs/pom.xml
+++ b/pulsar-io/docs/pom.xml
@@ -54,6 +54,11 @@
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
+      <artifactId>pulsar-io-alluxio</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
       <artifactId>pulsar-io-canal</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/pulsar-io/pom.xml
+++ b/pulsar-io/pom.xml
@@ -74,6 +74,7 @@
         <module>influxdb</module>
         <module>dynamodb</module>
         <module>nsq</module>
+        <module>alluxio</module>
       </modules>
     </profile>
 

--- a/site2/docs/io-connectors.md
+++ b/site2/docs/io-connectors.md
@@ -139,7 +139,13 @@ Pulsar has various sink connectors, which are sorted alphabetically as below.
 * [Configuration](io-aerospike-sink.md#configuration)
 
 * [Java class](https://github.com/apache/pulsar/blob/master/pulsar-io/aerospike/src/main/java/org/apache/pulsar/io/aerospike/AerospikeStringSink.java)
-  
+
+### Alluxio
+
+* [Configuration](io-alluxio.md#configuration)
+
+* [Java class](https://github.com/apache/pulsar/blob/master/pulsar-io/alluxio/src/main/java/org/apache/pulsar/io/alluxio/sink/AlluxioSink.java)
+
 ### Cassandra
 
 * [Configuration](io-cassandra-sink.md#configuration)


### PR DESCRIPTION
### Motivation

Currently, the alluxio submodule is not included in the Pulsar IO distribution.

```
$ ./mvnw clean install -DskipTests

...

[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  12:09 min
[INFO] Finished at: 2022-12-27T11:14:55+09:00
[INFO] ------------------------------------------------------------------------
$ ls -l distribution/io/target/apache-pulsar-io-connectors-2.12.0-SNAPSHOT-bin
total 1721216
-rw-r--r-- 1 sekikn sekikn     13300 12月 27 11:02 LICENSE
-rw-rw-r-- 1 sekikn sekikn   8352752 12月 27 11:02 pulsar-io-aerospike-2.12.0-SNAPSHOT.nar
-rw-rw-r-- 1 sekikn sekikn  15910726 12月 27 11:02 pulsar-io-batch-data-generator-2.12.0-SNAPSHOT.nar
...
```

### Modifications

This PR fixes the problem above and addresses some checkstyle and OWASP issues.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change is already covered by existing tests, such as unit tests under pulsar-io/alluxio/src/test.

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [x] Dependencies (add or upgrade a dependency): upgraded Alluxio 2.5.0 to 2.7.3 for addressing OWASP issues.
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [x] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

![toc](https://user-images.githubusercontent.com/898388/209879578-23448e9d-dd76-47c9-b420-39e6fceb47eb.png)

### Matching PR in forked repository

PR in forked repository: https://github.com/sekikn/incubator-pulsar/pull/4
There are a few failures in the BROKER_CLIENT_IMPL and OWASP tests, but I think the former is unrelated with this PR and no CVE is newly introduced in the latter.