### PR TITLE
[fix][build] Resolve OWASP Dependency Check false positives

### DIFF
--- a/src/owasp-dependency-check-false-positives.xml
+++ b/src/owasp-dependency-check-false-positives.xml
@@ -28,6 +28,12 @@
     <cpe>cpe:/a:apache:http_server</cpe>
   </suppress>
   <suppress>
+    <notes>
+      apache:apache_http_server is not used.
+    </notes>
+    <cpe>cpe:/a:apache:apache_http_server</cpe>
+  </suppress>
+  <suppress>
     <notes>pulsar-package-bookkeeper-storage gets mixed with bookkeeper.</notes>
     <gav regex="true">org\.apache\.pulsar:.*</gav>
     <cpe>cpe:/a:apache:bookkeeper</cpe>
@@ -164,5 +170,10 @@
    ]]></notes>
     <sha1>1a754a5dd672218a2ac667d7ff2b28df7a5a240e</sha1>
     <cve>CVE-2022-25647</cve>
+  </suppress>
+
+  <suppress>
+    <notes>commons-net is not used at all and therefore commons-net vulnerability CVE-2021-37533 is a false positive.</notes>
+    <cve>CVE-2021-37533</cve>
   </suppress>
 </suppressions>


### PR DESCRIPTION
### Motivation

OWASP Dependency Check is failing with some false positives:
```
One or more dependencies were identified with known vulnerabilities in Pulsar :: Distribution :: Server:

commons-cli-1.5.0.jar (pkg:maven/commons-cli/commons-cli@1.5.0, cpe:2.3:a:apache:commons_net:1.5.0:*:*:*:*:*:*:*) : CVE-2021-37533
commons-codec-1.15.jar (pkg:maven/commons-codec/commons-codec@1.15, cpe:2.3:a:apache:commons_net:1.15:*:*:*:*:*:*:*) : CVE-2021-37533
commons-compress-1.21.jar (pkg:maven/org.apache.commons/commons-compress@1.21, cpe:2.3:a:apache:commons_compress:1.21:*:*:*:*:*:*:*, cpe:2.3:a:apache:commons_net:1.21:*:*:*:*:*:*:*) : CVE-2021-37533
commons-configuration-1.10.jar (pkg:maven/commons-configuration/commons-configuration@1.10, cpe:2.3:a:apache:commons_configuration:1.10:*:*:*:*:*:*:*, cpe:2.3:a:apache:commons_net:1.10:*:*:*:*:*:*:*) : CVE-2021-37533
commons-io-2.8.0.jar (pkg:maven/commons-io/commons-io@2.8.0, cpe:2.3:a:apache:commons_io:2.8.0:*:*:*:*:*:*:*, cpe:2.3:a:apache:commons_net:2.8.0:*:*:*:*:*:*:*) : CVE-2021-37533
commons-lang-2.6.jar (pkg:maven/commons-lang/commons-lang@2.6, cpe:2.3:a:apache:commons_net:2.6:*:*:*:*:*:*:*) : CVE-2021-37533
commons-logging-1.1.1.jar (pkg:maven/commons-logging/commons-logging@1.1.1, cpe:2.3:a:apache:commons_net:1.1.1:*:*:*:*:*:*:*) : CVE-2021-37533
commons-text-1.10.0.jar (pkg:maven/org.apache.commons/commons-text@1.10.0, cpe:2.3:a:apache:commons_net:1.10.0:*:*:*:*:*:*:*, cpe:2.3:a:apache:commons_text:1.10.0:*:*:*:*:*:*:*) : CVE-2021-37533
http-server-4.15.3.jar (pkg:maven/org.apache.bookkeeper.http/http-server@4.15.3, cpe:2.3:a:apache:apache_http_server:4.15.3:*:*:*:*:*:*:*, cpe:2.3:a:apache:bookkeeper:4.15.3:*:*:*:*:*:*:*) : CVE-[201](https://github.com/apache/pulsar/actions/runs/3819386174/jobs/6496901705#step:8:202)0-1151
jcl-over-slf4j-1.7.32.jar (pkg:maven/org.slf4j/jcl-over-slf4j@1.7.32, cpe:2.3:a:apache:commons_net:1.7.32:*:*:*:*:*:*:*) : CVE-[202](https://github.com/apache/pulsar/actions/runs/3819386174/jobs/6496901705#step:8:203)1-37533
vertx-http-server-4.15.3.jar (pkg:maven/org.apache.bookkeeper.http/vertx-http-server@4.15.3, cpe:2.3:a:apache:apache_http_server:4.15.3:*:*:*:*:*:*:*, cpe:2.3:a:apache:bookkeeper:4.15.3:*:*:*:*:*:*:*) : CVE-2010-1151
```
example: https://github.com/apache/pulsar/actions/runs/3819386174/jobs/6496901705#step:8:194

### Modifications

Add suppressions to OWASP Dependency Check configuration.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->