### PR TITLE
[cleanup][broker] Fix ClusterDataImpl#clone and add test

### DIFF
--- a/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/ClusterDataImpl.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/ClusterDataImpl.java
@@ -205,13 +205,15 @@ public final class ClusterDataImpl implements  ClusterData, Cloneable {
                 .brokerClientTlsTrustStoreType(brokerClientTlsTrustStoreType)
                 .brokerClientTlsTrustStore(brokerClientTlsTrustStore)
                 .brokerClientTlsTrustStorePassword(brokerClientTlsTrustStorePassword)
-                .brokerClientTlsKeyStoreType(brokerClientTlsTrustStoreType)
-                .brokerClientTlsKeyStore(brokerClientTlsTrustStore)
-                .brokerClientTlsKeyStorePassword(brokerClientTlsTrustStorePassword)
+                .brokerClientTlsKeyStoreType(brokerClientTlsKeyStoreType)
+                .brokerClientTlsKeyStore(brokerClientTlsKeyStore)
+                .brokerClientTlsKeyStorePassword(brokerClientTlsKeyStorePassword)
                 .brokerClientTrustCertsFilePath(brokerClientTrustCertsFilePath)
                 .brokerClientCertificateFilePath(brokerClientCertificateFilePath)
                 .brokerClientKeyFilePath(brokerClientKeyFilePath)
-                .listenerName(listenerName);
+                .listenerName(listenerName)
+                .migrated(migrated)
+                .migratedClusterUrl(migratedClusterUrl);
     }
 
     @Data

--- a/pulsar-common/src/test/java/org/apache/pulsar/common/policies/data/ClusterDataImplTest.java
+++ b/pulsar-common/src/test/java/org/apache/pulsar/common/policies/data/ClusterDataImplTest.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.common.policies.data;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotSame;
+
+import org.apache.pulsar.client.api.ProxyProtocol;
+import org.testng.annotations.Test;
+
+import java.util.LinkedHashSet;
+
+public class ClusterDataImplTest {
+
+    @Test
+    public void verifyClone() {
+        ClusterDataImpl originalData = ClusterDataImpl.builder()
+                .serviceUrl("pulsar://test")
+                .serviceUrlTls("pulsar+ssl://test")
+                .brokerServiceUrl("pulsar://test:6650")
+                .brokerServiceUrlTls("pulsar://test:6651")
+                .proxyServiceUrl("pulsar://proxy:6650")
+                .authenticationPlugin("test-plugin")
+                .authenticationParameters("test-params")
+                .proxyProtocol(ProxyProtocol.SNI)
+                .peerClusterNames(new LinkedHashSet<>())
+                .brokerClientTlsEnabled(true)
+                .tlsAllowInsecureConnection(false)
+                .brokerClientTlsEnabledWithKeyStore(true)
+                .brokerClientTlsTrustStoreType("JKS")
+                .brokerClientTlsTrustStore("/my/trust/store")
+                .brokerClientTlsTrustStorePassword("some-password")
+                .brokerClientTlsKeyStoreType("PCKS12")
+                .brokerClientTlsKeyStore("/my/key/store")
+                .brokerClientTlsKeyStorePassword("a-different-password")
+                .brokerClientTrustCertsFilePath("/my/trusted/certs")
+                .brokerClientKeyFilePath("/my/key/file")
+                .brokerClientCertificateFilePath("/my/cert/file")
+                .listenerName("a-listener")
+                .migrated(true)
+                .migratedClusterUrl(new ClusterData.ClusterUrl("pulsar://remote", "pulsar+ssl://remote"))
+                .build();
+
+        ClusterDataImpl clone = originalData.clone().build();
+
+        assertEquals(clone, originalData, "Clones should have object equality.");
+        assertNotSame(clone, originalData, "Clones should not be the same reference.");
+    }
+}


### PR DESCRIPTION
### Motivation

In #17962, new configurations were added to the `ClusterDataImpl` without updating the `clone` method. In https://github.com/apache/pulsar/pull/17295, new configurations were incorrectly cloned. None of these "bugs" are in a released version of pulsar.

This PR fixes those issues and adds a test to verify the fixes. One gap on the test is that it won't easily test new fields unless the test is updated. I would guess we need smarter tests to make that work. I'm not aware of any solutions, but if someone has pointers, please let me know.

### Modifications

* Fix `ClusterDataImpl#clone`

### Verifying this change

A new test is added to cover the changes.

### Does this pull request potentially affect one of the following parts:

This is an internal change.

### Documentation

- [x] `doc-not-needed`

### Matching PR in forked repository

PR in forked repository: https://github.com/michaeljmarshall/pulsar/pull/10
