### PR TITLE
[fix][broker] Fix consumer with schema cannot subscribe when AUTO_CONSUME consumers exist

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractTopic.java
@@ -1335,4 +1335,15 @@ public abstract class AbstractTopic implements Topic, TopicPolicyListener<TopicP
         }
         return Optional.empty();
     }
+
+    protected static boolean hasActiveNonAutoConsumeConsumers(List<? extends Subscription> subscriptions) {
+        for (Subscription subscription : subscriptions) {
+            for (Consumer consumer : subscription.getConsumers()) {
+                if (!consumer.isAutoConsume()) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Consumer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Consumer.java
@@ -135,6 +135,8 @@ public class Consumer {
     private final String clientAddress; // IP address only, no port number included
     private final MessageId startMessageId;
     private final boolean isAcknowledgmentAtBatchIndexLevelEnabled;
+    @Getter
+    private final boolean autoConsume;
 
     @Getter
     @Setter
@@ -147,7 +149,15 @@ public class Consumer {
                     boolean isDurable, TransportCnx cnx, String appId,
                     Map<String, String> metadata, boolean readCompacted,
                     KeySharedMeta keySharedMeta, MessageId startMessageId, long consumerEpoch) {
+        this(subscription, subType, topicName, consumerId, priorityLevel, consumerName, isDurable, cnx, appId,
+                metadata, readCompacted, keySharedMeta, startMessageId, consumerEpoch, false);
+    }
 
+    public Consumer(Subscription subscription, SubType subType, String topicName, long consumerId,
+                    int priorityLevel, String consumerName,
+                    boolean isDurable, TransportCnx cnx, String appId,
+                    Map<String, String> metadata, boolean readCompacted,
+                    KeySharedMeta keySharedMeta, MessageId startMessageId, long consumerEpoch, boolean autoConsume) {
         this.subscription = subscription;
         this.subType = subType;
         this.topicName = topicName;
@@ -204,6 +214,7 @@ public class Consumer {
         this.consumerEpoch = consumerEpoch;
         this.isAcknowledgmentAtBatchIndexLevelEnabled = subscription.getTopic().getBrokerService()
                 .getPulsar().getConfiguration().isAcknowledgmentAtBatchIndexLevelEnabled();
+        this.autoConsume = autoConsume;
     }
 
     @VisibleForTesting
@@ -231,6 +242,7 @@ public class Consumer {
         this.clientAddress = null;
         this.startMessageId = null;
         this.isAcknowledgmentAtBatchIndexLevelEnabled = false;
+        this.autoConsume = false;
         MESSAGE_PERMITS_UPDATER.set(this, availablePermits);
     }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
@@ -1133,6 +1133,8 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
                                                         "Subscription does not exist"));
                             }
 
+                            boolean autoConsume = (schema != null)
+                                    && Commands.isAutoConsumeSchema(schema.getType(), schema.getData());
                             SubscriptionOption option = SubscriptionOption.builder().cnx(ServerCnx.this)
                                     .subscriptionName(subscriptionName)
                                     .consumerId(consumerId).subType(subType).priorityLevel(priorityLevel)
@@ -1143,8 +1145,9 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
                                     .replicatedSubscriptionStateArg(isReplicated).keySharedMeta(keySharedMeta)
                                     .subscriptionProperties(subscriptionProperties)
                                     .consumerEpoch(consumerEpoch)
+                                    .autoConsume(autoConsume)
                                     .build();
-                            if (schema != null) {
+                            if (schema != null && !autoConsume) {
                                 return topic.addSchemaIfIdleOrCheckCompatible(schema)
                                         .thenCompose(v -> topic.subscribe(option));
                             } else {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/SubscriptionOption.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/SubscriptionOption.java
@@ -49,6 +49,7 @@ public class SubscriptionOption {
     private KeySharedMeta keySharedMeta;
     private Optional<Map<String, String>> subscriptionProperties;
     private long consumerEpoch;
+    private boolean autoConsume;
 
     public static Optional<Map<String, String>> getPropertiesMap(List<KeyValue> list) {
         if (list == null) {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SimpleSchemaTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SimpleSchemaTest.java
@@ -1326,4 +1326,25 @@ public class SimpleSchemaTest extends ProducerConsumerBase {
         producer.close();
         consumer.close();
     }
+
+    @Test(dataProvider = "topicDomain")
+    public void testTopicAutoConsumeConsumerConnected(String domain) throws Exception {
+        final String topic = domain + "my-property/my-ns/test-topic-auto-consume-consumer-connected";
+
+        Consumer<GenericRecord> consumer = pulsarClient.newConsumer(Schema.AUTO_CONSUME())
+                .topic(topic)
+                .subscriptionType(SubscriptionType.Shared)
+                .subscriptionName("sub")
+                .subscribe();
+
+        // Consumer with schema should be able to subscribe if an AUTO_CONSUME consumer is already connected
+        Consumer<V1Data> consumerWithSchema = pulsarClient.newConsumer(Schema.AVRO(V1Data.class))
+                .topic(topic)
+                .subscriptionType(SubscriptionType.Shared)
+                .subscriptionName("sub")
+                .subscribe();
+
+        consumerWithSchema.close();
+        consumer.close();
+    }
 }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
@@ -83,6 +83,7 @@ import org.apache.pulsar.client.api.TypedMessageBuilder;
 import org.apache.pulsar.client.api.transaction.TxnID;
 import org.apache.pulsar.client.impl.conf.ConsumerConfigurationData;
 import org.apache.pulsar.client.impl.crypto.MessageCryptoBc;
+import org.apache.pulsar.client.impl.schema.AutoConsumeSchema;
 import org.apache.pulsar.client.impl.transaction.TransactionImpl;
 import org.apache.pulsar.client.util.ExecutorProvider;
 import org.apache.pulsar.client.util.RetryMessageUtil;
@@ -816,6 +817,8 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
         if (si != null && (SchemaType.BYTES == si.getType() || SchemaType.NONE == si.getType())) {
             // don't set schema for Schema.BYTES
             si = null;
+        } else if (schema instanceof AutoConsumeSchema) {
+            si = Commands.createAutoConsumeSchemaInfo();
         }
         // startMessageRollbackDurationInSec should be consider only once when consumer connects to first time
         long startMessageRollbackDuration = (startMessageRollbackDurationInSec > 0

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/protocol/Commands.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/protocol/Commands.java
@@ -30,6 +30,7 @@ import io.netty.util.concurrent.FastThreadLocal;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Base64;
 import java.util.Collections;
 import java.util.List;
@@ -120,6 +121,8 @@ public class Commands {
     // this present broker version don't have consumerEpoch feature,
     // so client don't need to think about consumerEpoch feature
     public static final long DEFAULT_CONSUMER_EPOCH = -1L;
+
+    private static final byte[] AUTO_CONSUME_SCHEMA_BYTES = SchemaType.AUTO_CONSUME.name().getBytes(UTF_8);
 
     @SuppressWarnings("checkstyle:ConstantName")
     public static final short magicCrc32c = 0x0e01;
@@ -1993,5 +1996,16 @@ public class Commands {
 
     public static boolean peerSupportsBrokerMetadata(int peerVersion) {
         return peerVersion >= ProtocolVersion.v16.getValue();
+    }
+
+    public static SchemaInfo createAutoConsumeSchemaInfo() {
+        return SchemaInfo.builder().type(SchemaType.NONE)
+                .schema(AUTO_CONSUME_SCHEMA_BYTES)
+                .name("")
+                .build();
+    }
+
+    public static boolean isAutoConsumeSchema(SchemaType schemaType, byte[] data) {
+        return schemaType == SchemaType.NONE && Arrays.equals(data, AUTO_CONSUME_SCHEMA_BYTES);
     }
 }


### PR DESCRIPTION
Fixes https://github.com/apache/pulsar/issues/17354

### Motivation

https://github.com/apache/pulsar/pull/17449 tried to fix this problem by exposing the `AUTO_CONSUME` schema type in PulsarApi.proto and check the schema type in `ServerCnx#handleSubscribe`. However, the negative schema type should only be used internally and it should be transparent to users.

Instead, the `Schema` command could carry a `name` field of `string` type and a `type` field of `bytes` type. Though the `name` field is ignored at the broker side, see the `SchemaData` class. So we can mark the consumer as the `AUTO_CONSUME` consumer in the schema data.

### Modifications

Add a `createAutoConsumeSchemaInfo` method to create a `SchemaInfo` that indicates an `AUTO_CONSUME` consumer at client side and a `isAutoConsumeSchema` method to check if the consumer is `AUTO_CONSUME` at broker side.

Client side: When subscribing a topic with the `AUTO_CONSUME` schema, instead of not setting the `schema` field, set the `schema` field with a schema whose type is `NONE` and data is the UTF-8 bytes of "AUTO_CONSUME".

Broker side: Add a `autoConsume` field to `Consumer`. In `addSchemaIfIdleOrCheckCompatible`, skip these consumers whose `autoConsume` field is true.

### Verifications

Add `testTopicAutoConsumeConsumerConnected` to verify a consumer with schema can be created when there is a connected `AUTO_CONSUME` consumer.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/BewareMyPower/pulsar/pull/16