### PR TITLE
[improve] Refresh ns policy when deciding auto topic creation eligibility

### DIFF
--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/resources/NamespaceResources.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/resources/NamespaceResources.java
@@ -122,7 +122,15 @@ public class NamespaceResources extends BaseResources<Policies> {
     }
 
     public CompletableFuture<Optional<Policies>> getPoliciesAsync(NamespaceName ns) {
-        return getCache().get(joinPath(BASE_POLICIES_PATH, ns.toString()));
+        return getPoliciesAsync(ns, false);
+    }
+
+    public CompletableFuture<Optional<Policies>> getPoliciesAsync(NamespaceName ns, boolean refresh) {
+        if (refresh) {
+            return refreshAndGetAsync(joinPath(BASE_POLICIES_PATH, ns.toString()));
+        } else {
+            return getAsync(joinPath(BASE_POLICIES_PATH, ns.toString()));
+        }
     }
 
     public void setPolicies(NamespaceName ns, Function<Policies, Policies> function) throws MetadataStoreException {

--- a/pulsar-broker-common/src/test/java/org/apache/pulsar/broker/resources/NamespaceResourcesTest.java
+++ b/pulsar-broker-common/src/test/java/org/apache/pulsar/broker/resources/NamespaceResourcesTest.java
@@ -20,15 +20,45 @@ package org.apache.pulsar.broker.resources;
 
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
+import java.util.concurrent.CompletableFuture;
+import org.apache.pulsar.common.naming.NamespaceName;
+import org.apache.pulsar.common.policies.data.Policies;
+import org.apache.pulsar.metadata.api.MetadataCache;
+import org.apache.pulsar.metadata.api.MetadataStore;
+import org.mockito.Mockito;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 
 public class NamespaceResourcesTest {
+
+    private MetadataStore mockMetadataStore;
+    private NamespaceResources namespaceResources;
+
+    @BeforeMethod
+    public void setUp() {
+        mockMetadataStore = Mockito.mock(MetadataStore.class);
+        Mockito.doReturn(Mockito.mock(MetadataCache.class)).when(mockMetadataStore).getMetadataCache(Policies.class);
+        Mockito.doReturn(CompletableFuture.completedFuture(null)).when(mockMetadataStore).sync(Mockito.anyString());
+        namespaceResources = new NamespaceResources(mockMetadataStore, 0);
+    }
     @Test
     public void test_pathIsFromNamespace() {
         assertFalse(NamespaceResources.pathIsFromNamespace("/admin/clusters"));
         assertFalse(NamespaceResources.pathIsFromNamespace("/admin/policies"));
         assertFalse(NamespaceResources.pathIsFromNamespace("/admin/policies/my-tenant"));
         assertTrue(NamespaceResources.pathIsFromNamespace("/admin/policies/my-tenant/my-ns"));
+    }
+
+    @Test
+    public void testGetPolicesAsync() {
+        namespaceResources.getPoliciesAsync(NamespaceName.get("public/default"));
+        Mockito.verify(mockMetadataStore, Mockito.never()).sync(Mockito.anyString());
+    }
+
+    @Test
+    public void testGetPolicesAsyncAndRefresh() {
+        namespaceResources.getPoliciesAsync(NamespaceName.get("public/default"), true);
+        Mockito.verify(mockMetadataStore, Mockito.times(1)).sync("/admin/policies/public/default");
     }
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/AdminResource.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/AdminResource.java
@@ -490,7 +490,7 @@ public abstract class AdminResource extends PulsarWebResource {
                 .thenCompose(__ -> {
                     if (checkAllowAutoCreation) {
                         return pulsar().getBrokerService()
-                                .fetchPartitionedTopicMetadataCheckAllowAutoCreationAsync(topicName);
+                                .fetchPartitionedTopicMetadataCheckAllowAutoCreationAsync(topicName, true);
                     } else {
                         return pulsar().getBrokerService().fetchPartitionedTopicMetadataAsync(topicName);
                     }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/lookup/TopicLookupBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/lookup/TopicLookupBase.java
@@ -72,7 +72,7 @@ public class TopicLookupBase extends PulsarWebResource {
                             ? CompletableFuture.completedFuture(true)
                             : pulsar().getNamespaceService().checkTopicExists(topicName)
                                 .thenCompose(exists -> exists ? CompletableFuture.completedFuture(true)
-                                        : pulsar().getBrokerService().isAllowAutoTopicCreationAsync(topicName));
+                                        : pulsar().getBrokerService().isAllowAutoTopicCreationAsync(topicName, true));
 
                     return existFuture;
                 })

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/lookup/http/HttpTopicLookupv2Test.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/lookup/http/HttpTopicLookupv2Test.java
@@ -19,6 +19,7 @@
 package org.apache.pulsar.broker.lookup.http;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
@@ -105,7 +106,7 @@ public class HttpTopicLookupv2Test {
         doReturn(auth).when(brokerService).getAuthorizationService();
         doReturn(new Semaphore(1000)).when(brokerService).getLookupRequestSemaphore();
         doReturn(CompletableFuture.completedFuture(false)).when(brokerService)
-                .isAllowAutoTopicCreationAsync(any(TopicName.class), true);
+                .isAllowAutoTopicCreationAsync(any(TopicName.class), eq(true));
     }
 
     @Test

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/lookup/http/HttpTopicLookupv2Test.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/lookup/http/HttpTopicLookupv2Test.java
@@ -105,7 +105,7 @@ public class HttpTopicLookupv2Test {
         doReturn(auth).when(brokerService).getAuthorizationService();
         doReturn(new Semaphore(1000)).when(brokerService).getLookupRequestSemaphore();
         doReturn(CompletableFuture.completedFuture(false)).when(brokerService)
-                .isAllowAutoTopicCreationAsync(any(TopicName.class));
+                .isAllowAutoTopicCreationAsync(any(TopicName.class), true);
     }
 
     @Test


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://docs.google.com/document/d/1d8Pw6ZbWk-_pCKdOmdvx9rnhPiyuxwq60_TrD68d7BA/edit#heading=h.trs9rsex3xom)*. 

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->

Continuation of https://github.com/apache/pulsar/pull/18518 and https://github.com/apache/pulsar/pull/17609 to ensure the ns policy deleted is in consistent state between brokers when performing and `isAllowAutoTopicCreationAsync`
### Motivation

<!-- Explain here the context, and why you're making that change. What is the problem you're trying to solve. -->

### Modifications

Leveraged the MetadataStore [sync](https://github.com/apache/pulsar/blob/492a9c3e44bef2334a77164afc8b033cc8f8d82f/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/api/MetadataStore.java#L60) api to have a consistent view of the ns policy that will feed into the `isAllowAutoTopicCreationAsync`. 

### Verifying this change

- [X] Make sure that the change passes the CI checks.

This change is already covered by existing tests, such as *(please describe tests)*.
* The main test is testPartitionedTopicAutoCreationForbiddenDuringNamespaceDeletion introduced by #17609
* Add unit tests to verify GetPolicesAsync hitting the sync api when needed

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [X] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->
### Matching PR in forked repository

PR in forked repository: https://github.com/aymkhalil/pulsar/pull/5

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
