### PR TITLE
[fix][broker][PIP-195] fix cursor skip read

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
@@ -2060,13 +2060,13 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
             long lastValidEntry = -1L;
             long entryId = firstEntry;
             for (; entryId <= lastEntry; entryId++) {
-                if (!opReadEntry.skipCondition.test(PositionImpl.get(ledger.getId(), entryId))) {
-                    if (firstValidEntry == -1L) {
-                        firstValidEntry = entryId;
-                    }
-                } else {
+                if (opReadEntry.skipCondition.test(PositionImpl.get(ledger.getId(), entryId))) {
                     if (firstValidEntry != -1L) {
                         break;
+                    }
+                } else {
+                    if (firstValidEntry == -1L) {
+                        firstValidEntry = entryId;
                     }
                 }
 

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
@@ -2068,9 +2068,7 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
                     if (firstValidEntry == -1L) {
                         firstValidEntry = entryId;
                     }
-                }
 
-                if (firstValidEntry != -1L) {
                     lastValidEntry = entryId;
                 }
             }

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
@@ -2060,7 +2060,7 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
             long lastValidEntry = -1L;
             long entryId = firstEntry;
             for (; entryId <= lastEntry; entryId++) {
-                if (opReadEntry.skipCondition.test(PositionImpl.get(ledger.getId(), entryId))) {
+                if (!opReadEntry.skipCondition.test(PositionImpl.get(ledger.getId(), entryId))) {
                     if (firstValidEntry == -1L) {
                         firstValidEntry = entryId;
                     }

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedCursorTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedCursorTest.java
@@ -4254,10 +4254,10 @@ public class ManagedCursorTest extends MockedBookKeeperTestCase {
     }
 
     @Test
-    public void testReadEntriesWithFilterOut() throws ManagedLedgerException, InterruptedException, ExecutionException {
+    public void testReadEntriesWithSkip() throws ManagedLedgerException, InterruptedException, ExecutionException {
         int readMaxNumber = 10;
         int sendNumber = 20;
-        ManagedLedger ledger = factory.open("testReadEntriesWithFilter");
+        ManagedLedger ledger = factory.open("testReadEntriesWithSkip");
         ManagedCursor cursor = ledger.openCursor("c");
         Position position = PositionImpl.EARLIEST;
         Position maxCanReadPosition = PositionImpl.EARLIEST;

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedCursorTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedCursorTest.java
@@ -4277,10 +4277,10 @@ public class ManagedCursorTest extends MockedBookKeeperTestCase {
             public void readEntriesComplete(List<Entry> entries, Object ctx) {
                 try {
                     entries.forEach(entry -> {
-                        assertNotEquals(entry.getEntryId() % 2, 0);
+                        assertEquals(entry.getEntryId() % 2, 0L);
                     });
                     completableFuture.complete(entries.size());
-                } catch (Exception e) {
+                } catch (Throwable e) {
                     completableFuture.completeExceptionally(e);
                 }
             }
@@ -4296,7 +4296,7 @@ public class ManagedCursorTest extends MockedBookKeeperTestCase {
         int number = completableFuture.get();
         assertEquals(number, readMaxNumber / 2);
 
-        assertEquals(cursor.getReadPosition().getEntryId(), 10);
+        assertEquals(cursor.getReadPosition().getEntryId(), 10L);
 
         CompletableFuture<Integer> completableFuture2 = new CompletableFuture<>();
         cursor.asyncReadEntriesWithSkipOrWait(sendNumber, new ReadEntriesCallback() {
@@ -4304,10 +4304,10 @@ public class ManagedCursorTest extends MockedBookKeeperTestCase {
             public void readEntriesComplete(List<Entry> entries, Object ctx) {
                 try {
                     entries.forEach(entry -> {
-                        assertEquals(entry.getEntryId() % 2, 0);
+                        assertEquals(entry.getEntryId() % 2, 0L);
                     });
                     completableFuture2.complete(entries.size());
-                } catch (Exception e) {
+                } catch (Throwable e) {
                     completableFuture2.completeExceptionally(e);
                 }
             }
@@ -4323,7 +4323,7 @@ public class ManagedCursorTest extends MockedBookKeeperTestCase {
         int number2 = completableFuture2.get();
         assertEquals(number2, readMaxNumber / 2);
 
-        assertEquals(cursor.getReadPosition().getEntryId(), 20);
+        assertEquals(cursor.getReadPosition().getEntryId(), 20L);
 
         cursor.seek(PositionImpl.EARLIEST);
         CompletableFuture<Integer> completableFuture3 = new CompletableFuture<>();
@@ -4341,7 +4341,7 @@ public class ManagedCursorTest extends MockedBookKeeperTestCase {
 
         int number3 = completableFuture3.get();
         assertEquals(number3, sendNumber);
-        assertEquals(cursor.getReadPosition().getEntryId(), 20);
+        assertEquals(cursor.getReadPosition().getEntryId(), 20L);
 
         cursor.seek(PositionImpl.EARLIEST);
         CompletableFuture<Integer> completableFuture4 = new CompletableFuture<>();
@@ -4359,7 +4359,7 @@ public class ManagedCursorTest extends MockedBookKeeperTestCase {
 
         int number4 = completableFuture4.get();
         assertEquals(number4, 0);
-        assertEquals(cursor.getReadPosition().getEntryId(), 20);
+        assertEquals(cursor.getReadPosition().getEntryId(), 20L);
 
         cursor.close();
         ledger.close();


### PR DESCRIPTION
PIP: #16763

<!-- Details of when a PIP is required and how the PIP process work, please see: https://github.com/apache/pulsar/blob/master/wiki/proposals/PIP.md -->

### Motivation

In #19035, the `skipCondition` parameter returns need to skip entry when reading entry, but the logic now is reversed.

### Modifications

Fix skip logic and add test to cover it.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

*testReadEntriesWithSkip*

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
