### PR TITLE
[improve][ci] Improve CI ssh access in forks, don't fail build if setting up ssh access fails

### DIFF
--- a/.github/actions/ssh-access/action.yml
+++ b/.github/actions/ssh-access/action.yml
@@ -121,8 +121,22 @@ runs:
             tmux set -t upterm window-size largest
             echo '::endgroup::'  
             echo -e "\nSSH connection information"
+            # wait up to 10 seconds for upterm admin socket to appear
+            for i in {1..10}; do
+              ADMIN_SOCKET=$(find $HOME/.upterm -name "*.sock")
+              if [ ! -S "$ADMIN_SOCKET" ]; then
+                echo "Waiting for upterm admin socket to appear in ~/.upterm/*.sock ..."
+                sleep 1
+              else
+                echo "upterm admin socket available in $ADMIN_SOCKET"
+                break
+              fi
+            done
             shopt -s nullglob
-            upterm session current --admin-socket ~/.upterm/*.sock
+            upterm session current --admin-socket ~/.upterm/*.sock || {
+              echo "Starting upterm failed."
+              exit 0
+            }
         elif [[ "${{ inputs.action }}" == "wait" ]]; then
             # only wait if upterm was installed
             if command -v upterm &>/dev/null; then

--- a/.github/workflows/pulsar-ci-flaky.yaml
+++ b/.github/workflows/pulsar-ci-flaky.yaml
@@ -83,6 +83,7 @@ jobs:
         # ssh access is enabled for builds in own forks
         if: ${{ github.repository != 'apache/pulsar' && github.event_name == 'pull_request' }}
         uses: ./.github/actions/ssh-access
+        continue-on-error: true
         with:
           limit-access-to-actor: true
 

--- a/.github/workflows/pulsar-ci.yaml
+++ b/.github/workflows/pulsar-ci.yaml
@@ -89,6 +89,7 @@ jobs:
         # ssh access is enabled for builds in own forks
         if: ${{ github.repository != 'apache/pulsar' && github.event_name == 'pull_request' }}
         uses: ./.github/actions/ssh-access
+        continue-on-error: true
         with:
           limit-access-to-actor: true
 
@@ -184,6 +185,7 @@ jobs:
         # ssh access is enabled for builds in own forks
         if: ${{ github.repository != 'apache/pulsar' && github.event_name == 'pull_request' }}
         uses: ./.github/actions/ssh-access
+        continue-on-error: true
         with:
           limit-access-to-actor: true
 
@@ -285,6 +287,7 @@ jobs:
         # ssh access is enabled for builds in own forks
         if: ${{ github.repository != 'apache/pulsar' && github.event_name == 'pull_request' }}
         uses: ./.github/actions/ssh-access
+        continue-on-error: true
         with:
           limit-access-to-actor: true
 
@@ -383,6 +386,7 @@ jobs:
         # ssh access is enabled for builds in own forks
         if: ${{ github.repository != 'apache/pulsar' && github.event_name == 'pull_request' }}
         uses: ./.github/actions/ssh-access
+        continue-on-error: true
         with:
           limit-access-to-actor: true
 
@@ -512,6 +516,7 @@ jobs:
         # ssh access is enabled for builds in own forks
         if: ${{ github.repository != 'apache/pulsar' && github.event_name == 'pull_request' }}
         uses: ./.github/actions/ssh-access
+        continue-on-error: true
         with:
           limit-access-to-actor: true
 
@@ -638,6 +643,7 @@ jobs:
         # ssh access is enabled for builds in own forks
         if: ${{ github.repository != 'apache/pulsar' && github.event_name == 'pull_request' }}
         uses: ./.github/actions/ssh-access
+        continue-on-error: true
         with:
           limit-access-to-actor: true
 
@@ -749,6 +755,7 @@ jobs:
         # ssh access is enabled for builds in own forks
         if: ${{ github.repository != 'apache/pulsar' && github.event_name == 'pull_request' }}
         uses: ./.github/actions/ssh-access
+        continue-on-error: true
         with:
           limit-access-to-actor: true
 
@@ -903,6 +910,7 @@ jobs:
         # ssh access is enabled for builds in own forks
         if: ${{ github.repository != 'apache/pulsar' && github.event_name == 'pull_request' }}
         uses: ./.github/actions/ssh-access
+        continue-on-error: true
         with:
           limit-access-to-actor: true
 


### PR DESCRIPTION
### Motivation

The ssh access setup step that is part of Pulsar CI can fail in builds that are run in forks. The ssh access feature is active in CI builds run in forks to allow connecting to the running build with ssh for debugging purposes.

This is the ssh access setup step:
https://github.com/apache/pulsar/blob/master/.github/workflows/pulsar-ci.yaml#L88-L93

Sometime this fails with an error message "flag needs an argument: --admin-socket". Example of failure:
https://github.com/michaeljmarshall/pulsar/actions/runs/3833202322/jobs/6527659487#step:4:150

### Modifications

- wait up to 10 seconds for admin socket to appear
- add "continue-on-error: true" to ssh setup step so that errors don't prevent the build from continuing

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/lhotari/pulsar/pull/122

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->