### PR TITLE
[fix][broker] change name limitSize to limitSizeInBytes

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/AdminResource.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/AdminResource.java
@@ -389,7 +389,7 @@ public abstract class AdminResource extends PulsarWebResource {
         }
 
         if (retention.getRetentionSizeInMB() > 0
-                && quota.getLimitSize() >= (retention.getRetentionSizeInMB() * 1024 * 1024)) {
+                && quota.getLimitSizeInBytes() >= (retention.getRetentionSizeInMB() * 1024 * 1024)) {
             return false;
         }
         // time based quota is in second

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BacklogQuotaManager.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BacklogQuotaManager.java
@@ -121,7 +121,7 @@ public class BacklogQuotaManager {
     private void dropBacklogForSizeLimit(PersistentTopic persistentTopic, BacklogQuota quota) {
         // Set the reduction factor to 90%. The aim is to drop down the backlog to 90% of the quota limit.
         double reductionFactor = 0.9;
-        double targetSize = reductionFactor * quota.getLimitSize();
+        double targetSize = reductionFactor * quota.getLimitSizeInBytes();
 
         // Get estimated unconsumed size for the managed ledger associated with this topic. Estimated size is more
         // useful than the actual storage size. Actual storage size gets updated only when managed ledger is trimmed.

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -2704,7 +2704,7 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
      * @return determine if backlog quota enforcement needs to be done for topic based on size limit
      */
     public boolean isSizeBacklogExceeded() {
-        long backlogQuotaLimitInBytes = getBacklogQuota(BacklogQuotaType.destination_storage).getLimitSize();
+        long backlogQuotaLimitInBytes = getBacklogQuota(BacklogQuotaType.destination_storage).getLimitSizeInBytes();
         if (backlogQuotaLimitInBytes < 0) {
             return false;
         }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/NamespaceStatsAggregator.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/NamespaceStatsAggregator.java
@@ -160,7 +160,7 @@ public class NamespaceStatsAggregator {
             stats.managedLedgerStats.backlogSize = ml.getEstimatedBacklogSize();
             stats.managedLedgerStats.offloadedStorageUsed = ml.getOffloadedSize();
             stats.backlogQuotaLimit = topic
-                    .getBacklogQuota(BacklogQuota.BacklogQuotaType.destination_storage).getLimitSize();
+                    .getBacklogQuota(BacklogQuota.BacklogQuotaType.destination_storage).getLimitSizeInBytes();
             stats.backlogQuotaLimitTime = topic
                     .getBacklogQuota(BacklogQuota.BacklogQuotaType.message_age).getLimitTimeInSec();
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BacklogQuotaManagerConfigurationTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BacklogQuotaManagerConfigurationTest.java
@@ -48,7 +48,7 @@ public class BacklogQuotaManagerConfigurationTest {
 
         BacklogQuotaManager backlogQuotaManager = new BacklogQuotaManager(pulsarService);
 
-        assertEquals(backlogQuotaManager.getDefaultQuota().getLimitSize(), 1717986918);
+        assertEquals(backlogQuotaManager.getDefaultQuota().getLimitSizeInBytes(), 1717986918);
     }
 
     @Test
@@ -58,7 +58,7 @@ public class BacklogQuotaManagerConfigurationTest {
 
         BacklogQuotaManager backlogQuotaManager = new BacklogQuotaManager(pulsarService);
 
-        assertEquals(backlogQuotaManager.getDefaultQuota().getLimitSize(), 1717986918);
+        assertEquals(backlogQuotaManager.getDefaultQuota().getLimitSizeInBytes(), 1717986918);
     }
 
     @Test
@@ -68,7 +68,7 @@ public class BacklogQuotaManagerConfigurationTest {
 
         BacklogQuotaManager backlogQuotaManager = new BacklogQuotaManager(pulsarService);
 
-        assertEquals(backlogQuotaManager.getDefaultQuota().getLimitSize(), 123);
+        assertEquals(backlogQuotaManager.getDefaultQuota().getLimitSizeInBytes(), 123);
     }
 
     private void initializeServiceConfiguration() {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatorTopicPoliciesTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatorTopicPoliciesTest.java
@@ -82,7 +82,7 @@ public class ReplicatorTopicPoliciesTest extends ReplicatorTestBase {
         init(namespace, topic);
         // set BacklogQuota
         BacklogQuotaImpl backlogQuota = new BacklogQuotaImpl();
-        backlogQuota.setLimitSize(1);
+        backlogQuota.setLimitSizeInBytes(1);
         backlogQuota.setLimitTimeInSec(2);
         // local
         admin1.topicPolicies().setBacklogQuota(topic, backlogQuota);

--- a/pulsar-client-admin-api/src/main/java/org/apache/pulsar/common/policies/data/BacklogQuota.java
+++ b/pulsar-client-admin-api/src/main/java/org/apache/pulsar/common/policies/data/BacklogQuota.java
@@ -42,7 +42,7 @@ public interface BacklogQuota {
      *
      * @return quota limit in bytes
      */
-    long getLimitSize();
+    long getLimitSizeInBytes();
 
     /**
      * Gets quota limit in time.

--- a/pulsar-client-admin-api/src/main/java/org/apache/pulsar/common/policies/data/impl/BacklogQuotaImpl.java
+++ b/pulsar-client-admin-api/src/main/java/org/apache/pulsar/common/policies/data/impl/BacklogQuotaImpl.java
@@ -40,7 +40,7 @@ public class BacklogQuotaImpl implements BacklogQuota {
     /**
      * backlog quota by size in byte.
      */
-    private Long limitSize;
+    private Long limitSizeInBytes;
 
     /**
      * backlog quota by time in second.
@@ -48,36 +48,36 @@ public class BacklogQuotaImpl implements BacklogQuota {
     private int limitTimeInSec;
     private RetentionPolicy policy;
 
-    public BacklogQuotaImpl(long limitSize, int limitTimeInSec, RetentionPolicy policy) {
-        this.limitSize = limitSize;
+    public BacklogQuotaImpl(long limitSizeInBytes, int limitTimeInSec, RetentionPolicy policy) {
+        this.limitSizeInBytes = limitSizeInBytes;
         this.limitTimeInSec = limitTimeInSec;
         this.policy = policy;
     }
 
     @Deprecated
     public long getLimit() {
-        if (limitSize == null) {
+        if (limitSizeInBytes == null) {
             return limit;
         }
-        return limitSize;
+        return limitSizeInBytes;
     }
 
     @Deprecated
     public void setLimit(long limit) {
         this.limit = limit;
-        this.limitSize = limit;
+        this.limitSizeInBytes = limit;
     }
 
-    public long getLimitSize() {
-        if (limitSize == null) {
+    public long getLimitSizeInBytes() {
+        if (limitSizeInBytes == null) {
             return limit;
         }
-        return limitSize;
+        return limitSizeInBytes;
     }
 
-    public void setLimitSize(long limitSize) {
-        this.limitSize = limitSize;
-        this.limit = limitSize;
+    public void setLimitSizeInBytes(long limitSizeInBytes) {
+        this.limitSizeInBytes = limitSizeInBytes;
+        this.limit = limitSizeInBytes;
     }
 
     public int getLimitTimeInSec() {

--- a/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/BacklogQuotaCompatibilityTest.java
+++ b/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/BacklogQuotaCompatibilityTest.java
@@ -55,7 +55,7 @@ public class BacklogQuotaCompatibilityTest {
         byte[] serialize = simpleType.serialize("/path", writePolicy);
         Policies policies = simpleType.deserialize("/path", serialize, null);
         BacklogQuota readBacklogQuota = policies.backlog_quota_map.get(BacklogQuota.BacklogQuotaType.destination_storage);
-        Assert.assertEquals(readBacklogQuota.getLimitSize(), 1024);
+        Assert.assertEquals(readBacklogQuota.getLimitSizeInBytes(), 1024);
         Assert.assertEquals(readBacklogQuota.getLimitTimeInSec(), 60);
         Assert.assertEquals(readBacklogQuota.getPolicy(), testPolicy);
     }
@@ -64,7 +64,7 @@ public class BacklogQuotaCompatibilityTest {
     public void testV28ClientSetV28BrokerRead() throws Exception {
         Policies writePolicy = new Policies();
         BacklogQuotaImpl writeBacklogQuota = new BacklogQuotaImpl();
-        writeBacklogQuota.setLimitSize(1024);
+        writeBacklogQuota.setLimitSizeInBytes(1024);
         writeBacklogQuota.setLimitTimeInSec(60);
         writeBacklogQuota.setPolicy(testPolicy);
         HashMap<BacklogQuota.BacklogQuotaType, BacklogQuota> quotaHashMap = new HashMap<>();
@@ -83,7 +83,7 @@ public class BacklogQuotaCompatibilityTest {
     @Test
     public void testV28ClientSetV27BrokerRead() {
         BacklogQuotaImpl writeBacklogQuota = new BacklogQuotaImpl();
-        writeBacklogQuota.setLimitSize(1024);
+        writeBacklogQuota.setLimitSizeInBytes(1024);
         Assert.assertEquals(1024, writeBacklogQuota.getLimit());
     }
 
@@ -101,7 +101,7 @@ public class BacklogQuotaCompatibilityTest {
                 + "\"UNDEFINED\",\"is_allow_auto_update_schema\":true,\"schema_validation_enforced\":false,"
                 + "\"subscription_types_enabled\":[]}\n";
         Policies policies = simpleType.deserialize(null, oldPolicyStr.getBytes(), null);
-        assertEquals(policies.backlog_quota_map.get(BacklogQuota.BacklogQuotaType.destination_storage).getLimitSize(),
+        assertEquals(policies.backlog_quota_map.get(BacklogQuota.BacklogQuotaType.destination_storage).getLimitSizeInBytes(),
                 1001);
         assertEquals(policies.backlog_quota_map.get(BacklogQuota.BacklogQuotaType.destination_storage).getLimitTimeInSec(),
                 0);
@@ -123,7 +123,7 @@ public class BacklogQuotaCompatibilityTest {
                 + "\"UNDEFINED\",\"is_allow_auto_update_schema\":true,\"schema_validation_enforced\":false,"
                 + "\"subscription_types_enabled\":[]}\n";
         Policies policies = simpleType.deserialize(null, oldPolicyStr.getBytes(), null);
-        assertEquals(policies.backlog_quota_map.get(BacklogQuota.BacklogQuotaType.destination_storage).getLimitSize(),
+        assertEquals(policies.backlog_quota_map.get(BacklogQuota.BacklogQuotaType.destination_storage).getLimitSizeInBytes(),
                 0);
         assertEquals(policies.backlog_quota_map.get(BacklogQuota.BacklogQuotaType.destination_storage).getLimitTimeInSec(),
                 0);


### PR DESCRIPTION
### Motivation

limitSize It's a confusing name, without the time unit, it is easy to cause bugs,
so we should deprecate the old name limitSize and introduce a new one limitSizeInBytes

### Modifications
change name limitSize to limitSizeInBytes

### Verifying this change
- [ ] Make sure that the change passes the CI checks.
This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation
Check the box below or label this PR directly.

Need to update docs?

- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository
PR in forked repository: https://github.com/StevenLuMT/pulsar/pull/3